### PR TITLE
Support ovirt CPU Policy

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ovirt/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/controller/plan/adapter/base",
         "//pkg/controller/plan/context",
+        "//pkg/controller/provider/container/ovirt",
         "//pkg/controller/provider/web",
         "//pkg/controller/provider/web/base",
         "//pkg/controller/provider/web/ocp",

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -2,6 +2,9 @@ package ovirt
 
 import (
 	"fmt"
+	"path"
+	"strings"
+
 	liberr "github.com/konveyor/controller/pkg/error"
 	libitr "github.com/konveyor/controller/pkg/itinerary"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
@@ -14,8 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	cnv "kubevirt.io/client-go/api/v1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"path"
-	"strings"
 )
 
 // BIOS types
@@ -56,6 +57,15 @@ const (
 	DefaultWindows = "win10"
 	DefaultLinux   = "rhel8.1"
 	Unknown        = "unknown"
+)
+
+// CPU Pinning Policies
+const (
+	None           = "none"
+	Manual         = "manual"
+	ResizeAndPin   = "resize_and_pin_numa"
+	Dedicated      = "dedicated"
+	IsolateThreads = "isolate_threads"
 )
 
 // Map of ovirt guest ids to osinfo ids.
@@ -358,6 +368,10 @@ func (r *Builder) mapCPU(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 		Cores:   uint32(vm.CpuCores),
 		Threads: uint32(vm.CpuThreads),
 	}
+	if vm.CpuPinningPolicy == Dedicated {
+		object.Template.Spec.Domain.CPU.DedicatedCPUPlacement = true
+	}
+
 }
 
 func (r *Builder) mapFirmware(vm *model.Workload, cluster *model.Cluster, object *cnv.VirtualMachineSpec) {

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -59,15 +59,6 @@ const (
 	Unknown        = "unknown"
 )
 
-// CPU Pinning Policies
-const (
-	None           = "none"
-	Manual         = "manual"
-	ResizeAndPin   = "resize_and_pin_numa"
-	Dedicated      = "dedicated"
-	IsolateThreads = "isolate_threads"
-)
-
 // Map of ovirt guest ids to osinfo ids.
 var osMap = map[string]string{
 	"rhel_6_10_plus_ppc64": "rhel6.10",
@@ -368,7 +359,7 @@ func (r *Builder) mapCPU(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 		Cores:   uint32(vm.CpuCores),
 		Threads: uint32(vm.CpuThreads),
 	}
-	if vm.CpuPinningPolicy == Dedicated {
+	if vm.CpuPinningPolicy == model.Dedicated {
 		object.Template.Spec.Domain.CPU.DedicatedCPUPlacement = true
 	}
 

--- a/pkg/controller/provider/BUILD.bazel
+++ b/pkg/controller/provider/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1",
         "//pkg/controller/base",
         "//pkg/controller/provider/container",
+        "//pkg/controller/provider/container/ovirt",
         "//pkg/controller/provider/model",
         "//pkg/controller/provider/web",
         "//pkg/controller/validation/policy",

--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -1,9 +1,10 @@
 package ovirt
 
 import (
-	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 	"sort"
 	"strconv"
+
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 )
 
 //
@@ -226,8 +227,9 @@ type VM struct {
 			Threads string `json:"threads"`
 		} `json:"topology"`
 	} `json:"cpu"`
-	CpuShares string `json:"cpu_shares"`
-	USB       struct {
+	CpuPinningPolicy string `json:"cpu_pinning_policy"`
+	CpuShares        string `json:"cpu_shares"`
+	USB              struct {
 		Enabled string `json:"enabled"`
 	} `json:"usb"`
 	Timezone struct {
@@ -352,6 +354,7 @@ func (r *VM) ApplyTo(m *model.VM) {
 	m.CpuSockets = r.int16(r.CPU.Topology.Sockets)
 	m.CpuCores = r.int16(r.CPU.Topology.Cores)
 	m.CpuThreads = r.int16(r.CPU.Topology.Threads)
+	m.CpuPinningPolicy = r.CpuPinningPolicy
 	m.CpuShares = r.int16(r.CpuShares)
 	m.Memory = r.int64(r.Memory)
 	m.BIOS = r.BIOS.Type

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -131,6 +131,7 @@ type VM struct {
 	CpuCores                    int16            `sql:""`
 	CpuThreads                  int16            `sql:""`
 	CpuAffinity                 []CpuPinning     `sql:""`
+	CpuPinningPolicy            string           `sql:""`
 	CpuShares                   int16            `sql:""`
 	Memory                      int64            `sql:""`
 	BalloonedMemory             bool             `sql:""`

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -2,13 +2,14 @@ package ovirt
 
 import (
 	"errors"
+	"net/http"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
-	"net/http"
-	"strings"
 )
 
 //
@@ -228,6 +229,7 @@ type VM struct {
 	CpuThreads                  int16        `json:"cpuThreads"`
 	CpuShares                   int16        `json:"cpuShares"`
 	CpuAffinity                 []CpuPinning `json:"cpuAffinity"`
+	CpuPinningPolicy            string       `json:"cpuPinningPolicy"`
 	Memory                      int64        `json:"memory"`
 	BalloonedMemory             bool         `json:"balloonedMemory"`
 	IOThreads                   int16        `json:"ioThreads"`
@@ -276,6 +278,7 @@ func (r *VM) With(m *model.VM) {
 	r.CpuThreads = m.CpuThreads
 	r.CpuShares = m.CpuShares
 	r.CpuAffinity = m.CpuAffinity
+	r.CpuPinningPolicy = m.CpuPinningPolicy
 	r.Memory = m.Memory
 	r.BalloonedMemory = m.BalloonedMemory
 	r.IOThreads = m.IOThreads

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -21,6 +21,16 @@ const (
 	VMRoot       = VMsRoot + "/:" + VMParam
 )
 
+type CpuPinningPolicy string
+
+// CPU Pinning Policies
+const (
+        None           CpuPinningPolicy = "none"
+        Manual         CpuPinningPolicy = "manual"
+        ResizeAndPin   CpuPinningPolicy = "resize_and_pin_numa"
+        Dedicated      CpuPinningPolicy = "dedicated"
+        IsolateThreads CpuPinningPolicy = "isolate_threads"
+)
 //
 // Virtual Machine handler.
 type VMHandler struct {
@@ -222,14 +232,14 @@ func (r *VM1) Content(detail int) interface{} {
 // VM resource.
 type VM struct {
 	VM1
-	PolicyVersion               int          `json:"policyVersion"`
-	GuestName                   string       `json:"guestName"`
-	CpuSockets                  int16        `json:"cpuSockets"`
-	CpuCores                    int16        `json:"cpuCores"`
-	CpuThreads                  int16        `json:"cpuThreads"`
-	CpuShares                   int16        `json:"cpuShares"`
-	CpuAffinity                 []CpuPinning `json:"cpuAffinity"`
-	CpuPinningPolicy            string       `json:"cpuPinningPolicy"`
+	PolicyVersion               int              `json:"policyVersion"`
+	GuestName                   string           `json:"guestName"`
+	CpuSockets                  int16            `json:"cpuSockets"`
+	CpuCores                    int16            `json:"cpuCores"`
+	CpuThreads                  int16            `json:"cpuThreads"`
+	CpuShares                   int16            `json:"cpuShares"`
+	CpuAffinity                 []CpuPinning     `json:"cpuAffinity"`
+	CpuPinningPolicy            CpuPinningPolicy `json:"cpuPinningPolicy"`
 	Memory                      int64        `json:"memory"`
 	BalloonedMemory             bool         `json:"balloonedMemory"`
 	IOThreads                   int16        `json:"ioThreads"`
@@ -267,6 +277,8 @@ type Snapshot = model.Snapshot
 type Concern = model.Concern
 type Guest = model.Guest
 
+
+
 //
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
@@ -278,7 +290,9 @@ func (r *VM) With(m *model.VM) {
 	r.CpuThreads = m.CpuThreads
 	r.CpuShares = m.CpuShares
 	r.CpuAffinity = m.CpuAffinity
-	r.CpuPinningPolicy = m.CpuPinningPolicy
+	if r.CpuPinningPolicy = CpuPinningPolicy(m.CpuPinningPolicy); len(r.CpuPinningPolicy) == 0 {
+		r.CpuPinningPolicy = None;
+	}
 	r.Memory = m.Memory
 	r.BalloonedMemory = m.BalloonedMemory
 	r.IOThreads = m.IOThreads

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_policy.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_policy.rego
@@ -1,0 +1,17 @@
+package io.konveyor.forklift.ovirt
+
+default not_supported_cpu_policy = false
+
+# no need to check for 'manual' pinning policy because 'cpuAffinity' is validated by the 'cpu_tune' policy
+not_supported_cpu_policy = true {
+    regex.match(`resize_and_pin_numa|isolate_threads`, input.cpuPinningPolicy)
+}
+
+concerns[flag] {
+    not_supported_cpu_policy
+    flag := {
+        "category": "Warning",
+        "label": "Unsupported CPU pinning policy detected",
+        "assessment": "Resize and Pin NUMA and Isolated Threads are not supported by OpenShift Virtualization. Some functionality may be missing after the VM is migrated."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_policy_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_policy_test.rego
@@ -1,0 +1,47 @@
+package io.konveyor.forklift.ovirt
+
+test_with_none {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "none"
+    }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_dedicated {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "dedicated"
+    }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_manual {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "manual",
+        "cpuAffinity": [0,2]
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_with_resize_and_pin_numa {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "resize_and_pin_numa"
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_with_isolate_threads {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "isolate_threads"
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}


### PR DESCRIPTION
When importing a VM from oVirt it has the property of CPU Pinning Policy.
Only having none or dedicated is supported on CNV. Therefore, only both
of them will be respected.
As for dedicated the user should enable the CPU manager on the nodes,
or else the VM won't be able to schedule and the migration will hang.
NUMA is out of the scope for this PR.
More about the feature at the [dedicated cpu resources page](https://kubevirt.io/user-guide/virtual_machines/dedicated_cpu_resources/).