### PR TITLE
Change VM names comply with RFC 1123 DNS Subdomain

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -729,7 +729,7 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus) (object *cnv.VirtualMachine
 			generatedName = generatedName + "-" + vm.ID[:4]
 		}
 		vm.Name = generatedName
-		r.Log.Info("VM name", originalName, " was incompatible with DNS1123 RFC, changing to ",
+		r.Log.Info("VM name ", originalName, " was incompatible with DNS1123 RFC, changing to ",
 			vm.Name)
 	}
 

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -1,0 +1,22 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestKubevirt(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	id := "1234-5678"
+
+	//Test all cases in name adjustments
+	originalVmName := "----------------Vm!@#$%^&*()_+-Name/.,';[]-CorREct-<>123----------------------"
+	newVmName := "vm-name-correct-123"
+	g.Expect(changeVmName(originalVmName, id)).To(gomega.Equal(newVmName))
+
+	//Test the case that the VM name is empty after all removals
+	emptyVM := ".__."
+	newVmNameFromId := "vm-1234-5678"
+	g.Expect(changeVmName(emptyVM, id)).To(gomega.Equal(newVmNameFromId))
+}

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
+
 	net "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -15,7 +17,6 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/controller/validation"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
-	"path"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -317,8 +318,8 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     NameNotValid,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Critical,
-		Message:  "Target VM name not valid.",
+		Category: Warn,
+		Message:  "Target VM name does not comply with DNS1123 RFC, will be automatically changed.",
 		Items:    []string{},
 	}
 	alreadyExists := libcnd.Condition{

--- a/validation/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name.rego
@@ -22,8 +22,8 @@ concerns[flag] {
     valid_vm_string
     not valid_vm_name
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will not be migrated."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will renamed automatically during the migration to meet the RFC convention."
     }
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name.rego
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will renamed automatically during the migration to meet the RFC convention."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }

--- a/validation/policies/io/konveyor/forklift/vmware/name.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/name.rego
@@ -22,8 +22,8 @@ concerns[flag] {
     valid_vm
     not valid_vm_name
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }


### PR DESCRIPTION
This PR changes VM names to match the DNS1123 RFC conventions,
As a first step, the names will be automatically adjusted to make the VMs ready for migration without user actions.
A newly generated name will be created and validated with the destination, if exists, will add the first 4 chars from the ID to the new name to avoid dups.
A new annotation with the previous name and ID will be added to the imported VM.

Currently, implementation checks the following:

contain at most 63 characters
contain only lowercase alphanumeric characters or '-'
start with an alphanumeric character
end with an alphanumeric character
In case the VM name is completely deleted after the adjustments a new name in the format vm-$ID will be given.

https://bugzilla.redhat.com/show_bug.cgi?id=1959883