### PR TITLE
E2E sanity ovirt test

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,6 +34,25 @@ jobs:
         run: |
           curl -k "$CLUSTER/apis/forklift.konveyor.io/v1beta1/namespaces/konveyor-forklift/providers" --header "Authorization: Bearer $TOKEN"
 
+      # Run e2e sanity
+      - name: Run e2e sanity suite
+        env:
+          OVIRT_USERNAME: admin@internal
+          OVIRT_PASSWORD: 123456
+          OVIRT_URL: https://fakeovirt.konveyor-forklift:30001/ovirt-engine/api
+          OVIRT_CACERT: /home/runner/work/_actions/kubev2v/forkliftci/main/ovirt/e2e_cacert.cer
+          STORAGE_CLASS: standard
+          OVIRT_VM_ID: 31573c08-717b-43e0-825f-69a36fb0e1a1
+        run: |
+          GOPATH=${GITHUB_WORKSPACE}/go make e2e-sanity
+
+      # Push code coverage using Codecov Action
+      - name: Push code coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: false # see https://github.com/codecov/codecov-action/issues/598
+
+
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ all: test manager
 test: generate fmt vet manifests
 	go test ./pkg/... ./cmd/... -coverprofile cover.out
 
+# Experimental e2e target
+e2e-sanity:
+	go test tests/base_test.go
+
 # Build manager binary
 manager: generate fmt vet
 	go build -o bin/manager github.com/konveyor/forklift-controller/cmd/manager

--- a/tests/base_test.go
+++ b/tests/base_test.go
@@ -1,0 +1,572 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/konveyor/forklift-controller/pkg/apis"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/provider"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+	ovirtsdk "github.com/ovirt/go-ovirt"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestSanityOvirtProvider(t *testing.T) {
+	var log logr.Logger
+
+	conf, err := config.GetConfig()
+	if err != nil {
+		fmt.Println("unable to set up client config")
+		os.Exit(1)
+	}
+
+	logf.SetLogger(
+		logf.ZapLogger(false))
+	log = logf.Log.WithName("entrypoint")
+
+	customEnvVar := os.Getenv("OVIRT_CUSTOM_ENV")
+	customEnv := false
+	migrationTimeout := "3"
+	if customEnvVar == "true" {
+		customEnv = true
+	}
+	username := os.Getenv("OVIRT_USERNAME")
+	if username == "" {
+		t.Fatal("OVIRT_USERNAME is not set")
+	}
+	password := os.Getenv("OVIRT_PASSWORD")
+	if password == "" {
+		t.Fatal("OVIRT_PASSWORD is not set")
+	}
+
+	ovirtURL := os.Getenv("OVIRT_URL")
+	if ovirtURL == "" {
+		t.Fatal("OVIRT_URL is not set")
+	}
+
+	cacertFile := os.Getenv("OVIRT_CACERT")
+	if cacertFile == "" {
+		t.Fatal("OVIRT_CACERT is not set")
+	}
+
+	fileinput, err := os.ReadFile(cacertFile)
+	if err != nil {
+		t.Fatalf("Could not read %s", cacertFile)
+	}
+	cacert := fmt.Sprintf("%s", fileinput)
+
+	sc := os.Getenv("STORAGE_CLASS")
+	if sc == "" {
+		t.Fatal("STORAGE_CLASS is not set")
+	}
+
+	vmId := os.Getenv("OVIRT_VM_ID")
+	if vmId == "" {
+		t.Fatal("OVIRT_VM is not set")
+	}
+	timeoutInput := os.Getenv("MIGRATION_TIMEOUT")
+	if timeoutInput != "" {
+		migrationTimeout = timeoutInput
+	}
+
+	// Register
+	err = v1beta1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Error(err, "Failed to build scheme")
+	}
+	err = apis.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Error(err, "Failed to add scheme")
+	}
+
+	cl, err := client.New(conf, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		t.Error(err, "Failed to create client")
+	}
+
+	localProviderNamespace := "konveyor-forklift"
+
+	log.Info("Creating secret...")
+
+	secret := &corev1.Secret{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: localProviderNamespace,
+			Name:      "ovirt-provider-test-secret",
+			Labels: map[string]string{
+				"createdForResource":     "ovirt-provider",
+				"createdForResourceType": "providers",
+			},
+		},
+		Data: map[string][]byte{
+			"user":     []byte(username),
+			"password": []byte(password),
+			"cacert":   []byte(cacert),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	err = cl.Create(context.TODO(), secret, &client.CreateOptions{})
+	if err != nil {
+		t.Fatal(err, "Failed to create secret")
+	}
+
+	providerName := v1.ObjectMeta{
+		Namespace: localProviderNamespace,
+		Name:      "ovirt-provider",
+	}
+
+	ovirtProvider := v1beta1.OVirt
+	p := &v1beta1.Provider{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Provider",
+			APIVersion: "forklift.konveyor.io/v1beta1",
+		},
+		ObjectMeta: providerName,
+		Spec: v1beta1.ProviderSpec{
+			Type: &ovirtProvider,
+			URL:  ovirtURL,
+			Secret: corev1.ObjectReference{
+				Name:      secret.Name,
+				Namespace: localProviderNamespace,
+			},
+		},
+	}
+
+	err = cl.Create(context.TODO(), p, &client.CreateOptions{})
+	if err != nil {
+		t.Fatal(err, "Failed to create ovirt provider")
+	}
+
+	returnedProvider := &v1beta1.Provider{}
+	providerIdentifier := types.NamespacedName{Namespace: providerName.Namespace, Name: providerName.Name}
+	err = cl.Get(context.TODO(), providerIdentifier, returnedProvider)
+	if err != nil {
+		t.Fatal(err, "Failed get ovirt provider")
+	}
+
+	done := make(chan struct{})
+
+	// Wait for provider to be ready
+	statusCheck := func() {
+		err = cl.Get(context.TODO(), providerIdentifier, returnedProvider)
+		if err != nil {
+			t.Fatal(err, "Failed to create ovirt provider")
+		}
+
+		if returnedProvider.Status.Conditions.IsReady() {
+			log.Info("oVirt Provider is ready")
+			close(done)
+		}
+	}
+
+	go wait.Until(statusCheck, time.Second, done)
+
+	timeout := time.After(1 * time.Minute)
+	select {
+	case <-timeout:
+		t.Errorf("Provider is not ready in time, last status: %v", returnedProvider.Status)
+	case <-done:
+	}
+
+	// sdPairs set with the default settings for kind CI.
+	sdPairs := []v1beta1.StoragePair{
+		{
+			Source: ref.Ref{ID: "95ef6fee-5773-46a2-9340-a636958a96b8"},
+			Destination: v1beta1.DestinationStorage{
+				StorageClass: sc,
+			},
+		},
+	}
+	// nicPairs set with the default settings for kind CI.
+	nicPairs := []v1beta1.NetworkPair{
+		{
+			Source: ref.Ref{ID: "6b6b7239-5ea1-4f08-a76e-be150ab8eb89"},
+			Destination: v1beta1.DestinationNetwork{
+				Type: "pod",
+			},
+		},
+	}
+
+	if customEnv {
+		ovirtCl := &Client{}
+		defer ovirtCl.Close()
+
+		err = ovirtCl.connect(secret, ovirtURL)
+		if err != nil {
+			t.Fatal(err, "Failed to connect ovirt sdk")
+		}
+		_, vmService, err := ovirtCl.getVMs(ref.Ref{ID: vmId})
+		if err != nil {
+			t.Fatal(err, "Failed to get vm")
+		}
+
+		diskAttachementResponse, err := vmService.DiskAttachmentsService().List().Send()
+		if err != nil {
+			t.Fatal(err, "Failed to get disk attachment service")
+		}
+
+		disks, ok := diskAttachementResponse.Attachments()
+		sdPairs := []v1beta1.StoragePair{}
+		if !ok {
+			t.Fatal("Failed to get disks")
+		}
+		for _, da := range disks.Slice() {
+			disk, ok := da.Disk()
+			if !ok {
+				t.Fatal("Failed to get disk")
+			}
+			diskService := ovirtCl.connection.SystemService().DisksService().DiskService(disk.MustId())
+			diskResponse, err := diskService.Get().Send()
+			if err != nil {
+				t.Fatal(err, "Failed to get disk")
+			}
+			sds, ok := diskResponse.MustDisk().StorageDomains()
+			if !ok {
+				t.Fatal("Failed to get sds")
+			}
+			for _, sd := range sds.Slice() {
+				sdId, ok := sd.Id()
+				if !ok {
+					t.Fatal("Failed to get sd id")
+				}
+				pair := v1beta1.StoragePair{
+					Source: ref.Ref{ID: sdId},
+					Destination: v1beta1.DestinationStorage{
+						StorageClass: sc,
+					},
+				}
+				sdPairs = append(sdPairs, pair)
+			}
+		}
+		nicsResponse, err := vmService.NicsService().List().Send()
+		nics, ok := nicsResponse.Nics()
+		if !ok {
+			t.Fatal("Failed to get nics")
+		}
+		nicPairs := []v1beta1.NetworkPair{}
+		for _, nic := range nics.Slice() {
+			vnicService := ovirtCl.connection.SystemService().VnicProfilesService().ProfileService(nic.MustVnicProfile().MustId())
+			vnicResponse, err := vnicService.Get().Send()
+			if err != nil {
+				t.Fatal(err, "Failed to get vnic service")
+			}
+			profile, ok := vnicResponse.Profile()
+			if !ok {
+				t.Fatal("Failed to get nic profile")
+			}
+
+			network, ok := profile.Network()
+			if !ok {
+				t.Fatal("Failed to get network")
+			}
+			networkId, ok := network.Id()
+			if !ok {
+				t.Fatal("Failed to get network id")
+			}
+			pair := v1beta1.NetworkPair{
+				Source: ref.Ref{ID: networkId},
+				Destination: v1beta1.DestinationNetwork{
+					Type: "pod",
+				},
+			}
+			nicPairs = append(nicPairs, pair)
+		}
+	}
+
+	storageMap := &v1beta1.StorageMap{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "StorageMap",
+			APIVersion: "forklift.konveyor.io/v1beta1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "storage-map-test",
+			Namespace: localProviderNamespace,
+		},
+		Spec: v1beta1.StorageMapSpec{
+			Map: sdPairs,
+			Provider: provider.Pair{
+				Destination: corev1.ObjectReference{
+					Name:      "host",
+					Namespace: localProviderNamespace,
+				},
+				Source: corev1.ObjectReference{
+					Name:      providerIdentifier.Name,
+					Namespace: providerIdentifier.Namespace,
+				}},
+		},
+	}
+
+	log.Info("Creating Storage Map...")
+	err = cl.Create(context.TODO(), storageMap, &client.CreateOptions{})
+	if err != nil {
+		t.Fatal(err, "Failed to create storagemap")
+	}
+
+	networkMap := &v1beta1.NetworkMap{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "NetworkMap",
+			APIVersion: "forklift.konveyor.io/v1beta1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "network-map-test",
+			Namespace: localProviderNamespace,
+		},
+		Spec: v1beta1.NetworkMapSpec{
+			Map: nicPairs,
+			Provider: provider.Pair{
+				Destination: corev1.ObjectReference{
+					Name:      "host",
+					Namespace: localProviderNamespace,
+				},
+				Source: corev1.ObjectReference{
+					Name:      providerIdentifier.Name,
+					Namespace: providerIdentifier.Namespace,
+				}},
+		},
+	}
+
+	log.Info("Creating Network Map...")
+	err = cl.Create(context.TODO(), networkMap, &client.CreateOptions{})
+	if err != nil {
+		t.Fatal(err, "Failed to create networkmap")
+	}
+
+	plan := &v1beta1.Plan{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Plan",
+			APIVersion: "forklift.konveyor.io/v1beta1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "plan-test",
+			Namespace: localProviderNamespace,
+		},
+		Spec: v1beta1.PlanSpec{
+			Provider: provider.Pair{
+				Destination: corev1.ObjectReference{
+					Name:      "host",
+					Namespace: localProviderNamespace,
+				},
+				Source: corev1.ObjectReference{
+					Name:      providerIdentifier.Name,
+					Namespace: providerIdentifier.Namespace,
+				},
+			},
+			Archived:        false,
+			Warm:            false,
+			TargetNamespace: providerIdentifier.Namespace,
+			Map: plan.Map{
+				Storage: corev1.ObjectReference{
+					Name:      "storage-map-test",
+					Namespace: localProviderNamespace,
+				},
+				Network: corev1.ObjectReference{
+					Name:      "network-map-test",
+					Namespace: localProviderNamespace,
+				},
+			},
+			VMs: []plan.VM{
+				{
+					Ref: ref.Ref{
+						//ID: vm.MustId(),
+						ID: vmId,
+					},
+				},
+			},
+		},
+	}
+
+	log.Info("Creating Plan...")
+	err = cl.Create(context.TODO(), plan, &client.CreateOptions{})
+	if err != nil {
+		t.Fatal(err, "Failed to create plan")
+	}
+
+	done = make(chan struct{})
+
+	returnedPlan := &v1beta1.Plan{}
+	planIdentifier := types.NamespacedName{Namespace: plan.Namespace, Name: plan.Name}
+	// Wait for plan to be ready
+	statusCheck = func() {
+		err = cl.Get(context.TODO(), planIdentifier, returnedPlan)
+		if err != nil {
+			t.Fatal(err, "Failed to get plan")
+		}
+
+		if returnedPlan.Status.Conditions.IsReady() {
+			log.Info("Plan is ready")
+			close(done)
+		}
+	}
+
+	go wait.Until(statusCheck, time.Second, done)
+
+	select {
+	case <-timeout:
+		t.Errorf("Plan is not ready in time, last status: %v", returnedPlan.Status)
+	case <-done:
+	}
+
+	migration := &v1beta1.Migration{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Migration",
+			APIVersion: "forklift.konveyor.io/v1beta1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "migration-test",
+			Namespace: localProviderNamespace,
+		},
+		Spec: v1beta1.MigrationSpec{
+			Plan: corev1.ObjectReference{
+				Name:      "plan-test",
+				Namespace: localProviderNamespace,
+			},
+		},
+	}
+
+	log.Info("Creating the migration...")
+	done = make(chan struct{})
+
+	err = cl.Create(context.TODO(), migration, &client.CreateOptions{})
+	if err != nil {
+		t.Fatal(err, "Failed to create migration")
+	}
+
+	returnedMigration := &v1beta1.Migration{}
+	migrationIdentifier := types.NamespacedName{Namespace: migration.Namespace, Name: migration.Name}
+	// Wait for migration to be ready
+	statusCheck = func() {
+		err = cl.Get(context.TODO(), migrationIdentifier, returnedMigration)
+		if err != nil {
+			t.Fatal(err, "Failed to get migration")
+		}
+
+		if returnedMigration.Status.Conditions.IsReady() {
+			log.Info("Migration is ready")
+			close(done)
+		}
+	}
+
+	go wait.Until(statusCheck, time.Second, done)
+
+	select {
+	case <-timeout:
+		t.Errorf("Migration is not ready in time, last status: %v", returnedMigration.Status)
+	case <-done:
+	}
+
+	// Wait for migration to end
+	done = make(chan struct{})
+	statusCheck = func() {
+		err = cl.Get(context.TODO(), migrationIdentifier, returnedMigration)
+		if err != nil {
+			t.Fatal(err, "Failed to get migration")
+		}
+
+		if condition := returnedMigration.Status.Conditions.FindCondition("Succeeded"); condition != nil {
+			log.Info("Migration succeeded")
+			close(done)
+		}
+		if condition := returnedMigration.Status.Conditions.FindCondition("Failed"); condition != nil {
+			t.Error("Migration failed")
+			close(done)
+			t.Fatalf("migration failed %v", returnedMigration.Status.VMs[0].Error.Reasons)
+		}
+	}
+
+	go wait.Until(statusCheck, time.Second, done)
+	migrationTimeoutInt, _ := strconv.Atoi(migrationTimeout)
+	timeout = time.After(time.Duration(migrationTimeoutInt) * time.Minute)
+
+	select {
+	case <-timeout:
+		t.Errorf("Migration is not ready done time, last status: %v", returnedMigration.Status)
+	case <-done:
+	}
+}
+
+//
+// Connect to the oVirt API.
+func (r *Client) connect(secret *corev1.Secret, url string) (err error) {
+	r.connection, err = ovirtsdk.NewConnectionBuilder().
+		URL(url).
+		Username(r.user(*secret)).
+		Password(r.password(*secret)).
+		CACert(r.cacert(*secret)).
+		Insecure(ovirt.GetInsecureSkipVerifyFlag(secret)).
+		Build()
+	if err != nil {
+		return err
+	}
+	return
+}
+
+func (r *Client) user(secret corev1.Secret) string {
+	if user, found := secret.Data["user"]; found {
+		return string(user)
+	}
+	return ""
+}
+
+func (r *Client) password(secret corev1.Secret) string {
+	if password, found := secret.Data["password"]; found {
+		return string(password)
+	}
+	return ""
+}
+
+func (r *Client) cacert(secret corev1.Secret) []byte {
+	if cacert, found := secret.Data["cacert"]; found {
+		return cacert
+	}
+	return nil
+}
+
+//
+// Get the VM by ref.
+func (r *Client) getVMs(vmRef ref.Ref) (ovirtVm *ovirtsdk.Vm, vmService *ovirtsdk.VmService, err error) {
+	vmService = r.connection.SystemService().VmsService().VmService(vmRef.ID)
+	vmResponse, err := vmService.Get().Send()
+	if err != nil {
+		return
+	}
+	ovirtVm, ok := vmResponse.Vm()
+	if !ok {
+		err = fmt.Errorf(
+			"VM %s source lookup failed",
+			vmRef.String())
+	}
+	return
+}
+
+//
+// Close the connection to the oVirt API.
+func (r *Client) Close() {
+	if r.connection != nil {
+		_ = r.connection.Close()
+		r.connection = nil
+	}
+}
+
+//
+// oVirt VM Client
+type Client struct {
+	connection *ovirtsdk.Connection
+}


### PR DESCRIPTION
The test will perform a single VM migration from existing ovirt
provider.
An existing k8s cluster with forklift installed, and a storage class
are required.
To use the CI in kind using fakeovirt, the test should be executed as
is. Otherwise the user shold provided enviromental variables:
`OVIRT_CUSTOM_ENV`, set `true` if you wish to use existing ovirt
environment.
`OVIRT_USERNAME`, the username in ovirt such as `admin@internal`.
`OVIRT_PASSWORD`, the password in ovirt.
`OVIRT_URL`, the API endpoint `https://<engine-fqdn>/ovirt-engine/api`.
`OVIRT_CACERT`, the CA certificate, located locally in a file:
`/path/to/cert`.
STORAGE_CLASS, the storage class to map the disks to.
`OVIRT_VM_ID`, the VM ID in ovirt.
`MIGRATION_TIMEOUT`, set the number of minutes to the migration completion
- by default it will be 3 minutes.