### PR TITLE
Migrate forklift-operator to forklift with bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,15 @@
+# Operator
+## Default operator config
+build --action_env=VERSION=99.0.0
+build --action_env=NAMESPACE=konveyor-forklift
+build --action_env=CHANNELS=development
+build --action_env=DEFAULT_CHANNEL=development
+
+## Images which should be installed
+build --action_env=CONTROLLER_IMAGE=quay.io/konveyor/forklift-controller:latest
+build --action_env=MUST_GATHER_IMAGE=quay.io/konveyor/forklift-must-gather:latest
+build --action_env=MUST_GATHER_API_IMAGE=quay.io/konveyor/forklift-must-gather-api:latest
+build --action_env=UI_IMAGE=quay.io/konveyor/forklift-ui:latest
+build --action_env=VALIDATION_IMAGE=quay.io/konveyor/forklift-validation:latest
+build --action_env=VIRT_V2V_IMAGE=quay.io/konveyor/forklift-virt-v2v:latest
+build --action_env=OPERATOR_IMAGE=quay.io/konveyor/forklift-operator:latest

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -53,8 +53,34 @@ container_push(
     name = "push-forklift-controller",
     format = "Docker",
     image = "//cmd/manager:forklift-controller-image",
-    registry = "image-registry.openshift-image-registry.svc:5000",
-    #registry = "default-route-openshift-image-registry.apps-crc.testing:5000",
-    repository = "openshift/forklift-controller",
-    tag = "devel",
+    registry = "$${REGISTRY:-quay.io}",
+    repository = "$${REGISTRY_ACCOUNT:-}$${REGISTRY_ACCOUNT:+/}forklift-controller",
+    tag = "$${REGISTRY_TAG:-devel}",
+)
+
+container_push(
+    name = "push-forklift-operator-index",
+    format = "Docker",
+    image = "//operator:forklift-operator-index-image",
+    registry = "$${REGISTRY:-quay.io}",
+    repository = "$${REGISTRY_ACCOUNT:-}$${REGISTRY_ACCOUNT:+/}forklift-operator-index",
+    tag = "$${REGISTRY_TAG:-devel}",
+)
+
+container_push(
+    name = "push-forklift-operator-bundle",
+    format = "Docker",
+    image = "//operator:forklift-operator-bundle-image",
+    registry = "$${REGISTRY:-quay.io}",
+    repository = "$${REGISTRY_ACCOUNT:-}$${REGISTRY_ACCOUNT:+/}forklift-operator-bundle",
+    tag = "$${REGISTRY_TAG:-devel}",
+)
+
+container_push(
+    name = "push-forklift-operator",
+    format = "Docker",
+    image = "//operator:forklift-operator-image",
+    registry = "$${REGISTRY:-quay.io}",
+    repository = "$${REGISTRY_ACCOUNT:-}$${REGISTRY_ACCOUNT:+/}forklift-operator",
+    tag = "$${REGISTRY_TAG:-devel}",
 )

--- a/README.md
+++ b/README.md
@@ -1,17 +1,75 @@
 ![CI](https://github.com/konveyor/forklift-controller/workflows/CI/badge.svg)&nbsp;[![Code Coverage](https://codecov.io/gh/konveyor/forklift-controller/branch/master/graph/badge.svg)](https://codecov.io/gh/konveyor/forklift-controller)
 
 # forklift-controller
+
 Konveyor Forklift controller.
 
 ---
-**Logging**
+
+## Build
+
+For the build, the forklift uses [Bazel](https://bazel.build/).
+
+### Configuration
+
+The environment which you can set across all projects.
+
+| Name             | Default value | Description                                                            |
+|------------------|---------------|------------------------------------------------------------------------|
+| REGISTRY_TAG     | devel         | The tag with which the image will be built and pushed to the registry. |
+| REGISTRY_ACCOUNT |               | The user account name to which the built image should be pushed.       |
+| REGISTRY         | quay.io       | The registry address to which the images should be pushed.             |
+
+## Operator
+
+### Variables
+
+The environment variables that you can set in .bazelrc, these variables are used during Bazel build process and used inside the bazel sandbox.
+Another option to override the default values can use `--action_env` as in the example.
+
+| Name                  | Default value                                    | Description                                                 |
+|-----------------------|--------------------------------------------------|-------------------------------------------------------------|
+| VERSION               | 99.0.0                                           | The version with which the forklift should be built.        |
+| NAMESPACE             | konveyor-forklift                                | The namespace in which the operator should be installed.    |
+| CHANNELS              | development                                      | The olm channels.                                           |
+| DEFAULT_CHANNEL       | development                                      | The default olm channel.                                    |
+| OPERATOR_IMAGE        | quay.io/konveyor/forklift-operator:latest        | The forklift operator image with the ansible-operator role. |
+| CONTROLLER_IMAGE      | quay.io/konveyor/forklift-controller:latest      | The forklift controller image.                              |
+| MUST_GATHER_IMAGE     | quay.io/konveyor/forklift-must-gather:latest     | The forklift must gather an image.                          |
+| MUST_GATHER_API_IMAGE | quay.io/konveyor/forklift-must-gather-api:latest | The forklift must gather image api.                         |
+| UI_IMAGE              | quay.io/konveyor/forklift-ui:latest              | The forklift UI image.                                      |
+| VALIDATION_IMAGE      | quay.io/konveyor/forklift-validation:latest      | The forklift validation image.                              |
+| VIRT_V2V_IMAGE        | quay.io/konveyor/forklift-virt-v2v:latest        | The forklift virt v2v image.                                |
+
+### Runing operator build
+
+```bash
+export REGISTRY_ACCOUNT=username
+export REGISTRY=quay.io
+export REGISTRY_TAG=latest
+
+CONTROLLER_IMAGE=quay.io/${REGISTRY_ACCOUNT}/forklift-controller:${REGISTRY_TAG}
+OPERATOR_IMAGE=quay.io/${REGISTRY_ACCOUNT}/forklift-controller:${REGISTRY_TAG}
+
+bazel run push-forklift-operator
+bazel run push-forklift-operator-bundle --action_env OPERATOR_IMAGE=${OPERATOR_IMAGE} --action_env CONTROLLER_IMAGE=${CONTROLLER_IMAGE}
+# The build of the catalog requires already pushed bundle
+# For http registry add --action_env OPM_OPTS="--use-http"
+bazel run push-forklift-operator-index --action_env REGISTRY=${REGISTRY} --action_env REGISTRY_ACCOUNT=${REGISTRY_ACCOUNT} --action_env REGISTRY_TAG=${REGISTRY_TAG}
+```
+
+---
+
+## Logging
 
 Logging can be configured using environment variables:
-- LOG_DEVELOPMENT: Development mode with human readable logs 
+
+- LOG_DEVELOPMENT: Development mode with human readable logs
   and (default) verbosity=4.
 - LOG_LEVEL: Set the verbosity.
 
 Verbosity:
+
 - Info(0) used for `Info` logging.
   - Reconcile begin,end,error.
   - Condition added,update,deleted.
@@ -39,9 +97,11 @@ Verbosity:
   - Policy agent HTTP request.
 
 ---
-**Profiler**
+
+## Profiler
 
 The profiler can be enabled using the following environment variables:
+
 - PROFILE_KIND: Kind of profile (memory|cpu|mutex).
 - PROFILE_PATH: Profiler output directory.
 - PROFILE_DURATION: The duration (minutes) the profiler

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3397,12 +3397,51 @@ container_pull(
     #tag = "stream8",
 )
 
+container_pull(
+    name = "ansible-operator-image",
+    digest = "sha256:0b92d03397ad85270eaaf8c4e3250944642ca7dbe659dd844914ca3da2ecaf7b",
+    registry = "quay.io",
+    repository = "operator-framework/ansible-operator",
+)
+
+container_pull(
+    name = "opm-image",
+    digest = "sha256:601c62a5e3fea961665aad2ed2834f3f165a020051d355eb24af2125da8e158e",
+    registry = "quay.io",
+    repository = "operator-framework/opm",
+)
+
 http_file(
     name = "opa",
     downloaded_file_path = "opa",
     executable = True,
     sha256 = "914453ebcc76781371ca27dd61086967ed5e0032e42ba85826ee77c9bca84659",
     urls = ["https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static"],
+)
+
+http_file(
+    name = "kustomize",
+    sha256 = "4a3372d7bfdffe2eaf729e77f88bc94ce37dc84de55616bfe90aac089bf6fd02",
+    downloaded_file_path = "kustomize.tar.gz",
+    urls = [
+        "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.7/kustomize_v3.8.7_linux_amd64.tar.gz",
+    ],
+)
+
+http_file(
+    name = "operator-sdk",
+    downloaded_file_path = "operator-sdk",
+    executable = True,
+    sha256 = "2fc68a50b94b7c477e804729365baa5de6d5afcfea9b7fcac9f93dd649c29e90",
+    urls = ["https://github.com/operator-framework/operator-sdk/releases/download/v1.22.0/operator-sdk_linux_amd64"],
+)
+
+http_file(
+    name = "opm",
+    downloaded_file_path = "opm",
+    executable = True,
+    sha256 = "dc0d4d287fef23f165c837b2e6cb68e2506ff295dc57110b9bfe3b553359eb36",
+    urls = ["https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/linux-amd64-opm"],
 )
 
 http_archive(

--- a/operator/BUILD.bazel
+++ b/operator/BUILD.bazel
@@ -1,0 +1,169 @@
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+    "container_push",
+)
+
+genrule(
+    name = 'kustomize_bin',
+    srcs = ['@kustomize//file'],
+    outs = ['kustomize'],
+    cmd = 'tar -C $(@D) -xf $(location @kustomize//file)',
+)
+
+# OPERATOR
+# 1. Build the oprator image with ansible dependencies and with roles.
+
+container_image(
+    name = "forklift-operator-requirements",
+    base = "@ansible-operator-image//image",
+    directory = "/opt/ansible/",
+    cmd = "ansible-galaxy collection install -r /opt/ansible/requirements.yml && chmod -R ug+rwx /opt/ansible/.ansible",
+    files = ['requirements.yml'],
+)
+
+container_image(
+    name = "forklift-operator-watches",
+    base = ":forklift-operator-requirements",
+    directory = "/opt/ansible/",
+    files = ['watches.yaml'],
+)
+
+container_image(
+    name = "forklift-operator-roles",
+    base = ":forklift-operator-watches",
+    directory = "/opt/ansible/",
+    files = ['roles'],
+)
+
+container_image(
+    name = "forklift-operator-image",
+    base = ":forklift-operator-roles",
+    user = "1001",
+    visibility = ["//visibility:public"],
+)
+
+# BUNDLE
+# 1. Change to the operator dir
+# 2. Get the current date with which the operator will be built
+# 3. Build the config files with kustomize
+# 4. Substitute env variables in the generated config
+# 5. Generate the bundle from the config
+# 6. Build the image with the bundle
+
+genrule(
+    name = 'bundle',
+    srcs = [':kustomize_bin', '@operator-sdk//file'] + glob(['**/*']),
+    outs = [
+        # Can be replaced with just dir 'bundle'
+        'bundle/manifests/forklift.konveyor.io_forkliftcontrollers.yaml',
+        'bundle/manifests/forklift.konveyor.io_hooks.yaml',
+        'bundle/manifests/forklift.konveyor.io_hosts.yaml',
+        'bundle/manifests/forklift.konveyor.io_migrations.yaml',
+        'bundle/manifests/forklift.konveyor.io_networkmaps.yaml',
+        'bundle/manifests/forklift.konveyor.io_plans.yaml',
+        'bundle/manifests/forklift.konveyor.io_providers.yaml',
+        'bundle/manifests/forklift.konveyor.io_storagemaps.yaml',
+        'bundle/manifests/forklift-operator.clusterserviceversion.yaml',
+        'bundle/metadata/annotations.yaml',
+        'bundle/tests/scorecard/config.yaml',
+    ],
+    # The `operator-sdk` needs to work in the operator dir
+
+    # The bazel is running the build in sandbox and linkes all the sources to it.
+    # The kustomize has restrictions for symlinks outside of the project scope, for this we use the ignore of LoadRestrictionsNone.
+    cmd = '''
+        cd operator;
+        export DATE=$$(date +%Y-%m-%dT%H:%M:%SZ);
+        ../$(location :kustomize_bin) build config/manifests --load_restrictor LoadRestrictionsNone | envsubst | ../$(location @operator-sdk//file) generate bundle -q --overwrite --extra-service-accounts forklift-controller --version $${VERSION} --output-dir ../$(RULEDIR)/bundle --channels=$${CHANNELS} --default-channel=$${DEFAULT_CHANNEL}
+    ''',
+)
+
+container_image(
+    name = "forklift-operator-bundle-manifests",
+    base = "@ubi8-minimal//image",
+    directory = "/manifests/",
+    files = [
+        ':bundle/manifests/forklift.konveyor.io_forkliftcontrollers.yaml',
+        ':bundle/manifests/forklift.konveyor.io_hooks.yaml',
+        ':bundle/manifests/forklift.konveyor.io_hosts.yaml',
+        ':bundle/manifests/forklift.konveyor.io_migrations.yaml',
+        ':bundle/manifests/forklift.konveyor.io_networkmaps.yaml',
+        ':bundle/manifests/forklift.konveyor.io_plans.yaml',
+        ':bundle/manifests/forklift.konveyor.io_providers.yaml',
+        ':bundle/manifests/forklift.konveyor.io_storagemaps.yaml',
+        ':bundle/manifests/forklift-operator.clusterserviceversion.yaml',
+    ],
+)
+
+container_image(
+    name = "forklift-operator-bundle-metadata",
+    base = ":forklift-operator-bundle-manifests",
+    directory = "/metadata/",
+    files = ["bundle/metadata/annotations.yaml"],
+)
+
+container_image(
+    name = "forklift-operator-bundle-tests",
+    base = ":forklift-operator-bundle-metadata",
+    directory = "/tests/scorecard/",
+    files = [":bundle/tests/scorecard/config.yaml"],
+)
+
+container_image(
+    name = "forklift-operator-bundle-image",
+    base = ":forklift-operator-bundle-tests",
+    labels = {
+        # Core bundle labels.
+        "operators.operatorframework.io.bundle.mediatype.v1": "registry+v1",
+        "operators.operatorframework.io.bundle.manifests.v1": "manifests/",
+        "operators.operatorframework.io.bundle.metadata.v1": "metadata/",
+        "operators.operatorframework.io.bundle.package.v1": "forklift-operator",
+        # The channels need to be changed during release
+        "operators.operatorframework.io.bundle.channels.v1": "development",
+        "operators.operatorframework.io.bundle.channel.default.v1": "development",
+        "operators.operatorframework.io.metrics.builder": "operator-sdk-v1.22.0",
+        "operators.operatorframework.io.metrics.mediatype.v1": "metrics+v1",
+        "operators.operatorframework.io.metrics.project_layout": "ansible.sdk.operatorframework.io/v1",
+        # Labels for testing.
+        "operators.operatorframework.io.test.mediatype.v1": "scorecard+v1",
+        "operators.operatorframework.io.test.config.v1": "tests/scorecard/",
+    },
+    user = "1001",
+    visibility = ["//visibility:public"],
+)
+
+# INDEX
+# 1. Substitute env variables in catalog/operator.yml
+# 2. Append the bundle render to the catalog/operator.yml
+# 3. Build the opm image which serves generated catalog
+
+genrule(
+    name = 'opm_render',
+    srcs = ['@opm//file', 'catalog/operator.yml'],
+    outs = ['operator.yaml'],
+    cmd = '''
+        cat $(location catalog/operator.yml) | envsubst > $@
+	    $(location @opm//file) render $${REGISTRY:-quay.io}/$${REGISTRY_ACCOUNT:-}$${REGISTRY_ACCOUNT:+/}forklift-operator-bundle:$${REGISTRY_TAG:-devel} -o yaml $${OPM_OPTS:-} >> $@
+    ''',
+)
+
+container_image(
+    name = "forklift-operator-index-database",
+    base = "@opm-image//image",
+    directory = "/configs",
+    files = [':operator.yaml'],
+)
+
+container_image(
+    name = "forklift-operator-index-image",
+    base = ":forklift-operator-index-database",
+    labels = {
+        "operators.operatorframework.io.index.configs.v1": "/configs",
+    },
+    entrypoint = ["/bin/opm"],
+    cmd = ["serve", "/configs"],
+    user = "1001",
+    visibility = ["//visibility:public"],
+)
+

--- a/operator/PROJECT
+++ b/operator/PROJECT
@@ -1,0 +1,16 @@
+domain: konveyor.io
+layout:
+- ansible.sdk.operatorframework.io/v1
+plugins:
+  manifests.sdk.operatorframework.io/v2: {}
+  scorecard.sdk.operatorframework.io/v2: {}
+projectName: forklift-operator
+resources:
+- api:
+    crdVersion: v1
+    namespaced: true
+  domain: konveyor.io
+  group: forklift
+  kind: ForkliftController
+  version: v1beta1
+version: "3"

--- a/operator/README.md
+++ b/operator/README.md
@@ -1,0 +1,91 @@
+# Forklift Operator
+
+[![Operator Repository on Quay](https://quay.io/repository/konveyor/forklift-operator/status "Operator Repository on Quay")](https://quay.io/repository/konveyor/forklift-operator) [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/konveyor/forklift-operator/pulls)
+
+Forklift Operator installs a suite of migration tools that facilitate the migration of VM workloads to [OpenShift Virtualization](https://cloud.redhat.com/learn/topics/virtualization/) or [KubeVirt](https://kubevirt.io/).
+
+## Prerequisites
+
+* [__OpenShift 4.9+__](https://www.openshift.com/) or [__k8s v1.22+__](https://kubernetes.io/)
+* [__OpenShift Virtualization 4.9+__](https://www.redhat.com/en/technologies/cloud-computing/openshift/) or [__KubeVirt__](https://kubevirt.io/)
+* [__Operator Lifecycle Manager (OLM) support__](https://olm.operatorframework.io/)
+
+## Compatibility
+
+OpenShift Virtualization/KubeVirt is required and must be installed prior attempting to deploy Forklift, see the table below for supported configurations:
+
+Forklift release | OpenShift Virtualization/KubeVirt | VMware | oVirt
+--- | --- | --- | --- 
+v2.2 | v4.9 | 6.5+ | 4.4.9+
+v2.3 | v4.10+ | 6.5+ | 4.4.9+
+
+**Note:** Please keep in mind Forklift will not deploy in unsupported configurations.
+
+## Component Overview
+
+The operator will install all the necessary components which Forklift needs to operate. The projects and a description of each are detailed below:
+
+* [Forklift UI](https://github.com/konveyor/forklift-ui), The Forklift UI is based on [Patternfly 4](https://www.patternfly.org/v4).
+* [Forklift Controller](https://github.com/konveyor/forklift-controller), The Forklift Controller orchestrates the migration.
+* [Forklift Validation](https://github.com/konveyor/forklift-validation), The Forklift Validation service checks the VMs for possible issues before migration. This service is based on [Open Policy Agent](https://www.openpolicyagent.org).
+* [Forklift Must Gather](https://github.com/konveyor/forklift-must-gather), Support tool for gathering information about the Forklift environment.
+
+## Development
+
+See [development.md](docs/development.md) for details in how to contribute to Forklift operator.
+
+## Forklift Operator Installation on OKD/OpenShift
+
+The method used for these instructions relies on OKD/OCP Web Console, it is also possible to automate the deployment in OpenShift using manifests if needed, please check the [k8s deployment manifest](./forklift-k8s.yaml) for details.
+
+### Installing _released versions_
+
+Released (or public betas) of Forklift are installable via community operators which appear in [OCP](https://openshift.com/) and [OKD](https://www.okd.io/) marketplace.
+
+1. Visit the OpenShift Web Console.
+1. Navigate to _Operators => OperatorHub_.
+1. Search for _Forklift Operator_.
+1. Install the desired _Forklift Operator_ version.
+
+### Installing _latest_ (or other unreleased versions)
+
+Installing latest is almost an identical procedure to released versions but requires creating a new catalog source.
+
+1. `oc create -f forklift-operator-catalog.yaml`
+1. Follow the same procedure as released versions until the Search for _Forklift Operator_ step.
+1. There should be two _Forklift Operator_ available for installation now.
+1. Select the _Forklift Operator_ without the _community_ tag.
+1. Proceed to install latest using the _development_ channel in the subscription step.
+
+**Note:** Installing _latest_ may also include OLM channels for other released versions.
+
+### ForkliftController CR Creation
+
+Once you have successfully installed the operator, proceed to deploy components by creating the _ForkliftController_ CR.
+
+1. Visit OpenShift Web Console, navigate to _Operators => Installed Operators_.
+1. Select _Forklift Operator_.
+1. Locate _ForkliftController_ on the top menu and click on it.
+1. Adjust settings if desired and click Create instance.
+
+Once the CR is created, the operator will deploy the controller, UI and configure the rest of required components.
+
+## Installing on Kubernetes (or Minikube)
+
+See [k8s.md](./docs/k8s.md) for details.
+
+## Customize Settings
+
+Custom deployment settings can be applied by editing the `ForkliftController` CR.
+
+`oc edit forkliftcontroller -n konveyor-forklift`
+
+## Removing Forklift Operator
+
+Use the [Forklift cleanup script](./tools/forklift-cleanup.sh), this is the recommended method to delete operator, CRDs and all related objects. It supports OpenShift and Kubernetes environments.
+
+`forklift-cleanup.sh -o`
+
+## Forklift Documentation
+
+See the [Forklift Documentation](https://konveyor.github.io/forklift/) for detailed installation instructions as well as how to use Forklift.

--- a/operator/catalog/operator.yml
+++ b/operator/catalog/operator.yml
@@ -1,0 +1,10 @@
+---
+defaultChannel: ${DEFAULT_CHANNEL}
+name: forklift-operator
+schema: olm.package
+---
+schema: olm.channel
+package: forklift-operator
+name: ${CHANNELS}
+entries:
+  - name: forklift-operator.v${VERSION}

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: forkliftcontrollers.forklift.konveyor.io
+spec:
+  group: forklift.konveyor.io
+  names:
+    kind: ForkliftController
+    listKind: ForkliftControllerList
+    plural: forkliftcontrollers
+    singular: forkliftcontroller
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ForkliftController is the Schema for the forkliftcontrollers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ForkliftController
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of ForkliftController
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/forklift.konveyor.io_hooks.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_hooks.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: hooks.forklift.konveyor.io
+spec:
+  group: forklift.konveyor.io
+  names:
+    kind: Hook
+    listKind: HookList
+    plural: hooks
+    singular: hook
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.image
+      name: Image
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Hook is the Schema for the hooks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Hook specification.
+            properties:
+              deadline:
+                description: Hook deadline in seconds.
+                format: int64
+                type: integer
+              image:
+                description: Image to run.
+                type: string
+              playbook:
+                description: A base64 encoded Ansible playbook.
+                type: string
+              serviceAccount:
+                description: Service account.
+                type: string
+            required:
+            - image
+            type: object
+          status:
+            description: Hook status.
+            properties:
+              conditions:
+                description: List of conditions.
+                items:
+                  description: Condition
+                  properties:
+                    category:
+                      description: The condition category.
+                      type: string
+                    durable:
+                      description: The condition is durable - never un-staged.
+                      type: boolean
+                    items:
+                      description: A list of items referenced in the `Message`.
+                      items:
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: When the last status transition occurred.
+                      format: date-time
+                      type: string
+                    message:
+                      description: The human readable description of the condition.
+                      type: string
+                    reason:
+                      description: The reason for the condition or transition.
+                      type: string
+                    status:
+                      description: The condition status [true,false].
+                      type: string
+                    type:
+                      description: The condition type.
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The most recent generation observed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_hosts.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_hosts.yaml
@@ -1,0 +1,170 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: hosts.forklift.konveyor.io
+spec:
+  group: forklift.konveyor.io
+  names:
+    kind: Host
+    listKind: HostList
+    plural: hosts
+    singular: host
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='ConnectionTestSucceeded')].status
+      name: CONNECTED
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostSpec defines the desired state of Host
+            properties:
+              id:
+                description: 'The object ID. vsphere:   The managed object ID.'
+                type: string
+              ipAddress:
+                description: IP address used for disk transfer.
+                type: string
+              name:
+                description: 'An object Name. vsphere:   A qualified name.'
+                type: string
+              provider:
+                description: Provider
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              secret:
+                description: Credentials.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              thumbprint:
+                description: Certificate SHA-1 fingerprint, called thumbprint by VMware.
+                type: string
+              type:
+                description: Type used to qualify the name.
+                type: string
+            required:
+            - ipAddress
+            - provider
+            - secret
+            type: object
+          status:
+            description: HostStatus defines the observed state of Host
+            properties:
+              conditions:
+                description: List of conditions.
+                items:
+                  description: Condition
+                  properties:
+                    category:
+                      description: The condition category.
+                      type: string
+                    durable:
+                      description: The condition is durable - never un-staged.
+                      type: boolean
+                    items:
+                      description: A list of items referenced in the `Message`.
+                      items:
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: When the last status transition occurred.
+                      format: date-time
+                      type: string
+                    message:
+                      description: The human readable description of the condition.
+                      type: string
+                    reason:
+                      description: The reason for the condition or transition.
+                      type: string
+                    status:
+                      description: The condition status [true,false].
+                      type: string
+                    type:
+                      description: The condition type.
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The most recent generation observed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -1,0 +1,442 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: migrations.forklift.konveyor.io
+spec:
+  group: forklift.konveyor.io
+  names:
+    kind: Migration
+    listKind: MigrationList
+    plural: migrations
+    singular: migration
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Running')].status
+      name: RUNNING
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Succeeded')].status
+      name: SUCCEEDED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Failed')].status
+      name: FAILED
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MigrationSpec defines the desired state of Migration
+            properties:
+              cancel:
+                description: List of VMs which will have their imports canceled.
+                items:
+                  description: Source reference. Either the ID or Name must be specified.
+                  properties:
+                    id:
+                      description: 'The object ID. vsphere:   The managed object ID.'
+                      type: string
+                    name:
+                      description: 'An object Name. vsphere:   A qualified name.'
+                      type: string
+                    type:
+                      description: Type used to qualify the name.
+                      type: string
+                  type: object
+                type: array
+              cutover:
+                description: Date and time to finalize a warm migration. If present, this will override the value set on the Plan.
+                format: date-time
+                type: string
+              plan:
+                description: Reference to the associated Plan.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+            required:
+            - plan
+            type: object
+          status:
+            description: MigrationStatus defines the observed state of Migration
+            properties:
+              completed:
+                description: Completed timestamp.
+                format: date-time
+                type: string
+              conditions:
+                description: List of conditions.
+                items:
+                  description: Condition
+                  properties:
+                    category:
+                      description: The condition category.
+                      type: string
+                    durable:
+                      description: The condition is durable - never un-staged.
+                      type: boolean
+                    items:
+                      description: A list of items referenced in the `Message`.
+                      items:
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: When the last status transition occurred.
+                      format: date-time
+                      type: string
+                    message:
+                      description: The human readable description of the condition.
+                      type: string
+                    reason:
+                      description: The reason for the condition or transition.
+                      type: string
+                    status:
+                      description: The condition status [true,false].
+                      type: string
+                    type:
+                      description: The condition type.
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The most recent generation observed by the controller.
+                format: int64
+                type: integer
+              started:
+                description: Started timestamp.
+                format: date-time
+                type: string
+              vms:
+                description: VM status
+                items:
+                  description: VM Status
+                  properties:
+                    completed:
+                      description: Completed timestamp.
+                      format: date-time
+                      type: string
+                    conditions:
+                      description: List of conditions.
+                      items:
+                        description: Condition
+                        properties:
+                          category:
+                            description: The condition category.
+                            type: string
+                          durable:
+                            description: The condition is durable - never un-staged.
+                            type: boolean
+                          items:
+                            description: A list of items referenced in the `Message`.
+                            items:
+                              type: string
+                            type: array
+                          lastTransitionTime:
+                            description: When the last status transition occurred.
+                            format: date-time
+                            type: string
+                          message:
+                            description: The human readable description of the condition.
+                            type: string
+                          reason:
+                            description: The reason for the condition or transition.
+                            type: string
+                          status:
+                            description: The condition status [true,false].
+                            type: string
+                          type:
+                            description: The condition type.
+                            type: string
+                        required:
+                        - category
+                        - lastTransitionTime
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    error:
+                      description: Errors
+                      properties:
+                        phase:
+                          type: string
+                        reasons:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - phase
+                      - reasons
+                      type: object
+                    hooks:
+                      description: Enable hooks.
+                      items:
+                        description: Plan hook.
+                        properties:
+                          hook:
+                            description: Hook reference.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          step:
+                            description: Pipeline step.
+                            type: string
+                        required:
+                        - hook
+                        - step
+                        type: object
+                      type: array
+                    id:
+                      description: 'The object ID. vsphere:   The managed object ID.'
+                      type: string
+                    name:
+                      description: 'An object Name. vsphere:   A qualified name.'
+                      type: string
+                    phase:
+                      description: Phase
+                      type: string
+                    pipeline:
+                      description: Migration pipeline.
+                      items:
+                        description: Pipeline step.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations.
+                            type: object
+                          completed:
+                            description: Completed timestamp.
+                            format: date-time
+                            type: string
+                          description:
+                            description: Name
+                            type: string
+                          error:
+                            description: Error.
+                            properties:
+                              phase:
+                                type: string
+                              reasons:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - phase
+                            - reasons
+                            type: object
+                          name:
+                            description: Name.
+                            type: string
+                          phase:
+                            description: Phase
+                            type: string
+                          progress:
+                            description: Progress.
+                            properties:
+                              completed:
+                                description: Completed units.
+                                format: int64
+                                type: integer
+                              total:
+                                description: Total units.
+                                format: int64
+                                type: integer
+                            required:
+                            - completed
+                            - total
+                            type: object
+                          reason:
+                            description: Reason
+                            type: string
+                          started:
+                            description: Started timestamp.
+                            format: date-time
+                            type: string
+                          tasks:
+                            description: Nested tasks.
+                            items:
+                              description: Migration task.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations.
+                                  type: object
+                                completed:
+                                  description: Completed timestamp.
+                                  format: date-time
+                                  type: string
+                                description:
+                                  description: Name
+                                  type: string
+                                error:
+                                  description: Error.
+                                  properties:
+                                    phase:
+                                      type: string
+                                    reasons:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - phase
+                                  - reasons
+                                  type: object
+                                name:
+                                  description: Name.
+                                  type: string
+                                phase:
+                                  description: Phase
+                                  type: string
+                                progress:
+                                  description: Progress.
+                                  properties:
+                                    completed:
+                                      description: Completed units.
+                                      format: int64
+                                      type: integer
+                                    total:
+                                      description: Total units.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - completed
+                                  - total
+                                  type: object
+                                reason:
+                                  description: Reason
+                                  type: string
+                                started:
+                                  description: Started timestamp.
+                                  format: date-time
+                                  type: string
+                              required:
+                              - name
+                              - progress
+                              type: object
+                            type: array
+                        required:
+                        - name
+                        - progress
+                        type: object
+                      type: array
+                    restorePowerState:
+                      description: Source VM power state before migration.
+                      type: string
+                    started:
+                      description: Started timestamp.
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type used to qualify the name.
+                      type: string
+                    warm:
+                      description: Warm migration status
+                      properties:
+                        consecutiveFailures:
+                          type: integer
+                        failures:
+                          type: integer
+                        nextPrecopyAt:
+                          format: date-time
+                          type: string
+                        precopies:
+                          items:
+                            description: Precopy durations
+                            properties:
+                              end:
+                                format: date-time
+                                type: string
+                              snapshot:
+                                type: string
+                              start:
+                                format: date-time
+                                type: string
+                            type: object
+                          type: array
+                        successes:
+                          type: integer
+                      required:
+                      - consecutiveFailures
+                      - failures
+                      - successes
+                      type: object
+                  required:
+                  - phase
+                  - pipeline
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
@@ -1,0 +1,214 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: networkmaps.forklift.konveyor.io
+spec:
+  group: forklift.konveyor.io
+  names:
+    kind: NetworkMap
+    listKind: NetworkMapList
+    plural: networkmaps
+    singular: networkmap
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Network map spec.
+            properties:
+              map:
+                description: Map.
+                items:
+                  description: Mapped network.
+                  properties:
+                    destination:
+                      description: Destination network.
+                      properties:
+                        name:
+                          description: The name.
+                          type: string
+                        namespace:
+                          description: The namespace (multus only).
+                          type: string
+                        type:
+                          description: The network type.
+                          enum:
+                          - pod
+                          - multus
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    source:
+                      description: Source network.
+                      properties:
+                        id:
+                          description: 'The object ID. vsphere:   The managed object ID.'
+                          type: string
+                        name:
+                          description: 'An object Name. vsphere:   A qualified name.'
+                          type: string
+                        type:
+                          description: Type used to qualify the name.
+                          type: string
+                      type: object
+                  required:
+                  - destination
+                  - source
+                  type: object
+                type: array
+              provider:
+                description: Provider
+                properties:
+                  destination:
+                    description: Destination.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  source:
+                    description: Source.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - destination
+                - source
+                type: object
+            required:
+            - map
+            - provider
+            type: object
+          status:
+            description: MapStatus defines the observed state of Maps.
+            properties:
+              conditions:
+                description: List of conditions.
+                items:
+                  description: Condition
+                  properties:
+                    category:
+                      description: The condition category.
+                      type: string
+                    durable:
+                      description: The condition is durable - never un-staged.
+                      type: boolean
+                    items:
+                      description: A list of items referenced in the `Message`.
+                      items:
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: When the last status transition occurred.
+                      format: date-time
+                      type: string
+                    message:
+                      description: The human readable description of the condition.
+                      type: string
+                    reason:
+                      description: The reason for the condition or transition.
+                      type: string
+                    status:
+                      description: The condition status [true,false].
+                      type: string
+                    type:
+                      description: The condition type.
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The most recent generation observed by the controller.
+                format: int64
+                type: integer
+              references:
+                items:
+                  description: Source reference. Either the ID or Name must be specified.
+                  properties:
+                    id:
+                      description: 'The object ID. vsphere:   The managed object ID.'
+                      type: string
+                    name:
+                      description: 'An object Name. vsphere:   A qualified name.'
+                      type: string
+                    type:
+                      description: Type used to qualify the name.
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1,0 +1,788 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: plans.forklift.konveyor.io
+spec:
+  group: forklift.konveyor.io
+  names:
+    kind: Plan
+    listKind: PlanList
+    plural: plans
+    singular: plan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Executing')].status
+      name: EXECUTING
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Succeeded')].status
+      name: SUCCEEDED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Failed')].status
+      name: FAILED
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PlanSpec defines the desired state of Plan.
+            properties:
+              archived:
+                description: Whether this plan should be archived.
+                type: boolean
+              description:
+                description: Description
+                type: string
+              map:
+                description: Resource mapping.
+                properties:
+                  network:
+                    description: Network.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  storage:
+                    description: Storage.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - network
+                - storage
+                type: object
+              provider:
+                description: Providers.
+                properties:
+                  destination:
+                    description: Destination.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  source:
+                    description: Source.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - destination
+                - source
+                type: object
+              targetNamespace:
+                description: Target namespace.
+                type: string
+              transferNetwork:
+                description: The network attachment definition that should be used for disk transfer.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              vms:
+                description: List of VMs.
+                items:
+                  description: A VM listed on the plan.
+                  properties:
+                    hooks:
+                      description: Enable hooks.
+                      items:
+                        description: Plan hook.
+                        properties:
+                          hook:
+                            description: Hook reference.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          step:
+                            description: Pipeline step.
+                            type: string
+                        required:
+                        - hook
+                        - step
+                        type: object
+                      type: array
+                    id:
+                      description: 'The object ID. vsphere:   The managed object ID.'
+                      type: string
+                    name:
+                      description: 'An object Name. vsphere:   A qualified name.'
+                      type: string
+                    type:
+                      description: Type used to qualify the name.
+                      type: string
+                  type: object
+                type: array
+              warm:
+                description: Whether this is a warm migration.
+                type: boolean
+            required:
+            - map
+            - provider
+            - targetNamespace
+            - vms
+            type: object
+          status:
+            description: PlanStatus defines the observed state of Plan.
+            properties:
+              conditions:
+                description: List of conditions.
+                items:
+                  description: Condition
+                  properties:
+                    category:
+                      description: The condition category.
+                      type: string
+                    durable:
+                      description: The condition is durable - never un-staged.
+                      type: boolean
+                    items:
+                      description: A list of items referenced in the `Message`.
+                      items:
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: When the last status transition occurred.
+                      format: date-time
+                      type: string
+                    message:
+                      description: The human readable description of the condition.
+                      type: string
+                    reason:
+                      description: The reason for the condition or transition.
+                      type: string
+                    status:
+                      description: The condition status [true,false].
+                      type: string
+                    type:
+                      description: The condition type.
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              migration:
+                description: Migration
+                properties:
+                  completed:
+                    description: Completed timestamp.
+                    format: date-time
+                    type: string
+                  history:
+                    description: History
+                    items:
+                      description: Snapshot
+                      properties:
+                        conditions:
+                          description: List of conditions.
+                          items:
+                            description: Condition
+                            properties:
+                              category:
+                                description: The condition category.
+                                type: string
+                              durable:
+                                description: The condition is durable - never un-staged.
+                                type: boolean
+                              items:
+                                description: A list of items referenced in the `Message`.
+                                items:
+                                  type: string
+                                type: array
+                              lastTransitionTime:
+                                description: When the last status transition occurred.
+                                format: date-time
+                                type: string
+                              message:
+                                description: The human readable description of the condition.
+                                type: string
+                              reason:
+                                description: The reason for the condition or transition.
+                                type: string
+                              status:
+                                description: The condition status [true,false].
+                                type: string
+                              type:
+                                description: The condition type.
+                                type: string
+                            required:
+                            - category
+                            - lastTransitionTime
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        map:
+                          description: Map.
+                          properties:
+                            network:
+                              description: Snapshot object reference.
+                              properties:
+                                generation:
+                                  format: int64
+                                  type: integer
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                uid:
+                                  description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                                  type: string
+                              required:
+                              - generation
+                              - name
+                              - namespace
+                              - uid
+                              type: object
+                            storage:
+                              description: Snapshot object reference.
+                              properties:
+                                generation:
+                                  format: int64
+                                  type: integer
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                uid:
+                                  description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                                  type: string
+                              required:
+                              - generation
+                              - name
+                              - namespace
+                              - uid
+                              type: object
+                          required:
+                          - network
+                          - storage
+                          type: object
+                        migration:
+                          description: Migration
+                          properties:
+                            generation:
+                              format: int64
+                              type: integer
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            uid:
+                              description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                              type: string
+                          required:
+                          - generation
+                          - name
+                          - namespace
+                          - uid
+                          type: object
+                        plan:
+                          description: Plan
+                          properties:
+                            generation:
+                              format: int64
+                              type: integer
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            uid:
+                              description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                              type: string
+                          required:
+                          - generation
+                          - name
+                          - namespace
+                          - uid
+                          type: object
+                        provider:
+                          description: Provider
+                          properties:
+                            destination:
+                              description: Snapshot object reference.
+                              properties:
+                                generation:
+                                  format: int64
+                                  type: integer
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                uid:
+                                  description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                                  type: string
+                              required:
+                              - generation
+                              - name
+                              - namespace
+                              - uid
+                              type: object
+                            source:
+                              description: Snapshot object reference.
+                              properties:
+                                generation:
+                                  format: int64
+                                  type: integer
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                uid:
+                                  description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                                  type: string
+                              required:
+                              - generation
+                              - name
+                              - namespace
+                              - uid
+                              type: object
+                          required:
+                          - destination
+                          - source
+                          type: object
+                      required:
+                      - map
+                      - migration
+                      - plan
+                      - provider
+                      type: object
+                    type: array
+                  started:
+                    description: Started timestamp.
+                    format: date-time
+                    type: string
+                  vms:
+                    description: VM status
+                    items:
+                      description: VM Status
+                      properties:
+                        completed:
+                          description: Completed timestamp.
+                          format: date-time
+                          type: string
+                        conditions:
+                          description: List of conditions.
+                          items:
+                            description: Condition
+                            properties:
+                              category:
+                                description: The condition category.
+                                type: string
+                              durable:
+                                description: The condition is durable - never un-staged.
+                                type: boolean
+                              items:
+                                description: A list of items referenced in the `Message`.
+                                items:
+                                  type: string
+                                type: array
+                              lastTransitionTime:
+                                description: When the last status transition occurred.
+                                format: date-time
+                                type: string
+                              message:
+                                description: The human readable description of the condition.
+                                type: string
+                              reason:
+                                description: The reason for the condition or transition.
+                                type: string
+                              status:
+                                description: The condition status [true,false].
+                                type: string
+                              type:
+                                description: The condition type.
+                                type: string
+                            required:
+                            - category
+                            - lastTransitionTime
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        error:
+                          description: Errors
+                          properties:
+                            phase:
+                              type: string
+                            reasons:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - phase
+                          - reasons
+                          type: object
+                        hooks:
+                          description: Enable hooks.
+                          items:
+                            description: Plan hook.
+                            properties:
+                              hook:
+                                description: Hook reference.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                              step:
+                                description: Pipeline step.
+                                type: string
+                            required:
+                            - hook
+                            - step
+                            type: object
+                          type: array
+                        id:
+                          description: 'The object ID. vsphere:   The managed object ID.'
+                          type: string
+                        name:
+                          description: 'An object Name. vsphere:   A qualified name.'
+                          type: string
+                        phase:
+                          description: Phase
+                          type: string
+                        pipeline:
+                          description: Migration pipeline.
+                          items:
+                            description: Pipeline step.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations.
+                                type: object
+                              completed:
+                                description: Completed timestamp.
+                                format: date-time
+                                type: string
+                              description:
+                                description: Name
+                                type: string
+                              error:
+                                description: Error.
+                                properties:
+                                  phase:
+                                    type: string
+                                  reasons:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - phase
+                                - reasons
+                                type: object
+                              name:
+                                description: Name.
+                                type: string
+                              phase:
+                                description: Phase
+                                type: string
+                              progress:
+                                description: Progress.
+                                properties:
+                                  completed:
+                                    description: Completed units.
+                                    format: int64
+                                    type: integer
+                                  total:
+                                    description: Total units.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - completed
+                                - total
+                                type: object
+                              reason:
+                                description: Reason
+                                type: string
+                              started:
+                                description: Started timestamp.
+                                format: date-time
+                                type: string
+                              tasks:
+                                description: Nested tasks.
+                                items:
+                                  description: Migration task.
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations.
+                                      type: object
+                                    completed:
+                                      description: Completed timestamp.
+                                      format: date-time
+                                      type: string
+                                    description:
+                                      description: Name
+                                      type: string
+                                    error:
+                                      description: Error.
+                                      properties:
+                                        phase:
+                                          type: string
+                                        reasons:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - phase
+                                      - reasons
+                                      type: object
+                                    name:
+                                      description: Name.
+                                      type: string
+                                    phase:
+                                      description: Phase
+                                      type: string
+                                    progress:
+                                      description: Progress.
+                                      properties:
+                                        completed:
+                                          description: Completed units.
+                                          format: int64
+                                          type: integer
+                                        total:
+                                          description: Total units.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - completed
+                                      - total
+                                      type: object
+                                    reason:
+                                      description: Reason
+                                      type: string
+                                    started:
+                                      description: Started timestamp.
+                                      format: date-time
+                                      type: string
+                                  required:
+                                  - name
+                                  - progress
+                                  type: object
+                                type: array
+                            required:
+                            - name
+                            - progress
+                            type: object
+                          type: array
+                        restorePowerState:
+                          description: Source VM power state before migration.
+                          type: string
+                        started:
+                          description: Started timestamp.
+                          format: date-time
+                          type: string
+                        type:
+                          description: Type used to qualify the name.
+                          type: string
+                        warm:
+                          description: Warm migration status
+                          properties:
+                            consecutiveFailures:
+                              type: integer
+                            failures:
+                              type: integer
+                            nextPrecopyAt:
+                              format: date-time
+                              type: string
+                            precopies:
+                              items:
+                                description: Precopy durations
+                                properties:
+                                  end:
+                                    format: date-time
+                                    type: string
+                                  snapshot:
+                                    type: string
+                                  start:
+                                    format: date-time
+                                    type: string
+                                type: object
+                              type: array
+                            successes:
+                              type: integer
+                          required:
+                          - consecutiveFailures
+                          - failures
+                          - successes
+                          type: object
+                      required:
+                      - phase
+                      - pipeline
+                      type: object
+                    type: array
+                type: object
+              observedGeneration:
+                description: The most recent generation observed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: providers.forklift.konveyor.io
+spec:
+  group: forklift.konveyor.io
+  names:
+    kind: Provider
+    listKind: ProviderList
+    plural: providers
+    singular: provider
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: TYPE
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='ConnectionTestSucceeded')].status
+      name: CONNECTED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='InventoryCreated')].status
+      name: INVENTORY
+      type: string
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Defines the desired state of Provider.
+            properties:
+              secret:
+                description: References a secret containing credentials and other confidential information.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              settings:
+                additionalProperties:
+                  type: string
+                description: Provider settings.
+                type: object
+              type:
+                description: Provider type.
+                type: string
+              url:
+                description: The provider URL. Empty may be used for the `host` provider.
+                type: string
+            required:
+            - secret
+            - type
+            type: object
+          status:
+            description: ProviderStatus defines the observed state of Provider
+            properties:
+              conditions:
+                description: List of conditions.
+                items:
+                  description: Condition
+                  properties:
+                    category:
+                      description: The condition category.
+                      type: string
+                    durable:
+                      description: The condition is durable - never un-staged.
+                      type: boolean
+                    items:
+                      description: A list of items referenced in the `Message`.
+                      items:
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: When the last status transition occurred.
+                      format: date-time
+                      type: string
+                    message:
+                      description: The human readable description of the condition.
+                      type: string
+                    reason:
+                      description: The reason for the condition or transition.
+                      type: string
+                    status:
+                      description: The condition status [true,false].
+                      type: string
+                    type:
+                      description: The condition type.
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The most recent generation observed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
@@ -1,0 +1,218 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: storagemaps.forklift.konveyor.io
+spec:
+  group: forklift.konveyor.io
+  names:
+    kind: StorageMap
+    listKind: StorageMapList
+    plural: storagemaps
+    singular: storagemap
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Storage map spec.
+            properties:
+              map:
+                description: Map.
+                items:
+                  description: Mapped storage.
+                  properties:
+                    destination:
+                      description: Destination storage.
+                      properties:
+                        accessMode:
+                          description: Access mode.
+                          enum:
+                          - ReadWriteOnce
+                          - ReadWriteMany
+                          - ReadOnlyMany
+                          type: string
+                        storageClass:
+                          description: A storage class.
+                          type: string
+                        volumeMode:
+                          description: Volume mode.
+                          enum:
+                          - Filesystem
+                          - Block
+                          type: string
+                      required:
+                      - storageClass
+                      type: object
+                    source:
+                      description: Source storage.
+                      properties:
+                        id:
+                          description: 'The object ID. vsphere:   The managed object ID.'
+                          type: string
+                        name:
+                          description: 'An object Name. vsphere:   A qualified name.'
+                          type: string
+                        type:
+                          description: Type used to qualify the name.
+                          type: string
+                      type: object
+                  required:
+                  - destination
+                  - source
+                  type: object
+                type: array
+              provider:
+                description: Provider
+                properties:
+                  destination:
+                    description: Destination.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  source:
+                    description: Source.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - destination
+                - source
+                type: object
+            required:
+            - map
+            - provider
+            type: object
+          status:
+            description: MapStatus defines the observed state of Maps.
+            properties:
+              conditions:
+                description: List of conditions.
+                items:
+                  description: Condition
+                  properties:
+                    category:
+                      description: The condition category.
+                      type: string
+                    durable:
+                      description: The condition is durable - never un-staged.
+                      type: boolean
+                    items:
+                      description: A list of items referenced in the `Message`.
+                      items:
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: When the last status transition occurred.
+                      format: date-time
+                      type: string
+                    message:
+                      description: The human readable description of the condition.
+                      type: string
+                    reason:
+                      description: The reason for the condition or transition.
+                      type: string
+                    status:
+                      description: The condition status [true,false].
+                      type: string
+                    type:
+                      description: The condition type.
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The most recent generation observed by the controller.
+                format: int64
+                type: integer
+              references:
+                items:
+                  description: Source reference. Either the ID or Name must be specified.
+                  properties:
+                    id:
+                      description: 'The object ID. vsphere:   The managed object ID.'
+                      type: string
+                    name:
+                      description: 'An object Name. vsphere:   A qualified name.'
+                      type: string
+                    type:
+                      description: Type used to qualify the name.
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operator/config/crd/kustomization.yaml
+++ b/operator/config/crd/kustomization.yaml
@@ -1,0 +1,13 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/forklift.konveyor.io_forkliftcontrollers.yaml
+- bases/forklift.konveyor.io_hooks.yaml
+- bases/forklift.konveyor.io_hosts.yaml
+- bases/forklift.konveyor.io_migrations.yaml
+- bases/forklift.konveyor.io_networkmaps.yaml
+- bases/forklift.konveyor.io_plans.yaml
+- bases/forklift.konveyor.io_providers.yaml
+- bases/forklift.konveyor.io_storagemaps.yaml
+#+kubebuilder:scaffold:crdkustomizeresource

--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -1,0 +1,30 @@
+# Adds namespace to all resources.
+namespace: forklift-operator-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: ""
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+patchesStrategicMerge:
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your forklift-operator to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
+#- manager_auth_proxy_patch.yaml
+
+# Mount the controller config file for loading manager configurations
+# through a ComponentConfig type
+#- manager_config_patch.yaml

--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -1,0 +1,41 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forklift-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+        # TODO(user): uncomment for common cases that do not require escalating privileges
+        # capabilities:
+        #   drop:
+        #     - "ALL"
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - name: manager
+        args:
+        - "--health-probe-bind-address=:6789"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
+        - "--leader-election-id=forklift-operator"

--- a/operator/config/default/manager_config_patch.yaml
+++ b/operator/config/default/manager_config_patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forklift-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "--config=controller_manager_config.yaml"
+        volumeMounts:
+        - name: manager-config
+          mountPath: /controller_manager_config.yaml
+          subPath: controller_manager_config.yaml
+      volumes:
+      - name: manager-config
+        configMap:
+          name: manager-config

--- a/operator/config/manager/controller_manager_config.yaml
+++ b/operator/config/manager/controller_manager_config.yaml
@@ -1,0 +1,10 @@
+apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+kind: ControllerManagerConfig
+health:
+  healthProbeBindAddress: :6789
+metrics:
+  bindAddress: 127.0.0.1:8080
+
+leaderElection:
+  leaderElect: true
+  resourceName: 811c9dc5.konveyor.io

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- manager.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: quay.io/konveyor/forklift-operator
+  newTag: latest

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: forklift-operator
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forklift-operator
+  namespace: system
+  labels:
+    control-plane: forklift-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: forklift
+      name: forklift-operator
+  template:
+    metadata:
+      labels:
+        app: forklift
+        name: forklift-operator
+    spec:
+      serviceAccountName: forklift-operator
+      containers:
+      - args:
+        - --health-probe-bind-address=:6789
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        - --leader-election-id=forklift-operator
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']
+        - name: ANSIBLE_GATHERING
+          value: explicit
+        - name: CONTROLLER_IMAGE
+          value: ${CONTROLLER_IMAGE}
+        - name: MUST_GATHER_IMAGE
+          value: ${MUST_GATHER_IMAGE}
+        - name: MUST_GATHER_API_IMAGE
+          value: ${MUST_GATHER_API_IMAGE}
+        - name: UI_IMAGE
+          value: ${UI_IMAGE}
+        - name: VALIDATION_IMAGE
+          value: ${VALIDATION_IMAGE}
+        - name: VIRT_V2V_IMAGE
+          value: ${VIRT_V2V_IMAGE}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 6789
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 6789
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        image: ${OPERATOR_IMAGE}
+        imagePullPolicy: Always
+        name: forklift-operator
+        resources: {}

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -1,0 +1,146 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Seamless Upgrades
+    categories: Modernization & Migration
+    certified: "false"
+    containerImage: ${OPERATOR_IMAGE}
+    createdAt: ${DATE}
+    description: Facilitates migration of VM workloads to OpenShift Virtualization
+    olm.skipRange: '>=0.0.0 <${VERSION}'
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "ForkliftController",
+        "metadata": {
+          "name": "forklift-controller",
+          "namespace": "konveyor-forklift"
+        },
+        "spec": {
+          "feature_ui": "true",
+          "feature_validation": "true",
+          "feature_must_gather_api": "true"
+        }
+      }
+    operatorframework.io/suggested-namespace: ${NAMESPACE}
+    repository: https://github.com/konveyor/forklift-operator
+    support: https://github.com/konveyor/forklift-operator/issues
+  name: forklift-operator.v${VERSION}
+  namespace: ${NAMESPACE}
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: VM migration controller
+      displayName: ForkliftController
+      kind: ForkliftController
+      name: forkliftcontrollers.forklift.konveyor.io
+      version: v1beta1
+    - description: VM migration
+      displayName: Migration
+      kind: Migration
+      name: migrations.forklift.konveyor.io
+      version: v1beta1
+    - description: VM migration plan
+      displayName: Plan
+      kind: Plan
+      name: plans.forklift.konveyor.io
+      version: v1beta1
+    - description: VM provider
+      displayName: Provider
+      kind: Provider
+      name: providers.forklift.konveyor.io
+      version: v1beta1
+    - description: VM host
+      displayName: Host
+      kind: Host
+      name: hosts.forklift.konveyor.io
+      version: v1beta1
+    - description: VM network map
+      displayName: NetworkMap
+      kind: NetworkMap
+      name: networkmaps.forklift.konveyor.io
+      version: v1beta1
+    - description: VM storage map
+      displayName: StorageMap
+      kind: StorageMap
+      name: storagemaps.forklift.konveyor.io
+      version: v1beta1
+    - description: Hook schema for the hooks API
+      displayName: Hook
+      kind: Hook
+      name: hooks.forklift.konveyor.io
+      version: v1beta1
+  description: |
+    The Forklift Operator fully manages the deployment and life cycle of Forklift on [OpenShift](https://www.openshift.com/).
+
+
+    Forklift is a project within the [Konveyor community](https://www.konveyor.io/).
+
+
+    ### Install
+
+    OpenShift Virtualization / KubeVirt is required and must be installed prior attempting to deploy Forklift.
+
+    Once you have successfully installed the Operator, proceed to deploy components by creating the required ForkliftController CR.
+
+    By default, the Operator installs the following components on a target cluster:
+
+    * Controller, to coordinate migration processes.
+    * UI, the web console to manage migrations.
+    * Validation, a service to validate migration workflows.
+    * Must-gather-api, a service to generate targeted must-gather archives.
+
+    ### Compatibility
+    Forklift 2.2 is supported in OpenShift 4.9
+
+    Forklift 2.3 is supported in OpenShift 4.10
+
+    ### Documentation
+    Documentation can be found on our [website](https://konveyor.github.io/forklift).
+
+    ### Getting help
+    If you encounter any issues while using Forklift operator, you can create an issue on our [Github repo](https://github.com/konveyor/forklift-operator/issues), for bugs, enhancements or other requests.
+
+    ### Contributing
+    You can contribute by:
+
+    * Raising any issues you find using Forklift Operator
+    * Fixing issues by opening [Pull Requests](https://github.com/konveyor/forklift-operator/pulls)
+    * Improving [documentation](https://github.com/konveyor/forklift-documentation)
+  displayName: Forklift Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAANUAAADVCAIAAABPIiLUAAAABmJLR0QA/wD/AP+gvaeTAAATZElEQVR42u2diZ+N5fvHv/9TG6JQvkVRlsn2I5RlrDNjjMGMsY19NzTImsmeJFtCKolQZClZohCtqFCY33vm4u6e5zznzME5+s45n+f1eXnNuc/znDlnztv93Nd1X8t/Hnp4uCT9W/qP/gSS+JPEnySJP0n8SZL4k8SfJIk/SfxJkviTxJ8kiT9J/EmS+JPEnySJP0n8SZL4k8SfJIk/SfxJkviTxJ8kiT9J/EmS+JPEnyT+JEn8SeJPksSfJP4kSfxJ4k+SxJ8k/iRJ/EniT5LEnyT+JEn8SeJPksSfJP6kBKvRUwVtWgx6+BHxJz0oPdWgsEu7vOH9+y2Y0GPVzK6oXct88SclUU/UK2qfkT+kb/a8cZnGnK9BfbLFn5Ro5uoONeZKi0OY81Va3FP8SQlQvbpD2zTPz+2eUzK818qSbrGx81X/iaHiT7oX1a5d1LLZ4DvMdY2fOV8dXhoo/qR4VavWbeamFvVeca/M+SrolyX+pGqYy3hhEMxNH9YrfuZmj84syuo3d2w1S8C5YzLFnxRVfV/NXTEj3vUctBX2y+rYeuCTd1Z1jRoWVntVgycLxZ8UrmHZWdUCNLmwd6e2AxvUD7Ek2rXIr/byl9vkiT8pXJ3b5MWmZ9n0bo8+Nsy/pE6dImzhgT2zZ43sGY8tPDQ7S/xJ4WpYv5obKIS99MLg2rWH8W9uj5wZd+l/QbimxZ8UVaFbF4kVlIs/KVxDs7KSzV/ntnniTwrXy63zks3fsJws8SeFiy2yZPNHRIz4k6JqzpikLwHxFIo/qUJPN5owpGD1mjX7583/yEYK+iZ9CfhK+zzxJ1VozNj15ZXH+fO/2UiHjIHJ5m9Ebj/xJ1WoZauZ5XeOps2mWRjp3Xr17laLJnZ/+JFh4k+q0IWLl42/ESPfsZFqg0nvX888XSj+pApt3Pil8bdh40EbGdQ7O9n8deswQPxJFRo56h3j78cfr9yOJGiZn2z+igf0FX9ShZq9MN0tAVu0LGHk8ceLVpYkl78lk7vX9IxM8ZcwnTv3m/E3esy7NjJzVM9kT4FNGhWIP6lC76z7wvh7b8thG8nrlZNs/jI75oq/tFbz5jPqPTGmIuygaI3x9/PPv9ttkYoFyeZvzMA+4i/t9NTTEwbmr1z91r6zZ38FuEGDVzHY5Lkpbgn4UuvXLLA02V7Asik12wso/u5Fm987VO4d7LzZ+JkzP9vI+AkbbYRUy2RPgc8/UyD+0kujRq3z+cPysPG31uyzkW3bj9pIbmbSl4C9OuWKv/TS802nllc9Xmw+g/HBQ1bbw8uXrz7y6AhGMl7UElD8JUHfffeLz5/5XBr9d+KtW7dH2rWf/VBlzYP40zHvVvgXcfF0rMkVEcTfPWr16r0+f1u3HrHxEycv2siUqe/ZyLSiBC8BXx+bSbEiShbVrVsU+cZq1R5lk7H4S2Vh//r8uRvu8hV7bOSjj47ZmTndcxLC3LCcfq+2HxCafM6v/r8OcyZO3LRly+ErV65hlYu/VM+zfGr8zZu3fAQ7dJzL+IC8Ffbwjz+uP1ZrJCOtmt3jEnDhhB6jcvvCXLRsNzb9iovXwdylS1cD69GmTaeJvxTXkSPn/K+8pGRrgMtOnedV3BBrDSPnPP6ovhjM4dbGs4hzB/v60qU/y6McvIH+ucvFX4prwYKP/W99956TNv71sR9sZEbJ+zYypbB3tcz16DjguWeHxJjn1q8/cOHCpfLox/ff/4JLnIVBg4bjdf9NfWX2fMP/+q9f/7vO48WMl735qY3s2nXczszq2j/A3OJJPcbm9+nVJRfmQjcwnm082bZYXFhDbObYkpH9m16qXaf42rW/fRp69nqD8eycZfbw6tW/atcZVeEvbDyEjTjCpUbn9eneccCzjQpCmcN9Y8xBVWzmmAuZEdnxU/xfWmv37hM+GYsW7WTwyfpj3RLwlVcX2JkUeQ6N1SN3DuaWLt3NavLWrajMEdaKnQFzNcWwEH8PQqzwfEqOHj1n44ePnLWR0tLtkVcRL8O9e+HCj2MzRxyNMZfx0qxU/QOKv/tShw5zA4Yn8xnjTIQ2snfvKTuzbr3RjrmA48Y/fv31jw8//Hr6jPfx56Vetxnxl2Dh+IUYH6D8/JWM9+lT5owSmPvyy+9v3LgZjTl81zt2fIX3uE3b0nRgTvwlUtwifZiwHuwO+/ffN2PYEH/++RdrR+Y5Fojmpk5Pib/7VfHod32wzp67vff1xRdnAsxhLMPczFnbOneZ/+hjI/WnE38J0AsvTg9whrvYNuL++usG2rf/29lzPujabaH5YiTxl2BZFL47sFhtHEeMmBN/CRbLNQKcsDA6V27v+mHPdmy5k/8mib/7ErF03EzxmzClYcYCFuF9zpLdv/+0nTZo0Cqfv99++9NisSTxdxebabh52YrAJsWGxVBgmyuGo44DELnDhsZi4b3Tn1T8VaPJUzZTNwjnXMCHF//hwpzY+fDHgVhsib9qFCOELs5jxcrP7KXchocdn356QmyJv2rMiFu37hO/chJ+7dV69V4SGoslib9wPfPspPJEHObtY/kIc/54ZuZi4SX+oorN1oTw56pd7dlz0h8nOlp4ib/o0cuZixPCnyt1MHPmVn+cECzhJf6iytUquM/j99+vWQAB+W+BWKwaGhMv/h6EJkzcWJ6gg3gCi8UKGNR5A1eKMPEXrtdf/zBR/BFeYK9JFQR/fNWqvSJM/IUrUEDjfo4DB87Ya7pGNAHvjCT+gsJuSBR/LPUaNBz3UGUt1GAdgmbTBJn4C9Hnn58uT9wxYMCK27FY56rEYlEpUJCJvxCdOvVjAvnjbm4vSy1Uf3zt2s8FmfgLEVFSCeTPlZyiFjRp55bbQRSMArHEX4hIv4gdW3UPh1XdI+CZqEGBJf5iiUoXiYXvk0+OR6YUMfk1bjKlbbvZWCHpnOQm/oKiilkC4Ttx4qIFojq1bVu6fsNBP6yQ5DcsbisQI6U7f917LEoUfFTJ8GuycPMlKDDGzZ1Uc3PWSOnLX37V6rn3c5D84QXxj6LgRrWXfPvtTywABF/68kc1FqbAadO20EmG0lL3DN/Jkz/6FTPwtsR5IblLSkFX/tFtW5jpMNBPIc7DVThFr3ZdEAioPnjwO3bkSJ8rLHyLcuSBa2kZrD+++Psn/23lys/ulj+rOW6iblUg/jRQTKho2Nv+urAGVakXf4nxuVATg+LdkyZtIm8tdAXGHfmu+HNmLwWHrl+/4caJhQ6tZLV8+R7/8tZtXhN/qf8hqTH12WenAjYpD3HaUcAvcHJZ2a444QM4d1WgEGBulPLzLVvN9E8bPnyt+Evlj4cHePEbn8RgiBXb3Lk7/LkKB4rrYRT7oLaQuyo7e6n/VKuMmdHej//fYOqdHkniLzXlepLHPmha5F/Vt9+b8VwFu9Z5GnXtutB/ypV9DgjPn3/a2LHrxV/KfjYy0+JfyWGiuguZDk+f/imeq1ydDfbZ/HEm3dC3xA3XP613nyXiLzU/WP0G4wIRLvv2fdsjczF2LpnhpIvjHPGfvXDxMk+5yxct3hkPfwUF/1Dr37XZbYssAdO48eSLFy+7c2jQ9Xjd0eIvNT9YoEX05s2HAqFQBASwFRYNpiEFcWXHkUQSLaGJvDhKoxph/C4CVH/44VJkpV7xl5ofbIfnjaM9H9NhqEeGOszuNCIG3FPUwqoWPio8L1u22998O33m50gbmQZGgTY1NvlRgEH8pSx/7LG6L5siV9FO853Ghw+f9Q1Vwkh9YoCYks5MWgSWUqaN26t/v3ZhNYAVT75IVtZSwZfK/P300z+7ukuW7Ip2ml+69HTVdLU5c3fQ0pIcXoKp4i8mBJf+Ii/yANCa0pxS/N27jh+/4L7y7XdKZETKb6Dl0ijvU5Sj5L4cec9l2mMmpl65sEt9/jZt+tJ98dxJQxdblK7yu3S8/fb+BL4BXINs99F/iz03zJTCoWsUc5VG/OHPCzhfnK/YOWgOHfreP0drMvGXMLGNFuicS4SV9fKj8tq4cRsCzxLJp4A88ZdIEQQQZ4VTVmZ4pEWD+EuwZs/+IB7+Jk3eLBTEX1JEBHKkKeqbJv7OryT+Eq/nnp+Kny9QnO+XX/7AMmVPVhCIvwchNmHZnyBQj6gTAo9VGUP8SeJPfwVJ/EniT5LEnyT+/sfVoOH4B1PChy1jBQ2kKX8kihPpSYwnjhJC2/mZcBVcJ8eO/WAOvK+/Pm891oh34llX2iy/sodvq4xZ/EuHVRtkz5eHOf2XETr6Wul2J/LWGJ84cZOdRmQeD1/u9Doxf4Qs2PYdhQqGFq2pjHAu5lkTqWvkHAmglOWPumZ898xz1tqUGL6c/ssteRbXsZXW4yG5kiTbWstJSybftes4DykvREiBqzFAbJVVA//gg68CaW+EPfMDIJKrQZAzrwPKFsZMDseFO8Gk7NEFsidxaCuYL8X5GzHyHSYhSCJc6vz5iogVpjTyIxGTEA/pUp6RcbuoACc83WiC44/iQPxAWzZOBiPA4kWMP+psUC4Icb6ljpOgZPmaZW9+aq9ASXErWsqkCOhs4kEb45cvX6Wk0LrKzGJOFkOpzB81BhBfvFUspdJoZJJH335lbk7aveek9aGEP/bW4ObAwe+Iia8g7L1DXGL8ffPNBW6vrnUgLdD5LbSLIR2pcZPJN27cBFbyidwvsmYhhUPfsmmPF7T2NTEi+6VU4M/1ODWGgMk/hx6TDDI/2SrN0s/sHg1/nEAfch6uqCxs1S/rTccfKRrQ5l6NZaUrWsUijx+uXLnmF+Ww2Y6KaYEMy4yMWWIolfljxcacRJRK6zalfN/A1LXbQjsB44OHrNisky92SYuWJXBjcBh/lsbLfMarWXip8QeLmDX+FrAl51ozaSwbfiZY1Z6iq5H96nbtSi1kxsp6QLBK3ae+/UGsMj8cPXqObDTLuiVvnLxJqOIhpqvZH/DHVdk5y/z5j7w1lmsVC7Wy2zfKgP3hDGSrP2nhMNBpli9Vs7ZsOWy2CBE0Zn/wxjiHAqa2jhRDqcnf++8fJjkNDxz3QZoK8TPxzHhMXJt7DAIsDJ4lvIpnXTkByvvxEAeKPZw5axsPXaU9XmHnJ984uUJp7757gNNcx17ShZhZXXQ0pSlZDvJmOIc39lBlwTV+3rrtiKbA9PI/43zG59Knb1myXdC4Y7BzmVAVIyj+JPEnSenDH3tuGBwxxM0xcAn2LNYx67/5Cz4i8Ztie02eC98iGz5irdtJ84Wjp1372dE2A02B2ro4hvxXGDxktZlB7n06EydU/EZ3Jr0LbZDFa+zPjmjrVe05Jv6S4u+uxSZb7KS1pUv92lPFmKKRl2DGspnBVxV4cfzPMV6ZOkPNW5REc0Zu86p50NjNfwpLuU2l3cNuij8Y42Oyf+M7z20w4GgMPUaMWBtnaU3+LOIvifxh/+KdiV0ozTnz4uGPg9qVeBNj8/fEk2P9KjP8FpdELP7ShT+CX+Kslcs9N37+rByb2wKJ5I+tYb92EccYr5iz+Esp/tgowycckO19UVHK/1uzjUFReZ7Fgffxx8cCqb7Ok+LzR91clpLmavnqq/P+JV1emR+Nv1Wr9vpnsuL033xi+cPHHvnxmfX9hxs2HvQvIWDMPRW5UBZ/d8dftAJqIOhX2GD/l+nQPwHns/+tuHKlPn9+2TUKRIfWRQjwN216lTY17JEEsjkTy19kk5JIYW/5l9QUn2XN4G/nzm/++8wkXxacMntOlfIa1FgOvAg3UEJm3AkUpTRQovGXWZU/zN5I/ohd8Ht4cHlkIdTE8kd4hP/ZA//HxN+/sP6zYJbtlWFRbpcskgNEbw//Qm5bAf4I4iIoGuE6CdgxBKVG8hewbEK/6aSu/2ynW/z9+/wRH+BHI4e+zqzXqtyCzb0Xj/3BxBlqfwQOvwS5+Esv/ggpDe0G6CvQAsmSNqrlj4Ar3xEdgz8O8zmLv5Tlj4A8emn4stvouPEb/D86kVqBFyH+ym8vTYC+TWnV8octHM3/bFOjJaDYQdChBQ4miT+Ma/+zUxJd/P1P2L8sxv3aajDhdzTFRbeu6uTnvCQ+f1YX1S+Ez0FrzGj8EXZK1gipdFWchUfO+vH6sn/Tgj80b96HgX4veARxu5A157cAsbhR14Um0v4lOtpldtrhTzOh+x8BF6C/H+jzR2YJbzJStlki/mo2f0xye/eeiqdXL9luofsfzv9C00rfm8iN2y0oQ/nD3A7cxyl4H8lftIP/IeKvxvOH6tYbjQc4xjcNSYGGqNH8f0RB+xe69LZo8Qdk5fkLAGL9bSEo/tKIPxPdE9imCzQ5x1dMe+lIuzgaf8Tf+10zSTGx2Jlo/Fm4f+RCUPzVeP46d5nfrfsiE00T4ryKPjNUL6CTJVnlhEL5OZS+OnWeZ3u+qEPHKt8uv8s9hSwQC0e0G2lzJ7PEbbGwa+dfAsSkRLk3H002U1Lrw424nBU+hX9moHNJqJ5vOtW/pKZkpSj+WRJ/kviTJPEniT9JEn+S+JMk8SeJP0kSf5L4kyTxJ4k/SRJ/kviTJPEniT9JEn+S+JMk8SeJP0kSf5L4kyTxJ4k/SRJ/kviTxJ8kiT9J/EmS+JPEnySJP0n8SZL4k8SfJIk/SfxJkviTxJ8kiT9J/EmS+JPEnyTFp/8Hhe6NJEDFtHIAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      deployments: null
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - migration
+  - konveyor
+  - forklift
+  links:
+  - name: Forklift Documentation
+    url: https://konveyor.github.io/forklift
+  - name: Forklift Operator
+    url: https://github.com/konveyor/forklift-operator
+  maintainers:
+  - email: forklift-dev@googlegroups.com
+    name: Forklift by Konveyor Community
+  maturity: stable
+  minKubeVersion: 1.23.0
+  provider:
+    name: Konveyor
+    url: https://www.konveyor.io
+  version: ${VERSION}

--- a/operator/config/manifests/kustomization.yaml
+++ b/operator/config/manifests/kustomization.yaml
@@ -1,0 +1,7 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
+resources:
+- bases/forklift-operator.clusterserviceversion.yaml
+- ../default
+- ../samples
+- ../scorecard

--- a/operator/config/manifests/test
+++ b/operator/config/manifests/test
@@ -1,0 +1,7 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
+resources:
+- bases/forklift-operator.clusterserviceversion.yaml
+- ../default
+- ../samples
+- ../scorecard

--- a/operator/config/prometheus/kustomization.yaml
+++ b/operator/config/prometheus/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- monitor.yaml

--- a/operator/config/prometheus/monitor.yaml
+++ b/operator/config/prometheus/monitor.yaml
@@ -1,0 +1,20 @@
+
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: forklift-operator
+  name: forklift-operator-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: forklift-operator

--- a/operator/config/rbac/authproxy/client_clusterrole.yaml
+++ b/operator/config/rbac/authproxy/client_clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/operator/config/rbac/authproxy/role.yaml
+++ b/operator/config/rbac/authproxy/role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/operator/config/rbac/authproxy/role_binding.yaml
+++ b/operator/config/rbac/authproxy/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: forklift-operator
+  namespace: system

--- a/operator/config/rbac/authproxy/service.yaml
+++ b/operator/config/rbac/authproxy/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: forklift-operator
+  name: forklift-operator-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: forklift-operator

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -1,0 +1,110 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: forklift-controller-role
+rules:
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  - namespaces
+  - events
+  - configmaps
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  - virtualmachines/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - cdi.kubevirt.io
+  resources:
+  - datavolumes
+  - datavolumes/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - anyuid
+  verbs:
+  - use
+- apiGroups:
+  - template.openshift.io
+  resources:
+  - templates
+  verbs:
+  - get
+  - list

--- a/operator/config/rbac/forklift-controller_role_binding.yaml
+++ b/operator/config/rbac/forklift-controller_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: forklift-controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: forklift-controller-role
+subjects:
+- kind: ServiceAccount
+  name: forklift-controller
+  namespace: system

--- a/operator/config/rbac/forklift-controller_service_account.yaml
+++ b/operator/config/rbac/forklift-controller_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: forklift-controller
+  namespace: system

--- a/operator/config/rbac/forkliftcontroller_editor_role.yaml
+++ b/operator/config/rbac/forkliftcontroller_editor_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit forkliftcontrollers.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: forkliftcontroller-editor-role
+rules:
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - forkliftcontrollers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - forkliftcontrollers/status
+  verbs:
+  - get

--- a/operator/config/rbac/forkliftcontroller_viewer_role.yaml
+++ b/operator/config/rbac/forkliftcontroller_viewer_role.yaml
@@ -1,0 +1,20 @@
+# permissions for end users to view forkliftcontrollers.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: forkliftcontroller-viewer-role
+rules:
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - forkliftcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - forkliftcontrollers/status
+  verbs:
+  - get

--- a/operator/config/rbac/kustomization.yaml
+++ b/operator/config/rbac/kustomization.yaml
@@ -1,0 +1,24 @@
+resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+
+# Add MyCustomObject service account
+- forklift-controller_service_account.yaml
+- forklift-controller_role.yaml
+- forklift-controller_role_binding.yaml
+
+# Comment the following 4 lines if you want to disable
+# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+# which protects your /metrics endpoint.
+# - authproxy/service.yaml
+# - authproxy/role.yaml
+# - authproxy/role_binding.yaml
+# - authproxy/client_clusterrole.yaml

--- a/operator/config/rbac/leader_election_role.yaml
+++ b/operator/config/rbac/leader_election_role.yaml
@@ -1,0 +1,78 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resourceNames:
+  - forklift-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/operator/config/rbac/leader_election_role_binding.yaml
+++ b/operator/config/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: forklift-operator
+  namespace: system

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  - proxies
+  verbs:
+  - get
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients
+  verbs:
+  - '*'
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - forkliftcontrollers
+  - forkliftcontrollers/status
+  - forkliftcontrollers/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/operator/config/rbac/role_binding.yaml
+++ b/operator/config/rbac/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: forklift-operator
+  namespace: system

--- a/operator/config/rbac/service_account.yaml
+++ b/operator/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: forklift-operator
+  namespace: system

--- a/operator/config/samples/forklift_v1beta1_forkliftcontroller.yaml
+++ b/operator/config/samples/forklift_v1beta1_forkliftcontroller.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: ForkliftController
+metadata:
+  name: forklift-controller
+  namespace: ${NAMESPACE}
+spec:
+  feature_ui: 'true'
+  feature_validation: 'true'
+  feature_must_gather_api: 'true'

--- a/operator/config/samples/forklift_v1beta1_hook.yaml
+++ b/operator/config/samples/forklift_v1beta1_hook.yaml
@@ -1,0 +1,9 @@
+---
+kind: Hook
+apiVersion: forklift.konveyor.io/v1beta1
+metadata:
+  name: example-hook
+  namespace: ${NAMESPACE}
+spec:
+  image: quay.io/konveyor/hook-runner
+  playbook: "<base64-encoded-playbook>"

--- a/operator/config/samples/forklift_v1beta1_host.yaml
+++ b/operator/config/samples/forklift_v1beta1_host.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Host
+metadata:
+  name: example-host
+  namespace: ${NAMESPACE}
+spec:
+  provider:
+    namespace: ''
+    name: ''
+  id: ''
+  ipAddress: ''

--- a/operator/config/samples/forklift_v1beta1_migration.yaml
+++ b/operator/config/samples/forklift_v1beta1_migration.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Migration
+metadata:
+  name: example-migration
+  namespace: ${NAMESPACE}
+spec:
+  plan:
+    name: example-plan
+    namespace: konveyor-forklift

--- a/operator/config/samples/forklift_v1beta1_networkmap.yaml
+++ b/operator/config/samples/forklift_v1beta1_networkmap.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: NetworkMap
+metadata:
+  name: example-networkmap
+  namespace: ${NAMESPACE}
+spec:
+  provider:
+    namespace: ''
+    name: ''
+  map:
+  - source:
+      id: ''
+    destination:
+      type: pod
+      namespace: ''
+      name: ''

--- a/operator/config/samples/forklift_v1beta1_plan.yaml
+++ b/operator/config/samples/forklift_v1beta1_plan.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Plan
+metadata:
+  name: example-plan
+  namespace: ${NAMESPACE}
+spec:
+  provider:
+    source:
+      namespace: ''
+      name: ''
+    destination:
+      namespace: ''
+      name: ''
+

--- a/operator/config/samples/forklift_v1beta1_provider.yaml
+++ b/operator/config/samples/forklift_v1beta1_provider.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: example-provider
+  namespace: ${NAMESPACE}
+spec:
+  type: vmware
+  secret:
+    name: ''
+    namespace: ''
+  url: ''

--- a/operator/config/samples/forklift_v1beta1_storagemap.yaml
+++ b/operator/config/samples/forklift_v1beta1_storagemap.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: example-storagemap
+  namespace: ${NAMESPACE}
+spec:
+  provider:
+    namespace: ''
+    name: ''
+  map:
+  - source:
+      id: ''
+    destination:
+      storageClass: ''

--- a/operator/config/samples/kustomization.yaml
+++ b/operator/config/samples/kustomization.yaml
@@ -1,0 +1,11 @@
+## Append samples you want in your CSV to this file as resources ##
+resources:
+- forklift_v1beta1_forkliftcontroller.yaml
+- forklift_v1beta1_hook.yaml
+- forklift_v1beta1_host.yaml
+- forklift_v1beta1_migration.yaml
+- forklift_v1beta1_networkmap.yaml
+- forklift_v1beta1_plan.yaml
+- forklift_v1beta1_provider.yaml
+- forklift_v1beta1_storagemap.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/operator/config/scorecard/bases/config.yaml
+++ b/operator/config/scorecard/bases/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests: []

--- a/operator/config/scorecard/kustomization.yaml
+++ b/operator/config/scorecard/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+- bases/config.yaml
+patchesJson6902:
+- path: patches/basic.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+- path: patches/olm.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+#+kubebuilder:scaffold:patchesJson6902

--- a/operator/config/scorecard/patches/basic.config.yaml
+++ b/operator/config/scorecard/patches/basic.config.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test

--- a/operator/config/scorecard/patches/olm.config.yaml
+++ b/operator/config/scorecard/patches/olm.config.yaml
@@ -1,0 +1,50 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test

--- a/operator/config/testing/debug_logs_patch.yaml
+++ b/operator/config/testing/debug_logs_patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forklift-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+          - name: ANSIBLE_DEBUG_LOGS
+            value: "TRUE"

--- a/operator/config/testing/kustomization.yaml
+++ b/operator/config/testing/kustomization.yaml
@@ -1,0 +1,23 @@
+# Adds namespace to all resources.
+namespace: osdk-test
+
+namePrefix: osdk-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+patchesStrategicMerge:
+- manager_image.yaml
+- debug_logs_patch.yaml
+- ../default/manager_auth_proxy_patch.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../crd
+- ../rbac
+- ../manager
+images:
+- name: testing
+  newName: testing-operator

--- a/operator/config/testing/manager_image.yaml
+++ b/operator/config/testing/manager_image.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forklift-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: testing

--- a/operator/config/testing/pull_policy/Always.yaml
+++ b/operator/config/testing/pull_policy/Always.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forklift-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: Always

--- a/operator/config/testing/pull_policy/IfNotPresent.yaml
+++ b/operator/config/testing/pull_policy/IfNotPresent.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forklift-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: IfNotPresent

--- a/operator/config/testing/pull_policy/Never.yaml
+++ b/operator/config/testing/pull_policy/Never.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forklift-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: Never

--- a/operator/docs/MTV_BZ_MAP.md
+++ b/operator/docs/MTV_BZ_MAP.md
@@ -1,0 +1,7 @@
+# Forklift/MTV Branch-to-Release Map
+
+This is the value last set in Konveyor's [MTV_PR_BZ_MAP](https://github.com/organizations/konveyor/settings/secrets/actions/MTV_PR_BZ_MAP) secret.
+
+```
+'release-v2.0.0:2.0.0,release-v2.1.0:2.1.0,release-v2.2.0:2.2.0,release-v2.3.0:2.3.0,release-v2.3.1:2.3.1,release-v2.3.2:2.3.2,main:2.3.3'
+```

--- a/operator/docs/README.md
+++ b/operator/docs/README.md
@@ -1,0 +1,4 @@
+# Konveyor Forklift Operator Documentation
+
+## Upstream Release Instructions
+See [releases.md](./releases.md) for details.

--- a/operator/docs/development.md
+++ b/operator/docs/development.md
@@ -1,0 +1,184 @@
+# Purpose
+
+The following guide attempts to aid developers in working and testing Forklift operator changes using a deployment within a cluster. This method is the safest and the most complete way to test operator changes.
+
+Alternatively, it is possible to test operators locally outside a cluster but is not covered in this guide, if you want to learn more about this see [here](https://sdk.operatorframework.io/docs/building-operators/ansible/tutorial/#1-run-locally-outside-the-cluster).
+
+## Development environment setup
+
+Before you begin, the following tools need to be installed in your dev system:
+
+* [__k8s v1.22+__](https://kubernetes.io/) or [__OpenShift 4.9+__](https://www.openshift.com/)
+* [__Operator SDK__](https://sdk.operatorframework.io/docs/installation/)
+* [__Operator Lifecycle Manager (OLM) support__](https://olm.operatorframework.io/) (minikube/k8s clusters)
+* [__OPM__](https://github.com/operator-framework/operator-registry/)
+* __Podman__ and __Docker__
+
+Also, at a very minimum you will need **three Quay repos** to serve and store images related to operator development:
+
+* forklift-operator, operator images (ansible operator itself)
+* forklift-operator-bundle, operator bundle images (operator versions)
+* forklift-operator-index, index images (index of operator versions used by CatalogSource)
+
+These repos must be **publicly accessible** and you must have enough permissions to push images with your Quay credentials. In most cases, your own organization (Quay username) in Quay is used (i.e quay.io/<username>/<repo-name>). This is the recommended setup for development.
+
+## Opdev script
+
+The [opdev helper](../tools/forklift-opdev.sh) script automates the process of building, publishing and installing operator development builds. It simplifies the most common tasks that would be otherwise manually done using operator-sdk and rest of tooling needed to build and publish operators for testing purposes.
+
+Usage:
+
+```
+./forklift-opdev.sh -h
+
+Valid arguments for forklift-opdev.sh:
+
+	-n : Quay ORG used for Forklift development repos (required)
+	-o : Build and push operator image
+	-b : Build and push bundle image
+	-i : Build and push index image
+	-c : Create custom Forklift catalogsource
+	-d : Deploy development Forklift for testing
+
+```
+
+The script resides in the tools directory of the operator repo. The only required option is -n , which is your Quay organization that hosts your operator development repos. You must be logged in to your cluster (as admin) and quay account prior attempting to run.
+
+If you want more in-depth details regarding these operator SDK procedures please check the [Operator SDK ansible tutorial](https://sdk.operatorframework.io/docs/building-operators/ansible/tutorial/).
+
+## Development flow
+
+The usual dev order flow for operator is as follows:
+
+* Create and make changes in your operator branch
+* Build and push your changes to your Quay org
+* Deploy from a development catalogsource and validate changes
+* Commit changes and submit PR to forklift-operator repo
+
+**Note**: Please use forks when submitting your PR, we want to avoid rogue branches in base repo.
+
+## How do I push and test my Forklift operator changes?
+
+|Where is your change?|You changed|To test your changes|
+|---|---|---|
+|`./roles`| Operator roles content |[Build and push a development operator image](#build-and-push-a-development-operator-container-image) |
+|`./bundle`| Operator OLM metadata | [Build and push a development bundle and index image](#build-and-push-a-development-operator-bundle-and-index-image) |
+|`both` | Operator OLM metadata and roles content | [Build and push operator including OLM metadata](#build-and-push-all)
+
+## Build and push all
+
+This is recommended as a first time run, as it will populate all dev repos and also will create a custom CatalogSource in your cluster
+
+```
+./forklift-opdev.sh -n <your-quay-org> -obic
+```
+
+## Build and push a development operator container image
+
+This example only builds and pushes an operator image, if changes were only made to the ansible roles, this is the option that makes the most sense.
+
+```
+./forklift-opdev.sh -n <your-quay-org> -o
+```
+
+## Build and push a development operator bundle and index image
+
+This is useful when only OLM metadata changes have taken place, bundle and index images are built and also a CatalogSource is created. In addition, the ClusterServiceVersion (CSV) is modified to use the custom operator development image prior building the bundle.
+
+```
+./forklift-opdev.sh -n <your-quay-org> -bic
+```
+
+## Testing a development operator using a deployment
+
+Before continuing, ensure the existance and health of the CatalogSource:
+
+```
+oc -n konveyor-forklift get catalogsource
+NAME                DISPLAY                TYPE   PUBLISHER   AGE
+konveyor-forklift   Forklift Development   grpc   Konveyor    3m29s
+```
+
+The index image used by CatalogSource includes the bundle created for this development build.
+
+### Deploy a development operator
+
+The deploy option will create a few resources necessary to install Forklift using OLM such as ensuring an OperatorGroup and Subscription are in place (by default all objects are created in the konveyor-forklift namespace).
+
+```
+./forklift-opdev.sh -n <your-quay-org> -d
+```
+
+### Check operator health:
+
+```
+oc get pods
+NAME                                                              READY   STATUS      RESTARTS   AGE
+7d2fe094ec9e26dfc42f576c46f4b73a432595ecef29ebd9d1b00d78732nzgw   0/1     Completed   0          5m27s
+forklift-operator-5979d986b7-4lj5h                                1/1     Running     0          5m11s
+konveyor-forklift-fzztn                                           1/1     Running     0          5m52s
+```
+
+The operator pod can be inspected further by ensuring the correct image is being pulled and there are other warnings or errors in logs.
+
+### Create a _ForkliftController_ CR
+
+Create and customize the CR spec as needed, example:
+
+```
+cat << EOF | oc apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: ForkliftController
+metadata:
+  name: forklift-controller
+  namespace: konveyor-forklift
+spec:
+  feature_ui: true
+  feature_validation: true
+EOF
+```
+
+### Check status of _ForkliftController_ CR
+
+The operator watches ForkliftController and uses managed status, we can check the health of each reconcile cycle by inspecting the CR:
+
+```
+oc describe forkliftcontrollers
+...
+Status:
+  Conditions:
+    Last Transition Time:  2022-07-13T03:12:17Z
+    Message:               
+    Reason:                
+    Status:                False
+    Type:                  Failure
+    Ansible Result:
+      Changed:             0
+      Completion:          2022-07-13T03:13:04.477987
+      Failures:            0
+      Ok:                  25
+      Skipped:             10
+    Last Transition Time:  2022-07-13T03:11:48Z
+    Message:               Awaiting next reconciliation
+    Reason:                Successful
+    Status:                True
+    Type:                  Running
+    Last Transition Time:  2022-07-13T03:13:04Z
+    Message:               Last reconciliation succeeded
+    Reason:                Successful
+    Status:                True
+    Type:                  Successful
+Events:                    <none>
+```
+
+Any errors encountered during reconcile will be reported, for further info, the operator pod logs can be inspected.
+
+## Cleanup Forklift
+
+Use the [Forklift cleanup script](../tools/forklift-cleanup.sh) which is supplied with operator, it will ensure all resources are properly deleted.
+
+Example for OpenShift clusters:
+
+```
+./forklift-cleanup.sh -o
+```

--- a/operator/docs/k8s.md
+++ b/operator/docs/k8s.md
@@ -1,0 +1,92 @@
+# Forklift k8s Installation
+
+## Pre-requisites
+
+- **Kubernetes cluster or Minikube v1.22+**
+- **Operator Lifecycle Manager (OLM)**
+
+## Installing OLM support
+
+We strongly suggest OLM support for Forklift deployments, in some production kubernetes clusters OLM might already be present, if not, see the following examples in how to add OLM support to minikube or standard kubernetes clusters below:
+
+### Minikube:
+`$ minikube addons enable olm`
+
+### Kubernetes:
+`$ kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/crds.yaml`
+
+`$ kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml`
+
+For details and official instructions in how to add OLM support to kubernetes and customize your installation see [here](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md)
+
+### Ensure OLM health
+
+Check OLM pods, they must all be in _Running_ state:
+
+```
+$ kubectl -n olm get pods
+NAME                                READY   STATUS    RESTARTS        AGE
+catalog-operator-755d759b4b-5286j   1/1     Running   1 (7d23h ago)   49d
+olm-operator-c755654d4-2447p        1/1     Running   1 (7d23h ago)   49d
+packageserver-d9c689b8f-57q7k       1/1     Running   1 (7d23h ago)   49d
+packageserver-d9c689b8f-g6pj9       1/1     Running   1 (7d23h ago)   49d
+```
+
+## Installing _latest_
+
+Deploy Forklift using the [forklift-k8s.yaml manifest](../forklift-k8s.yaml):
+
+`$ kubectl apply -f https://raw.githubusercontent.com/konveyor/forklift-operator/main/forklift-k8s.yaml`
+
+**Note**: When working with the main branch, the subscription in the manifest will pull the _latest_ operator image via development channel.
+
+### Veryfing Operator Health
+
+The [forklift-k8s.yaml manifest](../forklift-k8s.yaml) contains all the necesary objects to deploy operator via OLM, if successful, you should see the catalogsource, operator and OLM job pods all in _Running_ state and _Completed_ state:
+
+```
+$ kubectl -n konveyor-forklift get pods
+NAME                                                  READY   STATUS      RESTARTS   AGE
+d2d4595bc2822f45ea5aca8f9a09e3c65db3ee5de4574c7bceb   0/1     Completed   0          22m
+forklift-operator-5489797f8c-zj6l7                    1/1     Running     0          22m
+konveyor-forklift-bx8pt                               1/1     Running     0          22m
+```
+
+If this looks Ok, then you can proceed to create the forkliftcontroller CR that will install the rest of Forklift components.
+
+### Creating a _ForkliftController_ CR (SSL/TLS disabled)
+```
+$ cat << EOF | kubectl -n konveyor-forklift apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: ForkliftController
+metadata:
+  name: forklift-controller
+  namespace: konveyor-forklift
+spec:
+  feature_ui: false
+  feature_validation: true
+  inventory_tls_enabled: false
+  validation_tls_enabled: false
+  must_gather_api_tls_enabled: false
+  ui_tls_enabled: false
+EOF
+```
+
+### Creating a _ForkliftController_ CR (SSL/TLS disabled) with UI
+```
+$ cat << EOF | kubectl -n konveyor-forklift apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: ForkliftController
+metadata:
+  name: forklift-controller
+  namespace: konveyor-forklift
+spec:
+  feature_ui: true
+  feature_auth_required: false
+  feature_validation: true
+  inventory_tls_enabled: false
+  validation_tls_enabled: false
+  must_gather_api_tls_enabled: false
+  ui_tls_enabled: false
+EOF
+```

--- a/operator/docs/releases.md
+++ b/operator/docs/releases.md
@@ -1,0 +1,29 @@
+# Konveyor Forklift Upstream Release Instructions
+
+## Prerequisites
+
+- Podman 1.6.4+
+- [Operator SDK v1.3.0+](https://github.com/operator-framework/operator-sdk)
+- [Opm](https://github.com/operator-framework/operator-registry) for index image manipulation
+- [Quay.io](https://quay.io/organization/konveyor) access to Konveyor Forklift repos
+
+## Overview
+The Konveyor Forklift new release procedure consist of a few steps summarized below: 
+- Create a new release branch on Konveyor Forklift Operator repo
+- Create and submit PR preparing bundle manifests for the new release branch
+- Once merged, bundle images for new release will be automatically built on Quay.io
+- Build new index images and push new metadata to Quay.io
+
+## Konveyor Forklift Stable
+We use semantic versioning convention (semver) for stable releases, release branches should be in the form of release-v<semver>
+
+1. Create a new release branch, for example `release-v2.3.0`
+1. Create a PR for the new release branch
+   1. Run `VERSION=2.3.0 make bundle`
+   1. Bump the `forklift_operator_version` in `roles/forkliftcontroller/defaults/main.yml`
+   1. Add relatedImages to the CSV with the SHA digests.
+   1. Review changes, commmit, and submit the PR for review
+1. Once the release PR is ready and merged, add it to the index image and push to quay.io
+   1. `CATALOG_BASE_IMG=quay.io/konveyor/forklift-operator-index:release-v2.2.0 VERSION=2.3.0 make catalog-build bundle-push`
+   1. `CATALOG_BASE_IMG=quay.io/konveyor/forklift-operator-index:release-v2.3.0 TAG=latest make catalog-build catalog-push`
+   1. Create or refresh existing konveyor-forklift catalog source and validate `oc create -f forklift-operator-catalog.yaml`

--- a/operator/forklift-k8s-dev.yaml
+++ b/operator/forklift-k8s-dev.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: migration
+  namespace: konveyor-forklift
+spec:
+  targetNamespaces:
+    - konveyor-forklift
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: forklift-operator
+  namespace: konveyor-forklift
+spec:
+  channel: development
+  installPlanApproval: Automatic
+  name: forklift-operator
+  source: konveyor-forklift
+  sourceNamespace: konveyor-forklift

--- a/operator/forklift-k8s.yaml
+++ b/operator/forklift-k8s.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: konveyor-forklift
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: konveyor-forklift
+  namespace: konveyor-forklift
+spec:
+  displayName: Forklift Operator
+  publisher: Konveyor
+  sourceType: grpc
+  image: quay.io/konveyor/forklift-operator-index:latest
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: migration
+  namespace: konveyor-forklift
+spec:
+  targetNamespaces:
+    - konveyor-forklift
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: forklift-operator
+  namespace: konveyor-forklift
+spec:
+  channel: development
+  installPlanApproval: Automatic
+  name: forklift-operator
+  source: konveyor-forklift
+  sourceNamespace: konveyor-forklift

--- a/operator/forklift-operator-catalog.yaml
+++ b/operator/forklift-operator-catalog.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: konveyor-forklift
+  namespace: openshift-marketplace
+spec:
+  displayName: Forklift Operator
+  publisher: Konveyor
+  sourceType: grpc
+  image: quay.io/konveyor/forklift-operator-index:latest

--- a/operator/molecule/default/converge.yml
+++ b/operator/molecule/default/converge.yml
@@ -1,0 +1,18 @@
+---
+- name: Converge
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  collections:
+    - kubernetes.core
+
+  tasks:
+    - name: Create Namespace
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: '{{ namespace }}'
+
+    - import_tasks: kustomize.yml
+      vars:
+        state: present

--- a/operator/molecule/default/create.yml
+++ b/operator/molecule/default/create.yml
@@ -1,0 +1,6 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks: []

--- a/operator/molecule/default/destroy.yml
+++ b/operator/molecule/default/destroy.yml
@@ -1,0 +1,24 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - kubernetes.core
+
+  tasks:
+    - import_tasks: kustomize.yml
+      vars:
+        state: absent
+
+    - name: Destroy Namespace
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: '{{ namespace }}'
+        state: absent
+
+    - name: Unset pull policy
+      command: '{{ kustomize }} edit remove patch pull_policy/{{ operator_pull_policy }}.yaml'
+      args:
+        chdir: '{{ config_dir }}/testing'

--- a/operator/molecule/default/kustomize.yml
+++ b/operator/molecule/default/kustomize.yml
@@ -1,0 +1,22 @@
+---
+- name: Build kustomize testing overlay
+  # load_restrictor must be set to none so we can load patch files from the default overlay
+  command: '{{ kustomize }} build  --load_restrictor none .'
+  args:
+    chdir: '{{ config_dir }}/testing'
+  register: resources
+  changed_when: false
+
+- name: Set resources to {{ state }}
+  k8s:
+    definition: '{{ item }}'
+    state: '{{ state }}'
+    wait: no
+  loop: '{{ resources.stdout | from_yaml_all | list }}'
+
+- name: Wait for resources to get to {{ state }}
+  k8s:
+    definition: '{{ item }}'
+    state: '{{ state }}'
+    wait: yes
+  loop: '{{ resources.stdout | from_yaml_all | list }}'

--- a/operator/molecule/default/molecule.yml
+++ b/operator/molecule/default/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+lint: |
+  set -e
+  yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" .
+platforms:
+  - name: cluster
+    groups:
+      - k8s
+provisioner:
+  name: ansible
+  lint: |
+    set -e
+    ansible-lint
+  inventory:
+    group_vars:
+      all:
+        namespace: ${TEST_OPERATOR_NAMESPACE:-osdk-test}
+    host_vars:
+      localhost:
+        ansible_python_interpreter: '{{ ansible_playbook_python }}'
+        config_dir: ${MOLECULE_PROJECT_DIRECTORY}/config
+        samples_dir: ${MOLECULE_PROJECT_DIRECTORY}/config/samples
+        operator_image: ${OPERATOR_IMAGE:-""}
+        operator_pull_policy: ${OPERATOR_PULL_POLICY:-"Always"}
+        kustomize: ${KUSTOMIZE_PATH:-kustomize}
+  env:
+    K8S_AUTH_KUBECONFIG: ${KUBECONFIG:-"~/.kube/config"}
+verifier:
+  name: ansible
+  lint: |
+    set -e
+    ansible-lint

--- a/operator/molecule/default/prepare.yml
+++ b/operator/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Prepare
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Ensure operator image is set
+      fail:
+        msg: |
+          You must specify the OPERATOR_IMAGE environment variable in order to run the
+          'default' scenario
+      when: not operator_image
+
+    - name: Set testing image
+      command: '{{ kustomize }} edit set image testing={{ operator_image }}'
+      args:
+        chdir: '{{ config_dir }}/testing'
+
+    - name: Set pull policy
+      command: '{{ kustomize }} edit add patch --path pull_policy/{{ operator_pull_policy }}.yaml'
+      args:
+        chdir: '{{ config_dir }}/testing'
+
+    - name: Set testing namespace
+      command: '{{ kustomize }} edit set namespace {{ namespace }}'
+      args:
+        chdir: '{{ config_dir }}/testing'

--- a/operator/molecule/default/tasks/forkliftcontroller_test.yml
+++ b/operator/molecule/default/tasks/forkliftcontroller_test.yml
@@ -1,0 +1,18 @@
+---
+- name: Create the forklift.konveyor.io/v1beta1.ForkliftController
+  k8s:
+    state: present
+    namespace: '{{ namespace }}'
+    definition: "{{ lookup('template', '/'.join([samples_dir, cr_file])) | from_yaml }}"
+    wait: yes
+    wait_timeout: 300
+    wait_condition:
+      type: Successful
+      status: "True"
+  vars:
+    cr_file: 'forklift_v1beta1_forkliftcontroller.yaml'
+
+- name: Add assertions here
+  assert:
+    that: false
+    fail_msg: FIXME Add real assertions for your operator

--- a/operator/molecule/default/verify.yml
+++ b/operator/molecule/default/verify.yml
@@ -1,0 +1,57 @@
+---
+- name: Verify
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  collections:
+    - kubernetes.core
+
+  vars:
+    ctrl_label: control-plane=controller-manager
+
+  tasks:
+    - block:
+        - name: Import all test files from tasks/
+          include_tasks: '{{ item }}'
+          with_fileglob:
+            - tasks/*_test.yml
+      rescue:
+        - name: Retrieve relevant resources
+          k8s_info:
+            api_version: '{{ item.api_version }}'
+            kind: '{{ item.kind }}'
+            namespace: '{{ namespace }}'
+          loop:
+            - api_version: v1
+              kind: Pod
+            - api_version: apps/v1
+              kind: Deployment
+            - api_version: v1
+              kind: Secret
+            - api_version: v1
+              kind: ConfigMap
+          register: debug_resources
+
+        - name: Retrieve Pod logs
+          k8s_log:
+            name: '{{ item.metadata.name }}'
+            namespace: '{{ namespace }}'
+            container: manager
+          loop: "{{ q('k8s', api_version='v1', kind='Pod', namespace=namespace, label_selector=ctrl_label) }}"
+          register: debug_logs
+
+        - name: Output gathered resources
+          debug:
+            var: debug_resources
+
+        - name: Output gathered logs
+          debug:
+            var: item.log_lines
+          loop: '{{ debug_logs.results }}'
+
+        - name: Re-emit failure
+          vars:
+            failed_task:
+              result: '{{ ansible_failed_result }}'
+          fail:
+            msg: '{{ failed_task }}'

--- a/operator/molecule/kind/converge.yml
+++ b/operator/molecule/kind/converge.yml
@@ -1,0 +1,24 @@
+---
+- name: Converge
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  tasks:
+    - name: Build operator image
+      docker_image:
+        build:
+          path: '{{ project_dir }}'
+          pull: no
+        name: '{{ operator_image }}'
+        tag: latest
+        push: no
+        source: build
+        force_source: yes
+
+    - name: Load image into kind cluster
+      command: kind load docker-image --name osdk-test '{{ operator_image }}'
+      register: result
+      changed_when: '"not yet present" in result.stdout'
+
+- import_playbook: ../default/converge.yml

--- a/operator/molecule/kind/create.yml
+++ b/operator/molecule/kind/create.yml
@@ -1,0 +1,8 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Create test kind cluster
+      command: kind create cluster --name osdk-test --kubeconfig {{ kubeconfig }}

--- a/operator/molecule/kind/destroy.yml
+++ b/operator/molecule/kind/destroy.yml
@@ -1,0 +1,16 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - kubernetes.core
+
+  tasks:
+    - name: Destroy test kind cluster
+      command: kind delete cluster --name osdk-test --kubeconfig {{ kubeconfig }}
+
+    - name: Unset pull policy
+      command: '{{ kustomize }} edit remove patch pull_policy/{{ operator_pull_policy }}.yaml'
+      args:
+        chdir: '{{ config_dir }}/testing'

--- a/operator/molecule/kind/molecule.yml
+++ b/operator/molecule/kind/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+lint: |
+  set -e
+  yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" .
+platforms:
+  - name: cluster
+    groups:
+      - k8s
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../default/prepare.yml
+    verify: ../default/verify.yml
+  lint: |
+    set -e
+    ansible-lint
+  inventory:
+    group_vars:
+      all:
+        namespace: ${TEST_OPERATOR_NAMESPACE:-osdk-test}
+    host_vars:
+      localhost:
+        ansible_python_interpreter: '{{ ansible_playbook_python }}'
+        config_dir: ${MOLECULE_PROJECT_DIRECTORY}/config
+        samples_dir: ${MOLECULE_PROJECT_DIRECTORY}/config/samples
+        project_dir: ${MOLECULE_PROJECT_DIRECTORY}
+        operator_image: testing-operator
+        operator_pull_policy: "Never"
+        kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+        kustomize: ${KUSTOMIZE_PATH:-kustomize}
+  env:
+    K8S_AUTH_KUBECONFIG: ${MOLECULE_EPHEMERAL_DIRECTORY}/kubeconfig
+    KUBECONFIG: ${MOLECULE_EPHEMERAL_DIRECTORY}/kubeconfig
+verifier:
+  name: ansible
+  lint: |
+    set -e
+    ansible-lint

--- a/operator/requirements.yml
+++ b/operator/requirements.yml
@@ -1,0 +1,10 @@
+---
+collections:
+  - name: community.kubernetes
+    version: "2.0.1"
+  - name: operator_sdk.util
+    version: "0.4.0"
+  - name: kubernetes.core
+    version: "2.3.1"
+  - name: cloud.common
+    version: "2.1.1"

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -1,0 +1,97 @@
+---
+app_name: "{{ lookup('env', 'APP_NAME') or 'forklift' }}"
+app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
+
+# Feature defaults
+feature_ui: true
+feature_validation: true
+feature_must_gather_api: true
+
+k8s_cluster: false
+feature_auth_required: true
+image_pull_policy: Always
+forklift_operator_version: "latest"
+forklift_resources:
+  - Deployment
+  - ConfigMap
+  - Service
+  - Route
+
+controller_image_fqin: "{{ lookup( 'env', 'CONTROLLER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_CONTROLLER') }}"
+controller_configmap_name: "{{ controller_service_name }}-config"
+controller_service_name: "{{ app_name }}-controller"
+controller_deployment_name: "{{ controller_service_name }}"
+controller_container_name: "{{ app_name }}-controller"
+controller_container_limits_cpu: "500m"
+controller_container_limits_memory: "800Mi"
+controller_container_requests_cpu: "100m"
+controller_container_requests_memory: "350Mi"
+controller_log_level: 3
+controller_precopy_interval: 60
+controller_vsphere_incremental_backup: true
+controller_ovirt_warm_migration: true
+controller_max_vm_inflight: 20
+profiler_volume_path: "/var/cache/profiler"
+
+inventory_volume_path: "/var/cache/inventory"
+inventory_container_name: "{{ app_name }}-inventory"
+inventory_service_name: "{{ app_name }}-inventory"
+inventory_route_name: "{{ inventory_service_name }}"
+inventory_container_limits_cpu: "1000m"
+inventory_container_limits_memory: "1Gi"
+inventory_container_requests_cpu: "500m"
+inventory_container_requests_memory: "500Mi"
+inventory_tls_secret_name: "{{ inventory_service_name }}-serving-cert"
+inventory_tls_enabled: true
+
+validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VALIDATION') }}"
+validation_configmap_name: "{{ validation_service_name }}-config"
+validation_service_name: "{{ app_name }}-validation"
+validation_deployment_name: "{{ validation_service_name }}"
+validation_container_name: "{{ app_name }}-validation"
+validation_extra_volume_name: "validation-extra-rules"
+validation_extra_volume_mountpath: "/usr/share/opa/policies/extra"
+validation_policy_agent_search_interval: "120"
+validation_container_limits_cpu: "1000m"
+validation_container_limits_memory: "300Mi"
+validation_container_requests_cpu: "400m"
+validation_container_requests_memory: "50Mi"
+validation_tls_secret_name: "{{ validation_service_name }}-serving-cert"
+validation_tls_enabled: true
+validation_state: absent
+
+ui_image_fqin: "{{ lookup( 'env', 'UI_IMAGE') or lookup( 'env', 'RELATED_IMAGE_UI') }}"
+ui_oauth_user_scope: "user:full"
+ui_configmap_path: "/etc/forklift-ui"
+ui_configmap_name: "{{ ui_service_name }}-config"
+ui_service_name: "{{ app_name }}-ui"
+ui_deployment_name: "{{ ui_service_name }}"
+ui_container_name: "{{ app_name }}-ui"
+ui_container_limits_cpu: "100m"
+ui_container_limits_memory: "800Mi"
+ui_container_requests_cpu: "100m"
+ui_container_requests_memory: "150Mi"
+ui_tls_secret_name: "{{ ui_service_name }}-serving-cert"
+ui_tls_enabled: true
+ui_route_name: "virt"
+ui_meta_file_name: "meta.json"
+ui_node_extra_ca_certs: "/opt/app-root/src/ca.crt"
+ui_state: absent
+
+must_gather_api_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_API_IMAGE') or lookup( 'env', 'RELATED_IMAGE_MUST_GATHER_API') }}"
+must_gather_api_service_name: "{{ app_name }}-must-gather-api"
+must_gather_api_deployment_name: "{{ must_gather_api_service_name }}"
+must_gather_api_container_name: "{{ app_name }}-must-gather-api"
+must_gather_api_container_limits_cpu: "1000m"
+must_gather_api_container_limits_memory: "1Gi"
+must_gather_api_container_requests_cpu: "100m"
+must_gather_api_container_requests_memory: "150Mi"
+must_gather_api_tls_secret_name: "{{ must_gather_api_service_name }}-serving-cert"
+must_gather_api_tls_enabled: true
+must_gather_api_db_path: "/tmp/gatherings.db"
+must_gather_api_cleanup_max_age: "-1"
+must_gather_api_debug: false
+must_gather_api_state: absent
+
+must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_MUST_GATHER') }}"
+virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V') }}"

--- a/operator/roles/forkliftcontroller/meta/main.yml
+++ b/operator/roles/forkliftcontroller/meta/main.yml
@@ -1,0 +1,31 @@
+---
+galaxy_info:
+  author: Konveyor Forklift Operator
+  description: Konveyor Forklift Operator installs a suite of migration tools that facilitate the migration of VM workloads to OpenShift Virtualization.
+  license: Apache
+
+  min_ansible_version: 2.9
+
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+  - name: EL
+    versions:
+    - 8
+
+  galaxy_tags:
+  - forklift
+  - konveyor
+  - kubernetes
+  - kubevirt
+  - openshift
+  - operator
+  - vm
+
+dependencies: []
+collections:
+- operator_sdk.util
+- community.kubernetes

--- a/operator/roles/forkliftcontroller/tasks/cleanup.yml
+++ b/operator/roles/forkliftcontroller/tasks/cleanup.yml
@@ -1,0 +1,22 @@
+---
+- block:
+
+  - name: "Get {{ resource_kind }} resources labeled {{ feature_label }}"
+    k8s_info:
+      namespace: "{{ app_namespace }}"
+      kind: "{{ resource_kind }}"
+      label_selectors:
+        - "service = {{ feature_label }}"
+    register: results
+
+  - name: "Clean up {{ resource_kind }} resources labeled {{ feature_label }}"
+    k8s:
+      namespace: "{{ app_namespace }}"
+      kind: "{{ results.resources[0].kind }}"
+      name: "{{ results.resources[0].metadata.name }}"
+      state: absent
+    when: (results.resources|length) > 0
+
+  rescue:
+  - debug:
+      msg: "Something went wrong, ignoring empty or missing resources for {{ resource_kind }} label {{ feature_label }}"

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -1,0 +1,217 @@
+---
+- block:
+
+  - name: "Set UI feature state"
+    set_fact:
+      ui_state: "present"
+    when: feature_ui|bool
+
+  - name: "Set validation feature state"
+    set_fact:
+      validation_state: "present"
+    when: feature_validation|bool
+
+  - name: "Set must-gather-api feature state"
+    set_fact:
+      must_gather_api_state: "present"
+    when: feature_must_gather_api|bool
+
+  - name: "Load cluster API groups"
+    set_fact:
+      api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+
+  - when: "'route.openshift.io' not in api_groups"
+    block:
+    - name: "Enable k8s cluster environment"
+      set_fact:
+        k8s_cluster: true
+
+    - name: "Obtain k8s cluster version"
+      set_fact:
+        k8s_cluster_version: "{{ lookup('k8s', cluster_info='version').kubernetes.gitVersion }}"
+
+  - when: not k8s_cluster|bool
+    block:
+    - name: "Get cluster proxy object"
+      set_fact:
+        proxy_cluster: "{{ lookup('k8s', api_version='config.openshift.io/v1', kind='Proxy', resource_name='cluster') }}"
+
+    - when: proxy_cluster.spec.trustedCA.name|length > 0
+      block:
+      - name: "Enable trusted CA environment"
+        set_fact:
+          trusted_ca_enabled: true
+
+      - name: "Create an empty ConfigMap that will hold the trusted CA"
+        k8s:
+          state: present
+          definition: "{{ lookup('template', 'configmap-trusted-ca.yml.j2') }}"
+
+  - name: "Setup the webhook secret"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'secret-webhook-server-secret.yml.j2') }}"
+
+  - name: "Setup controller config map"
+    k8s:
+      state : present
+      definition: "{{ lookup('template', 'configmap-controller.yml.j2') }}"
+
+  - name: "Setup inventory service"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'service-inventory.yml.j2') }}"
+
+  - name: "Setup controller deployment"
+    k8s:
+      state : present
+      definition: "{{ lookup('template', 'deployment-controller.yml.j2') }}"
+      merge_type: "merge"
+
+  - name: "Setup inventory route"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'route-inventory.yml.j2') }}"
+    when: not k8s_cluster|bool
+
+  - name: "Set up default provider"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'provider-host.yml.j2') }}"
+    when: "'kubevirt.io' in api_groups"
+
+  - when: feature_validation|bool
+    block:
+    - name: "Setup validation service"
+      k8s:
+        state: "{{ validation_state }}"
+        definition: "{{ lookup('template', 'service-validation.yml.j2') }}"
+
+    - name: "Setup validation config map"
+      k8s:
+        state: "{{ validation_state }}"
+        definition: "{{ lookup('template', 'configmap-validation.yml.j2') }}"
+
+    - name: "Setup validation deployment"
+      k8s:
+        state: "{{ validation_state }}"
+        definition: "{{ lookup('template', 'deployment-validation.yml.j2') }}"
+
+  - when: feature_must_gather_api|bool
+    block:
+    - name: "Setup must-gather-api service"
+      k8s:
+        state: "{{ must_gather_api_state }}"
+        definition: "{{ lookup('template', 'service-must-gather-api.yml.j2') }}"
+
+    - name: "Setup must-gather-api deployment"
+      k8s:
+        state: "{{ must_gather_api_state }}"
+        definition: "{{ lookup('template', 'deployment-must-gather-api.yml.j2') }}"
+
+  # Non-k8s UI tasks
+  - when: feature_ui|bool and not k8s_cluster|bool
+    block:
+
+    - name: "Setup UI route"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'route-ui.yml.j2') }}"
+
+    - name: "Obtain UI route"
+      k8s_info:
+        api_version: "route.openshift.io/v1"
+        kind: "Route"
+        namespace: "{{ app_namespace }}"
+        name: "{{ ui_route_name }}"
+      register: route
+      until: (route.resources|length) > 0
+      delay: 10
+      retries: 6
+
+    - name: "Extract UI FQDN from the route"
+      set_fact:
+        ui_route_fqdn: "{{ route.resources[0].spec.host }}"
+
+    - name: "Obtain OCP cluster version"
+      k8s_info:
+        kind: ClusterVersion
+        name: version
+      register: ocp_cv
+
+    - name: "Extract OCP cluster version"
+      set_fact:
+        forklift_cluster_version: "{{ ocp_cv | json_query(query) | first }}"
+      vars:
+        query: "resources[0].status.history[?state=='Completed'].version"
+      when: (ocp_cv.resources|length) > 0
+
+    - name: "Check if UI oauthclient exists already so we don't update it"
+      k8s_info:
+        api_version: v1
+        kind: OAuthClient
+        name: "{{ ui_service_name }}"
+        namespace: "{{ app_namespace }}"
+      register: ui_oauthclient_status
+
+    - when: (ui_oauthclient_status.resources | length) == 0
+      block:
+      - name: "Generate random secret value for oauth client"
+        set_fact:
+          ui_oauth_secret: "{{ 99999999 | random | to_uuid | b64encode }}"
+
+      - name: "Setup UI oauthclient"
+        k8s:
+          state: present
+          definition: "{{ lookup('template', 'oauthclient-ui.yml.j2') }}"
+
+    - name: "Use existing secret value for oauth client"
+      set_fact:
+        ui_oauth_secret: "{{ ui_oauthclient_status.resources[0].secret }}"
+      when: (ui_oauthclient_status.resources | length) > 0
+
+  - when: feature_ui|bool
+    block:
+
+    - name: "Setup UI config map"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'configmap-ui.yml.j2') }}"
+
+    - name: "Setup UI service"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'service-ui.yml.j2') }}"
+
+    - name: "Setup UI deployment"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'deployment-ui.yml.j2') }}"
+
+  - when: not feature_ui|bool
+    name: "Cleanup {{ ui_service_name }} if disabled"
+    include_tasks: cleanup.yml
+    loop: "{{ forklift_resources }}"
+    loop_control:
+      loop_var: resource_kind
+    vars:
+      feature_label: "{{ ui_service_name }}"
+
+  - when: not feature_validation|bool
+    name: "Cleanup {{ validation_service_name }} if disabled"
+    include_tasks: cleanup.yml
+    loop: "{{ forklift_resources }}"
+    loop_control:
+      loop_var: resource_kind
+    vars:
+      feature_label: "{{ validation_service_name }}"
+
+  - when: not feature_must_gather_api|bool
+    name: "Cleanup {{ must_gather_api_service_name }} if disabled"
+    include_tasks: cleanup.yml
+    loop: "{{ forklift_resources }}"
+    loop_control:
+      loop_var: resource_kind
+    vars:
+      feature_label: "{{ must_gather_api_service_name }}"
+

--- a/operator/roles/forkliftcontroller/templates/configmap-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/configmap-controller.yml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ app_name }}
+    service: {{ controller_service_name }}
+    control-plane: forklift-operator
+    controller-tools.k8s.io: "1.0"
+  name: {{ controller_configmap_name }}
+  namespace: {{ app_namespace }}
+data:
+  WORKING_DIR: {{ inventory_volume_path }}
+{% if controller_precopy_interval is number %}
+  PRECOPY_INTERVAL: "{{ controller_precopy_interval }}"
+{% endif %}
+{% if controller_max_vm_inflight is number %}
+  MAX_VM_INFLIGHT: "{{ controller_max_vm_inflight }}"
+{% endif %}

--- a/operator/roles/forkliftcontroller/templates/configmap-trusted-ca.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/configmap-trusted-ca.yml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/operator/roles/forkliftcontroller/templates/configmap-ui.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/configmap-ui.yml.j2
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ app_name }}
+    service: {{ ui_service_name }}
+  name: "{{ ui_configmap_name }}"
+  namespace: "{{ app_namespace }}"
+data:
+  "{{ ui_meta_file_name }}": |
+    {    
+      "namespace": "{{ app_namespace }}",
+      "configNamespace": "{{ app_namespace }}",
+      "clusterApi": "https://kubernetes.default.svc.cluster.local",
+{% if inventory_tls_enabled|bool %}
+      "inventoryApi": "https://{{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local:8443",
+{% else %}
+      "inventoryApi": "http://{{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local:8080",
+{% endif %}
+{% if must_gather_api_tls_enabled|bool %}
+      "mustGatherApi": "https://{{ must_gather_api_service_name }}.{{ app_namespace }}.svc.cluster.local:8443",
+{% else %}
+      "mustGatherApi": "http://{{ must_gather_api_service_name }}.{{ app_namespace }}.svc.cluster.local:8080",
+{% endif %}
+      "oauth": {
+{% if not k8s_cluster|bool %}
+        "clientId": "{{ ui_service_name }}",
+{% if ui_tls_enabled|bool %}
+        "redirectUrl": "https://{{ ui_route_fqdn }}/login/callback",
+{% else %}
+        "redirectUrl": "http://{{ ui_route_fqdn }}/login/callback",
+{% endif %}
+        "userScope": "{{ ui_oauth_user_scope }}",
+        "clientSecret": "{{ ui_oauth_secret }}"
+{% endif %}
+      }
+    }

--- a/operator/roles/forkliftcontroller/templates/configmap-validation.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/configmap-validation.yml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ validation_configmap_name }}
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+    service: {{ validation_service_name }}

--- a/operator/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -1,0 +1,216 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ app_name }}
+    control-plane: forklift-operator
+    controller-tools.k8s.io: "1.0"
+  name: {{ controller_deployment_name }}
+  namespace: {{ app_namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ app_name }}
+      control-plane: forklift-operator
+      controller-tools.k8s.io: "1.0"
+  serviceName: {{ controller_service_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_name }}
+        control-plane: forklift-operator
+        controller-tools.k8s.io: "1.0"
+      annotations:
+        configHash: "{{ (inventory_volume_path | string) }}"
+    spec:
+      serviceAccountName: {{ controller_service_name }}
+      containers:
+      - name: main
+        command:
+        - /usr/local/bin/manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ROLE
+          value: main
+        - name: API_HOST
+          value: {{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local
+        - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
+          value: "v1"
+        - name: VIRT_V2V_IMAGE
+          value: {{ virt_v2v_image_fqin }}
+{% if inventory_tls_enabled|bool %}
+        - name: API_PORT
+          value: "8443"
+        - name: API_TLS_ENABLED
+          value: "true"
+{% else %}
+        - name: API_PORT
+          value: "8080"
+        - name: API_TLS_ENABLED
+          value: "false"
+{% endif %}
+        - name: METRICS_PORT
+          value: '8081'
+        - name: SECRET_NAME
+          value: webhook-server-secret
+{% if controller_log_level is defined and controller_log_level is number %}
+        - name: LOG_LEVEL
+          value: "{{ controller_log_level }}"
+{% endif %}
+{% if controller_precopy_interval is number %}
+        - name: PRECOPY_INTERVAL
+          value: "{{ controller_precopy_interval }}"
+{% endif %}
+{% if controller_max_vm_inflight is number %}
+        - name: MAX_VM_INFLIGHT
+          value: "{{ controller_max_vm_inflight }}"
+{% endif %}
+{% if controller_vsphere_incremental_backup|bool %}
+        - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
+          value: "true"
+{% endif %}
+{% if controller_ovirt_warm_migration|bool %}
+        - name: FEATURE_OVIRT_WARM_MIGRATION
+          value: "true"
+{% endif %}
+{% if controller_profile_kind is defined and controller_profile_path is defined and controller_profile_duration is defined %}
+        - name: PROFILE_KIND
+          value: "{{ controller_profile_kind }}"
+        - name: PROFILE_PATH
+          value: "{{ controller_profile_path }}/main"
+        - name: PROFILE_DURATION
+          value: "{{ controller_profile_duration }}"
+{% endif %}
+        envFrom:
+        - configMapRef:
+            name: {{ controller_configmap_name }}
+        image: {{ controller_image_fqin }}
+        imagePullPolicy: {{ image_pull_policy }}
+        ports:
+        - containerPort: 9876
+          name: webhook-server
+          protocol: TCP
+        resources:
+          limits:
+            cpu: {{ controller_container_limits_cpu }}
+            memory: {{ controller_container_limits_memory }}
+          requests:
+            cpu: {{ controller_container_requests_cpu }}
+            memory: {{ controller_container_requests_memory }}
+        volumeMounts:
+        - mountPath: /tmp/cert
+          name: cert
+          readOnly: true
+        - mountPath: {{ profiler_volume_path }}
+          name: profiler
+      - name: inventory
+        command:
+        - /usr/local/bin/manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ROLE
+          value: inventory
+        - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
+          value: "v1"
+        - name: AUTH_REQUIRED
+          value: '{{ feature_auth_required|lower }}'
+{% if inventory_tls_enabled|bool %}
+        - name: API_PORT
+          value: "8443"
+        - name: API_TLS_ENABLED
+          value: "true"
+        - name: API_TLS_CERTIFICATE
+          value: "/var/run/secrets/{{ inventory_tls_secret_name }}/tls.crt"
+        - name: API_TLS_KEY
+          value: /var/run/secrets/{{ inventory_tls_secret_name }}/tls.key
+{% else %}
+        - name: API_PORT
+          value: "8080"
+        - name: API_TLS_ENABLED
+          value: "false"
+{% endif %}
+        - name: METRICS_PORT
+          value: '8082'
+        - name: SECRET_NAME
+          value: webhook-server-secret
+{% if feature_validation|bool and validation_tls_enabled|bool %}
+        - name: POLICY_AGENT_URL
+          value: "https://{{ validation_service_name }}.{{ app_namespace }}.svc.cluster.local:8181"
+        - name: POLICY_AGENT_CA
+          value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+{% else %}
+        - name: POLICY_AGENT_URL
+          value: "http://{{ validation_service_name }}.{{ app_namespace }}.svc.cluster.local:8181"
+        - name: POLICY_AGENT_CA
+          value: ""
+{% endif %}
+{% if feature_validation|bool %}
+        - name: POLICY_AGENT_SEARCH_INTERVAL
+          value: "{{ validation_policy_agent_search_interval }}"
+{% endif %}
+{% if controller_log_level is defined and controller_log_level is number %}
+        - name: LOG_LEVEL
+          value: "{{ controller_log_level }}"
+{% endif %}
+{% if controller_profile_kind is defined and controller_profile_path is defined and controller_profile_duration is defined %}
+        - name: PROFILE_KIND
+          value: "{{ controller_profile_kind }}"
+        - name: PROFILE_PATH
+          value: "{{ controller_profile_path }}/inventory"
+        - name: PROFILE_DURATION
+          value: "{{ controller_profile_duration }}"
+{% endif %}
+        envFrom:
+        - configMapRef:
+            name: {{ controller_configmap_name }}
+        image: {{ controller_image_fqin }}
+        imagePullPolicy: {{ image_pull_policy }}
+        ports:
+{% if inventory_tls_enabled|bool %}
+        - name: api
+          containerPort: 8443
+          protocol: TCP
+{% else %}
+        - name: api
+          containerPort: 8080
+          protocol: TCP
+{% endif %}
+        resources:
+          limits:
+            cpu: {{ inventory_container_limits_cpu }}
+            memory: {{ inventory_container_limits_memory }}
+          requests:
+            cpu: {{ inventory_container_requests_cpu }}
+            memory: {{ inventory_container_requests_memory }}
+        volumeMounts:
+        - mountPath: {{ inventory_volume_path }}
+          name: inventory
+        - mountPath: {{ profiler_volume_path }}
+          name: profiler
+{% if inventory_tls_enabled|bool %}
+        - mountPath: /var/run/secrets/{{ inventory_tls_secret_name }}
+          name: {{ inventory_service_name }}-serving-cert
+{% endif %}
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-secret
+{% if inventory_tls_enabled|bool %}
+      - name: {{ inventory_tls_secret_name }}
+        secret:
+          defaultMode: 420
+          secretName: {{ inventory_tls_secret_name }}
+{% endif %}
+      - name: inventory
+        emptyDir: {}
+      - name: profiler
+        emptyDir: {}

--- a/operator/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
@@ -1,0 +1,85 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ must_gather_api_deployment_name }}
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+    service: {{ must_gather_api_service_name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ app_name }}
+      service: {{ must_gather_api_service_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_name }}
+        service: {{ must_gather_api_service_name }}
+    spec:
+      containers:
+        - name: {{ must_gather_api_container_name }}
+          image: {{ must_gather_api_image_fqin }}
+          imagePullPolicy: {{ image_pull_policy }}
+          ports:
+{% if must_gather_api_tls_enabled|bool %}
+          - name: api
+            containerPort: 8443
+            protocol: TCP
+{% else %}
+          - name: api
+            containerPort: 8080
+            protocol: TCP
+{% endif %}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+{% if must_gather_api_tls_enabled|bool %}
+            - name: PORT
+              value: "8443"
+            - name: API_TLS_ENABLED
+              value: "true"
+            - name: API_TLS_CERTIFICATE
+              value: "/var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.crt"
+            - name: API_TLS_KEY
+              value: "/var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.key"
+{% else %}
+            - name: PORT
+              value: "8080"
+            - name: API_TLS_ENABLED
+              value: "false"
+{% endif %}
+            - name: DB_PATH
+              value: "{{ must_gather_api_db_path }}"
+            - name: CLEANUP_MAX_AGE
+              value: "{{ must_gather_api_cleanup_max_age }}"
+            - name: MUST_GATHER_IMAGE
+              value: "{{ must_gather_image_fqin }}"
+{% if must_gather_api_debug|bool %}
+            - name: DEBUG
+              value: "true"
+{% endif %}
+          resources:
+            limits:
+              cpu: {{ must_gather_api_container_limits_cpu }}
+              memory: {{ must_gather_api_container_limits_memory }}
+            requests:
+              cpu: {{ must_gather_api_container_requests_cpu }}
+              memory: {{ must_gather_api_container_requests_memory }}
+          volumeMounts:
+{% if must_gather_api_tls_enabled|bool %}
+            - name: {{ must_gather_api_tls_secret_name }}
+              mountPath: /var/run/secrets/{{ must_gather_api_tls_secret_name }}
+{% endif %}
+      volumes:
+{% if must_gather_api_tls_enabled|bool %}
+        - name: {{ must_gather_api_tls_secret_name }}
+          secret:
+            secretName: {{ must_gather_api_tls_secret_name }}
+            defaultMode: 420
+{% endif %}

--- a/operator/roles/forkliftcontroller/templates/deployment-ui.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/deployment-ui.yml.j2
@@ -1,0 +1,95 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ ui_deployment_name }}
+  namespace: "{{ app_namespace }}"
+  labels:
+    app: {{ app_name }}
+    service: {{ ui_service_name }}
+spec:
+  selector:
+     matchLabels:
+       app: {{ app_name }}
+       service: {{ ui_service_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_name }}
+        service: {{ ui_service_name }}
+    spec:
+      containers:
+        - name: {{ ui_container_name }}
+          image: "{{ ui_image_fqin }}"
+          imagePullPolicy: "{{ image_pull_policy }}"
+          env:
+            - name: AUTH_REQUIRED
+              value: '{{ feature_auth_required|lower }}'
+            - name: META_FILE
+              value: {{ ui_configmap_path }}/{{ ui_meta_file_name }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: {{ ui_node_extra_ca_certs }}
+            - name: FORKLIFT_OPERATOR_VERSION
+              value: {{ forklift_operator_version }}
+{% if k8s_cluster|bool %}
+            - name: FORKLIFT_CLUSTER_VERSION
+              value: "{{ k8s_cluster_version }}"
+{% else %}
+            - name: FORKLIFT_CLUSTER_VERSION
+              value: "{{ forklift_cluster_version }}"
+{% endif %}
+{% if ui_tls_enabled|bool %}
+            - name: UI_TLS_ENABLED
+              value: 'true'
+            - name: UI_TLS_CERTIFICATE
+              value: "/var/run/secrets/{{ ui_tls_secret_name }}/tls.crt"
+            - name: UI_TLS_KEY
+              value: "/var/run/secrets/{{ ui_tls_secret_name }}/tls.key"
+{% else %}
+            - name: UI_TLS_ENABLED
+              value: 'false'
+{% endif %}
+          ports:
+{% if ui_tls_enabled|bool %}
+            - containerPort: 8443
+{% else %}
+            - containerPort: 8080
+{% endif %}
+              protocol: TCP
+          resources:
+            limits:
+              cpu: {{ ui_container_limits_cpu }}
+              memory: {{ ui_container_limits_memory }}
+            requests:
+              cpu: {{ ui_container_requests_cpu }}
+              memory: {{ ui_container_requests_memory }}
+          volumeMounts:
+            - name: "{{ ui_configmap_name }}"
+              mountPath: "{{ ui_configmap_path }}"
+{% if ui_tls_enabled|bool %}
+            - name: "{{ ui_tls_secret_name }}"
+              mountPath: "/var/run/secrets/{{ ui_tls_secret_name }}"
+{% endif %}
+{% if trusted_ca_enabled is defined and trusted_ca_enabled|bool %}
+            - name: trusted-ca
+              mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
+{% endif %}
+      volumes:
+        - name: "{{ ui_configmap_name }}"
+          configMap:
+            name: "{{ ui_configmap_name }}"
+{% if ui_tls_enabled|bool %}
+        - name: "{{ ui_tls_secret_name }}"
+          secret:
+            defaultMode: 420
+            secretName: "{{ ui_tls_secret_name }}"
+{% endif %}
+{% if trusted_ca_enabled is defined and trusted_ca_enabled|bool %}
+        - name: trusted-ca
+          configMap:
+            name: trusted-ca
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem
+{% endif %}

--- a/operator/roles/forkliftcontroller/templates/deployment-validation.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/deployment-validation.yml.j2
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ validation_deployment_name }}
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+    service: {{ validation_service_name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ app_name }}
+      service: {{ validation_service_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_name }}
+        service: {{ validation_service_name }}
+    spec:
+      containers:
+        - name: {{ validation_container_name }}
+          image: {{ validation_image_fqin }}
+          imagePullPolicy: {{ image_pull_policy }}
+          ports:
+            - name: opa
+              containerPort: 8181
+          resources:
+            limits:
+              cpu: {{ validation_container_limits_cpu }}
+              memory: {{ validation_container_limits_memory }}
+            requests:
+              cpu: {{ validation_container_requests_cpu }}
+              memory: {{ validation_container_requests_memory }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: INVENTORY_SERVICE
+              value: {{ inventory_service_name }}
+{% if validation_tls_enabled|bool %}
+            - name: TLS_ENABLED
+              value: 'true'
+            - name: TLS_CERT_FILE
+              value: /var/run/secrets/{{ validation_tls_secret_name }}/tls.crt
+            - name: TLS_KEY_FILE
+              value: /var/run/secrets/{{ validation_tls_secret_name }}/tls.key
+            - name: CA_TLS_CERTIFICATE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+{% else %}
+            - name: TLS_ENABLED
+              value: 'false'
+{% endif %}
+          volumeMounts:
+            - name: {{ validation_extra_volume_name }}
+              mountPath: {{ validation_extra_volume_mountpath }}
+{% if validation_tls_enabled|bool %}
+            - name: {{ validation_tls_secret_name }}
+              mountPath: /var/run/secrets/{{ validation_tls_secret_name }}
+{% endif %}
+      volumes:
+        - name: {{ validation_extra_volume_name }}
+          configMap:
+            name: {{ validation_configmap_name }}
+{% if validation_tls_enabled|bool %}
+        - name: {{ validation_tls_secret_name }}
+          secret:
+            secretName: {{ validation_tls_secret_name }}
+            defaultMode: 420
+{% endif %}

--- a/operator/roles/forkliftcontroller/templates/oauthclient-ui.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/oauthclient-ui.yml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: {{ ui_service_name }}
+  namespace: "{{ app_namespace }}"
+grantMethod: auto
+redirectURIs:
+- "https://{{ ui_route_fqdn }}/login/callback"
+secret: "{{ ui_oauth_secret }}"

--- a/operator/roles/forkliftcontroller/templates/provider-host.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/provider-host.yml.j2
@@ -1,0 +1,10 @@
+---
+kind: Provider
+apiVersion: forklift.konveyor.io/v1beta1
+metadata:
+  name: host
+  namespace: {{ app_namespace }}
+spec:
+  type: openshift
+  secret: {}
+  url: ""

--- a/operator/roles/forkliftcontroller/templates/route-inventory.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/route-inventory.yml.j2
@@ -1,0 +1,20 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ inventory_route_name }}
+  namespace: {{ app_namespace }}
+  labels:
+    control-plane: forklift-operator
+    controller-tools.k8s.io: "1.0"
+    app: {{ app_name }}
+    service: {{ inventory_service_name }}
+spec:
+  to:
+    kind: Service
+    name: {{ inventory_service_name }}
+{% if inventory_tls_enabled|bool %}
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+{% endif %}

--- a/operator/roles/forkliftcontroller/templates/route-ui.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/route-ui.yml.j2
@@ -1,0 +1,20 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: 300s
+  name: "{{ ui_route_name }}"
+  namespace: "{{ app_namespace }}"
+  labels:
+    app: {{ app_name }}
+    service: {{ ui_service_name }}
+spec:
+  to:
+    kind: Service
+    name: {{ ui_service_name }}
+{% if ui_tls_enabled|bool %}
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+{% endif %}

--- a/operator/roles/forkliftcontroller/templates/secret-webhook-server-secret.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/secret-webhook-server-secret.yml.j2
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-server-secret
+  namespace: {{ app_namespace }}

--- a/operator/roles/forkliftcontroller/templates/service-inventory.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/service-inventory.yml.j2
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ inventory_tls_secret_name }}
+  labels:
+    app: {{ app_name }}
+    service: {{ inventory_service_name }}
+    control-plane: forklift-operator
+    controller-tools.k8s.io: "1.0"
+  name: {{ inventory_service_name }}
+  namespace: {{ app_namespace }}
+spec:
+  ports:
+{% if inventory_tls_enabled|bool %}
+  - name: api-https
+    port: 8443
+    targetPort: 8443
+    protocol: TCP
+{% else %}
+  - name: api-http
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+{% endif %}
+  selector:
+    control-plane: forklift-operator
+    controller-tools.k8s.io: "1.0"

--- a/operator/roles/forkliftcontroller/templates/service-must-gather-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/service-must-gather-api.yml.j2
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ must_gather_api_tls_secret_name }}
+  name: {{ must_gather_api_service_name }}
+  namespace: "{{ app_namespace }}"
+  labels:
+    app: {{ app_name }}
+    service: {{ must_gather_api_service_name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ app_name }}
+    service: {{ must_gather_api_service_name }}
+  ports:
+{% if must_gather_api_tls_enabled|bool %}
+  - name: api-https
+    port: 8443
+    targetPort: 8443
+    protocol: TCP
+{% else %}
+  - name: api-http
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+{% endif %}

--- a/operator/roles/forkliftcontroller/templates/service-ui.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/service-ui.yml.j2
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ ui_tls_secret_name }}
+  name: {{ ui_service_name }}
+  namespace: "{{ app_namespace }}"
+  labels:
+    app: {{ app_name }}
+    service: {{ ui_service_name }}
+spec:
+  ports:
+{% if ui_tls_enabled|bool %}
+    - name: ui-https
+      port: 8443
+      targetPort: 8443
+      protocol: TCP
+{% else %}
+    - name: ui-http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+{% endif %}
+  selector:
+    app: {{ app_name }}
+    service: {{ ui_service_name }}

--- a/operator/roles/forkliftcontroller/templates/service-validation.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/service-validation.yml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ validation_tls_secret_name }}
+  name: {{ validation_service_name }}
+  namespace: "{{ app_namespace }}"
+  labels:
+    app: {{ app_name }}
+    service: {{ validation_service_name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ app_name }}
+    service: {{ validation_service_name }}
+  ports:
+    - name: opa
+      port: 8181
+      targetPort: 8181
+      protocol: TCP

--- a/operator/watches.yaml
+++ b/operator/watches.yaml
@@ -1,0 +1,7 @@
+---
+# Use the 'create api' subcommand to add watches to this file.
+- version: v1beta1
+  group: forklift.konveyor.io
+  kind: ForkliftController
+  role: forkliftcontroller
+#+kubebuilder:scaffold:watch


### PR DESCRIPTION
This patch changes the build processes to the bazel tool, because of it we need to change the behavior of the builds.

Adding the environment variables for customizing the build process.

The step-by-step description of builds:

Operator build:
- Build the operator image with ansible dependencies and with roles. 

Bundle build:
- Change to the operator dir
- Get the current date with which the operator will be built
- Build the config files with kustomize
- Substitute env variables in the generated config
- Generate the bundle from the config
- Build the image with the bundle

Index build:
- Substitute env variables in catalog/operator.yml
- Append the bundle render to the catalog/operator.yml
- Build the opm image which serves generated catalog

This is not pure forklift-operator migration this patch also contains changes from https://github.com/konveyor/forklift-operator/pull/250. The 250 PR was added for the split configuration instead of one large CSV with multiple scripts.