### PR TITLE
Fix unit test for vm name change

### DIFF
--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -17,6 +17,6 @@ func TestKubevirt(t *testing.T) {
 
 	//Test the case that the VM name is empty after all removals
 	emptyVM := ".__."
-	newVmNameFromId := "vm-1234-5678"
+	newVmNameFromId := "vm-1234"
 	g.Expect(changeVmName(emptyVM, id)).To(gomega.Equal(newVmNameFromId))
 }


### PR DESCRIPTION
changing the VM test name to match the final auto-generated name convention.