### PR TITLE
Bazel: Set opa version in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3401,8 +3401,8 @@ http_file(
     name = "opa",
     downloaded_file_path = "opa",
     executable = True,
-    sha256 = "914453ebcc76781371ca27dd61086967ed5e0032e42ba85826ee77c9bca84659",
-    urls = ["https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static"],
+    sha256 = "5ddb21d3fcfca130a47a42e730c05f055c68af6c1b37465879f6c59b10527eae",
+    urls = ["https://openpolicyagent.org/downloads/v0.44.0/opa_linux_amd64_static"],
 )
 
 http_archive(


### PR DESCRIPTION
Once the opa releases new version the latest binary will not have matching hash and it would cause ci failure.