### PR TITLE
Add phase status

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .spec.type
       name: TYPE
       type: string
+    - jsonPath: .status.phase
+      name: STATUS
+      type: string
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: READY
       type: string
@@ -152,6 +155,9 @@ spec:
                 description: The most recent generation observed by the controller.
                 format: int64
                 type: integer
+              phase:
+                description: Current life cycle phase of the provider.
+                type: string
             type: object
         type: object
     served: true

--- a/pkg/apis/forklift/v1beta1/provider.go
+++ b/pkg/apis/forklift/v1beta1/provider.go
@@ -75,6 +75,9 @@ type ProviderSpec struct {
 //
 // ProviderStatus defines the observed state of Provider
 type ProviderStatus struct {
+	// Current life cycle phase of the provider.
+	// +optional
+	Phase string `json:"phase,omitempty"`
 	// Conditions.
 	libcnd.Conditions `json:",inline"`
 	// The most recent generation observed by the controller.
@@ -88,6 +91,7 @@ type ProviderStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="TYPE",type="string",JSONPath=".spec.type"
+// +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="READY",type=string,JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="CONNECTED",type=string,JSONPath=".status.conditions[?(@.type=='ConnectionTestSucceeded')].status"
 // +kubebuilder:printcolumn:name="INVENTORY",type=string,JSONPath=".status.conditions[?(@.type=='InventoryCreated')].status"

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -18,6 +18,10 @@ package provider
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"sync"
+
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libfb "github.com/konveyor/controller/pkg/filebacked"
@@ -36,15 +40,12 @@ import (
 	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/storage/names"
-	"os"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"sync"
 )
 
 const (
@@ -180,6 +181,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	}
 
 	// Begin staging conditions.
+	provider.Status.Phase = Staging
 	provider.Status.BeginStagingConditions()
 
 	// Validations.
@@ -197,6 +199,7 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 	// Ready condition.
 	if !provider.Status.HasBlockerCondition() &&
 		provider.Status.HasCondition(ConnectionTestSucceeded, InventoryCreated) {
+		provider.Status.Phase = Ready
 		provider.Status.SetCondition(
 			libcnd.Condition{
 				Type:     libcnd.Ready,


### PR DESCRIPTION
Add phase status to Ptoviders CRD.

K8S resources uses `status.phase` fields to help users follow the resources life cycle from creation to deletion.
the `phase` helps users to easily catch resource that stray into sad paths or get stuck.
`phase`s do not replace `conditions`, `conditions` role is to report the state of the resource while `phase` report the place of the resource during it's life voyage.
Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/

Issue:
The UI want to show the resource stage in it's life cycle as a way to help users easily glance the happiness of there cluster. Currently providers only report it's `conditions`, and require the users to guess the stage of the providers using this conditions.

Proposed solution:
Add `phase` field to the providers status.

Screenshot:
![mtv-phase](https://user-images.githubusercontent.com/2181522/191707819-de32fb0b-fbfc-4ecb-ad4e-1e5748307bb3.gif)

