### PR TITLE
Switch to EFI without secure boot

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -23,6 +23,7 @@ import (
 const (
 	ClusterDefault = "cluster_default"
 	Q35Ovmf        = "q35_ovmf"
+	Q35SecureBoot  = "q35_secure_boot"
 )
 
 // Bus types
@@ -379,12 +380,12 @@ func (r *Builder) mapFirmware(vm *model.Workload, cluster *model.Cluster, object
 		Serial: serial,
 	}
 	switch biosType {
-	case Q35Ovmf:
-		smmEnabled := true
-		features.SMM = &cnv.FeatureState{
-			Enabled: &smmEnabled,
-		}
-		firmware.Bootloader = &cnv.Bootloader{EFI: &cnv.EFI{}}
+	case Q35Ovmf, Q35SecureBoot:
+		secureBootEnabled := false
+		firmware.Bootloader = &cnv.Bootloader{
+			EFI: &cnv.EFI{
+				SecureBoot: &secureBootEnabled,
+			}}
 	default:
 		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -454,11 +454,11 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	}
 	switch vm.Firmware {
 	case Efi:
-		smmEnabled := true
-		features.SMM = &cnv.FeatureState{
-			Enabled: &smmEnabled,
-		}
-		firmware.Bootloader = &cnv.Bootloader{EFI: &cnv.EFI{}}
+		secureBootEnabled := false
+		firmware.Bootloader = &cnv.Bootloader{
+			EFI: &cnv.EFI{
+				SecureBoot: &secureBootEnabled,
+			}}
 	default:
 		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	}

--- a/validation/policies/io/konveyor/forklift/vmware/uefi_boot.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/uefi_boot.rego
@@ -8,7 +8,7 @@ concerns[flag] {
     has_uefi_boot
     flag := {
         "category": "Warning",
-        "label": "UEFI secure boot detected",
-        "assessment": "UEFI secure boot is enabled. NVRAM data is not copied during the migration and thus the VM might not boot on OpenShift Virtualization."
+        "label": "UEFI detected",
+        "assessment": "UEFI secure boot will be disabled on Openshift Virtualization. If the VM was set with UEFI secure boot, manual steps within the guest would be needed for the guest operating system to boot."
     }
 }


### PR DESCRIPTION
Since we can't transfer NVRAM or TPM data, it is better to have EFI VMs without secure boot.