### PR TITLE
Add UI plugin to operator

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,7 +10,7 @@ build --action_env=CONTROLLER_IMAGE=quay.io/konveyor/forklift-controller:latest
 build --action_env=MUST_GATHER_IMAGE=quay.io/konveyor/forklift-must-gather:latest
 build --action_env=MUST_GATHER_API_IMAGE=quay.io/konveyor/forklift-must-gather-api:latest
 build --action_env=UI_IMAGE=quay.io/konveyor/forklift-ui:latest
-build --action_env=UI_PLUGIN_IMAGE=quay.io/kubevirt-ui/forklift-console-plugin:latest
+build --action_env=UI_PLUGIN_IMAGE=quay.io/kubev2v/forklift-console-plugin:latest
 build --action_env=VALIDATION_IMAGE=quay.io/konveyor/forklift-validation:latest
 build --action_env=VIRT_V2V_IMAGE=quay.io/konveyor/forklift-virt-v2v:latest
 build --action_env=OPERATOR_IMAGE=quay.io/konveyor/forklift-operator:latest

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,7 @@ build --action_env=CONTROLLER_IMAGE=quay.io/konveyor/forklift-controller:latest
 build --action_env=MUST_GATHER_IMAGE=quay.io/konveyor/forklift-must-gather:latest
 build --action_env=MUST_GATHER_API_IMAGE=quay.io/konveyor/forklift-must-gather-api:latest
 build --action_env=UI_IMAGE=quay.io/konveyor/forklift-ui:latest
+build --action_env=UI_PLUGIN_IMAGE=quay.io/kubevirt-ui/forklift-console-plugin:latest
 build --action_env=VALIDATION_IMAGE=quay.io/konveyor/forklift-validation:latest
 build --action_env=VIRT_V2V_IMAGE=quay.io/konveyor/forklift-virt-v2v:latest
 build --action_env=OPERATOR_IMAGE=quay.io/konveyor/forklift-operator:latest

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Another option to override the default values can use `--action_env` as in the e
 | MUST_GATHER_IMAGE     | quay.io/konveyor/forklift-must-gather:latest     | The forklift must gather an image.                          |
 | MUST_GATHER_API_IMAGE | quay.io/konveyor/forklift-must-gather-api:latest | The forklift must gather image api.                         |
 | UI_IMAGE              | quay.io/konveyor/forklift-ui:latest              | The forklift UI image.                                      |
+| UI_PLUGIN_IMAGE       | quay.io/kubevirt-ui/forklift-console-plugin:latest | The forklift UI plugin image.                                      |
 | VALIDATION_IMAGE      | quay.io/konveyor/forklift-validation:latest      | The forklift validation image.                              |
 | VIRT_V2V_IMAGE        | quay.io/konveyor/forklift-virt-v2v:latest        | The forklift virt v2v image.                                |
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Another option to override the default values can use `--action_env` as in the e
 | MUST_GATHER_IMAGE     | quay.io/konveyor/forklift-must-gather:latest     | The forklift must gather an image.                          |
 | MUST_GATHER_API_IMAGE | quay.io/konveyor/forklift-must-gather-api:latest | The forklift must gather image api.                         |
 | UI_IMAGE              | quay.io/konveyor/forklift-ui:latest              | The forklift UI image.                                      |
-| UI_PLUGIN_IMAGE       | quay.io/kubevirt-ui/forklift-console-plugin:latest | The forklift UI plugin image.                                      |
+| UI_PLUGIN_IMAGE       | quay.io/kubevirt-ui/forklift-console-plugin:latest | The forklift OKD/OpenShift UI plugin image.                                      |
 | VALIDATION_IMAGE      | quay.io/konveyor/forklift-validation:latest      | The forklift validation image.                              |
 | VIRT_V2V_IMAGE        | quay.io/konveyor/forklift-virt-v2v:latest        | The forklift virt v2v image.                                |
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Another option to override the default values can use `--action_env` as in the e
 | MUST_GATHER_IMAGE     | quay.io/konveyor/forklift-must-gather:latest     | The forklift must gather an image.                          |
 | MUST_GATHER_API_IMAGE | quay.io/konveyor/forklift-must-gather-api:latest | The forklift must gather image api.                         |
 | UI_IMAGE              | quay.io/konveyor/forklift-ui:latest              | The forklift UI image.                                      |
-| UI_PLUGIN_IMAGE       | quay.io/kubevirt-ui/forklift-console-plugin:latest | The forklift OKD/OpenShift UI plugin image.                                      |
+| UI_PLUGIN_IMAGE       | quay.io/kubev2v/forklift-console-plugin:latest   | The forklift OKD/OpenShift UI plugin image.                                      |
 | VALIDATION_IMAGE      | quay.io/konveyor/forklift-validation:latest      | The forklift validation image.                              |
 | VIRT_V2V_IMAGE        | quay.io/konveyor/forklift-virt-v2v:latest        | The forklift virt v2v image.                                |
 

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -46,6 +46,8 @@ spec:
           value: ${MUST_GATHER_API_IMAGE}
         - name: UI_IMAGE
           value: ${UI_IMAGE}
+        - name: UI_PLUGIN_IMAGE
+          value: ${UI_PLUGIN_IMAGE}
         - name: VALIDATION_IMAGE
           value: ${VALIDATION_IMAGE}
         - name: VIRT_V2V_IMAGE

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -19,6 +19,7 @@ metadata:
         },
         "spec": {
           "feature_ui": "true",
+          "feature_ui_plugin": "true",
           "feature_validation": "true",
           "feature_must_gather_api": "true"
         }

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -31,3 +31,19 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleplugins
+  verbs:
+  - '*'
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - consoles
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/operator/config/samples/forklift_v1beta1_forkliftcontroller.yaml
+++ b/operator/config/samples/forklift_v1beta1_forkliftcontroller.yaml
@@ -6,5 +6,6 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   feature_ui: 'true'
+  feature_ui_plugin: 'true'
   feature_validation: 'true'
   feature_must_gather_api: 'true'

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -78,6 +78,16 @@ ui_meta_file_name: "meta.json"
 ui_node_extra_ca_certs: "/opt/app-root/src/ca.crt"
 ui_state: absent
 
+ui_plugin_image_fqin: "{{ lookup( 'env', 'UI_PLUGIN_IMAGE') }}"
+ui_plugin_console_name: "{{ app_name }}-console-plugin"
+ui_plugin_service_name: "{{ app_name }}-ui-plugin"
+ui_plugin_deployment_name: "{{ ui_plugin_service_name }}"
+ui_plugin_container_name: "{{ app_name }}-ui-plugin"
+ui_plugin_container_limits_cpu: "100m"
+ui_plugin_container_limits_memory: "800Mi"
+ui_plugin_container_requests_cpu: "100m"
+ui_plugin_container_requests_memory: "150Mi"
+
 must_gather_api_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_API_IMAGE') or lookup( 'env', 'RELATED_IMAGE_MUST_GATHER_API') }}"
 must_gather_api_service_name: "{{ app_name }}-must-gather-api"
 must_gather_api_deployment_name: "{{ must_gather_api_service_name }}"

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -188,6 +188,38 @@
         state: "{{ ui_state }}"
         definition: "{{ lookup('template', 'deployment-ui.yml.j2') }}"
 
+  - when: feature_ui_plugin|bool and not k8s_cluster|bool
+    block:
+
+    - name: "Setup UI configmap"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'ui-plugin/configmap-ui-plugin.yml.j2') }}"
+
+    - name: "Setup UI plugin service"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'ui-plugin/service-ui-plugin.yml.j2') }}"
+
+    - name: "Setup UI plugin deployment"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'ui-plugin/deployment-ui-plugin.yml.j2') }}"
+
+    - name: "Setup console plugin"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'ui-plugin/console-plugin.yml.j2') }}"
+
+  - when: not feature_ui_plugin|bool
+    name: "Cleanup {{ ui_plugin_service_name }} if disabled"
+    include_tasks: cleanup.yml
+    loop: "{{ forklift_resources }}"
+    loop_control:
+      loop_var: resource_kind
+    vars:
+      feature_label: "{{ ui_plugin_service_name }}"
+
   - when: not feature_ui|bool
     name: "Cleanup {{ ui_service_name }} if disabled"
     include_tasks: cleanup.yml

--- a/operator/roles/forkliftcontroller/templates/ui-plugin/configmap-ui-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/configmap-ui-plugin.yml.j2
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ app_name }}
+    service: {{ ui_plugin_service_name }}
+  name: nginx-conf
+  namespace: "{{ app_namespace }}"
+data:
+  nginx.conf: |
+    error_log /dev/stdout info;
+    events {}
+    http {
+      access_log         /dev/stdout;
+      include            /etc/nginx/mime.types;
+      default_type       application/octet-stream;
+      keepalive_timeout  65;
+      server {
+        listen              9443 ssl;
+        ssl_certificate     /var/serving-cert/tls.crt;
+        ssl_certificate_key /var/serving-cert/tls.key;
+        root                /opt/app-root/src;
+      }
+    }

--- a/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
@@ -1,0 +1,29 @@
+---
+apiVersion: console.openshift.io/v1alpha1
+kind: ConsolePlugin
+metadata:
+  name: {{ ui_plugin_console_name }}
+  annotations:
+    console.openshift.io/use-i18n: "true" 
+spec:
+  displayName: 'Console Plugin Template'
+  service:
+    name: {{ ui_plugin_service_name }}
+    port: 9443
+    basePath: '/'
+    namespace: {{ app_namespace }}
+  proxy:
+    - type: Service
+      alias: {{ inventory_service_name }}
+      authorize: true
+      service:
+        name: {{ inventory_service_name }}
+        namespace: {{ app_namespace }}
+        port: 8443
+    - type: Service
+      alias: {{ must_gather_api_service_name }}
+      authorize: true
+      service:
+        name: {{ must_gather_api_service_name }}
+        namespace: {{ app_namespace }}
+        port: 8443

--- a/operator/roles/forkliftcontroller/templates/ui-plugin/deployment-ui-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/deployment-ui-plugin.yml.j2
@@ -1,0 +1,59 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ ui_plugin_deployment_name }}
+  namespace: "{{ app_namespace }}"
+  labels:
+    app: {{ app_name }}
+    service: {{ ui_plugin_service_name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ app_name }}
+      service: {{ ui_plugin_service_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_name }}
+        service: {{ ui_plugin_service_name }}
+    spec:
+      containers:
+        - name: "{{ ui_plugin_container_name }}"
+          image: "{{ ui_plugin_image_fqin }}"
+          ports:
+            - containerPort: 9443
+              protocol: TCP
+          imagePullPolicy: "{{ image_pull_policy }}"
+          resources:
+            limits:
+              cpu: "{{ ui_plugin_container_limits_cpu }}"
+              memory: "{{ ui_plugin_container_limits_memory }}"
+            requests:
+              cpu: "{{ ui_plugin_container_requests_cpu }}"
+              memory: "{{ ui_plugin_container_requests_memory }}"
+          volumeMounts:
+            - name: plugin-serving-cert
+              readOnly: true
+              mountPath: /var/serving-cert
+            - name: nginx-conf
+              readOnly: true
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
+        - name: plugin-serving-cert
+          secret:
+            secretName: plugin-serving-cert
+            defaultMode: 420
+        - name: nginx-conf
+          configMap:
+            name: nginx-conf
+            defaultMode: 420
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%

--- a/operator/roles/forkliftcontroller/templates/ui-plugin/service-ui-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/service-ui-plugin.yml.j2
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: plugin-serving-cert
+  name: {{ ui_plugin_service_name }}
+  namespace: "{{ app_namespace }}"
+  labels:
+    app: {{ app_name }}
+    service: {{ ui_plugin_service_name }}
+spec:
+  ports:
+    - name: 9443-tcp
+      protocol: TCP
+      port: 9443
+      targetPort: 9443
+  selector:
+    app: {{ app_name }}
+    service: {{ ui_plugin_service_name }}
+  type: ClusterIP
+  sessionAffinity: None


### PR DESCRIPTION
Add forklift ui plugin from https://github.com/kubev2v/forklift-console-plugin This patch adds to the operator:
- RBAC config so the operator have permission to add the ConsolePlugin
- New parameter `feature_ui_plugin` to enable/disable the plugin installation

The UI plugin installation is made of 4 parts:
- ConfigMap with nginx configuration
- Deployment for the forklift UI plugin itself
- Service
- ConsolePlugin

Results:
![image](https://user-images.githubusercontent.com/18332586/200375670-f6732919-4e1d-4d67-9354-fc4c4ad9c3d3.png)
