### PR TITLE
Add ConnectionAuthFailed for one try auth check

### DIFF
--- a/pkg/controller/provider/container/ovirt/client.go
+++ b/pkg/controller/provider/container/ovirt/client.go
@@ -47,7 +47,7 @@ type ovirtTokenResponse struct {
 
 //
 // Connect.
-func (r *Client) connect() (err error) {
+func (r *Client) connect() (status int, err error) {
 	var TLSClientConfig *tls.Config
 
 	if !r.clientExpiration.IsZero() && time.Now().After(r.clientExpiration) {
@@ -111,7 +111,7 @@ func (r *Client) connect() (err error) {
 
 	response := &ovirtTokenResponse{}
 	url.RawQuery = values.Encode()
-	status, err := client.Get(url.String(), response)
+	status, err = client.Get(url.String(), response)
 	if err != nil {
 		return
 	}
@@ -196,18 +196,14 @@ func (r *Client) get(path string, object interface{}, param ...libweb.Param) (er
 
 //
 // Get system.
-func (r *Client) system() (s *System, err error) {
-	err = r.connect()
+func (r *Client) system() (s *System, status int, err error) {
+	status, err = r.connect()
 	if err != nil {
 		return
 	}
 	system := &System{}
-	status, err := r.client.Get(r.url, system)
+	status, err = r.client.Get(r.url, system)
 	if err != nil {
-		return
-	}
-	if status != http.StatusOK {
-		err = liberr.New(http.StatusText(status))
 		return
 	}
 

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libmodel "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
 	libweb "github.com/konveyor/forklift-controller/pkg/lib/inventory/web"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
-	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
-	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -140,8 +140,8 @@ func (r *Collector) HasParity() bool {
 
 //
 // Test connect/logout.
-func (r *Collector) Test() (err error) {
-	_, err = r.client.system()
+func (r *Collector) Test() (status int, err error) {
+	_, status, err = r.client.system()
 	return
 }
 
@@ -527,5 +527,6 @@ func (r *Collector) listEvent() (list []Event, err error) {
 //
 // Connect.
 func (r *Collector) connect() error {
-	return r.client.connect()
+	_, err := r.client.connect()
+	return err
 }

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
@@ -88,7 +88,7 @@ func (admitter *SecretAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissio
 		}
 	}
 	log.Info("Starting provider connection test")
-	err = collector.Test()
+	_, err = collector.Test()
 	if err != nil {
 		return &admissionv1.AdmissionResponse{
 			Allowed: false,

--- a/pkg/lib/cmd/inventory/main.go
+++ b/pkg/lib/cmd/inventory/main.go
@@ -5,6 +5,12 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"strconv"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	"github.com/konveyor/forklift-controller/pkg/lib/inventory/container"
@@ -12,11 +18,6 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/lib/inventory/web"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
-	"os"
-	"runtime"
-	"strconv"
-	"time"
 )
 
 var log = logging.WithName("TESTER")
@@ -201,8 +202,8 @@ func (r *Collector) HasParity() bool {
 	return true
 }
 
-func (r *Collector) Test() error {
-	return nil
+func (r *Collector) Test() (int, error) {
+	return 0, nil
 }
 
 func (r *Collector) Reset() {

--- a/pkg/lib/inventory/container/container.go
+++ b/pkg/lib/inventory/container/container.go
@@ -1,13 +1,14 @@
 package container
 
 import (
+	"sync"
+
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	"github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
 	"github.com/konveyor/forklift-controller/pkg/lib/ref"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sync"
 )
 
 //
@@ -152,8 +153,9 @@ type Collector interface {
 	HasParity() bool
 	// Get the associated DB.
 	DB() model.DB
-	// Test connection with credentials.
-	Test() error
+	// Return the status code of the connection
+	// 0 = Ignore
+	Test() (int, error)
 	// Reset
 	Reset()
 }

--- a/pkg/lib/inventory/container/ocp/collector.go
+++ b/pkg/lib/inventory/container/ocp/collector.go
@@ -2,6 +2,9 @@ package ocp
 
 import (
 	"context"
+	"path"
+	"time"
+
 	"github.com/go-logr/logr"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libmodel "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
@@ -11,14 +14,12 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"path"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 const (
@@ -136,8 +137,8 @@ func (r *Collector) UpdateThreshold(m libmodel.Model) {
 }
 
 // Test connection with credentials.
-func (r *Collector) Test() error {
-	return r.buildClient()
+func (r *Collector) Test() (int, error) {
+	return 0, r.buildClient()
 }
 
 //


### PR DESCRIPTION
Issue: when a user enters the correct username for the provider but an incorrect password it will try to connect multiple times to the engine. Which locks the user account.
Fix: Adding a special case of condition ConnectionAuthFailed and finishing the reconciliation.

Migrated patches from: https://github.com/konveyor/controller/pull/104 and https://github.com/kubev2v/forklift-controller/pull/447