### PR TITLE
Enable non-admin users to query providers from inventory

### DIFF
--- a/pkg/apis/forklift/v1beta1/register.go
+++ b/pkg/apis/forklift/v1beta1/register.go
@@ -23,6 +23,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
 )
@@ -33,3 +36,19 @@ var SchemeGroupVersion = schema.GroupVersion{
 }
 
 var SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+
+// TODO: find a better place for this, it would be nice to use it also to
+// determine the plural configuration of a resource for the operator
+func GetGroupResource(required runtime.Object) (group string, resource string, err error) {
+
+	switch required.(type) {
+	case *Provider:
+		group = SchemeGroupVersion.Group
+		resource = "providers"
+	default:
+		err = fmt.Errorf("resource type is not known")
+		return
+	}
+
+	return
+}

--- a/pkg/controller/provider/web/base/auth.go
+++ b/pkg/controller/provider/web/base/auth.go
@@ -2,19 +2,20 @@ package base
 
 import (
 	"context"
-	"github.com/gin-gonic/gin"
-	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
-	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
-	auth "k8s.io/api/authentication/v1"
-	auth2 "k8s.io/api/authorization/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"net/http"
 	"path"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	auth "k8s.io/api/authentication/v1"
+	auth2 "k8s.io/api/authorization/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 //
@@ -108,7 +109,7 @@ func (r *Auth) permit(token string, p *api.Provider) (allowed bool, err error) {
 			auth2.ExtraValue{},
 			v...)
 	}
-	ar := &auth2.SubjectAccessReview{
+	review := &auth2.SubjectAccessReview{
 		Spec: auth2.SubjectAccessReviewSpec{
 			ResourceAttributes: &auth2.ResourceAttributes{
 				Group:     gvk.Group,
@@ -123,13 +124,13 @@ func (r *Auth) permit(token string, p *api.Provider) (allowed bool, err error) {
 			UID:    user.UID,
 		},
 	}
-	err = w.Create(context.TODO(), ar)
+	err = w.Create(context.TODO(), review)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
 
-	allowed = ar.Status.Allowed
+	allowed = review.Status.Allowed
 	return
 }
 


### PR DESCRIPTION
Previously, querying '/providers' by users that don't have cluster-admin
permissions failed because the request doesn't specify a UID of a
provider to query and thus, we ended up checking if the user has
permissions on all resources.
    
With this change, we'd always query 'providers.forklift.konveyor.io' for
'get' when a provider is specified and for 'list' otherwise. That way,
all users with ClusterRole on providers.forklift.konveyor.io can access
the data of providers from the inventory.