### PR TITLE
making kvm device for the virt-v2v pod optional

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -118,3 +118,4 @@ must_gather_api_state: absent
 
 must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_MUST_GATHER') }}"
 virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V') }}"
+virt_v2v_dont_request_kvm: "{{ lookup( 'env', 'VIRT_V2V_DONT_REQUEST_KVM') }}"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -167,6 +167,11 @@ spec:
         - name: PROFILE_DURATION
           value: "{{ controller_profile_duration }}"
 {% endif %}
+{% if virt_v2v_dont_request_kvm|bool %}
+        - name: VIRT_V2V_DONT_REQUEST_KVM
+          value: "true"
+{% endif %}
+
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -7,11 +7,12 @@ import (
 
 // Environment variables.
 const (
-	MaxVmInFlight   = "MAX_VM_INFLIGHT"
-	HookRetry       = "HOOK_RETRY"
-	ImporterRetry   = "IMPORTER_RETRY"
-	VirtV2vImage    = "VIRT_V2V_IMAGE"
-	PrecopyInterval = "PRECOPY_INTERVAL"
+	MaxVmInFlight         = "MAX_VM_INFLIGHT"
+	HookRetry             = "HOOK_RETRY"
+	ImporterRetry         = "IMPORTER_RETRY"
+	VirtV2vImage          = "VIRT_V2V_IMAGE"
+	PrecopyInterval       = "PRECOPY_INTERVAL"
+	VirtV2vDontRequestKVM = "VIRT_V2V_DONT_REQUEST_KVM"
 )
 
 // Default virt-v2v image.
@@ -31,6 +32,8 @@ type Migration struct {
 	PrecopyInterval int
 	// Virt-v2v image for guest conversion
 	VirtV2vImage string
+	// Virt-v2v require KVM flags for guest conversion
+	VirtV2vDontRequestKVM bool
 }
 
 // Load settings.
@@ -57,5 +60,6 @@ func (r *Migration) Load() (err error) {
 	} else {
 		r.VirtV2vImage = DefaultVirtV2vImage
 	}
+	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
 	return
 }


### PR DESCRIPTION
we want to be able to run virt-v2v on nodes without KVM capabilities (ci)

