### PR TITLE
Go 1.19

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          # NOTE: Keep the version in sync with Go toolchain in WORKSPACE.
+          go-version: '1.19.3'
 
       # Setup the run environment and run CI test suite
       - name: Run test suite

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3354,7 +3354,8 @@ go_repository(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.16.5")
+# NOTE: Keep the version in sync with Go toolchain in GitHub action.
+go_register_toolchains(version = "1.19.3")
 
 # override rules_docker issue with this dependency
 # rules_docker 0.16 uses 0.1.4, bit since there the checksum changed, which is very weird, going with 0.1.4.1 to

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,19 +2,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb",
+    sha256 = "ae013bf35bd23234d1dea46b079f1e05ba74ac0321423830119d3e787ec73483",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.36.0/rules_go-v0.36.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.36.0/rules_go-v0.36.0.zip",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
     ],
 )
 
@@ -3356,8 +3356,6 @@ go_rules_dependencies()
 
 go_register_toolchains(version = "1.16.5")
 
-gazelle_dependencies()
-
 # override rules_docker issue with this dependency
 # rules_docker 0.16 uses 0.1.4, bit since there the checksum changed, which is very weird, going with 0.1.4.1 to
 go_repository(
@@ -3368,6 +3366,11 @@ go_repository(
     type = "tar.gz",
     urls = ["https://api.github.com/repos/google/go-containerregistry/tarball/efb2d62d93a7705315b841d0544cb5b13565ff2a"],  # v0.1.4.1
 )
+
+# All dependencies defined with go_repository should be above
+# gazelle_dependencies. Otherwise dependencies defined by Gazelle would be used
+# because the first definitions of external repository wins.
+gazelle_dependencies()
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",


### PR DESCRIPTION
In #29 we talked about keeping Go version for Bazel and for CI synchronized, but the patch was somehow merged without a plan how to achieve that. Here we update Bazel and Gazelle so that we can build the project with new Go and finally update Go toolchain to 1.19.3 in both places.