### PR TITLE
plan: store disk source in annotation

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -10,6 +10,13 @@ import (
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
+// Annotations
+const (
+	// Used on DataVolume, contains disk source -- e.g. backing file in
+	// VMware or disk ID in oVirt.
+	AnnDiskSource = "forklift.konveyor.io/disk-source"
+)
+
 // Adapter API.
 // Constructs provider-specific implementations
 // of the Builder, Client, and Validator.
@@ -33,7 +40,7 @@ type Builder interface {
 	// Build the Kubevirt VirtualMachine spec.
 	VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []core.PersistentVolumeClaim) error
 	// Build DataVolumes.
-	DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap) (dvs []cdi.DataVolumeSpec, err error)
+	DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume) (dvs []cdi.DataVolume, err error)
 	// Build tasks.
 	Tasks(vmRef ref.Ref) ([]*planapi.Task, error)
 	// Build template labels.

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/ocp"
@@ -164,7 +165,7 @@ func (r *Builder) Secret(_ ref.Ref, in, object *core.Secret) (err error) {
 }
 
 // Create DataVolume specs for the VM.
-func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap) (dvs []cdi.DataVolumeSpec, err error) {
+func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume) (dvs []cdi.DataVolume, err error) {
 	vm := &model.Workload{}
 	err = r.Source.Inventory.Find(vm, vmRef)
 	if err != nil {
@@ -220,7 +221,14 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 				if mapped.Destination.VolumeMode != "" {
 					dvSpec.Storage.VolumeMode = &mapped.Destination.VolumeMode
 				}
-				dvs = append(dvs, dvSpec)
+
+				dv := dvTemplate.DeepCopy()
+				dv.Spec = dvSpec
+				if dv.ObjectMeta.Annotations == nil {
+					dv.ObjectMeta.Annotations = make(map[string]string)
+				}
+				dv.ObjectMeta.Annotations[planbase.AnnDiskSource] = da.Disk.ID
+				dvs = append(dvs, *dv)
 			}
 		}
 	}
@@ -503,7 +511,7 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 
 // Return a stable identifier for a DataVolume.
 func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
-	return dv.Spec.Source.Imageio.DiskID
+	return dv.ObjectMeta.Annotations[planbase.AnnDiskSource]
 }
 
 // Return a stable identifier for a PersistentDataVolume.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -717,39 +717,35 @@ func (r *KubeVirt) DeleteHookJobs(vm *plan.VMStatus) (err error) {
 }
 
 // Build the DataVolume CRs.
-func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap *core.ConfigMap) (objects []cdi.DataVolume, err error) {
+func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap *core.ConfigMap) (dataVolumes []cdi.DataVolume, err error) {
 	_, err = r.Source.Inventory.VM(&vm.Ref)
 	if err != nil {
 		return
 	}
 
-	dataVolumes, err := r.Builder.DataVolumes(vm.Ref, secret, configMap)
+	annotations := r.vmLabels(vm.Ref)
+	if !r.Plan.Spec.Warm || Settings.RetainPrecopyImporterPods {
+		annotations[AnnRetainAfterCompletion] = "true"
+	}
+	if r.Plan.Spec.TransferNetwork != nil {
+		annotations[AnnDefaultNetwork] = path.Join(
+			r.Plan.Spec.TransferNetwork.Namespace, r.Plan.Spec.TransferNetwork.Name)
+	}
+	// Do not delete the DV when the import completes as we check the DV to get the current
+	// disk transfer status.
+	annotations[AnnDeleteAfterCompletion] = "false"
+	dvTemplate := cdi.DataVolume{
+		ObjectMeta: meta.ObjectMeta{
+			Namespace:    r.Plan.Spec.TargetNamespace,
+			Annotations:  annotations,
+			GenerateName: r.getGeneratedName(vm),
+		},
+	}
+	dvTemplate.Labels = r.vmLabels(vm.Ref)
+
+	dataVolumes, err = r.Builder.DataVolumes(vm.Ref, secret, configMap, &dvTemplate)
 	if err != nil {
 		return
-	}
-
-	for i := range dataVolumes {
-		annotations := r.vmLabels(vm.Ref)
-		if !r.Plan.Spec.Warm || Settings.RetainPrecopyImporterPods {
-			annotations[AnnRetainAfterCompletion] = "true"
-		}
-		if r.Plan.Spec.TransferNetwork != nil {
-			annotations[AnnDefaultNetwork] = path.Join(
-				r.Plan.Spec.TransferNetwork.Namespace, r.Plan.Spec.TransferNetwork.Name)
-		}
-		// Do not delete the DV when the import completes as we check the DV to get the current
-		// disk transfer status.
-		annotations[AnnDeleteAfterCompletion] = "false"
-		dv := cdi.DataVolume{
-			ObjectMeta: meta.ObjectMeta{
-				Namespace:    r.Plan.Spec.TargetNamespace,
-				Annotations:  annotations,
-				GenerateName: r.getGeneratedName(vm),
-			},
-			Spec: dataVolumes[i],
-		}
-		dv.Labels = r.vmLabels(vm.Ref)
-		objects = append(objects, dv)
 	}
 
 	return


### PR DESCRIPTION
Instead of relying on disk source being part of DataVolume.Spec we store the source also in the annotation. This is a preliminary change that will ease our transition from CDI.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>