### PR TITLE
Fix operator bundle crd bases

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_hooks.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_hooks.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operator/config/crd/bases/forklift.konveyor.io_hosts.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_hosts.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
Issue: 
When running the opm to create the index from bundle, it reads the base files.
A few of the base files started with empty space on top and `---` right after it.
Which the OPM understood as the end of an empty file.
 
```
WARN[0005] found more than one document inside forklift.konveyor.io_storagemaps.yaml,
...
error checking provided apis in bundle mtv-operator.v2.3.5: couldn't find forklift.konveyor.io/v1beta1/StorageMap (storagemaps) in bundle. found: map[forklift.konveyor.io/v1beta1/ForkliftController (forkliftcontrollers):{} forklift.konveyor.io/v1beta1/Hook 
```