### PR TITLE
Update controller-gen to v0.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,9 @@ deploy: manifests
 	kubectl apply -f config/crds
 	kustomize build config/default | kubectl apply -f -
 
-CRD_OPTIONS ?= "crd:trivialVersions=true"
-
 # Generate manifests e.g. CRD, Webhooks
 manifests: controller-gen
-	${CONTROLLER_GEN} ${CRD_OPTIONS} crd rbac:roleName=manager-role webhook paths="./..." output:dir=operator/config/crd/bases
+	${CONTROLLER_GEN} crd rbac:roleName=manager-role webhook paths="./pkg/apis/..." output:dir=operator/config/crd/bases
 
 # Run go fmt against code
 fmt:
@@ -60,7 +58,7 @@ vet:
 
 # Generate code
 generate: controller-gen
-	${CONTROLLER_GEN} object:headerFile="./hack/boilerplate.go.txt" paths="./..."
+	${CONTROLLER_GEN} object:headerFile="./hack/boilerplate.go.txt" paths="./pkg/apis/..."
 
 # Build the docker image
 build-controller:
@@ -79,7 +77,7 @@ bazel-generate:
 controller-gen:
 ifeq (, $(shell which controller-gen))
 	@{ \
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0 ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else

--- a/operator/config/crd/bases/forklift.konveyor.io_hooks.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_hooks.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: hooks.forklift.konveyor.io
 spec:
@@ -114,9 +113,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_hosts.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_hosts.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: hosts.forklift.konveyor.io
 spec:
@@ -46,13 +45,13 @@ spec:
             description: HostSpec defines the desired state of Host
             properties:
               id:
-                description: 'The object ID. vsphere:   The managed object ID.'
+                description: 'The object ID. vsphere: The managed object ID.'
                 type: string
               ipAddress:
                 description: IP address used for disk transfer.
                 type: string
               name:
-                description: 'An object Name. vsphere:   A qualified name.'
+                description: 'An object Name. vsphere: A qualified name.'
                 type: string
               provider:
                 description: Provider
@@ -189,9 +188,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: migrations.forklift.konveyor.io
 spec:
@@ -57,10 +56,10 @@ spec:
                   description: Source reference. Either the ID or Name must be specified.
                   properties:
                     id:
-                      description: 'The object ID. vsphere:   The managed object ID.'
+                      description: 'The object ID. vsphere: The managed object ID.'
                       type: string
                     name:
-                      description: 'An object Name. vsphere:   A qualified name.'
+                      description: 'An object Name. vsphere: A qualified name.'
                       type: string
                     type:
                       description: Type used to qualify the name.
@@ -279,10 +278,10 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: 'The object ID. vsphere:   The managed object ID.'
+                      description: 'The object ID. vsphere: The managed object ID.'
                       type: string
                     name:
-                      description: 'An object Name. vsphere:   A qualified name.'
+                      description: 'An object Name. vsphere: A qualified name.'
                       type: string
                     phase:
                       description: Phase
@@ -465,9 +464,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: networkmaps.forklift.konveyor.io
 spec:
@@ -69,11 +68,11 @@ spec:
                       description: Source network.
                       properties:
                         id:
-                          description: 'The object ID. vsphere:   The managed object
+                          description: 'The object ID. vsphere: The managed object
                             ID.'
                           type: string
                         name:
-                          description: 'An object Name. vsphere:   A qualified name.'
+                          description: 'An object Name. vsphere: A qualified name.'
                           type: string
                         type:
                           description: Type used to qualify the name.
@@ -218,10 +217,10 @@ spec:
                   description: Source reference. Either the ID or Name must be specified.
                   properties:
                     id:
-                      description: 'The object ID. vsphere:   The managed object ID.'
+                      description: 'The object ID. vsphere: The managed object ID.'
                       type: string
                     name:
-                      description: 'An object Name. vsphere:   A qualified name.'
+                      description: 'An object Name. vsphere: A qualified name.'
                       type: string
                     type:
                       description: Type used to qualify the name.
@@ -234,9 +233,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: plans.forklift.konveyor.io
 spec:
@@ -313,10 +312,10 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: 'The object ID. vsphere:   The managed object ID.'
+                      description: 'The object ID. vsphere: The managed object ID.'
                       type: string
                     name:
-                      description: 'An object Name. vsphere:   A qualified name.'
+                      description: 'An object Name. vsphere: A qualified name.'
                       type: string
                     type:
                       description: Type used to qualify the name.
@@ -709,11 +708,11 @@ spec:
                             type: object
                           type: array
                         id:
-                          description: 'The object ID. vsphere:   The managed object
+                          description: 'The object ID. vsphere: The managed object
                             ID.'
                           type: string
                         name:
-                          description: 'An object Name. vsphere:   A qualified name.'
+                          description: 'An object Name. vsphere: A qualified name.'
                           type: string
                         phase:
                           description: Phase
@@ -901,9 +900,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: providers.forklift.konveyor.io
 spec:
@@ -164,9 +163,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: storagemaps.forklift.konveyor.io
 spec:
@@ -73,11 +72,11 @@ spec:
                       description: Source storage.
                       properties:
                         id:
-                          description: 'The object ID. vsphere:   The managed object
+                          description: 'The object ID. vsphere: The managed object
                             ID.'
                           type: string
                         name:
-                          description: 'An object Name. vsphere:   A qualified name.'
+                          description: 'An object Name. vsphere: A qualified name.'
                           type: string
                         type:
                           description: Type used to qualify the name.
@@ -222,10 +221,10 @@ spec:
                   description: Source reference. Either the ID or Name must be specified.
                   properties:
                     id:
-                      description: 'The object ID. vsphere:   The managed object ID.'
+                      description: 'The object ID. vsphere: The managed object ID.'
                       type: string
                     name:
-                      description: 'An object Name. vsphere:   A qualified name.'
+                      description: 'An object Name. vsphere: A qualified name.'
                       type: string
                     type:
                       description: Type used to qualify the name.
@@ -238,9 +237,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
This fixes the following issue:
When running the opm to create the index from bundle, it reads the base files. A few of the base files started with empty space on top and --- right after it. Which the OPM understood as the end of an empty file.

Replaces #57 