### PR TITLE
build: update io_bazel_rules_docker to v0.25.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,11 +20,9 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "95d39fd84ff4474babaf190450ee034d958202043e366b9fc38f438c9e6c3334",
-    strip_prefix = "rules_docker-0.16.0",
+    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
     urls = [
-        "https://github.com/bazelbuild/rules_docker/releases/download/v0.16.0/rules_docker-v0.16.0.tar.gz",
-        "https://storage.googleapis.com/builddeps/95d39fd84ff4474babaf190450ee034d958202043e366b9fc38f438c9e6c3334",
+        "https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Bazel's platform constraints, a dependency of `io_bazel_rules_docker`, were moved into separate project. With Bazel 6 the builds now fail and `io_bazel_rules_docker` need to be updated to at least v0.21.0 to work properly. Update to latest available version.

No other changes seem to be necessary.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>