### PR TITLE
openstack: enable Reauth for gopehrcloud authentication

### DIFF
--- a/pkg/controller/provider/container/openstack/client.go
+++ b/pkg/controller/provider/container/openstack/client.go
@@ -84,6 +84,7 @@ func (r *Client) connect() (err error) {
 			Password:    r.password(),
 			ProjectName: r.projectName(),
 			DomainName:  r.domainName(),
+			AllowReauth: true,
 		},
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{


### PR DESCRIPTION
Otherwise the token will expire after an hour by default and subsequent calls will fail

