### PR TITLE
vsphere: Allow insecure connection to the server

### DIFF
--- a/pkg/controller/provider/BUILD.bazel
+++ b/pkg/controller/provider/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/controller/base",
         "//pkg/controller/provider/container",
         "//pkg/controller/provider/container/ovirt",
+        "//pkg/controller/provider/container/vsphere",
         "//pkg/controller/provider/model",
         "//pkg/controller/provider/web",
         "//pkg/controller/validation/policy",

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	liburl "net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -917,4 +918,21 @@ func (r Collector) applyLeave(tx *libmodel.Tx, u types.ObjectUpdate) error {
 	}
 
 	return nil
+}
+
+
+// GetInsecureSkipVerifyFlag gets the insecureSkipVerify boolean flag
+// value from the VSphere connection secret.
+func GetInsecureSkipVerifyFlag(secret *core.Secret) bool {
+	insecure, found := secret.Data["insecureSkipVerify"]
+	if !found {
+		return false
+	}
+
+	insecureSkipVerify, err := strconv.ParseBool(string(insecure))
+	if err != nil {
+		return false
+	}
+
+	return insecureSkipVerify
 }

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -9,6 +9,7 @@ import (
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/container"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/vsphere"
 	libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libref "github.com/konveyor/forklift-controller/pkg/lib/ref"
@@ -206,6 +207,16 @@ func (r *Reconciler) validateSecret(provider *api.Provider) (secret *core.Secret
 	case api.OpenShift:
 		keyList = []string{"token"}
 	case api.VSphere:
+		if vsphere.GetInsecureSkipVerifyFlag(secret) {
+			provider.Status.SetCondition(libcnd.Condition{
+				Type:     ConnectionInsecure,
+				Status:   True,
+				Reason:   SkipTLSVerification,
+				Category: Warn,
+				Message:  "TLS is susceptible to machine-in-the-middle attacks when certificate verification is skipped.",
+			})
+                }
+
 		keyList = []string{
 			"user",
 			"password",


### PR DESCRIPTION
This is a preparation for future changes. Virt-v2v and libvirt cannot handle SSL certificates that it cannot verify (e.g. self-signed) and need a flag that tell it to disable checks. This does not mean we don't need the thumbprint (certificate fingerprint). Thumbprint is still needed by controller and will remain necessary for conversion pod when VDDK is used.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>