### PR TITLE
add VIRT_V2V_DONT_REQUEST_KVM env to the forklift operator

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -54,6 +54,8 @@ spec:
           value: ${VALIDATION_IMAGE}
         - name: VIRT_V2V_IMAGE
           value: ${VIRT_V2V_IMAGE}
+        - name: VIRT_V2V_DONT_REQUEST_KVM
+          value: ${VIRT_V2V_DONT_REQUEST_KVM}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
this is completion PR to  https://github.com/kubev2v/forklift/pull/36 , adding VIRT_V2V_DONT_REQUEST_KVM env to the operator, so it can be properly propagated to the controller pod.