### PR TITLE
Cleanup in validation of provider secrets

### DIFF
--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
@@ -59,7 +59,7 @@ func (admitter *SecretAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissio
 		log.Info("Starting provider connection test")
 		status, err := collector.Test()
 		if err != nil && (status == http.StatusUnauthorized || status == http.StatusBadRequest) {
-			log.Info("Connection test failed, failing")
+			log.Info("Connection test failed, failing", "status", status)
 			return &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
@@ -69,7 +69,7 @@ func (admitter *SecretAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissio
 			}
 		} else {
 			if err != nil {
-				log.Info("Connection test failed, yet passing")
+				log.Info("Connection test failed, yet passing", "status", status, "error", err.Error())
 			} else {
 				log.Info("Test succeeded, passing")
 			}

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
@@ -64,7 +64,7 @@ func (admitter *SecretAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissio
 				Allowed: false,
 				Result: &metav1.Status{
 					Code:    http.StatusForbidden,
-					Message: err.Error(),
+					Message: "Invalid credentials",
 				},
 			}
 		} else {


### PR DESCRIPTION
This is a cleanup for #54 :

- Add debug information to logs in secret admitter
- Return proper error from secret-admitter