### PR TITLE
Make the Makefile build fully customizable

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,6 @@
+# Container Runtime
+build --action_env=CONTAINER_CMD
+build --action_env=XDG_RUNTIME_DIR
 # Operator
 ## Default operator config
 build --action_env=VERSION=99.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,45 @@
+GOOS ?= `go env GOOS`
+GOPATH ?= `go env GOPATH`
+GOBIN ?= $(GOPATH)/bin
+GO111MODULE = auto
+
+CONTAINER_CMD ?= $(shell command -v podman)
+ifeq ($(CONTAINER_CMD),)
+CONTAINER_CMD := $(shell command -v docker)
+endif
+
 REGISTRY ?= quay.io
 REGISTRY_ACCOUNT ?= kubev2v
 REGISTRY_TAG ?= devel
-CONTROLLER_IMAGE ?= ${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-controller:${REGISTRY_TAG}
-API_IMAGE ?= ${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-api:${REGISTRY_TAG}
-VALIDATION_IMAGE ?= ${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-validation:${REGISTRY_TAG}
-VIRT_V2V_IMAGE_COLD ?= ${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-virt-v2v:${REGISTRY_TAG}
-VIRT_V2V_IMAGE_WARM ?= ${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-virt-v2v-warm:${REGISTRY_TAG}
-OPERATOR_IMAGE ?= ${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-operator:${REGISTRY_TAG}
-OPERATOR_BUNDLE_IMAGE ?= ${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-operator-bundle:${REGISTRY_TAG}
-OPERATOR_INDEX_IMAGE ?= ${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-operator-index:${REGISTRY_TAG}
-GOOS ?= `go env GOOS`
-GOBIN ?= ${GOPATH}/bin
-GO111MODULE = auto
 
-ifeq (, $(shell which docker))
-    CONTAINER_CMD = podman
-else
-    CONTAINER_CMD = docker
-endif
+VERSION ?= 99.0.0
+NAMESPACE ?= konveyor-forklift
+CHANNELS ?= development
+DEFAULT_CHANNEL ?= development
+
+# Use OPM_OPTS="--use-http" when using a non HTTPS registry
+OPM_OPTS ?=
+
+# By default use the controller gen installed by the
+# 'controller-gen' target
+DEFAULT_CONTROLLER_GEN = $(GOBIN)/controller-gen
+CONTROLLER_GEN ?= $(DEFAULT_CONTROLLER_GEN)
+
+# Image URLs to use all building/pushing image targets
+CONTROLLER_IMAGE ?= $(REGISTRY)/$(REGISTRY_ACCOUNT)/forklift-controller:$(REGISTRY_TAG)
+API_IMAGE ?= $(REGISTRY)/$(REGISTRY_ACCOUNT)/forklift-api:$(REGISTRY_TAG)
+VALIDATION_IMAGE ?= $(REGISTRY)/$(REGISTRY_ACCOUNT)/forklift-validation:$(REGISTRY_TAG)
+VIRT_V2V_IMAGE_COLD ?= $(REGISTRY)/$(REGISTRY_ACCOUNT)/forklift-virt-v2v:$(REGISTRY_TAG)
+VIRT_V2V_IMAGE_WARM ?= $(REGISTRY)/$(REGISTRY_ACCOUNT)/forklift-virt-v2v-warm:$(REGISTRY_TAG)
+OPERATOR_IMAGE ?= $(REGISTRY)/$(REGISTRY_ACCOUNT)/forklift-operator:$(REGISTRY_TAG)
+OPERATOR_BUNDLE_IMAGE ?= $(REGISTRY)/$(REGISTRY_ACCOUNT)/forklift-operator-bundle:$(REGISTRY_TAG)
+OPERATOR_INDEX_IMAGE ?= $(REGISTRY)/$(REGISTRY_ACCOUNT)/forklift-operator-index:$(REGISTRY_TAG)
+
+### External images
+MUST_GATHER_IMAGE ?= quay.io/kubev2v/forklift-must-gather:latest
+MUST_GATHER_API_IMAGE ?= quay.io/kubev2v/forklift-must-gather-api:latest
+UI_IMAGE ?= quay.io/kubev2v/forklift-ui:latest
+UI_PLUGIN_IMAGE ?= quay.io/kubev2v/forklift-console-plugin:latest
 
 ci: all
 
@@ -57,7 +79,7 @@ deploy: manifests
 
 # Generate manifests e.g. CRD, Webhooks
 manifests: controller-gen
-	${CONTROLLER_GEN} crd rbac:roleName=manager-role webhook paths="./pkg/apis/..." output:dir=operator/config/crd/bases
+	$(CONTROLLER_GEN) crd rbac:roleName=manager-role webhook paths="./pkg/apis/..." output:dir=operator/config/crd/bases
 
 # Run go fmt against code
 fmt:
@@ -69,77 +91,126 @@ vet:
 
 # Generate code
 generate: controller-gen
-	${CONTROLLER_GEN} object:headerFile="./hack/boilerplate.go.txt" paths="./pkg/apis/..."
+	$(CONTROLLER_GEN) object:headerFile="./hack/boilerplate.go.txt" paths="./pkg/apis/..."
 
-build-controller-image:
-	bazel run cmd/forklift-controller:forklift-controller-image
+build-controller-image: check_container_runtmime
+	export CONTAINER_CMD=$(CONTAINER_CMD); \
+	bazel run cmd/forklift-controller:forklift-controller-image \
+		--verbose_failures \
+		--sandbox_writable_path=$${HOME}/.ccache \
+		--sandbox_writable_path=$${XDG_RUNTIME_DIR} \
+		--action_env CONTAINER_CMD=$(CONTAINER_CMD)
 
 push-controller-image: build-controller-image
-	$(CONTAINER_CMD) tag cmd/forklift-controller:forklift-controller-image ${CONTROLLER_IMAGE}
-	$(CONTAINER_CMD) push ${CONTROLLER_IMAGE}
+	$(CONTAINER_CMD) tag bazel/cmd/forklift-controller:forklift-controller-image $(CONTROLLER_IMAGE)
+	$(CONTAINER_CMD) push $(CONTROLLER_IMAGE)
 
-build-api-image:
-	bazel run cmd/forklift-api:forklift-api-image
+build-api-image: check_container_runtmime
+	export CONTAINER_CMD=$(CONTAINER_CMD); \
+	bazel run cmd/forklift-api:forklift-api-image \
+		--verbose_failures \
+		--sandbox_writable_path=$${HOME}/.ccache \
+		--sandbox_writable_path=$${XDG_RUNTIME_DIR} \
+		--action_env CONTAINER_CMD=$(CONTAINER_CMD)
 
 push-api-image: build-api-image
-	$(CONTAINER_CMD) tag cmd/forklift-api:forklift-api-image ${API_IMAGE}
-	$(CONTAINER_CMD) push ${API_IMAGE}
+	$(CONTAINER_CMD) tag bazel/cmd/forklift-api:forklift-api-image $(API_IMAGE)
+	$(CONTAINER_CMD) push $(API_IMAGE)
 
-build-validation-image:
-	bazel run validation:forklift-validation-image
+build-validation-image: check_container_runtmime
+	export CONTAINER_CMD=$(CONTAINER_CMD); \
+	bazel run validation:forklift-validation-image \
+		--verbose_failures \
+		--action_env CONTAINER_CMD=$(CONTAINER_CMD)
 
 push-validation-image: build-validation-image
-	$(CONTAINER_CMD) tag validation:forklift-validation-image ${VALIDATION_IMAGE}
-	$(CONTAINER_CMD) push ${VALIDATION_IMAGE}
+	$(CONTAINER_CMD) tag bazel/validation:forklift-validation-image $(VALIDATION_IMAGE)
+	$(CONTAINER_CMD) push $(VALIDATION_IMAGE)
 
-build-operator-image:
-	bazel run operator:forklift-operator-image
+build-operator-image: check_container_runtmime
+	export CONTAINER_CMD=$(CONTAINER_CMD); \
+	bazel run operator:forklift-operator-image \
+		--verbose_failures \
+		--action_env CONTAINER_CMD=$(CONTAINER_CMD)
 
 push-operator-image: build-operator-image
-	$(CONTAINER_CMD) tag operator:forklift-operator-image ${OPERATOR_IMAGE}
-	$(CONTAINER_CMD) push ${OPERATOR_IMAGE}
+	$(CONTAINER_CMD) tag bazel/operator:forklift-operator-image $(OPERATOR_IMAGE)
+	$(CONTAINER_CMD) push $(OPERATOR_IMAGE)
 
-build-virt-v2v-image:
-	bazel run virt-v2v:forklift-virt-v2v
+build-virt-v2v-image: check_container_runtmime
+	export CONTAINER_CMD=$(CONTAINER_CMD); \
+	bazel run virt-v2v:forklift-virt-v2v \
+		--verbose_failures \
+		--action_env CONTAINER_CMD=$(CONTAINER_CMD)
 
 push-virt-v2v-image: build-virt-v2v-image
-	$(CONTAINER_CMD) tag virt-v2v:forklift-virt-v2v ${VIRT_V2V_IMAGE_COLD}
-	$(CONTAINER_CMD) push ${VIRT_V2V_IMAGE_COLD}
+	$(CONTAINER_CMD) tag bazel/virt-v2v:virt-v2v-image $(VIRT_V2V_IMAGE_COLD)
+	$(CONTAINER_CMD) push $(VIRT_V2V_IMAGE_COLD)
 
 build-virt-v2v-warm-image:
 	bazel run virt-v2v:forklift-virt-v2v-warm
 
 push-virt-v2v-warm-image: build-virt-v2v-warm-image
-	$(CONTAINER_CMD) tag virt-v2v:forklift-virt-v2v-warm ${VIRT_V2V_IMAGE_WARM}
+	$(CONTAINER_CMD) tag bazel/virt-v2v:forklift-virt-v2v-warm ${VIRT_V2V_IMAGE_WARM}
 	$(CONTAINER_CMD) push ${VIRT_V2V_IMAGE_WARM}
 
-build-operator-bundle-image:
-	bazel run operator:forklift-operator-bundle-image --action_env CONTROLLER_IMAGE=${CONTROLLER_IMAGE} --action_env VALIDATION_IMAGE=${VALIDATION_IMAGE} --action_env OPERATOR_IMAGE=${OPERATOR_IMAGE} --action_env VIRT_V2V_IMAGE=${VIRT_V2V_IMAGE_COLD} --action_env API_IMAGE=${API_IMAGE}
+build-operator-bundle-image: check_container_runtmime
+	export CONTAINER_CMD=$(CONTAINER_CMD); \
+	bazel run operator:forklift-operator-bundle-image \
+		--verbose_failures \
+		--action_env CONTAINER_CMD=$(CONTAINER_CMD) \
+		--action_env VERSION=$(VERSION) \
+		--action_env NAMESPACE=$(NAMESPACE) \
+		--action_env CHANNELS=$(CHANNELS) \
+		--action_env DEFAULT_CHANNEL=$(DEFAULT_CHANNEL) \
+		--action_env OPERATOR_IMAGE=$(OPERATOR_IMAGE) \
+		--action_env MUST_GATHER_IMAGE=$(MUST_GATHER_IMAGE) \
+		--action_env MUST_GATHER_API_IMAGE=$(MUST_GATHER_API_IMAGE) \
+		--action_env UI_IMAGE=$(UI_IMAGE) \
+		--action_env UI_PLUGIN_IMAGE=$(UI_PLUGIN_IMAGE) \
+		--action_env VALIDATION_IMAGE=$(VALIDATION_IMAGE) \
+		--action_env VIRT_V2V_IMAGE=$(VIRT_V2V_IMAGE_COLD) \
+		--action_env CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) \
+		--action_env API_IMAGE=$(API_IMAGE) \
 
 push-operator-bundle-image: build-operator-bundle-image
-	 $(CONTAINER_CMD) tag operator:forklift-operator-bundle-image ${OPERATOR_BUNDLE_IMAGE}
-	 $(CONTAINER_CMD) push ${OPERATOR_BUNDLE_IMAGE}
+	 $(CONTAINER_CMD) tag bazel/operator:forklift-operator-bundle-image $(OPERATOR_BUNDLE_IMAGE)
+	 $(CONTAINER_CMD) push $(OPERATOR_BUNDLE_IMAGE)
 
-build-operator-index-image:
-	bazel run operator:forklift-operator-index-image --action_env REGISTRY=${REGISTRY} --action_env REGISTRY_ACCOUNT=${REGISTRY_ACCOUNT} --action_env REGISTRY_TAG=${REGISTRY_TAG}
+build-operator-index-image: check_container_runtmime
+	export CONTAINER_CMD=$(CONTAINER_CMD); \
+	bazel run operator:forklift-operator-index-image \
+		--verbose_failures \
+		--sandbox_writable_path=$${XDG_RUNTIME_DIR} \
+		--action_env CONTAINER_CMD=$(CONTAINER_CMD) \
+		--action_env VERSION=$(VERSION) \
+		--action_env CHANNELS=$(CHANNELS) \
+		--action_env DEFAULT_CHANNEL=$(DEFAULT_CHANNEL) \
+		--action_env OPT_OPTS=$(OPM_OPTS) \
+		--action_env REGISTRY=$(REGISTRY) \
+		--action_env REGISTRY_TAG=$(REGISTRY_TAG) \
+		--action_env REGISTRY_ACCOUNT=$(REGISTRY_ACCOUNT)
 
 push-operator-index-image: build-operator-index-image
-	$(CONTAINER_CMD) tag operator:forklift-operator-index-image ${OPERATOR_INDEX_IMAGE}
-	$(CONTAINER_CMD) push ${OPERATOR_INDEX_IMAGE}
+	$(CONTAINER_CMD) tag bazel/operator:forklift-operator-index-image $(OPERATOR_INDEX_IMAGE)
+	$(CONTAINER_CMD) push $(OPERATOR_INDEX_IMAGE)
+
+build-all-images: build-api-image build-controller-image build-validation-image build-operator-image build-virt-v2v-image build-virt-v2v-warm-image build-operator-bundle-image build-operator-index-image
 
 push-all-images: push-api-image push-controller-image push-validation-image push-operator-image push-virt-v2v-image push-virt-v2v-warm-image push-operator-bundle-image push-operator-index-image
+
+.PHONY: check_container_runtmime
+check_container_runtmime:
+	@if [ ! -x "$(CONTAINER_CMD)" ]; then \
+			echo "Container runtime was not automatically detected"; \
+			echo "Please install podman or docker and make sure it's available in PATH"; \
+			exit 1; \
+	fi
 
 bazel-generate:
 	bazel run //:gazelle
 
-# find or download controller-gen
-# download controller-gen if necessary
-controller-gen:
-ifeq (, $(shell which controller-gen))
-	@{ \
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0 ;\
-	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
-endif
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN)
+$(DEFAULT_CONTROLLER_GEN):
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Install the following system components:
 - bazel >= 5
 - gcc
 - glibc-static
+- podman (or docker)
 
 ### Configuration
 
@@ -35,6 +36,7 @@ Another option to override the default values can use `--action_env` as in the e
 
 | Name                  | Default value                                    | Description                                                 |
 |-----------------------|--------------------------------------------------|-------------------------------------------------------------|
+| CONTAINER_CMD         | autodetected                                     | The container runtime command (e.g.: /usr/bin/podman)
 | VERSION               | 99.0.0                                           | The version with which the forklift should be built.        |
 | NAMESPACE             | konveyor-forklift                                | The namespace in which the operator should be installed.    |
 | CHANNELS              | development                                      | The olm channels.                                           |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,6 +36,18 @@ http_file(
     ],
 )
 
+load("@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
+    docker_toolchain_configure="toolchain_configure"
+)
+
+docker_toolchain_configure(
+  name = "docker_config",
+  docker_path="${CONTAINER_CMD:-$(command -v podman||command -v docker)}",
+  docker_flags = [
+    "--log-level=info",
+  ],
+)
+
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 

--- a/operator/BUILD.bazel
+++ b/operator/BUILD.bazel
@@ -149,8 +149,26 @@ genrule(
     ],
     outs = ["operator.yaml"],
     cmd = """
+        CONTAINER_RUNTIME="$$(basename $${CONTAINER_CMD:-$$(command -v podman || command -v docker)})"
+        if [ ! -z "$${XDG_RUNTIME_DIR}" ]; then
+          PODMAN_AUTH_FILE="$${XDG_RUNTIME_DIR}/containers/auth.json"
+          if [ "$${CONTAINER_RUNTIME}" == "podman" ]; then
+            if [ -e "$${PODMAN_AUTH_FILE}" ]; then 
+              DOCKER_CONFIG="$$(mktemp -d)"
+              DOCKER_AUTH_FILE="$${DOCKER_CONFIG}/config.json"
+              cp "$${PODMAN_AUTH_FILE}" "$${DOCKER_AUTH_FILE}"
+              export DOCKER_CONFIG
+            else
+              unset DOCKER_CONFIG
+            fi
+          fi
+        fi
+        OPERATOR_BUNDLE_IMAGE="$${REGISTRY:-quay.io}/$${REGISTRY_ACCOUNT:-}$${REGISTRY_ACCOUNT:+/}forklift-operator-bundle:$${REGISTRY_TAG:-devel}"
         cat $(location catalog/operator.yml) | envsubst > $@
-\t    $(location @opm//file) render $${REGISTRY:-quay.io}/$${REGISTRY_ACCOUNT:-}$${REGISTRY_ACCOUNT:+/}forklift-operator-bundle:$${REGISTRY_TAG:-devel} -o yaml $${OPM_OPTS:-} >> $@
+        $(location @opm//file) render "$${OPERATOR_BUNDLE_IMAGE}" -o yaml $${OPM_OPTS:-} >> $@
+        if [ "$${CONTAINER_RUNTIME}" == "podman" && ! -z "$${DOCKER_CONFIG}" ]; then
+          rm -rf "$${DOCKER_CONFIG}"
+        fi
     """,
 )
 


### PR DESCRIPTION
- Prefer `podman` over `docker` in Makefile builds
- Make the build fully customizable through environment
variables.
- Use `CONTROLLER_GEN` var to specify which `controller-gen`
binary must be used and make sure the correct version is
installed when using the default one.
- Make consistent use of parentheses instead of curly braces
for variable delimitation.
- Add sandbox writeable paths, needed after `bazel clean`.
