### PR TITLE
Add mutating webhook to modify missing ovirt CA

### DIFF
--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -50,6 +50,7 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
+  - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
   - '*'

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -101,6 +101,11 @@
       state: present
       definition: "{{ lookup('template', 'api/validatingwebhookconfiguration-forklift-api.yml.j2') }}"
 
+  - name: "Setup api mutating webhook configuration"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'api/mutatingwebhookconfiguration-forklift-api.yml.j2') }}"
+      
   - when: feature_validation|bool
     block:
     - name: "Setup validation service"

--- a/operator/roles/forkliftcontroller/templates/api/mutatingwebhookconfiguration-forklift-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/mutatingwebhookconfiguration-forklift-api.yml.j2
@@ -1,0 +1,43 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: secret-mutate
+  namespace: ""
+  annotations:
+{% if k8s_cluster|bool %}
+    cert-manager.io/inject-ca-from: {{ app_namespace }}/{{ api_certificate_name }}
+{% else %}
+    service.beta.openshift.io/inject-cabundle: "true"
+{% endif %}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ api_service_name }}
+      namespace: {{ app_namespace }}
+      path: /secret-mutate
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: ca-mutatur.forklift.konveyor
+  namespaceSelector: {}
+  objectSelector: 
+    matchExpressions:
+    - key: createdForProviderType
+      operator: Exists
+  rules:
+  - apiGroups:
+    - ''
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: Namespaced
+  sideEffects: None
+  timeoutSeconds: 30
+

--- a/pkg/forklift-api/api.go
+++ b/pkg/forklift-api/api.go
@@ -66,6 +66,7 @@ func (app *forkliftAPIApp) Execute() {
 	}
 
 	mux := http.NewServeMux()
+	webhooks.RegisterMutetingWebhooks(mux)
 	webhooks.RegisterValidatingWebhooks(mux)
 	server := http.Server{
 		Addr:    ":8443",

--- a/pkg/forklift-api/webhooks/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/BUILD.bazel
@@ -3,12 +3,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "webhooks",
     srcs = [
+        "mutating-webhook.go",
         "validating-webhook.go",
         "webhooks.go",
     ],
     importpath = "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/forklift-api/webhooks/mutating-webhook",
+        "//pkg/forklift-api/webhooks/mutating-webhook/mutators",
         "//pkg/forklift-api/webhooks/validating-webhook",
         "//pkg/forklift-api/webhooks/validating-webhook/admitters",
         "//pkg/lib/logging",

--- a/pkg/forklift-api/webhooks/mutating-webhook.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook.go
@@ -1,0 +1,12 @@
+package webhooks
+
+import (
+	"net/http"
+
+	mutating_webhooks "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/mutating-webhook"
+	"github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/mutating-webhook/mutators"
+)
+
+func ServeOvirtCa(resp http.ResponseWriter, req *http.Request) {
+	mutating_webhooks.Serve(resp, req, &mutators.OvirtCertMutator{})
+}

--- a/pkg/forklift-api/webhooks/mutating-webhook/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/mutating-webhook/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mutating-webhook",
+    srcs = ["mutating-webhook.go"],
+    importpath = "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/mutating-webhook",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/forklift-api/webhooks/util",
+        "//pkg/lib/logging",
+        "//vendor/k8s.io/api/admission/v1beta1",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/apimachinery/pkg/runtime",
+    ],
+)

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -1,0 +1,55 @@
+package mutating_webhook
+
+import (
+	"encoding/json"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/util"
+	"github.com/konveyor/forklift-controller/pkg/lib/logging"
+)
+
+var log = logging.WithName("mutating_webhooks")
+
+type mutator interface {
+	Mutate(*admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
+}
+
+func Serve(resp http.ResponseWriter, req *http.Request, m mutator) {
+	review, err := util.GetAdmissionReview(req)
+	if err != nil {
+		log.Error(err, "mutating Serve error")
+		resp.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	response := admissionv1.AdmissionReview{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: review.APIVersion,
+			Kind:       "AdmissionReview",
+		},
+	}
+	reviewResponse := m.Mutate(review)
+	if reviewResponse != nil {
+		response.Response = reviewResponse
+		response.Response.UID = review.Request.UID
+	}
+	// reset the Object and OldObject, they are not needed in a response.
+	review.Request.Object = runtime.RawExtension{}
+	review.Request.OldObject = runtime.RawExtension{}
+
+	responseBytes, err := json.Marshal(response)
+	if err != nil {
+		log.Error(err, "mutating Serve error, failed to marshal response")
+		resp.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if _, err := resp.Write(responseBytes); err != nil {
+		log.Error(err, "mutating Serve error, failed to write response")
+		resp.WriteHeader(http.StatusBadRequest)
+	}
+	return
+}

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mutators",
+    srcs = ["ovirt-cert-mutator.go"],
+    importpath = "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/mutating-webhook/mutators",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/forklift-api/webhooks/util",
+        "//pkg/lib/logging",
+        "//vendor/k8s.io/api/admission/v1beta1",
+        "//vendor/k8s.io/api/core/v1:core",
+    ],
+)

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/ovirt-cert-mutator.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/ovirt-cert-mutator.go
@@ -1,0 +1,87 @@
+package mutators
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/util"
+	"github.com/konveyor/forklift-controller/pkg/lib/logging"
+	admissionv1 "k8s.io/api/admission/v1beta1"
+	core "k8s.io/api/core/v1"
+)
+
+var log = logging.WithName("mutator")
+
+type OvirtCertMutator struct {
+}
+
+func (mutator *OvirtCertMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	log.Info("secret mutator was called")
+	raw := ar.Request.Object.Raw
+	secret := &core.Secret{}
+	err := json.Unmarshal(raw, secret)
+	if err != nil {
+		log.Error(err, "mutating webhook error")
+		util.ToAdmissionResponseError(err)
+	}
+
+	if providerType, ok := secret.GetLabels()["createdForProviderType"]; ok && providerType == "ovirt" {
+
+		url, err := url.Parse(string(secret.Data["url"]))
+		if err != nil {
+			log.Error(err, "mutating webhook URL parsing error")
+			util.ToAdmissionResponseError(err)
+		}
+
+		certUrl := fmt.Sprint(url.Scheme, "://", url.Host, "/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA")
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		response, err := http.Get(certUrl)
+		if err != nil {
+			log.Error(err, "mutating webhook error")
+			util.ToAdmissionResponseError(err)
+		}
+
+		b, err := io.ReadAll(response.Body)
+		if err != nil {
+			log.Error(err, "mutating webhook error")
+			util.ToAdmissionResponseError(err)
+		}
+
+		//check if the CA included in the secrete provided by the user and update it if needed
+		if !strings.Contains(string(secret.Data["cacert"]), string(b)) {
+			secret.Data["cacert"] = append(secret.Data["cacert"], b...)
+			secret.Labels["ca-cert-updated"] = "true"
+		}
+	}
+
+	patchBytes, err := util.GeneratePatchPayload(
+		util.PatchOperation{
+			Op:    "replace",
+			Path:  "/data",
+			Value: secret.Data,
+		},
+		util.PatchOperation{
+			Op:    "replace",
+			Path:  "/metadata/labels",
+			Value: secret.Labels,
+		},
+	)
+
+	if err != nil {
+		log.Error(err, "mutating webhook error")
+		util.ToAdmissionResponseError(err)
+	}
+
+	jsonPatchType := admissionv1.PatchTypeJSONPatch
+	return &admissionv1.AdmissionResponse{
+		Allowed:   true,
+		Patch:     patchBytes,
+		PatchType: &jsonPatchType,
+	}
+
+}

--- a/pkg/forklift-api/webhooks/util/util.go
+++ b/pkg/forklift-api/webhooks/util/util.go
@@ -11,6 +11,12 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
 func GetAdmissionReview(r *http.Request) (*admissionv1.AdmissionReview, error) {
 	var body []byte
 	if r.Body != nil {
@@ -67,4 +73,17 @@ func ToAdmissionResponseError(err error) *admissionv1.AdmissionResponse {
 			Code:    http.StatusBadRequest,
 		},
 	}
+}
+
+func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
+	if len(patches) == 0 {
+		return nil, fmt.Errorf("list of patches is empty")
+	}
+
+	payloadBytes, err := json.Marshal(patches)
+	if err != nil {
+		return nil, err
+	}
+
+	return payloadBytes, nil
 }

--- a/pkg/forklift-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/validating-webhook.go
@@ -91,4 +91,5 @@ func Serve(resp http.ResponseWriter, req *http.Request, admitter Admitter) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	return
 }

--- a/pkg/forklift-api/webhooks/webhooks.go
+++ b/pkg/forklift-api/webhooks/webhooks.go
@@ -10,6 +10,7 @@ import (
 var log = logging.WithName("webhooks")
 
 const SecretValidatePath = "/secret-validate"
+const OvirtCaMutatorPath = "/secret-mutate"
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager) error
@@ -25,8 +26,16 @@ func AddToManager(m manager.Manager) error {
 }
 
 func RegisterValidatingWebhooks(mux *http.ServeMux) {
-	log.Info("register validation webhooks\n")
+	log.Info("register validation webhooks")
 	mux.HandleFunc(SecretValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		ServeSecretCreate(w, r)
+	})
+
+}
+
+func RegisterMutetingWebhooks(mux *http.ServeMux) {
+	log.Info("register mutation webhook")
+	mux.HandleFunc(OvirtCaMutatorPath, func(w http.ResponseWriter, r *http.Request) {
+		ServeOvirtCa(w, r)
 	})
 }


### PR DESCRIPTION
Currently, in case users have configured ovirt engine with a 3rd party certificate when this engine will be added as a new provider in forklift with only that certificate the migration of the VMs will fail and no prior indication will be displayed when adding the provider.
This PR introduces a new mutating webhook that will automatically run for each new provider of type ovirt that will automatically retrieve the engine CA certificate if missing and post it to the existing provider secret following the 3rd party one without any action by the user.