### PR TITLE
GitHub Action: Set REGISTRY_TAG 'latest' on main branch

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: quay.io
-      REGISTRY_TAG: ${{ github.head_ref || github.ref_name }}
+      # Set tag 'latest' on main branch
+      REGISTRY_TAG: ${{ (github.head_ref||github.ref_name)=='main' && 'latest' || (github.head_ref||github.ref_name) }}
       REGISTRY_ACCOUNT: kubev2v
       USE_BAZEL_VERSION: 5.4.0
     steps:


### PR DESCRIPTION
Issue: When the action from the main branch pushes to the quay it does not update the latest tag but only the main tag. 