### PR TITLE
Update pattern of openstack owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @ahadas
 operator/ @mnecas
 virt-v2v/ @nyoxi
-*/openstack/* @ahadas @bennyz @mmartinv
+**/*openstack* @ahadas @bennyz @mmartinv


### PR DESCRIPTION
@bennyz was not added as a reviewer of #116  - fixing the definition of openstack code owners