### PR TITLE
Returning empty reply for providers different than oVirt 

### DIFF
--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -10,5 +10,6 @@ go_library(
         "//pkg/lib/logging",
         "//vendor/k8s.io/api/admission/v1beta1",
         "//vendor/k8s.io/api/core/v1:core",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
     ],
 )


### PR DESCRIPTION
As part of the mutating webhook flow, changing the admission response to be empty instead of a response with redundant patch operation for providers type different than oVirt.
