### PR TITLE
Ease execution of forkliftci locally

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,6 @@ jobs:
           STORAGE_CLASS: standard
           OVIRT_VM_ID: 31573c08-717b-43e0-825f-69a36fb0e1a1
         run: |
-          kind get kubeconfig > /tmp/kubeconfig
           GOPATH=${GITHUB_WORKSPACE}/go make e2e-sanity
 
       - name: show abnormal events and all objects in konveyor-forklift

--- a/tests/suit/tests_suite_test.go
+++ b/tests/suit/tests_suite_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	kubectlPath       = flag.String("kubectl-path", "/home/eslutsky/bin/kubectl", "The path to the kubectl binary")
+	kubectlPath       = flag.String("kubectl-path", "kubectl", "The path to the kubectl binary")
 	ocPath            = flag.String("oc-path", "oc", "The path to the oc binary")
 	forkliftInstallNs = flag.String("forklift-namespace", "konveyor-forklift", "The namespace of the CDI controller")
 	kubeConfig        = flag.String("kubeconfig2", "/tmp/kubeconfig", "The absolute path to the kubeconfig file")


### PR DESCRIPTION
1. By default use 'kubectl', assuming it's within PATH rather than `/home/eslutsky/bin/kubectl`
2. Do not store kubeconfig in /tmp before executing the end-to-end tests, there's no need for this anymore (see https://github.com/kubev2v/forkliftci/pull/55)