### PR TITLE
Set version to 2.4.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@ build --action_env=CONTAINER_CMD
 build --action_env=XDG_RUNTIME_DIR
 # Operator
 ## Default operator config
-build --action_env=VERSION=99.0.0
+build --action_env=VERSION=2.4.0
 build --action_env=NAMESPACE=konveyor-forklift
 build --action_env=CHANNELS=development
 build --action_env=DEFAULT_CHANNEL=development

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ REGISTRY ?= quay.io
 REGISTRY_ACCOUNT ?= kubev2v
 REGISTRY_TAG ?= devel
 
-VERSION ?= 99.0.0
+VERSION ?= 2.4.0
 NAMESPACE ?= konveyor-forklift
 CHANNELS ?= development
 DEFAULT_CHANNEL ?= development

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,6 @@ build-controller-image: check_container_runtmime
 	export CONTAINER_CMD=$(CONTAINER_CMD); \
 	bazel run cmd/forklift-controller:forklift-controller-image \
 		--verbose_failures \
-		--sandbox_writable_path=$${HOME}/.ccache \
 		--sandbox_writable_path=$${XDG_RUNTIME_DIR} \
 		--action_env CONTAINER_CMD=$(CONTAINER_CMD)
 
@@ -110,7 +109,6 @@ build-api-image: check_container_runtmime
 	export CONTAINER_CMD=$(CONTAINER_CMD); \
 	bazel run cmd/forklift-api:forklift-api-image \
 		--verbose_failures \
-		--sandbox_writable_path=$${HOME}/.ccache \
 		--sandbox_writable_path=$${XDG_RUNTIME_DIR} \
 		--action_env CONTAINER_CMD=$(CONTAINER_CMD)
 
@@ -145,7 +143,7 @@ build-virt-v2v-image: check_container_runtmime
 		--action_env CONTAINER_CMD=$(CONTAINER_CMD)
 
 push-virt-v2v-image: build-virt-v2v-image
-	$(CONTAINER_CMD) tag bazel/virt-v2v:virt-v2v-image $(VIRT_V2V_IMAGE_COLD)
+	$(CONTAINER_CMD) tag bazel/virt-v2v:forklift-virt-v2v $(VIRT_V2V_IMAGE_COLD)
 	$(CONTAINER_CMD) push $(VIRT_V2V_IMAGE_COLD)
 
 build-virt-v2v-warm-image:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Another option to override the default values can use `--action_env` as in the e
 
 | Name                  | Default value                                    | Description                                                 |
 |-----------------------|--------------------------------------------------|-------------------------------------------------------------|
-| CONTAINER_CMD         | autodetected                                     | The container runtime command (e.g.: /usr/bin/podman)
-| VERSION               | 99.0.0                                           | The version with which the forklift should be built.        |
+| CONTAINER_CMD         | autodetected                                     | The container runtime command (e.g.: /usr/bin/podman)       |
+| VERSION               | 2.4.0                                            | The version with which the forklift should be built.        |
 | NAMESPACE             | konveyor-forklift                                | The namespace in which the operator should be installed.    |
 | CHANNELS              | development                                      | The olm channels.                                           |
 | DEFAULT_CHANNEL       | development                                      | The default olm channel.                                    |


### PR DESCRIPTION
Previously, the version was 99.0.0 although the upcoming version is 2.4.0.
This PR also includes two more changes, in a separate commit, that I had to do in order to deploy to CRC using the `deploy-to-crc.sh` script