### PR TITLE
Improving automated VM rename handling

### DIFF
--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -12,7 +12,7 @@ func TestKubevirt(t *testing.T) {
 
 	//Test all cases in name adjustments
 	originalVmName := "----------------Vm!@#$%^&*()_+-Name/.,';[]-CorREct-<>123----------------------"
-	newVmName := "vm-name-correct-123"
+	newVmName := "vm--name-correct-123"
 	g.Expect(changeVmName(originalVmName, id)).To(gomega.Equal(newVmName))
 
 	//Test the case that the VM name is empty after all removals

--- a/validation/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name.rego
@@ -14,7 +14,7 @@ valid_vm_string = true {
 
 valid_vm_name = true {
     regex.match("^[a-z0-9][a-z0-9-]*[a-z0-9]$", input.name)
-    count(input.name) <= 64
+    count(input.name) < 64
 }
 
 concerns[flag] {

--- a/validation/policies/io/konveyor/forklift/vmware/name.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/name.rego
@@ -14,7 +14,7 @@ valid_vm = true {
 
 valid_vm_name = true {
     regex.match("^[a-z0-9][a-z0-9-]*[a-z0-9]$", input.name)
-    count(input.name) <= 64
+    count(input.name) < 64
 }
 
 concerns[flag] {


### PR DESCRIPTION
Follow up the automated VM name renaming feature, improving some flows:

1. [MTV-404](https://issues.redhat.com/browse/MTV-404): Fixing long name handling, in case the name exists in the system and its length is already 63 chars after adding the VM ID as a unique identifier the name will exceed the allowed length limit and the migration will fail.
2. [MTV-480](https://issues.redhat.com/browse/MTV-480): change the check scope for the already existing VM name from the cluster to the plan namespace.
3. [MTV-382](https://issues.redhat.com/browse/MTV-382): Fix VM length validation to be a maximum of 63 chars and not 64.