### PR TITLE
Split the populator image

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -38,4 +38,4 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}
           ./hack/release-images.sh
-          make push-populator-image
+          make push-ovirt-populator-image

--- a/README.md
+++ b/README.md
@@ -34,21 +34,22 @@ The environment which you can set across all projects.
 The environment variables that you can set in .bazelrc, these variables are used during Bazel build process and used inside the bazel sandbox.
 Another option to override the default values can use `--action_env` as in the example.
 
-| Name                  | Default value                                    | Description                                                 |
-|-----------------------|--------------------------------------------------|-------------------------------------------------------------|
-| CONTAINER_CMD         | autodetected                                     | The container runtime command (e.g.: /usr/bin/podman)       |
-| VERSION               | 2.4.0                                            | The version with which the forklift should be built.        |
-| NAMESPACE             | konveyor-forklift                                | The namespace in which the operator should be installed.    |
-| CHANNELS              | development                                      | The olm channels.                                           |
-| DEFAULT_CHANNEL       | development                                      | The default olm channel.                                    |
-| OPERATOR_IMAGE        | quay.io/kubev2v/forklift-operator:latest         | The forklift operator image with the ansible-operator role. |
-| CONTROLLER_IMAGE      | quay.io/kubev2v/forklift-controller:latest       | The forklift controller image.                              |
-| MUST_GATHER_IMAGE     | quay.io/kubev2v/forklift-must-gather:latest      | The forklift must gather an image.                          |
-| MUST_GATHER_API_IMAGE | quay.io/kubev2v/forklift-must-gather-api:latest  | The forklift must gather image api.                         |
-| UI_IMAGE              | quay.io/kubev2v/forklift-ui:latest               | The forklift UI image.                                      |
-| UI_PLUGIN_IMAGE       | quay.io/kubev2v/forklift-console-plugin:latest   | The forklift OKD/OpenShift UI plugin image.                 |
-| VALIDATION_IMAGE      | quay.io/kubev2v/forklift-validation:latest       | The forklift validation image.                              |
-| VIRT_V2V_IMAGE        | *see below*                                      | The forklift virt v2v image. See note below.                |
+| Name                       | Default value                                   | Description                                                 |
+|----------------------------|-------------------------------------------------|-------------------------------------------------------------|
+| CONTAINER_CMD              | autodetected                                    | The container runtime command (e.g.: /usr/bin/podman)       |
+| VERSION                    | 2.4.0                                           | The version with which the forklift should be built.        |
+| NAMESPACE                  | konveyor-forklift                               | The namespace in which the operator should be installed.    |
+| CHANNELS                   | development                                     | The olm channels.                                           |
+| DEFAULT_CHANNEL            | development                                     | The default olm channel.                                    |
+| OPERATOR_IMAGE             | quay.io/kubev2v/forklift-operator:latest        | The forklift operator image with the ansible-operator role. |
+| CONTROLLER_IMAGE           | quay.io/kubev2v/forklift-controller:latest      | The forklift controller image.                              |
+| MUST_GATHER_IMAGE          | quay.io/kubev2v/forklift-must-gather:latest     | The forklift must gather an image.                          |
+| MUST_GATHER_API_IMAGE      | quay.io/kubev2v/forklift-must-gather-api:latest | The forklift must gather image api.                         |
+| UI_IMAGE                   | quay.io/kubev2v/forklift-ui:latest              | The forklift UI image.                                      |
+| UI_PLUGIN_IMAGE            | quay.io/kubev2v/forklift-console-plugin:latest  | The forklift OKD/OpenShift UI plugin image.                 |
+| VALIDATION_IMAGE           | quay.io/kubev2v/forklift-validation:latest      | The forklift validation image.                              |
+| VIRT_V2V_IMAGE             | *see below*                                     | The forklift virt v2v image. See note below.                |
+| POPULATOR_CONTROLLER_IMAGE | quay.io/kubev2v/populator-controller:latest     | The populator controller image.                             |
 
 Value for `VIRT_V2V_IMAGE` can be either a single image location, or it can be two different images separated by `|`. The second form can be used to specify different image for cold migration and warm migration. The syntax in this case is `<cold_image>|<warm_image>`. Currently the default value is: `quay.io/kubev2v/forklift-virt-v2v:latest|quay.io/kubev2v/forklift-virt-v2v-warm:latest`.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Another option to override the default values can use `--action_env` as in the e
 | UI_PLUGIN_IMAGE            | quay.io/kubev2v/forklift-console-plugin:latest  | The forklift OKD/OpenShift UI plugin image.                 |
 | VALIDATION_IMAGE           | quay.io/kubev2v/forklift-validation:latest      | The forklift validation image.                              |
 | VIRT_V2V_IMAGE             | *see below*                                     | The forklift virt v2v image. See note below.                |
-| POPULATOR_CONTROLLER_IMAGE | quay.io/kubev2v/populator-controller:latest     | The populator controller image.                             |
+| POPULATOR_CONTROLLER_IMAGE | quay.io/kubev2v/populator-controller:latest     | The forklift volume-populator controller image.             |
+| OVIRT_POPULATOR_IMAGE      | quay.io/kubev2v/ovirt-populator:latest          | The oVirt populator image.                                  |
 
 Value for `VIRT_V2V_IMAGE` can be either a single image location, or it can be two different images separated by `|`. The second form can be used to specify different image for cold migration and warm migration. The syntax in this case is `<cold_image>|<warm_image>`. Currently the default value is: `quay.io/kubev2v/forklift-virt-v2v:latest|quay.io/kubev2v/forklift-virt-v2v-warm:latest`.
 

--- a/cmd/ovirt-populator/BUILD.bazel
+++ b/cmd/ovirt-populator/BUILD.bazel
@@ -1,16 +1,13 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "ovirt-populator_lib",
+    name = "ovirt-populator",
     srcs = ["ovirt-populator.go"],
-    importpath = "github.com/konveyor/forklift-controller/cmd/ovirt-populator",
-    visibility = ["//visibility:private"],
+    importpath = "github.com/konveyor/forklift-controller/ovirt-populator",
+    visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/forklift/v1beta1",
-        "//vendor/github.com/kubev2v/lib-volume-populator/populator-machinery",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-        "//vendor/k8s.io/apimachinery/pkg/runtime",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor/k8s.io/client-go/dynamic",
         "//vendor/k8s.io/client-go/kubernetes",
@@ -19,8 +16,18 @@ go_library(
     ],
 )
 
-go_binary(
-    name = "ovirt-populator",
-    embed = [":ovirt-populator_lib"],
-    visibility = ["//visibility:public"],
+go_library(
+    name = "ovirt-populator_lib",
+    srcs = ["ovirt-populator.go"],
+    importpath = "github.com/konveyor/forklift-controller/cmd/ovirt-populator",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor/k8s.io/client-go/dynamic",
+        "//vendor/k8s.io/client-go/kubernetes",
+        "//vendor/k8s.io/client-go/rest",
+        "//vendor/k8s.io/klog/v2:klog",
+    ],
 )

--- a/cmd/ovirt-populator/ovirt-populator.go
+++ b/cmd/ovirt-populator/ovirt-populator.go
@@ -9,73 +9,14 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
-	populator_machinery "github.com/kubev2v/lib-volume-populator/populator-machinery"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 )
-
-const (
-	prefix     = "forklift.konveyor.io"
-	mountPath  = "/mnt/"
-	devicePath = "/dev/block"
-)
-
-const (
-	groupName  = "forklift.konveyor.io"
-	apiVersion = "v1beta1"
-	kind       = "OvirtVolumePopulator"
-	resource   = "ovirtvolumepopulators"
-)
-
-func main() {
-	var mode, engineUrl, secretName, diskID, volPath, crName, crNamespace, httpEndpoint, metricsPath, masterURL, kubeconfig, imageName, namespace string
-
-	// Main arg
-	flag.StringVar(&mode, "mode", "", "Mode to run in (controller, populate)")
-	// Populate args
-	flag.StringVar(&engineUrl, "engine-url", "", "ovirt-engine url (https//engine.fqdn)")
-	flag.StringVar(&secretName, "secret-name", "", "secret containing oVirt credentials")
-	flag.StringVar(&diskID, "disk-id", "", "ovirt-engine disk id")
-	flag.StringVar(&volPath, "volume-path", "", "Volume path to populate")
-	flag.StringVar(&crName, "cr-name", "", "Custom Resource instance name")
-	flag.StringVar(&crNamespace, "cr-namespace", "", "Custom Resource instance namespace")
-
-	// Controller args
-	if f := flag.Lookup("kubeconfig"); f != nil {
-		kubeconfig = f.Value.String()
-	} else {
-		flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	}
-	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	flag.StringVar(&imageName, "image-name", "", "Image to use for populating")
-	// Metrics args
-	flag.StringVar(&httpEndpoint, "http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled.")
-	flag.StringVar(&metricsPath, "metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
-	// Other args
-	flag.StringVar(&namespace, "namespace", "konveyor-forklift", "Namespace to deploy controller")
-	flag.Parse()
-
-	switch mode {
-	case "controller":
-		var (
-			gk  = schema.GroupKind{Group: groupName, Kind: kind}
-			gvr = schema.GroupVersionResource{Group: groupName, Version: apiVersion, Resource: resource}
-		)
-		populator_machinery.RunController(masterURL, kubeconfig, imageName, httpEndpoint, metricsPath,
-			namespace, prefix, gk, gvr, mountPath, devicePath, getPopulatorPodArgs)
-	case "populate":
-		populate(masterURL, kubeconfig, crName, engineUrl, secretName, diskID, volPath, namespace, crNamespace)
-	default:
-		klog.Fatalf("Invalid mode: %s", mode)
-	}
-}
 
 type engineConfig struct {
 	URL      string
@@ -91,54 +32,30 @@ type TransferProgress struct {
 	Elapsed     float64 `json:"elapsed"`
 }
 
-func loadEngineConfig(secretName, engineURL, namespace string) engineConfig {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		klog.Fatal(err.Error())
-	}
-	// creates the clientset
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		klog.Fatal(err.Error())
-	}
+const (
+	groupName  = "forklift.konveyor.io"
+	apiVersion = "v1beta1"
+	resource   = "ovirtvolumepopulators"
+)
 
-	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
-	if err != nil {
-		klog.Fatal(err.Error())
-	}
+func main() {
+	var engineUrl, secretName, diskID, volPath, crName, crNamespace, namespace string
+	// Populate args
+	flag.StringVar(&engineUrl, "engine-url", "", "ovirt-engine url (https//engine.fqdn)")
+	flag.StringVar(&secretName, "secret-name", "", "secret containing oVirt credentials")
+	flag.StringVar(&diskID, "disk-id", "", "ovirt-engine disk id")
+	flag.StringVar(&volPath, "volume-path", "", "Volume path to populate")
+	flag.StringVar(&crName, "cr-name", "", "Custom Resource instance name")
+	flag.StringVar(&crNamespace, "cr-namespace", "", "Custom Resource instance namespace")
 
-	return engineConfig{
-		URL:      engineURL,
-		username: string(secret.Data["user"]),
-		password: string(secret.Data["password"]),
-		ca:       string(secret.Data["cacert"]),
-	}
+	// Other args
+	flag.StringVar(&namespace, "namespace", "konveyor-forklift", "Namespace to deploy controller")
+	flag.Parse()
+
+	populate(crName, engineUrl, secretName, diskID, volPath, namespace, crNamespace)
 }
 
-func getPopulatorPodArgs(rawBlock bool, u *unstructured.Unstructured) ([]string, error) {
-	var ovirtVolumePopulator v1beta1.OvirtVolumePopulator
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &ovirtVolumePopulator)
-	args := []string{"--mode=populate"}
-	if nil != err {
-		return nil, err
-	}
-
-	if rawBlock {
-		args = append(args, "--volume-path="+devicePath)
-	} else {
-		args = append(args, "--volume-path="+mountPath+"disk.img")
-	}
-
-	args = append(args, "--secret-name="+ovirtVolumePopulator.Spec.EngineSecretName)
-	args = append(args, "--disk-id="+ovirtVolumePopulator.Spec.DiskID)
-	args = append(args, "--engine-url="+ovirtVolumePopulator.Spec.EngineURL)
-	args = append(args, "--cr-name="+ovirtVolumePopulator.Name)
-	args = append(args, "--cr-namespace="+ovirtVolumePopulator.Namespace)
-
-	return args, nil
-}
-
-func populate(masterURL, kubeconfig, crName, engineURL, secretName, diskID, volPath, namespace, crNamespace string) {
+func populate(crName, engineURL, secretName, diskID, volPath, namespace, crNamespace string) {
 	engineConfig := loadEngineConfig(secretName, engineURL, namespace)
 
 	// Write credentials to files
@@ -232,5 +149,29 @@ func populate(masterURL, kubeconfig, crName, engineURL, secretName, diskID, volP
 	err = cmd.Wait()
 	if err != nil {
 		klog.Error(err)
+	}
+}
+
+func loadEngineConfig(secretName, engineURL, namespace string) engineConfig {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		klog.Fatal(err.Error())
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Fatal(err.Error())
+	}
+
+	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		klog.Fatal(err.Error())
+	}
+
+	return engineConfig{
+		URL:      engineURL,
+		username: string(secret.Data["user"]),
+		password: string(secret.Data["password"]),
+		ca:       string(secret.Data["cacert"]),
 	}
 }

--- a/cmd/populator-controller/BUILD.bazel
+++ b/cmd/populator-controller/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "populator-controller",
+    embed = [":populator-controller_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "populator-controller_lib",
+    srcs = ["populator-controller.go"],
+    importpath = "github.com/konveyor/forklift-controller/cmd/populator-controller",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/apis/forklift/v1beta1",
+        "//vendor/github.com/kubev2v/lib-volume-populator/populator-machinery",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+        "//vendor/k8s.io/apimachinery/pkg/runtime",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema",
+    ],
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+)
+
+container_image(
+    name = "populator-controller-image",
+    base = "@ubi9-minimal//image",
+    directory = "/usr/local/bin/",
+    entrypoint = ["/usr/local/bin/populator-controller"],
+    # workaround for github.com/bazelbuild/rules_go/issues/1706
+    env = {"GODEBUG": "netdns=go"},
+    files = [":populator-controller"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/populator-controller/populator-controller.go
+++ b/cmd/populator-controller/populator-controller.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"flag"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	populator_machinery "github.com/kubev2v/lib-volume-populator/populator-machinery"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	prefix     = "forklift.konveyor.io"
+	mountPath  = "/mnt/"
+	devicePath = "/dev/block"
+)
+
+const (
+	groupName  = "forklift.konveyor.io"
+	apiVersion = "v1beta1"
+	kind       = "OvirtVolumePopulator"
+	resource   = "ovirtvolumepopulators"
+)
+
+func main() {
+	var httpEndpoint, metricsPath, masterURL, kubeconfig, imageName, namespace string
+
+	// Controller args
+	if f := flag.Lookup("kubeconfig"); f != nil {
+		kubeconfig = f.Value.String()
+	} else {
+		flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	}
+	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&imageName, "image-name", "", "Image to use for populating")
+	// Metrics args
+	flag.StringVar(&httpEndpoint, "http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled.")
+	flag.StringVar(&metricsPath, "metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
+	// Other args
+	flag.StringVar(&namespace, "namespace", "konveyor-forklift", "Namespace to deploy controller")
+	flag.Parse()
+
+	var (
+		gk  = schema.GroupKind{Group: groupName, Kind: kind}
+		gvr = schema.GroupVersionResource{Group: groupName, Version: apiVersion, Resource: resource}
+	)
+	populator_machinery.RunController(masterURL, kubeconfig, imageName, httpEndpoint, metricsPath,
+		namespace, prefix, gk, gvr, mountPath, devicePath, getPopulatorPodArgs)
+}
+
+func getPopulatorPodArgs(rawBlock bool, u *unstructured.Unstructured) ([]string, error) {
+	var ovirtVolumePopulator v1beta1.OvirtVolumePopulator
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &ovirtVolumePopulator)
+	var args []string
+	if nil != err {
+		return nil, err
+	}
+
+	if rawBlock {
+		args = append(args, "--volume-path="+devicePath)
+	} else {
+		args = append(args, "--volume-path="+mountPath+"disk.img")
+	}
+
+	args = append(args, "--secret-name="+ovirtVolumePopulator.Spec.EngineSecretName)
+	args = append(args, "--disk-id="+ovirtVolumePopulator.Spec.DiskID)
+	args = append(args, "--engine-url="+ovirtVolumePopulator.Spec.EngineURL)
+	args = append(args, "--cr-name="+ovirtVolumePopulator.Name)
+	args = append(args, "--cr-namespace="+ovirtVolumePopulator.Namespace)
+
+	return args, nil
+}

--- a/hack/ovirt-populator/Containerfile
+++ b/hack/ovirt-populator/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine3.16 as builder
+FROM golang:1.19.5-alpine3.17 as builder
 WORKDIR /app
 
 COPY . ./
@@ -6,7 +6,6 @@ WORKDIR /app/cmd/ovirt-populator
 
 # When debugging by replacing the lib-volume-populator with a local modified copy
 # COPY . ./
-
 RUN CGO_ENABLED=0 go build -o /ovirt-populator
 
 FROM quay.io/centos/centos:stream9-minimal

--- a/hack/release-images.sh
+++ b/hack/release-images.sh
@@ -17,10 +17,12 @@ VALIDATION_IMAGE=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-validation:${REGISTRY_
 VIRT_V2V_IMAGE_COLD=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-virt-v2v:${REGISTRY_TAG}
 VIRT_V2V_IMAGE_WARM=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-virt-v2v-warm:${REGISTRY_TAG}
 API_IMAGE=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-api:${REGISTRY_TAG}
+POPULATOR_CONTROLLER_IMAGE=${REGISTRY}/${REGISTRY_ACCOUNT}/populator-controller:${REGISTRY_TAG}
 
 bazel run push-forklift-api
 bazel run push-forklift-virt-v2v
 bazel run push-forklift-virt-v2v-warm
+bazel run push-populator-controller-image
 bazel run push-forklift-controller
 bazel run push-forklift-validation
 bazel run push-forklift-operator
@@ -33,7 +35,8 @@ bazel run push-forklift-operator-bundle \
     --action_env VALIDATION_IMAGE=${VALIDATION_IMAGE} \
     --action_env VIRT_V2V_IMAGE="${VIRT_V2V_IMAGE_COLD}|${VIRT_V2V_IMAGE_WARM}" \
     --action_env CONTROLLER_IMAGE=${CONTROLLER_IMAGE} \
-    --action_env API_IMAGE=${API_IMAGE}
+    --action_env API_IMAGE=${API_IMAGE} \
+    --action_env POPULATOR_CONTROLLER_IMAGE=${POPULATOR_CONTROLLER_IMAGE}
 bazel run push-forklift-operator-index \
     --action_env REGISTRY=${REGISTRY} \
     --action_env REGISTRY_TAG=${REGISTRY_TAG} \


### PR DESCRIPTION
This patch will split the populator image.
One image acts as a controller to the populator - 'populator-controller' and the actual populator action will be executed by the 'ovirt-populator' image.

This will allow a separation in logic, allowing to add more source providers images and use the same controller for all.

Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>