### PR TITLE
Let virt-v2v copy the data

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,5 +16,5 @@ build --action_env=MUST_GATHER_API_IMAGE=quay.io/kubev2v/forklift-must-gather-ap
 build --action_env=UI_IMAGE=quay.io/kubev2v/forklift-ui:latest
 build --action_env=UI_PLUGIN_IMAGE=quay.io/kubev2v/forklift-console-plugin:latest
 build --action_env=VALIDATION_IMAGE=quay.io/kubev2v/forklift-validation:latest
-build --action_env=VIRT_V2V_IMAGE=quay.io/kubev2v/forklift-virt-v2v:latest
+build --action_env=VIRT_V2V_IMAGE="quay.io/kubev2v/forklift-virt-v2v:latest|quay.io/kubev2v/forklift-virt-v2v-warm:latest"
 build --action_env=OPERATOR_IMAGE=quay.io/kubev2v/forklift-operator:latest

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ build-operator-bundle-image: check_container_runtmime
 		--action_env UI_IMAGE=$(UI_IMAGE) \
 		--action_env UI_PLUGIN_IMAGE=$(UI_PLUGIN_IMAGE) \
 		--action_env VALIDATION_IMAGE=$(VALIDATION_IMAGE) \
-		--action_env VIRT_V2V_IMAGE=$(VIRT_V2V_IMAGE_COLD) \
+		--action_env VIRT_V2V_IMAGE="$(VIRT_V2V_IMAGE_COLD)|$(VIRT_V2V_IMAGE_WARM)" \
 		--action_env CONTROLLER_IMAGE=$(CONTROLLER_IMAGE) \
 		--action_env API_IMAGE=$(API_IMAGE) \
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Another option to override the default values can use `--action_env` as in the e
 | MUST_GATHER_IMAGE     | quay.io/kubev2v/forklift-must-gather:latest      | The forklift must gather an image.                          |
 | MUST_GATHER_API_IMAGE | quay.io/kubev2v/forklift-must-gather-api:latest  | The forklift must gather image api.                         |
 | UI_IMAGE              | quay.io/kubev2v/forklift-ui:latest               | The forklift UI image.                                      |
-| UI_PLUGIN_IMAGE       | quay.io/kubev2v/forklift-console-plugin:latest   | The forklift OKD/OpenShift UI plugin image.                                      |
+| UI_PLUGIN_IMAGE       | quay.io/kubev2v/forklift-console-plugin:latest   | The forklift OKD/OpenShift UI plugin image.                 |
 | VALIDATION_IMAGE      | quay.io/kubev2v/forklift-validation:latest       | The forklift validation image.                              |
-| VIRT_V2V_IMAGE        | quay.io/kubev2v/forklift-virt-v2v:latest         | The forklift virt v2v image. See note below.                |
+| VIRT_V2V_IMAGE        | *see below*                                      | The forklift virt v2v image. See note below.                |
 
-Value for `VIRT_V2V_IMAGE` can be either a single image location, or it can be two different images separated `|`. The second form can be used to specify different image for cold migration and warm migration. The syntax in this case is `<cold_image>|<warm_image>`.
+Value for `VIRT_V2V_IMAGE` can be either a single image location, or it can be two different images separated by `|`. The second form can be used to specify different image for cold migration and warm migration. The syntax in this case is `<cold_image>|<warm_image>`. Currently the default value is: `quay.io/kubev2v/forklift-virt-v2v:latest|quay.io/kubev2v/forklift-virt-v2v-warm:latest`.
 
 ### Runing operator build
 

--- a/hack/release-images.sh
+++ b/hack/release-images.sh
@@ -15,7 +15,7 @@ UI_IMAGE=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-ui:${REGISTRY_TAG}
 UI_PLUGIN_IMAGE=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-console-plugin:${REGISTRY_TAG}
 VALIDATION_IMAGE=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-validation:${REGISTRY_TAG}
 VIRT_V2V_IMAGE_COLD=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-virt-v2v:${REGISTRY_TAG}
-#VIRT_V2V_IMAGE_WARM=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-virt-v2v-warm:${REGISTRY_TAG}
+VIRT_V2V_IMAGE_WARM=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-virt-v2v-warm:${REGISTRY_TAG}
 API_IMAGE=${REGISTRY}/${REGISTRY_ACCOUNT}/forklift-api:${REGISTRY_TAG}
 
 bazel run push-forklift-api
@@ -31,7 +31,7 @@ bazel run push-forklift-operator-bundle \
     --action_env UI_IMAGE=${UI_IMAGE} \
     --action_env UI_PLUGIN_IMAGE=${UI_PLUGIN_IMAGE} \
     --action_env VALIDATION_IMAGE=${VALIDATION_IMAGE} \
-    --action_env VIRT_V2V_IMAGE=${VIRT_V2V_IMAGE_COLD} \
+    --action_env VIRT_V2V_IMAGE="${VIRT_V2V_IMAGE_COLD}|${VIRT_V2V_IMAGE_WARM}" \
     --action_env CONTROLLER_IMAGE=${CONTROLLER_IMAGE} \
     --action_env API_IMAGE=${API_IMAGE}
 bazel run push-forklift-operator-index \

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -49,6 +49,8 @@ type Builder interface {
 	ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string
 	// Return a stable identifier for a PersistentDataVolume
 	ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVolumeClaim) string
+	// Conversion Pod environment
+	PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env []core.EnvVar, err error)
 }
 
 // Client API.

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -155,6 +155,10 @@ func (r *Builder) ConfigMap(_ ref.Ref, in *core.Secret, object *core.ConfigMap) 
 	return
 }
 
+func (r *Builder) PodEnvironment(_ ref.Ref, _ *core.Secret) (env []core.EnvVar, err error) {
+	return
+}
+
 // Build the DataVolume credential secret.
 func (r *Builder) Secret(_ ref.Ref, in, object *core.Secret) (err error) {
 	object.StringData = map[string]string{

--- a/pkg/controller/plan/adapter/vsphere/BUILD.bazel
+++ b/pkg/controller/plan/adapter/vsphere/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/controller/plan/adapter/base",
         "//pkg/controller/plan/context",
+        "//pkg/controller/provider/container/vsphere",
         "//pkg/controller/provider/model/vsphere",
         "//pkg/controller/provider/web",
         "//pkg/controller/provider/web/base",

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1006,6 +1006,12 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	} else {
 		virtV2vImage = Settings.Migration.VirtV2vImageCold
 	}
+	// pod environment
+	environment, err := r.Builder.PodEnvironment(vm.Ref, r.Source.Secret)
+	if err != nil {
+		return
+	}
+	// pod
 	pod = &core.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Namespace:    r.Plan.Spec.TargetNamespace,
@@ -1033,6 +1039,7 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 			Containers: []core.Container{
 				{
 					Name: "virt-v2v",
+					Env: environment,
 					EnvFrom: []core.EnvFromSource{
 						{
 							Prefix: "V2V_",

--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -11,24 +11,66 @@ if [ -f "$1" ] ; then
     LIBGUESTFS_PATH="$APPLIANCE/appliance"
 fi
 
-echo "Run virt-v2v with the following input:"
-cat /mnt/v2v/input.xml
+echo "Preparing virt-v2v"
 
-virt-v2v -v -x -i libvirtxml -o null --debug-overlays --no-copy --root=first /mnt/v2v/input.xml
-[ $? != 0 ] && exit 1
+# This variable is used to build the list of arguments for virt-v2v.
+args=()
 
-echo "Conversion successful. Committing all overlays to local disks."
-for OVERLAY in /var/tmp/*.qcow2
-do
-	if ! qemu-img commit -p "$OVERLAY"
-	then
-		echo Failed to commit overlay "$OVERLAY"!
-		echo Unable to complete import!
-		exit 1
-	fi
+# Temporary storage location
+DIR="/var/tmp/v2v"
+mkdir -p $DIR
+args=("${args[@]}"
+    -o local
+    -os "$DIR"
+)
+
+# Generate disk name suffix from disk number. E.g. "c" (as in "sdc") for
+# 3rd disk.
+gen_name() {
+    local chars=({a..z})
+    local cnt="${#chars[@]}"
+    local i=$(($1 % cnt))
+    local rest=$(($1 / cnt))
+    local prefix=""
+    if [ $rest -gt 0 ] ; then
+        prefix="$(gen_name $rest)"
+    fi
+    echo "$prefix${chars[$i-1]}"
+}
+
+# Disks on filesystem storage.
+# e.g.: /mnt/disks/disk0/disk.img -> vmName-sda
+for disk in /mnt/disks/disk[0-9]* ; do
+	num="${disk:15}"
+	ln -s "$disk/disk.img" "$DIR/$V2V_vmName-sd$(gen_name "$((num+1))")"
+done
+# Disks on block storage.
+# e.g.: /dev/block0 -> vmName-sda
+for disk in /dev/block[0-9]* ; do
+	num="${disk:10}"
+	ln -s "$disk" "$DIR/$V2V_vmName-sd$(gen_name "$((num+1))")"
 done
 
-echo "Commit successful. Cleaning up."
-find /var/tmp -name '*.qcow2' -exec rm -f {} \;
+# Store password to file
+echo -n "$V2V_secretKey" > "$DIR/vmware.pw"
+args=("${args[@]}"
+    -ip "$DIR/vmware.pw"
+)
 
-exit 0
+# Use VDDK if present
+if [ -d "/opt/vmware-vix-disklib-distrib" ]; then
+    args=("${args[@]}"
+        -it vddk
+        -io vddk-libdir=/opt/vmware-vix-disklib-distrib
+        -io "vddk-thumbprint=$V2V_thumbprint"
+    )
+fi
+
+echo "Starting virt-v2v"
+set -x
+ls -l "$DIR"
+exec virt-v2v -v -x \
+    -i libvirt \
+    -ic "$V2V_libvirtURL" \
+    "${args[@]}" \
+    "$V2V_vmName"


### PR DESCRIPTION
This is a set of patches that modify Forklift controller and forklift-virt-v2v image to make virt-v2v do the data copying instead of CDI.

The gap we will have with this is that progress for data copying is not reported as it used to. That is still work to be done and a topic for a separate PR.