### PR TITLE
Fix the file-name to vol-name

### DIFF
--- a/cmd/ovirt-populator/ovirt-populator.go
+++ b/cmd/ovirt-populator/ovirt-populator.go
@@ -124,9 +124,9 @@ func getPopulatorPodArgs(rawBlock bool, u *unstructured.Unstructured) ([]string,
 	}
 
 	if rawBlock {
-		args = append(args, "--file-name="+devicePath)
+		args = append(args, "--volume-path="+devicePath)
 	} else {
-		args = append(args, "--file-name="+mountPath+"disk.img")
+		args = append(args, "--volume-path="+mountPath+"disk.img")
 	}
 
 	args = append(args, "--secret-name="+ovirtVolumePopulator.Spec.EngineSecretName)


### PR DESCRIPTION
When calling the populator we add args, it expected to get `volume-path` but we sent `file-name`. This cause a failure to the populator container.

Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>