### PR TITLE
Fix the step and phasing for initialization

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -596,6 +596,8 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			}
 		}
 
+		step.MarkCompleted()
+		step.Phase = Completed
 		vm.Phase = r.next(vm.Phase)
 	case CreateVM:
 		step, found := vm.FindStep(r.step(vm))
@@ -631,6 +633,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			vm.AddError(fmt.Sprintf("Step '%s' not found", r.step(vm)))
 			break
 		}
+		step.MarkStarted()
 		step.Phase = Running
 		err = r.updateCopyProgress(vm, step)
 		if err != nil {


### PR DESCRIPTION
When changing the phasing of the disk transfer before the VM creation, the scheduling of the VM removed. Doing so, we didn't end up with the Initialization phase, and signal the step as completed. It caused the the phase to keep running and harmed the time counter for the upcoming phases.

This patch ends the step and fix the issue above.

Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>