### PR TITLE
Bazel: Fix libguestfs-appliance digest

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3422,7 +3422,7 @@ container_pull(
 
 container_pull(
     name = "libguestfs-appliance",
-    digest = "sha256:f0a67de4ff8c61eebce46a81eba908be6175094ea64d95518b7d85e50326ed19",
+    digest = "sha256:1c40f82eac823fc417dc69453685bb0cf79391e1306a2b576f88217d61abd644",
     registry = "quay.io",
     repository = "kubev2v/libguestfs-appliance",
 )


### PR DESCRIPTION
The CI fails on the build/push of the virtv-v2v image with error
```
MANIFEST_UNKNOWN: manifest unknown; map[]
```


https://github.com/kubev2v/forklift/actions/runs/4072203778/jobs/7014720982