### PR TITLE
virt-v2v: Extract compressed tar with libguestfs appliance

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3422,7 +3422,7 @@ container_pull(
 
 container_pull(
     name = "libguestfs-appliance",
-    digest = "sha256:1c40f82eac823fc417dc69453685bb0cf79391e1306a2b576f88217d61abd644",
+    digest = "sha256:6416ecadf57ea1d558f1c6a64b740180f21ae330ed945552eab387ff5e4434b0",
     registry = "quay.io",
     repository = "kubev2v/libguestfs-appliance",
 )
@@ -5734,6 +5734,12 @@ rpm(
     name = "systemd-udev-0__239-70.el8.x86_64",
     sha256 = "bebff1d796265dccbc9e83875b99559ed4b4c547f912ee7604aa0cca7e702f71",
     urls = ["http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/systemd-udev-239-70.el8.x86_64.rpm"],
+)
+
+rpm(
+    name = "tar-2__1.30-8.el8.x86_64",
+    sha256 = "55056b8b60c9382f41e97004ed64fb300c930b29f15b70394d6a5aeffe23010e",
+    urls = ["http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/tar-1.30-8.el8.x86_64.rpm"],
 )
 
 rpm(

--- a/hack/virt-v2v-stream8-rpm-deps.sh
+++ b/hack/virt-v2v-stream8-rpm-deps.sh
@@ -14,6 +14,7 @@ bazel run \
 
 # These are the packages we really depend on.
 virt_v2v="
+  tar
   virt-v2v
   virtio-win
 "

--- a/rpm/BUILD.bazel
+++ b/rpm/BUILD.bazel
@@ -374,6 +374,7 @@ rpmtree(
         "@systemd-libs-0__239-70.el8.x86_64//rpm",
         "@systemd-pam-0__239-70.el8.x86_64//rpm",
         "@systemd-udev-0__239-70.el8.x86_64//rpm",
+        "@tar-2__1.30-8.el8.x86_64//rpm",
         "@tzdata-0__2022g-2.el8.x86_64//rpm",
         "@unbound-libs-0__1.16.2-5.el8.x86_64//rpm",
         "@unzip-0__6.0-46.el8.x86_64//rpm",

--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+shopt -s nullglob
+
+export LIBGUESTFS_PATH=/usr/lib64/guestfs
+set -- "$LIBGUESTFS_PATH"/appliance-*.tar.xz
+if [ -f "$1" ] ; then
+    echo "Extracting libguestfs appliance..."
+    APPLIANCE="/var/tmp/libguestfs-appliance"
+    mkdir -p "$APPLIANCE"
+    tar -xvJf "$1" -C "$APPLIANCE"
+    LIBGUESTFS_PATH="$APPLIANCE/appliance"
+fi
 
 echo "Run virt-v2v with the following input:"
 cat /mnt/v2v/input.xml

--- a/virt-v2v/warm/entrypoint
+++ b/virt-v2v/warm/entrypoint
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+shopt -s nullglob
+
+export LIBGUESTFS_PATH=/usr/lib64/guestfs
+set -- "$LIBGUESTFS_PATH"/appliance-*.tar.xz
+if [ -f "$1" ] ; then
+    echo "Extracting libguestfs appliance..."
+    APPLIANCE="/var/tmp/libguestfs-appliance"
+    mkdir -p "$APPLIANCE"
+    tar -xvJf "$1" -C "$APPLIANCE"
+    LIBGUESTFS_PATH="$APPLIANCE/appliance"
+fi
 
 echo "Run virt-v2v with the following input:"
 cat /mnt/v2v/input.xml


### PR DESCRIPTION
libguestfs in EL8 cannot use appliance in QCOW2. Use compressed tar archive for transport.

This is tied to https://github.com/kubev2v/libguestfs-appliance/pull/2 and depends on #146.