### PR TITLE
Introducing random suffix generator for VM name in case of an already used name.

### DIFF
--- a/pkg/controller/plan/BUILD.bazel
+++ b/pkg/controller/plan/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "migration.go",
         "predicate.go",
         "validation.go",
+        "vm_name_handler.go",
     ],
     importpath = "github.com/konveyor/forklift-controller/pkg/controller/plan",
     visibility = ["//visibility:public"],
@@ -68,7 +69,7 @@ go_library(
 
 go_test(
     name = "plan_test",
-    srcs = ["kubevirt_test.go"],
+    srcs = ["vm_name_handler_test.go"],
     embed = [":plan"],
     deps = ["//vendor/github.com/onsi/gomega"],
 )

--- a/pkg/controller/plan/vm_name_handler.go
+++ b/pkg/controller/plan/vm_name_handler.go
@@ -1,0 +1,103 @@
+package plan
+
+import (
+	"context"
+	"math/rand"
+	"regexp"
+	"strings"
+	"time"
+
+	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	"k8s.io/apimachinery/pkg/fields"
+	cnv "kubevirt.io/client-go/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *KubeVirt) changeVmNameDNS1123(vmName string, vmNamespace string) (generatedName string, err error) {
+	generatedName = changeVmName(vmName)
+	nameExist, errName := r.checkIfVmNameExistsInNamespace(generatedName, vmNamespace)
+	if errName != nil {
+		err = liberr.Wrap(errName)
+		return
+	}
+	if nameExist {
+		// If the name exists and it's at max allowed length, remove 5 chars from the end
+		// so we won't reach the limit after appending vmId
+		if len(generatedName) == NameMaxLength {
+			generatedName = generatedName[0 : NameMaxLength-5]
+		}
+		generatedName = generatedName + "-" + generateRandVmNameSuffix()
+	}
+	return
+}
+
+// changes VM name to match DNS1123 RFC convention.
+func changeVmName(currName string) string {
+	var underscoreExcluded = regexp.MustCompile("[_]")
+	var nameExcludeChars = regexp.MustCompile("[^a-z0-9-]")
+
+	newName := strings.ToLower(currName)
+	if len(newName) > NameMaxLength {
+		newName = newName[0:NameMaxLength]
+	}
+	if underscoreExcluded.MatchString(newName) {
+		newName = underscoreExcluded.ReplaceAllString(newName, "-")
+	}
+	if nameExcludeChars.MatchString(newName) {
+		newName = nameExcludeChars.ReplaceAllString(newName, "")
+	}
+	newName = strings.Trim(newName, "-")
+	if len(newName) == 0 {
+		newName = "vm-" + generateRandVmNameSuffix()
+	}
+	return newName
+}
+
+// Checks if VM with the newly generated name exists on the destination
+func (r *KubeVirt) checkIfVmNameExistsInNamespace(name string, namespace string) (nameExist bool, err error) {
+	list := &cnv.VirtualMachineList{}
+	nameField := "metadata.name"
+	namespaceField := "metadata.namespace"
+	listOptions := &client.ListOptions{
+		FieldSelector: fields.SelectorFromSet(map[string]string{
+			nameField:      name,
+			namespaceField: namespace,
+		}),
+	}
+	err = r.Destination.Client.List(
+		context.TODO(),
+		list,
+		listOptions,
+	)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if len(list.Items) > 0 {
+		nameExist = true
+		return
+	}
+	// Checks that the new name does not match a valid
+	// VM name in the same plan
+	for _, vm := range r.Migration.Status.VMs {
+		if vm.Name == name {
+			nameExist = true
+			return
+		}
+	}
+	nameExist = false
+	return
+}
+
+// Generates a random string of length four, consisting of lowercase letters and digits.
+func generateRandVmNameSuffix() string {
+	const charset = "abcdefghijklmnopqrstuvwxyz" + "0123456789"
+	source := rand.NewSource(time.Now().UTC().UnixNano())
+	seededRand := rand.New(source)
+
+	b := make([]byte, 4)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/pkg/controller/plan/vm_name_handler_test.go
+++ b/pkg/controller/plan/vm_name_handler_test.go
@@ -6,17 +6,16 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func TestKubevirt(t *testing.T) {
+func TestVmNameHandler(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	id := "1234-5678"
 
 	//Test all cases in name adjustments
 	originalVmName := "----------------Vm!@#$%^&*()_+-Name/.,';[]-CorREct-<>123----------------------"
 	newVmName := "vm--name-correct-123"
-	g.Expect(changeVmName(originalVmName, id)).To(gomega.Equal(newVmName))
+	g.Expect(changeVmName(originalVmName)).To(gomega.Equal(newVmName))
 
 	//Test the case that the VM name is empty after all removals
 	emptyVM := ".__."
-	newVmNameFromId := "vm-1234"
-	g.Expect(changeVmName(emptyVM, id)).To(gomega.Equal(newVmNameFromId))
+	newVmNameFromId := "vm-"
+	g.Expect(changeVmName(emptyVM)).To(gomega.ContainSubstring(newVmNameFromId))
 }


### PR DESCRIPTION
Currently, during the migration, if the VM has an invalid name and the newly generated name exists in the namespace, a name of the format `vm-vmId[0:4]` is picked as a unique identifier.
For oVirt, this solution works well, but for vmware, the vm Id is in the following format: `vm-#vm_number_counter`. Because the counter can be any number and is not sufficiently unique, attaching it to the new name can cause issues.
To address this issue, this PR introduces a tool that generates a new random string of six lowercase letters and digits.

Also, this PR separates all VM name changing flow into a new file. 