### PR TITLE
Introduce openstack test suite to the CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   ci_setup:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -23,6 +24,9 @@ jobs:
 
           - os: ubuntu-latest
             source_provider: vsphere
+
+          - os: ubuntu-latest
+            source_provider: openstack
 
     runs-on: ${{ matrix.os }}
     env:
@@ -36,6 +40,7 @@ jobs:
         uses: kubev2v/forkliftci@main
         with:
           gh_access_token: ${{ secrets.GITHUB_TOKEN }}
+          provider_name: ${{ matrix.source_provider }}
 
       - run: kubectl version
 

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ e2e-sanity-vsphere:
 	# vsphere suit
 	go test ./tests/suit -v -ginkgo.focus ".*vSphere.*"
 
+e2e-sanity-openstack:
+	# openstack suit
+	go test ./tests/suit -v -ginkgo.focus ".*Openstack.*"
+
 # Build forklift-controller binary
 forklift-controller: generate fmt vet
 	go build -o bin/forklift-controller github.com/konveyor/forklift-controller/cmd/forklift-controller

--- a/tests/suit/openstack_test.go
+++ b/tests/suit/openstack_test.go
@@ -1,0 +1,29 @@
+package suit_test
+
+import (
+	"github.com/konveyor/forklift-controller/tests/suit/framework"
+	"github.com/konveyor/forklift-controller/tests/suit/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	openstackProviderName = "openstack-provider"
+)
+
+var _ = Describe("[level:component]Migration tests for Openstack provider", func() {
+	f := framework.NewFramework("migration-func-test")
+
+	It("[test] should create provider with NetworkMap", func() {
+
+		By("Create Secret from Definition")
+		_, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
+			map[string][]byte{
+				"thumbprint": []byte("52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF"),
+				"password":   []byte("MTIzNDU2Cg=="),
+				"user":       []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
+			}, f.Namespace.Name, "provider-test-secret"))
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+})


### PR DESCRIPTION
when we trigger  a ci  job from the matrix,  we want specify which provider env setup is needed (openstack/ovirt/vsphere), so we will  run tests only on that provider.

- split the setup jobs across different providers
- depends on this PR https://github.com/kubev2v/forkliftci/pull/59

this PR doesn't  cover the whole ginko test suite for OSP.