### PR TITLE
build: Use packaging rules from external repository

### DIFF
--- a/virt-v2v/cold/BUILD.bazel
+++ b/virt-v2v/cold/BUILD.bazel
@@ -4,7 +4,7 @@ load(
     "container_push",
 )
 load("@bazeldnf//:deps.bzl", "rpmtree")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 container_push(
     name = "push-forklift-virt-v2v",

--- a/virt-v2v/cold/WORKSPACE
+++ b/virt-v2v/cold/WORKSPACE
@@ -130,6 +130,17 @@ go_repository(
 # because the first definitions of external repository wins.
 gazelle_dependencies()
 
+http_archive(
+    name = "rules_pkg",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
+    ],
+    sha256 = "8c20f74bca25d2d442b327ae26768c02cf3c99e93fad0381f32be9aab1967675",
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",


### PR DESCRIPTION
The rules have been extracted from Bazel and are in external repository now. Use of the original rules is deprecated.

Also, container build fails on Bazel 6.0 withe the original rules reporting error:

    no such attribute 'mode' in '_real_pkg_tar' rule