### PR TITLE
ovirt-populator: change an error to fatal

### DIFF
--- a/cmd/ovirt-populator/ovirt-populator.go
+++ b/cmd/ovirt-populator/ovirt-populator.go
@@ -148,7 +148,7 @@ func populate(crName, engineURL, secretName, diskID, volPath, namespace, crNames
 	<-done
 	err = cmd.Wait()
 	if err != nil {
-		klog.Error(err)
+		klog.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
In case we are exiting from ovirt-imgio with an error - we should end the pod with fatal error, indicating a failure in the transfer.
Until now, it just printed the error and could finish as completed even when it didn't.