### PR TITLE
fix for ovirt CI migration test e2e_cacert.cer changed path

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -56,7 +56,7 @@ jobs:
           OVIRT_USERNAME: admin@internal
           OVIRT_PASSWORD: 123456
           OVIRT_URL: https://fakeovirt.konveyor-forklift:30001/ovirt-engine/api
-          OVIRT_CACERT: /home/runner/work/_actions/kubev2v/forkliftci/main/ovirt/e2e_cacert.cer
+          OVIRT_CACERT: /home/runner/work/_actions/kubev2v/forkliftci/main/cluster/providers/ovirt/e2e_cacert.cer
           STORAGE_CLASS: standard
           OVIRT_VM_ID: 31573c08-717b-43e0-825f-69a36fb0e1a1
         run: |


### PR DESCRIPTION
the cert path has changed  in the CI https://github.com/kubev2v/forkliftci/pull/63

