### PR TITLE
Authenticate requests for the currect namespace

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -210,11 +210,11 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 	env = append(
 		env,
 		core.EnvVar{
-			Name: "V2V_vmName",
+			Name:  "V2V_vmName",
 			Value: vm.Name,
 		},
 		core.EnvVar{
-			Name:"V2V_libvirtURL",
+			Name:  "V2V_libvirtURL",
 			Value: libvirtURL.String(),
 		},
 	)

--- a/pkg/controller/provider/web/base/auth_test.go
+++ b/pkg/controller/provider/web/base/auth_test.go
@@ -3,6 +3,7 @@ package base
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -87,6 +88,7 @@ func TestAuth(t *testing.T) {
 			Header: map[string][]string{
 				"Authorization": {"Bearer " + token},
 			},
+			URL: &url.URL{},
 		},
 	}
 	provider := &api.Provider{

--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -86,7 +86,8 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, err error) {
 	content = []interface{}{}
 	list := h.Container.List()
-	ns := ctx.Param(base.NsParam)
+	q := ctx.Request.URL.Query()
+	ns := q.Get(base.NsParam)
 	for _, collector := range list {
 		if p, cast := collector.Owner().(*api.Provider); cast {
 			if p.Type() != api.OpenShift {

--- a/pkg/controller/provider/web/openstack/provider.go
+++ b/pkg/controller/provider/web/openstack/provider.go
@@ -95,7 +95,8 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, err error) {
 	content = []interface{}{}
 	list := h.Container.List()
-	ns := ctx.Param(base.NsParam)
+	q := ctx.Request.URL.Query()
+	ns := q.Get(base.NsParam)
 	for _, collector := range list {
 		if p, cast := collector.Owner().(*api.Provider); cast {
 			if p.Type() != api.OpenStack {

--- a/pkg/controller/provider/web/ovirt/provider.go
+++ b/pkg/controller/provider/web/ovirt/provider.go
@@ -91,7 +91,8 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, err error) {
 	content = []interface{}{}
 	list := h.Container.List()
-	ns := ctx.Param(base.NsParam)
+	q := ctx.Request.URL.Query()
+	ns := q.Get(base.NsParam)
 	for _, collector := range list {
 		if p, cast := collector.Owner().(*api.Provider); cast {
 			if p.Type() != api.OVirt {

--- a/pkg/controller/provider/web/vsphere/provider.go
+++ b/pkg/controller/provider/web/vsphere/provider.go
@@ -91,7 +91,8 @@ func (h ProviderHandler) Get(ctx *gin.Context) {
 func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, err error) {
 	content = []interface{}{}
 	list := h.Container.List()
-	ns := ctx.Param(base.NsParam)
+	q := ctx.Request.URL.Query()
+	ns := q.Get(base.NsParam)
 	for _, collector := range list {
 		if p, cast := collector.Owner().(*api.Provider); cast {
 			if p.Type() != api.VSphere {


### PR DESCRIPTION
Issue: currently the authentication code checks if user can list providers on all namespaces (or on "POD_NAMESPACE" env variable if available) but list the providers using a URL param, this may allow users to list providers the do not have permission to list.

Fix:
  - [x] use the context `Request` param instead of the context param to get the namespace, the  `Request` param was never defined, and is empty always.
  - [x] fix the authentication code to use the real namespace, preventing a user that can list providers on "POD_NAMESPACE" from listing providers on other namespaces.

example of use:
``` bash
export TOKEN=[secret-token]
curl -k -H "Authorization: Bearer ${TOKEN}" http://localhost:8080/providers?namespace=forklift | jq
```