### PR TITLE
Fix end-to-end tests

### DIFF
--- a/tests/suit/openstack_test.go
+++ b/tests/suit/openstack_test.go
@@ -15,6 +15,7 @@ var _ = Describe("[level:component]Migration tests for Openstack provider", func
 	f := framework.NewFramework("migration-func-test")
 
 	It("[test] should create provider with NetworkMap", func() {
+		namespace := f.Namespace.Name
 
 		By("Create Secret from Definition")
 		_, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,

--- a/tests/suit/openstack_test.go
+++ b/tests/suit/openstack_test.go
@@ -23,7 +23,7 @@ var _ = Describe("[level:component]Migration tests for Openstack provider", func
 				"thumbprint": []byte("52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF"),
 				"password":   []byte("MTIzNDU2Cg=="),
 				"user":       []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
-			}, f.Namespace.Name, "provider-test-secret"))
+			}, namespace, "provider-test-secret"))
 		Expect(err).ToNot(HaveOccurred())
 
 	})

--- a/tests/suit/ovirt_test.go
+++ b/tests/suit/ovirt_test.go
@@ -16,10 +16,9 @@ const (
 
 var _ = Describe("[level:component]Migration tests for oVirt provider", func() {
 	f := framework.NewFramework("migration-func-test")
-	namespace := f.Namespace.Name
 
 	FIt("[oVirt MTV] should create provider with NetworkMap", func() {
-
+		namespace := f.Namespace.Name
 		err := f.Clients.OvirtClient.SetupClient()
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/suit/utils/networkmap.go
+++ b/tests/suit/utils/networkmap.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 	"fmt"
+	"time"
+
 	forkliftv1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/provider"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
@@ -12,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // CreateNetworkMapFromDefinition is used by tests to create a NetworkMap

--- a/tests/suit/utils/plan.go
+++ b/tests/suit/utils/plan.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 	"fmt"
+	"time"
+
 	forkliftv1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/provider"
@@ -13,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // CreatePlanFromDefinition is used by tests to create a Plan

--- a/tests/suit/utils/storagemap.go
+++ b/tests/suit/utils/storagemap.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 	"fmt"
+	"time"
+
 	forkliftv1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/provider"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
@@ -12,14 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // CreateStorageMapFromDefinition is used by tests to create a StorageMap
 func CreateStorageMapFromDefinition(cl crclient.Client, def *forkliftv1.StorageMap) error {
-	var err error
-	err = cl.Create(context.TODO(), def, &crclient.CreateOptions{})
-
+	err := cl.Create(context.TODO(), def, &crclient.CreateOptions{})
 	if err == nil || apierrs.IsAlreadyExists(err) {
 		return nil
 	}

--- a/tests/suit/vsphere_test.go
+++ b/tests/suit/vsphere_test.go
@@ -18,7 +18,8 @@ var _ = Describe("[level:component]Migration tests for vSphere provider", func()
 	f := framework.NewFramework("migration-func-test")
 
 	It("[test] should create provider with NetworkMap", func() {
-		namespace := f.Namespace.Name
+		// TODO: use a different (the generated) namespace
+		namespace := "konveyor-forklift"
 		By("Create Secret from Definition")
 		s, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
 			map[string][]byte{
@@ -29,24 +30,24 @@ var _ = Describe("[level:component]Migration tests for vSphere provider", func()
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create vSphere provider")
-		pr := utils.NewProvider(vsphereProviderName, forkliftv1.VSphere, f.Namespace.Name, map[string]string{"vddkInitImage": "quay.io/kubev2v/vddk-test-vmdk"}, "https://vcsim.konveyor-forklift:8989/sdk", s)
+		pr := utils.NewProvider(vsphereProviderName, forkliftv1.VSphere, namespace, map[string]string{"vddkInitImage": "quay.io/kubev2v/vddk-test-vmdk"}, "https://vcsim.konveyor-forklift:8989/sdk", s)
 		err = utils.CreateProviderFromDefinition(f.CrClient, pr)
 		Expect(err).ToNot(HaveOccurred())
-		err = utils.WaitForProviderReadyWithTimeout(f.CrClient, f.Namespace.Name, vsphereProviderName, 30*time.Second)
+		err = utils.WaitForProviderReadyWithTimeout(f.CrClient, namespace, vsphereProviderName, 30*time.Second)
 		Expect(err).ToNot(HaveOccurred())
-		provider, err := utils.GetProvider(f.CrClient, vsphereProviderName, f.Namespace.Name)
+		provider, err := utils.GetProvider(f.CrClient, vsphereProviderName, namespace)
 		Expect(err).ToNot(HaveOccurred())
 		By("Create Network Map")
 		networkMapDef := utils.NewNetworkMap(namespace, *provider, networkMapName, "dvportgroup-13")
 		err = utils.CreateNetworkMapFromDefinition(f.CrClient, networkMapDef)
 		Expect(err).ToNot(HaveOccurred())
-		err = utils.WaitForNetworkMapReadyWithTimeout(f.CrClient, f.Namespace.Name, networkMapName, 10*time.Second)
+		err = utils.WaitForNetworkMapReadyWithTimeout(f.CrClient, namespace, networkMapName, 10*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 		By("Create Storage Map")
 		storageMapDef := utils.NewStorageMap(namespace, *provider, test_storage_map_name, []string{"datastore-52"})
 		err = utils.CreateStorageMapFromDefinition(f.CrClient, storageMapDef)
 		Expect(err).ToNot(HaveOccurred())
-		err = utils.WaitForStorageMapReadyWithTimeout(f.CrClient, f.Namespace.Name, test_storage_map_name, 10*time.Second)
+		err = utils.WaitForStorageMapReadyWithTimeout(f.CrClient, namespace, test_storage_map_name, 10*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Creating plan")
@@ -54,7 +55,7 @@ var _ = Describe("[level:component]Migration tests for vSphere provider", func()
 
 		err = utils.CreatePlanFromDefinition(f.CrClient, planDef)
 		Expect(err).ToNot(HaveOccurred())
-		err = utils.WaitForPlanReadyWithTimeout(f.CrClient, f.Namespace.Name, test_plan_name, 15*time.Second)
+		err = utils.WaitForPlanReadyWithTimeout(f.CrClient, namespace, test_plan_name, 15*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Creating migration")

--- a/tests/suit/vsphere_test.go
+++ b/tests/suit/vsphere_test.go
@@ -16,10 +16,9 @@ const (
 
 var _ = Describe("[level:component]Migration tests for vSphere provider", func() {
 	f := framework.NewFramework("migration-func-test")
-	namespace := f.Namespace.Name
 
 	It("[test] should create provider with NetworkMap", func() {
-
+		namespace := f.Namespace.Name
 		By("Create Secret from Definition")
 		s, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
 			map[string][]byte{


### PR DESCRIPTION
The end-to-end tests were not executed properly with the changes that we done in #165 as the framework's generated namespaces are created in BeforeEach and we tried to retrieve them before that.

In addition, there's a problem with running the vSphere tests when the entities are created within the generated namespace, so we keep using the 'konveyor-forklift' namespace until this will be further investigated.