### PR TITLE
Fix the access modes of the PVC

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -693,8 +693,16 @@ func (r *KubeVirt) getStorageProfileModes(storageName string) (accessModes []cor
 		storageProfile := &storageProfileList.Items[i]
 		if storageProfile.Name == storageName {
 			for _, claimProperty := range storageProfile.Status.ClaimPropertySets {
-				accessModes = append(accessModes, claimProperty.AccessModes...)
 				volumeMode = claimProperty.VolumeMode
+				if *volumeMode == core.PersistentVolumeBlock {
+					// Preferring Block volume mode
+					break
+				}
+			}
+			for _, claimProperty := range storageProfile.Status.ClaimPropertySets {
+				if *claimProperty.VolumeMode == *volumeMode {
+					accessModes = append(accessModes, claimProperty.AccessModes...)
+				}
 			}
 			break
 		}


### PR DESCRIPTION
When passing on the storage profile it can have multiple accessmodes and multiple volume modes. We prefer the block volume mode and set the access modes accordingly.