### PR TITLE
Short names for OpenStack/oVirt volume populators

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_openstackvolumepopulators.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_openstackvolumepopulators.yaml
@@ -13,6 +13,9 @@ spec:
     listKind: OpenstackVolumePopulatorList
     plural: openstackvolumepopulators
     singular: openstackvolumepopulator
+    shortNames:
+    - osvp
+    - osvps
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/operator/config/crd/bases/forklift.konveyor.io_ovirtvolumepopulators.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_ovirtvolumepopulators.yaml
@@ -13,6 +13,9 @@ spec:
     listKind: OvirtVolumePopulatorList
     plural: ovirtvolumepopulators
     singular: ovirtvolumepopulator
+    shortNames:
+    - ovvp
+    - ovvps
   scope: Namespaced
   versions:
   - name: v1beta1


### PR DESCRIPTION
For OpenStack the names are: osvp, osvps.
For oVirt the bames are: ovvp, ovvps.
The ease querying the populator CRs from the CLI a bit.