### PR TITLE
Enable UI plugin by default

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -4,6 +4,7 @@ app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
 
 # Feature defaults
 feature_ui: true
+feature_ui_plugin: true
 feature_validation: true
 feature_must_gather_api: true
 feature_volume_populator: true


### PR DESCRIPTION
Previously the 'feature_ui_plugin' var wasn't set with a default value
and thus triggered the following error when it wasn't define in
ForkliftController:

The conditional check 'feature_ui_plugin|bool and not k8s_cluster|bool'
failed. The error was: error while evaluating conditional
(feature_ui_plugin|bool and not k8s_cluster|bool): 'feature_ui_plugin'
is undefined

Now this variable is defined and set to 'true' in order to deploy the
console plugin by default.