### PR TITLE
Do not set 'kubevirt.io/schedulable' when VirtV2vDontRequestKVM is set

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1135,6 +1135,7 @@ func (r *KubeVirt) findTemplate(vm *plan.VMStatus) (tmpl *template.Template, err
 func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, configMap *core.ConfigMap, pvcs *[]core.PersistentVolumeClaim, v2vSecret *core.Secret) (pod *core.Pod, err error) {
 	volumes, volumeMounts, volumeDevices := r.podVolumeMounts(vmVolumes, configMap, pvcs)
 	resourceReq := core.ResourceRequirements{}
+	var nodeSelector map[string]string
 
 	// Request access to /dev/kvm via Kubevirt's Device Manager
 	// That is to ensure the appliance virt-v2v uses would not
@@ -1143,6 +1144,8 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 		resourceReq.Limits = core.ResourceList{
 			"devices.kubevirt.io/kvm": resource.MustParse("1"),
 		}
+		// Ensure that the pod is deployed on a node where /dev/kvm is present.
+		nodeSelector["kubevirt.io/schedulable"] = "true"
 	}
 
 	// qemu group
@@ -1204,11 +1207,8 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 					Resources:     resourceReq,
 				},
 			},
-			Volumes: volumes,
-			// Ensure that the pod is deployed on a node where /dev/kvm is present.
-			NodeSelector: map[string]string{
-				"kubevirt.io/schedulable": "true",
-			},
+			Volumes:      volumes,
+			NodeSelector: nodeSelector,
 		},
 	}
 


### PR DESCRIPTION
When we don't require KVM, we shouldn't filter hosts that have kubevirt.io/schedulable=true