### PR TITLE
Rename insecure secret key to insecureSkipVerify in openstack

### DIFF
--- a/cmd/openstack-populator/openstack-populator.go
+++ b/cmd/openstack-populator/openstack-populator.go
@@ -53,12 +53,12 @@ func main() {
 }
 
 type openstackConfig struct {
-	username    string
-	password    string
-	domainName  string
-	projectName string
-	insecure    string
-	region      string
+	username           string
+	password           string
+	domainName         string
+	projectName        string
+	insecureSkipVerify string
+	region             string
 }
 
 func loadConfig(secretName, endpoint, namespace string) openstackConfig {
@@ -82,18 +82,18 @@ func loadConfig(secretName, endpoint, namespace string) openstackConfig {
 	if err != nil {
 		klog.Fatal(err.Error())
 	}
-	insecure, err := os.ReadFile("/etc/secret-volume/insecure")
+	insecureSkipVerify, err := os.ReadFile("/etc/secret-volume/insecureSkipVerify")
 	if err != nil {
 		klog.Fatal(err.Error())
 	}
 
 	return openstackConfig{
-		username:    string(username),
-		password:    string(password),
-		insecure:    string(insecure),
-		projectName: string(projectName),
-		region:      string(region),
-		domainName:  string(domainName),
+		username:           string(username),
+		password:           string(password),
+		insecureSkipVerify: string(insecureSkipVerify),
+		projectName:        string(projectName),
+		region:             string(region),
+		domainName:         string(domainName),
 	}
 }
 

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -219,12 +219,12 @@ func (r *Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVol
 // Build credential secret.
 func (r *Builder) Secret(_ ref.Ref, in, secret *core.Secret) (err error) {
 	secret.StringData = map[string]string{
-		"username":    string(in.Data["username"]),
-		"password":    string(in.Data["password"]),
-		"domainName":  string(in.Data["domainName"]),
-		"projectName": string(in.Data["projectName"]),
-		"region":      string(in.Data["region"]),
-		"insecure":    string(in.Data["insecure"]),
+		"username":           string(in.Data["username"]),
+		"password":           string(in.Data["password"]),
+		"domainName":         string(in.Data["domainName"]),
+		"projectName":        string(in.Data["projectName"]),
+		"region":             string(in.Data["region"]),
+		"insecureSkipVerify": string(in.Data["insecureSkipVerify"]),
 	}
 	return
 }

--- a/pkg/controller/provider/container/openstack/client.go
+++ b/pkg/controller/provider/container/openstack/client.go
@@ -49,7 +49,7 @@ func (r *Client) Connect() (err error) {
 	// 	return
 	// }
 
-	if r.insecure() {
+	if r.insecureSkipVerify() {
 		TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	} else {
 		cacert := []byte(r.cacert())
@@ -176,14 +176,14 @@ func (r *Client) cacert() string {
 	return ""
 }
 
-// Insecure
-func (r *Client) insecure() bool {
-	if insecure, found := r.Secret.Data["insecure"]; found {
-		insecure, err := strconv.ParseBool(string(insecure))
+// insecureSkipVerify
+func (r *Client) insecureSkipVerify() bool {
+	if insecureSkipVerifyStr, found := r.Secret.Data["insecureSkipVerify"]; found {
+		insecureSkipVerify, err := strconv.ParseBool(string(insecureSkipVerifyStr))
 		if err != nil {
 			return false
 		}
-		return insecure
+		return insecureSkipVerify
 	}
 	return false
 }


### PR DESCRIPTION
Rename insecure secret key to insecureSkipVerify in openstack to macth the secret key in vmware and ovirt

Issue:
Currently we use `insecureSkipVerify` secret key in oVirt and vmWare secrets, and `insecure` in openstack provider

Fix:
Align the openstack secret key with ovirt and vmWare

  - [x] change the secret key in the provider
  - [x] change the config file key in openstack populator (to keep identical secret for provider and populater)