### PR TITLE
Update console plugin display name

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -82,6 +82,7 @@ ui_state: absent
 
 ui_plugin_image_fqin: "{{ lookup( 'env', 'UI_PLUGIN_IMAGE') or lookup( 'env', 'RELATED_IMAGE_UI_PLUGIN') }}"
 ui_plugin_console_name: "{{ app_name }}-console-plugin"
+ui_plugin_display_name: "Console plugin for {{ app_name }}"
 ui_plugin_service_name: "{{ app_name }}-ui-plugin"
 ui_plugin_deployment_name: "{{ ui_plugin_service_name }}"
 ui_plugin_container_name: "{{ app_name }}-ui-plugin"

--- a/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
@@ -6,7 +6,7 @@ metadata:
   annotations:
     console.openshift.io/use-i18n: "true" 
 spec:
-  displayName: 'Console Plugin Template'
+  displayName: {{ ui_plugin_display_name }}
   service:
     name: {{ ui_plugin_service_name }}
     port: 9443


### PR DESCRIPTION
Issue:
when creating the automation we didn't change the template pluging display name, so it currently say "Console Plugin Template"

Fix:
update the display name to be "Console plugin for {app name}"