### PR TITLE
Use nfs-csi in vSphere test

### DIFF
--- a/tests/suit/vsphere_test.go
+++ b/tests/suit/vsphere_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	vsphereProviderName = "vsphere-provider"
-	vsphereStorageClass = "standard"
+	vsphereStorageClass = "nfs-csi"
 )
 
 var _ = Describe("[level:component]Migration tests for vSphere provider", func() {


### PR DESCRIPTION
With CDI 1.56.0, the vSphere test fails with the 'standard' storage class. While we need to investigate this, it seems like the right time to align with ovirt's and openstack's tests, and use nfs-csi also in the vsphere test.