### PR TITLE
Create a consumer to PVC

### DIFF
--- a/cmd/virt-v2v-monitor/BUILD.bazel
+++ b/cmd/virt-v2v-monitor/BUILD.bazel
@@ -12,9 +12,9 @@ go_library(
     importpath = "github.com/konveyor/forklift-controller/cmd/virt-v2v-monitor",
     visibility = ["//visibility:private"],
     deps = [
-	"//vendor/github.com/prometheus/client_golang/prometheus",
-	"//vendor/github.com/prometheus/client_golang/prometheus/promhttp",
-	"//vendor/github.com/prometheus/client_model/go",
+        "//vendor/github.com/prometheus/client_golang/prometheus",
+        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp",
+        "//vendor/github.com/prometheus/client_model/go",
         "//vendor/k8s.io/klog/v2:klog",
     ],
 )

--- a/tests/suit/framework/BUILD.bazel
+++ b/tests/suit/framework/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "exec_util.go",
         "framework.go",
+        "openstack.go",
         "ovirt.go",
     ],
     importpath = "github.com/konveyor/forklift-controller/tests/suit/framework",
@@ -13,6 +14,7 @@ go_library(
         "//pkg/apis",
         "//pkg/apis/forklift/v1beta1",
         "//pkg/apis/forklift/v1beta1/ref",
+        "//tests/suit/utils",
         "//vendor/github.com/onsi/ginkgo",
         "//vendor/github.com/onsi/gomega",
         "//vendor/github.com/ovirt/go-ovirt",

--- a/virt-v2v/cold/BUILD.bazel
+++ b/virt-v2v/cold/BUILD.bazel
@@ -45,7 +45,10 @@ container_image(
     empty_dirs = ["/disks"],
     entrypoint = ["/usr/local/bin/entrypoint"],
     env = {"LIBGUESTFS_BACKEND": "direct"},
-    files = ["entrypoint", "@forklift//cmd/virt-v2v-monitor:virt-v2v-monitor"],
+    files = [
+        "entrypoint",
+        "@forklift//cmd/virt-v2v-monitor",
+    ],
     user = "1001",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
When having a storage class with `WaitForConsumer` the disk transfer won't start until the PVC had a consumer and it has the annotation `volume.kubernetes.io/selected-node`. For that, we will create a simple pod associated with the PVC to let kubernetes schedule it - making a consumer to the PVC.

When executed by the volume populator, the PV won't create, letting the volume populator to be executed. As for vSphere, the data is overriden when transferred.

The pod will remain on destination namespace. Once the plan is archived it will be cleaned up.