### PR TITLE
Drop SeccompProfile from populator pod

### DIFF
--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -735,9 +735,6 @@ func makePopulatePodSpec(pvcPrimeName, secretName string) corev1.PodSpec {
 					AllowPrivilegeEscalation: &allowPrivilageEscalation,
 					RunAsNonRoot:             &nonRoot,
 					RunAsUser:                &user,
-					SeccompProfile: &corev1.SeccompProfile{
-						Type: corev1.SeccompProfileTypeRuntimeDefault,
-					},
 					Capabilities: &corev1.Capabilities{
 						Drop: []corev1.Capability{"ALL"},
 					},


### PR DESCRIPTION
Having the SeccompProfile set to runtime caused an issue starting the pod with the error:

`
E0308 21:59:06.167954 1 controller.go:418] error syncing 'pvc/arik/2d096ab7-44fa-4935-b0d0-333532e84e5f': pods "populate-f4436d1b-2075-4a51-b6a1-3b1d72e29cde" is forbidden: unable to validate against any security context constraint: [pod.metadata.annotations[[container.seccomp.security.alpha.kubernetes.io/populate](http://container.seccomp.security.alpha.kubernetes.io/populate)]: Forbidden: seccomp may not be set, provider "containerized-data-importer": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: []int64{107}: 107 is not an allowed group, spec.containers[0].securityContext.runAsUser: Invalid value: 107: must be in the ranges: [1000700000, 1000709999], provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "kubevirt-controller": Forbidden: not usable b...
`
That came from PR #189 and relates to https://github.com/openshift/cluster-kube-apiserver-operator/issues/1325