### PR TITLE
Fix imports using virt-v2v to remote clusters

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -54,6 +54,8 @@ spec:
           value: ${VALIDATION_IMAGE}
         - name: VIRT_V2V_IMAGE
           value: ${VIRT_V2V_IMAGE}
+        - name: VIRT_V2V_WARM_IMAGE
+          value: ${VIRT_V2V_WARM_IMAGE}
         - name: VIRT_V2V_DONT_REQUEST_KVM
           value: ${VIRT_V2V_DONT_REQUEST_KVM}
         - name: POPULATOR_CONTROLLER_IMAGE

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1145,7 +1145,7 @@ func (r *KubeVirt) findTemplate(vm *plan.VMStatus) (tmpl *template.Template, err
 func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, configMap *core.ConfigMap, pvcs *[]core.PersistentVolumeClaim, v2vSecret *core.Secret) (pod *core.Pod, err error) {
 	volumes, volumeMounts, volumeDevices := r.podVolumeMounts(vmVolumes, configMap, pvcs)
 	resourceReq := core.ResourceRequirements{}
-	var nodeSelector map[string]string
+	nodeSelector := make(map[string]string)
 
 	// Request access to /dev/kvm via Kubevirt's Device Manager
 	// That is to ensure the appliance virt-v2v uses would not


### PR DESCRIPTION
1. Fix seg fault in `guestConversionPod`
2. Add missing VIRT_V2V_WARM_IMAGE env var to CSV
