### PR TITLE
Fix generation of manifests for populator CRDs

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_openstackvolumepopulators.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_openstackvolumepopulators.yaml
@@ -12,10 +12,10 @@ spec:
     kind: OpenstackVolumePopulator
     listKind: OpenstackVolumePopulatorList
     plural: openstackvolumepopulators
-    singular: openstackvolumepopulator
     shortNames:
     - osvp
     - osvps
+    singular: openstackvolumepopulator
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/operator/config/crd/bases/forklift.konveyor.io_ovirtvolumepopulators.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_ovirtvolumepopulators.yaml
@@ -12,10 +12,10 @@ spec:
     kind: OvirtVolumePopulator
     listKind: OvirtVolumePopulatorList
     plural: ovirtvolumepopulators
-    singular: ovirtvolumepopulator
     shortNames:
     - ovvp
     - ovvps
+    singular: ovirtvolumepopulator
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/pkg/apis/forklift/v1beta1/openstackpopulator.go
+++ b/pkg/apis/forklift/v1beta1/openstackpopulator.go
@@ -9,11 +9,13 @@ var OpenstackVolumePopulatorKind = "OpenstackVolumePopulator"
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName={osvp,osvps}
 type OpenstackVolumePopulator struct {
 	meta.TypeMeta   `json:",inline"`
 	meta.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   OpenstackVolumePopulatorSpec   `json:"spec"`
+	// +optional
 	Status OpenstackVolumePopulatorStatus `json:"status"`
 }
 
@@ -24,6 +26,7 @@ type OpenstackVolumePopulatorSpec struct {
 }
 
 type OpenstackVolumePopulatorStatus struct {
+	// +optional
 	Transferred string `json:"transferred"`
 }
 

--- a/pkg/apis/forklift/v1beta1/ovirtpopulator.go
+++ b/pkg/apis/forklift/v1beta1/ovirtpopulator.go
@@ -9,6 +9,7 @@ var OvirtVolumePopulatorKind = "OvirtVolumePopulator"
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName={ovvp,ovvps}
 type OvirtVolumePopulator struct {
 	meta.TypeMeta   `json:",inline"`
 	meta.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
1. Add 'optional' comments to the status properties of OpenstackVolumePopulator
2. Add 'shortNames' as comments for OpenstackVolumePopulator and OvirtVolumePopulator

And updated the manifets with `make manifests`