### PR TITLE
Fix PVC consumer pod security

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -650,6 +650,7 @@ func (r *KubeVirt) createPodToBindPVCs(vm *plan.VMStatus, pvcNames []string) err
 		})
 	}
 	nonRoot := true
+	user := qemuUser
 	allowPrivilageEscalation := false
 	pod := &core.Pod{
 		ObjectMeta: meta.ObjectMeta{
@@ -667,11 +668,9 @@ func (r *KubeVirt) createPodToBindPVCs(vm *plan.VMStatus, pvcNames []string) err
 					SecurityContext: &core.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilageEscalation,
 						RunAsNonRoot:             &nonRoot,
+						RunAsUser:                &user,
 						Capabilities: &core.Capabilities{
 							Drop: []core.Capability{"ALL"},
-						},
-						SeccompProfile: &core.SeccompProfile{
-							Type: core.SeccompProfileTypeRuntimeDefault,
 						},
 					},
 				},


### PR DESCRIPTION
Having `RunAsNonRoot` requires to specify the user the container is intended to run with.