### PR TITLE
openstack: parallelize creation of PVCs

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -55,7 +55,7 @@ type Builder interface {
 	// Create PersistentVolumeClaim with a DataSourceRef
 	PersistentVolumeClaimWithSourceRef(da interface{}, storageName *string, populatorName string, accessModes []core.PersistentVolumeAccessMode, volumeMode *core.PersistentVolumeMode) *core.PersistentVolumeClaim
 	// Add custom steps before creating PVC/DataVolume
-	BeforeTransferHook(c Client, vmRef ref.Ref) (ready bool, err error)
+	PreTransferActions(c Client, vmRef ref.Ref) (ready bool, err error)
 }
 
 // Client API.

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -870,7 +870,7 @@ func (r *Builder) PersistentVolumeClaimWithSourceRef(da interface{}, storageName
 	}
 }
 
-func (r *Builder) BeforeTransferHook(c planbase.Client, vmRef ref.Ref) (ready bool, err error) {
+func (r *Builder) PreTransferActions(c planbase.Client, vmRef ref.Ref) (ready bool, err error) {
 	// TODO:
 	// 1. Dedup
 	// 2. Improve concurrency, as soon as the image is ready we can create the PVC, no need to wait

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -566,6 +566,6 @@ func (r *Builder) PersistentVolumeClaimWithSourceRef(da interface{}, storageName
 	}
 }
 
-func (r *Builder) BeforeTransferHook(c planbase.Client, vmRef ref.Ref) (ready bool, err error) {
+func (r *Builder) PreTransferActions(c planbase.Client, vmRef ref.Ref) (ready bool, err error) {
 	return true, nil
 }

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -785,6 +785,6 @@ func (r *Builder) PersistentVolumeClaimWithSourceRef(da interface{}, storageName
 	return nil
 }
 
-func (r *Builder) BeforeTransferHook(c planbase.Client, vmRef ref.Ref) (ready bool, err error) {
+func (r *Builder) PreTransferActions(c planbase.Client, vmRef ref.Ref) (ready bool, err error) {
 	return true, nil
 }

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -594,7 +594,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			break
 		}
 		var ready bool
-		ready, err = r.builder.BeforeTransferHook(r.provider, vm.Ref)
+		ready, err = r.builder.PreTransferActions(r.provider, vm.Ref)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -620,7 +620,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		}
 
 		if !ready {
-			r.Log.Info("BeforeTransfer hook isn't ready yet")
+			r.Log.Info("PreTransferActions hook isn't ready yet")
 			return
 		}
 

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -603,13 +603,13 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		var pvcNames []string
 		if r.kubevirt.isOpenstack(vm) {
 			pvcNames, err = r.kubevirt.ensureOpenStackVolumes(vm.Ref, ready)
-			if !ready {
-				return
-			}
 			if err != nil {
 				step.AddError(err.Error())
 				err = nil
 				break
+			}
+			if !ready {
+				return
 			}
 			err = r.kubevirt.createPodToBindPVCs(vm, pvcNames)
 			if err != nil {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -593,7 +593,6 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			vm.AddError(fmt.Sprintf("Step '%s' not found", r.step(vm)))
 			break
 		}
-		var pvcNames []string
 		var ready bool
 		ready, err = r.builder.BeforeTransferHook(r.provider, vm.Ref)
 		if err != nil {
@@ -601,11 +600,18 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			return
 		}
 
+		var pvcNames []string
 		if r.kubevirt.isOpenstack(vm) {
 			pvcNames, err = r.kubevirt.ensureOpenStackVolumes(vm.Ref, ready)
 			if !ready {
 				return
 			}
+			if err != nil {
+				step.AddError(err.Error())
+				err = nil
+				break
+			}
+			err = r.kubevirt.createPodToBindPVCs(vm, pvcNames)
 			if err != nil {
 				step.AddError(err.Error())
 				err = nil
@@ -618,12 +624,6 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			return
 		}
 
-		err = r.kubevirt.createPodToBindPVCs(vm, pvcNames)
-		if err != nil {
-			step.AddError(err.Error())
-			err = nil
-			break
-		}
 		if r.kubevirt.useOvirtPopulator(vm) {
 			pvcNames, err = r.kubevirt.createVolumesForOvirt(vm.Ref)
 			if err != nil {


### PR DESCRIPTION
Currently the BeforeTransferHook waits for all images to be ready before creating the PVCs. However, some images will be slower than other to create, so instead we create the PVC as soon as the image is ready to save some time.