### PR TITLE
Revert "virt-v2v: cold: extract the appliance if it is stored in comp…

### DIFF
--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -11,10 +11,6 @@ if [ -z "$V2V_libvirtURL" ] || \
     exit 1
 fi
 
-for f in /usr/lib64/guestfs/appliance-*.tar.xz ; do
-    tar xvJf "$f" -C /usr/lib64/guestfs
-    break  # Idealy there should be just one such file.
-done
 export LIBGUESTFS_PATH=/usr/lib64/guestfs/appliance
 
 echo "Preparing virt-v2v"


### PR DESCRIPTION
…ressed tar"

This reverts commit 279e1eca012c493a2a8ee625f60f5fa11b49306b.

The change was wrong. Downstream can use qcow2 image too and what will happen with upstream remains to be seen.