### PR TITLE
Validate dynamic storage class

### DIFF
--- a/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
@@ -19,6 +19,7 @@ spec:
         app: {{ app_name }}
         service: {{ api_service_name }}
     spec:
+      serviceAccountName: forklift-controller
       containers:
         - name: {{ api_container_name }}
           image: {{ api_image_fqin }}

--- a/operator/roles/forkliftcontroller/templates/api/validatingwebhookconfiguration-forklift-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/validatingwebhookconfiguration-forklift-api.yml.j2
@@ -39,3 +39,27 @@ webhooks:
     - secrets
     scope: Namespaced
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ api_service_name }}
+      namespace: {{ app_namespace }}
+      path: /plan-validate
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: plans.forklift.konveyor
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - forklift.konveyor.io
+    resources:
+    - plans
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+  sideEffects: None

--- a/pkg/forklift-api/webhooks/util/util.go
+++ b/pkg/forklift-api/webhooks/util/util.go
@@ -87,3 +87,10 @@ func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
 
 	return payloadBytes, nil
 }
+
+// ToAdmissionResponseAllow returns allowed response
+func ToAdmissionResponseAllow() *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
+		Allowed: true,
+	}
+}

--- a/pkg/forklift-api/webhooks/validating-webhook.go
+++ b/pkg/forklift-api/webhooks/validating-webhook.go
@@ -10,3 +10,7 @@ import (
 func ServeSecretCreate(resp http.ResponseWriter, req *http.Request) {
 	validating_webhooks.Serve(resp, req, &admitters.SecretAdmitter{})
 }
+
+func ServePlanCreate(resp http.ResponseWriter, req *http.Request) {
+	validating_webhooks.Serve(resp, req, &admitters.PlanAdmitter{})
+}

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -2,15 +2,24 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "admitters",
-    srcs = ["secret-admitter.go"],
+    srcs = [
+        "plan-admitter.go",
+        "secret-admitter.go",
+    ],
     importpath = "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/validating-webhook/admitters",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis",
         "//pkg/apis/forklift/v1beta1",
         "//pkg/controller/provider/container",
+        "//pkg/forklift-api/webhooks/util",
         "//pkg/lib/logging",
         "//vendor/k8s.io/api/admission/v1beta1",
         "//vendor/k8s.io/api/core/v1:core",
+        "//vendor/k8s.io/api/storage/v1:storage",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/client-go/kubernetes/scheme",
+        "//vendor/k8s.io/client-go/rest",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
     ],
 )

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
@@ -1,0 +1,121 @@
+package admitters
+
+import (
+	"context"
+	v1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"encoding/json"
+	"fmt"
+	admissionv1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"net/http"
+
+	"github.com/konveyor/forklift-controller/pkg/apis"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/util"
+)
+
+type PlanAdmitter struct {
+}
+
+func (admitter *PlanAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	log.Info("Plan admitter was called")
+	raw := ar.Request.Object.Raw
+
+	plan := &api.Plan{}
+	err := json.Unmarshal(raw, plan)
+	if err != nil {
+		return util.ToAdmissionResponseError(err)
+	}
+
+	if plan.Spec.Warm {
+		log.Info("Warm migration supports all storages, passing")
+		return util.ToAdmissionResponseAllow()
+	}
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Error(err, "Couldn't get the cluster configuration", err.Error())
+		return util.ToAdmissionResponseError(err)
+	}
+
+	err = api.SchemeBuilder.AddToScheme(scheme.Scheme)
+	if err != nil {
+		log.Error(err, "Couldn't build the scheme", err.Error())
+		return util.ToAdmissionResponseError(err)
+	}
+	err = apis.AddToScheme(scheme.Scheme)
+	if err != nil {
+		log.Error(err, "Couldn't add forklift API to the scheme", err.Error())
+		return util.ToAdmissionResponseError(err)
+	}
+
+	cl, err := client.New(config, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		log.Error(err, "Couldn't create a cluster client", err.Error())
+		return util.ToAdmissionResponseError(err)
+	}
+
+	sourceProvider := api.Provider{}
+	err = cl.Get(context.TODO(), client.ObjectKey{Namespace: plan.Spec.Provider.Source.Namespace, Name: plan.Spec.Provider.Source.Name}, &sourceProvider)
+	if err != nil {
+		log.Error(err, "Couldn't get the source provider", err.Error())
+		return util.ToAdmissionResponseError(err)
+	}
+
+	if sourceProvider.Type() == api.VSphere {
+		log.Info("Provider supports all storages, passing")
+		return util.ToAdmissionResponseAllow()
+	}
+
+	destinationProvider := api.Provider{}
+	err = cl.Get(context.TODO(), client.ObjectKey{Namespace: plan.Spec.Provider.Destination.Namespace, Name: plan.Spec.Provider.Destination.Name}, &destinationProvider)
+	if err != nil {
+		log.Error(err, "Couldn't get the destination provider", err.Error())
+		return util.ToAdmissionResponseError(err)
+	}
+
+	if !destinationProvider.IsHost() {
+		log.Info("Migration to a remote provider supports all storages, passing")
+		return util.ToAdmissionResponseAllow()
+	}
+
+	storageClasses := v1.StorageClassList{}
+	err = cl.List(context.TODO(), &storageClasses, &client.ListOptions{})
+	if err != nil {
+		log.Error(err, "Couldn't get the cluster storage classes", err.Error())
+		return util.ToAdmissionResponseError(err)
+	}
+
+	storageMap := api.StorageMap{}
+	err = cl.Get(context.TODO(), client.ObjectKey{Namespace: plan.Spec.Map.Storage.Namespace, Name: plan.Spec.Map.Storage.Name}, &storageMap)
+	if err != nil {
+		log.Error(err, "Couldn't get the storage map", err.Error())
+		return util.ToAdmissionResponseError(err)
+	}
+	storagePairList := storageMap.Spec.Map
+	var badStorageClasses []string
+	for _, storagePair := range storagePairList {
+		scName := storagePair.Destination.StorageClass
+		for _, sc := range storageClasses.Items {
+			if scName == sc.Name && sc.Provisioner == "kubernetes.io/no-provisioner" {
+				badStorageClasses = append(badStorageClasses, sc.Name)
+			}
+		}
+	}
+	if len(badStorageClasses) > 0 {
+		log.Error(fmt.Errorf("storage class(es) '%v' is static, failing", badStorageClasses), "Storage class(es) is static")
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("This plan requires dynamic volume provisioning. Therefore the following destination storage classes cannot be used: %v", badStorageClasses),
+			},
+		}
+	}
+	log.Info("Passed storage validation")
+	return util.ToAdmissionResponseAllow()
+}

--- a/pkg/forklift-api/webhooks/webhooks.go
+++ b/pkg/forklift-api/webhooks/webhooks.go
@@ -11,6 +11,7 @@ var log = logging.WithName("webhooks")
 
 const SecretValidatePath = "/secret-validate"
 const SecretMutatorPath = "/secret-mutate"
+const PlanValidatePath = "/plan-validate"
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager) error
@@ -30,7 +31,9 @@ func RegisterValidatingWebhooks(mux *http.ServeMux) {
 	mux.HandleFunc(SecretValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		ServeSecretCreate(w, r)
 	})
-
+	mux.HandleFunc(PlanValidatePath, func(w http.ResponseWriter, r *http.Request) {
+		ServePlanCreate(w, r)
+	})
 }
 
 func RegisterMutatingWebhooks(mux *http.ServeMux) {


### PR DESCRIPTION
When using the volume populator, it can't migrate to a static storage class. This patch will prevent from starting such plan, indicating the problem to the user.