### PR TITLE
Fix default setting for insecureSkipVerify (backport)

### DIFF
--- a/cmd/ovirt-populator/ovirt-populator.go
+++ b/cmd/ovirt-populator/ovirt-populator.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -165,9 +166,19 @@ func loadEngineConfig(engineURL string) engineConfig {
 		klog.Fatal(err.Error())
 	}
 
-	insecureSkipVerify, err := os.ReadFile("/etc/secret-volume/insecureSkipVerify")
+	var insecureSkipVerify []byte
+	_, err = os.Stat("/etc/secret-volume/insecureSkipVerify")
 	if err != nil {
-		klog.Fatal(err.Error())
+		if errors.Is(err, os.ErrNotExist) {
+			insecureSkipVerify = []byte("false")
+		} else {
+			klog.Fatal(err.Error())
+		}
+	} else {
+		insecureSkipVerify, err = os.ReadFile("/etc/secret-volume/insecureSkipVerify")
+		if err != nil {
+			klog.Fatal(err.Error())
+		}
 	}
 	insecure, err := strconv.ParseBool(string(insecureSkipVerify))
 	if err != nil {


### PR DESCRIPTION
Backport [insecure fix for default value]( https://github.com/kubev2v/forklift/pull/243) for 2.4 release.