### PR TITLE
operator: Fix console_plugins list in case there are no other plugins

### DIFF
--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -263,7 +263,7 @@
 
     - name: "Set console_plugins variable"
       set_fact:
-        console_plugins: "{{ console_operator['resources'][0]['spec']['plugins'] }}"
+        console_plugins: "{{ console_operator['resources'][0]['spec']['plugins'] | default([]) }}"
 
     - name: "Enable console plugin"
       k8s:


### PR DESCRIPTION
Issue:
```
TASK [Set console_plugins variable] ********************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'plugins'\n\nThe error appears to be in '/opt/ansible/roles/forkliftcontroller/tasks/main.yml': line 264, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n - name: \"Set console_plugins variable\"\n ^ here\n"}
```
Fix:
Set `console_plugins` as an empty list in case there are no other plugins