### PR TITLE
Switch the KVM resource to limits (backport)

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -696,6 +696,10 @@ func (r *KubeVirt) setKvmOnPodSpec(podSpec *core.PodSpec) {
 		}
 		podSpec.NodeSelector["kubevirt.io/schedulable"] = "true"
 		container := &podSpec.Containers[0]
+		if container.Resources.Limits == nil {
+			container.Resources.Limits = make(map[core.ResourceName]resource.Quantity)
+		}
+		container.Resources.Limits["devices.kubevirt.io/kvm"] = resource.MustParse("1")
 		if container.Resources.Requests == nil {
 			container.Resources.Requests = make(map[core.ResourceName]resource.Quantity)
 		}


### PR DESCRIPTION
Having the consumer container and the v2v conversion container with the KVM device as required caused:
`spec.containers[0].resources.limits: Required value: Limit must be set for non overcommitable resources`. This patch switch it to be as Limit and Request of the container.