### PR TITLE
openstack: use openstack time instead of openshift time

### DIFF
--- a/cmd/openstack-populator/openstack-populator.go
+++ b/cmd/openstack-populator/openstack-populator.go
@@ -80,11 +80,12 @@ func loadConfig(secretName, endpoint string) openstackConfig {
 	}
 	insecureSkipVerify, err := os.ReadFile("/etc/secret-volume/insecureSkipVerify")
 	if err != nil {
-		klog.Fatal(err.Error())
+		klog.Error(err.Error())
+		insecureSkipVerify = []byte("false")
 	}
 	cacert, err := os.ReadFile("/etc/secret-volume/cacert")
 	if err != nil {
-		klog.Fatal(err.Error())
+		klog.Error(err.Error())
 	}
 
 	return openstackConfig{

--- a/pkg/controller/provider/container/openstack/model.go
+++ b/pkg/controller/provider/container/openstack/model.go
@@ -247,7 +247,8 @@ type ImageAdapter struct {
 func (r *ImageAdapter) List(ctx *Context) (itr fb.Iterator, err error) {
 	opts := &ImageListOpts{}
 	imageList := []Image{}
-	now := time.Now()
+	// Set time to epoch start
+	updateTime := time.Unix(0, 0)
 	err = ctx.client.list(&imageList, opts)
 	if err != nil {
 		return
@@ -259,12 +260,12 @@ func (r *ImageAdapter) List(ctx *Context) (itr fb.Iterator, err error) {
 		}
 		image.ApplyTo(m)
 		list.Append(m)
-		if image.UpdatedAt.After(now) {
-			now = image.UpdatedAt
+		if image.UpdatedAt.After(updateTime) {
+			updateTime = image.UpdatedAt
 		}
 	}
 	itr = list.Iter()
-	r.lastSync = now
+	r.lastSync = updateTime
 	return
 }
 
@@ -272,7 +273,8 @@ func (r *ImageAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 	opts := &ImageListOpts{}
 	opts.setUpdateAtQueryFilterGT(r.lastSync)
 	imageList := []Image{}
-	now := time.Now()
+	// Set time to epoch start
+	updateTime := time.Unix(0, 0)
 	err = ctx.client.list(&imageList, opts)
 	if err != nil {
 		return
@@ -314,11 +316,11 @@ func (r *ImageAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 			updates = append(updates, updater)
 		}
 
-		if image.UpdatedAt.After(now) {
-			now = image.UpdatedAt
+		if image.UpdatedAt.After(updateTime) {
+			updateTime = image.UpdatedAt
 		}
 	}
-	r.lastSync = now
+	r.lastSync = updateTime
 	return
 }
 
@@ -452,7 +454,8 @@ type VMAdapter struct {
 func (r *VMAdapter) List(ctx *Context) (itr fb.Iterator, err error) {
 	opts := &VMListOpts{}
 	vmList := []VM{}
-	now := time.Now()
+	// Set time to epoch start
+	updateTime := time.Unix(0, 0)
 	err = ctx.client.list(&vmList, opts)
 	if err != nil {
 		return
@@ -468,7 +471,7 @@ func (r *VMAdapter) List(ctx *Context) (itr fb.Iterator, err error) {
 		list.Append(m)
 	}
 	itr = list.Iter()
-	r.lastSync = now
+	r.lastSync = updateTime
 	return
 }
 
@@ -477,7 +480,8 @@ func (r *VMAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 	opts := &VMListOpts{}
 	opts.ChangesSince = r.lastSync.Format(time.RFC3339)
 	vmList := []VM{}
-	now := time.Now()
+	// Set time to epoch start
+	updateTime := time.Unix(0, 0)
 	err = ctx.client.list(&vmList, opts)
 	if err != nil {
 		return
@@ -521,11 +525,11 @@ func (r *VMAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 			}
 			updates = append(updates, updater)
 		}
-		if vm.Updated.After(now) {
-			now = vm.Updated
+		if vm.Updated.After(updateTime) {
+			updateTime = vm.Updated
 		}
 	}
-	r.lastSync = now
+	r.lastSync = updateTime
 	return
 }
 

--- a/pkg/controller/provider/container/openstack/model.go
+++ b/pkg/controller/provider/container/openstack/model.go
@@ -259,6 +259,9 @@ func (r *ImageAdapter) List(ctx *Context) (itr fb.Iterator, err error) {
 		}
 		image.ApplyTo(m)
 		list.Append(m)
+		if image.UpdatedAt.After(now) {
+			now = image.UpdatedAt
+		}
 	}
 	itr = list.Iter()
 	r.lastSync = now
@@ -267,7 +270,7 @@ func (r *ImageAdapter) List(ctx *Context) (itr fb.Iterator, err error) {
 
 func (r *ImageAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 	opts := &ImageListOpts{}
-	opts.setUpdateAtQueryFilterGTE(r.lastSync)
+	opts.setUpdateAtQueryFilterGT(r.lastSync)
 	imageList := []Image{}
 	now := time.Now()
 	err = ctx.client.list(&imageList, opts)
@@ -309,6 +312,10 @@ func (r *ImageAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 				return
 			}
 			updates = append(updates, updater)
+		}
+
+		if image.UpdatedAt.After(now) {
+			now = image.UpdatedAt
 		}
 	}
 	r.lastSync = now
@@ -513,6 +520,9 @@ func (r *VMAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 				return
 			}
 			updates = append(updates, updater)
+		}
+		if vm.Updated.After(now) {
+			now = vm.Updated
 		}
 	}
 	r.lastSync = now

--- a/pkg/controller/provider/container/openstack/resource.go
+++ b/pkg/controller/provider/container/openstack/resource.go
@@ -111,8 +111,8 @@ type ImageListOpts struct {
 	images.ListOpts
 }
 
-func (r *ImageListOpts) setUpdateAtQueryFilterGTE(lastSync time.Time) {
-	r.UpdatedAtQuery = &images.ImageDateQuery{Date: lastSync, Filter: images.FilterGTE}
+func (r *ImageListOpts) setUpdateAtQueryFilterGT(lastSync time.Time) {
+	r.UpdatedAtQuery = &images.ImageDateQuery{Date: lastSync, Filter: images.FilterGT}
 }
 
 type Flavor struct {


### PR DESCRIPTION
Request changes since using the time in the controller may be an issue if there is a time difference between openstack and openshift.

Instead, where possible, this patch attempts to use the time from resource's updated_at field as the value for changes-since.