### PR TITLE
backport: openstack: check the migration label value

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -572,7 +572,9 @@ func (r *KubeVirt) getPVCs(vm *plan.VMStatus) (pvcs []core.PersistentVolumeClaim
 			pvcs = append(pvcs, *pvc)
 		} else if r.isOpenstack(vm) {
 			if _, ok := pvc.Labels["migration"]; ok {
-				pvcs = append(pvcs, *pvc)
+				if pvc.Labels["migration"] == r.Migration.Name {
+					pvcs = append(pvcs, *pvc)
+				}
 			}
 		} else if r.useOvirtPopulator(vm) {
 			ovirtVm := &ovirt.Workload{}


### PR DESCRIPTION
To avoid including oVirt PVCs, we need to make sure we look only at PVCs relevant for the current migration