### PR TITLE
virt-v2v: make sure VM name is not confused for argument

### DIFF
--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -75,4 +75,4 @@ exec virt-v2v -v -x \
     -i libvirt \
     -ic "$V2V_libvirtURL" \
     "${args[@]}" \
-    "$V2V_vmName" |& /usr/local/bin/virt-v2v-monitor
+    -- "$V2V_vmName" |& /usr/local/bin/virt-v2v-monitor


### PR DESCRIPTION
Separate the VM name from rest of the arguments with `--`. Thus make sure the name is not confused for argument if it starts with dash.