### PR TITLE
openstack: fix graphics device mapping

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -373,12 +373,8 @@ func (r *Builder) mapVideo(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 	if imageVideoModel, ok := vm.Image.Properties[VideoModel]; ok {
 		videoModel = imageVideoModel.(string)
 	}
-	switch videoModel {
-	case VideoNONE:
-	default:
-		autoAttachGraphicsDevice := false
-		object.Template.Spec.Domain.Devices.AutoattachGraphicsDevice = &autoAttachGraphicsDevice
-	}
+	autoAttachGraphicsDevice := videoModel != VideoNONE
+	object.Template.Spec.Domain.Devices.AutoattachGraphicsDevice = &autoAttachGraphicsDevice
 }
 
 func (r *Builder) mapInput(vm *model.Workload, object *cnv.VirtualMachineSpec) {


### PR DESCRIPTION
Currently the graphics device is disabled by default
for the migrated VM unless the "hw_video_model" property
is set to "none" in the image. This logic is wrong
and it's exactly the opposite of the desired behavior.

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
