### PR TITLE
openstack add missing constants

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -142,6 +142,7 @@ const (
 // Video models
 const (
 	VideoVga    = "vga"
+	VideoVirtio = "virtio"
 	VideoCirrus = "cirrus"
 	VideoVmVga  = "vmvga"
 	VideoXen    = "xen"
@@ -149,6 +150,22 @@ const (
 	VideoGop    = "gop"
 	VideoNONE   = "none"
 	VideoBochs  = "bochs"
+)
+
+// Vif models
+const (
+	VifModelE1000   = "e1000"
+	VifModelE1000e  = "e1000e"
+	VifModelNe2kpci = "ne2k_pci"
+	VifModelPcnet   = "pcnet"
+	VifModelRtl8139 = "rtl8139"
+	VifModelVirtio  = "virtio"
+	VifModelVmxnet3 = "vmxnet3"
+)
+
+// HW RNG models
+const (
+	HwRngModelVirtio = "virtio"
 )
 
 // Disk Formats
@@ -222,12 +239,12 @@ var DefaultProperties = map[string]string{
 	MachineType:     PC,
 	CdromBus:        IdeBus,
 	PointerModel:    UsbTablet,
-	VideoModel:      VirtioBus,
+	VideoModel:      VideoVirtio,
 	DiskBus:         VirtioBus,
-	VifModel:        VirtioBus,
+	VifModel:        VifModelVirtio,
 	OsType:          Linux,
 	OsSecureBoot:    SecureBootDisabled,
-	HwRngModel:      VirtioBus,
+	HwRngModel:      HwRngModelVirtio,
 }
 
 // Create the destination Kubevirt VM.

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -586,6 +586,10 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 				if imageVIFModel, ok := vm.Image.Properties[VifModel]; ok {
 					interfaceModel = imageVIFModel.(string)
 				}
+				// vmxnet3 is unsupported in OpenShift Virtualization
+				if interfaceModel == VifModelVmxnet3 {
+					interfaceModel = DefaultProperties[VifModel]
+				}
 				kInterface.Model = interfaceModel
 				if m := nic.(map[string]interface{}); ok {
 					if macAddress, ok := m["OS-EXT-IPS-MAC:mac_addr"]; ok {


### PR DESCRIPTION
- openstack: Add missing virtual hardware constants
- openstack: Map unsupported "vmxnet3" interface
