### PR TITLE
Use patch instead of update to set PVC owner references

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"math/rand"
@@ -326,8 +327,17 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) (err error) {
 
 	for _, pvc := range pvcs {
 		ownerRefs := []meta.OwnerReference{vmOwnerReference(virtualMachine)}
-		pvc.SetOwnerReferences(ownerRefs)
-		err = r.Destination.Client.Update(context.TODO(), &pvc)
+		patch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"ownerReferences": ownerRefs,
+			},
+		}
+		patchBytes, patchErr := json.Marshal(patch)
+		if patchErr != nil {
+			err = liberr.Wrap(patchErr)
+			return
+		}
+		err = r.Client.Patch(context.TODO(), &pvc, client.RawPatch(types.MergePatchType, patchBytes))
 		if err != nil {
 			err = liberr.Wrap(err)
 			return


### PR DESCRIPTION
Replace the Update method with Patch for setting ownerReferences on PVCs to avoid potential failures due to resource version conflicts which may happen because the volume populator controller removes the finalizer after the PVC is marked as Bound.