### PR TITLE
Build our own libguestfs appliance

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,3 +22,9 @@ build --action_env=POPULATOR_CONTROLLER_IMAGE=quay.io/kubev2v/populator-controll
 build --action_env=OPENSTACK_POPULATOR_IMAGE=quay.io/kubev2v/openstack-populator:latest
 build --action_env=OVIRT_POPULATOR_IMAGE=quay.io/kubev2v/ovirt-populator:latest
 build --action_env=OPERATOR_IMAGE=quay.io/kubev2v/forklift-operator:latest
+
+# Appliance build
+# container_run_and_extract() does not work inside Podman and Docker
+# sandboxes. Use slightly less secure but working processwrapper sandbox.
+# NOTE: Same configuration is in virt-v2v/cold/.bazelrc.
+build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox

--- a/hack/virt-v2v-cold-rpm-deps.sh
+++ b/hack/virt-v2v-cold-rpm-deps.sh
@@ -31,6 +31,7 @@ v2v_missing="
 # choice is mostly arbitrary with package size taken into consideration.
 alternative_picks="
   coreutils-single
+  curl-minimal
   glibc-langpack-en
   kernel-core
   libcurl-minimal

--- a/virt-v2v/cold/.bazerlc
+++ b/virt-v2v/cold/.bazerlc
@@ -1,0 +1,5 @@
+# Appliance build
+# container_run_and_extract() does not work inside Podman and Docker
+# sandboxes. Use slightly less secure but working processwrapper sandbox.
+# NOTE: Same configuration is in .bazelrc in repository root.
+build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox

--- a/virt-v2v/cold/BUILD.bazel
+++ b/virt-v2v/cold/BUILD.bazel
@@ -76,7 +76,7 @@ rpmtree(
         "@cracklib-dicts-0__2.9.6-27.el9.x86_64//rpm",
         "@crypto-policies-0__20221215-1.git9a18988.el9.x86_64//rpm",
         "@cryptsetup-libs-0__2.6.0-2.el9.x86_64//rpm",
-        "@curl-0__7.76.1-23.el9.x86_64//rpm",
+        "@curl-minimal-0__7.76.1-23.el9.x86_64//rpm",
         "@cyrus-sasl-0__2.1.27-21.el9.x86_64//rpm",
         "@cyrus-sasl-gssapi-0__2.1.27-21.el9.x86_64//rpm",
         "@cyrus-sasl-lib-0__2.1.27-21.el9.x86_64//rpm",

--- a/virt-v2v/cold/BUILD.bazel
+++ b/virt-v2v/cold/BUILD.bazel
@@ -3,6 +3,10 @@ load(
     "container_image",
     "container_push",
 )
+load(
+    "@io_bazel_rules_docker//docker/util:run.bzl",
+    "container_run_and_extract",
+)
 load("@bazeldnf//:deps.bzl", "rpmtree")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
@@ -15,17 +19,30 @@ container_push(
     tag = "$${REGISTRY_TAG:-devel}",
 )
 
-pkg_tar(
-    name = "appliance_layer",
-    srcs = [
-        "@libguestfs-appliance//appliance:README.fixed",
-        "@libguestfs-appliance//appliance:initrd",
-        "@libguestfs-appliance//appliance:kernel",
-        "@libguestfs-appliance//appliance:root",
+# Appliance build
+# NOTE: We deliberately do not use (and cannot use) rpmtree to build a base
+# layer with packages. Supermin queries the RPM database to track package files
+# and dependencies. Tar constructed by rpmtree is just a bunch of files and it
+# does not preserve the RPM database info. Therefore we imitate a Dockerfile
+# build here.
+container_run_and_extract(
+    name = "appliance",
+    commands = [
+        "set -x",
+        "dnf -y update",
+        "dnf -y install libguestfs libguestfs-appliance libguestfs-xfs libguestfs-winsupport qemu-img supermin",
+        "depmod \\$(ls /lib/modules/ |tail -n1)",
+        "export LIBGUESTFS_BACKEND=direct",
+        "export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1",
+        "mkdir -p /usr/lib64/guestfs/appliance",
+        "cd /usr/lib64/guestfs/appliance",
+        "libguestfs-make-fixed-appliance .",
+        "qemu-img convert -c -O qcow2 root root.qcow2",
+        "mv -vf root.qcow2 root",
+        "tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance",
     ],
-    mode = "0444",
-    package_dir = "/usr/lib64/guestfs/appliance",
-    visibility = ["//visibility:public"],
+    extract_file = "/libguestfs-appliance.tar",
+    image = "@centos9//image",
 )
 
 container_image(
@@ -34,7 +51,7 @@ container_image(
     directory = "/",
     tars = [
         ":virt-v2v",
-        ":appliance_layer",
+        "appliance/libguestfs-appliance.tar",
     ],
 )
 

--- a/virt-v2v/cold/WORKSPACE
+++ b/virt-v2v/cold/WORKSPACE
@@ -186,18 +186,18 @@ load("@bazeldnf//:deps.bzl", "bazeldnf_dependencies", "rpm")
 
 bazeldnf_dependencies()
 
-http_archive(
-    name = "libguestfs-appliance",
-    sha256 = "124d6325a799e958843be4818ef2c32661755be1c56e519665779948861b04f6",
-    urls = [
-        "https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance/libguestfs-appliance-1.48.4-qcow2-linux-5.14.0-183-centos9.tar.xz",
-    ],
+container_pull(
+    name = "centos9",
+    # 'tag' is also supported, but digest is encouraged for reproducibility.
+    digest = "sha256:66d2ee16970b1c15b26bfad256e5fbf2d57e72510974da0f0ebac4b49a166e94",  # built on 2023-04-25
+    registry = "quay.io",
+    repository = "centos/centos",
 )
 
 container_pull(
     name = "ubi9-minimal",
     # 'tag' is also supported, but digest is encouraged for reproducibility.
-    digest = "sha256:e9ea62ea2017705205ba7bc55d20827e06abe4fe071f0793c6cae46edd5855cf",
+    digest = "sha256:e9ea62ea2017705205ba7bc55d20827e06abe4fe071f0793c6cae46edd5855cf",  # 9.1.0-1760
     registry = "registry.access.redhat.com",
     repository = "ubi9/ubi-minimal",
 )

--- a/virt-v2v/cold/WORKSPACE
+++ b/virt-v2v/cold/WORKSPACE
@@ -323,9 +323,9 @@ rpm(
 )
 
 rpm(
-    name = "curl-0__7.76.1-23.el9.x86_64",
-    sha256 = "e08f95656a19787d18b52f96a2329fc63758253d96297434cb5fb51b857482b7",
-    urls = ["https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/curl-7.76.1-23.el9.x86_64.rpm"],
+    name = "curl-minimal-0__7.76.1-23.el9.x86_64",
+    sha256 = "3d2ed0db2e85e18edd897ae63b463255536e597abc6ca4b8f189bf08c263ed65",
+    urls = ["https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/curl-minimal-7.76.1-23.el9.x86_64.rpm"],
 )
 
 rpm(


### PR DESCRIPTION
The appliance from Kubevirt [1] is missing some packages we need. For legal
reasons it is not possible to include the missing packages there. We need to
build our own fixed appliance.

We imitate multi-stage Dockerfile build in Bazel. Unfortunately
container_run_and_extract() does not work with Podmana [2] and Bazel's
linux-sandbox. Slightly less secure but working processwrapper sandbox
is used as a workaround.

[1] https://github.com/kubevirt/libguestfs-appliance/pull/17
[2] https://github.com/bazelbuild/rules_docker/issues/2251
