### PR TITLE
Operator: Use original control-plane name

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: forklift-operator
+    control-plane: controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,18 +11,18 @@ metadata:
   name: forklift-operator
   namespace: system
   labels:
-    control-plane: forklift-operator
+    control-plane: controller-manager
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: forklift
-      name: forklift-operator
+      name: controller-manager
   template:
     metadata:
       labels:
         app: forklift
-        name: forklift-operator
+        name: controller-manager
     spec:
       serviceAccountName: forklift-operator
       containers:

--- a/operator/config/prometheus/monitor.yaml
+++ b/operator/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: forklift-operator
+    control-plane: controller-manager
   name: forklift-operator-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: forklift-operator
+      control-plane: controller-manager

--- a/operator/config/rbac/authproxy/service.yaml
+++ b/operator/config/rbac/authproxy/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: forklift-operator
+    control-plane: controller-manager
   name: forklift-operator-metrics-service
   namespace: system
 spec:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: forklift-operator
+    control-plane: controller-manager

--- a/operator/roles/forkliftcontroller/templates/controller/configmap-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/configmap-controller.yml.j2
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ app_name }}
     service: {{ controller_service_name }}
-    control-plane: forklift-operator
+    control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
   name: {{ controller_configmap_name }}
   namespace: {{ app_namespace }}

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   labels:
     app: {{ app_name }}
-    control-plane: forklift-operator
+    control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
   name: {{ controller_deployment_name }}
   namespace: {{ app_namespace }}
@@ -12,14 +12,14 @@ spec:
   selector:
     matchLabels:
       app: {{ app_name }}
-      control-plane: forklift-operator
+      control-plane: controller-manager
       controller-tools.k8s.io: "1.0"
   serviceName: {{ controller_service_name }}
   template:
     metadata:
       labels:
         app: {{ app_name }}
-        control-plane: forklift-operator
+        control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
       annotations:
         configHash: "{{ (inventory_volume_path | string) }}"

--- a/operator/roles/forkliftcontroller/templates/controller/route-inventory.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/route-inventory.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: {{ inventory_route_name }}
   namespace: {{ app_namespace }}
   labels:
-    control-plane: forklift-operator
+    control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
     app: {{ app_name }}
     service: {{ inventory_service_name }}

--- a/operator/roles/forkliftcontroller/templates/controller/service-inventory.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/service-inventory.yml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: {{ app_name }}
     service: {{ inventory_service_name }}
-    control-plane: forklift-operator
+    control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
   name: {{ inventory_service_name }}
   namespace: {{ app_namespace }}
@@ -25,5 +25,5 @@ spec:
     protocol: TCP
 {% endif %}
   selector:
-    control-plane: forklift-operator
+    control-plane: controller-manager
     controller-tools.k8s.io: "1.0"


### PR DESCRIPTION
Issue: The control-plane field is immutable so once the operator tried to deploy the 2.4 it failed.
Fixes: https://github.com/kubev2v/forklift/issues/314