### PR TITLE
Revert "Use patch instead of update to set PVC owner references (backport)"

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2,7 +2,6 @@ package plan
 
 import (
 	"context"
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"math/rand"
@@ -328,17 +327,8 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) (err error) {
 
 	for _, pvc := range pvcs {
 		ownerRefs := []meta.OwnerReference{vmOwnerReference(virtualMachine)}
-		patch := map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"ownerReferences": ownerRefs,
-			},
-		}
-		patchBytes, patchErr := json.Marshal(patch)
-		if patchErr != nil {
-			err = liberr.Wrap(patchErr)
-			return
-		}
-		err = r.Client.Patch(context.TODO(), &pvc, client.RawPatch(types.MergePatchType, patchBytes))
+		pvc.SetOwnerReferences(ownerRefs)
+		err = r.Destination.Client.Update(context.TODO(), &pvc)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return


### PR DESCRIPTION
Reverts kubev2v/forklift#328

This is related to the issue: https://github.com/kubev2v/forklift/issues/333
It does not fix it, it just removes the commit form 2.4.1 so we can have a stable release.

