### PR TITLE
Revert Revert "Use patch instead of update to set PVC owner references"

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"math/rand"
@@ -327,8 +328,17 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) (err error) {
 
 	for _, pvc := range pvcs {
 		ownerRefs := []meta.OwnerReference{vmOwnerReference(virtualMachine)}
-		pvc.SetOwnerReferences(ownerRefs)
-		err = r.Destination.Client.Update(context.TODO(), &pvc)
+		patch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"ownerReferences": ownerRefs,
+			},
+		}
+		patchBytes, patchErr := json.Marshal(patch)
+		if patchErr != nil {
+			err = liberr.Wrap(patchErr)
+			return
+		}
+		err = r.Destination.Client.Patch(context.TODO(), &pvc, client.RawPatch(types.MergePatchType, patchBytes))
 		if err != nil {
 			err = liberr.Wrap(err)
 			return


### PR DESCRIPTION
Revert of Revert https://github.com/kubev2v/forklift/pull/334
And fix the client `r.Client.Patch` -> `r.Destination.Client.Patch`