### PR TITLE
Split forklift-api service account

### DIFF
--- a/operator/BUILD.bazel
+++ b/operator/BUILD.bazel
@@ -80,7 +80,7 @@ genrule(
     cmd = """
         cd operator;
         export DATE=$$(date +%Y-%m-%dT%H:%M:%SZ);
-        ../$(location :kustomize_bin) build config/manifests --load_restrictor LoadRestrictionsNone | envsubst | ../$(location @operator-sdk//file) generate bundle -q --overwrite --extra-service-accounts forklift-controller --version $${VERSION} --output-dir ../$(RULEDIR)/bundle --channels=$${CHANNELS} --default-channel=$${DEFAULT_CHANNEL}
+        ../$(location :kustomize_bin) build config/manifests --load_restrictor LoadRestrictionsNone | envsubst | ../$(location @operator-sdk//file) generate bundle -q --overwrite --extra-service-accounts forklift-controller,forklift-api --version $${VERSION} --output-dir ../$(RULEDIR)/bundle --channels=$${CHANNELS} --default-channel=$${DEFAULT_CHANNEL}
     """,
 )
 

--- a/operator/config/rbac/api/role.yaml
+++ b/operator/config/rbac/api/role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: forklift-api-role
+rules:
+  - apiGroups:
+      - forklift.konveyor.io
+    resources:
+      - providers
+      - storagemaps
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list

--- a/operator/config/rbac/api/role_binding.yaml
+++ b/operator/config/rbac/api/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: forklift-api-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: forklift-api-role
+subjects:
+  - kind: ServiceAccount
+    name: forklift-api
+    namespace: system

--- a/operator/config/rbac/api/service_account.yaml
+++ b/operator/config/rbac/api/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: forklift-api
+  namespace: system

--- a/operator/config/rbac/kustomization.yaml
+++ b/operator/config/rbac/kustomization.yaml
@@ -15,6 +15,11 @@ resources:
 - forklift-controller_role.yaml
 - forklift-controller_role_binding.yaml
 
+# forklift-api service account
+- api/service_account.yaml
+- api/role.yaml
+- api/role_binding.yaml
+
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
@@ -19,7 +19,7 @@ spec:
         app: {{ app_name }}
         service: {{ api_service_name }}
     spec:
-      serviceAccountName: forklift-controller
+      serviceAccountName: forklift-api
       containers:
         - name: {{ api_container_name }}
           image: {{ api_image_fqin }}


### PR DESCRIPTION
forklift-api doesn't need big amount of permissions to resources. Therefore, a new service account for the API with strict permissions can be introduced.