### PR TITLE
ovirt: perform snapshot removal sequentially

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -58,6 +58,10 @@ spec:
           value: ${VIRT_V2V_WARM_IMAGE}
         - name: VIRT_V2V_DONT_REQUEST_KVM
           value: ${VIRT_V2V_DONT_REQUEST_KVM}
+        - name: SNAPSHOT_REMOVAL_TIMEOUT
+          value: ${SNAPSHOT_REMOVAL_TIMEOUT}
+        - name: SNAPSHOT_STATUS_CHECK_RATE
+          value: ${SNAPSHOT_STATUS_CHECK_RATE}
         - name: POPULATOR_CONTROLLER_IMAGE
           value: ${POPULATOR_CONTROLLER_IMAGE}
         - name: OVIRT_POPULATOR_IMAGE

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -30,6 +30,8 @@ controller_container_requests_cpu: "100m"
 controller_container_requests_memory: "350Mi"
 controller_log_level: 3
 controller_precopy_interval: 60
+controller_snapshot_removal_timeout_minuts: 120
+controller_snapshot_status_check_rate_seconds: 10
 controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_max_vm_inflight: 20

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -65,6 +65,14 @@ spec:
         - name: PRECOPY_INTERVAL
           value: "{{ controller_precopy_interval }}"
 {% endif %}
+{% if controller_snapshot_removal_timeout_minuts is number %}
+        - name: SNAPSHOT_REMOVAL_TIMEOUT_MINUTES
+          value: "{{ controller_snapshot_removal_timeout_minuts }}"
+{% endif %}
+{% if controller_snapshot_status_check_rate_seconds is number %}
+        - name: SNAPSHOT_STATUS_CHECK_RATE_SECONDS
+          value: "{{ controller_snapshot_status_check_rate_seconds }}"
+{% endif %}
 {% if controller_max_vm_inflight is number %}
         - name: MAX_VM_INFLIGHT
           value: "{{ controller_max_vm_inflight }}"

--- a/pkg/controller/plan/adapter/ovirt/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ovirt/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/types",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait",
         "//vendor/kubevirt.io/client-go/api/v1:api",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1",
     ],

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/ovirt"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	"github.com/konveyor/forklift-controller/pkg/settings"
 	ovirtsdk "github.com/ovirt/go-ovirt"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -510,11 +511,11 @@ func (r Client) removePrecopies(precopies []planapi.Precopy, vmService *ovirtsdk
 			}
 
 			select {
-			case <-time.After(2 * time.Hour):
+			case <-time.After(time.Duration(settings.Settings.Migration.SnapshotRemovalTimeout)):
 				r.Log.Info("Timeout waiting for snapshot removal")
 				return
 			default:
-				time.Sleep(30 * time.Second)
+				time.Sleep(time.Duration(settings.Settings.Migration.SnapshotStatusCheckRate))
 			}
 		}
 	}

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -485,6 +485,7 @@ func (r Client) removePrecopies(precopies []planapi.Precopy, vmService *ovirtsdk
 						_, err = snapService.Remove().Query("correlation_id", correlationID).Send()
 						if err != nil {
 							err = liberr.Wrap(err)
+							r.Log.Error(err, "Error removing snapshot")
 							return true, err
 						}
 					}

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -435,6 +435,7 @@ func (r Client) Finalize(vms []*planapi.VMStatus, planName string) {
 	}
 
 	wg.Wait()
+	r.Log.Info("Finished removing precopies")
 }
 
 func (r Client) removePrecopies(precopies []planapi.Precopy, vmService *ovirtsdk.VmService, wg *sync.WaitGroup) {

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -1,19 +1,22 @@
 package settings
 
 import (
-	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	"os"
 	"strings"
+
+	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 )
 
 // Environment variables.
 const (
-	MaxVmInFlight         = "MAX_VM_INFLIGHT"
-	HookRetry             = "HOOK_RETRY"
-	ImporterRetry         = "IMPORTER_RETRY"
-	VirtV2vImage          = "VIRT_V2V_IMAGE"
-	PrecopyInterval       = "PRECOPY_INTERVAL"
-	VirtV2vDontRequestKVM = "VIRT_V2V_DONT_REQUEST_KVM"
+	MaxVmInFlight           = "MAX_VM_INFLIGHT"
+	HookRetry               = "HOOK_RETRY"
+	ImporterRetry           = "IMPORTER_RETRY"
+	VirtV2vImage            = "VIRT_V2V_IMAGE"
+	PrecopyInterval         = "PRECOPY_INTERVAL"
+	VirtV2vDontRequestKVM   = "VIRT_V2V_DONT_REQUEST_KVM"
+	SnapshotRemovalTimeout  = "SNAPSHOT_REMOVAL_TIMEOUT"
+	SnapshotStatusCheckRate = "SNAPSHOT_STATUS_CHECK_RATE"
 )
 
 // Default virt-v2v image.
@@ -31,6 +34,10 @@ type Migration struct {
 	ImporterRetry int
 	// Warm migration precopy interval in minutes
 	PrecopyInterval int
+	// Snapshot removal timeout in minutes
+	SnapshotRemovalTimeout int
+	// Snapshot status check rate in seconds
+	SnapshotStatusCheckRate int
 	// Virt-v2v images for guest conversion
 	VirtV2vImageCold string
 	VirtV2vImageWarm string
@@ -53,6 +60,14 @@ func (r *Migration) Load() (err error) {
 		err = liberr.Wrap(err)
 	}
 	r.PrecopyInterval, err = getEnvLimit(PrecopyInterval, 60)
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
+	r.SnapshotRemovalTimeout, err = getEnvLimit(SnapshotRemovalTimeout, 120)
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
+	r.SnapshotStatusCheckRate, err = getEnvLimit(SnapshotStatusCheckRate, 10)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}


### PR DESCRIPTION
Because of ovirt-engine's internal locks, starting a snapshot removal operation will lock the VM, and will prevent other snapshot removals on the same VM, leaving all snapshots around except for the first one.

This patch waits for each snapshot removal to complete before starting the next one. And if one fails it would retry 3 times, because there is a possible race with image transfer, as CDI does not currently wait correctly for the transfer to finish.