### PR TITLE
VMware snapshots removal during warm migration

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -416,7 +416,12 @@ func (r *Migration) CleanUp(vm *plan.VMStatus) (err error) {
 		return
 	}
 	if vm.Warm != nil {
-		_ = r.provider.RemoveSnapshots(vm.Ref, vm.Warm.Precopies)
+		if errLocal := r.provider.RemoveSnapshots(vm.Ref, vm.Warm.Precopies); errLocal != nil {
+			r.Log.Error(
+				errLocal,
+				"Failed to clean up warm migration snapshots.",
+				"vm", vm)
+		}
 	}
 
 	return


### PR DESCRIPTION
After moving VM creation to the end of the flow checkpoint update became
broken. As a result old snapshots were not removed during incremental
warm migration and checkpoints were not updated on DateVolume CR.

Fixes #301 