### PR TITLE
Fix the warning message for an invalid VM name.

### DIFF
--- a/validation/policies/io/konveyor/forklift/openstack/name.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/name.rego
@@ -26,6 +26,6 @@ concerns[flag] {
 	flag := {
 		"category": "Warning",
 		"label": "Invalid VM Name",
-		"assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention.",
+		"assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention.",
 	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name.rego
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }

--- a/validation/policies/io/konveyor/forklift/vmware/name.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/name.rego
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }


### PR DESCRIPTION
The warning message for an invalid VM name should  display that the maximum vm length should be 63 chars and not 64.