### PR TITLE
CI collect rabbitmq log for packstack container

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -113,6 +113,7 @@ jobs:
             kubectl logs -n konveyor-forklift $(kubectl get po -n konveyor-forklift  -o=name | grep openstack-populator) >> /tmp/artifacts/k8s-forklift-openstack-populator.log
             kubectl logs -n konveyor-forklift $(kubectl get po -n konveyor-forklift  -o=name | grep forklift-volume-populator) >> /tmp/artifacts/k8s-forklift-volume-populator-controller.log
             kubectl exec -n konveyor-forklift $(kubectl get po -n konveyor-forklift  -o=name | grep packstack|cut -d/ -f2) -- journalctl -b0 >> /tmp/artifacts/k8s-packstack-journal.log
+            kubectl exec -n konveyor-forklift $(kubectl get po -n konveyor-forklift  -o=name | grep packstack|cut -d/ -f2) -- bash -c "more /var/log/rabbitmq/*.log" >> /tmp/artifacts/k8s-packstack-rabbitmq.log
           fi
           # export kind cluster full logs
           kind export logs /tmp/artifacts/kind-logs


### PR DESCRIPTION
improve OpenStack CI job stability,include the packstack  rabbitmq logs in the CI artifacts.