### PR TITLE
controller: vsphere: make VDDK image optional

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -313,7 +313,12 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 			if disk.Datastore.ID == ds.ID {
 				storageClass := mapped.Destination.StorageClass
 				var dvSource cdi.DataVolumeSource
-				if r.Context.UseEl9VirtV2v() {
+				el9, el9Err := r.Context.Plan.VSphereUsesEl9VirtV2v()
+				if el9Err != nil {
+					err = el9Err
+					return
+				}
+				if el9 {
 					// Let virt-v2v do the copying
 					dvSource = cdi.DataVolumeSource{
 						Blank: &cdi.DataVolumeBlankImage{},

--- a/pkg/controller/plan/context/migration.go
+++ b/pkg/controller/plan/context/migration.go
@@ -5,7 +5,6 @@ import (
 	"path"
 
 	"github.com/go-logr/logr"
-	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
@@ -103,10 +102,6 @@ func (r *Context) SetMigration(migration *api.Migration) {
 		path.Join(
 			migration.Namespace,
 			migration.Name))
-}
-
-func (r *Context) UseEl9VirtV2v() bool {
-	return r.Source.Provider.Type() == v1beta1.VSphere && r.Destination.Provider.IsHost() && !r.Plan.Spec.Warm
 }
 
 // Source.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -520,7 +520,12 @@ func (r *KubeVirt) EnsureDataVolumes(vm *plan.VMStatus, dataVolumes []cdi.DataVo
 		// DataVolume and PVC names are the same
 		pvcNames = append(pvcNames, dv.Name)
 	}
-	if r.UseEl9VirtV2v() {
+	el9, el9Err := r.Context.Plan.VSphereUsesEl9VirtV2v()
+	if el9Err != nil {
+		err = el9Err
+		return
+	}
+	if el9 {
 		err = r.createPodToBindPVCs(vm, pvcNames)
 		if err != nil {
 			return err
@@ -1237,7 +1242,12 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	allowPrivilageEscalation := false
 	// virt-v2v image
 	var virtV2vImage string
-	if r.Context.UseEl9VirtV2v() {
+	el9, el9Err := r.Context.Plan.VSphereUsesEl9VirtV2v()
+	if el9Err != nil {
+		err = el9Err
+		return
+	}
+	if el9 {
 		virtV2vImage = Settings.Migration.VirtV2vImageCold
 	} else {
 		virtV2vImage = Settings.Migration.VirtV2vImageWarm

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -83,10 +83,6 @@ func (r *Reconciler) validate(provider *api.Provider) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	err = r.validateSettings(provider)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
 	err = r.testConnection(provider, secret)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -251,33 +247,6 @@ func (r *Reconciler) validateSecret(provider *api.Provider) (secret *core.Secret
 	}
 	if len(newCnd.Items) > 0 {
 		newCnd.Reason = DataErr
-		provider.Status.Phase = ValidationFailed
-		provider.Status.SetCondition(newCnd)
-	}
-
-	return
-}
-
-// Validate provider settings.
-func (r *Reconciler) validateSettings(provider *api.Provider) (err error) {
-	newCnd := libcnd.Condition{
-		Type:     SettingsNotValid,
-		Status:   True,
-		Reason:   DataErr,
-		Category: Critical,
-		Message:  "The `settings` are not valid.",
-	}
-	keyList := []string{}
-	switch provider.Type() {
-	case api.VSphere:
-		keyList = []string{"vddkInitImage"}
-	}
-	for _, key := range keyList {
-		if _, found := provider.Spec.Settings[key]; !found {
-			newCnd.Items = append(newCnd.Items, key)
-		}
-	}
-	if len(newCnd.Items) > 0 {
 		provider.Status.Phase = ValidationFailed
 		provider.Status.SetCondition(newCnd)
 	}


### PR DESCRIPTION
Do not require VDDK image to be configured in the VMware provider. Instead of validating on the provider level we now validate on the plan. For migration that do not use the EL9 virt-v2v image (cold to remote cluster and warm) the VDDK image remains mandatory.