### PR TITLE
Cleanup related to source provider types

### DIFF
--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -102,3 +102,7 @@ func init() {
 func (r *Plan) IsSourceProviderOpenstack() bool {
 	return r.Provider.Source.Type() == OpenStack
 }
+
+func (r *Plan) IsSourceProviderOvirt() bool {
+	return r.Provider.Source.Type() == OVirt
+}

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -98,3 +98,7 @@ type PlanList struct {
 func init() {
 	SchemeBuilder.Register(&Plan{}, &PlanList{})
 }
+
+func (r *Plan) IsSourceProviderOpenstack() bool {
+	return r.Provider.Source.Type() == OpenStack
+}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -577,7 +577,7 @@ func (r *KubeVirt) getPVCs(vm *plan.VMStatus) (pvcs []core.PersistentVolumeClaim
 		pvcAnn := pvc.GetAnnotations()
 		if pvcAnn[kVM] == vmLabels[kVM] && pvcAnn[kPlan] == vmLabels[kPlan] {
 			pvcs = append(pvcs, *pvc)
-		} else if r.isOpenstack(vm) {
+		} else if r.Plan.IsSourceProviderOpenstack() {
 			if _, ok := pvc.Labels["migration"]; ok {
 				if pvc.Labels["migration"] == r.Migration.Name {
 					pvcs = append(pvcs, *pvc)
@@ -1840,11 +1840,6 @@ func (r *KubeVirt) ensureOpenStackVolumes(vm ref.Ref, ready bool) (pvcNames []st
 	}
 
 	return
-}
-
-// Return if the import done with Openstack
-func (r *KubeVirt) isOpenstack(vm *plan.VMStatus) bool {
-	return *r.Plan.Provider.Source.Spec.Type == v1beta1.OpenStack
 }
 
 func (r *KubeVirt) openstackPVCsReady(vm ref.Ref, step *plan.Step) (ready bool, err error) {

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -794,7 +794,7 @@ func (r *KubeVirt) getDefaultVolumeAndAccessMode(storageName string) ([]core.Per
 
 // Return true when the import is done with OvirtVolumePopulator
 func (r *KubeVirt) useOvirtPopulator(vm *plan.VMStatus) bool {
-	return *r.Plan.Provider.Source.Spec.Type == v1beta1.OVirt && vm.Warm == nil && r.Destination.Provider.IsHost()
+	return r.Plan.IsSourceProviderOvirt() && vm.Warm == nil && r.Destination.Provider.IsHost()
 }
 
 // Return namespace specific ListOption.

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -606,7 +606,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		}
 
 		var pvcNames []string
-		if r.kubevirt.isOpenstack(vm) {
+		if r.Plan.IsSourceProviderOpenstack() {
 			pvcNames, err = r.kubevirt.ensureOpenStackVolumes(vm.Ref, ready)
 			if err != nil {
 				step.AddError(err.Error())
@@ -728,7 +728,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		case r.kubevirt.useOvirtPopulator(vm):
 			progressFn = r.updateCopyProgressForOvirt
 			readyFn = r.kubevirt.areOvirtPVCsReady
-		case r.kubevirt.isOpenstack(vm):
+		case r.Plan.IsSourceProviderOpenstack():
 			progressFn = r.updateCopyProgressForOpenstack
 			readyFn = r.kubevirt.openstackPVCsReady
 		}


### PR DESCRIPTION
1. Move KubeVirt#isOpenstack Plan#IsSourceProviderOpenstack as it's a property of the source provider of a plan, and also removed the unused 'vm' argument
2. Introduce a similar utility method Plan#IsSourceProviderOvirt