### PR TITLE
Migrate VMs with direct LUNs from ovirt

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -86,8 +86,8 @@ type Client interface {
 	Close()
 	// Finalize migrations
 	Finalize(vms []*planapi.VMStatus, planName string)
-	// Remove disk attachment from the VM.
-	DetachDisk(vmRef ref.Ref) error
+	// Detach disks that are attached to the target VM without being cloned.
+	DetachDisks(vmRef ref.Ref) error
 }
 
 // Validator API.

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -86,7 +86,7 @@ type Client interface {
 	Close()
 	// Finalize migrations
 	Finalize(vms []*planapi.VMStatus, planName string)
-	// Detach disks that are attached to the target VM without being cloned.
+	// Detach disks that are attached to the target VM without being cloned (e.g., LUNs).
 	DetachDisks(vmRef ref.Ref) error
 }
 

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -53,11 +53,14 @@ type Builder interface {
 	ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVolumeClaim) string
 	// Conversion Pod environment
 	PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env []core.EnvVar, err error)
-
 	// Create PersistentVolumeClaim with a DataSourceRef
 	PersistentVolumeClaimWithSourceRef(da interface{}, storageName *string, populatorName string, accessModes []core.PersistentVolumeAccessMode, volumeMode *core.PersistentVolumeMode) *core.PersistentVolumeClaim
 	// Add custom steps before creating PVC/DataVolume
 	PreTransferActions(c Client, vmRef ref.Ref) (ready bool, err error)
+	// Build LUN PVs.
+	LunPersistentVolumes(vmRef ref.Ref) (pvs []core.PersistentVolume, err error)
+	// Build LUN PVCs.
+	LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.PersistentVolumeClaim, err error)
 }
 
 // Client API.
@@ -83,6 +86,8 @@ type Client interface {
 	Close()
 	// Finalize migrations
 	Finalize(vms []*planapi.VMStatus, planName string)
+	// Remove disk attachment from the VM.
+	DetachDisk(vmRef ref.Ref) error
 }
 
 // Validator API.

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1153,3 +1153,15 @@ func (r *Builder) cleanup(c planbase.Client, imageName string) {
 		}
 	}
 }
+
+// Build LUN PVs.
+func (r *Builder) LunPersistentVolumes(vmRef ref.Ref) (pvs []core.PersistentVolume, err error) {
+	// do nothing
+	return
+}
+
+// Build LUN PVCs.
+func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.PersistentVolumeClaim, err error) {
+	// do nothing
+	return
+}

--- a/pkg/controller/plan/adapter/openstack/client.go
+++ b/pkg/controller/plan/adapter/openstack/client.go
@@ -395,3 +395,8 @@ func (r *Client) Finalize(vms []*planapi.VMStatus, migrationName string) {
 		}
 	}
 }
+
+func (r *Client) DetachDisk(vmRef ref.Ref) (err error) {
+	// no-op
+	return
+}

--- a/pkg/controller/plan/adapter/openstack/client.go
+++ b/pkg/controller/plan/adapter/openstack/client.go
@@ -396,7 +396,7 @@ func (r *Client) Finalize(vms []*planapi.VMStatus, migrationName string) {
 	}
 }
 
-func (r *Client) DetachDisk(vmRef ref.Ref) (err error) {
+func (r *Client) DetachDisks(vmRef ref.Ref) (err error) {
 	// no-op
 	return
 }

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -545,8 +545,7 @@ func allJobsFinished(jobs []*ovirtsdk.Job) bool {
 	return true
 }
 
-// Remove disk attachment from the VM.
-func (r *Client) DetachDisk(vmRef ref.Ref) (err error) {
+func (r *Client) DetachDisks(vmRef ref.Ref) (err error) {
 	_, vmService, err := r.getVM(vmRef)
 	if err != nil {
 		return

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -559,6 +559,7 @@ func (r *Client) DetachDisk(vmRef ref.Ref) (err error) {
 			"VM lookup failed.",
 			"vm",
 			vmRef.String())
+		return
 	}
 	diskAttachments := vm.DiskAttachments
 	for _, da := range diskAttachments {
@@ -567,7 +568,7 @@ func (r *Client) DetachDisk(vmRef ref.Ref) (err error) {
 			if err != nil {
 				err = liberr.Wrap(
 					err,
-					"failed to detach the LUN disk.",
+					"failed to detach LUN disk.",
 					"vm",
 					vmRef.String(),
 					"disk",

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -106,7 +106,12 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 		return
 	}
 	for _, da := range vm.DiskAttachments {
-		if !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: da.Disk.StorageDomain}) {
+		if da.Disk.StorageType != "lun" {
+			if !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: da.Disk.StorageDomain}) {
+				return
+			}
+		} else if len(da.Disk.Lun.LogicalUnits.LogicalUnit) > 0 && da.Disk.Lun.LogicalUnits.LogicalUnit[0].Address == "" {
+			// Have LUN disk but without the relevant data. This might happen with older oVirt versions.
 			return
 		}
 	}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -823,3 +823,15 @@ func (r *Builder) PersistentVolumeClaimWithSourceRef(da interface{}, storageName
 func (r *Builder) PreTransferActions(c planbase.Client, vmRef ref.Ref) (ready bool, err error) {
 	return true, nil
 }
+
+// Build LUN PVs.
+func (r *Builder) LunPersistentVolumes(vmRef ref.Ref) (pvs []core.PersistentVolume, err error) {
+	// do nothing
+	return
+}
+
+// Build LUN PVCs.
+func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.PersistentVolumeClaim, err error) {
+	// do nothing
+	return
+}

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -371,7 +371,7 @@ func (r *Client) thumbprint() string {
 	return ""
 }
 
-func (r *Client) DetachDisk(vmRef ref.Ref) (err error) {
+func (r *Client) DetachDisks(vmRef ref.Ref) (err error) {
 	// no-op
 	return
 }

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -370,3 +370,8 @@ func (r *Client) thumbprint() string {
 	}
 	return ""
 }
+
+func (r *Client) DetachDisk(vmRef ref.Ref) (err error) {
+	// no-op
+	return
+}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2006,13 +2006,12 @@ func (r *KubeVirt) EnsurePersistentVolume(vm *plan.VMStatus, persistentVolumes [
 	}
 
 	for _, pv := range persistentVolumes {
+		pvVolume := pv.Labels["volume"]
 		exists := false
 		for _, item := range list.Items {
-			if val, ok := item.Labels["volume"]; ok {
-				if val == pv.Labels["volume"] {
-					exists = true
-					break
-				}
+			if val, ok := item.Labels["volume"]; ok && val == pvVolume {
+				exists = true
+				break
 			}
 		}
 
@@ -2043,13 +2042,12 @@ func (r *KubeVirt) EnsurePersistentVolumeClaim(vm *plan.VMStatus, persistentVolu
 	}
 
 	for _, pvc := range persistentVolumeClaims {
+		pvcVolume := pvc.Labels["volume"]
 		exists := false
 		for _, item := range list {
-			if val, ok := item.Labels["volume"]; ok {
-				if val == pvc.Labels["volume"] {
-					exists = true
-					break
-				}
+			if val, ok := item.Labels["volume"]; ok && val == pvcVolume {
+				exists = true
+				break
 			}
 		}
 

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1025,7 +1025,6 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 	}
 	vm.ReflectPipeline()
 	if vm.Phase == Completed && vm.Error == nil {
-		// Detach LUNs
 		err = r.provider.DetachDisks(vm.Ref)
 		if err != nil {
 			step, found := vm.FindStep(r.step(vm))
@@ -1034,7 +1033,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			}
 			step.AddError(err.Error())
 			r.Log.Error(err,
-				"Could not detach source VM LUN disks.",
+				"Could not detach LUN disk(s) from the source VM.",
 				"vm",
 				vm.String())
 			err = nil

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1351,8 +1351,8 @@ func (r *Migration) updateCopyProgressForOvirt(vm *plan.VMStatus, step *plan.Ste
 		return
 	}
 	for _, pvc := range pvcs {
-		if _, ok := pvc.Annotations["lun"]; !ok {
-			// it's a lun
+		if _, ok := pvc.Annotations["lun"]; ok {
+			// skip LUNs
 			continue
 		}
 		claim := pvc.Spec.DataSource.Name

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1026,7 +1026,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 	vm.ReflectPipeline()
 	if vm.Phase == Completed && vm.Error == nil {
 		// Detach LUNs
-		err = r.provider.DetachDisk(vm.Ref)
+		err = r.provider.DetachDisks(vm.Ref)
 		if err != nil {
 			step, found := vm.FindStep(r.step(vm))
 			if !found {

--- a/pkg/controller/provider/container/ovirt/model.go
+++ b/pkg/controller/provider/container/ovirt/model.go
@@ -1011,6 +1011,12 @@ func (r *DiskAdapter) List(ctx *Context) (itr fb.Iterator, err error) {
 	}
 	list := fb.NewList()
 	for _, object := range diskList.Items {
+		if object.StorageType == "lun" {
+			err = ctx.client.list(fmt.Sprintf("disks/%s", object.ID), &object)
+			if err != nil {
+				return
+			}
+		}
 		m := &model.Disk{
 			Base: model.Base{ID: object.ID},
 		}

--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -649,6 +649,23 @@ type Disk struct {
 	ActualSize  string `json:"actual_size"`
 	Backup      string `json:"backup"`
 	StorageType string `json:"storage_type"`
+	Lun         Lun    `json:"lun_storage"`
+}
+
+// LUN Resource.
+type Lun struct {
+	LogicalUnits struct {
+		LogicalUnit []LogicalUnit `json:"logical_unit"`
+	} `json:"logical_units"`
+}
+
+type LogicalUnit struct {
+	Base
+	Address    string `json:"address"`
+	Port       string `json:"port"`
+	Target     string `json:"target"`
+	LunMapping string `json:"lun_mapping"`
+	Size       string `json:"size"`
 }
 
 // Apply to (update) the model.
@@ -663,6 +680,7 @@ func (r *Disk) ApplyTo(m *model.Disk) {
 	m.StorageType = r.StorageType
 	m.ProvisionedSize = r.int64(r.ProvisionedSize)
 	r.setStorageDomain(m)
+	r.setLun(m)
 }
 
 func (r *Disk) setStorageDomain(m *model.Disk) {
@@ -670,6 +688,24 @@ func (r *Disk) setStorageDomain(m *model.Disk) {
 		m.StorageDomain = ref.ID
 		break
 	}
+}
+
+func (r *Disk) setLun(m *model.Disk) {
+	m.Lun = model.Lun{}
+	m.Lun.LogicalUnits.LogicalUnit = []model.LogicalUnit{}
+	for _, rlu := range r.Lun.LogicalUnits.LogicalUnit {
+		mlu := &model.LogicalUnit{}
+		rlu.ApplyTo(mlu)
+		m.Lun.LogicalUnits.LogicalUnit = append(m.Lun.LogicalUnits.LogicalUnit, *mlu)
+	}
+}
+
+func (r *LogicalUnit) ApplyTo(m *model.LogicalUnit) {
+	m.Address = r.Address
+	m.Port = r.Port
+	m.Target = r.Target
+	m.LunMapping = r.int32(r.LunMapping)
+	m.Size = r.int64(r.Size)
 }
 
 // Disk (list).

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -234,4 +234,19 @@ type Disk struct {
 	Backup          string `sql:""`
 	StorageType     string `sql:""`
 	ProvisionedSize int64  `sql:""`
+	Lun             Lun    `sql:""`
+}
+
+type Lun struct {
+	LogicalUnits struct {
+		LogicalUnit []LogicalUnit `json:"logicalUnit"`
+	}
+}
+
+type LogicalUnit struct {
+	Address    string `json:"address"`
+	Port       string `json:"port"`
+	Target     string `json:"target"`
+	LunMapping int32  `json:"lunMapping"`
+	Size       int64  `json:"size"`
 }

--- a/pkg/controller/provider/web/ovirt/disk.go
+++ b/pkg/controller/provider/web/ovirt/disk.go
@@ -138,7 +138,10 @@ type Disk struct {
 	ActualSize      int64  `json:"actualSize"`
 	StorageType     string `json:"storageType"`
 	Status          string `json:"status"`
+	Lun             Lun    `json:"lunStorage"`
 }
+
+type Lun = model.Lun
 
 // Build the resource using the model.
 func (r *Disk) With(m *model.Disk) {
@@ -150,6 +153,7 @@ func (r *Disk) With(m *model.Disk) {
 	r.ActualSize = m.ActualSize
 	r.Shared = m.Shared
 	r.StorageDomain = m.StorageDomain
+	r.Lun = m.Lun
 }
 
 // Build self link (URI).

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type.rego
@@ -5,11 +5,16 @@ valid_disk_storage_type [i] {
     input.diskAttachments[i].disk.storageType == "image"
 }
 
+valid_disk_storage_type_lun [i] {
+    some i
+    input.diskAttachments[i].disk.storageType == "lun"
+}
+
 concerns[flag] {
-    count(valid_disk_storage_type) != count(number_of_disks)
+    count(valid_disk_storage_type) + count(valid_disk_storage_type_lun) != count(number_of_disks)
     flag := {
         "category": "Critical",
         "label": "Unsupported disk storage type detected",
-        "assessment": "The VM has a disk with a storage type other than 'image', which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."
+        "assessment": "The VM has a disk with a storage type other than 'image' or 'lun', which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."
     }
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type_test.rego
@@ -46,3 +46,21 @@ test_with_invalid_storage_type {
     results := concerns with input as mock_vm
     count(results) == 1
 }
+
+test_with_valid_lun_storage_type {
+    mock_vm := {
+        "name": "test",
+        "diskAttachments": [
+            {
+              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+              "interface": "virtio_scsi",
+              "disk":
+                { "storageType": "lun",
+                  "status": "ok"
+                }
+            }
+        ]
+    }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}


### PR DESCRIPTION
This patch will allow importing direct LUNs from oVirt provider to
kubeVirt. The attached direct LUNs will be created in the destination
cluster. It will be connected to the VM as PVC and a PV which contains
the relevant direct LUN details.

Only on late oVirt version the API provides the relevant details.
Therefore, older version can not perform this flow.

The storage should be exposed to the destination environment.
