### PR TITLE
run e2e-openstack-extended test in self hosted runner

### DIFF
--- a/.github/workflows/create-new-pr.yml
+++ b/.github/workflows/create-new-pr.yml
@@ -1,0 +1,39 @@
+name: new PR greeter
+on:
+  pull_request_target:
+    types: [opened,reopened]
+
+jobs:
+  new_pr_greeter:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout forklift
+        uses: actions/checkout@v3
+
+      - id: codeowner
+        uses: SvanBoxel/codeowners-action@v1
+        with:
+          path: './.github/CODEOWNERS'
+
+      - name: fail if the commenter doesnt exists in codeowners
+        id: allowedaccess
+        run: |
+          echo allowed=$(echo '${{ steps.codeowner.outputs.codeowners }}' | \
+          jq  -r '."tests/" | index("@${{ github.actor }}")') >> $GITHUB_OUTPUT 
+
+      - name: Add comment to PR
+        uses: actions/github-script@v6
+        if: ${{ steps.allowedaccess.outputs.allowed == '1' }}
+        with:
+          script: |
+
+            const body = `Welcome ${{ github.actor }}, you can run extended openstack test with **/test-osp-extended** comment`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })

--- a/.github/workflows/create-new-pr.yml
+++ b/.github/workflows/create-new-pr.yml
@@ -5,27 +5,14 @@ on:
 
 jobs:
   new_pr_greeter:
+    if: github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'COLLABORATOR'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - name: Checkout forklift
-        uses: actions/checkout@v3
-
-      - id: codeowner
-        uses: SvanBoxel/codeowners-action@v1
-        with:
-          path: './.github/CODEOWNERS'
-
-      - name: fail if the commenter doesnt exists in codeowners
-        id: allowedaccess
-        run: |
-          echo allowed=$(echo '${{ steps.codeowner.outputs.codeowners }}' | \
-          jq  -r '."tests/" | index("@${{ github.actor }}")') >> $GITHUB_OUTPUT 
-
       - name: Add comment to PR
         uses: actions/github-script@v6
-        if: ${{ steps.allowedaccess.outputs.allowed == '1' }}
         with:
           script: |
 

--- a/.github/workflows/run-osp-extended-tests.yml
+++ b/.github/workflows/run-osp-extended-tests.yml
@@ -1,0 +1,132 @@
+name: openstack-extended-tests
+on:
+  workflow_dispatch:
+    name:
+      description: 'run e2e openstack  extended tests on Self hosted runner'
+  workflow_call:
+
+# ensures that only a single workflow  will run at the same time
+# if another workflow triggered it will pending until first completion.
+concurrency:
+  group: hosted-e2e
+
+# A workflow run is made up of one or more jobs that can run sequentially
+jobs:
+  create_ovirt_runner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out forkliftci repository
+        uses: actions/checkout@v3
+
+      - name: Checkout forkliftci
+        uses: actions/checkout@v3
+        with:
+          #repository: kubev2v/forkliftci
+          repository: eslutsky/forkliftci
+          ref: provision-gh-worker
+          path: forkliftci
+
+      - name: run hosted_runner deployment
+        shell: bash
+        run: |
+          cd ${GITHUB_WORKSPACE}/forkliftci/cluster/gh-action-runner/
+          pwd
+          source utils.sh
+          
+          mkdir .conf/
+          echo ${{ secrets.OKD_ENGINE_SECRETS }} >${SECRETS_PATH}.b64
+          echo ${{ secrets.OKD_SSH_KEY }}  >>/tmp/id_ssh_rsa.b64
+
+
+          cat ${SECRETS_PATH}.b64 | base64 -d >${SECRETS_PATH}
+          cat /tmp/id_ssh_rsa.b64 | base64 -d >/tmp/id_ssh_rsa
+          sudo chown root:root /tmp/id_ssh_rsa
+          sudo chmod 600 /tmp/id_ssh_rsa
+
+          # deploy okd on ovirt using ansible
+          gh_action_runner_create
+  ci_setup:
+    runs-on: self-hosted
+    #runs-on: ubuntu-latest
+    needs: create_ovirt_runner
+    env:
+      USE_BAZEL_VERSION: 5.4.0
+      source_provider: openstack
+    timeout-minutes: 45
+    steps:
+      - name: Checkout forklift
+        uses: actions/checkout@v3
+        with:
+          path: forklift
+
+      - name: Checkout forkliftci
+        uses: actions/checkout@v3
+        with:
+          #repository: kubev2v/forkliftci
+          repository: eslutsky/forkliftci
+          ref: provision-gh-worker
+          #path: forkliftci
+
+      - name: add docker-hub token
+        run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login --username "${{  secrets.DOCKER_HUB_USER }}" --password-stdin
+
+      - name: build and setup everything
+        #uses: kubev2v/forkliftci/ci/build-and-setup@main
+        uses: eslutsky/forkliftci/ci/build-and-setup@provision-gh-worker
+        with:
+          provider_name: openstack
+          gh_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: kubectl version
+
+      - run: kubectl get pods -n konveyor-forklift
+
+      # e2e-sanity-openstack
+      - name: run e2e-sanity-openstack
+       # uses: kubev2v/forkliftci/ci/run-suite@main
+        uses: eslutsky/forkliftci/ci/run-suite@provision-gh-worker
+        with:
+          suite_name: e2e-sanity-openstack
+
+      - name: save logs
+        if: ${{ always() }}
+        uses: kubev2v/forkliftci/ci/save-artifacts@main
+        with:
+          source_provider: openstack
+
+
+  remove_ovirt_runner:
+    runs-on: ubuntu-latest
+    if: ${{ failure() || cancelled() }}
+    needs: [create_ovirt_runner,ci_setup]
+    steps:
+      - name: Check out forkliftci repository
+        uses: actions/checkout@v3
+
+      - name: Checkout forkliftci
+        uses: actions/checkout@v3
+        with:
+          #repository: kubev2v/forkliftci
+          repository: eslutsky/forkliftci
+          ref: provision-gh-worker
+          path: forkliftci
+
+      - name: run hosted_runner deployment
+        shell: bash
+        run: |
+          cd ${GITHUB_WORKSPACE}/forkliftci/cluster/gh-action-runner/
+          pwd
+          source utils.sh
+          
+          mkdir .conf/
+          echo ${{ secrets.OKD_ENGINE_SECRETS }} >${SECRETS_PATH}.b64
+          echo ${{ secrets.OKD_SSH_KEY }}  >>/tmp/id_ssh_rsa.b64
+
+
+          cat ${SECRETS_PATH}.b64 | base64 -d >${SECRETS_PATH}
+          cat /tmp/id_ssh_rsa.b64 | base64 -d >/tmp/id_ssh_rsa
+          sudo chown root:root /tmp/id_ssh_rsa
+          sudo chmod 600 /tmp/id_ssh_rsa
+
+          # deploy okd on ovirt using ansible
+          gh_action_runner_create -t cleanup

--- a/.github/workflows/run-osp-extended-tests.yml
+++ b/.github/workflows/run-osp-extended-tests.yml
@@ -5,6 +5,9 @@ on:
       description: 'run e2e openstack  extended tests on Self hosted runner'
   workflow_call:
 
+  issue_comment:
+    types: [ created ]
+
 # ensures that only a single workflow  will run at the same time
 # if another workflow triggered it will pending until first completion.
 concurrency:
@@ -15,36 +18,15 @@ jobs:
   create_ovirt_runner:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out forkliftci repository
-        uses: actions/checkout@v3
-
-      - name: Checkout forkliftci
-        uses: actions/checkout@v3
+      - name: prepare the secrets
+        uses: kubev2v/forkliftci/ci/prepare-ansible-secrets@v4.0
         with:
-          #repository: kubev2v/forkliftci
-          repository: eslutsky/forkliftci
-          ref: provision-gh-worker
-          path: forkliftci
+          OKD_ENGINE_SECRETS: ${{ secrets.OKD_ENGINE_SECRETS }}
+          OKD_SSH_KEY: ${{ secrets.OKD_SSH_KEY }}
 
-      - name: run hosted_runner deployment
-        shell: bash
-        run: |
-          cd ${GITHUB_WORKSPACE}/forkliftci/cluster/gh-action-runner/
-          pwd
-          source utils.sh
-          
-          mkdir .conf/
-          echo ${{ secrets.OKD_ENGINE_SECRETS }} >${SECRETS_PATH}.b64
-          echo ${{ secrets.OKD_SSH_KEY }}  >>/tmp/id_ssh_rsa.b64
+      - name: provision self hosted runner
+        uses: kubev2v/forkliftci/ci/create-self-runner@v4.0
 
-
-          cat ${SECRETS_PATH}.b64 | base64 -d >${SECRETS_PATH}
-          cat /tmp/id_ssh_rsa.b64 | base64 -d >/tmp/id_ssh_rsa
-          sudo chown root:root /tmp/id_ssh_rsa
-          sudo chmod 600 /tmp/id_ssh_rsa
-
-          # deploy okd on ovirt using ansible
-          gh_action_runner_create
   ci_setup:
     runs-on: self-hosted
     #runs-on: ubuntu-latest
@@ -62,71 +44,46 @@ jobs:
       - name: Checkout forkliftci
         uses: actions/checkout@v3
         with:
-          #repository: kubev2v/forkliftci
-          repository: eslutsky/forkliftci
-          ref: provision-gh-worker
-          #path: forkliftci
+          repository: kubev2v/forkliftci
+          ref: v4.0
 
       - name: add docker-hub token
         run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login --username "${{  secrets.DOCKER_HUB_USER }}" --password-stdin
 
       - name: build and setup everything
-        #uses: kubev2v/forkliftci/ci/build-and-setup@main
-        uses: eslutsky/forkliftci/ci/build-and-setup@provision-gh-worker
+        #uses: kubev2v/forkliftci/ci/build-and-setup@v4.0
+        uses: eslutsky/forkliftci/ci/build-and-setup@add-ssl-to-action
         with:
           provider_name: openstack
           gh_access_token: ${{ secrets.GITHUB_TOKEN }}
+          enable_openstack_ssl: true
 
       - run: kubectl version
 
       - run: kubectl get pods -n konveyor-forklift
 
-      # e2e-sanity-openstack
       - name: run e2e-sanity-openstack
-       # uses: kubev2v/forkliftci/ci/run-suite@main
-        uses: eslutsky/forkliftci/ci/run-suite@provision-gh-worker
+        uses: kubev2v/forkliftci/ci/run-suite@v3.0
         with:
-          suite_name: e2e-sanity-openstack
+          suite_name: e2e-sanity-openstack-extended
 
-      - name: save logs
+      - name: save k8s logs and upload-artifact
         if: ${{ always() }}
-        uses: kubev2v/forkliftci/ci/save-artifacts@main
+        uses: kubev2v/forkliftci/ci/save-artifacts@v3.0
         with:
           source_provider: openstack
 
-
   remove_ovirt_runner:
     runs-on: ubuntu-latest
-    if: ${{ failure() || cancelled() }}
+    if: ${{ success() || failure() || cancelled() }}
     needs: [create_ovirt_runner,ci_setup]
     steps:
-      - name: Check out forkliftci repository
-        uses: actions/checkout@v3
-
-      - name: Checkout forkliftci
-        uses: actions/checkout@v3
+      - name: prepare the secrets
+        uses: kubev2v/forkliftci/ci/prepare-ansible-secrets@v4.0
         with:
-          #repository: kubev2v/forkliftci
-          repository: eslutsky/forkliftci
-          ref: provision-gh-worker
-          path: forkliftci
-
-      - name: run hosted_runner deployment
-        shell: bash
-        run: |
-          cd ${GITHUB_WORKSPACE}/forkliftci/cluster/gh-action-runner/
-          pwd
-          source utils.sh
-          
-          mkdir .conf/
-          echo ${{ secrets.OKD_ENGINE_SECRETS }} >${SECRETS_PATH}.b64
-          echo ${{ secrets.OKD_SSH_KEY }}  >>/tmp/id_ssh_rsa.b64
-
-
-          cat ${SECRETS_PATH}.b64 | base64 -d >${SECRETS_PATH}
-          cat /tmp/id_ssh_rsa.b64 | base64 -d >/tmp/id_ssh_rsa
-          sudo chown root:root /tmp/id_ssh_rsa
-          sudo chmod 600 /tmp/id_ssh_rsa
-
-          # deploy okd on ovirt using ansible
-          gh_action_runner_create -t cleanup
+          OKD_ENGINE_SECRETS: ${{ secrets.OKD_ENGINE_SECRETS }}
+          OKD_SSH_KEY: ${{ secrets.OKD_SSH_KEY }}
+      - name: provision self hosted runner
+        uses: kubev2v/forkliftci/ci/create-self-runner@v4.0
+        with:
+          perform_cleanup: true

--- a/.github/workflows/run-osp-extended-tests.yml
+++ b/.github/workflows/run-osp-extended-tests.yml
@@ -4,7 +4,6 @@ on:
     name:
       description: 'run e2e openstack  extended tests on Self hosted runner'
   workflow_call:
-
   issue_comment:
     types: [ created ]
 
@@ -16,18 +15,54 @@ concurrency:
 # A workflow run is made up of one or more jobs that can run sequentially
 jobs:
   create_ovirt_runner:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/test-osp-extended')
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR branch
+        uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+      - name: Set latest commit status as pending
+        if: always()
+        uses: myrotvorets/set-commit-status-action@master
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+
+      - name: Checkout forklift
+        uses: actions/checkout@v3
+
+      - id: codeowner
+        uses: SvanBoxel/codeowners-action@v1
+        with:
+          path: './.github/CODEOWNERS'
+
+      - name: fail if the commenter doesnt exists in codeowners
+        run: |
+          [[ $(echo '${{ steps.codeowner.outputs.codeowners }}' | \
+          jq  -r '."tests/" | index("@${{ github.event.comment.user.login }}")') -eq 1 ]]
+
       - name: prepare the secrets
-        uses: kubev2v/forkliftci/ci/prepare-ansible-secrets@v4.0
+        #uses: kubev2v/forkliftci/ci/prepare-ansible-secrets@v4.0
+        uses: eslutsky/forkliftci/ci/prepare-ansible-secrets@gh-runner-fail-early
         with:
           OKD_ENGINE_SECRETS: ${{ secrets.OKD_ENGINE_SECRETS }}
           OKD_SSH_KEY: ${{ secrets.OKD_SSH_KEY }}
 
       - name: provision self hosted runner
-        uses: kubev2v/forkliftci/ci/create-self-runner@v4.0
+        #uses: kubev2v/forkliftci/ci/create-self-runner@v4.0
+        uses: eslutsky/forkliftci/ci/create-self-runner@gh-runner-fail-early
+
+      - name: Set latest commit status as ${{ job.status }}
+        uses: myrotvorets/set-commit-status-action@master
+        if: ${{ failure() || cancelled() }}
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
 
   ci_setup:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/test-osp-extended')
     runs-on: self-hosted
     #runs-on: ubuntu-latest
     needs: create_ovirt_runner
@@ -52,7 +87,7 @@ jobs:
 
       - name: build and setup everything
         #uses: kubev2v/forkliftci/ci/build-and-setup@v4.0
-        uses: eslutsky/forkliftci/ci/build-and-setup@add-ssl-to-action
+        uses: eslutsky/forkliftci/ci/build-and-setup@gh-runner-fail-early
         with:
           provider_name: openstack
           gh_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,6 +107,36 @@ jobs:
         uses: kubev2v/forkliftci/ci/save-artifacts@v3.0
         with:
           source_provider: openstack
+
+      - name: Get PR branch
+        if: always()
+        uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+
+      - name: Set latest commit status as ${{ job.status }}
+        uses: myrotvorets/set-commit-status-action@master
+        if: always()
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+
+      - name: Add comment to PR
+        uses: actions/github-script@v6
+        if: always()
+        with:
+          script: |
+            const name = '${{ github.workflow   }}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const success = '${{ job.status }}' === 'success';
+            const body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
 
   remove_ovirt_runner:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-osp-extended-tests.yml
+++ b/.github/workflows/run-osp-extended-tests.yml
@@ -2,27 +2,33 @@ name: openstack-extended-tests
 on:
   workflow_dispatch:
     name:
-      description: 'run e2e openstack  extended tests on Self hosted runner'
+      description: 'run e2e openstack extended tests on a self hosted runner'
   workflow_call:
   issue_comment:
     types: [ created ]
 
 # ensures that only a single workflow  will run at the same time
-# if another workflow triggered it will pending until first completion.
+# if another workflow triggered it will be pending until first completion.
 concurrency:
   group: hosted-e2e
 
 # A workflow run is made up of one or more jobs that can run sequentially
 jobs:
   create_ovirt_runner:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/test-osp-extended')
+    if: github.event_name == 'workflow_dispatch' ||
+        ( github.event_name == 'issue_comment' &&
+          startsWith(github.event.comment.body, '/test-osp-extended') && (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR')
+        )
     runs-on: ubuntu-latest
     steps:
       - name: Get PR branch
         uses: xt0rted/pull-request-comment-branch@v1
         id: comment-branch
+        if: github.event_name == 'issue_comment'
       - name: Set latest commit status as pending
-        if: always()
+        if: github.event_name == 'issue_comment'
         uses: myrotvorets/set-commit-status-action@master
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
@@ -31,16 +37,6 @@ jobs:
 
       - name: Checkout forklift
         uses: actions/checkout@v3
-
-      - id: codeowner
-        uses: SvanBoxel/codeowners-action@v1
-        with:
-          path: './.github/CODEOWNERS'
-
-      - name: fail if the commenter doesnt exists in codeowners
-        run: |
-          [[ $(echo '${{ steps.codeowner.outputs.codeowners }}' | \
-          jq  -r '."tests/" | index("@${{ github.event.comment.user.login }}")') -eq 1 ]]
 
       - name: prepare the secrets
         uses: kubev2v/forkliftci/ci/prepare-ansible-secrets@v5.0
@@ -60,9 +56,7 @@ jobs:
           status: ${{ job.status }}
 
   ci_setup:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/test-osp-extended')
     runs-on: self-hosted
-    #runs-on: ubuntu-latest
     needs: create_ovirt_runner
     env:
       USE_BAZEL_VERSION: 5.4.0
@@ -106,13 +100,13 @@ jobs:
           source_provider: openstack
 
       - name: Get PR branch
-        if: always()
+        if: always() && github.event_name == 'issue_comment'
         uses: xt0rted/pull-request-comment-branch@v1
         id: comment-branch
 
       - name: Set latest commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@master
-        if: always()
+        if: always() && github.event_name == 'issue_comment'
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -120,10 +114,10 @@ jobs:
 
       - name: Add comment to PR
         uses: actions/github-script@v6
-        if: always()
+        if: always() && github.event_name == 'issue_comment'
         with:
           script: |
-            const name = '${{ github.workflow   }}';
+            const name = '${{ github.workflow }}';
             const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
             const success = '${{ job.status }}' === 'success';
             const body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}`;

--- a/.github/workflows/run-osp-extended-tests.yml
+++ b/.github/workflows/run-osp-extended-tests.yml
@@ -43,15 +43,13 @@ jobs:
           jq  -r '."tests/" | index("@${{ github.event.comment.user.login }}")') -eq 1 ]]
 
       - name: prepare the secrets
-        #uses: kubev2v/forkliftci/ci/prepare-ansible-secrets@v4.0
-        uses: eslutsky/forkliftci/ci/prepare-ansible-secrets@gh-runner-fail-early
+        uses: kubev2v/forkliftci/ci/prepare-ansible-secrets@v5.0
         with:
           OKD_ENGINE_SECRETS: ${{ secrets.OKD_ENGINE_SECRETS }}
           OKD_SSH_KEY: ${{ secrets.OKD_SSH_KEY }}
 
       - name: provision self hosted runner
-        #uses: kubev2v/forkliftci/ci/create-self-runner@v4.0
-        uses: eslutsky/forkliftci/ci/create-self-runner@gh-runner-fail-early
+        uses: kubev2v/forkliftci/ci/create-self-runner@v5.0
 
       - name: Set latest commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@master
@@ -80,14 +78,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: kubev2v/forkliftci
-          ref: v4.0
+          ref: v5.0
 
       - name: add docker-hub token
         run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login --username "${{  secrets.DOCKER_HUB_USER }}" --password-stdin
 
       - name: build and setup everything
-        #uses: kubev2v/forkliftci/ci/build-and-setup@v4.0
-        uses: eslutsky/forkliftci/ci/build-and-setup@gh-runner-fail-early
+        uses: kubev2v/forkliftci/ci/build-and-setup@v5.0
         with:
           provider_name: openstack
           gh_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,13 +95,13 @@ jobs:
       - run: kubectl get pods -n konveyor-forklift
 
       - name: run e2e-sanity-openstack
-        uses: kubev2v/forkliftci/ci/run-suite@v3.0
+        uses: kubev2v/forkliftci/ci/run-suite@v5.0
         with:
           suite_name: e2e-sanity-openstack-extended
 
       - name: save k8s logs and upload-artifact
         if: ${{ always() }}
-        uses: kubev2v/forkliftci/ci/save-artifacts@v3.0
+        uses: kubev2v/forkliftci/ci/save-artifacts@v5.0
         with:
           source_provider: openstack
 
@@ -144,11 +141,11 @@ jobs:
     needs: [create_ovirt_runner,ci_setup]
     steps:
       - name: prepare the secrets
-        uses: kubev2v/forkliftci/ci/prepare-ansible-secrets@v4.0
+        uses: kubev2v/forkliftci/ci/prepare-ansible-secrets@v5.0
         with:
           OKD_ENGINE_SECRETS: ${{ secrets.OKD_ENGINE_SECRETS }}
           OKD_SSH_KEY: ${{ secrets.OKD_SSH_KEY }}
       - name: provision self hosted runner
-        uses: kubev2v/forkliftci/ci/create-self-runner@v4.0
+        uses: kubev2v/forkliftci/ci/create-self-runner@v5.0
         with:
           perform_cleanup: true


### PR DESCRIPTION
this GH action will trigger  openstack extended tests in  a self hosted runner .

this PR consists of the following items:
-  [x] trigger the test  with a certain comment and report the job status on the PR.
-  [ ] provision self hosted fedora VM on ovirt and join as a runner to forklift gh repo.
    - [x] create a fedora template  with kind cluster +  gh-runner instance pre-configured.
            each template is configured to work with specific `org/repo`
    - [x] create a VM from the template (limited to 1  VM per template)
    - [ ] allow running several VM instances from same template - generate runner-id and reconfigure the runner 
-  [x] run the extended on the self hosted runner.
-  [x] remove the runner VM
-  [x] make sure only [codeowner](https://github.com/kubev2v/forklift/blob/main/.github/CODEOWNERS#L5) in `tests/ can trigger the job using  comment.
-  [ ] scale-out - support multiple  concurrent runs (up to maximum)