### PR TITLE
Fix CA var reading for insecure flow

### DIFF
--- a/cmd/openstack-populator/openstack-populator.go
+++ b/cmd/openstack-populator/openstack-populator.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -83,9 +84,19 @@ func loadConfig(secretName, endpoint string) openstackConfig {
 		klog.Error(err.Error())
 		insecureSkipVerify = []byte("false")
 	}
-	cacert, err := os.ReadFile("/etc/secret-volume/cacert")
+	insecure, err := strconv.ParseBool(string(insecureSkipVerify))
 	if err != nil {
-		klog.Error(err.Error())
+		klog.Fatal(err.Error())
+	}
+	//If the insecure option is set, the ca file field in the secret is not required.
+	var cacert []byte
+	if insecure {
+		cacert = []byte("")
+	} else {
+		cacert, err = os.ReadFile("/etc/secret-volume/cacert")
+		if err != nil {
+			klog.Error(err.Error())
+		}
 	}
 
 	return openstackConfig{


### PR DESCRIPTION
When creating the populate pod all the secret var being fetch and read, including the CA filed for insecure flow.
From the UI it's not causing any issue because this field is automatically added with empty value,
but from the CLI if a secret being create without the CA (like it should for insecure migration) the pod creation will failed and crush when trying to read this value, this fix should solve the issue.