### PR TITLE
ovirt: do not show json parsing error in the log

### DIFF
--- a/cmd/ovirt-populator/ovirt-populator.go
+++ b/cmd/ovirt-populator/ovirt-populator.go
@@ -131,7 +131,10 @@ func populate(engineURL, diskID, volPath string) {
 			klog.Info(text)
 			err = json.Unmarshal([]byte(text), &progressOutput)
 			if err != nil {
-				klog.Error(err)
+				var syntaxError *json.SyntaxError
+				if !errors.As(err, &syntaxError) {
+					klog.Error(err)
+				}
 			}
 
 			progressGague.WithLabelValues(diskID).Set(float64(progressOutput.Transferred))


### PR DESCRIPTION
Make the log more pleasant to look at, example:

```
I0605 13:04:29.609857       1 ovirt-populator.go:131] {"transferred": 0, "elapsed": 2.337852492928505e-06, "description": "creating transfer"}
I0605 13:04:30.707293       1 ovirt-populator.go:131] {"transferred": 0, "elapsed": 1.0974310429301113, "description": "command failed"}
I0605 13:04:30.707454       1 ovirt-populator.go:131] {"transferred": 0, "elapsed": 1.0978067519608885, "description": "command failed"}
I0605 13:04:30.719615       1 ovirt-populator.go:131] 2023-06-05 13:04:30,707 ERROR   (MainThread) [tool] Command failed
I0605 13:04:30.719698       1 ovirt-populator.go:131] Traceback (most recent call last):
I0605 13:04:30.719769       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirt_imageio/client/_tool.py", line 35, in main
I0605 13:04:30.719796       1 ovirt-populator.go:131]     args.command(args)
I0605 13:04:30.719810       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirt_imageio/client/_download.py", line 42, in download_disk
I0605 13:04:30.719822       1 ovirt-populator.go:131]     disk = _ovirt.find_disk(con, args.disk_id)
I0605 13:04:30.719834       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirt_imageio/client/_ovirt.py", line 57, in find_disk
I0605 13:04:30.719846       1 ovirt-populator.go:131]     return service.get()
I0605 13:04:30.719858       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirtsdk4/services.py", line 39808, in get
I0605 13:04:30.719871       1 ovirt-populator.go:131]     return self._internal_get(headers, query, wait)
I0605 13:04:30.719883       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirtsdk4/service.py", line 211, in _internal_get
I0605 13:04:30.719895       1 ovirt-populator.go:131]     return future.wait() if wait else future
I0605 13:04:30.719907       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirtsdk4/service.py", line 55, in wait
I0605 13:04:30.719920       1 ovirt-populator.go:131]     return self._code(response)
I0605 13:04:30.719932       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirtsdk4/service.py", line 208, in callback
I0605 13:04:30.719966       1 ovirt-populator.go:131]     self._check_fault(response)
I0605 13:04:30.720000       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirtsdk4/service.py", line 130, in _check_fault
I0605 13:04:30.720012       1 ovirt-populator.go:131]     body = self._internal_read_body(response)
I0605 13:04:30.720025       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirtsdk4/service.py", line 316, in _internal_read_body
I0605 13:04:30.720039       1 ovirt-populator.go:131]     self._connection.check_xml_content_type(response)
I0605 13:04:30.720051       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirtsdk4/__init__.py", line 846, in check_xml_content_type
I0605 13:04:30.720063       1 ovirt-populator.go:131]     return self._check_content_type(
I0605 13:04:30.720075       1 ovirt-populator.go:131]   File "/usr/local/lib64/python3.9/site-packages/ovirtsdk4/__init__.py", line 889, in _check_content_type
I0605 13:04:30.720086       1 ovirt-populator.go:131]     raise Error(msg)
I0605 13:04:30.720122       1 ovirt-populator.go:131] ovirtsdk4.Error: The response content type 'text/html;charset=UTF-8' isn't the expected XML. Is the path '/ovirt-engine/api/ovirt-engine/api' included in the 'url' parameter correct? The typical one is '/ovirt-engine/api'
F0605 13:04:30.761884       1 ovirt-populator.go:154] exit status 1
```