### PR TITLE
ovirt: limit snapshot cleanup to warm migrations only

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -420,6 +420,12 @@ func (r *Client) cacert() []byte {
 }
 
 func (r Client) Finalize(vms []*planapi.VMStatus, planName string) {
+	defer func() {
+		if p := recover(); p != nil {
+			r.Log.Info("Recovered from panic:", p)
+		}
+	}()
+
 	if !r.Plan.Spec.Warm {
 		r.Log.Info("Skipping precopy removal for cold migration")
 		return

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -420,6 +420,11 @@ func (r *Client) cacert() []byte {
 }
 
 func (r Client) Finalize(vms []*planapi.VMStatus, planName string) {
+	if !r.Plan.Spec.Warm {
+		r.Log.Info("Skipping precopy removal for cold migration")
+		return
+	}
+
 	r.connect()
 	defer r.Close()
 	var wg sync.WaitGroup


### PR DESCRIPTION
Fix #381 