### PR TITLE
Enforce TLS on Kubernetes

### DIFF
--- a/operator/docs/k8s.md
+++ b/operator/docs/k8s.md
@@ -65,7 +65,6 @@ metadata:
 spec:
   feature_ui: false
   feature_validation: true
-  inventory_tls_enabled: false
   must_gather_api_tls_enabled: false
   ui_tls_enabled: false
 EOF
@@ -83,7 +82,6 @@ spec:
   feature_ui: true
   feature_auth_required: false
   feature_validation: true
-  inventory_tls_enabled: false
   must_gather_api_tls_enabled: false
   ui_tls_enabled: false
 EOF

--- a/operator/docs/k8s.md
+++ b/operator/docs/k8s.md
@@ -65,7 +65,6 @@ metadata:
 spec:
   feature_ui: false
   feature_validation: true
-  must_gather_api_tls_enabled: false
   ui_tls_enabled: false
 EOF
 ```
@@ -82,7 +81,6 @@ spec:
   feature_ui: true
   feature_auth_required: false
   feature_validation: true
-  must_gather_api_tls_enabled: false
   ui_tls_enabled: false
 EOF
 ```

--- a/operator/docs/k8s.md
+++ b/operator/docs/k8s.md
@@ -66,7 +66,6 @@ spec:
   feature_ui: false
   feature_validation: true
   inventory_tls_enabled: false
-  validation_tls_enabled: false
   must_gather_api_tls_enabled: false
   ui_tls_enabled: false
 EOF
@@ -85,7 +84,6 @@ spec:
   feature_auth_required: false
   feature_validation: true
   inventory_tls_enabled: false
-  validation_tls_enabled: false
   must_gather_api_tls_enabled: false
   ui_tls_enabled: false
 EOF

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -46,7 +46,9 @@ inventory_container_limits_memory: "1Gi"
 inventory_container_requests_cpu: "500m"
 inventory_container_requests_memory: "500Mi"
 inventory_tls_secret_name: "{{ inventory_service_name }}-serving-cert"
-inventory_tls_enabled: true
+inventory_selfsigned_issuer_name: "{{ inventory_service_name }}-selfsigned-issuer"
+inventory_issuer_name: "{{ inventory_service_name }}-issuer"
+inventory_certificate_name: "{{ inventory_service_name }}-selfsigned-ca"
 
 validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VALIDATION') }}"
 validation_configmap_name: "{{ validation_service_name }}-config"

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -61,7 +61,9 @@ validation_container_limits_memory: "300Mi"
 validation_container_requests_cpu: "400m"
 validation_container_requests_memory: "50Mi"
 validation_tls_secret_name: "{{ validation_service_name }}-serving-cert"
-validation_tls_enabled: true
+validation_selfsigned_issuer_name: "{{ validation_service_name }}-selfsigned-issuer"
+validation_issuer_name: "{{ validation_service_name }}-issuer"
+validation_certificate_name: "{{ validation_service_name }}-selfsigned-ca"
 validation_state: absent
 
 ui_image_fqin: "{{ lookup( 'env', 'UI_IMAGE') or lookup( 'env', 'RELATED_IMAGE_UI') }}"

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -126,7 +126,9 @@ must_gather_api_container_limits_memory: "1Gi"
 must_gather_api_container_requests_cpu: "100m"
 must_gather_api_container_requests_memory: "150Mi"
 must_gather_api_tls_secret_name: "{{ must_gather_api_service_name }}-serving-cert"
-must_gather_api_tls_enabled: true
+must_gather_api_selfsigned_issuer_name: "{{ must_gather_api_service_name }}-selfsigned-issuer"
+must_gather_api_issuer_name: "{{ must_gather_api_service_name  }}-issuer"
+must_gather_api_certificate_name: "{{ must_gather_api_service_name }}-selfsigned-ca"
 must_gather_api_db_path: "/tmp/gatherings.db"
 must_gather_api_cleanup_max_age: "-1"
 must_gather_api_debug: false

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -101,7 +101,10 @@
       k8s:
         state: present
         definition: "{{ lookup('template', 'validation/ca.yml.j2') }}"
-
+    - name: "Configure inventory certificate on K8s"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'controller/ca.yml.j2') }}"
 
   - name: "Setup api service"
     k8s:

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -91,11 +91,17 @@
         state: "{{ volume_populator_state }}"
         definition: "{{ lookup('template', 'populator/deployment-populator-controller.yml.j2') }}"
 
-  - name: "Configure webhook certificate on K8s"
-    k8s:
-      state: present
-      definition: "{{ lookup('template', 'api/ca.yml.j2') }}"
-    when: k8s_cluster|bool
+  - when: k8s_cluster|bool
+    block:
+    - name: "Configure webhook certificate on K8s"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'api/ca.yml.j2') }}"
+    - name: "Configure validation certificate on K8s"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'validation/ca.yml.j2') }}"
+
 
   - name: "Setup api service"
     k8s:

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -105,6 +105,10 @@
       k8s:
         state: present
         definition: "{{ lookup('template', 'controller/ca.yml.j2') }}"
+    - name: "Configure must-gather certificate on K8s"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'must-gather-api/ca.yml.j2') }}"
 
   - name: "Setup api service"
     k8s:

--- a/operator/roles/forkliftcontroller/templates/api/service-forklift-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/service-forklift-api.yml.j2
@@ -2,8 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+{% if not k8s_cluster|bool %}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ api_tls_secret_name }}
+{% endif %}
   name: {{ api_service_name }}
   namespace: "{{ app_namespace }}"
   labels:

--- a/operator/roles/forkliftcontroller/templates/controller/ca.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/ca.yml.j2
@@ -1,0 +1,38 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ inventory_selfsigned_issuer_name }}
+  namespace: {{ app_namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ inventory_certificate_name }}
+  namespace: {{ app_namespace }}
+spec:
+  isCA: true
+  dnsNames:
+  - {{ inventory_service_name }}.{{ app_namespace }}.svc
+  - {{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local
+  commonName: {{ inventory_certificate_name }}
+  secretName: {{ inventory_tls_secret_name }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ inventory_selfsigned_issuer_name }}
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ inventory_issuer_name }}
+  namespace: {{ app_namespace }}
+spec:
+  ca:
+    secretName: {{ inventory_tls_secret_name }}
+

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -152,18 +152,15 @@ spec:
           value: '8082'
         - name: SECRET_NAME
           value: webhook-server-secret
-{% if feature_validation|bool and validation_tls_enabled|bool %}
+{% if feature_validation|bool %}
         - name: POLICY_AGENT_URL
           value: "https://{{ validation_service_name }}.{{ app_namespace }}.svc.cluster.local:8181"
         - name: POLICY_AGENT_CA
-          value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+{% if k8s_cluster|bool %}
+          value: /var/run/secrets/{{ validation_tls_secret_name }}/ca.crt
 {% else %}
-        - name: POLICY_AGENT_URL
-          value: "http://{{ validation_service_name }}.{{ app_namespace }}.svc.cluster.local:8181"
-        - name: POLICY_AGENT_CA
-          value: ""
+          value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 {% endif %}
-{% if feature_validation|bool %}
         - name: POLICY_AGENT_SEARCH_INTERVAL
           value: "{{ validation_policy_agent_search_interval }}"
 {% endif %}
@@ -211,6 +208,10 @@ spec:
         - mountPath: /var/run/secrets/{{ inventory_tls_secret_name }}
           name: {{ inventory_service_name }}-serving-cert
 {% endif %}
+{% if feature_validation|bool %}
+        - name: {{ validation_tls_secret_name }}
+          mountPath: /var/run/secrets/{{ validation_tls_secret_name }}
+{% endif %}
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert
@@ -222,6 +223,12 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ inventory_tls_secret_name }}
+{% endif %}
+{% if feature_validation|bool %}
+      - name: {{ validation_tls_secret_name }}
+        secret:
+          secretName: {{ validation_tls_secret_name }}
+          defaultMode: 420
 {% endif %}
       - name: inventory
         emptyDir: {}

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -42,19 +42,12 @@ spec:
           value: "v1"
         - name: VIRT_V2V_IMAGE
           value: {{ virt_v2v_image_fqin }}|{{ virt_v2v_warm_image_fqin }}
-{% if inventory_tls_enabled|bool %}
         - name: API_PORT
           value: "8443"
-        - name: API_TLS_ENABLED
-          value: "true"
-{% else %}
-        - name: API_PORT
-          value: "8080"
-        - name: API_TLS_ENABLED
-          value: "false"
-{% endif %}
         - name: METRICS_PORT
           value: '8081'
+        - name: API_TLS_CA
+          value: /var/run/secrets/{{ inventory_tls_secret_name }}/ca.crt
         - name: SECRET_NAME
           value: webhook-server-secret
 {% if controller_log_level is defined and controller_log_level is number %}
@@ -119,6 +112,8 @@ spec:
           readOnly: true
         - mountPath: {{ profiler_volume_path }}
           name: profiler
+        - mountPath: /var/run/secrets/{{ inventory_tls_secret_name }}
+          name: {{ inventory_service_name }}-serving-cert
       - name: inventory
         command:
         - /usr/local/bin/forklift-controller
@@ -133,21 +128,12 @@ spec:
           value: "v1"
         - name: AUTH_REQUIRED
           value: '{{ feature_auth_required|lower }}'
-{% if inventory_tls_enabled|bool %}
         - name: API_PORT
           value: "8443"
-        - name: API_TLS_ENABLED
-          value: "true"
         - name: API_TLS_CERTIFICATE
           value: "/var/run/secrets/{{ inventory_tls_secret_name }}/tls.crt"
         - name: API_TLS_KEY
           value: /var/run/secrets/{{ inventory_tls_secret_name }}/tls.key
-{% else %}
-        - name: API_PORT
-          value: "8080"
-        - name: API_TLS_ENABLED
-          value: "false"
-{% endif %}
         - name: METRICS_PORT
           value: '8082'
         - name: SECRET_NAME
@@ -183,15 +169,9 @@ spec:
         image: {{ controller_image_fqin }}
         imagePullPolicy: {{ image_pull_policy }}
         ports:
-{% if inventory_tls_enabled|bool %}
         - name: api
           containerPort: 8443
           protocol: TCP
-{% else %}
-        - name: api
-          containerPort: 8080
-          protocol: TCP
-{% endif %}
         resources:
           limits:
             cpu: {{ inventory_container_limits_cpu }}
@@ -204,10 +184,8 @@ spec:
           name: inventory
         - mountPath: {{ profiler_volume_path }}
           name: profiler
-{% if inventory_tls_enabled|bool %}
         - mountPath: /var/run/secrets/{{ inventory_tls_secret_name }}
           name: {{ inventory_service_name }}-serving-cert
-{% endif %}
 {% if feature_validation|bool %}
         - name: {{ validation_tls_secret_name }}
           mountPath: /var/run/secrets/{{ validation_tls_secret_name }}
@@ -218,12 +196,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-secret
-{% if inventory_tls_enabled|bool %}
       - name: {{ inventory_tls_secret_name }}
         secret:
           defaultMode: 420
           secretName: {{ inventory_tls_secret_name }}
-{% endif %}
 {% if feature_validation|bool %}
       - name: {{ validation_tls_secret_name }}
         secret:

--- a/operator/roles/forkliftcontroller/templates/controller/route-inventory.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/route-inventory.yml.j2
@@ -13,8 +13,6 @@ spec:
   to:
     kind: Service
     name: {{ inventory_service_name }}
-{% if inventory_tls_enabled|bool %}
   tls:
     termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
-{% endif %}

--- a/operator/roles/forkliftcontroller/templates/controller/service-inventory.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/service-inventory.yml.j2
@@ -13,17 +13,10 @@ metadata:
   namespace: {{ app_namespace }}
 spec:
   ports:
-{% if inventory_tls_enabled|bool %}
   - name: api-https
     port: 8443
     targetPort: 8443
     protocol: TCP
-{% else %}
-  - name: api-http
-    port: 8080
-    targetPort: 8080
-    protocol: TCP
-{% endif %}
   selector:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"

--- a/operator/roles/forkliftcontroller/templates/controller/service-inventory.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/service-inventory.yml.j2
@@ -2,8 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+{% if not k8s_cluster|bool %}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ inventory_tls_secret_name }}
+{% endif %}
   labels:
     app: {{ app_name }}
     service: {{ inventory_service_name }}

--- a/operator/roles/forkliftcontroller/templates/must-gather-api/ca.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/must-gather-api/ca.yml.j2
@@ -1,0 +1,38 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ must_gather_api_selfsigned_issuer_name }}
+  namespace: {{ app_namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ must_gather_api_certificate_name }}
+  namespace: {{ app_namespace }}
+spec:
+  isCA: true
+  dnsNames:
+  - {{ must_gather_api_service_name }}.{{ app_namespace }}.svc
+  - {{ must_gather_api_service_name }}.{{ app_namespace }}.svc.cluster.local
+  commonName: {{ must_gather_api_certificate_name }}
+  secretName: {{ must_gather_api_tls_secret_name }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ must_gather_api_selfsigned_issuer_name }}
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ must_gather_api_issuer_name }}
+  namespace: {{ app_namespace }}
+spec:
+  ca:
+    secretName: {{ must_gather_api_tls_secret_name }}
+

--- a/operator/roles/forkliftcontroller/templates/must-gather-api/deployment-must-gather-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/must-gather-api/deployment-must-gather-api.yml.j2
@@ -24,36 +24,21 @@ spec:
           image: {{ must_gather_api_image_fqin }}
           imagePullPolicy: {{ image_pull_policy }}
           ports:
-{% if must_gather_api_tls_enabled|bool %}
           - name: api
             containerPort: 8443
             protocol: TCP
-{% else %}
-          - name: api
-            containerPort: 8080
-            protocol: TCP
-{% endif %}
           env:
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-{% if must_gather_api_tls_enabled|bool %}
             - name: PORT
               value: "8443"
-            - name: API_TLS_ENABLED
-              value: "true"
             - name: API_TLS_CERTIFICATE
               value: "/var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.crt"
             - name: API_TLS_KEY
               value: "/var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.key"
-{% else %}
-            - name: PORT
-              value: "8080"
-            - name: API_TLS_ENABLED
-              value: "false"
-{% endif %}
             - name: DB_PATH
               value: "{{ must_gather_api_db_path }}"
             - name: CLEANUP_MAX_AGE
@@ -72,14 +57,10 @@ spec:
               cpu: {{ must_gather_api_container_requests_cpu }}
               memory: {{ must_gather_api_container_requests_memory }}
           volumeMounts:
-{% if must_gather_api_tls_enabled|bool %}
             - name: {{ must_gather_api_tls_secret_name }}
               mountPath: /var/run/secrets/{{ must_gather_api_tls_secret_name }}
-{% endif %}
       volumes:
-{% if must_gather_api_tls_enabled|bool %}
         - name: {{ must_gather_api_tls_secret_name }}
           secret:
             secretName: {{ must_gather_api_tls_secret_name }}
             defaultMode: 420
-{% endif %}

--- a/operator/roles/forkliftcontroller/templates/must-gather-api/service-must-gather-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/must-gather-api/service-must-gather-api.yml.j2
@@ -15,14 +15,7 @@ spec:
     app: {{ app_name }}
     service: {{ must_gather_api_service_name }}
   ports:
-{% if must_gather_api_tls_enabled|bool %}
   - name: api-https
     port: 8443
     targetPort: 8443
     protocol: TCP
-{% else %}
-  - name: api-http
-    port: 8080
-    targetPort: 8080
-    protocol: TCP
-{% endif %}

--- a/operator/roles/forkliftcontroller/templates/must-gather-api/service-must-gather-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/must-gather-api/service-must-gather-api.yml.j2
@@ -2,8 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+{% if not k8s_cluster|bool %}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ must_gather_api_tls_secret_name }}
+{% endif %}
   name: {{ must_gather_api_service_name }}
   namespace: "{{ app_namespace }}"
   labels:

--- a/operator/roles/forkliftcontroller/templates/ui/configmap-ui.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui/configmap-ui.yml.j2
@@ -13,11 +13,7 @@ data:
       "namespace": "{{ app_namespace }}",
       "configNamespace": "{{ app_namespace }}",
       "clusterApi": "https://kubernetes.default.svc.cluster.local",
-{% if inventory_tls_enabled|bool %}
       "inventoryApi": "https://{{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local:8443",
-{% else %}
-      "inventoryApi": "http://{{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local:8080",
-{% endif %}
 {% if must_gather_api_tls_enabled|bool %}
       "mustGatherApi": "https://{{ must_gather_api_service_name }}.{{ app_namespace }}.svc.cluster.local:8443",
 {% else %}

--- a/operator/roles/forkliftcontroller/templates/ui/configmap-ui.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui/configmap-ui.yml.j2
@@ -14,11 +14,7 @@ data:
       "configNamespace": "{{ app_namespace }}",
       "clusterApi": "https://kubernetes.default.svc.cluster.local",
       "inventoryApi": "https://{{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local:8443",
-{% if must_gather_api_tls_enabled|bool %}
       "mustGatherApi": "https://{{ must_gather_api_service_name }}.{{ app_namespace }}.svc.cluster.local:8443",
-{% else %}
-      "mustGatherApi": "http://{{ must_gather_api_service_name }}.{{ app_namespace }}.svc.cluster.local:8080",
-{% endif %}
       "oauth": {
 {% if not k8s_cluster|bool %}
         "clientId": "{{ ui_service_name }}",

--- a/operator/roles/forkliftcontroller/templates/validation/ca.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/validation/ca.yml.j2
@@ -1,0 +1,38 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ validation_selfsigned_issuer_name }}
+  namespace: {{ app_namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ validation_certificate_name }}
+  namespace: {{ app_namespace }}
+spec:
+  isCA: true
+  dnsNames:
+  - {{ validation_service_name }}.{{ app_namespace }}.svc
+  - {{ validation_service_name }}.{{ app_namespace }}.svc.cluster.local
+  commonName: {{ validation_certificate_name }}
+  secretName: {{ validation_tls_secret_name }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ validation_selfsigned_issuer_name }}
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ validation_issuer_name }}
+  namespace: {{ app_namespace }}
+spec:
+  ca:
+    secretName: {{ validation_tls_secret_name }}
+

--- a/operator/roles/forkliftcontroller/templates/validation/deployment-validation.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/validation/deployment-validation.yml.j2
@@ -41,33 +41,26 @@ spec:
                   fieldPath: metadata.namespace
             - name: INVENTORY_SERVICE
               value: {{ inventory_service_name }}
-{% if validation_tls_enabled|bool %}
-            - name: TLS_ENABLED
-              value: 'true'
             - name: TLS_CERT_FILE
               value: /var/run/secrets/{{ validation_tls_secret_name }}/tls.crt
             - name: TLS_KEY_FILE
               value: /var/run/secrets/{{ validation_tls_secret_name }}/tls.key
             - name: CA_TLS_CERTIFICATE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+{% if k8s_cluster|bool %}
+              value: /var/run/secrets/{{ validation_tls_secret_name }}/ca.crt
 {% else %}
-            - name: TLS_ENABLED
-              value: 'false'
+              value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
 {% endif %}
           volumeMounts:
             - name: {{ validation_extra_volume_name }}
               mountPath: {{ validation_extra_volume_mountpath }}
-{% if validation_tls_enabled|bool %}
             - name: {{ validation_tls_secret_name }}
               mountPath: /var/run/secrets/{{ validation_tls_secret_name }}
-{% endif %}
       volumes:
         - name: {{ validation_extra_volume_name }}
           configMap:
             name: {{ validation_configmap_name }}
-{% if validation_tls_enabled|bool %}
         - name: {{ validation_tls_secret_name }}
           secret:
             secretName: {{ validation_tls_secret_name }}
             defaultMode: 420
-{% endif %}

--- a/operator/roles/forkliftcontroller/templates/validation/service-validation.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/validation/service-validation.yml.j2
@@ -2,8 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+{% if not k8s_cluster|bool %}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ validation_tls_secret_name }}
+{% endif %}
   name: {{ validation_service_name }}
   namespace: "{{ app_namespace }}"
   labels:

--- a/pkg/settings/inventory.go
+++ b/pkg/settings/inventory.go
@@ -18,7 +18,6 @@ const (
 	AuthRequired   = "AUTH_REQUIRED"
 	Host           = "API_HOST"
 	Port           = "API_PORT"
-	TLSEnabled     = "API_TLS_ENABLED"
 	TLSCertificate = "API_TLS_CERTIFICATE"
 	TLSKey         = "API_TLS_KEY"
 	TLSCa          = "API_TLS_CA"
@@ -90,19 +89,16 @@ func (r *Inventory) Load() error {
 		r.Port = 8080
 	}
 	// TLS
-	r.TLS.Enabled = getEnvBool(TLSEnabled, false)
-	if r.TLS.Enabled {
-		if s, found := os.LookupEnv(TLSCertificate); found {
-			r.TLS.Certificate = s
-		}
-		if s, found := os.LookupEnv(TLSKey); found {
-			r.TLS.Key = s
-		}
-		if s, found := os.LookupEnv(TLSCa); found {
-			r.TLS.CA = s
-		} else {
-			r.TLS.CA = ServiceCAFile
-		}
+	if s, found := os.LookupEnv(TLSCertificate); found {
+		r.TLS.Certificate = s
+	}
+	if s, found := os.LookupEnv(TLSKey); found {
+		r.TLS.Key = s
+	}
+	if s, found := os.LookupEnv(TLSCa); found {
+		r.TLS.CA = s
+	} else {
+		r.TLS.CA = ServiceCAFile
 	}
 
 	return nil

--- a/validation/entrypoint.sh
+++ b/validation/entrypoint.sh
@@ -2,16 +2,14 @@
 set -e
 
 CMD="/usr/bin/opa run --server"
-if [ "$TLS_ENABLED" == "true" ]; then
-  if [ -f "$TLS_CERT_FILE" ] && [ -f "$TLS_KEY_FILE" ]; then
-    CMD="$CMD --tls-cert-file $TLS_CERT_FILE --tls-private-key-file $TLS_KEY_FILE"
-  else
-    echo "ERROR: TLS_CERT_FILE and/or TLS_KEY_FILE variables not defined correctly"
-    exit 1 # terminate and indicate error
-  fi
-  if [ -f "$CA_TLS_CERTIFICATE" ]; then
-    CMD="$CMD --tls-ca-cert-file $CA_TLS_CERTIFICATE"
-  fi
+if [ -f "$TLS_CERT_FILE" ] && [ -f "$TLS_KEY_FILE" ]; then
+  CMD="$CMD --tls-cert-file $TLS_CERT_FILE --tls-private-key-file $TLS_KEY_FILE"
+else
+  echo "ERROR: TLS_CERT_FILE and/or TLS_KEY_FILE variables not defined correctly"
+  exit 1 # terminate and indicate error
+fi
+if [ -f "$CA_TLS_CERTIFICATE" ]; then
+  CMD="$CMD --tls-ca-cert-file $CA_TLS_CERTIFICATE"
 fi
 CMD="$CMD /usr/share/opa/policies"
 echo "Starting with CMD: $CMD"


### PR DESCRIPTION
Previously, users had to disable TLS when running Forklift on plain Kubernetes.
However, since it was introduced forklift-api requires to generate certificates also on Kubernetes using cert-manager.
This PR forces the validation, inventory and must-gather-api services to use TLS on Kubernetes in a similar way.
The ui service has not changed since it is going to be dropped soon.