### PR TITLE
Add default host provider after starting forklift-api

### DIFF
--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -84,12 +84,6 @@
       definition: "{{ lookup('template', 'controller/route-inventory.yml.j2') }}"
     when: not k8s_cluster|bool
 
-  - name: "Set up default provider"
-    k8s:
-      state: present
-      definition: "{{ lookup('template', 'controller/provider-host.yml.j2') }}"
-    when: "'kubevirt.io' in api_groups"
-
   - when: feature_volume_populator|bool
     block:
     - name: "Setup populator controller deployment"
@@ -122,7 +116,13 @@
     k8s:
       state: present
       definition: "{{ lookup('template', 'api/mutatingwebhookconfiguration-forklift-api.yml.j2') }}"
-      
+
+  - name: "Set up default provider"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'controller/provider-host.yml.j2') }}"
+    when: "'kubevirt.io' in api_groups"
+
   - when: feature_validation|bool
     block:
     - name: "Setup validation service"


### PR DESCRIPTION
Otherwise, when the configuration of the mutating/validating webhook already exists and the forklift-api pod doesn't exist, the request to add the default host provider fails and the operator gets stuck.