### PR TITLE
Fix transition of plans back to Ready state once they are completed

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -330,15 +330,13 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 			}
 		}
 	}()
-	var migration *api.Migration
-	snapshot := plan.Status.Migration.ActiveSnapshot()
 	ctx, err := plancontext.New(r, plan, r.Log)
 	if err != nil {
 		return
 	}
 	//
 	// Find and validate the current (active) migration.
-	migration, err = r.activeMigration(plan)
+	migration, err := r.activeMigration(plan)
 	if err != nil {
 		return
 	}
@@ -356,6 +354,7 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	// The active snapshot may be marked canceled by:
 	//   activeMigration()
 	//   matchSnapshot()
+	snapshot := plan.Status.Migration.ActiveSnapshot()
 	if snapshot.HasCondition(Canceled) {
 		r.Log.Info("migration (active) marked as canceled.")
 		for _, vm := range plan.Status.Migration.VMs {

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -223,6 +223,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	}
 
 	// Set PopulatorDataSource with labels when needed
+	// must be after Referenced data is set (in 'validate')
 	if _, ok := plan.Annotations[AnnPopulatorLabels]; !ok {
 		r.setPopulatorDataSourceLabels(plan)
 	}
@@ -285,6 +286,10 @@ func (r *Reconciler) setPopulatorDataSourceLabels(plan *api.Plan) {
 			plan.Annotations[AnnPopulatorLabels] = "True"
 			patch := client.MergeFrom(planCopy)
 			err = r.Client.Patch(context.TODO(), plan, patch)
+			// Restore Referenced data that is not returned back from the server
+			plan.Referenced = planCopy.Referenced
+			// Restore original status with staged conditions
+			plan.Status = planCopy.Status
 		}
 	}
 }

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -250,17 +250,18 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 
 	// Apply changes.
 	plan.Status.ObservedGeneration = plan.Generation
-	// The update removes plan.Referenced data
-	copyPlan := plan.DeepCopy()
+	referenced := plan.Referenced
 	err = r.Status().Update(context.TODO(), plan)
 	if err != nil {
 		return
 	}
+	// Referenced data is not persisted so we don't get it back from the server
+	plan.Referenced = referenced
 
 	//
 	// Execute.
 	// The plan is updated as needed to reflect status.
-	result.RequeueAfter, err = r.execute(copyPlan)
+	result.RequeueAfter, err = r.execute(plan)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
We lost the execution-completed condition on the plan when adding the `populatorLabels` annotation because the plan was returned back from the server (while patched) with conditions that are not 'staged'. We also preserve the Referenced data of the plan when patching it, as we do elsewhere when updating it.