### PR TITLE
vol-pop: backport empty apiGroup check

### DIFF
--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -472,7 +472,11 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 		return nil
 	}
 
-	if c.gk.Group != *dataSourceRef.APIGroup || c.gk.Kind != dataSourceRef.Kind || "" == dataSourceRef.Name {
+	apiGroup := ""
+	if dataSourceRef.APIGroup != nil {
+		apiGroup = *dataSourceRef.APIGroup
+	}
+	if c.gk.Group != apiGroup || c.gk.Kind != dataSourceRef.Kind || "" == dataSourceRef.Name {
 		// Ignore PVCs that aren't for this populator to handle
 		return nil
 	}


### PR DESCRIPTION
Commit [1] adds handling for PVCs that have a dataSourceRef but no apiGroup set, we need to have it as well

[1] https://github.com/kubernetes-csi/lib-volume-populator/commit/ad80fae14b31289c97245a8a468bbf1723c54ad6