### PR TITLE
missing password in ovirt custom Environment tests

### DIFF
--- a/tests/suit/framework/ovirt.go
+++ b/tests/suit/framework/ovirt.go
@@ -65,6 +65,10 @@ func (r *OvirtClient) LoadSourceDetails() (vm *OvirtVM, err error) {
 		defer r.Close()
 		err = r.Connect()
 
+		if err != nil {
+			return nil, fmt.Errorf("error connecting to oVirt engine - %v", err)
+		}
+
 		// get storage domain from the test VM
 		sdomains, err = r.vmData.getSDFromVM(r.connection, ref.Ref{ID: r.vmData.testVMId})
 		if err != nil {
@@ -88,7 +92,8 @@ func (r *OvirtClient) LoadSourceDetails() (vm *OvirtVM, err error) {
 func (r *OvirtClient) Connect() (err error) {
 	builder := ovirtsdk.NewConnectionBuilder().
 		URL(r.OvirtURL).
-		Username(r.Username)
+		Username(r.Username).
+		Password(r.Password)
 
 	if r.Insecure {
 		builder = builder.Insecure(r.Insecure)


### PR DESCRIPTION
this PR fixes issue in ovirt  tests infra where connection to oVirt fails due to missing password   and error is not handled

example: 

https://github.com/eslutsky/forkliftci/actions/runs/5303377976/jobs/9598959057#step:8:41 
```

    Test Panicked
    runtime error: invalid memory address or nil pointer dereference
    /opt/hostedtoolcache/go/1.20.5/x64/src/runtime/panic.go:260
```    