### PR TITLE
openstack: Ignore OpenStack floating IP addresses

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -613,6 +613,11 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 					if macAddress, ok := m["OS-EXT-IPS-MAC:mac_addr"]; ok {
 						kInterface.MacAddress = macAddress.(string)
 					}
+					if ipType, ok := m["OS-EXT-IPS:type"]; ok {
+						if ipType.(string) == "floating" {
+							continue
+						}
+					}
 				}
 
 				var vmNetworkID string

--- a/validation/policies/io/konveyor/forklift/openstack/floating_ips.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/floating_ips.rego
@@ -1,0 +1,17 @@
+package io.konveyor.forklift.openstack
+
+addresses := input.addresses
+
+floating_ips[i] {
+  some i
+	addresses[i][_]["OS-EXT-IPS:type"] == "floating"
+}
+
+concerns[flag] {
+	count(floating_ips) != 0
+	flag := {
+		"category": "Warning",
+		"label": "Floating IPs detected",
+		"assessment": "The VM has floating IPs assigned. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but the Floating IP configuration will be missing in the target environment.",
+	}
+}

--- a/validation/policies/io/konveyor/forklift/openstack/floating_ips_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/floating_ips_test.rego
@@ -1,0 +1,56 @@
+package io.konveyor.forklift.openstack
+
+test_without_floating_ips {
+	mock_vm := {
+		"name": "test",
+		"addresses": {
+      "network1": [
+        {
+          "OS-EXT-IPS:type": "fixed",
+        },
+        {
+          "OS-EXT-IPS:type": "fixed",
+        },
+      ],
+      "network2": [
+        {
+          "OS-EXT-IPS:type": "fixed",
+        },
+        {
+          "OS-EXT-IPS:type": "fixed",
+        }
+      ]
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
+}
+
+test_with_floating_ips {
+	mock_vm := {
+		"name": "test",
+		"addresses": {
+      "network1": [
+        {
+          "OS-EXT-IPS:type": "fixed",
+        },
+        {
+          "OS-EXT-IPS:type": "fixed",
+        },
+        {
+          "OS-EXT-IPS:type": "floating",
+        }
+      ],
+      "network2": [
+        {
+          "OS-EXT-IPS:type": "fixed",
+        },
+        {
+          "OS-EXT-IPS:type": "fixed",
+        }
+      ]
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
+}


### PR DESCRIPTION
Although the OpenStack Floating IPs do not represent any physical
network interface within the VM, they are associated to specific
VM's IP/Port and therefore they both use the same MAC addresses.

As this is causing conflicts in network mappings we will
ignore them.

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
