### PR TITLE
oVirt provider: Fix the POST auth request

### DIFF
--- a/pkg/controller/provider/container/ovirt/client.go
+++ b/pkg/controller/provider/container/ovirt/client.go
@@ -103,15 +103,11 @@ func (r *Client) connect() (status int, err error) {
 	values.Add("scope", "ovirt-app-api")
 
 	client.Header = http.Header{
-		"Accept": []string{"application/json"},
+		"Accept":       []string{"application/json"},
+		"Content-Type": []string{"application/x-www-form-urlencoded"},
 	}
-	request := &struct {
-		Input interface{} `json:"input"`
-	}{}
-	request.Input = values
 	response := &ovirtTokenResponse{}
-	url.RawQuery = values.Encode()
-	status, err = client.Post(url.String(), request, response)
+	status, err = client.Post(url.String(), values.Encode(), response)
 	if err != nil {
 		return
 	}

--- a/pkg/lib/inventory/web/client.go
+++ b/pkg/lib/inventory/web/client.go
@@ -161,7 +161,10 @@ func (r *Client) Get(url string, out interface{}, params ...Param) (status int, 
 	return
 }
 
-// HTTP POST (method).
+/*
+HTTP POST (method).
+When the `in interface{}` is a string, it is passed as raw bytes otherwise it uses the json.Marshal on it.
+*/
 func (r *Client) Post(url string, in interface{}, out interface{}) (status int, err error) {
 	parsedURL, err := liburl.Parse(url)
 	if err != nil {
@@ -172,8 +175,14 @@ func (r *Client) Post(url string, in interface{}, out interface{}) (status int, 
 			url)
 		return
 	}
-	body, _ := json.Marshal(in)
-	reader := bytes.NewReader(body)
+	var reader *bytes.Reader
+	switch v := in.(type) {
+	case string:
+		reader = bytes.NewReader([]byte(v))
+	default:
+		body, _ := json.Marshal(in)
+		reader = bytes.NewReader(body)
+	}
 	request := &http.Request{
 		Header: r.Header,
 		Method: http.MethodPost,


### PR DESCRIPTION
The oVirt auth request must be Content-type `application/x-www-form-urlencoded`, which requires the URL encoding inside the POST data request. [1]

For this was necessary to update the Post method in Client. If the posted body is a type string, it will pass it as it is. If the body is any other type, it uses the json.Marshal for json formatting, which the oVirt auth API does not support.
[1] https://www.ovirt.org/documentation/doc-REST_API_Guide/#oauth-authentication