### PR TITLE
Backport for 2.4.2: Use POST request instead of GET for auth with fix

### DIFF
--- a/pkg/controller/provider/container/ovirt/client.go
+++ b/pkg/controller/provider/container/ovirt/client.go
@@ -96,7 +96,7 @@ func (r *Client) connect() (status int, err error) {
 	}
 
 	url.Path = "/ovirt-engine/sso/oauth/token"
-	values := url.Query()
+	values := liburl.Values{}
 	values.Add("grant_type", "password")
 	values.Add("username", string(r.secret.Data["user"]))
 	values.Add("password", string(r.secret.Data["password"]))
@@ -105,10 +105,13 @@ func (r *Client) connect() (status int, err error) {
 	client.Header = http.Header{
 		"Accept": []string{"application/json"},
 	}
-
+	request := &struct {
+		Input interface{} `json:"input"`
+	}{}
+	request.Input = values
 	response := &ovirtTokenResponse{}
 	url.RawQuery = values.Encode()
-	status, err = client.Get(url.String(), response)
+	status, err = client.Post(url.String(), request, response)
 	if err != nil {
 		return
 	}

--- a/pkg/controller/provider/container/ovirt/client.go
+++ b/pkg/controller/provider/container/ovirt/client.go
@@ -103,15 +103,11 @@ func (r *Client) connect() (status int, err error) {
 	values.Add("scope", "ovirt-app-api")
 
 	client.Header = http.Header{
-		"Accept": []string{"application/json"},
+		"Accept":       []string{"application/json"},
+		"Content-Type": []string{"application/x-www-form-urlencoded"},
 	}
-	request := &struct {
-		Input interface{} `json:"input"`
-	}{}
-	request.Input = values
 	response := &ovirtTokenResponse{}
-	url.RawQuery = values.Encode()
-	status, err = client.Post(url.String(), request, response)
+	status, err = client.Post(url.String(), values.Encode(), response)
 	if err != nil {
 		return
 	}

--- a/pkg/lib/inventory/web/client.go
+++ b/pkg/lib/inventory/web/client.go
@@ -161,7 +161,10 @@ func (r *Client) Get(url string, out interface{}, params ...Param) (status int, 
 	return
 }
 
-// HTTP POST (method).
+/*
+HTTP POST (method).
+When the `in interface{}` is a string, it is passed as raw bytes otherwise it uses the json.Marshal on it.
+*/
 func (r *Client) Post(url string, in interface{}, out interface{}) (status int, err error) {
 	parsedURL, err := liburl.Parse(url)
 	if err != nil {
@@ -172,8 +175,14 @@ func (r *Client) Post(url string, in interface{}, out interface{}) (status int, 
 			url)
 		return
 	}
-	body, _ := json.Marshal(in)
-	reader := bytes.NewReader(body)
+	var reader *bytes.Reader
+	switch v := in.(type) {
+	case string:
+		reader = bytes.NewReader([]byte(v))
+	default:
+		body, _ := json.Marshal(in)
+		reader = bytes.NewReader(body)
+	}
 	request := &http.Request{
 		Header: r.Header,
 		Method: http.MethodPost,


### PR DESCRIPTION
Continuation of: https://github.com/kubev2v/forklift/pull/403

Commits:
oVirt provider: Use POST request instead of GET for auth https://github.com/kubev2v/forklift/commit/ae45b2ee79e5f78d72b47ea9a041326705700789
oVirt provider: Fix the POST auth request https://github.com/kubev2v/forklift/commit/fbd454fcda60bcbdc76e0f4f3d92c38aad873dbf