### PR TITLE
ovirt: fix ovirt-populator build

### DIFF
--- a/hack/ovirt-populator/Containerfile
+++ b/hack/ovirt-populator/Containerfile
@@ -1,10 +1,14 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-8 as builder
 ENV GOPATH=$APP_ROOT
-COPY . .
 
+COPY go.mod ./
+COPY go.sum ./
+COPY cmd/ovirt-populator/ovirt-populator.go ./
+COPY vendor/ ./vendor/
 # When debugging by replacing the lib-volume-populator with a local modified copy
 # COPY . ./
-RUN CGO_ENABLED=0 go build -o ovirt-populator github.com/konveyor/forklift-controller/cmd/ovirt-populator
+
+RUN CGO_ENABLED=0 go build -o ovirt-populator
 
 FROM quay.io/centos/centos:stream9-minimal
 COPY --from=builder /opt/app-root/src/ovirt-populator /usr/local/bin


### PR DESCRIPTION
Fix oVirt populator build when done in a git workspace

Resolves #411

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
