### PR TITLE
ovirt: Add bootable attribute to the provider

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -452,6 +452,11 @@ func (r *Builder) mapDisks(vm *model.Workload, persistentVolumeClaims []core.Per
 				},
 			},
 		}
+		if da.DiskAttachment.Bootable {
+			var bootOrder uint = 1
+			disk.BootOrder = &bootOrder
+		}
+
 		kVolumes = append(kVolumes, volume)
 		kDisks = append(kDisks, disk)
 	}

--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -299,6 +299,7 @@ type VM struct {
 	Disks struct {
 		Attachment []struct {
 			ID              string `json:"id"`
+			Bootable        string `json:"bootable"`
 			Name            string
 			Interface       string `json:"interface"`
 			SCSIReservation string `json:"uses_scsi_reservation"`
@@ -418,6 +419,7 @@ func (r *VM) addDiskAttachment(m *model.VM) {
 				Interface:       da.Interface,
 				SCSIReservation: r.bool(da.SCSIReservation),
 				Disk:            da.Disk.ID,
+				Bootable:        r.bool(da.Bootable),
 			})
 	}
 }

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -174,6 +174,7 @@ type DiskAttachment struct {
 	Interface       string `json:"interface"`
 	SCSIReservation bool   `json:"scsiReservation"`
 	Disk            string `json:"disk"`
+	Bootable        bool   `json:"bootable"`
 }
 
 type NIC struct {


### PR DESCRIPTION
Add a bootable attribute to the ovirt provider, which allows us to specify from which disk the VM should be booted.