### PR TITLE
fix: add 10% buffer for vSphere disks

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -364,12 +364,13 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 						},
 					}
 				}
+				bufferedCapacity := int64(float64(disk.Capacity) * 1.1)
 				dvSpec := cdi.DataVolumeSpec{
 					Source: &dvSource,
 					Storage: &cdi.StorageSpec{
 						Resources: core.ResourceRequirements{
 							Requests: core.ResourceList{
-								core.ResourceStorage: *resource.NewQuantity(disk.Capacity, resource.BinarySI),
+								core.ResourceStorage: *resource.NewQuantity(bufferedCapacity, resource.BinarySI),
 							},
 						},
 						StorageClassName: &storageClass,


### PR DESCRIPTION
This PR is a bit of a hack, but it resolves the following issue encountered when migrating vSphere disks to PortWorx filesystem-type PVCs.

```bash
I0714 17:00:41.240629       1 data-processor.go:282] New phase: Resize
W0714 17:00:41.248185       1 data-processor.go:361] Available space less than requested size, resizing image to available space 40755003392.
I0714 17:00:41.248213       1 data-processor.go:369] Calculated new size is < than current size, not resizing: requested size 40755003392, virtual size: 53687091200.
I0714 17:00:41.248223       1 data-processor.go:288] Validating image
E0714 17:00:41.254396       1 data-processor.go:278] Virtual image size 53687091200 is larger than the reported available storage 43127955456. A larger PVC is required.
Unable to resize disk image to requested size
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).initDefaultPhases.func7
    pkg/importer/data-processor.go:249
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).ProcessDataWithPause
    pkg/importer/data-processor.go:275
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).ProcessData
    pkg/importer/data-processor.go:184
main.handleImport
    cmd/cdi-importer/importer.go:174
main.main
    cmd/cdi-importer/importer.go:140
runtime.main
    GOROOT/src/runtime/proc.go:250
runtime.goexit
    GOROOT/src/runtime/asm_amd64.s:1571
E0714 17:00:41.254455       1 importer.go:177] Virtual image size 53687091200 is larger than the reported available storage 43127955456. A larger PVC is required.
Unable to resize disk image to requested size
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).initDefaultPhases.func7
    pkg/importer/data-processor.go:249
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).ProcessDataWithPause
    pkg/importer/data-processor.go:275
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).ProcessData
    pkg/importer/data-processor.go:184
main.handleImport
    cmd/cdi-importer/importer.go:174
main.main
    cmd/cdi-importer/importer.go:140
runtime.main
    GOROOT/src/runtime/proc.go:250
runtime.goexit
    GOROOT/src/runtime/asm_amd64.s:1571
```