### PR TITLE
fix NPE when libmodel.Error is received

### DIFF
--- a/pkg/lib/inventory/web/client.go
+++ b/pkg/lib/inventory/web/client.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	liburl "net/url"
@@ -412,7 +413,7 @@ func (r *WatchReader) start() {
 			case libmodel.Parity:
 				r.handler.Parity()
 			case libmodel.Error:
-				r.handler.Error(&Watch{reader: r}, nil)
+				r.handler.Error(&Watch{reader: r}, errors.New("unknown error event received"))
 			case libmodel.End:
 				return
 			case libmodel.Created:


### PR DESCRIPTION
It seems that in
  `pkg/controller/watch/handler/handler.go`

```go
  func (r *Handler) Error(w *libweb.Watch, err error) {
	  log.Info(
		  "event: error.",
		  "id",
		  r.id,
		  "error",
		  err.Error())
	  if !r.ended {
		  _ = w.Repair()
	  }
  }
```

err will always be nil if we get there from:

```go
  case libmodel.Error:
    r.handler.Error(&Watch{reader: r}, nil)
```