### PR TITLE
Minor cleanup

### DIFF
--- a/pkg/controller/provider/container/openstack/client.go
+++ b/pkg/controller/provider/container/openstack/client.go
@@ -599,9 +599,7 @@ func (r *Client) get(object interface{}, ID string) (err error) {
 func (r *Client) isNotFound(err error) bool {
 	switch unWrapErr := liberr.Unwrap(err).(type) {
 	case gophercloud.ErrUnexpectedResponseCode:
-		if unWrapErr.GetStatusCode() == http.StatusNotFound {
-			return true
-		}
+		return unWrapErr.GetStatusCode() == http.StatusNotFound
 	}
 	return false
 }
@@ -609,9 +607,7 @@ func (r *Client) isNotFound(err error) bool {
 func (r *Client) isForbidden(err error) bool {
 	switch unWrapErr := liberr.Unwrap(err).(type) {
 	case gophercloud.ErrUnexpectedResponseCode:
-		if unWrapErr.GetStatusCode() == http.StatusForbidden {
-			return true
-		}
+		return unWrapErr.GetStatusCode() == http.StatusForbidden
 	}
 	return false
 }

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator.go
@@ -37,8 +37,7 @@ func (mutator *SecretMutator) Mutate(ar *admissionv1.AdmissionReview) *admission
 		return util.ToAdmissionResponseError(err)
 	}
 
-	var insecure = false
-	var secretChanged = false
+	var insecure, secretChanged bool
 	// Applies to all secrets with 'createdForProviderType' label.
 	if insecureSkipVerify, ok := secret.Data["insecureSkipVerify"]; ok {
 		insecure, err = strconv.ParseBool(string(insecureSkipVerify))


### PR DESCRIPTION
- Shorten checks of errors we get from gophercloud
- Shorten definition of boolean variables in secret-mutator.go