### PR TITLE
Improve logs of forklift-api

### DIFF
--- a/cmd/forklift-api/BUILD.bazel
+++ b/cmd/forklift-api/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/forklift-api",
+        "//pkg/lib/logging",
         "//vendor/github.com/go-logr/logr",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/log",
     ],

--- a/cmd/forklift-api/forklift-api.go
+++ b/cmd/forklift-api/forklift-api.go
@@ -19,12 +19,15 @@ package main
 import (
 	"github.com/go-logr/logr"
 	forklift_api "github.com/konveyor/forklift-controller/pkg/forklift-api"
+	"github.com/konveyor/forklift-controller/pkg/lib/logging"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var log logr.Logger
 
 func init() {
+	logger := logging.Factory.New()
+	logf.SetLogger(logger)
 	log = logf.Log.WithName("entrypoint")
 }
 

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/plan-mutator.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/plan-mutator.go
@@ -73,36 +73,36 @@ func (mutator *PlanMutator) setTransferNetworkIfNotSet() (bool, error) {
 	if mutator.plan.Spec.TransferNetwork == nil {
 		config, err := rest.InClusterConfig()
 		if err != nil {
-			log.Error(err, "Couldn't get the cluster configuration", err.Error())
+			log.Error(err, "Couldn't get the cluster configuration")
 			return false, err
 		}
 
 		err = api.SchemeBuilder.AddToScheme(scheme.Scheme)
 		if err != nil {
-			log.Error(err, "Couldn't build the scheme", err.Error())
+			log.Error(err, "Couldn't build the scheme")
 			return false, err
 		}
 		err = apis.AddToScheme(scheme.Scheme)
 		if err != nil {
-			log.Error(err, "Couldn't add forklift API to the scheme", err.Error())
+			log.Error(err, "Couldn't add forklift API to the scheme")
 			return false, err
 		}
 		err = net.AddToScheme(scheme.Scheme)
 		if err != nil {
-			log.Error(err, "Couldn't add network-attachment-definition-client to the scheme", err.Error())
+			log.Error(err, "Couldn't add network-attachment-definition-client to the scheme")
 			return false, err
 		}
 
 		cl, err := client.New(config, client.Options{Scheme: scheme.Scheme})
 		if err != nil {
-			log.Error(err, "Couldn't create a cluster client", err.Error())
+			log.Error(err, "Couldn't create a cluster client")
 			return false, err
 		}
 
 		targetProvider := api.Provider{}
 		err = cl.Get(context.TODO(), client.ObjectKey{Namespace: mutator.plan.Spec.Provider.Destination.Namespace, Name: mutator.plan.Spec.Provider.Destination.Name}, &targetProvider)
 		if err != nil {
-			log.Error(err, "Couldn't get the target provider", err.Error())
+			log.Error(err, "Couldn't get the target provider")
 			return false, err
 		}
 
@@ -126,13 +126,13 @@ func (mutator *PlanMutator) setTransferNetworkIfNotSet() (bool, error) {
 					},
 					secret)
 				if err != nil {
-					log.Error(err, "Failed to get secret for target provider", err.Error())
+					log.Error(err, "Failed to get secret for target provider")
 					return false, err
 				}
 				tcl, err = targetProvider.Client(secret)
 			}
 			if err != nil {
-				log.Error(err, "Failed to initiate client to target cluster", err.Error())
+				log.Error(err, "Failed to initiate client to target cluster")
 				return false, err
 			}
 
@@ -145,7 +145,7 @@ func (mutator *PlanMutator) setTransferNetworkIfNotSet() (bool, error) {
 				}
 				planChanged = true
 			} else if !k8serr.IsNotFound(err) { // TODO: else if !NotFound ...
-				log.Error(err, "Failed to get the network-attachment-definition", err.Error())
+				log.Error(err, "Failed to get the network-attachment-definition")
 				return false, err
 			}
 		}

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
@@ -149,24 +149,24 @@ func (admitter *SecretAdmitter) buildProviderCollector(providerType *api.Provide
 func (admitter *SecretAdmitter) testConnectionToHost(hostName string) (tested bool, err error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		log.Error(err, "Couldn't get the cluster configuration", err.Error())
+		log.Error(err, "Couldn't get the cluster configuration")
 		return
 	}
 
 	err = api.SchemeBuilder.AddToScheme(scheme.Scheme)
 	if err != nil {
-		log.Error(err, "Couldn't build the scheme", err.Error())
+		log.Error(err, "Couldn't build the scheme")
 		return
 	}
 	err = apis.AddToScheme(scheme.Scheme)
 	if err != nil {
-		log.Error(err, "Couldn't add forklift API to the scheme", err.Error())
+		log.Error(err, "Couldn't add forklift API to the scheme")
 		return
 	}
 
 	cl, err := client.New(config, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
-		log.Error(err, "Couldn't create a cluster client", err.Error())
+		log.Error(err, "Couldn't create a cluster client")
 		return
 	}
 
@@ -183,7 +183,7 @@ func (admitter *SecretAdmitter) testConnectionToHost(hostName string) (tested bo
 			err = nil
 			return
 		} else {
-			log.Error(err, "Couldn't get the target provider", err.Error())
+			log.Error(err, "Couldn't get the target provider")
 			return
 		}
 	}


### PR DESCRIPTION
- Fix the 'entrypoint' logger that wasn't set correctly
- Fix for 'odd number of arguments passed as key-value pairs for logging' error