### PR TITLE
Add compatibility ID field for OCP base resource type

### DIFF
--- a/pkg/controller/provider/web/ocp/resource.go
+++ b/pkg/controller/provider/web/ocp/resource.go
@@ -16,8 +16,11 @@ type Resource struct {
 	Name string `json:"name"`
 	// self link.
 	SelfLink string `json:"selfLink"`
-
+	// self path.
 	Path string `json:"path,omitempty"`
+
+	// forklift ID, for compatability with providers using ID instead of UID
+	ID string `json:"id,omitempty"`
 }
 
 // Populate the fields with the specified object.
@@ -26,4 +29,6 @@ func (r *Resource) With(m *model.Base) {
 	r.Version = m.Version
 	r.Namespace = m.Namespace
 	r.Name = m.Name
+
+	r.ID = m.UID
 }


### PR DESCRIPTION
Add compatibility ID field for OCP base resource type

Why this is needed:
Users of forklift API (for example the UI) expect an "id" json field and not a "uid" field.