### PR TITLE
ocp: use source client where needed

### DIFF
--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -49,7 +49,7 @@ func (r *Builder) ConfigMap(vmRef ref.Ref, secret *core.Secret, object *core.Con
 		Namespace: vmRef.Namespace,
 		Name:      vmRef.Name,
 	}
-	err := r.Client.Get(context.TODO(), key, vmExport)
+	err := r.Source.Client.Get(context.TODO(), key, vmExport)
 	if err != nil {
 		r.Log.Error(err, "Failed to get VM-export ConfigMap")
 		return liberr.Wrap(err)
@@ -70,7 +70,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 		Name:      vmRef.Name,
 	}
 
-	err = r.Client.Get(context.TODO(), key, vmExport)
+	err = r.Source.Client.Get(context.TODO(), key, vmExport)
 	if err != nil {
 		r.Log.Error(err, "Failed to get VM-export ConfigMap")
 		return nil, liberr.Wrap(err)
@@ -86,7 +86,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 	for _, volume := range vmExport.Status.Links.External.Volumes {
 		// Get PVC
 		pvc := &core.PersistentVolumeClaim{}
-		err = r.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: volume.Name}, pvc)
+		err = r.Source.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: volume.Name}, pvc)
 		if err != nil {
 			return nil, liberr.Wrap(err)
 		}
@@ -144,7 +144,7 @@ func (*Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVolum
 // Secret implements base.Builder
 func (r *Builder) Secret(vmRef ref.Ref, in *core.Secret, object *core.Secret) error {
 	vmExport := &export.VirtualMachineExport{}
-	err := r.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
+	err := r.Source.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
 	if err != nil {
 		r.Log.Error(err, "Failed to get VM-export Secret")
 		return liberr.Wrap(err)
@@ -158,7 +158,7 @@ func (r *Builder) Secret(vmRef ref.Ref, in *core.Secret, object *core.Secret) er
 		return liberr.Wrap(err, "Token secret ref is nil")
 	}
 	tokenSecret := &core.Secret{}
-	err = r.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: *vmExport.Status.TokenSecretRef}, tokenSecret)
+	err = r.Source.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: *vmExport.Status.TokenSecretRef}, tokenSecret)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -179,7 +179,7 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*planapi.Task, err error) {
 		Name:      vmRef.Name,
 	}
 
-	err = r.Client.Get(context.TODO(), key, vm)
+	err = r.Source.Client.Get(context.TODO(), key, vm)
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
@@ -190,7 +190,7 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*planapi.Task, err error) {
 		switch {
 		case vol.PersistentVolumeClaim != nil:
 			pvc := &core.PersistentVolumeClaim{}
-			err = r.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vol.PersistentVolumeClaim.ClaimName}, pvc)
+			err = r.Source.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vol.PersistentVolumeClaim.ClaimName}, pvc)
 			if err != nil {
 				return nil, liberr.Wrap(err)
 			}
@@ -199,7 +199,7 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*planapi.Task, err error) {
 			size = pvc.Spec.Resources.Requests["storage"]
 		case vol.DataVolume != nil:
 			pvc := &core.PersistentVolumeClaim{}
-			err = r.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vol.DataVolume.Name}, pvc)
+			err = r.Source.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vol.DataVolume.Name}, pvc)
 			if err != nil {
 				return nil, liberr.Wrap(err)
 			}
@@ -238,7 +238,7 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 // VirtualMachine implements base.Builder
 func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []core.PersistentVolumeClaim) error {
 	vmExport := &export.VirtualMachineExport{}
-	err := r.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
+	err := r.Source.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -372,14 +372,14 @@ func (r *Builder) mapNetworks(sourceVm *cnv.VirtualMachine, targetVmSpec *cnv.Vi
 
 func (r *Builder) getSourceVmFromDefinition(vme *export.VirtualMachineExport) (*cnv.VirtualMachine, error) {
 	var vmManifestUrl string
-	for _, manifest := range vme.Status.Links.Internal.Manifests {
+	for _, manifest := range vme.Status.Links.External.Manifests {
 		if manifest.Type == export.AllManifests {
 			vmManifestUrl = manifest.Url
 			break
 		}
 	}
 
-	caCert := vme.Status.Links.Internal.Cert
+	caCert := vme.Status.Links.External.Cert
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM([]byte(caCert))
 
@@ -399,7 +399,7 @@ func (r *Builder) getSourceVmFromDefinition(vme *export.VirtualMachineExport) (*
 	// Read token from secret
 	token := &core.Secret{}
 	key := client.ObjectKey{Namespace: vme.Namespace, Name: *vme.Status.TokenSecretRef}
-	err = r.Client.Get(context.Background(), key, token)
+	err = r.Source.Client.Get(context.Background(), key, token)
 	if err != nil {
 		return nil, liberr.Wrap(err, "failed to get token secret")
 	}

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -38,6 +38,7 @@ const (
 type Builder struct {
 	*plancontext.Context
 	macConflictsMap map[string]string
+	sourceClient    client.Client
 }
 
 // ConfigMap implements base.Builder
@@ -49,7 +50,7 @@ func (r *Builder) ConfigMap(vmRef ref.Ref, secret *core.Secret, object *core.Con
 		Namespace: vmRef.Namespace,
 		Name:      vmRef.Name,
 	}
-	err := r.Source.Client.Get(context.TODO(), key, vmExport)
+	err := r.sourceClient.Get(context.TODO(), key, vmExport)
 	if err != nil {
 		r.Log.Error(err, "Failed to get VM-export ConfigMap")
 		return liberr.Wrap(err)
@@ -70,7 +71,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 		Name:      vmRef.Name,
 	}
 
-	err = r.Source.Client.Get(context.TODO(), key, vmExport)
+	err = r.sourceClient.Get(context.TODO(), key, vmExport)
 	if err != nil {
 		r.Log.Error(err, "Failed to get VM-export ConfigMap")
 		return nil, liberr.Wrap(err)
@@ -86,7 +87,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 	for _, volume := range vmExport.Status.Links.External.Volumes {
 		// Get PVC
 		pvc := &core.PersistentVolumeClaim{}
-		err = r.Source.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: volume.Name}, pvc)
+		err = r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: volume.Name}, pvc)
 		if err != nil {
 			return nil, liberr.Wrap(err)
 		}
@@ -144,7 +145,7 @@ func (*Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVolum
 // Secret implements base.Builder
 func (r *Builder) Secret(vmRef ref.Ref, in *core.Secret, object *core.Secret) error {
 	vmExport := &export.VirtualMachineExport{}
-	err := r.Source.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
+	err := r.sourceClient.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
 	if err != nil {
 		r.Log.Error(err, "Failed to get VM-export Secret")
 		return liberr.Wrap(err)
@@ -158,7 +159,7 @@ func (r *Builder) Secret(vmRef ref.Ref, in *core.Secret, object *core.Secret) er
 		return liberr.Wrap(err, "Token secret ref is nil")
 	}
 	tokenSecret := &core.Secret{}
-	err = r.Source.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: *vmExport.Status.TokenSecretRef}, tokenSecret)
+	err = r.sourceClient.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: *vmExport.Status.TokenSecretRef}, tokenSecret)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -179,7 +180,7 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*planapi.Task, err error) {
 		Name:      vmRef.Name,
 	}
 
-	err = r.Source.Client.Get(context.TODO(), key, vm)
+	err = r.sourceClient.Get(context.TODO(), key, vm)
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
@@ -190,7 +191,7 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*planapi.Task, err error) {
 		switch {
 		case vol.PersistentVolumeClaim != nil:
 			pvc := &core.PersistentVolumeClaim{}
-			err = r.Source.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vol.PersistentVolumeClaim.ClaimName}, pvc)
+			err = r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vol.PersistentVolumeClaim.ClaimName}, pvc)
 			if err != nil {
 				return nil, liberr.Wrap(err)
 			}
@@ -199,7 +200,7 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*planapi.Task, err error) {
 			size = pvc.Spec.Resources.Requests["storage"]
 		case vol.DataVolume != nil:
 			pvc := &core.PersistentVolumeClaim{}
-			err = r.Source.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vol.DataVolume.Name}, pvc)
+			err = r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vol.DataVolume.Name}, pvc)
 			if err != nil {
 				return nil, liberr.Wrap(err)
 			}
@@ -238,7 +239,7 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 // VirtualMachine implements base.Builder
 func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []core.PersistentVolumeClaim) error {
 	vmExport := &export.VirtualMachineExport{}
-	err := r.Source.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
+	err := r.sourceClient.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -399,7 +400,7 @@ func (r *Builder) getSourceVmFromDefinition(vme *export.VirtualMachineExport) (*
 	// Read token from secret
 	token := &core.Secret{}
 	key := client.ObjectKey{Namespace: vme.Namespace, Name: *vme.Status.TokenSecretRef}
-	err = r.Source.Client.Get(context.Background(), key, token)
+	err = r.sourceClient.Get(context.Background(), key, token)
 	if err != nil {
 		return nil, liberr.Wrap(err, "failed to get token secret")
 	}

--- a/pkg/controller/plan/adapter/ocp/client.go
+++ b/pkg/controller/plan/adapter/ocp/client.go
@@ -15,10 +15,12 @@ import (
 	export "kubevirt.io/api/export/v1alpha1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Client struct {
 	*plancontext.Context
+	sourceClient k8sclient.Client
 }
 
 // CheckSnapshotReady implements base.Client
@@ -44,7 +46,7 @@ func (r *Client) Finalize(vms []*planapi.VMStatus, planName string) {
 			Namespace: vm.Namespace,
 		}}
 
-		err := r.Source.Client.Delete(context.TODO(), vmExport)
+		err := r.sourceClient.Delete(context.TODO(), vmExport)
 		if err != nil {
 			r.Log.Info("Failed to delete VMExport", "VMExport", vmExport, "Error", err)
 			continue
@@ -55,14 +57,14 @@ func (r *Client) Finalize(vms []*planapi.VMStatus, planName string) {
 // PowerOff implements base.Client
 func (r *Client) PowerOff(vmRef ref.Ref) error {
 	vm := cnv.VirtualMachine{}
-	err := r.Source.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		return err
 	}
 
 	running := false
 	vm.Spec.Running = &running
-	err = r.Source.Client.Update(context.Background(), &vm)
+	err = r.sourceClient.Update(context.Background(), &vm)
 	if err != nil {
 		return err
 	}
@@ -91,7 +93,7 @@ func (r *Client) PowerOn(vmRef ref.Ref) error {
 // PowerState implements base.Client
 func (r *Client) PowerState(vmRef ref.Ref) (string, error) {
 	vm := cnv.VirtualMachine{}
-	err := r.Source.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return "", err
@@ -107,7 +109,7 @@ func (r *Client) PowerState(vmRef ref.Ref) (string, error) {
 // PoweredOff implements base.Client
 func (r *Client) PoweredOff(vmRef ref.Ref) (bool, error) {
 	vm := cnv.VirtualMachine{}
-	err := r.Source.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return false, err
@@ -141,7 +143,7 @@ func (r *Client) PreTransferActions(vmRef ref.Ref) (ready bool, err error) {
 
 	// Check if VM export exists
 	vmExport := &export.VirtualMachineExport{}
-	err = r.Source.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
+	err = r.sourceClient.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
 	if err != nil {
 		if !k8serr.IsNotFound(err) {
 			r.Log.Error(err, "Failed to get VM-export.", "vm", vmRef.Name)
@@ -166,7 +168,7 @@ func (r *Client) PreTransferActions(vmRef ref.Ref) (ready bool, err error) {
 			},
 		}
 
-		err = r.Source.Client.Create(context.Background(), vmExport, &client.CreateOptions{})
+		err = r.sourceClient.Create(context.Background(), vmExport, &client.CreateOptions{})
 		if err != nil {
 			return true, liberr.Wrap(err)
 		}

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -17,9 +17,9 @@ import (
 
 // Validator
 type Validator struct {
-	plan      *api.Plan
-	inventory web.Client
-	client    k8sclient.Client
+	plan         *api.Plan
+	inventory    web.Client
+	sourceClient k8sclient.Client
 }
 
 // MaintenanceMode implements base.Validator
@@ -34,7 +34,7 @@ func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	vm := &cnv.VirtualMachine{}
-	err = r.client.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
+	err = r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
 	if err != nil {
 		err = liberr.Wrap(
 			err,
@@ -73,7 +73,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	vm := &cnv.VirtualMachine{}
-	err = r.client.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
+	err = r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
 	if err != nil {
 		err = liberr.Wrap(
 			err,
@@ -88,7 +88,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 		case vol.PersistentVolumeClaim != nil:
 			// Get PVC
 			pvc := &core.PersistentVolumeClaim{}
-			err = r.client.Get(context.TODO(), k8sclient.ObjectKey{
+			err = r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{
 				Namespace: vmRef.Namespace,
 				Name:      vol.PersistentVolumeClaim.ClaimName,
 			}, pvc)
@@ -130,7 +130,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	vm := &cnv.VirtualMachine{}
-	err = r.client.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
+	err = r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
 	if err != nil {
 		err = liberr.Wrap(
 			err,

--- a/pkg/controller/plan/context/migration.go
+++ b/pkg/controller/plan/context/migration.go
@@ -10,7 +10,6 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	core "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -115,7 +114,7 @@ type Source struct {
 	// Provider Secret.
 	Secret *core.Secret
 	// k8s Client for OCP sources
-	Client client.Client
+	k8sclient.Client
 }
 
 // Build.
@@ -152,13 +151,11 @@ func (r *Source) build(ctx *Context) (err error) {
 	}
 
 	if r.Provider.Type() == v1beta1.OpenShift {
-		client, err := r.Provider.Client(r.Secret)
+		r.Client, err = r.Provider.Client(r.Secret)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return err
 		}
-
-		r.Client = client
 	}
 
 	return

--- a/pkg/controller/plan/context/migration.go
+++ b/pkg/controller/plan/context/migration.go
@@ -5,7 +5,6 @@ import (
 	"path"
 
 	"github.com/go-logr/logr"
-	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
@@ -113,8 +112,6 @@ type Source struct {
 	Inventory web.Client
 	// Provider Secret.
 	Secret *core.Secret
-	// k8s Client for OCP sources
-	k8sclient.Client
 }
 
 // Build.
@@ -128,9 +125,9 @@ func (r *Source) build(ctx *Context) (err error) {
 		return
 	}
 
-	r.Secret = &core.Secret{}
 	if !r.Provider.IsHost() {
 		ref := r.Provider.Spec.Secret
+		r.Secret = &core.Secret{}
 		err = ctx.Get(
 			context.TODO(),
 			k8sclient.ObjectKey{
@@ -148,14 +145,6 @@ func (r *Source) build(ctx *Context) (err error) {
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
-	}
-
-	if r.Provider.Type() == v1beta1.OpenShift {
-		r.Client, err = r.Provider.Client(r.Secret)
-		if err != nil {
-			err = liberr.Wrap(err)
-			return err
-		}
 	}
 
 	return


### PR DESCRIPTION
Since migration can be done from a remote source we have to use the source client