### PR TITLE
Skip LUN task progress

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1323,6 +1323,10 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 			return
 		}
 		for _, pvc := range pvcs {
+			if _, ok := pvc.Annotations["lun"]; ok {
+				// skip LUNs
+				continue
+			}
 			var task *plan.Task
 			name := r.builder.ResolvePersistentVolumeClaimIdentifier(&pvc)
 			found := false
@@ -1585,6 +1589,10 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 	}
 
 	for _, pvc := range pvcs {
+		if _, ok := pvc.Annotations["lun"]; ok {
+			// skip LUNs
+			continue
+		}
 		var task *plan.Task
 		var taskName string
 		taskName, err = r.builder.GetPopulatorTaskName(&pvc)


### PR DESCRIPTION
LUNs disks are a special case. They do not have a task when migrating and we do not need to update their progress. The disk are pre-made and just being attached. Therefore, we need to skip them.