### PR TITLE
Fix LUN warm migration

### DIFF
--- a/pkg/apis/forklift/v1beta1/plan/migration.go
+++ b/pkg/apis/forklift/v1beta1/plan/migration.go
@@ -104,9 +104,6 @@ func (r *Step) ReflectTasks() {
 	tasksStarted := 0
 	tasksCompleted := 0
 	completed := int64(0)
-	if len(r.Tasks) == 0 {
-		return
-	}
 	for _, task := range r.Tasks {
 		if task.MarkedStarted() {
 			tasksStarted++


### PR DESCRIPTION
When migrating a LUN disk from ovirt source in warm migration we need to mark the CopyDisk as completed.