### PR TITLE
ovirt client: Add retry for creating of snapshot 

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ovirt/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/labels",
         "//vendor/k8s.io/apimachinery/pkg/types",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait",
         "//vendor/kubevirt.io/api/core/v1:core",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -102,11 +102,7 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool,
 		return
 	}
 	for _, event := range events {
-		code, exists := event.Code()
-		if !exists {
-			err = liberr.New("The event does not have a code.", "event", event)
-			continue
-		}
+		code, _ := event.Code()
 		switch code {
 		case SNAPSHOT_FINISHED_FAILURE:
 			err = liberr.New("Snapshot creation failed!", "correlationID", correlationID)
@@ -530,11 +526,7 @@ func (r *Client) isSnapshotRemovalFinished(correlationID string) (finished bool,
 		return
 	}
 	for _, event := range events {
-		code, exists := event.Code()
-		if !exists {
-			err = liberr.New("The event does not have a code.", "event", event)
-			continue
-		}
+		code, _ := event.Code()
 		switch code {
 		case REMOVE_SNAPSHOT_FINISHED_FAILURE:
 			r.Log.Info("Snapshot removal failed!")

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -476,12 +476,6 @@ func (r Client) removePrecopies(precopies []planapi.Precopy, vmService *ovirtsdk
 		correlationID := fmt.Sprintf("%s_finalize", snapshotID[0:8])
 		cleanupTimeout := time.Now().Add(time.Duration(settings.Settings.Migration.SnapshotRemovalTimeout) * time.Minute)
 		for {
-			if time.Now().After(cleanupTimeout) {
-				r.Log.Info("Timeout waiting for snapshot removal")
-				return
-			} else {
-				time.Sleep(time.Duration(settings.Settings.Migration.SnapshotStatusCheckRate) * time.Second)
-			}
 			_, err := snapService.Get().Send()
 			if err != nil {
 				r.Log.Info("The snapshot was removed", "snapshotID", snapshotID)
@@ -511,6 +505,13 @@ func (r Client) removePrecopies(precopies []planapi.Precopy, vmService *ovirtsdk
 				if finished {
 					break
 				}
+			}
+
+			if time.Now().After(cleanupTimeout) {
+				r.Log.Info("Timeout waiting for snapshot removal")
+				return
+			} else {
+				time.Sleep(time.Duration(settings.Settings.Migration.SnapshotStatusCheckRate) * time.Second)
 			}
 		}
 	}

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -102,11 +102,18 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool,
 		return
 	}
 	for _, event := range events {
-		switch event.MustCode() {
+		code, exists := event.Code()
+		if !exists {
+			err = liberr.New("The event does not have a code.", "event", event)
+			continue
+		}
+		switch code {
 		case SNAPSHOT_FINISHED_FAILURE:
 			err = liberr.New("Snapshot creation failed!", "correlationID", correlationID)
+			return
 		case SNAPSHOT_FINISHED_SUCCESS:
 			ready = true
+			return
 		}
 	}
 	return
@@ -523,7 +530,12 @@ func (r *Client) isSnapshotRemovalFinished(correlationID string) (finished bool,
 		return
 	}
 	for _, event := range events {
-		switch event.MustCode() {
+		code, exists := event.Code()
+		if !exists {
+			err = liberr.New("The event does not have a code.", "event", event)
+			continue
+		}
+		switch code {
 		case REMOVE_SNAPSHOT_FINISHED_FAILURE:
 			r.Log.Info("Snapshot removal failed!")
 			return true, nil

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -807,13 +807,12 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		var snapshot string
 		snapshot, err = r.provider.CreateSnapshot(vm.Ref)
 		if err != nil {
-			if !errors.As(err, &web.ProviderNotReadyError{}) {
-				step.AddError(err.Error())
-				err = nil
-				break
-			} else {
+			if errors.As(err, &web.ProviderNotReadyError{}) || errors.As(err, &web.ConflictError{}) {
 				return
 			}
+			step.AddError(err.Error())
+			err = nil
+			break
 		}
 		now := meta.Now()
 		precopy := plan.Precopy{Snapshot: snapshot, Start: &now}

--- a/pkg/controller/provider/web/client.go
+++ b/pkg/controller/provider/web/client.go
@@ -33,6 +33,15 @@ func (r ProviderNotReadyError) Error() string {
 	return fmt.Sprintf("Provider not ready: %#v", r.Provider)
 }
 
+type ConflictError struct {
+	Provider *api.Provider
+	Err      error
+}
+
+func (r ConflictError) Error() string {
+	return fmt.Sprintf("Conflict Error: '%s' from provider: '%#v'", r.Err.Error(), r.Provider)
+}
+
 type RefNotUniqueError = base.RefNotUniqueError
 type NotFoundError = base.NotFoundError
 

--- a/pkg/controller/provider/web/client.go
+++ b/pkg/controller/provider/web/client.go
@@ -39,7 +39,7 @@ type ConflictError struct {
 }
 
 func (r ConflictError) Error() string {
-	return fmt.Sprintf("Conflict Error: '%s' from provider: '%#v'", r.Err.Error(), r.Provider)
+	return fmt.Sprintf("Conflict Error from provider '%#v': %s", r.Provider, r.Err.Error())
 }
 
 type RefNotUniqueError = base.RefNotUniqueError


### PR DESCRIPTION
Issue:
If there is some operation on VMs snapshots (creation, deletion). The migration fails because of the locked disks, and the migration ends.

Fix:
Add a retry in the form of a different exception, `ProviderNotReadyError`, which does not end the migration but reconciles. 
There was another issue during this fix. Every try created another failed job with the same correlation ID which failed the migration. The fix for this was to use events and check the proper event codes.