### PR TITLE
validation: fix openstack shared disk validation

### DIFF
--- a/validation/policies/io/konveyor/forklift/openstack/shared_disk.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/shared_disk.rego
@@ -2,13 +2,13 @@ package io.konveyor.forklift.openstack
 
 volumes := input.volumes
 
-non_shared_disks[i] {
+shared_disks[i] {
 	some i
-	count(volumes[i].attachments) == 1
+	count(volumes[i].attachments) > 1
 }
 
 concerns[flag] {
-	count(non_shared_disks) != count(volumes)
+	count(shared_disks) > 0
 	flag := {
 		"category": "Warning",
 		"label": "Shared disk detected",

--- a/validation/policies/io/konveyor/forklift/openstack/shared_disk_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/shared_disk_test.rego
@@ -1,5 +1,14 @@
 package io.konveyor.forklift.openstack
 
+test_with_no_volumes {
+	mock_vm := {
+		"name": "test",
+		"volumes": [],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
+}
+
 test_without_shared_disk {
 	mock_vm := {
 		"name": "test",
@@ -7,6 +16,8 @@ test_without_shared_disk {
 			{"id": "1", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "2", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "3", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
+			{"id": "4", "status": "in-use", "attachments": []},
+			{"id": "5", "status": "in-use" },
 		],
 	}
 	results := concerns with input as mock_vm
@@ -20,6 +31,8 @@ test_with_shared_disk {
 			{"id": "1", "status": "in-use", "attachments": [{"AttachmentID": "1"}, {"AttachmentID": "2"}]},
 			{"id": "2", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "3", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
+			{"id": "4", "status": "in-use", "attachments": []},
+			{"id": "5", "status": "in-use" },
 		],
 	}
 	results := concerns with input as mock_vm


### PR DESCRIPTION
Fix the shared disk validation when the attachments
array is empty.

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
