### PR TITLE
Change the storage mapping for OVA

### DIFF
--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -97,25 +97,8 @@ func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
 
 // Validate that a VM's disk backing storage has been mapped.
 func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.plan.Referenced.Map.Storage == nil {
-		return
-	}
-	vm := &model.VM{}
-	err = r.inventory.Find(vm, vmRef)
-	if err != nil {
-		err = liberr.Wrap(
-			err,
-			ErrVMNotFound,
-			"vm",
-			vmRef.String())
-		return
-	}
-
-	for _, disk := range vm.Disks {
-		if !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: disk.ID}) {
-			return
-		}
-	}
+	//For OVA providers, we don't have an actual storage connected,
+	// since we use a dummy storage for mapping the function should always return true.
 	ok = true
 	return
 }

--- a/pkg/controller/provider/container/ova/collector.go
+++ b/pkg/controller/provider/container/ova/collector.go
@@ -229,7 +229,7 @@ func (r *Collector) load(ctx *Context) (err error) {
 
 // List and create resources using the adapter.
 func (r *Collector) create(ctx *Context, adapter Adapter) (err error) {
-	itr, aErr := adapter.List(ctx)
+	itr, aErr := adapter.List(ctx, r.provider)
 
 	if aErr != nil {
 		err = aErr

--- a/pkg/controller/provider/container/ova/resource.go
+++ b/pkg/controller/provider/container/ova/resource.go
@@ -219,3 +219,13 @@ func (r *Disk) ApplyTo(m *model.Disk) {
 	m.Format = r.Format
 	m.PopulatedSize = r.PopulatedSize
 }
+
+type Storage struct {
+	Name string
+	ID   string
+}
+
+func (r *Storage) ApplyTo(m *model.Storage) {
+	m.Base.Name = m.Name
+	m.Base.ID = m.ID
+}

--- a/pkg/controller/provider/model/ova/doc.go
+++ b/pkg/controller/provider/model/ova/doc.go
@@ -11,5 +11,6 @@ func All() []interface{} {
 		&VM{},
 		&Network{},
 		&Disk{},
+		&Storage{},
 	}
 }

--- a/pkg/controller/provider/model/ova/model.go
+++ b/pkg/controller/provider/model/ova/model.go
@@ -124,3 +124,7 @@ type NIC struct {
 	Network string `sql:""`
 	Config  []Conf `sql:""`
 }
+
+type Storage struct {
+	Base
+}

--- a/pkg/controller/provider/model/ova/tree.go
+++ b/pkg/controller/provider/model/ova/tree.go
@@ -7,9 +7,10 @@ import (
 
 // Kinds
 var (
-	VmKind   = libref.ToKind(VM{})
-	NetKind  = libref.ToKind(Network{})
-	DiskKind = libref.ToKind(Disk{})
+	VmKind      = libref.ToKind(VM{})
+	NetKind     = libref.ToKind(Network{})
+	DiskKind    = libref.ToKind(Disk{})
+	StorageKind = libref.ToKind(Storage{})
 )
 
 // Types.

--- a/pkg/controller/provider/web/ova/BUILD.bazel
+++ b/pkg/controller/provider/web/ova/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "network.go",
         "provider.go",
         "resource.go",
+        "storage.go",
         "tree.go",
         "vm.go",
         "workload.go",

--- a/pkg/controller/provider/web/ova/base.go
+++ b/pkg/controller/provider/web/ova/base.go
@@ -75,6 +75,9 @@ func (r *PathBuilder) Path(m model.Model) (path string) {
 	case *model.Disk:
 		disk := m.(*model.Disk)
 		path = pathlib.Join(disk.ID)
+	case *model.Storage:
+		storage := m.(*model.Storage)
+		path = pathlib.Join(storage.ID)
 	}
 
 	if err != nil {

--- a/pkg/controller/provider/web/ova/doc.go
+++ b/pkg/controller/provider/web/ova/doc.go
@@ -45,5 +45,10 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 				base.Handler{Container: container},
 			},
 		},
+		&StorageHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
 	}
 }

--- a/pkg/controller/provider/web/ova/provider.go
+++ b/pkg/controller/provider/web/ova/provider.go
@@ -147,6 +147,12 @@ func (h ProviderHandler) AddDerived(r *Provider) (err error) {
 		return
 	}
 	r.DiskCount = n
+	// Storage count
+	n, err = db.Count(&ova.Storage{}, nil)
+	if err != nil {
+		return
+	}
+	r.StorageCount = n
 
 	return
 }
@@ -161,6 +167,7 @@ type Provider struct {
 	VMCount      int64        `json:"vmCount"`
 	NetworkCount int64        `json:"networkCount"`
 	DiskCount    int64        `json:"diskCount"`
+	StorageCount int64        `json:"storageCount"`
 }
 
 // Set fields with the specified object.

--- a/pkg/controller/provider/web/ova/storage.go
+++ b/pkg/controller/provider/web/ova/storage.go
@@ -1,0 +1,204 @@
+package ova
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ova"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
+	libmodel "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
+)
+
+// Routes.
+const (
+	StorageParam      = "storage"
+	StorageCollection = "storages"
+	StoragesRoot      = ProviderRoot + "/" + StorageCollection
+	StorageRoot       = StoragesRoot + "/:" + StorageParam
+)
+
+// Storage handler.
+type StorageHandler struct {
+	Handler
+}
+
+// Add routes to the `gin` router.
+func (h *StorageHandler) AddRoutes(e *gin.Engine) {
+	e.GET(StoragesRoot, h.List)
+	e.GET(StoragesRoot+"/", h.List)
+	e.GET(StorageRoot, h.Get)
+}
+
+// List resources in a REST collection.
+// A GET onn the collection that includes the `X-Watch`
+// header will negotiate an upgrade of the connection
+// to a websocket and push watch events.
+func (h StorageHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+	defer func() {
+		if err != nil {
+			log.Trace(
+				err,
+				"url",
+				ctx.Request.URL)
+			ctx.Status(http.StatusInternalServerError)
+		}
+	}()
+	db := h.Collector.DB()
+	list := []model.Storage{}
+	err = db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		return
+	}
+	err = h.filter(ctx, &list)
+	if err != nil {
+		return
+	}
+	pb := PathBuilder{DB: db}
+	content := []interface{}{}
+	for _, m := range list {
+		r := &Storage{}
+		r.With(&m)
+		r.Link(h.Provider)
+		r.Path = pb.Path(&m)
+		content = append(content, r.Content(h.Detail))
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// Get a specific REST resource.
+func (h StorageHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	m := &model.Storage{
+		Base: model.Base{
+			ID: ctx.Param(StorageParam),
+		},
+	}
+	db := h.Collector.DB()
+	err = db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	pb := PathBuilder{DB: db}
+	r := &Storage{}
+	r.With(m)
+	r.Link(h.Provider)
+	r.Path = pb.Path(m)
+	content := r.Content(model.MaxDetail)
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// Watch.
+func (h *StorageHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.Storage{},
+		func(in libmodel.Model) (r interface{}) {
+			pb := PathBuilder{DB: db}
+			m := in.(*model.Storage)
+			storage := &Storage{}
+			storage.With(m)
+			storage.Link(h.Provider)
+			storage.Path = pb.Path(m)
+			r = storage
+			return
+		})
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+	}
+}
+
+// Filter result set.
+// Filter by path for `name` query.
+func (h *StorageHandler) filter(ctx *gin.Context, list *[]model.Storage) (err error) {
+	if len(*list) < 2 {
+		return
+	}
+	q := ctx.Request.URL.Query()
+	name := q.Get(NameParam)
+	if len(name) == 0 {
+		return
+	}
+	if len(strings.Split(name, "/")) < 2 {
+		return
+	}
+	db := h.Collector.DB()
+	pb := PathBuilder{DB: db}
+	kept := []model.Storage{}
+	for _, m := range *list {
+		path := pb.Path(&m)
+		if h.PathMatchRoot(path, name) {
+			kept = append(kept, m)
+		}
+	}
+
+	*list = kept
+
+	return
+}
+
+// REST Resource.
+type Storage struct {
+	Resource
+}
+
+// Build the resource using the model.
+func (r *Storage) With(m *model.Storage) {
+	r.Resource.With(&m.Base)
+	r.Variant = m.Variant
+	r.Name = m.Name
+	r.ID = m.ID
+}
+
+// Build self link (URI).
+func (r *Storage) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		StorageRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			StorageParam:       r.ID,
+		})
+}
+
+// As content.
+func (r *Storage) Content(detail int) interface{} {
+	if detail == 0 {
+		return r.Resource
+	}
+
+	return r
+}

--- a/pkg/controller/provider/web/ova/tree.go
+++ b/pkg/controller/provider/web/ova/tree.go
@@ -172,6 +172,17 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 			Kind:   kind,
 			Object: object,
 		}
+	case model.StorageKind:
+		resource := &Storage{}
+		resource.With(m.(*model.Storage))
+		resource.Link(provider)
+		resource.Path = r.pathBuilder.Path(m)
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
 	}
 
 	return node


### PR DESCRIPTION
This fix changes the storage mapping for OVA provider from disk -> SC into general storage name -> SC.
The mapping should be in the following format:

```
apiVersion: forklift.konveyor.io/v1beta1
kind: StorageMap
metadata:
  name: storage-map
  namespace: konveyor-forklift
spec:
  map:
    - destination:
        storageClass: nfs-csi
      source:
        name: VM storage
  provider:
    destination:
      name: host
      namespace: konveyor-forklift
    source:
      name: provider-ova
      namespace: konveyor-forklift
```


