### PR TITLE
Exit when virt-v2v cold hit an error (backport)

### DIFF
--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o pipefail
+set -o pipefail -e
 shopt -s nullglob
 
 if [ -z "$V2V_source"] ; then


### PR DESCRIPTION
Since we now support two flows in the virt-v2v image, it doesn't end with the actual `virt-v2v` command. In that case the pod may end with success although, it didn't. Now the script will exit with an error on the first error occurrence.