### PR TITLE
Fix virt-v2v bracket

### DIFF
--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -2,7 +2,7 @@
 set -o pipefail -e
 shopt -s nullglob
 
-if [ -z "$V2V_source"] ; then
+if [ -z "$V2V_source" ] ; then
     echo "Following environment needs to be defined:"
     echo
     echo "    V2V_source"


### PR DESCRIPTION
fixing the error in the entrypoint script:
line 5: [: missing `]'