### PR TITLE
virt-v2v: Build our own fixed appliance on el8

### DIFF
--- a/cmd/forklift-controller/BUILD.bazel
+++ b/cmd/forklift-controller/BUILD.bazel
@@ -15,11 +15,6 @@ load(
 
 container_image(
     name = "forklift-controller-image",
-    #architecture = select({
-    #    "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
-    #    "//conditions:default": "amd64",
-    #}),
-    #base = "@centos-stream8//image",
     base = "@ubi9-minimal//image",
     directory = "/usr/local/bin/",
     entrypoint = ["/usr/local/bin/forklift-controller"],

--- a/virt-v2v/cold/WORKSPACE
+++ b/virt-v2v/cold/WORKSPACE
@@ -159,14 +159,6 @@ load(
 
 container_repositories()
 
-container_pull(
-    name = "ubi8-minimal",
-    # 'tag' is also supported, but digest is encouraged for reproducibility.
-    digest = "sha256:d1f8eff6032334a81d7cbfd73dacee680e8138db57ecbc91548b97bb45e698e5",
-    registry = "registry.access.redhat.com",
-    repository = "ubi8/ubi-minimal",
-)
-
 http_archive(
     name = "bazeldnf",
     sha256 = "404fc34e6bd3b568a7ca6fbcde70267d43830d0171d3192e3ecd83c14c320cfc",

--- a/virt-v2v/warm/.bazelrc
+++ b/virt-v2v/warm/.bazelrc
@@ -1,0 +1,6 @@
+# Appliance build
+# container_run_and_extract() does not work inside Podman and Docker
+# sandboxes. Use slightly less secure but working processwrapper sandbox.
+# NOTE: Same configuration is in .bazelrc in repository root.
+build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
+

--- a/virt-v2v/warm/BUILD.bazel
+++ b/virt-v2v/warm/BUILD.bazel
@@ -4,6 +4,10 @@ load(
     "container_image",
     "container_push",
 )
+load(
+    "@io_bazel_rules_docker//docker/util:run.bzl",
+    "container_run_and_extract",
+)
 
 container_push(
     name = "push-forklift-virt-v2v-warm",
@@ -14,9 +18,40 @@ container_push(
     tag = "$${REGISTRY_TAG:-devel}",
 )
 
+# Appliance build
+# NOTE: We deliberately do not use (and cannot use) rpmtree to build a base
+# layer with packages. Supermin queries the RPM database to track package files
+# and dependencies. Tar constructed by rpmtree is just a bunch of files and it
+# does not preserve the RPM database info. Therefore we imitate a Dockerfile
+# build here.
+container_run_and_extract(
+    name = "appliance",
+    commands = [
+        "set -x",
+        "dnf -y update",
+        "dnf -y install libguestfs-devel libguestfs-appliance libguestfs-xfs libguestfs-winsupport supermin",
+        "depmod \\$(ls /lib/modules/ |tail -n1)",
+        "export LIBGUESTFS_BACKEND=direct",
+        "export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1",
+        "mkdir -p /usr/lib64/guestfs/appliance",
+        "cd /usr/lib64/guestfs/appliance",
+        "libguestfs-make-fixed-appliance --xz",
+        "cp /usr/lib64/guestfs/appliance/appliance-*.tar.xz /libguestfs-appliance.tar.xz",
+    ],
+    extract_file = "/libguestfs-appliance.tar.xz",
+    image = "@centos-stream-8//image",
+)
+
+container_image(
+    name = "appliance-image",
+    base = "@ubi8-minimal//image",
+    directory = "/usr/lib64/guestfs",
+    files = [":appliance/libguestfs-appliance.tar.xz"],
+)
+
 container_image(
     name = "virt-v2v-image",
-    base = "@libguestfs-appliance//image",
+    base = "appliance-image",
     directory = "/",
     tars = [":virt-v2v"],
 )

--- a/virt-v2v/warm/WORKSPACE
+++ b/virt-v2v/warm/WORKSPACE
@@ -143,17 +143,16 @@ container_repositories()
 
 container_pull(
     name = "ubi8-minimal",
-    # 'tag' is also supported, but digest is encouraged for reproducibility.
-    digest = "sha256:d1f8eff6032334a81d7cbfd73dacee680e8138db57ecbc91548b97bb45e698e5",
     registry = "registry.access.redhat.com",
     repository = "ubi8/ubi-minimal",
+    tag = "latest",
 )
 
 container_pull(
-    name = "libguestfs-appliance",
-    digest = "sha256:6abc2a68f4a42dbf3a7db1042a73862e763b6c864c1e04659dc6bd981e430ae5",
+    name = "centos-stream-8",
     registry = "quay.io",
-    repository = "kubev2v/libguestfs-appliance",
+    repository = "centos/centos",
+    tag = "stream8",
 )
 
 http_archive(

--- a/virt-v2v/warm/entrypoint
+++ b/virt-v2v/warm/entrypoint
@@ -2,7 +2,7 @@
 shopt -s nullglob
 
 export LIBGUESTFS_PATH=/usr/lib64/guestfs
-set -- "$LIBGUESTFS_PATH"/appliance-*.tar.xz
+set -- "$LIBGUESTFS_PATH"/libguestfs-appliance.tar.xz
 if [ -f "$1" ] ; then
     echo "Extracting libguestfs appliance..."
     APPLIANCE="/var/tmp/libguestfs-appliance"


### PR DESCRIPTION
Similar to #226 but on el8 (the appliance used with el8 libguestfs does not support qcow2 images so the image is still compressed within the container image and extract by the 'entrypoint' script).

fix #479 