### PR TITLE
Fix TLS SSL connection on FIPS enabled systems (backport)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,4 +30,4 @@ build --action_env=OVA_PROVIDER_SERVER_IMAGE=quay.io/kubev2v/forklift-ova-provid
 # sandboxes. Use slightly less secure but working processwrapper sandbox.
 # NOTE: Same configuration is in virt-v2v/cold/.bazelrc.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
-build --strategy_regexp="RunAndCommitLayer no-ems-in-fips.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer no-ems-in-fips-layer.tar"=processwrapper-sandbox

--- a/.bazelrc
+++ b/.bazelrc
@@ -30,3 +30,4 @@ build --action_env=OVA_PROVIDER_SERVER_IMAGE=quay.io/kubev2v/forklift-ova-provid
 # sandboxes. Use slightly less secure but working processwrapper sandbox.
 # NOTE: Same configuration is in virt-v2v/cold/.bazelrc.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer no-ems-in-fips.tar"=processwrapper-sandbox

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3419,10 +3419,9 @@ container_repositories()
 
 container_pull(
     name = "ubi9-minimal",
-    # 'tag' is also supported, but digest is encouraged for reproducibility.
-    digest = "sha256:e9ea62ea2017705205ba7bc55d20827e06abe4fe071f0793c6cae46edd5855cf",
     registry = "registry.access.redhat.com",
     repository = "ubi9/ubi-minimal",
+    tag = "latest",
 )
 
 container_pull(

--- a/virt-v2v/cold/.bazerlc
+++ b/virt-v2v/cold/.bazerlc
@@ -3,4 +3,4 @@
 # sandboxes. Use slightly less secure but working processwrapper sandbox.
 # NOTE: Same configuration is in .bazelrc in repository root.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
-build --strategy_regexp="RunAndCommitLayer no-ems-in-fips.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer no-ems-in-fips-layer.tar"=processwrapper-sandbox

--- a/virt-v2v/cold/.bazerlc
+++ b/virt-v2v/cold/.bazerlc
@@ -3,3 +3,4 @@
 # sandboxes. Use slightly less secure but working processwrapper sandbox.
 # NOTE: Same configuration is in .bazelrc in repository root.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer no-ems-in-fips.tar"=processwrapper-sandbox

--- a/virt-v2v/cold/BUILD.bazel
+++ b/virt-v2v/cold/BUILD.bazel
@@ -5,6 +5,7 @@ load(
 )
 load(
     "@io_bazel_rules_docker//docker/util:run.bzl",
+    "container_run_and_commit_layer",
     "container_run_and_extract",
 )
 load("@bazeldnf//:deps.bzl", "rpmtree")
@@ -59,9 +60,28 @@ container_image(
     ],
 )
 
+container_run_and_commit_layer(
+    name = "no-ems-in-fips",
+    commands = [
+        "touch /etc/crypto-policies/back-ends/openssl_fips.config",
+        "printf '[fips_sect]\ntls1-prf-ems-check = 0\nactivate = 1' > /etc/crypto-policies/back-ends/openssl_fips.config",
+        "printf '[crypto_policy]\nOptions=RHNoEnforceEMSinFIPS' >> /etc/crypto-policies/back-ends/opensslcnf.config",
+    ],
+    image = ":virt-v2v-image.tar",
+)
+
+container_image(
+    name = "virt-v2v-layer",
+    base = ":virt-v2v-image",
+    layers = [
+        ":no-ems-in-fips",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 container_image(
     name = "forklift-virt-v2v",
-    base = ":virt-v2v-image",
+    base = ":virt-v2v-layer",
     directory = "/usr/local/bin/",
     empty_dirs = ["/disks"],
     entrypoint = ["/usr/local/bin/entrypoint"],


### PR DESCRIPTION
This patch will bump the ubi9-minimal image and include the fix of the SSL connection to the cold virt-v2v.

backport of #509 , #511 