### PR TITLE
ocp: copy loop var when iterating over interfaces

### DIFF
--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -458,8 +458,9 @@ func (r *Builder) mapNetworks(sourceVm *cnv.VirtualMachine, targetVmSpec *cnv.Vi
 	// Map networks to NICs
 	interfacesMap := make(map[string]*cnv.Interface)
 	for _, ifc := range sourceVm.Spec.Template.Spec.Domain.Devices.Interfaces {
+		currentInterface := ifc
 		networkName := ifc.Name
-		interfacesMap[networkName] = &ifc
+		interfacesMap[networkName] = &currentInterface
 	}
 
 	var kInterface *cnv.Interface


### PR DESCRIPTION
Otherwise we end up using the variable which we copy over the same interface and keep the type

https://github.com/golang/go/wiki/LoopvarExperiment