### PR TITLE
backport ocp boot order

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,4 +30,4 @@ build --action_env=OVA_PROVIDER_SERVER_IMAGE=quay.io/kubev2v/forklift-ova-provid
 # sandboxes. Use slightly less secure but working processwrapper sandbox.
 # NOTE: Same configuration is in virt-v2v/cold/.bazelrc.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
-build --strategy_regexp="RunAndCommitLayer no-ems-in-fips.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer no-ems-in-fips-layer.tar"=processwrapper-sandbox

--- a/.bazelrc
+++ b/.bazelrc
@@ -30,3 +30,4 @@ build --action_env=OVA_PROVIDER_SERVER_IMAGE=quay.io/kubev2v/forklift-ova-provid
 # sandboxes. Use slightly less secure but working processwrapper sandbox.
 # NOTE: Same configuration is in virt-v2v/cold/.bazelrc.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer no-ems-in-fips.tar"=processwrapper-sandbox

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3419,10 +3419,9 @@ container_repositories()
 
 container_pull(
     name = "ubi9-minimal",
-    # 'tag' is also supported, but digest is encouraged for reproducibility.
-    digest = "sha256:e9ea62ea2017705205ba7bc55d20827e06abe4fe071f0793c6cae46edd5855cf",
     registry = "registry.access.redhat.com",
     repository = "ubi9/ubi-minimal",
+    tag = "latest",
 )
 
 container_pull(

--- a/cmd/forklift-controller/BUILD.bazel
+++ b/cmd/forklift-controller/BUILD.bazel
@@ -15,11 +15,6 @@ load(
 
 container_image(
     name = "forklift-controller-image",
-    #architecture = select({
-    #    "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
-    #    "//conditions:default": "amd64",
-    #}),
-    #base = "@centos-stream8//image",
     base = "@ubi9-minimal//image",
     directory = "/usr/local/bin/",
     entrypoint = ["/usr/local/bin/forklift-controller"],

--- a/cmd/ova-provider-server/ova-provider-server.go
+++ b/cmd/ova-provider-server/ova-provider-server.go
@@ -10,7 +10,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -294,7 +293,7 @@ func scanOVAsOnNFS() (envelopes []Envelope, ovaPaths []string) {
 }
 
 func findOVAFiles(directory string) ([]string, []string, error) {
-	childs, err := ioutil.ReadDir(directory)
+	childs, err := os.ReadDir(directory)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -305,7 +304,7 @@ func findOVAFiles(directory string) ([]string, []string, error) {
 			continue
 		}
 		newDir := directory + "/" + child.Name()
-		files, err := ioutil.ReadDir(newDir)
+		files, err := os.ReadDir(newDir)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -62,6 +62,8 @@ spec:
           value: ${SNAPSHOT_REMOVAL_TIMEOUT}
         - name: SNAPSHOT_STATUS_CHECK_RATE
           value: ${SNAPSHOT_STATUS_CHECK_RATE}
+        - name: CDI_EXPORT_TOKEN_TTL
+          value: ${CDI_EXPORT_TOKEN_TTL}
         - name: POPULATOR_CONTROLLER_IMAGE
           value: ${POPULATOR_CONTROLLER_IMAGE}
         - name: OVIRT_POPULATOR_IMAGE

--- a/operator/roles/forkliftcontroller/templates/controller/controller-scc.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/controller-scc.yml.j2
@@ -4,7 +4,7 @@ apiVersion: security.openshift.io/v1
 metadata:
   name: forklift-controller-scc
 users:
-  - system:serviceaccount:konveyor-forklift:forklift-controller
+  - system:serviceaccount:{{ app_namespace }}:forklift-controller
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -72,6 +72,10 @@ spec:
         - name: MAX_VM_INFLIGHT
           value: "{{ controller_max_vm_inflight }}"
 {% endif %}
+{% if controller_cdi_export_token_ttl is number %}
+        - name: CDI_EXPORT_TOKEN_TTL
+          value: "{{ CDI_EXPORT_TOKEN_TTL }}"
+{% endif %}
 {% if controller_vsphere_incremental_backup|bool %}
         - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
           value: "true"

--- a/pkg/apis/forklift/v1beta1/mapping.go
+++ b/pkg/apis/forklift/v1beta1/mapping.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/provider"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
@@ -133,7 +135,12 @@ func (r *NetworkMap) FindNetworkByType(networkType string) (pair NetworkPair, fo
 // Find network map for source name and namespace.
 func (r *NetworkMap) FindNetworkByNameAndNamespace(namespace, name string) (pair NetworkPair, found bool) {
 	for _, pair = range r.Spec.Map {
-		if pair.Source.Namespace == namespace && pair.Source.Name == name {
+		if pair.Source.Namespace != "" {
+			if pair.Source.Namespace == namespace && pair.Source.Name == name {
+				found = true
+				break
+			}
+		} else if pair.Source.Name == fmt.Sprintf("%s/%s", namespace, name) {
 			found = true
 			break
 		}

--- a/pkg/apis/forklift/v1beta1/plan/migration.go
+++ b/pkg/apis/forklift/v1beta1/plan/migration.go
@@ -104,9 +104,6 @@ func (r *Step) ReflectTasks() {
 	tasksStarted := 0
 	tasksCompleted := 0
 	completed := int64(0)
-	if len(r.Tasks) == 0 {
-		return
-	}
 	for _, task := range r.Tasks {
 		if task.MarkedStarted() {
 			tasksStarted++

--- a/pkg/controller/plan/adapter/ocp/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ocp/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/controller/provider/web",
         "//pkg/lib/error",
         "//pkg/lib/itinerary",
+        "//pkg/settings",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/api/errors",
         "//vendor/k8s.io/apimachinery/pkg/api/resource",

--- a/pkg/controller/plan/adapter/ocp/adapter.go
+++ b/pkg/controller/plan/adapter/ocp/adapter.go
@@ -1,9 +1,12 @@
 package ocp
 
 import (
+	"context"
+
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	core "k8s.io/api/core/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -13,12 +16,45 @@ type Adapter struct{}
 
 // Constructs a openstack builder.
 func (r *Adapter) Builder(ctx *plancontext.Context) (builder base.Builder, err error) {
-	builder = &Builder{Context: ctx}
+	sourceClient, err := createClient(ctx.Source.Provider)
+	if err != nil {
+		return
+	}
+
+	builder = &Builder{Context: ctx, sourceClient: sourceClient}
 	return
 }
 
 // Constructs a openshift validator.
 func (r *Adapter) Validator(plan *api.Plan) (validator base.Validator, err error) {
+	sourceClient, err := createClient(plan.Provider.Source)
+	if err != nil {
+		return
+	}
+
+	validator = &Validator{plan: plan, sourceClient: sourceClient}
+	return
+}
+
+// Constructs an openshift client.
+func (r *Adapter) Client(ctx *plancontext.Context) (client base.Client, err error) {
+	sourceClient, err := createClient(ctx.Source.Provider)
+	if err != nil {
+		return
+	}
+
+	client = &Client{Context: ctx, sourceClient: sourceClient}
+
+	return
+}
+
+// Constucts a destination client.
+func (r *Adapter) DestinationClient(ctx *plancontext.Context) (destinationClient base.DestinationClient, err error) {
+	destinationClient = &DestinsationClient{Context: ctx}
+	return
+}
+
+func createClient(sourceProvider *api.Provider) (sourceClient k8sclient.Client, err error) {
 	conf, err := config.GetConfig()
 	if err != nil {
 		return
@@ -29,18 +65,20 @@ func (r *Adapter) Validator(plan *api.Plan) (validator base.Validator, err error
 		return
 	}
 
-	v := &Validator{plan: plan, client: client}
-	return v, nil
-}
+	if sourceProvider.IsHost() {
+		sourceClient = client
+	} else {
+		ref := sourceProvider.Spec.Secret
+		secret := &core.Secret{}
+		err = client.Get(context.TODO(), k8sclient.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}, secret)
+		if err != nil {
+			return
+		}
+		sourceClient, err = sourceProvider.Client(secret)
+		if err != nil {
+			return
+		}
+	}
 
-// Constructs an openshift client.
-func (r *Adapter) Client(ctx *plancontext.Context) (client base.Client, err error) {
-	client = &Client{Context: ctx}
-	return client, nil
-}
-
-// Constucts a destination client.
-func (r *Adapter) DestinationClient(ctx *plancontext.Context) (destinationClient base.DestinationClient, err error) {
-	destinationClient = &DestinsationClient{Context: ctx}
 	return
 }

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -324,17 +324,7 @@ func (r *Builder) mapPVCsToTarget(targetVmSpec *cnv.VirtualMachineSpec, persiste
 				},
 			}
 			targetVmSpec.Template.Spec.Volumes = append(targetVmSpec.Template.Spec.Volumes, targetVolume)
-
-			targetDisk := cnv.Disk{
-				Name: disk.Name,
-				DiskDevice: cnv.DiskDevice{
-					Disk: &cnv.DiskTarget{
-						Bus: disk.Disk.Bus,
-					},
-				},
-			}
-
-			targetVmSpec.Template.Spec.Domain.Devices.Disks = append(targetVmSpec.Template.Spec.Domain.Devices.Disks, targetDisk)
+			targetVmSpec.Template.Spec.Domain.Devices.Disks = append(targetVmSpec.Template.Spec.Domain.Devices.Disks, *disk.DeepCopy())
 		}
 	}
 }
@@ -412,17 +402,7 @@ func (r *Builder) mapConfigMapsToTarget(targetVmSpec *cnv.VirtualMachineSpec, co
 		}
 
 		if disk, ok := diskMap[sourceConfigMap.Name]; ok {
-			targetDisk := cnv.Disk{
-				Name:   disk.Name,
-				Serial: disk.Serial,
-				DiskDevice: cnv.DiskDevice{
-					Disk: &cnv.DiskTarget{
-						Bus: disk.Disk.Bus,
-					},
-				},
-			}
-
-			targetVmSpec.Template.Spec.Domain.Devices.Disks = append(targetVmSpec.Template.Spec.Domain.Devices.Disks, targetDisk)
+			targetVmSpec.Template.Spec.Domain.Devices.Disks = append(targetVmSpec.Template.Spec.Domain.Devices.Disks, *disk.DeepCopy())
 		} else {
 			r.Log.Info("ConfigMap disk not found in diskMap, should never happen", "configMap", sourceConfigMap.Name)
 		}
@@ -462,17 +442,7 @@ func (r *Builder) mapSecretsToTarget(targetVmSpec *cnv.VirtualMachineSpec, secre
 		}
 
 		if disk, ok := diskMap[sourceSecret.Name]; ok {
-			targetDisk := cnv.Disk{
-				Name:   disk.Name,
-				Serial: disk.Serial,
-				DiskDevice: cnv.DiskDevice{
-					Disk: &cnv.DiskTarget{
-						Bus: disk.Disk.Bus,
-					},
-				},
-			}
-
-			targetVmSpec.Template.Spec.Domain.Devices.Disks = append(targetVmSpec.Template.Spec.Domain.Devices.Disks, targetDisk)
+			targetVmSpec.Template.Spec.Domain.Devices.Disks = append(targetVmSpec.Template.Spec.Domain.Devices.Disks, *disk.DeepCopy())
 		} else {
 			r.Log.Info("Secret disk not found in diskMap, should never happen", "secret", sourceSecret.Name)
 		}

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -417,7 +417,7 @@ func (r *Builder) getSourceVmFromDefinition(vme *export.VirtualMachineExport) (*
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, liberr.Wrap(err, "failed to read vm manifest body")
 	}

--- a/pkg/controller/plan/adapter/ocp/client.go
+++ b/pkg/controller/plan/adapter/ocp/client.go
@@ -2,19 +2,19 @@ package ocp
 
 import (
 	"context"
+	"time"
 
 	planapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	"github.com/konveyor/forklift-controller/pkg/settings"
 	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cnv "kubevirt.io/api/core/v1"
 	export "kubevirt.io/api/export/v1alpha1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -41,7 +41,7 @@ func (r *Client) CreateSnapshot(vmRef ref.Ref) (string, error) {
 // Finalize implements base.Client
 func (r *Client) Finalize(vms []*planapi.VMStatus, planName string) {
 	for _, vm := range vms {
-		vmExport := &export.VirtualMachineExport{ObjectMeta: v1.ObjectMeta{
+		vmExport := &export.VirtualMachineExport{ObjectMeta: metav1.ObjectMeta{
 			Name:      vm.Name,
 			Namespace: vm.Namespace,
 		}}
@@ -57,7 +57,7 @@ func (r *Client) Finalize(vms []*planapi.VMStatus, planName string) {
 // PowerOff implements base.Client
 func (r *Client) PowerOff(vmRef ref.Ref) error {
 	vm := cnv.VirtualMachine{}
-	err := r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (r *Client) PowerOff(vmRef ref.Ref) error {
 // PowerOn implements base.Client
 func (r *Client) PowerOn(vmRef ref.Ref) error {
 	vm := cnv.VirtualMachine{}
-	err := r.Destination.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.Destination.Client.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (r *Client) PowerOn(vmRef ref.Ref) error {
 // PowerState implements base.Client
 func (r *Client) PowerState(vmRef ref.Ref) (string, error) {
 	vm := cnv.VirtualMachine{}
-	err := r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return "", err
@@ -109,7 +109,7 @@ func (r *Client) PowerState(vmRef ref.Ref) (string, error) {
 // PoweredOff implements base.Client
 func (r *Client) PoweredOff(vmRef ref.Ref) (bool, error) {
 	vm := cnv.VirtualMachine{}
-	err := r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return false, err
@@ -143,23 +143,31 @@ func (r *Client) PreTransferActions(vmRef ref.Ref) (ready bool, err error) {
 
 	// Check if VM export exists
 	vmExport := &export.VirtualMachineExport{}
-	err = r.sourceClient.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
+	err = r.sourceClient.Get(context.Background(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
+
 	if err != nil {
 		if !k8serr.IsNotFound(err) {
 			r.Log.Error(err, "Failed to get VM-export.", "vm", vmRef.Name)
 			return true, liberr.Wrap(err)
 		}
+
+		var tokenTTLDuration *metav1.Duration
+		if settings.Settings.CDIExportTokenTTL > 0 {
+			tokenTTLDuration = &metav1.Duration{Duration: time.Duration(settings.Settings.CDIExportTokenTTL) * time.Minute}
+		}
+
 		// Create VM export
 		vmExport = &export.VirtualMachineExport{
-			TypeMeta: meta.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				Kind:       "VirtualMachineExport",
 				APIVersion: "kubevirt.io/v1alpha3",
 			},
-			ObjectMeta: meta.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      vmRef.Name,
 				Namespace: vmRef.Namespace,
 			},
 			Spec: export.VirtualMachineExportSpec{
+				TTLDuration: tokenTTLDuration,
 				Source: core.TypedLocalObjectReference{
 					APIGroup: &apiGroup,
 					Kind:     "VirtualMachine",
@@ -168,7 +176,7 @@ func (r *Client) PreTransferActions(vmRef ref.Ref) (ready bool, err error) {
 			},
 		}
 
-		err = r.sourceClient.Create(context.Background(), vmExport, &client.CreateOptions{})
+		err = r.sourceClient.Create(context.Background(), vmExport, &k8sclient.CreateOptions{})
 		if err != nil {
 			return true, liberr.Wrap(err)
 		}

--- a/pkg/controller/plan/adapter/ocp/client.go
+++ b/pkg/controller/plan/adapter/ocp/client.go
@@ -15,10 +15,12 @@ import (
 	export "kubevirt.io/api/export/v1alpha1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Client struct {
 	*plancontext.Context
+	sourceClient k8sclient.Client
 }
 
 // CheckSnapshotReady implements base.Client
@@ -44,7 +46,7 @@ func (r *Client) Finalize(vms []*planapi.VMStatus, planName string) {
 			Namespace: vm.Namespace,
 		}}
 
-		err := r.Client.Delete(context.TODO(), vmExport)
+		err := r.sourceClient.Delete(context.TODO(), vmExport)
 		if err != nil {
 			r.Log.Info("Failed to delete VMExport", "VMExport", vmExport, "Error", err)
 			continue
@@ -55,14 +57,14 @@ func (r *Client) Finalize(vms []*planapi.VMStatus, planName string) {
 // PowerOff implements base.Client
 func (r *Client) PowerOff(vmRef ref.Ref) error {
 	vm := cnv.VirtualMachine{}
-	err := r.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		return err
 	}
 
 	running := false
 	vm.Spec.Running = &running
-	err = r.Client.Update(context.Background(), &vm)
+	err = r.sourceClient.Update(context.Background(), &vm)
 	if err != nil {
 		return err
 	}
@@ -73,14 +75,14 @@ func (r *Client) PowerOff(vmRef ref.Ref) error {
 // PowerOn implements base.Client
 func (r *Client) PowerOn(vmRef ref.Ref) error {
 	vm := cnv.VirtualMachine{}
-	err := r.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.Destination.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		return err
 	}
 
 	running := true
 	vm.Spec.Running = &running
-	err = r.Client.Update(context.Background(), &vm)
+	err = r.Destination.Client.Update(context.Background(), &vm)
 	if err != nil {
 		return err
 	}
@@ -91,7 +93,7 @@ func (r *Client) PowerOn(vmRef ref.Ref) error {
 // PowerState implements base.Client
 func (r *Client) PowerState(vmRef ref.Ref) (string, error) {
 	vm := cnv.VirtualMachine{}
-	err := r.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return "", err
@@ -107,7 +109,7 @@ func (r *Client) PowerState(vmRef ref.Ref) (string, error) {
 // PoweredOff implements base.Client
 func (r *Client) PoweredOff(vmRef ref.Ref) (bool, error) {
 	vm := cnv.VirtualMachine{}
-	err := r.Client.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
+	err := r.sourceClient.Get(context.TODO(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, &vm)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return false, err
@@ -141,7 +143,7 @@ func (r *Client) PreTransferActions(vmRef ref.Ref) (ready bool, err error) {
 
 	// Check if VM export exists
 	vmExport := &export.VirtualMachineExport{}
-	err = r.Client.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
+	err = r.sourceClient.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
 	if err != nil {
 		if !k8serr.IsNotFound(err) {
 			r.Log.Error(err, "Failed to get VM-export.", "vm", vmRef.Name)
@@ -166,7 +168,7 @@ func (r *Client) PreTransferActions(vmRef ref.Ref) (ready bool, err error) {
 			},
 		}
 
-		err = r.Client.Create(context.Background(), vmExport, &client.CreateOptions{})
+		err = r.sourceClient.Create(context.Background(), vmExport, &client.CreateOptions{})
 		if err != nil {
 			return true, liberr.Wrap(err)
 		}

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -17,9 +17,9 @@ import (
 
 // Validator
 type Validator struct {
-	plan      *api.Plan
-	inventory web.Client
-	client    k8sclient.Client
+	plan         *api.Plan
+	inventory    web.Client
+	sourceClient k8sclient.Client
 }
 
 // MaintenanceMode implements base.Validator
@@ -34,7 +34,7 @@ func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	vm := &cnv.VirtualMachine{}
-	err = r.client.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
+	err = r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
 	if err != nil {
 		err = liberr.Wrap(
 			err,
@@ -73,7 +73,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	vm := &cnv.VirtualMachine{}
-	err = r.client.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
+	err = r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
 	if err != nil {
 		err = liberr.Wrap(
 			err,
@@ -88,7 +88,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 		case vol.PersistentVolumeClaim != nil:
 			// Get PVC
 			pvc := &core.PersistentVolumeClaim{}
-			err = r.client.Get(context.TODO(), k8sclient.ObjectKey{
+			err = r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{
 				Namespace: vmRef.Namespace,
 				Name:      vol.PersistentVolumeClaim.ClaimName,
 			}, pvc)
@@ -130,7 +130,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	vm := &cnv.VirtualMachine{}
-	err = r.client.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
+	err = r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
 	if err != nil {
 		err = liberr.Wrap(
 			err,

--- a/pkg/controller/plan/adapter/openstack/BUILD.bazel
+++ b/pkg/controller/plan/adapter/openstack/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/controller/plan/adapter/base",
         "//pkg/controller/plan/context",
+        "//pkg/controller/plan/util",
         "//pkg/controller/provider/web",
         "//pkg/controller/provider/web/base",
         "//pkg/controller/provider/web/ocp",

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	utils "github.com/konveyor/forklift-controller/pkg/controller/plan/util"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/ocp"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/openstack"
@@ -1099,7 +1100,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image, storageC
 	}
 
 	if *volumeMode == core.PersistentVolumeFilesystem {
-		virtualSize = int64(float64(virtualSize) * 1.1)
+		virtualSize = utils.CalculateSpaceWithOverhead(virtualSize, 0.1)
 	}
 
 	// The image might be a VM Snapshot Image and has no volume associated to it

--- a/pkg/controller/plan/adapter/ova/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ova/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "ova",
@@ -31,4 +31,11 @@ go_library(
         "//vendor/kubevirt.io/api/core/v1:core",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1",
     ],
+)
+
+go_test(
+    name = "ova_test",
+    srcs = ["ova_capacity_test.go"],
+    embed = [":ova"],
+    deps = ["//vendor/github.com/onsi/gomega"],
 )

--- a/pkg/controller/plan/adapter/ova/ova_capacity_test.go
+++ b/pkg/controller/plan/adapter/ova/ova_capacity_test.go
@@ -1,0 +1,45 @@
+package ova
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestGetResourceCapacity(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tests := []struct {
+		name        string
+		capacity    int64
+		units       string
+		expected    int64
+		expectError bool
+	}{
+		{"empty units", 10, "", 10, false},
+		{"byte units", 20, "byte", 20, false},
+		{"pow 10", 2, "byte * 2^10", 2048, false},
+		{"pow 20", 1, "byte * 2^20", 1048576, false},
+		{"missing pow", 2, "byte * 1024", 2048, false},
+		{"malformed units", 100, "byte*2^", 0, true},
+		{"no spaces", 1, "byte*2^20", 1048576, false},
+		{"unsupported units", 10, "kilobytes", 0, true},
+		{"unsupported operand", 1, "byte + 2^20", 0, true},
+		{"diffrent base", 1, "byte * 3^10", 59049, false},
+		{"uncommon format", 1, "byte * 2 * 2^10", 2048, false},
+		{"uncommon format no spaces", 1, "byte*3*2^10", 3072, false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, err := getResourceCapacity(testCase.capacity, testCase.units)
+			if testCase.expectError {
+				g.Expect(err).To(gomega.HaveOccurred(), fmt.Sprintf("expected an error for input: %v", testCase.units))
+			} else {
+				g.Expect(err).To(gomega.BeNil(), fmt.Sprintf("did not expect an error for input: %v, but got: %v", testCase.units, err))
+				g.Expect(result).To(gomega.Equal(testCase.expected), fmt.Sprintf("expected %v, but got %v", testCase.expected, result))
+			}
+		})
+	}
+}

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -97,25 +97,8 @@ func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
 
 // Validate that a VM's disk backing storage has been mapped.
 func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.plan.Referenced.Map.Storage == nil {
-		return
-	}
-	vm := &model.VM{}
-	err = r.inventory.Find(vm, vmRef)
-	if err != nil {
-		err = liberr.Wrap(
-			err,
-			ErrVMNotFound,
-			"vm",
-			vmRef.String())
-		return
-	}
-
-	for _, disk := range vm.Disks {
-		if !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: disk.ID}) {
-			return
-		}
-	}
+	//For OVA providers, we don't have an actual storage connected,
+	// since we use a dummy storage for mapping the function should always return true.
 	ok = true
 	return
 }

--- a/pkg/controller/plan/adapter/ovirt/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ovirt/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/controller/plan/adapter/base",
         "//pkg/controller/plan/context",
+        "//pkg/controller/plan/util",
         "//pkg/controller/provider/container/ovirt",
         "//pkg/controller/provider/web",
         "//pkg/controller/provider/web/base",

--- a/pkg/controller/plan/adapter/ovirt/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ovirt/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/labels",
         "//vendor/k8s.io/apimachinery/pkg/types",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait",
         "//vendor/kubevirt.io/api/core/v1:core",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	planbase "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	utils "github.com/konveyor/forklift-controller/pkg/controller/plan/util"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/ocp"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/ovirt"
@@ -794,7 +795,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(diskAttachment model.XDiskA
 	// Accounting for fsOverhead is only required for `volumeMode: Filesystem`, as we may not have enough space
 	// after creating a filesystem on an underlying block device
 	if *volumeMode == core.PersistentVolumeFilesystem {
-		diskSize = int64(float64(diskSize) * 1.1)
+		diskSize = utils.CalculateSpaceWithOverhead(diskSize, 0.1)
 	}
 
 	annotations[AnnImportDiskId] = diskAttachment.ID

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -102,11 +102,7 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool,
 		return
 	}
 	for _, event := range events {
-		code, exists := event.Code()
-		if !exists {
-			err = liberr.New("The event does not have a code.", "event", event)
-			continue
-		}
+		code, _ := event.Code()
 		switch code {
 		case SNAPSHOT_FINISHED_FAILURE:
 			err = liberr.New("Snapshot creation failed!", "correlationID", correlationID)
@@ -530,11 +526,7 @@ func (r *Client) isSnapshotRemovalFinished(correlationID string) (finished bool,
 		return
 	}
 	for _, event := range events {
-		code, exists := event.Code()
-		if !exists {
-			err = liberr.New("The event does not have a code.", "event", event)
-			continue
-		}
+		code, _ := event.Code()
 		switch code {
 		case REMOVE_SNAPSHOT_FINISHED_FAILURE:
 			r.Log.Info("Snapshot removal failed!")

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -476,12 +476,6 @@ func (r Client) removePrecopies(precopies []planapi.Precopy, vmService *ovirtsdk
 		correlationID := fmt.Sprintf("%s_finalize", snapshotID[0:8])
 		cleanupTimeout := time.Now().Add(time.Duration(settings.Settings.Migration.SnapshotRemovalTimeout) * time.Minute)
 		for {
-			if time.Now().After(cleanupTimeout) {
-				r.Log.Info("Timeout waiting for snapshot removal")
-				return
-			} else {
-				time.Sleep(time.Duration(settings.Settings.Migration.SnapshotStatusCheckRate) * time.Second)
-			}
 			_, err := snapService.Get().Send()
 			if err != nil {
 				r.Log.Info("The snapshot was removed", "snapshotID", snapshotID)
@@ -511,6 +505,13 @@ func (r Client) removePrecopies(precopies []planapi.Precopy, vmService *ovirtsdk
 				if finished {
 					break
 				}
+			}
+
+			if time.Now().After(cleanupTimeout) {
+				r.Log.Info("Timeout waiting for snapshot removal")
+				return
+			} else {
+				time.Sleep(time.Duration(settings.Settings.Migration.SnapshotStatusCheckRate) * time.Second)
 			}
 		}
 	}

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -102,11 +102,18 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool,
 		return
 	}
 	for _, event := range events {
-		switch event.MustCode() {
+		code, exists := event.Code()
+		if !exists {
+			err = liberr.New("The event does not have a code.", "event", event)
+			continue
+		}
+		switch code {
 		case SNAPSHOT_FINISHED_FAILURE:
 			err = liberr.New("Snapshot creation failed!", "correlationID", correlationID)
+			return
 		case SNAPSHOT_FINISHED_SUCCESS:
 			ready = true
+			return
 		}
 	}
 	return
@@ -523,7 +530,12 @@ func (r *Client) isSnapshotRemovalFinished(correlationID string) (finished bool,
 		return
 	}
 	for _, event := range events {
-		switch event.MustCode() {
+		code, exists := event.Code()
+		if !exists {
+			err = liberr.New("The event does not have a code.", "event", event)
+			continue
+		}
+		switch code {
 		case REMOVE_SNAPSHOT_FINISHED_FAILURE:
 			r.Log.Info("Snapshot removal failed!")
 			return true, nil

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1733,7 +1733,7 @@ type VirtualMachine struct {
 // owner of the CDI DataVolume.
 func (r *VirtualMachine) Owner(dv *cdi.DataVolume) bool {
 	for _, vol := range r.Spec.Template.Spec.Volumes {
-		if vol.PersistentVolumeClaim.ClaimName == dv.Name {
+		if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == dv.Name {
 			return true
 		}
 	}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1326,7 +1326,8 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.Confi
 		},
 	})
 
-	if r.Source.Provider.Type() == api.Ova {
+	switch r.Source.Provider.Type() {
+	case api.Ova:
 		server := r.Source.Provider.Spec.URL
 		splitted := strings.Split(server, ":")
 
@@ -1359,6 +1360,17 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.Confi
 			core.VolumeMount{
 				Name:      "nfs",
 				MountPath: "/ova",
+			},
+		)
+	case api.VSphere:
+		mounts = append(mounts,
+			core.VolumeMount{
+				Name:      "libvirt-domain-xml",
+				MountPath: "/mnt/v2v",
+			},
+			core.VolumeMount{
+				Name:      "vddk-vol-mount",
+				MountPath: "/opt",
 			},
 		)
 	}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -807,13 +807,12 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		var snapshot string
 		snapshot, err = r.provider.CreateSnapshot(vm.Ref)
 		if err != nil {
-			if !errors.As(err, &web.ProviderNotReadyError{}) {
-				step.AddError(err.Error())
-				err = nil
-				break
-			} else {
+			if errors.As(err, &web.ProviderNotReadyError{}) || errors.As(err, &web.ConflictError{}) {
 				return
 			}
+			step.AddError(err.Error())
+			err = nil
+			break
 		}
 		now := meta.Now()
 		precopy := plan.Precopy{Snapshot: snapshot, Start: &now}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1596,6 +1596,9 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 		var task *plan.Task
 		var taskName string
 		taskName, err = r.builder.GetPopulatorTaskName(&pvc)
+		if err != nil {
+			return
+		}
 
 		found := false
 		if task, found = step.FindTask(taskName); !found {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1323,6 +1323,10 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 			return
 		}
 		for _, pvc := range pvcs {
+			if _, ok := pvc.Annotations["lun"]; ok {
+				// skip LUNs
+				continue
+			}
 			var task *plan.Task
 			name := r.builder.ResolvePersistentVolumeClaimIdentifier(&pvc)
 			found := false
@@ -1585,6 +1589,10 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 	}
 
 	for _, pvc := range pvcs {
+		if _, ok := pvc.Annotations["lun"]; ok {
+			// skip LUNs
+			continue
+		}
 		var task *plan.Task
 		var taskName string
 		taskName, err = r.builder.GetPopulatorTaskName(&pvc)

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"regexp"
@@ -1518,7 +1518,7 @@ func (r *Migration) updateConversionProgressEl9(pod *core.Pod, step *plan.Step) 
 		return
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}

--- a/pkg/controller/plan/util/BUILD.bazel
+++ b/pkg/controller/plan/util/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "openstack.go",
         "ovirt.go",
+        "utils.go",
     ],
     importpath = "github.com/konveyor/forklift-controller/pkg/controller/plan/util",
     visibility = ["//visibility:public"],

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -1,0 +1,23 @@
+package util
+
+import "math"
+
+// Disk alignment size used to align FS overhead,
+// its a multiple of all known hardware block sizes 512/4k/8k/32k/64k
+const (
+	DefaultAlignBlockSize = 1024 * 1024
+)
+
+func roundUp(requestedSpace, multiple int64) int64 {
+	if multiple == 0 {
+		return requestedSpace
+	}
+	partitions := math.Ceil(float64(requestedSpace) / float64(multiple))
+	return int64(partitions) * multiple
+}
+
+func CalculateSpaceWithOverhead(requestedSpace int64, filesystemOverhead float64) int64 {
+	alignedSize := roundUp(requestedSpace, DefaultAlignBlockSize)
+	spaceWithOverhead := int64(math.Ceil(float64(alignedSize) / (1 - filesystemOverhead)))
+	return spaceWithOverhead
+}

--- a/pkg/controller/provider/container/ova/collector.go
+++ b/pkg/controller/provider/container/ova/collector.go
@@ -229,8 +229,7 @@ func (r *Collector) load(ctx *Context) (err error) {
 
 // List and create resources using the adapter.
 func (r *Collector) create(ctx *Context, adapter Adapter) (err error) {
-	itr, aErr := adapter.List(ctx)
-
+	itr, aErr := adapter.List(ctx, r.provider)
 	if aErr != nil {
 		err = aErr
 		return

--- a/pkg/controller/provider/container/ova/resource.go
+++ b/pkg/controller/provider/container/ova/resource.go
@@ -219,3 +219,13 @@ func (r *Disk) ApplyTo(m *model.Disk) {
 	m.Format = r.Format
 	m.PopulatedSize = r.PopulatedSize
 }
+
+type Storage struct {
+	Name string
+	ID   string
+}
+
+func (r *Storage) ApplyTo(m *model.Storage) {
+	m.Base.Name = m.Name
+	m.Base.ID = m.ID
+}

--- a/pkg/controller/provider/model/ova/doc.go
+++ b/pkg/controller/provider/model/ova/doc.go
@@ -11,5 +11,6 @@ func All() []interface{} {
 		&VM{},
 		&Network{},
 		&Disk{},
+		&Storage{},
 	}
 }

--- a/pkg/controller/provider/model/ova/model.go
+++ b/pkg/controller/provider/model/ova/model.go
@@ -124,3 +124,7 @@ type NIC struct {
 	Network string `sql:""`
 	Config  []Conf `sql:""`
 }
+
+type Storage struct {
+	Base
+}

--- a/pkg/controller/provider/model/ova/tree.go
+++ b/pkg/controller/provider/model/ova/tree.go
@@ -7,9 +7,10 @@ import (
 
 // Kinds
 var (
-	VmKind   = libref.ToKind(VM{})
-	NetKind  = libref.ToKind(Network{})
-	DiskKind = libref.ToKind(Disk{})
+	VmKind      = libref.ToKind(VM{})
+	NetKind     = libref.ToKind(Network{})
+	DiskKind    = libref.ToKind(Disk{})
+	StorageKind = libref.ToKind(Storage{})
 )
 
 // Types.

--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -4,10 +4,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	liburl "net/url"
+	"os"
 	"reflect"
 	"time"
 
@@ -297,7 +297,7 @@ func (c *RestClient) buildTransport() (err error) {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 	pool := x509.NewCertPool()
-	ca, xErr := ioutil.ReadFile(Settings.Inventory.TLS.CA)
+	ca, xErr := os.ReadFile(Settings.Inventory.TLS.CA)
 	if xErr != nil {
 		err = liberr.Wrap(xErr)
 		return

--- a/pkg/controller/provider/web/client.go
+++ b/pkg/controller/provider/web/client.go
@@ -33,6 +33,15 @@ func (r ProviderNotReadyError) Error() string {
 	return fmt.Sprintf("Provider not ready: %#v", r.Provider)
 }
 
+type ConflictError struct {
+	Provider *api.Provider
+	Err      error
+}
+
+func (r ConflictError) Error() string {
+	return fmt.Sprintf("Conflict Error: '%s' from provider: '%#v'", r.Err.Error(), r.Provider)
+}
+
 type RefNotUniqueError = base.RefNotUniqueError
 type NotFoundError = base.NotFoundError
 

--- a/pkg/controller/provider/web/client.go
+++ b/pkg/controller/provider/web/client.go
@@ -39,7 +39,7 @@ type ConflictError struct {
 }
 
 func (r ConflictError) Error() string {
-	return fmt.Sprintf("Conflict Error: '%s' from provider: '%#v'", r.Err.Error(), r.Provider)
+	return fmt.Sprintf("Conflict Error from provider '%#v': %s", r.Provider, r.Err.Error())
 }
 
 type RefNotUniqueError = base.RefNotUniqueError

--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -158,8 +158,16 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 		}
 		name := ref.Name
 		if name != "" {
-			ns, name := path.Split(name)
-			ns = strings.TrimRight(ns, "/")
+			var ns string
+
+			// ref.Namespace might be missing when passed from NetworkMaps
+			// or StorageMaps
+			if ref.Namespace != "" {
+				ns = ref.Namespace
+			} else {
+				ns, name = path.Split(name)
+				ns = strings.TrimRight(ns, "/")
+			}
 			list := []VM{}
 			err = r.List(
 				&list,

--- a/pkg/controller/provider/web/ova/BUILD.bazel
+++ b/pkg/controller/provider/web/ova/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "network.go",
         "provider.go",
         "resource.go",
+        "storage.go",
         "tree.go",
         "vm.go",
         "workload.go",

--- a/pkg/controller/provider/web/ova/base.go
+++ b/pkg/controller/provider/web/ova/base.go
@@ -75,6 +75,9 @@ func (r *PathBuilder) Path(m model.Model) (path string) {
 	case *model.Disk:
 		disk := m.(*model.Disk)
 		path = pathlib.Join(disk.ID)
+	case *model.Storage:
+		storage := m.(*model.Storage)
+		path = pathlib.Join(storage.ID)
 	}
 
 	if err != nil {

--- a/pkg/controller/provider/web/ova/doc.go
+++ b/pkg/controller/provider/web/ova/doc.go
@@ -45,5 +45,10 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 				base.Handler{Container: container},
 			},
 		},
+		&StorageHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
 	}
 }

--- a/pkg/controller/provider/web/ova/provider.go
+++ b/pkg/controller/provider/web/ova/provider.go
@@ -147,6 +147,12 @@ func (h ProviderHandler) AddDerived(r *Provider) (err error) {
 		return
 	}
 	r.DiskCount = n
+	// Storage count
+	n, err = db.Count(&ova.Storage{}, nil)
+	if err != nil {
+		return
+	}
+	r.StorageCount = n
 
 	return
 }
@@ -161,6 +167,7 @@ type Provider struct {
 	VMCount      int64        `json:"vmCount"`
 	NetworkCount int64        `json:"networkCount"`
 	DiskCount    int64        `json:"diskCount"`
+	StorageCount int64        `json:"storageCount"`
 }
 
 // Set fields with the specified object.

--- a/pkg/controller/provider/web/ova/storage.go
+++ b/pkg/controller/provider/web/ova/storage.go
@@ -1,0 +1,204 @@
+package ova
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ova"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
+	libmodel "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
+)
+
+// Routes.
+const (
+	StorageParam      = "storage"
+	StorageCollection = "storages"
+	StoragesRoot      = ProviderRoot + "/" + StorageCollection
+	StorageRoot       = StoragesRoot + "/:" + StorageParam
+)
+
+// Storage handler.
+type StorageHandler struct {
+	Handler
+}
+
+// Add routes to the `gin` router.
+func (h *StorageHandler) AddRoutes(e *gin.Engine) {
+	e.GET(StoragesRoot, h.List)
+	e.GET(StoragesRoot+"/", h.List)
+	e.GET(StorageRoot, h.Get)
+}
+
+// List resources in a REST collection.
+// A GET onn the collection that includes the `X-Watch`
+// header will negotiate an upgrade of the connection
+// to a websocket and push watch events.
+func (h StorageHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+	defer func() {
+		if err != nil {
+			log.Trace(
+				err,
+				"url",
+				ctx.Request.URL)
+			ctx.Status(http.StatusInternalServerError)
+		}
+	}()
+	db := h.Collector.DB()
+	list := []model.Storage{}
+	err = db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		return
+	}
+	err = h.filter(ctx, &list)
+	if err != nil {
+		return
+	}
+	pb := PathBuilder{DB: db}
+	content := []interface{}{}
+	for _, m := range list {
+		r := &Storage{}
+		r.With(&m)
+		r.Link(h.Provider)
+		r.Path = pb.Path(&m)
+		content = append(content, r.Content(h.Detail))
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// Get a specific REST resource.
+func (h StorageHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	m := &model.Storage{
+		Base: model.Base{
+			ID: ctx.Param(StorageParam),
+		},
+	}
+	db := h.Collector.DB()
+	err = db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	pb := PathBuilder{DB: db}
+	r := &Storage{}
+	r.With(m)
+	r.Link(h.Provider)
+	r.Path = pb.Path(m)
+	content := r.Content(model.MaxDetail)
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// Watch.
+func (h *StorageHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.Storage{},
+		func(in libmodel.Model) (r interface{}) {
+			pb := PathBuilder{DB: db}
+			m := in.(*model.Storage)
+			storage := &Storage{}
+			storage.With(m)
+			storage.Link(h.Provider)
+			storage.Path = pb.Path(m)
+			r = storage
+			return
+		})
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+	}
+}
+
+// Filter result set.
+// Filter by path for `name` query.
+func (h *StorageHandler) filter(ctx *gin.Context, list *[]model.Storage) (err error) {
+	if len(*list) < 2 {
+		return
+	}
+	q := ctx.Request.URL.Query()
+	name := q.Get(NameParam)
+	if len(name) == 0 {
+		return
+	}
+	if len(strings.Split(name, "/")) < 2 {
+		return
+	}
+	db := h.Collector.DB()
+	pb := PathBuilder{DB: db}
+	kept := []model.Storage{}
+	for _, m := range *list {
+		path := pb.Path(&m)
+		if h.PathMatchRoot(path, name) {
+			kept = append(kept, m)
+		}
+	}
+
+	*list = kept
+
+	return
+}
+
+// REST Resource.
+type Storage struct {
+	Resource
+}
+
+// Build the resource using the model.
+func (r *Storage) With(m *model.Storage) {
+	r.Resource.With(&m.Base)
+	r.Variant = m.Variant
+	r.Name = m.Name
+	r.ID = m.ID
+}
+
+// Build self link (URI).
+func (r *Storage) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		StorageRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			StorageParam:       r.ID,
+		})
+}
+
+// As content.
+func (r *Storage) Content(detail int) interface{} {
+	if detail == 0 {
+		return r.Resource
+	}
+
+	return r
+}

--- a/pkg/controller/provider/web/ova/tree.go
+++ b/pkg/controller/provider/web/ova/tree.go
@@ -172,6 +172,17 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 			Kind:   kind,
 			Object: object,
 		}
+	case model.StorageKind:
+		resource := &Storage{}
+		resource.With(m.(*model.Storage))
+		resource.Link(provider)
+		resource.Path = r.pathBuilder.Path(m)
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
 	}
 
 	return node

--- a/pkg/controller/validation/policy/client.go
+++ b/pkg/controller/validation/policy/client.go
@@ -5,17 +5,18 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
+	"net/http"
+	liburl "net/url"
+	"os"
+	"time"
+
 	refapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libweb "github.com/konveyor/forklift-controller/pkg/lib/inventory/web"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
 	"github.com/konveyor/forklift-controller/pkg/settings"
-	"io/ioutil"
-	"net"
-	"net/http"
-	liburl "net/url"
-	"time"
 )
 
 var log = logging.WithName("validation|policy")
@@ -189,7 +190,7 @@ func (c *Client) buildTransport() (err error) {
 	}
 	if len(Settings.PolicyAgent.TLS.CA) > 0 {
 		pool := x509.NewCertPool()
-		ca, xErr := ioutil.ReadFile(Settings.PolicyAgent.TLS.CA)
+		ca, xErr := os.ReadFile(Settings.PolicyAgent.TLS.CA)
 		if xErr != nil {
 			err = liberr.Wrap(xErr)
 			return

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator_test.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator_test.go
@@ -1,7 +1,7 @@
 package mutators
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -10,10 +10,10 @@ import (
 func TestCertAppending(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	providedCa, err := ioutil.ReadFile("completeCerts.pem")
+	providedCa, err := os.ReadFile("completeCerts.pem")
 	g.Expect(err).ToNot(HaveOccurred())
 
-	newCa, err := ioutil.ReadFile("engineCert.pem")
+	newCa, err := os.ReadFile("engineCert.pem")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	//Test the case where two certificates are identical but have a different line count due to new lines.

--- a/pkg/forklift-api/webhooks/util/util.go
+++ b/pkg/forklift-api/webhooks/util/util.go
@@ -3,7 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
@@ -20,7 +20,7 @@ type PatchOperation struct {
 func GetAdmissionReview(r *http.Request) (*admissionv1.AdmissionReview, error) {
 	var body []byte
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -19,7 +19,7 @@ package populator_machinery
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -815,7 +815,7 @@ func (c *controller) updateProgress(pvc *corev1.PersistentVolumeClaim, podIP str
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPopulatorProgress, "Failed to read response, error: %w", url, err)

--- a/pkg/lib-volume-populator/populator-machinery/metrics_test.go
+++ b/pkg/lib-volume-populator/populator-machinery/metrics_test.go
@@ -19,7 +19,6 @@ package populator_machinery
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"sort"
@@ -142,7 +141,7 @@ func verifyInFlightMetric(expected string, srvAddr string) error {
 	if rsp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to get response from serve: %s", http.StatusText(rsp.StatusCode))
 	}
-	r, err := ioutil.ReadAll(rsp.Body)
+	r, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return err
 	}
@@ -162,7 +161,7 @@ func verifyMetric(expected, srvAddr string) error {
 	if rsp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to get response from serve: %s", http.StatusText(rsp.StatusCode))
 	}
-	r, err := ioutil.ReadAll(rsp.Body)
+	r, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/client/openstack/client.go
+++ b/pkg/lib/client/openstack/client.go
@@ -1480,7 +1480,7 @@ func (c *Client) UploadImage(name, volumeID string) (image *Image, err error) {
 	}
 	opts := volumeactions.UploadImageOpts{
 		ImageName:  name,
-		DiskFormat: "qcow2",
+		DiskFormat: "raw",
 	}
 	volumeImage, err := volumeactions.UploadImage(c.blockStorageService, volumeID, opts).Extract()
 	if err != nil {

--- a/pkg/lib/inventory/web/client.go
+++ b/pkg/lib/inventory/web/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	liburl "net/url"
 	"reflect"
@@ -138,7 +138,7 @@ func (r *Client) Get(url string, out interface{}, params ...Param) (status int, 
 	defer func() {
 		_ = response.Body.Close()
 	}()
-	content, err := ioutil.ReadAll(response.Body)
+	content, err := io.ReadAll(response.Body)
 	if err != nil {
 		err = liberr.Wrap(
 			err,
@@ -188,7 +188,7 @@ func (r *Client) Post(url string, in interface{}, out interface{}) (status int, 
 	request := &http.Request{
 		Header: r.Header,
 		Method: http.MethodPost,
-		Body:   ioutil.NopCloser(reader),
+		Body:   io.NopCloser(reader),
 		URL:    parsedURL,
 	}
 	client := http.Client{Transport: r.Transport}
@@ -205,7 +205,7 @@ func (r *Client) Post(url string, in interface{}, out interface{}) (status int, 
 	defer func() {
 		_ = response.Body.Close()
 	}()
-	content, err := ioutil.ReadAll(response.Body)
+	content, err := io.ReadAll(response.Body)
 	if err != nil {
 		err = liberr.Wrap(
 			err,

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -17,6 +17,7 @@ const (
 	VirtV2vDontRequestKVM   = "VIRT_V2V_DONT_REQUEST_KVM"
 	SnapshotRemovalTimeout  = "SNAPSHOT_REMOVAL_TIMEOUT"
 	SnapshotStatusCheckRate = "SNAPSHOT_STATUS_CHECK_RATE"
+	CDIExportTokenTTL       = "CDI_EXPORT_TOKEN_TTL"
 )
 
 // Default virt-v2v image.
@@ -43,6 +44,8 @@ type Migration struct {
 	VirtV2vImageWarm string
 	// Virt-v2v require KVM flags for guest conversion
 	VirtV2vDontRequestKVM bool
+	// OCP Export token TTL minutes
+	CDIExportTokenTTL int
 }
 
 // Load settings.
@@ -84,5 +87,11 @@ func (r *Migration) Load() (err error) {
 		r.VirtV2vImageWarm = DefaultVirtV2vImage
 	}
 	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
+
+	r.CDIExportTokenTTL, err = getEnvLimit(CDIExportTokenTTL, 0)
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
+
 	return
 }

--- a/tests/suit/utils/common.go
+++ b/tests/suit/utils/common.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -81,7 +80,7 @@ func RemoveLocalCA() error {
 
 func UpdateLocalCA(caCert string) error {
 
-	file, err := ioutil.TempFile("/tmp", "prefix")
+	file, err := os.CreateTemp("/tmp", "prefix")
 	if err != nil {
 		return err
 	}

--- a/validation/policies/io/konveyor/forklift/openstack/shared_disk.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/shared_disk.rego
@@ -2,13 +2,13 @@ package io.konveyor.forklift.openstack
 
 volumes := input.volumes
 
-non_shared_disks[i] {
+shared_disks[i] {
 	some i
-	count(volumes[i].attachments) == 1
+	count(volumes[i].attachments) > 1
 }
 
 concerns[flag] {
-	count(non_shared_disks) != count(volumes)
+	count(shared_disks) > 0
 	flag := {
 		"category": "Warning",
 		"label": "Shared disk detected",

--- a/validation/policies/io/konveyor/forklift/openstack/shared_disk_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/shared_disk_test.rego
@@ -1,5 +1,14 @@
 package io.konveyor.forklift.openstack
 
+test_with_no_volumes {
+	mock_vm := {
+		"name": "test",
+		"volumes": [],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
+}
+
 test_without_shared_disk {
 	mock_vm := {
 		"name": "test",
@@ -7,6 +16,8 @@ test_without_shared_disk {
 			{"id": "1", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "2", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "3", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
+			{"id": "4", "status": "in-use", "attachments": []},
+			{"id": "5", "status": "in-use" },
 		],
 	}
 	results := concerns with input as mock_vm
@@ -20,6 +31,8 @@ test_with_shared_disk {
 			{"id": "1", "status": "in-use", "attachments": [{"AttachmentID": "1"}, {"AttachmentID": "2"}]},
 			{"id": "2", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "3", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
+			{"id": "4", "status": "in-use", "attachments": []},
+			{"id": "5", "status": "in-use" },
 		],
 	}
 	results := concerns with input as mock_vm

--- a/virt-v2v/cold/.bazerlc
+++ b/virt-v2v/cold/.bazerlc
@@ -3,4 +3,4 @@
 # sandboxes. Use slightly less secure but working processwrapper sandbox.
 # NOTE: Same configuration is in .bazelrc in repository root.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
-build --strategy_regexp="RunAndCommitLayer no-ems-in-fips.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer no-ems-in-fips-layer.tar"=processwrapper-sandbox

--- a/virt-v2v/cold/.bazerlc
+++ b/virt-v2v/cold/.bazerlc
@@ -3,3 +3,4 @@
 # sandboxes. Use slightly less secure but working processwrapper sandbox.
 # NOTE: Same configuration is in .bazelrc in repository root.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer no-ems-in-fips.tar"=processwrapper-sandbox

--- a/virt-v2v/cold/BUILD.bazel
+++ b/virt-v2v/cold/BUILD.bazel
@@ -5,6 +5,7 @@ load(
 )
 load(
     "@io_bazel_rules_docker//docker/util:run.bzl",
+    "container_run_and_commit_layer",
     "container_run_and_extract",
 )
 load("@bazeldnf//:deps.bzl", "rpmtree")
@@ -59,9 +60,28 @@ container_image(
     ],
 )
 
+container_run_and_commit_layer(
+    name = "no-ems-in-fips",
+    commands = [
+        "touch /etc/crypto-policies/back-ends/openssl_fips.config",
+        "printf '[fips_sect]\ntls1-prf-ems-check = 0\nactivate = 1' > /etc/crypto-policies/back-ends/openssl_fips.config",
+        "printf '[crypto_policy]\nOptions=RHNoEnforceEMSinFIPS' >> /etc/crypto-policies/back-ends/opensslcnf.config",
+    ],
+    image = ":virt-v2v-image.tar",
+)
+
+container_image(
+    name = "virt-v2v-layer",
+    base = ":virt-v2v-image",
+    layers = [
+        ":no-ems-in-fips",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 container_image(
     name = "forklift-virt-v2v",
-    base = ":virt-v2v-image",
+    base = ":virt-v2v-layer",
     directory = "/usr/local/bin/",
     empty_dirs = ["/disks"],
     entrypoint = ["/usr/local/bin/entrypoint"],

--- a/virt-v2v/cold/WORKSPACE
+++ b/virt-v2v/cold/WORKSPACE
@@ -159,14 +159,6 @@ load(
 
 container_repositories()
 
-container_pull(
-    name = "ubi8-minimal",
-    # 'tag' is also supported, but digest is encouraged for reproducibility.
-    digest = "sha256:d1f8eff6032334a81d7cbfd73dacee680e8138db57ecbc91548b97bb45e698e5",
-    registry = "registry.access.redhat.com",
-    repository = "ubi8/ubi-minimal",
-)
-
 http_archive(
     name = "bazeldnf",
     sha256 = "404fc34e6bd3b568a7ca6fbcde70267d43830d0171d3192e3ecd83c14c320cfc",

--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o pipefail
+set -o pipefail -e
 shopt -s nullglob
 
 if [ -z "$V2V_source"] ; then

--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -2,7 +2,7 @@
 set -o pipefail -e
 shopt -s nullglob
 
-if [ -z "$V2V_source"] ; then
+if [ -z "$V2V_source" ] ; then
     echo "Following environment needs to be defined:"
     echo
     echo "    V2V_source"

--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o pipefail -e
+set -eo pipefail
 shopt -s nullglob
 
 if [ -z "$V2V_source" ] ; then
@@ -8,6 +8,9 @@ if [ -z "$V2V_source" ] ; then
     echo "    V2V_source"
     exit 1
 fi
+
+# This variable is used to build the command with args for virt-v2v.
+args=(virt-v2v -v -x)
 
 if [ "$V2V_source" == "vCenter" ] ; then
   if [ -z "$V2V_libvirtURL" ] || \
@@ -18,6 +21,7 @@ if [ "$V2V_source" == "vCenter" ] ; then
       echo "    V2V_libvirtURL, V2V_secretKey, V2V_vmName"
       exit 1
   fi
+  args+=(-i libvirt -ic "$V2V_libvirtURL")
 fi
 
 if [ "$V2V_source" == "ova" ] ; then
@@ -28,22 +32,17 @@ if [ "$V2V_source" == "ova" ] ; then
       echo "    V2V_diskPath, V2V_vmName"
       exit 1
   fi
+  args+=(-i ova "$V2V_diskPath")
 fi
 
 export LIBGUESTFS_PATH=/usr/lib64/guestfs/appliance
 
 echo "Preparing virt-v2v"
 
-# This variable is used to build the list of arguments for virt-v2v.
-args=()
-
 # Temporary storage location
 DIR="/var/tmp/v2v"
 mkdir -p $DIR
-args=("${args[@]}"
-    -o local
-    -os "$DIR"
-)
+args+=(-o local -os "$DIR")
 
 # Generate disk name suffix from disk number. E.g. "c" (as in "sdc") for
 # 3rd disk.
@@ -75,34 +74,21 @@ done
 if [ "$V2V_source" == "vCenter" ] ; then
   # Store password to file
   echo -n "$V2V_secretKey" > "$DIR/vmware.pw"
-  args=("${args[@]}"
-      -ip "$DIR/vmware.pw"
-  )
+  args+=(-ip "$DIR/vmware.pw")
 
   # Use VDDK if present
   if [ -d "/opt/vmware-vix-disklib-distrib" ]; then
-      args=("${args[@]}"
+      args+=(
           -it vddk
           -io vddk-libdir=/opt/vmware-vix-disklib-distrib
           -io "vddk-thumbprint=$V2V_thumbprint"
       )
   fi
+  args+=(-- "$V2V_vmName")
 fi
 
 echo "Starting virt-v2v"
 set -x
 ls -l "$DIR"
-if [ "$V2V_source" == "vCenter" ] ; then
-  exec virt-v2v -v -x \
-      -i libvirt \
-      -ic "$V2V_libvirtURL" \
-      "${args[@]}" \
-      -- "$V2V_vmName" |& /usr/local/bin/virt-v2v-monitor
-fi
 
-if [ "$V2V_source" == "ova" ] ; then
-  exec virt-v2v -v -x \
-      -i ova "$V2V_diskPath" \
-      "${args[@]}"\
-      |& /usr/local/bin/virt-v2v-monitor
-fi
+exec "${args[@]}" |& /usr/local/bin/virt-v2v-monitor

--- a/virt-v2v/warm/.bazelrc
+++ b/virt-v2v/warm/.bazelrc
@@ -1,0 +1,6 @@
+# Appliance build
+# container_run_and_extract() does not work inside Podman and Docker
+# sandboxes. Use slightly less secure but working processwrapper sandbox.
+# NOTE: Same configuration is in .bazelrc in repository root.
+build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
+

--- a/virt-v2v/warm/BUILD.bazel
+++ b/virt-v2v/warm/BUILD.bazel
@@ -4,6 +4,10 @@ load(
     "container_image",
     "container_push",
 )
+load(
+    "@io_bazel_rules_docker//docker/util:run.bzl",
+    "container_run_and_extract",
+)
 
 container_push(
     name = "push-forklift-virt-v2v-warm",
@@ -14,9 +18,40 @@ container_push(
     tag = "$${REGISTRY_TAG:-devel}",
 )
 
+# Appliance build
+# NOTE: We deliberately do not use (and cannot use) rpmtree to build a base
+# layer with packages. Supermin queries the RPM database to track package files
+# and dependencies. Tar constructed by rpmtree is just a bunch of files and it
+# does not preserve the RPM database info. Therefore we imitate a Dockerfile
+# build here.
+container_run_and_extract(
+    name = "appliance",
+    commands = [
+        "set -x",
+        "dnf -y update",
+        "dnf -y install libguestfs-devel libguestfs-appliance libguestfs-xfs libguestfs-winsupport supermin",
+        "depmod \\$(ls /lib/modules/ |tail -n1)",
+        "export LIBGUESTFS_BACKEND=direct",
+        "export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1",
+        "mkdir -p /usr/lib64/guestfs/appliance",
+        "cd /usr/lib64/guestfs/appliance",
+        "libguestfs-make-fixed-appliance --xz",
+        "cp /usr/lib64/guestfs/appliance/appliance-*.tar.xz /libguestfs-appliance.tar.xz",
+    ],
+    extract_file = "/libguestfs-appliance.tar.xz",
+    image = "@centos-stream-8//image",
+)
+
+container_image(
+    name = "appliance-image",
+    base = "@ubi8-minimal//image",
+    directory = "/usr/lib64/guestfs",
+    files = [":appliance/libguestfs-appliance.tar.xz"],
+)
+
 container_image(
     name = "virt-v2v-image",
-    base = "@libguestfs-appliance//image",
+    base = "appliance-image",
     directory = "/",
     tars = [":virt-v2v"],
 )

--- a/virt-v2v/warm/WORKSPACE
+++ b/virt-v2v/warm/WORKSPACE
@@ -143,17 +143,16 @@ container_repositories()
 
 container_pull(
     name = "ubi8-minimal",
-    # 'tag' is also supported, but digest is encouraged for reproducibility.
-    digest = "sha256:d1f8eff6032334a81d7cbfd73dacee680e8138db57ecbc91548b97bb45e698e5",
     registry = "registry.access.redhat.com",
     repository = "ubi8/ubi-minimal",
+    tag = "latest",
 )
 
 container_pull(
-    name = "libguestfs-appliance",
-    digest = "sha256:6abc2a68f4a42dbf3a7db1042a73862e763b6c864c1e04659dc6bd981e430ae5",
+    name = "centos-stream-8",
     registry = "quay.io",
-    repository = "kubev2v/libguestfs-appliance",
+    repository = "centos/centos",
+    tag = "stream8",
 )
 
 http_archive(

--- a/virt-v2v/warm/entrypoint
+++ b/virt-v2v/warm/entrypoint
@@ -2,7 +2,7 @@
 shopt -s nullglob
 
 export LIBGUESTFS_PATH=/usr/lib64/guestfs
-set -- "$LIBGUESTFS_PATH"/appliance-*.tar.xz
+set -- "$LIBGUESTFS_PATH"/libguestfs-appliance.tar.xz
 if [ -f "$1" ] ; then
     echo "Extracting libguestfs appliance..."
     APPLIANCE="/var/tmp/libguestfs-appliance"


### PR DESCRIPTION
- Skip LUN task progress
- Fix controller SCC namespace
- Add missing mounts for virt-v2v container
- Remove usages of ioutil because it's deprected as of go 1.16
- Fix LUN warm migration
- validation: fix openstack shared disk validation
- plan: check error returned by GetPopulatorTaskName
- ocp: use source client where needed
- Exit when virt-v2v cold hit an error
- Change the storage mapping for OVA
- OCP: add support for secrets and configmaps
- fix virt-v2v bracket
- ocp: use namespace from Ref when present
- ocp: make export token TTL configurable
- openstack: use raw format for images
- backport https://github.com/kubev2v/forklift/pull/497
- Fix virt-v2v entrypoint script
- ocp: fix mapping name check
- Fix TLS SSL connection to FIPS enabled systems
- add -layer suffix to ems layer
- ovirt client: Check if snapshot was created sucesfully
- ovirt: Do not wait for timeout when snapshot removal fails
- Refactor snapshot removal
- Add check for snapshot removal
- Update the timeout phase with the start time
- Remove go util wait from bazel
- Replace MustCode with Code and check if the element exists
- ignore events from ovirt without 'code'
- backport https://github.com/kubev2v/forklift/pull/512
- virt-v2v: Build our own fixed appliance on el8
- ocp: preserve boot order for disks
