### PR TITLE
Default OVA VMs firmware to EFI (backport)

### DIFF
--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -28,7 +28,7 @@ import (
 
 // BIOS types
 const (
-	Efi = "efi"
+	Bios = "bios"
 )
 
 // Bus types
@@ -364,8 +364,10 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 		Serial: vm.UUID,
 	}
 	switch vm.Firmware {
-	case Efi:
-		// We don't distinguish between UEFI and UEFI with secure boot but we anyway would have
+	case Bios:
+		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
+	default:
+		// We don't distinguish between UEFI and UEFI with secure boot, but we anyway would have
 		// disabled secure boot, even if we knew it was enabled on the source, because the guest
 		// OS won't be able to boot without getting the NVRAM data. By starting the VM without
 		// secure boot we ease the procedure users need to do in order to make a guest OS that
@@ -375,8 +377,6 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 			EFI: &cnv.EFI{
 				SecureBoot: &secureBootEnabled,
 			}}
-	default:
-		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	}
 	object.Template.Spec.Domain.Features = features
 	object.Template.Spec.Domain.Firmware = firmware

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -28,7 +28,7 @@ import (
 
 // BIOS types
 const (
-	Bios = "bios"
+	BIOS = "bios"
 )
 
 // Bus types
@@ -364,7 +364,7 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 		Serial: vm.UUID,
 	}
 	switch vm.Firmware {
-	case Bios:
+	case BIOS:
 		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	default:
 		// We don't distinguish between UEFI and UEFI with secure boot, but we anyway would have

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -371,7 +371,7 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 		// disabled secure boot, even if we knew it was enabled on the source, because the guest
 		// OS won't be able to boot without getting the NVRAM data. By starting the VM without
 		// secure boot we ease the procedure users need to do in order to make a guest OS that
-		// was previously configured with secure boot to boot.
+		// was previously configured with secure boot bootable.
 		secureBootEnabled := false
 		firmware.Bootloader = &cnv.Bootloader{
 			EFI: &cnv.EFI{

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -577,11 +577,11 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	}
 	switch vm.Firmware {
 	case Efi:
-		// We don't distinguish between UEFI and UEFI with secure boot but we anyway would have
+		// We don't distinguish between UEFI and UEFI with secure boot, but we anyway would have
 		// disabled secure boot, even if we knew it was enabled on the source, because the guest
 		// OS won't be able to boot without getting the NVRAM data. By starting the VM without
 		// secure boot we ease the procedure users need to do in order to make a guest OS that
-		// was previously configured with secure boot to boot.
+		// was previously configured with secure boot bootable.
 		secureBootEnabled := false
 		firmware.Bootloader = &cnv.Bootloader{
 			EFI: &cnv.EFI{


### PR DESCRIPTION
When no firmware is provided by the OVF of the imported OVA, default the firmware to EFI.

backport of #564 