### PR TITLE
openstack: update VM revision on volume change

### DIFF
--- a/pkg/controller/provider/container/openstack/BUILD.bazel
+++ b/pkg/controller/provider/container/openstack/BUILD.bazel
@@ -26,5 +26,6 @@ go_library(
         "//pkg/settings",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/klog/v2:klog",
     ],
 )

--- a/pkg/controller/provider/container/openstack/model.go
+++ b/pkg/controller/provider/container/openstack/model.go
@@ -755,7 +755,7 @@ func (r *VolumeAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) 
 							klog.Info("VM not found, skipping", "vmID", vmID)
 							continue
 						}
-						vm.Revision += 1
+						vm.RevisionValidated = 0
 						err = tx.Update(vm)
 						if err != nil {
 							klog.Error("Could not update VM revision", "vmID", vmID, "err", err)


### PR DESCRIPTION
If a volume of a VM changes we need to update the VM's revision to make sure it is revalidated