### PR TITLE
openstack: fix image format validation

### DIFF
--- a/validation/policies/io/konveyor/forklift/openstack/image_format.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/image_format.rego
@@ -5,7 +5,7 @@ import future.keywords.if
 default has_invalid_image_format = false
 
 has_invalid_image_format if {
-	not regex.match(`qcow2|raw`, input.image.disk_format)
+	not regex.match(`qcow2|raw`, input.image.diskFormat)
 }
 
 concerns[flag] {

--- a/validation/policies/io/konveyor/forklift/openstack/image_format_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/image_format_test.rego
@@ -5,7 +5,7 @@ test_with_valid_image_format {
 		"name": "test",
 		"image": {
 			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-			"disk_format": "qcow2",
+			"diskFormat": "qcow2",
 		},
 	}
 	results := concerns with input as mock_vm
@@ -17,7 +17,7 @@ test_with_invalid_storage_type {
 		"name": "test",
 		"image": {
 			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-			"disk_format": "ami",
+			"diskFormat": "ami",
 		},
 	}
 	results := concerns with input as mock_vm


### PR DESCRIPTION
The format of the image is stored as image.diskFormat rather than image.disk_format - change the validation and its tests accordingly.