### PR TITLE
openstack: update VM revision on volume change

### DIFF
--- a/pkg/controller/provider/container/openstack/BUILD.bazel
+++ b/pkg/controller/provider/container/openstack/BUILD.bazel
@@ -27,5 +27,6 @@ go_library(
         "//vendor/github.com/go-logr/logr",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/klog/v2:klog",
     ],
 )

--- a/pkg/controller/provider/container/openstack/model.go
+++ b/pkg/controller/provider/container/openstack/model.go
@@ -755,7 +755,7 @@ func (r *VolumeAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) 
 							klog.Info("VM not found, skipping", "vmID", vmID)
 							continue
 						}
-						vm.Revision += 1
+						vm.RevisionValidated = 0
 						err = tx.Update(vm)
 						if err != nil {
 							klog.Error("Could not update VM revision", "vmID", vmID, "err", err)

--- a/pkg/controller/provider/container/openstack/model.go
+++ b/pkg/controller/provider/container/openstack/model.go
@@ -10,6 +10,7 @@ import (
 	libclient "github.com/konveyor/forklift-controller/pkg/lib/client/openstack"
 	fb "github.com/konveyor/forklift-controller/pkg/lib/filebacked"
 	libmodel "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
+	"k8s.io/klog/v2"
 )
 
 // All adapters.
@@ -704,6 +705,7 @@ func (r *VolumeAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) 
 	}
 	for i := range volumeList {
 		volume := &Volume{volumeList[i]}
+		klog.Info("Getting update for volume", "volume", volume.ID)
 		switch volume.Status {
 		case VolumeStatusDeleting:
 			updater := func(tx *libmodel.Tx) (err error) {
@@ -732,11 +734,36 @@ func (r *VolumeAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) 
 					}
 					return
 				}
+
 				if !volume.updatedAfter(m) {
 					return
 				}
+
 				volume.ApplyTo(m)
 				err = tx.Update(m)
+				if err == nil {
+					// If an attached volume has changed, we have to update the relevant VM revision
+					// to make sure it is revalidated.
+					klog.Info("Volume changed, updating attached VMs", "volume", volume.ID)
+					for _, attachment := range volume.Attachments {
+						vmID := attachment.ServerID
+						vm := &model.VM{
+							Base: model.Base{ID: vmID},
+						}
+						err = tx.Get(vm)
+						if err != nil {
+							klog.Info("VM not found, skipping", "vmID", vmID)
+							continue
+						}
+						vm.Revision += 1
+						err = tx.Update(vm)
+						if err != nil {
+							klog.Error("Could not update VM revision", "vmID", vmID, "err", err)
+							continue
+						}
+					}
+				}
+
 				return
 			}
 			updates = append(updates, updater)

--- a/pkg/controller/provider/container/openstack/model.go
+++ b/pkg/controller/provider/container/openstack/model.go
@@ -705,7 +705,6 @@ func (r *VolumeAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) 
 	}
 	for i := range volumeList {
 		volume := &Volume{volumeList[i]}
-		klog.Info("Getting update for volume", "volume", volume.ID)
 		switch volume.Status {
 		case VolumeStatusDeleting:
 			updater := func(tx *libmodel.Tx) (err error) {


### PR DESCRIPTION
If a volume of a VM changes we need to update the VM's revision to make sure it is revalidated

backport of  #569