### PR TITLE
Fix migrations to restricted namespaces

### DIFF
--- a/operator/BUILD.bazel
+++ b/operator/BUILD.bazel
@@ -80,7 +80,7 @@ genrule(
     cmd = """
         cd operator;
         export DATE=$$(date +%Y-%m-%dT%H:%M:%SZ);
-        ../$(location :kustomize_bin) build config/manifests --load_restrictor LoadRestrictionsNone | envsubst | ../$(location @operator-sdk//file) generate bundle -q --overwrite --extra-service-accounts forklift-controller,forklift-api --version $${VERSION} --output-dir ../$(RULEDIR)/bundle --channels=$${CHANNELS} --default-channel=$${DEFAULT_CHANNEL}
+        ../$(location :kustomize_bin) build config/manifests --load_restrictor LoadRestrictionsNone | envsubst | ../$(location @operator-sdk//file) generate bundle -q --overwrite --extra-service-accounts forklift-controller,forklift-api,forklift-populator-controller --version $${VERSION} --output-dir ../$(RULEDIR)/bundle --channels=$${CHANNELS} --default-channel=$${DEFAULT_CHANNEL}
     """,
 )
 

--- a/operator/config/rbac/kustomization.yaml
+++ b/operator/config/rbac/kustomization.yaml
@@ -20,6 +20,11 @@ resources:
 - api/role.yaml
 - api/role_binding.yaml
 
+# forklift-populator-controller service account
+- populator-controller/service_account.yaml
+- populator-controller/role.yaml
+- populator-controller/role_binding.yaml
+
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/operator/config/rbac/populator-controller/role.yaml
+++ b/operator/config/rbac/populator-controller/role.yaml
@@ -1,0 +1,137 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: forklift-populator-controller-role
+rules:
+  - apiGroups:
+      - forklift.konveyor.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - secrets
+      - namespaces
+      - events
+      - configmaps
+      # PVs added for the populator(s) that uses the same role as forklift-controller
+      - persistentvolumes
+      - persistentvolumeclaims
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - k8s.cni.cncf.io
+    resources:
+      - network-attachment-definitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachines/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datavolumes
+      - datavolumes/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - anyuid
+    verbs:
+      - use
+  - apiGroups:
+      - template.openshift.io
+    resources:
+      - templates
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - export.kubevirt.io
+    resources:
+      - virtualmachineexports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/operator/config/rbac/populator-controller/role_binding.yaml
+++ b/operator/config/rbac/populator-controller/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: forklift-populator-controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: forklift-populator-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: forklift-populator-controller
+    namespace: system

--- a/operator/config/rbac/populator-controller/service_account.yaml
+++ b/operator/config/rbac/populator-controller/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: forklift-populator-controller
+  namespace: system

--- a/operator/roles/forkliftcontroller/templates/controller/controller-scc.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/controller-scc.yml.j2
@@ -10,3 +10,5 @@ runAsUser:
 seLinuxContext:
   type: RunAsAny
 allowPrivilegedContainer: false
+seccompProfiles:
+  - runtime/default

--- a/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
@@ -13,7 +13,7 @@ spec:
       labels:
         app: {{ app_name }}
     spec:
-      serviceAccountName: forklift-controller
+      serviceAccountName: forklift-populator-controller
       containers:
         - name: {{ populator_controller_container_name }}
           image: {{ populator_controller_image_fqin }}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -655,6 +655,11 @@ func (r *KubeVirt) createPodToBindPVCs(vm *plan.VMStatus, pvcNames []string) (er
 				},
 			},
 			Volumes: volumes,
+			SecurityContext: &core.PodSecurityContext{
+				SeccompProfile: &core.SeccompProfile{
+					Type: core.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 		},
 	}
 	// Align with the conversion pod request, to prevent breakage
@@ -1236,6 +1241,9 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 				FSGroup:      &fsGroup,
 				RunAsUser:    &user,
 				RunAsNonRoot: &nonRoot,
+				SeccompProfile: &core.SeccompProfile{
+					Type: core.SeccompProfileTypeRuntimeDefault,
+				},
 			},
 			RestartPolicy:  core.RestartPolicyNever,
 			InitContainers: initContainers,

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -922,6 +922,9 @@ func makePopulatePodSpec(pvcPrimeName, secretName string) corev1.PodSpec {
 		},
 		SecurityContext: &corev1.PodSecurityContext{
 			FSGroup: &user,
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		},
 		RestartPolicy: corev1.RestartPolicyNever,
 		Volumes: []corev1.Volume{


### PR DESCRIPTION
In order to run on restricted namespaces, the v2v/populator pods need to be set with securityContext.seccompProfile.type that is either RuntimeDefault or Localhost. Thus, we set it in the security context constraints of the service account forklift-controller.
This PR also introduces a new service account for the forklift-populator-controller pod. Currently, it uses the same RBAC as forklift-controller service account. Later on, we will restrict the RBAC to what the populator-controller needs.

Fixes #173
