### PR TITLE
api: Add Forklift API to scheme during initialization

### DIFF
--- a/cmd/forklift-api/BUILD.bazel
+++ b/cmd/forklift-api/BUILD.bazel
@@ -6,9 +6,11 @@ go_library(
     importpath = "github.com/konveyor/forklift-controller/cmd/forklift-api",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis",
         "//pkg/forklift-api",
         "//pkg/lib/logging",
         "//vendor/github.com/go-logr/logr",
+        "//vendor/k8s.io/client-go/kubernetes/scheme",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/log",
     ],
 )

--- a/cmd/forklift-api/forklift-api.go
+++ b/cmd/forklift-api/forklift-api.go
@@ -17,9 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"os"
+
 	"github.com/go-logr/logr"
+	"github.com/konveyor/forklift-controller/pkg/apis"
 	forklift_api "github.com/konveyor/forklift-controller/pkg/forklift-api"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
+	"k8s.io/client-go/kubernetes/scheme"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -34,5 +38,12 @@ func init() {
 func main() {
 	log.Info("start forklift-api")
 	app := forklift_api.NewForkliftApi()
+
+	err := apis.AddToScheme(scheme.Scheme)
+	if err != nil {
+		log.Error(err, "unable to add forklift API to scheme")
+		os.Exit(1)
+	}
+
 	app.Execute()
 }

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/konveyor/forklift-controller/pkg/apis"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	adapter "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/container"
@@ -163,17 +162,6 @@ func (admitter *SecretAdmitter) testConnectionToHost(hostName string) (tested bo
 		return
 	}
 
-	err = api.SchemeBuilder.AddToScheme(scheme.Scheme)
-	if err != nil {
-		log.Error(err, "Couldn't build the scheme")
-		return
-	}
-	err = apis.AddToScheme(scheme.Scheme)
-	if err != nil {
-		log.Error(err, "Couldn't add forklift API to the scheme")
-		return
-	}
-
 	cl, err := client.New(config, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		log.Error(err, "Couldn't create a cluster client")
@@ -243,21 +231,9 @@ func (admitter *SecretAdmitter) validateUpdateOfOVAProviderSecret() *admissionv1
 }
 
 func (admitter *SecretAdmitter) isOvaUrlChanged() (bool, error) {
-
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		log.Error(err, "Couldn't get the cluster configuration")
-		return false, err
-	}
-
-	err = api.SchemeBuilder.AddToScheme(scheme.Scheme)
-	if err != nil {
-		log.Error(err, "Couldn't build the scheme")
-		return false, err
-	}
-	err = apis.AddToScheme(scheme.Scheme)
-	if err != nil {
-		log.Error(err, "Couldn't add forklift API to the scheme")
 		return false, err
 	}
 


### PR DESCRIPTION
... rather than when the hooks are called to avoid "concurrent map read and map write" error.

backport of #578 