### PR TITLE
OVA: changing nfs mount to server and conversion pod to use shared PVC

### DIFF
--- a/pkg/controller/plan/BUILD.bazel
+++ b/pkg/controller/plan/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime",
         "//vendor/k8s.io/apimachinery/pkg/types",
         "//vendor/k8s.io/apimachinery/pkg/util/validation",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait",
         "//vendor/k8s.io/apiserver/pkg/storage/names",
         "//vendor/k8s.io/client-go/kubernetes/scheme",
         "//vendor/kubevirt.io/api/core/v1:core",

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -340,7 +340,7 @@ func (r *Migration) Archive() {
 	if r.Plan.Provider.Source.Type() == v1beta1.Ova {
 		err = r.deletePvcPvForOva()
 		if err != nil {
-			r.Log.Error(err, "Failed to cleanup the PVC and PV for OVA plan")
+			r.Log.Error(err, "Failed to clean up the PVC and PV for the OVA plan")
 			return
 		}
 	}

--- a/pkg/controller/provider/BUILD.bazel
+++ b/pkg/controller/provider/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "provider",
     srcs = [
         "controller.go",
+        "ova-setup.go",
         "predicate.go",
         "validation.go",
     ],
@@ -30,6 +31,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:apps",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/api/errors",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr",
         "//vendor/k8s.io/apiserver/pkg/storage/names",

--- a/pkg/controller/provider/container/ova/client.go
+++ b/pkg/controller/provider/container/ova/client.go
@@ -48,7 +48,7 @@ func (r *Client) Connect(provider *api.Provider) (err error) {
 		},
 	}
 
-	serverURL := fmt.Sprintf("http://ova-service-%s:8080", provider.Name)
+	serverURL := fmt.Sprintf("http://ova-service-%s.%s.svc.cluster.local:8080", provider.Name, provider.Namespace)
 	if serverURL == "" {
 		return
 	}

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -187,7 +187,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 
 	if provider.Type() == api.Ova {
 
-		deploymentName := fmt.Sprintf("%s-deployment-%s", ovaServerPrefix, provider.Name)
+		deploymentName := fmt.Sprintf("%s-deployment-%s", ovaServer, provider.Name)
 
 		deployment := &appsv1.Deployment{}
 		err = r.Get(context.TODO(), client.ObjectKey{

--- a/pkg/controller/provider/ova-setup.go
+++ b/pkg/controller/provider/ova-setup.go
@@ -93,7 +93,7 @@ func (r *Reconciler) createPvForNfs(provider *api.Provider, ctx context.Context,
 
 func (r *Reconciler) createPvcForNfs(provider *api.Provider, ctx context.Context, ownerReference metav1.OwnerReference, pvName, pvcName string) (err error) {
 	sc := ""
-	labels := map[string]string{"providerName": provider.Name, "app": "forklift", "subapp": "ova-server"}
+	labels := map[string]string{"provider": provider.Name, "app": "forklift", "subapp": "ova-server"}
 	pvc := &core.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            pvcName,
@@ -137,11 +137,7 @@ func (r *Reconciler) createServerDeployment(provider *api.Provider, ctx context.
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app":      "forklift",
-					"provider": provider.Name,
-					"subapp":   "ova-server",
-				},
+				MatchLabels: labels,
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/provider/ova-setup.go
+++ b/pkg/controller/provider/ova-setup.go
@@ -1,0 +1,205 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	ovaServerPrefix     = "ova-server"
+	ovaImageVar         = "OVA_PROVIDER_SERVER_IMAGE"
+	nfsVolumeNamePrefix = "nfs-volume"
+	mountPath           = "/ova"
+	pvSize              = "1Gi"
+)
+
+func (r *Reconciler) CreateOVAServerDeployment(provider *api.Provider, ctx context.Context) {
+
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "forklift.konveyor.io/v1beta1",
+		Kind:       "Provider",
+		Name:       provider.Name,
+		UID:        provider.UID,
+	}
+
+	pvName := fmt.Sprintf("%s-pv-%s", ovaServerPrefix, provider.Name)
+	splitted := strings.Split(provider.Spec.URL, ":")
+
+	if len(splitted) != 2 {
+		r.Log.Error(nil, "NFS server path doesn't contains :")
+	}
+	nfsServer := splitted[0]
+	nfsPath := splitted[1]
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pvName,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+		},
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadOnlyMany,
+			},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				NFS: &v1.NFSVolumeSource{
+					Path:   nfsPath,
+					Server: nfsServer,
+				},
+			},
+		},
+	}
+	err := r.Create(ctx, pv)
+	if err != nil {
+		r.Log.Error(err, "Failed to create OVA server PV")
+		return
+	}
+
+	pvcName := fmt.Sprintf("%s-pvc-%s", ovaServerPrefix, provider.Name)
+	sc := ""
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pvcName,
+			Namespace:       provider.Namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadOnlyMany,
+			},
+			VolumeName:       pvName,
+			StorageClassName: &sc,
+		},
+	}
+	err = r.Create(ctx, pvc)
+	if err != nil {
+		r.Log.Error(err, "Failed to create OVA server PVC")
+		return
+	}
+
+	deploymentName := fmt.Sprintf("%s-deployment-%s", ovaServerPrefix, provider.Name)
+	annotations := make(map[string]string)
+	labels := map[string]string{"providerName": provider.Name, "app": "forklift"}
+	var replicas int32 = 1
+
+	//OVA server deployment
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            deploymentName,
+			Namespace:       provider.Namespace,
+			Annotations:     annotations,
+			Labels:          labels,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "forklift",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"providerName": provider.Name,
+						"app":          "forklift",
+					},
+				},
+				Spec: r.makeOvaProviderPodSpec(pvcName, string(provider.Name)),
+			},
+		},
+	}
+
+	err = r.Create(ctx, deployment)
+	if err != nil {
+		r.Log.Error(err, "Failed to create OVA server deployment")
+		return
+	}
+
+	// OVA Server Service
+	serviceName := fmt.Sprintf("ova-service-%s", provider.Name)
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            serviceName,
+			Namespace:       provider.Namespace,
+			Labels:          labels,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+		},
+		Spec: v1.ServiceSpec{
+			Selector: map[string]string{
+				"providerName": provider.Name,
+				"app":          "forklift",
+			},
+			Ports: []v1.ServicePort{
+				{
+					Name:       "api-http",
+					Protocol:   v1.ProtocolTCP,
+					Port:       8080,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+			Type: v1.ServiceTypeClusterIP,
+		},
+	}
+
+	err = r.Create(ctx, service)
+	if err != nil {
+		r.Log.Error(err, "Failed to create OVA server service")
+		return
+	}
+}
+
+func (r *Reconciler) makeOvaProviderPodSpec(pvcName string, providerName string) v1.PodSpec {
+
+	imageName, ok := os.LookupEnv(ovaImageVar)
+	if !ok {
+		r.Log.Error(nil, "Failed to find OVA server image")
+	}
+
+	nfsVolumeName := fmt.Sprintf("%s-%s", nfsVolumeNamePrefix, providerName)
+
+	ovaContainerName := fmt.Sprintf("%s-pod-%s", ovaServerPrefix, providerName)
+
+	return v1.PodSpec{
+
+		Containers: []v1.Container{
+			{
+				Name:  ovaContainerName,
+				Ports: []v1.ContainerPort{{ContainerPort: 8080, Protocol: v1.ProtocolTCP}},
+				Image: imageName,
+				VolumeMounts: []v1.VolumeMount{
+					{
+						Name:      nfsVolumeName,
+						MountPath: "/ova",
+					},
+				},
+			},
+		},
+		Volumes: []v1.Volume{
+			{
+				Name: nfsVolumeName,
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/provider/ova-setup.go
+++ b/pkg/controller/provider/ova-setup.go
@@ -29,21 +29,21 @@ func (r Reconciler) CreateOVAServerDeployment(provider *api.Provider, ctx contex
 		Name:       provider.Name,
 		UID:        provider.UID,
 	}
-	pvName := fmt.Sprintf("%s-pv-%s", ovaServerPrefix, provider.Name)
+	pvName := fmt.Sprintf("%s-pv-%s-%s", ovaServerPrefix, provider.Name, provider.Namespace)
 	err := r.createPvForNfs(provider, ctx, ownerReference, pvName)
 	if err != nil {
-		r.Log.Error(err, "Failed to create NFS PV for the OVA server")
+		r.Log.Error(err, "Failed to create PV for the OVA server")
 		return
 	}
 
 	pvcName := fmt.Sprintf("%s-pvc-%s", ovaServerPrefix, provider.Name)
 	err = r.createPvcForNfs(provider, ctx, ownerReference, pvName, pvcName)
 	if err != nil {
-		r.Log.Error(err, "Failed to create NFS PVC for the OVA server")
+		r.Log.Error(err, "Failed to create PVC for the OVA server")
 		return
 	}
 
-	labels := map[string]string{"providerName": provider.Name, "app": "forklift"}
+	labels := map[string]string{"provider": provider.Name, "app": "forklift", "subapp": "ova-server"}
 	err = r.createServerDeployment(provider, ctx, ownerReference, pvcName, labels)
 	if err != nil {
 		r.Log.Error(err, "Failed to create OVA server deployment")
@@ -59,17 +59,15 @@ func (r Reconciler) CreateOVAServerDeployment(provider *api.Provider, ctx contex
 
 func (r *Reconciler) createPvForNfs(provider *api.Provider, ctx context.Context, ownerReference metav1.OwnerReference, pvName string) (err error) {
 	splitted := strings.Split(provider.Spec.URL, ":")
-	if len(splitted) != 2 {
-		r.Log.Error(nil, "NFS server path doesn't contains: ", "provider", provider, "url", provider.Spec.URL)
-		return fmt.Errorf("wrong NFS server path")
-	}
 	nfsServer := splitted[0]
 	nfsPath := splitted[1]
+	labels := map[string]string{"provider": provider.Name, "app": "forklift", "subapp": "ova-server"}
 
 	pv := &core.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            pvName,
 			OwnerReferences: []metav1.OwnerReference{ownerReference},
+			Labels:          labels,
 		},
 		Spec: core.PersistentVolumeSpec{
 			Capacity: core.ResourceList{
@@ -95,11 +93,13 @@ func (r *Reconciler) createPvForNfs(provider *api.Provider, ctx context.Context,
 
 func (r *Reconciler) createPvcForNfs(provider *api.Provider, ctx context.Context, ownerReference metav1.OwnerReference, pvName, pvcName string) (err error) {
 	sc := ""
+	labels := map[string]string{"providerName": provider.Name, "app": "forklift", "subapp": "ova-server"}
 	pvc := &core.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            pvcName,
 			Namespace:       provider.Namespace,
 			OwnerReferences: []metav1.OwnerReference{ownerReference},
+			Labels:          labels,
 		},
 		Spec: core.PersistentVolumeClaimSpec{
 			Resources: core.ResourceRequirements{
@@ -138,7 +138,9 @@ func (r *Reconciler) createServerDeployment(provider *api.Provider, ctx context.
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": "forklift",
+					"app":      "forklift",
+					"provider": provider.Name,
+					"subapp":   "ova-server",
 				},
 			},
 			Template: core.PodTemplateSpec{


### PR DESCRIPTION
Until now when adding a new OVA provider we were mount the NFS volume directly to the server/ conversion pod, this worked for some of the cases but wasn't supported on a restricted or different namespaces from forklift/MTV since NFS is not permitted. This fix switch the use of NFS to used shared PVC for both of the cases instead.

