### PR TITLE
ocp: consider missing namespace in network name

### DIFF
--- a/pkg/controller/plan/adapter/ocp/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ocp/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "ocp",
@@ -34,4 +34,11 @@ go_library(
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client/config",
     ],
+)
+
+go_test(
+    name = "ocp_test",
+    srcs = ["validator_test.go"],
+    embed = [":ocp"],
+    deps = ["//pkg/apis/forklift/v1beta1/ref"],
 )

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -161,15 +161,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 				return false, err
 			}
 		} else if net.Multus != nil {
-			var namespace, name string
-
-			if !strings.Contains(net.Multus.NetworkName, "/") {
-				namespace = vmRef.Namespace
-				name = net.Multus.NetworkName
-			} else {
-				splitName := strings.Split(net.Multus.NetworkName, "/")
-				namespace, name = splitName[0], splitName[1]
-			}
+			namespace, name := getNetworkNameAndNamespace(net.Multus.NetworkName, &vmRef)
 
 			_, found := r.plan.Referenced.Map.Network.FindNetworkByNameAndNamespace(namespace, name)
 			if !found {
@@ -185,4 +177,16 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	return true, nil
+}
+
+func getNetworkNameAndNamespace(networkName string, vmRef *ref.Ref) (name, namespace string) {
+	if !strings.Contains(networkName, "/") {
+		namespace = vmRef.Namespace
+		name = networkName
+	} else {
+		splitName := strings.Split(networkName, "/")
+		namespace, name = splitName[0], splitName[1]
+	}
+
+	return
 }

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -161,8 +161,16 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 				return false, err
 			}
 		} else if net.Multus != nil {
-			namespace := strings.Split(net.Multus.NetworkName, "/")[0]
-			name := strings.Split(net.Multus.NetworkName, "/")[1]
+			var namespace, name string
+
+			if !strings.Contains(net.Multus.NetworkName, "/") {
+				namespace = vmRef.Namespace
+				name = net.Multus.NetworkName
+			} else {
+				splitName := strings.Split(net.Multus.NetworkName, "/")
+				namespace, name = splitName[0], splitName[1]
+			}
+
 			_, found := r.plan.Referenced.Map.Network.FindNetworkByNameAndNamespace(namespace, name)
 			if !found {
 				err = liberr.Wrap(

--- a/pkg/controller/plan/adapter/ocp/validator_test.go
+++ b/pkg/controller/plan/adapter/ocp/validator_test.go
@@ -1,0 +1,41 @@
+package ocp
+
+import (
+	"testing"
+
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+)
+
+func TestGetNetworkNameAndNamespace(t *testing.T) {
+	tests := []struct {
+		name         string
+		networkName  string
+		vmRef        *ref.Ref
+		expectedName string
+		expectedNS   string
+	}{
+		{
+			name:         "no slash in network name",
+			networkName:  "network",
+			vmRef:        &ref.Ref{Namespace: "vmNamespace"},
+			expectedName: "network",
+			expectedNS:   "vmNamespace",
+		},
+		{
+			name:         "slash in network name",
+			networkName:  "namespace/network",
+			vmRef:        &ref.Ref{Namespace: "vmNamespace"},
+			expectedName: "network",
+			expectedNS:   "namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualName, actualNS := getNetworkNameAndNamespace(tt.networkName, &ref.Ref{Namespace: tt.vmRef.Namespace})
+			if actualName != tt.expectedName || actualNS != tt.expectedNS {
+				t.Errorf("got (%s, %s), want (%s, %s)", actualName, actualNS, tt.expectedName, tt.expectedNS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The namespace may be missing from the network name, in this case we need to use the VM's namespace