### PR TITLE
Increase timeout of validation webhooks to 30 sec

### DIFF
--- a/operator/roles/forkliftcontroller/templates/api/validatingwebhookconfiguration-plans.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/validatingwebhookconfiguration-plans.yml.j2
@@ -35,3 +35,4 @@ webhooks:
     - CREATE
     - UPDATE
   sideEffects: None
+  timeoutSeconds: 30

--- a/operator/roles/forkliftcontroller/templates/api/validatingwebhookconfiguration-providers.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/validatingwebhookconfiguration-providers.yml.j2
@@ -35,3 +35,4 @@ webhooks:
     - CREATE
     - UPDATE
   sideEffects: None
+  timeoutSeconds: 30

--- a/operator/roles/forkliftcontroller/templates/api/validatingwebhookconfiguration-secrets.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/validatingwebhookconfiguration-secrets.yml.j2
@@ -39,3 +39,4 @@ webhooks:
     - secrets
     scope: Namespaced
   sideEffects: None
+  timeoutSeconds: 30


### PR DESCRIPTION
10 seconds are usually enough but in some cases, it takes few seconds to instantiate a client for interacting with the cluster and then this 10 seconds timeout is reached. Therefore, aligning the timeout of the validation webhooks with that of mutating webhooks.

backport of https://github.com/kubev2v/forklift/pull/607