### PR TITLE
use a single client in webhooks

### DIFF
--- a/cmd/forklift-api/BUILD.bazel
+++ b/cmd/forklift-api/BUILD.bazel
@@ -10,7 +10,11 @@ go_library(
         "//pkg/forklift-api",
         "//pkg/lib/logging",
         "//vendor/github.com/go-logr/logr",
+        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:k8s_cni_cncf_io",
         "//vendor/k8s.io/client-go/kubernetes/scheme",
+        "//vendor/k8s.io/client-go/rest",
+        "//vendor/k8s.io/client-go/tools/clientcmd/api",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/log",
     ],
 )

--- a/pkg/forklift-api/BUILD.bazel
+++ b/pkg/forklift-api/BUILD.bazel
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//pkg/forklift-api/webhooks",
         "//pkg/lib/logging",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
     ],
 )

--- a/pkg/forklift-api/api.go
+++ b/pkg/forklift-api/api.go
@@ -22,6 +22,7 @@ import (
 
 	webhooks "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -42,13 +43,15 @@ type forkliftAPIApp struct {
 	Name        string
 	BindAddress string
 	Port        int
+	client      client.Client
 }
 
-func NewForkliftApi() ForkliftApi {
+func NewForkliftApi(client client.Client) ForkliftApi {
 
 	app := &forkliftAPIApp{}
 	app.BindAddress = defaultHost
 	app.Port = defaultPort
+	app.client = client
 
 	return app
 }
@@ -66,8 +69,8 @@ func (app *forkliftAPIApp) Execute() {
 	}
 
 	mux := http.NewServeMux()
-	webhooks.RegisterMutatingWebhooks(mux)
-	webhooks.RegisterValidatingWebhooks(mux)
+	webhooks.RegisterMutatingWebhooks(mux, app.client)
+	webhooks.RegisterValidatingWebhooks(mux, app.client)
 	server := http.Server{
 		Addr:    ":8443",
 		Handler: mux,

--- a/pkg/forklift-api/webhooks/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/forklift-api/webhooks/validating-webhook",
         "//pkg/forklift-api/webhooks/validating-webhook/admitters",
         "//pkg/lib/logging",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager",
     ],
 )

--- a/pkg/forklift-api/webhooks/mutating-webhook.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook.go
@@ -5,12 +5,13 @@ import (
 
 	mutating_webhooks "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/mutating-webhook"
 	"github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/mutating-webhook/mutators"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func ServeSecretMutator(resp http.ResponseWriter, req *http.Request) {
 	mutating_webhooks.Serve(resp, req, &mutators.SecretMutator{})
 }
 
-func ServePlanMutator(resp http.ResponseWriter, req *http.Request) {
-	mutating_webhooks.Serve(resp, req, &mutators.PlanMutator{})
+func ServePlanMutator(resp http.ResponseWriter, req *http.Request, client client.Client) {
+	mutating_webhooks.Serve(resp, req, &mutators.PlanMutator{Client: client})
 }

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/mutating-webhook/mutators",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis",
         "//pkg/apis/forklift/v1beta1",
         "//pkg/forklift-api/webhooks/util",
         "//pkg/lib/error",
@@ -19,8 +18,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/api/errors",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
-        "//vendor/k8s.io/client-go/kubernetes/scheme",
-        "//vendor/k8s.io/client-go/rest",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
     ],
 )

--- a/pkg/forklift-api/webhooks/validating-webhook.go
+++ b/pkg/forklift-api/webhooks/validating-webhook.go
@@ -5,16 +5,17 @@ import (
 
 	validating_webhooks "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/validating-webhook"
 	"github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/validating-webhook/admitters"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ServeSecretCreate(resp http.ResponseWriter, req *http.Request) {
-	validating_webhooks.Serve(resp, req, &admitters.SecretAdmitter{})
+func ServeSecretCreate(resp http.ResponseWriter, req *http.Request, client client.Client) {
+	validating_webhooks.Serve(resp, req, &admitters.SecretAdmitter{Client: client})
 }
 
-func ServePlanCreate(resp http.ResponseWriter, req *http.Request) {
-	validating_webhooks.Serve(resp, req, &admitters.PlanAdmitter{})
+func ServePlanCreate(resp http.ResponseWriter, req *http.Request, client client.Client) {
+	validating_webhooks.Serve(resp, req, &admitters.PlanAdmitter{Client: client})
 }
 
-func ServeProviderCreate(resp http.ResponseWriter, req *http.Request) {
-	validating_webhooks.Serve(resp, req, &admitters.ProviderAdmitter{})
+func ServeProviderCreate(resp http.ResponseWriter, req *http.Request, client client.Client) {
+	validating_webhooks.Serve(resp, req, &admitters.ProviderAdmitter{Client: client})
 }

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/validating-webhook/admitters",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis",
         "//pkg/apis/forklift/v1beta1",
         "//pkg/controller/plan/adapter/vsphere",
         "//pkg/controller/provider/container",
@@ -26,8 +25,6 @@ go_library(
         "//vendor/k8s.io/api/storage/v1:storage",
         "//vendor/k8s.io/apimachinery/pkg/api/errors",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
-        "//vendor/k8s.io/client-go/kubernetes/scheme",
-        "//vendor/k8s.io/client-go/rest",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
     ],
 )

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
@@ -4,22 +4,21 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/konveyor/forklift-controller/pkg/apis"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/util"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	admissionv1 "k8s.io/api/admission/v1beta1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ProviderAdmitter struct {
-	client   client.Client
+	Client   client.Client
 	provider api.Provider
 }
 
 func (admitter *ProviderAdmitter) validateVDDK() error {
+	log.Info("not sleeping for 10 seconds")
+	//time.Sleep(10 * time.Second)
 	if admitter.provider.Type() != api.VSphere {
 		log.Info("Provider of this type does not require VDDK, passing", "type", admitter.provider.Type())
 		return nil
@@ -31,7 +30,7 @@ func (admitter *ProviderAdmitter) validateVDDK() error {
 	}
 
 	plans := api.PlanList{}
-	err := admitter.client.List(context.TODO(), &plans, &client.ListOptions{})
+	err := admitter.Client.List(context.TODO(), &plans, &client.ListOptions{})
 	if err != nil {
 		log.Error(err, "Couldn't get all plans", "namespace", admitter.provider.Namespace)
 		return err
@@ -53,7 +52,7 @@ func (admitter *ProviderAdmitter) validateVDDK() error {
 		}
 
 		var destinationProvider api.Provider
-		err = admitter.client.Get(
+		err = admitter.Client.Get(
 			context.TODO(),
 			client.ObjectKey{
 				Namespace: plan.Spec.Provider.Destination.Namespace,
@@ -93,29 +92,6 @@ func (admitter *ProviderAdmitter) Admit(ar *admissionv1.AdmissionReview) *admiss
 
 	err := json.Unmarshal(raw, &admitter.provider)
 	if err != nil {
-		return util.ToAdmissionResponseError(err)
-	}
-
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		log.Error(err, "Couldn't get the cluster configuration")
-		return util.ToAdmissionResponseError(err)
-	}
-
-	err = api.SchemeBuilder.AddToScheme(scheme.Scheme)
-	if err != nil {
-		log.Error(err, "Couldn't build the scheme")
-		return util.ToAdmissionResponseError(err)
-	}
-	err = apis.AddToScheme(scheme.Scheme)
-	if err != nil {
-		log.Error(err, "Couldn't add forklift API to the scheme")
-		return util.ToAdmissionResponseError(err)
-	}
-
-	admitter.client, err = client.New(config, client.Options{Scheme: scheme.Scheme})
-	if err != nil {
-		log.Error(err, "Couldn't create a cluster client")
 		return util.ToAdmissionResponseError(err)
 	}
 

--- a/pkg/forklift-api/webhooks/webhooks.go
+++ b/pkg/forklift-api/webhooks/webhooks.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -28,25 +29,25 @@ func AddToManager(m manager.Manager) error {
 	return nil
 }
 
-func RegisterValidatingWebhooks(mux *http.ServeMux) {
+func RegisterValidatingWebhooks(mux *http.ServeMux, client client.Client) {
 	log.Info("register validation webhooks")
 	mux.HandleFunc(SecretValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		ServeSecretCreate(w, r)
+		ServeSecretCreate(w, r, client)
 	})
 	mux.HandleFunc(PlanValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		ServePlanCreate(w, r)
+		ServePlanCreate(w, r, client)
 	})
 	mux.HandleFunc(ProviderValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		ServeProviderCreate(w, r)
+		ServeProviderCreate(w, r, client)
 	})
 }
 
-func RegisterMutatingWebhooks(mux *http.ServeMux) {
+func RegisterMutatingWebhooks(mux *http.ServeMux, client client.Client) {
 	log.Info("register mutation webhook")
 	mux.HandleFunc(SecretMutatorPath, func(w http.ResponseWriter, r *http.Request) {
 		ServeSecretMutator(w, r)
 	})
 	mux.HandleFunc(PlanMutatorPath, func(w http.ResponseWriter, r *http.Request) {
-		ServePlanMutator(w, r)
+		ServePlanMutator(w, r, client)
 	})
 }


### PR DESCRIPTION
By using a single client that is injected to the webooks we not only decrease the execution time of webhooks that interact with the cluster (and thus need the client) but also resolve an issue that happens in some environments where it takes relatively long time to instantiate the client (few seconds) and then the execution of the webhook reaches a 13-seconds timeout. The deployment of Forklift gets stuck when this repeatedly happens when trying to add the "default host provider".