### PR TITLE
Backport https://github.com/kubev2v/forklift/pull/592

### DIFF
--- a/pkg/controller/plan/BUILD.bazel
+++ b/pkg/controller/plan/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime",
         "//vendor/k8s.io/apimachinery/pkg/types",
         "//vendor/k8s.io/apimachinery/pkg/util/validation",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait",
         "//vendor/k8s.io/apiserver/pkg/storage/names",
         "//vendor/k8s.io/client-go/kubernetes/scheme",
         "//vendor/kubevirt.io/api/core/v1:core",

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/controller/plan/adapter"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
@@ -336,6 +337,14 @@ func (r *Migration) Archive() {
 		return
 	}
 
+	if r.Plan.Provider.Source.Type() == v1beta1.Ova {
+		err = r.deletePvcPvForOva()
+		if err != nil {
+			r.Log.Error(err, "Failed to clean up the PVC and PV for the OVA plan")
+			return
+		}
+	}
+
 	for _, vm := range r.Plan.Status.Migration.VMs {
 		err = r.CleanUp(vm)
 		if err != nil {
@@ -482,6 +491,41 @@ func (r *Migration) deleteImporterPods(vm *plan.VMStatus) (err error) {
 		if err != nil {
 			return
 		}
+	}
+	return
+}
+
+func (r *Migration) deletePvcPvForOva() (err error) {
+	pvc, _, err := GetOvaPvcNfs(r.Destination.Client, r.Plan.Name, r.Plan.Spec.TargetNamespace, r.Plan.Provider.Source.Name)
+	if err != nil {
+		r.Log.Error(err, "Failed to get the plan PVC")
+		return
+	}
+	// The PVC was already deleted
+	if pvc == nil {
+		return
+	}
+
+	err = r.Destination.Client.Delete(context.TODO(), pvc)
+	if err != nil {
+		r.Log.Error(err, "Failed to delete the plan PVC")
+		return
+	}
+
+	pv, _, err := GetOvaPvNfs(r.Destination.Client, r.Plan.Name, r.Plan.Provider.Source.Name)
+	if err != nil {
+		r.Log.Error(err, "Failed to get the plan PV")
+		return
+	}
+	// The PV was already deleted
+	if pv == nil {
+		return
+	}
+
+	err = r.Destination.Client.Delete(context.TODO(), pv)
+	if err != nil {
+		r.Log.Error(err, "Failed to delete the plan PV")
+		return
 	}
 	return
 }

--- a/pkg/controller/provider/BUILD.bazel
+++ b/pkg/controller/provider/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "provider",
     srcs = [
         "controller.go",
+        "ova-setup.go",
         "predicate.go",
         "validation.go",
     ],
@@ -30,6 +31,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:apps",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/api/errors",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr",
         "//vendor/k8s.io/apiserver/pkg/storage/names",

--- a/pkg/controller/provider/container/ova/client.go
+++ b/pkg/controller/provider/container/ova/client.go
@@ -48,7 +48,7 @@ func (r *Client) Connect(provider *api.Provider) (err error) {
 		},
 	}
 
-	serverURL := fmt.Sprintf("http://ova-service-%s:8080", provider.Name)
+	serverURL := fmt.Sprintf("http://ova-service-%s.%s.svc.cluster.local:8080", provider.Name, provider.Namespace)
 	if serverURL == "" {
 		return
 	}

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
@@ -42,8 +41,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apiserver/pkg/storage/names"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -63,13 +60,6 @@ var log = logging.WithName(Name)
 
 // Application settings.
 var Settings = &settings.Settings
-
-const (
-	ovaServerPrefix     = "ova-server"
-	ovaImageVar         = "OVA_PROVIDER_SERVER_IMAGE"
-	nfsVolumeNamePrefix = "nfs-volume"
-	mountPath           = "/ova"
-)
 
 // Creates a new Inventory Controller and adds it to the Manager.
 func Add(mgr manager.Manager) error {
@@ -199,7 +189,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 
 	if provider.Type() == api.Ova {
 
-		deploymentName := fmt.Sprintf("%s-deployment-%s", ovaServerPrefix, provider.Name)
+		deploymentName := fmt.Sprintf("%s-deployment-%s", ovaServer, provider.Name)
 
 		deployment := &appsv1.Deployment{}
 		err = r.Get(context.TODO(), client.ObjectKey{
@@ -209,7 +199,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 
 		// If the deployment does not exist
 		if k8serr.IsNotFound(err) {
-			r.createOVAServerDeployment(provider, ctx)
+			r.CreateOVAServerDeployment(provider, ctx)
 		} else if err != nil {
 			return
 		}
@@ -364,141 +354,6 @@ func (r *Reconciler) getSecret(provider *api.Provider) (*v1.Secret, error) {
 	}
 
 	return secret, nil
-}
-
-func (r *Reconciler) createOVAServerDeployment(provider *api.Provider, ctx context.Context) {
-
-	deploymentName := fmt.Sprintf("%s-deployment-%s", ovaServerPrefix, provider.Name)
-	annotations := make(map[string]string)
-	labels := map[string]string{"providerName": provider.Name, "app": "forklift"}
-	url := provider.Spec.URL
-	var replicas int32 = 1
-
-	ownerReference := metav1.OwnerReference{
-		APIVersion: "forklift.konveyor.io/v1beta1",
-		Kind:       "Provider",
-		Name:       provider.Name,
-		UID:        provider.UID,
-	}
-
-	//OVA server deployment
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            deploymentName,
-			Namespace:       provider.Namespace,
-			Annotations:     annotations,
-			Labels:          labels,
-			OwnerReferences: []metav1.OwnerReference{ownerReference},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": "forklift",
-				},
-			},
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"providerName": provider.Name,
-						"app":          "forklift",
-					},
-				},
-				Spec: r.makeOvaProviderPodSpec(url, string(provider.Name)),
-			},
-		},
-	}
-
-	err := r.Create(ctx, deployment)
-	if err != nil {
-		r.Log.Error(err, "Failed to create OVA server deployment")
-		return
-	}
-
-	// OVA Server Service
-	serviceName := fmt.Sprintf("ova-service-%s", provider.Name)
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            serviceName,
-			Namespace:       provider.Namespace,
-			Labels:          labels,
-			OwnerReferences: []metav1.OwnerReference{ownerReference},
-		},
-		Spec: v1.ServiceSpec{
-			Selector: map[string]string{
-				"providerName": provider.Name,
-				"app":          "forklift",
-			},
-			Ports: []v1.ServicePort{
-				{
-					Name:       "api-http",
-					Protocol:   v1.ProtocolTCP,
-					Port:       8080,
-					TargetPort: intstr.FromInt(8080),
-				},
-			},
-			Type: v1.ServiceTypeClusterIP,
-		},
-	}
-
-	err = r.Create(ctx, service)
-	if err != nil {
-		r.Log.Error(err, "Failed to create OVA server service")
-		return
-	}
-}
-
-func (r *Reconciler) makeOvaProviderPodSpec(url string, providerName string) v1.PodSpec {
-	splitted := strings.Split(url, ":")
-	nonRoot := false
-
-	if len(splitted) != 2 {
-		r.Log.Error(nil, "NFS server path doesn't contains :")
-	}
-	nfsServer := splitted[0]
-	nfsPath := splitted[1]
-
-	imageName, ok := os.LookupEnv(ovaImageVar)
-	if !ok {
-		r.Log.Error(nil, "Failed to find OVA server image")
-	}
-
-	nfsVolumeName := fmt.Sprintf("%s-%s", nfsVolumeNamePrefix, providerName)
-
-	ovaContainerName := fmt.Sprintf("%s-pod-%s", ovaServerPrefix, providerName)
-
-	return v1.PodSpec{
-
-		Containers: []v1.Container{
-			{
-				Name:  ovaContainerName,
-				Ports: []v1.ContainerPort{{ContainerPort: 8080, Protocol: v1.ProtocolTCP}},
-				SecurityContext: &v1.SecurityContext{
-					RunAsNonRoot: &nonRoot,
-				},
-				Image: imageName,
-				VolumeMounts: []v1.VolumeMount{
-					{
-						Name:      nfsVolumeName,
-						MountPath: "/ova",
-					},
-				},
-			},
-		},
-		ServiceAccountName: "forklift-controller",
-		Volumes: []v1.Volume{
-			{
-				Name: nfsVolumeName,
-				VolumeSource: v1.VolumeSource{
-					NFS: &v1.NFSVolumeSource{
-						Server:   nfsServer,
-						Path:     nfsPath,
-						ReadOnly: false,
-					},
-				},
-			},
-		},
-	}
 }
 
 // Provider catalog.

--- a/pkg/controller/provider/ova-setup.go
+++ b/pkg/controller/provider/ova-setup.go
@@ -1,0 +1,222 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	ovaServer           = "ova-server"
+	ovaImageVar         = "OVA_PROVIDER_SERVER_IMAGE"
+	nfsVolumeNamePrefix = "nfs-volume"
+	mountPath           = "/ova"
+	pvSize              = "1Gi"
+)
+
+func (r Reconciler) CreateOVAServerDeployment(provider *api.Provider, ctx context.Context) {
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "forklift.konveyor.io/v1beta1",
+		Kind:       "Provider",
+		Name:       provider.Name,
+		UID:        provider.UID,
+	}
+	pvName := fmt.Sprintf("%s-pv-%s-%s", ovaServer, provider.Name, provider.Namespace)
+	err := r.createPvForNfs(provider, ctx, ownerReference, pvName)
+	if err != nil {
+		r.Log.Error(err, "Failed to create PV for the OVA server")
+		return
+	}
+
+	pvcName := fmt.Sprintf("%s-pvc-%s", ovaServer, provider.Name)
+	err = r.createPvcForNfs(provider, ctx, ownerReference, pvName, pvcName)
+	if err != nil {
+		r.Log.Error(err, "Failed to create PVC for the OVA server")
+		return
+	}
+
+	labels := map[string]string{"provider": provider.Name, "app": "forklift", "subapp": ovaServer}
+	err = r.createServerDeployment(provider, ctx, ownerReference, pvcName, labels)
+	if err != nil {
+		r.Log.Error(err, "Failed to create OVA server deployment")
+		return
+	}
+
+	err = r.createServerService(provider, ctx, ownerReference, labels)
+	if err != nil {
+		r.Log.Error(err, "Failed to create OVA server service")
+		return
+	}
+}
+
+func (r *Reconciler) createPvForNfs(provider *api.Provider, ctx context.Context, ownerReference metav1.OwnerReference, pvName string) (err error) {
+	splitted := strings.Split(provider.Spec.URL, ":")
+	nfsServer := splitted[0]
+	nfsPath := splitted[1]
+	labels := map[string]string{"provider": provider.Name, "app": "forklift", "subapp": ovaServer}
+
+	pv := &core.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pvName,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+			Labels:          labels,
+		},
+		Spec: core.PersistentVolumeSpec{
+			Capacity: core.ResourceList{
+				core.ResourceStorage: resource.MustParse(pvSize),
+			},
+			AccessModes: []core.PersistentVolumeAccessMode{
+				core.ReadOnlyMany,
+			},
+			PersistentVolumeSource: core.PersistentVolumeSource{
+				NFS: &core.NFSVolumeSource{
+					Path:   nfsPath,
+					Server: nfsServer,
+				},
+			},
+		},
+	}
+	err = r.Create(ctx, pv)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func (r *Reconciler) createPvcForNfs(provider *api.Provider, ctx context.Context, ownerReference metav1.OwnerReference, pvName, pvcName string) (err error) {
+	sc := ""
+	labels := map[string]string{"provider": provider.Name, "app": "forklift", "subapp": ovaServer}
+	pvc := &core.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pvcName,
+			Namespace:       provider.Namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+			Labels:          labels,
+		},
+		Spec: core.PersistentVolumeClaimSpec{
+			Resources: core.ResourceRequirements{
+				Requests: core.ResourceList{
+					core.ResourceStorage: resource.MustParse(pvSize),
+				},
+			},
+			AccessModes: []core.PersistentVolumeAccessMode{
+				core.ReadOnlyMany,
+			},
+			VolumeName:       pvName,
+			StorageClassName: &sc,
+		},
+	}
+	err = r.Create(ctx, pvc)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func (r *Reconciler) createServerDeployment(provider *api.Provider, ctx context.Context, ownerReference metav1.OwnerReference, pvcName string, labels map[string]string) (err error) {
+	deploymentName := fmt.Sprintf("%s-deployment-%s", ovaServer, provider.Name)
+	annotations := make(map[string]string)
+	var replicas int32 = 1
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            deploymentName,
+			Namespace:       provider.Namespace,
+			Annotations:     annotations,
+			Labels:          labels,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: r.makeOvaProviderPodSpec(pvcName, provider.Name),
+			},
+		},
+	}
+
+	err = r.Create(ctx, deployment)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func (r *Reconciler) createServerService(provider *api.Provider, ctx context.Context, ownerReference metav1.OwnerReference, labels map[string]string) (err error) {
+	serviceName := fmt.Sprintf("ova-service-%s", provider.Name)
+	service := &core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            serviceName,
+			Namespace:       provider.Namespace,
+			Labels:          labels,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+		},
+		Spec: core.ServiceSpec{
+			Selector: labels,
+			Ports: []core.ServicePort{
+				{
+					Name:       "api-http",
+					Protocol:   core.ProtocolTCP,
+					Port:       8080,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+			Type: core.ServiceTypeClusterIP,
+		},
+	}
+
+	err = r.Create(ctx, service)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func (r *Reconciler) makeOvaProviderPodSpec(pvcName string, providerName string) core.PodSpec {
+	imageName, ok := os.LookupEnv(ovaImageVar)
+	if !ok {
+		r.Log.Error(nil, "Failed to find OVA server image")
+	}
+
+	nfsVolumeName := fmt.Sprintf("%s-%s", nfsVolumeNamePrefix, providerName)
+	ovaContainerName := fmt.Sprintf("%s-pod-%s", ovaServer, providerName)
+
+	return core.PodSpec{
+		Containers: []core.Container{
+			{
+				Name:  ovaContainerName,
+				Ports: []core.ContainerPort{{ContainerPort: 8080, Protocol: core.ProtocolTCP}},
+				Image: imageName,
+				VolumeMounts: []core.VolumeMount{
+					{
+						Name:      nfsVolumeName,
+						MountPath: mountPath,
+					},
+				},
+			},
+		},
+		Volumes: []core.Volume{
+			{
+				Name: nfsVolumeName,
+				VolumeSource: core.VolumeSource{
+					PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Until now when adding a new OVA provider we were mount the NFS volume directly to the server/ conversion pod, this worked for some of the cases but wasn't supported on a restricted or different namespaces from forklift/MTV since NFS is not permitted. This fix switch the use of NFS to used shared PVC for both of the cases instead.