### PR TITLE
Fix the build of virt-v2v images

### DIFF
--- a/virt-v2v/cold/WORKSPACE
+++ b/virt-v2v/cold/WORKSPACE
@@ -97,6 +97,13 @@ go_repository(
     version = "v1.0.5",
 )
 
+go_repository(
+    name = "com_github_pkg_errors",
+    importpath = "github.com/pkg/errors",
+    sum = "h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=",
+    version = "v0.9.1",
+)
+
 load(
     "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
     docker_toolchain_configure = "toolchain_configure",

--- a/virt-v2v/warm/WORKSPACE
+++ b/virt-v2v/warm/WORKSPACE
@@ -92,6 +92,13 @@ go_repository(
     version = "v1.0.5",
 )
 
+go_repository(
+    name = "com_github_pkg_errors",
+    importpath = "github.com/pkg/errors",
+    sum = "h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=",
+    version = "v0.9.1",
+)
+
 load(
     "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
     docker_toolchain_configure = "toolchain_configure",


### PR DESCRIPTION
After upgrading io_bazel_rules_docker, there is a requirment to have com_github_pkg_errors.

```
Analyzing: target //:push-forklift-virt-v2v (47 packages loaded, 519 targets configured)
ERROR: /home/runner/.cache/bazel/_bazel_runner/77ef990d3c7f0c39ee8ff0e654aac8c8/external/io_bazel_rules_docker/container/go/cmd/pusher/BUILD:22:11: no such package '@com_github_pkg_errors//': The repository '@com_github_pkg_errors' could not be resolved: Repository '@com_github_pkg_errors' is not defined and referenced by '@io_bazel_rules_docker//container/go/cmd/pusher:go_pusher'
ERROR: Analysis of target '//:push-forklift-virt-v2v' failed; build aborted: 
```