### PR TITLE
Fix creation of ova provider in restricted namespaces.

### DIFF
--- a/pkg/controller/provider/ova-setup.go
+++ b/pkg/controller/provider/ova-setup.go
@@ -193,6 +193,8 @@ func (r *Reconciler) makeOvaProviderPodSpec(pvcName string, providerName string)
 
 	nfsVolumeName := fmt.Sprintf("%s-%s", nfsVolumeNamePrefix, providerName)
 	ovaContainerName := fmt.Sprintf("%s-pod-%s", ovaServer, providerName)
+	allowPrivilegeEscalation := false
+	nonRoot := true
 
 	return core.PodSpec{
 		Containers: []core.Container{
@@ -204,6 +206,13 @@ func (r *Reconciler) makeOvaProviderPodSpec(pvcName string, providerName string)
 					{
 						Name:      nfsVolumeName,
 						MountPath: mountPath,
+					},
+				},
+				SecurityContext: &core.SecurityContext{
+					AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+					RunAsNonRoot:             &nonRoot,
+					Capabilities: &core.Capabilities{
+						Drop: []core.Capability{"ALL"},
 					},
 				},
 			},


### PR DESCRIPTION
Currently migration to restricted namespaces is working but the provider creation is failing since the ova-server pod doesn't have proper security configuration to run on such namespaces, this fix adds the missing parts.