### PR TITLE
fix #437: Post VMs with desired 'Running' state

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -464,18 +464,6 @@ func (r *KubeVirt) DeleteVM(vm *plan.VMStatus) (err error) {
 	return
 }
 
-// Set the Running state on a Kubevirt VirtualMachine.
-func (r *KubeVirt) SetRunning(vmCr *VirtualMachine, running bool) (err error) {
-	vmCopy := vmCr.VirtualMachine.DeepCopy()
-	vmCr.VirtualMachine.Spec.Running = &running
-	patch := client.MergeFrom(vmCopy)
-	err = r.Destination.Client.Patch(context.TODO(), vmCr.VirtualMachine, patch)
-	if err != nil {
-		err = liberr.Wrap(err)
-	}
-	return
-}
-
 func (r *KubeVirt) DataVolumes(vm *plan.VMStatus) (dataVolumes []cdi.DataVolume, err error) {
 	secret, err := r.ensureSecret(vm.Ref, r.secretDataSetterForCDI(vm.Ref))
 	if err != nil {
@@ -1091,7 +1079,8 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus) (object *cnv.VirtualMachine
 		object.ObjectMeta.Annotations = annotations
 	}
 
-	running := false
+	// Power on the destination VM if the source VM was originally powered on.
+	running := vm.RestorePowerState == On
 	object.Spec.Running = &running
 
 	err = r.Builder.VirtualMachine(vm.Ref, &object.Spec, pvcs)

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1066,15 +1066,6 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				Durable:  true,
 			})
 
-		// Power on the destination VM if the source VM was originally powered on.
-		err = r.setRunning(vm, vm.RestorePowerState == On)
-		if err != nil {
-			r.Log.Error(err,
-				"Could not power on destination VM.",
-				"vm",
-				vm.String())
-			err = nil
-		}
 	} else if vm.Error != nil {
 		vm.Phase = Completed
 		vm.SetCondition(
@@ -1328,38 +1319,6 @@ func (r *Migration) ensureGuestConversionPod(vm *plan.VMStatus) (err error) {
 	}
 
 	err = r.kubevirt.EnsureGuestConversionPod(vm, &vmCr, &pvcs)
-	return
-}
-
-// Set the running state of the kubevirt VM.
-func (r *Migration) setRunning(vm *plan.VMStatus, running bool) (err error) {
-	if r.vmMap == nil {
-		r.vmMap, err = r.kubevirt.VirtualMachineMap()
-		if err != nil {
-			return
-		}
-	}
-	var vmCr VirtualMachine
-	found := false
-	if vmCr, found = r.vmMap[vm.ID]; !found {
-		// Recreate the map and check again, the map may be stale
-		r.vmMap, err = r.kubevirt.VirtualMachineMap()
-		if err != nil {
-			return
-		}
-
-		if vmCr, found = r.vmMap[vm.ID]; !found {
-			msg := "VirtualMachine CR not found."
-			vm.AddError(msg)
-			return
-		}
-	}
-
-	if vmCr.Spec.Running != nil && *vmCr.Spec.Running == running {
-		return
-	}
-
-	err = r.kubevirt.SetRunning(&vmCr, running)
 	return
 }
 


### PR DESCRIPTION
Long time ago, we posted VMs at the beginning of the migration and then started and stopped them during the migration and therefore in order to restore their original power state, we had to initiate another call to patch the VM with its desired power state.

However, now that we post the VMs at the very last steps of the migration, we can set their desired power state in their specification and avoid another call to the target environment.