### PR TITLE
Keep the populator pod on failure

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -903,7 +903,7 @@ func (r *KubeVirt) SetPopulatorPodOwnership(vm *plan.VMStatus) (err error) {
 		return
 	}
 	for _, pod := range pods {
-		pvcId := strings.Split(pod.Name, "populate-")[1]
+		pvcId := pod.Name[len(PopulatorPodPrefix):]
 		for _, pvc := range pvcs {
 			if string(pvc.UID) != pvcId {
 				continue
@@ -987,7 +987,7 @@ func (r *KubeVirt) getPopulatorPods() (pods []core.Pod, err error) {
 		return nil, liberr.Wrap(err)
 	}
 	for _, pod := range migrationPods.Items {
-		if strings.HasPrefix(pod.Name, "populate-") {
+		if strings.HasPrefix(pod.Name, PopulatorPodPrefix) {
 			pods = append(pods, pod)
 		}
 	}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -89,7 +89,8 @@ const (
 )
 
 const (
-	TransferCompleted = "Transfer completed."
+	TransferCompleted  = "Transfer completed."
+	PopulatorPodPrefix = "populate-"
 )
 
 var (
@@ -1620,7 +1621,7 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 			continue
 		}
 
-		err = r.isPopulatorFailed(populatorPods, string(pvc.UID))
+		_, err = r.isPopulatorFailed(populatorPods, string(pvc.UID))
 		if err != nil {
 			return
 		}
@@ -1647,17 +1648,18 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 	return
 }
 
-func (r *Migration) isPopulatorFailed(populatorPods []core.Pod, givenPvcId string) error {
+func (r *Migration) isPopulatorFailed(populatorPods []core.Pod, givenPvcId string) (bool, error) {
 	for _, pod := range populatorPods {
-		pvcId := strings.Split(pod.Name, "populate-")[1]
+		pvcId := pod.Name[len(PopulatorPodPrefix):]
 		if givenPvcId != pvcId {
 			continue
 		}
 		if pod.Status.Phase == core.PodFailed {
-			return fmt.Errorf("populator pod %s/%s failed for PVC %s. Please check the pod logs.", pod.Namespace, pod.Name, pvcId)
+			return true, fmt.Errorf("populator pod %s/%s failed for PVC %s. Please check the pod logs.", pod.Namespace, pod.Name, pvcId)
 		}
+		break
 	}
-	return nil
+	return false, nil
 }
 
 func (r *Migration) setPopulatorPodsWithLabels(vm *plan.VMStatus, migrationID string) {
@@ -1666,7 +1668,7 @@ func (r *Migration) setPopulatorPodsWithLabels(vm *plan.VMStatus, migrationID st
 		return
 	}
 	for _, pod := range podList.Items {
-		if strings.HasPrefix(pod.Name, "populate-") {
+		if strings.HasPrefix(pod.Name, PopulatorPodPrefix) {
 			// it's populator pod
 			if _, ok := pod.Labels["migration"]; !ok {
 				// un-labeled pod, we need to set it

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1453,7 +1453,7 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 				if r.Plan.Spec.Warm && len(importer.Status.ContainerStatuses) > 0 {
 					vm.Warm.Failures = int(importer.Status.ContainerStatuses[0].RestartCount)
 				}
-				if RestartLimitExceeded(importer) {
+				if restartLimitExceeded(importer) {
 					task.MarkedCompleted()
 					msg, _ := terminationMessage(importer)
 					task.AddError(msg)
@@ -1598,6 +1598,10 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 	if err != nil {
 		return
 	}
+	populatorPods, err := r.kubevirt.getPopulatorPods()
+	if err != nil {
+		return
+	}
 
 	for _, pvc := range pvcs {
 		if _, ok := pvc.Annotations["lun"]; ok {
@@ -1614,6 +1618,16 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 		found := false
 		if task, found = step.FindTask(taskName); !found {
 			continue
+		}
+
+		for _, pod := range populatorPods {
+			pvcId := strings.Split(pod.Name, "populate-")[1]
+			if string(pvc.UID) != pvcId {
+				continue
+			}
+			if pod.Status.Phase == core.PodFailed {
+				return fmt.Errorf("populator pod %s/%s failed for PVC %s. Please check the pod logs.", pod.Namespace, pod.Name, pvcId)
+			}
 		}
 
 		if pvc.Status.Phase == core.ClaimBound {
@@ -1701,7 +1715,7 @@ func terminationMessage(pod *core.Pod) (msg string, ok bool) {
 }
 
 // Return whether the pod has failed and restarted too many times.
-func RestartLimitExceeded(pod *core.Pod) (exceeded bool) {
+func restartLimitExceeded(pod *core.Pod) (exceeded bool) {
 	if len(pod.Status.ContainerStatuses) == 0 {
 		return
 	}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1599,10 +1599,6 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 	if err != nil {
 		return
 	}
-	populatorPods, err := r.kubevirt.getPopulatorPods()
-	if err != nil {
-		return
-	}
 
 	for _, pvc := range pvcs {
 		if _, ok := pvc.Annotations["lun"]; ok {
@@ -1621,11 +1617,6 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 			continue
 		}
 
-		_, err = r.isPopulatorFailed(populatorPods, string(pvc.UID))
-		if err != nil {
-			return
-		}
-
 		if pvc.Status.Phase == core.ClaimBound {
 			task.Phase = Completed
 			task.Reason = TransferCompleted
@@ -1641,25 +1632,39 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 		}
 
 		percent := float64(transferredBytes/0x100000) / float64(task.Progress.Total)
-		task.Progress.Completed = int64(percent * float64(task.Progress.Total))
+		newProgress := int64(percent * float64(task.Progress.Total))
+		if newProgress == task.Progress.Completed {
+			pvcId := string(pvc.UID)
+			populatorFailed := r.isPopulatorPodFailed(pvcId)
+			if populatorFailed {
+				return fmt.Errorf("populator pod failed for PVC %s. Please check the pod logs", pvcId)
+			}
+		}
+		task.Progress.Completed = newProgress
 	}
 
 	step.ReflectTasks()
 	return
 }
 
-func (r *Migration) isPopulatorFailed(populatorPods []core.Pod, givenPvcId string) (bool, error) {
+// Checks if the populator pod failed when the progress didn't change
+func (r *Migration) isPopulatorPodFailed(givenPvcId string) bool {
+	populatorPods, err := r.kubevirt.getPopulatorPods()
+	if err != nil {
+		r.Log.Error(err, "couldn't get the populator pods")
+		return false
+	}
 	for _, pod := range populatorPods {
 		pvcId := pod.Name[len(PopulatorPodPrefix):]
 		if givenPvcId != pvcId {
 			continue
 		}
 		if pod.Status.Phase == core.PodFailed {
-			return true, fmt.Errorf("populator pod %s/%s failed for PVC %s. Please check the pod logs.", pod.Namespace, pod.Name, pvcId)
+			return true
 		}
 		break
 	}
-	return false, nil
+	return false
 }
 
 func (r *Migration) setPopulatorPodsWithLabels(vm *plan.VMStatus, migrationID string) {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1620,14 +1620,9 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 			continue
 		}
 
-		for _, pod := range populatorPods {
-			pvcId := strings.Split(pod.Name, "populate-")[1]
-			if string(pvc.UID) != pvcId {
-				continue
-			}
-			if pod.Status.Phase == core.PodFailed {
-				return fmt.Errorf("populator pod %s/%s failed for PVC %s. Please check the pod logs.", pod.Namespace, pod.Name, pvcId)
-			}
+		err = r.isPopulatorFailed(populatorPods, string(pvc.UID))
+		if err != nil {
+			return
 		}
 
 		if pvc.Status.Phase == core.ClaimBound {
@@ -1650,6 +1645,19 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 
 	step.ReflectTasks()
 	return
+}
+
+func (r *Migration) isPopulatorFailed(populatorPods []core.Pod, givenPvcId string) error {
+	for _, pod := range populatorPods {
+		pvcId := strings.Split(pod.Name, "populate-")[1]
+		if givenPvcId != pvcId {
+			continue
+		}
+		if pod.Status.Phase == core.PodFailed {
+			return fmt.Errorf("populator pod %s/%s failed for PVC %s. Please check the pod logs.", pod.Namespace, pod.Name, pvcId)
+		}
+	}
+	return nil
 }
 
 func (r *Migration) setPopulatorPodsWithLabels(vm *plan.VMStatus, migrationID string) {

--- a/pkg/lib-volume-populator/populator-machinery/BUILD.bazel
+++ b/pkg/lib-volume-populator/populator-machinery/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/forklift/v1beta1",
-        "//pkg/controller/plan",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/api/storage/v1:storage",
         "//vendor/k8s.io/apimachinery/pkg/api/errors",

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
-	"github.com/konveyor/forklift-controller/pkg/controller/plan"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -698,13 +697,6 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 		if corev1.PodSucceeded != pod.Status.Phase {
 			if corev1.PodFailed == pod.Status.Phase {
 				c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPodFailed, "Populator failed: %s", pod.Status.Message)
-				// Delete failed pods so we can try again
-				if !plan.RestartLimitExceeded(pod) {
-					err = c.kubeClient.CoreV1().Pods(populatorNamespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-					if err != nil {
-						return err
-					}
-				}
 			}
 			// We'll get called again later when the pod succeeds
 			return nil


### PR DESCRIPTION
This patch will keep the populator pod existence when failing. It won't restart or recreated. This is in the mind of aligning with v2v pod failure and the thought that once we fail, we will most likely keep failing. This change will allow to get the populator logs in case of failure in a easy way.