### PR TITLE
Set Hyperv features from KubeVirt template

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -391,10 +391,8 @@ func (r *Builder) mapFirmware(vm *model.Workload, object *cnv.VirtualMachineSpec
 	default:
 		bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	}
-	features := &cnv.Features{}
 	firmware := &cnv.Firmware{}
 	firmware.Bootloader = bootloader
-	object.Template.Spec.Domain.Features = features
 	object.Template.Spec.Domain.Firmware = firmware
 }
 

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -241,7 +241,6 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	r.mapDisks(vm, persistentVolumeClaims, object)
 	r.mapFirmware(vm, object)
 	r.mapCPU(vm, object)
-	r.mapClock(object)
 	r.mapInput(object)
 	err = r.mapMemory(vm, object)
 	if err != nil {
@@ -319,13 +318,6 @@ func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {
 	object.Template.Spec.Domain.Devices.Inputs = []cnv.Input{tablet}
 }
 
-func (r *Builder) mapClock(object *cnv.VirtualMachineSpec) {
-	clock := &cnv.Clock{
-		Timer: &cnv.Timer{},
-	}
-	object.Template.Spec.Domain.Clock = clock
-}
-
 func (r *Builder) mapMemory(vm *model.VM, object *cnv.VirtualMachineSpec) error {
 	var memoryBytes int64
 	memoryBytes, err := getResourceCapacity(int64(vm.MemoryMB), vm.MemoryUnits)
@@ -353,7 +345,6 @@ func (r *Builder) mapCPU(vm *model.VM, object *cnv.VirtualMachineSpec) {
 }
 
 func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
-	features := &cnv.Features{}
 	firmware := &cnv.Firmware{
 		Serial: vm.UUID,
 	}
@@ -372,7 +363,6 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 				SecureBoot: &secureBootEnabled,
 			}}
 	}
-	object.Template.Spec.Domain.Features = features
 	object.Template.Spec.Domain.Firmware = firmware
 }
 

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -359,12 +359,14 @@ func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {
 }
 
 func (r *Builder) mapClock(vm *model.Workload, object *cnv.VirtualMachineSpec) {
-	clock := cnv.Clock{
-		Timer: &cnv.Timer{},
+	if object.Template.Spec.Domain.Clock == nil {
+		object.Template.Spec.Domain.Clock = &cnv.Clock{
+			Timer: &cnv.Timer{},
+		}
 	}
+
 	timezone := cnv.ClockOffsetTimezone(vm.Timezone)
-	clock.Timezone = &timezone
-	object.Template.Spec.Domain.Clock = &clock
+	object.Template.Spec.Domain.Clock.Timezone = &timezone
 }
 
 func (r *Builder) mapMemory(vm *model.Workload, object *cnv.VirtualMachineSpec) {
@@ -397,7 +399,6 @@ func (r *Builder) mapFirmware(vm *model.Workload, cluster *model.Cluster, object
 	if serial == "" {
 		serial = vm.ID
 	}
-	features := &cnv.Features{}
 	firmware := &cnv.Firmware{
 		Serial: serial,
 		UUID:   types.UID(vm.ID),
@@ -415,7 +416,6 @@ func (r *Builder) mapFirmware(vm *model.Workload, cluster *model.Cluster, object
 	default:
 		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	}
-	object.Template.Spec.Domain.Features = features
 	object.Template.Spec.Domain.Firmware = firmware
 }
 

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -542,14 +542,15 @@ func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {
 }
 
 func (r *Builder) mapClock(host *model.Host, object *cnv.VirtualMachineSpec) {
-	clock := &cnv.Clock{
-		Timer: &cnv.Timer{},
-	}
 	if host.Timezone != "" {
+		if object.Template.Spec.Domain.Clock == nil {
+			object.Template.Spec.Domain.Clock = &cnv.Clock{
+				Timer: &cnv.Timer{},
+			}
+		}
 		tz := cnv.ClockOffsetTimezone(host.Timezone)
-		clock.ClockOffset.Timezone = &tz
+		object.Template.Spec.Domain.Clock.ClockOffset.Timezone = &tz
 	}
-	object.Template.Spec.Domain.Clock = clock
 }
 
 func (r *Builder) mapMemory(vm *model.VM, object *cnv.VirtualMachineSpec) {
@@ -571,7 +572,6 @@ func (r *Builder) mapCPU(vm *model.VM, object *cnv.VirtualMachineSpec) {
 }
 
 func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
-	features := &cnv.Features{}
 	firmware := &cnv.Firmware{
 		Serial: vm.UUID,
 	}
@@ -590,7 +590,6 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	default:
 		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	}
-	object.Template.Spec.Domain.Features = features
 	object.Template.Spec.Domain.Firmware = firmware
 }
 


### PR DESCRIPTION
When we migrate from oVirt, vSphere, OpenStack and OVA, we override the Features and Clock sections of the VMs that are based on the template in KubeVirt that corresponds to the operating system of the migrated VM, if such a template exists. This PR changes the relevant Builders to avoid overriding these sections with empty settings. It's OK to override fields that are taken from the template with values based on the configuration of VMs in the source system, but it makes no sense to override fields from the template with empty values, as for example it clears Hyperv features that are useful for Windows guests.

When we take Hyperv flags from the template, we need to make sure that the clock is also taken from the template (since it needs to be Hypervclock).

https://issues.redhat.com/browse/MTV-812

Backport of #638 