### PR TITLE
Add support for ova provider creation for k8s in restricted namespace

### DIFF
--- a/pkg/controller/provider/BUILD.bazel
+++ b/pkg/controller/provider/BUILD.bazel
@@ -35,6 +35,8 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr",
         "//vendor/k8s.io/apiserver/pkg/storage/names",
+        "//vendor/k8s.io/client-go/kubernetes",
+        "//vendor/k8s.io/client-go/rest",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/controller",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/event",


### PR DESCRIPTION
This fix checks on which platform it running on and accordingly setting the appropriate pod security setting.
- For openShift we have this configured in the SCC file.
- For k8s we need to set it as art of the pod security while creation.