### PR TITLE
Make the filesystem overhead configurable

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -64,6 +64,8 @@ spec:
           value: ${SNAPSHOT_STATUS_CHECK_RATE}
         - name: CDI_EXPORT_TOKEN_TTL
           value: ${CDI_EXPORT_TOKEN_TTL}
+        - name: FILESYSTEM_OVERHEAD
+          value: ${FILESYSTEM_OVERHEAD}
         - name: POPULATOR_CONTROLLER_IMAGE
           value: ${POPULATOR_CONTROLLER_IMAGE}
         - name: OVIRT_POPULATOR_IMAGE

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -34,6 +34,7 @@ controller_snapshot_status_check_rate_seconds: 10
 controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_max_vm_inflight: 20
+controller_filesystem_overhead: 10
 profiler_volume_path: "/var/cache/profiler"
 
 inventory_volume_path: "/var/cache/inventory"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -74,7 +74,7 @@ spec:
 {% endif %}
 {% if controller_cdi_export_token_ttl is number %}
         - name: CDI_EXPORT_TOKEN_TTL
-          value: "{{ CDI_EXPORT_TOKEN_TTL }}"
+          value: "{{ controller_cdi_export_token_ttl }}"
 {% endif %}
 {% if controller_filesystem_overhead is number %}
         - name: FILESYSTEM_OVERHEAD

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -76,6 +76,10 @@ spec:
         - name: CDI_EXPORT_TOKEN_TTL
           value: "{{ CDI_EXPORT_TOKEN_TTL }}"
 {% endif %}
+{% if controller_filesystem_overhead is number %}
+        - name: FILESYSTEM_OVERHEAD
+          value: "{{ controller_filesystem_overhead }}"
+{% endif %}
 {% if controller_vsphere_incremental_backup|bool %}
         - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
           value: "true"

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1100,7 +1100,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image, storageC
 	}
 
 	if *volumeMode == core.PersistentVolumeFilesystem {
-		virtualSize = utils.CalculateSpaceWithOverhead(virtualSize, 0.1)
+		virtualSize = utils.CalculateSpaceWithOverhead(virtualSize)
 	}
 
 	// The image might be a VM Snapshot Image and has no volume associated to it

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -783,6 +783,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(diskAttachment model.XDiskA
 	annotations map[string]string) (pvc *core.PersistentVolumeClaim, err error) {
 
 	// We add 10% overhead because of the fsOverhead in CDI, around 5% to ext4 and 5% for root partition.
+	// This value is configurable using `FILESYSTEM_OVERHEAD`
 	diskSize := diskAttachment.Disk.ProvisionedSize
 
 	var accessModes []core.PersistentVolumeAccessMode
@@ -796,7 +797,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(diskAttachment model.XDiskA
 	// Accounting for fsOverhead is only required for `volumeMode: Filesystem`, as we may not have enough space
 	// after creating a filesystem on an underlying block device
 	if *volumeMode == core.PersistentVolumeFilesystem {
-		diskSize = utils.CalculateSpaceWithOverhead(diskSize, 0.1)
+		diskSize = utils.CalculateSpaceWithOverhead(diskSize)
 	}
 
 	annotations[AnnImportDiskId] = diskAttachment.ID

--- a/pkg/controller/plan/util/BUILD.bazel
+++ b/pkg/controller/plan/util/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1",
         "//pkg/controller/provider/web/openstack",
         "//pkg/controller/provider/web/ovirt",
+        "//pkg/settings",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
     ],

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -1,6 +1,10 @@
 package util
 
-import "math"
+import (
+	"math"
+
+	"github.com/konveyor/forklift-controller/pkg/settings"
+)
 
 // Disk alignment size used to align FS overhead,
 // its a multiple of all known hardware block sizes 512/4k/8k/32k/64k
@@ -16,8 +20,8 @@ func roundUp(requestedSpace, multiple int64) int64 {
 	return int64(partitions) * multiple
 }
 
-func CalculateSpaceWithOverhead(requestedSpace int64, filesystemOverhead float64) int64 {
+func CalculateSpaceWithOverhead(requestedSpace int64) int64 {
 	alignedSize := roundUp(requestedSpace, DefaultAlignBlockSize)
-	spaceWithOverhead := int64(math.Ceil(float64(alignedSize) / (1 - filesystemOverhead)))
+	spaceWithOverhead := int64(math.Ceil(float64(alignedSize) / (1 - float64(settings.Settings.FileSystemOverhead)/100)))
 	return spaceWithOverhead
 }

--- a/pkg/settings/logging.go
+++ b/pkg/settings/logging.go
@@ -21,6 +21,6 @@ type Logging struct {
 // Load settings.
 func (r *Logging) Load() error {
 	r.Development = getEnvBool(LogDevelopment, false)
-	r.Level, _ = getEnvLimit(LogLevel, 0)
+	r.Level, _ = getPositiveEnvLimit(LogLevel, 0)
 	return nil
 }

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -18,6 +18,7 @@ const (
 	SnapshotRemovalTimeout  = "SNAPSHOT_REMOVAL_TIMEOUT"
 	SnapshotStatusCheckRate = "SNAPSHOT_STATUS_CHECK_RATE"
 	CDIExportTokenTTL       = "CDI_EXPORT_TOKEN_TTL"
+	FileSystemOverhead      = "FILESYSTEM_OVERHEAD"
 )
 
 // Default virt-v2v image.
@@ -46,31 +47,33 @@ type Migration struct {
 	VirtV2vDontRequestKVM bool
 	// OCP Export token TTL minutes
 	CDIExportTokenTTL int
+	// FileSystem overhead in percantage
+	FileSystemOverhead int
 }
 
 // Load settings.
 func (r *Migration) Load() (err error) {
-	r.MaxInFlight, err = getEnvLimit(MaxVmInFlight, 20)
+	r.MaxInFlight, err = getPositiveEnvLimit(MaxVmInFlight, 20)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}
-	r.HookRetry, err = getEnvLimit(HookRetry, 3)
+	r.HookRetry, err = getPositiveEnvLimit(HookRetry, 3)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}
-	r.ImporterRetry, err = getEnvLimit(ImporterRetry, 3)
+	r.ImporterRetry, err = getPositiveEnvLimit(ImporterRetry, 3)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}
-	r.PrecopyInterval, err = getEnvLimit(PrecopyInterval, 60)
+	r.PrecopyInterval, err = getPositiveEnvLimit(PrecopyInterval, 60)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}
-	r.SnapshotRemovalTimeout, err = getEnvLimit(SnapshotRemovalTimeout, 120)
+	r.SnapshotRemovalTimeout, err = getPositiveEnvLimit(SnapshotRemovalTimeout, 120)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}
-	r.SnapshotStatusCheckRate, err = getEnvLimit(SnapshotStatusCheckRate, 10)
+	r.SnapshotStatusCheckRate, err = getPositiveEnvLimit(SnapshotStatusCheckRate, 10)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}
@@ -87,8 +90,11 @@ func (r *Migration) Load() (err error) {
 		r.VirtV2vImageWarm = DefaultVirtV2vImage
 	}
 	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
-
-	r.CDIExportTokenTTL, err = getEnvLimit(CDIExportTokenTTL, 0)
+	r.CDIExportTokenTTL, err = getPositiveEnvLimit(CDIExportTokenTTL, 0)
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
+	r.FileSystemOverhead, err = getNonNegativeEnvLimit(FileSystemOverhead, 10)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -55,27 +55,27 @@ type Migration struct {
 func (r *Migration) Load() (err error) {
 	r.MaxInFlight, err = getPositiveEnvLimit(MaxVmInFlight, 20)
 	if err != nil {
-		err = liberr.Wrap(err)
+		return liberr.Wrap(err)
 	}
 	r.HookRetry, err = getPositiveEnvLimit(HookRetry, 3)
 	if err != nil {
-		err = liberr.Wrap(err)
+		return liberr.Wrap(err)
 	}
 	r.ImporterRetry, err = getPositiveEnvLimit(ImporterRetry, 3)
 	if err != nil {
-		err = liberr.Wrap(err)
+		return liberr.Wrap(err)
 	}
 	r.PrecopyInterval, err = getPositiveEnvLimit(PrecopyInterval, 60)
 	if err != nil {
-		err = liberr.Wrap(err)
+		return liberr.Wrap(err)
 	}
 	r.SnapshotRemovalTimeout, err = getPositiveEnvLimit(SnapshotRemovalTimeout, 120)
 	if err != nil {
-		err = liberr.Wrap(err)
+		return liberr.Wrap(err)
 	}
 	r.SnapshotStatusCheckRate, err = getPositiveEnvLimit(SnapshotStatusCheckRate, 10)
 	if err != nil {
-		err = liberr.Wrap(err)
+		return liberr.Wrap(err)
 	}
 	if virtV2vImage, ok := os.LookupEnv(VirtV2vImage); ok {
 		if cold, warm, found := strings.Cut(virtV2vImage, "|"); found {
@@ -92,11 +92,11 @@ func (r *Migration) Load() (err error) {
 	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
 	r.CDIExportTokenTTL, err = getPositiveEnvLimit(CDIExportTokenTTL, 0)
 	if err != nil {
-		err = liberr.Wrap(err)
+		return liberr.Wrap(err)
 	}
 	r.FileSystemOverhead, err = getNonNegativeEnvLimit(FileSystemOverhead, 10)
 	if err != nil {
-		err = liberr.Wrap(err)
+		return liberr.Wrap(err)
 	}
 
 	return

--- a/pkg/settings/policy.go
+++ b/pkg/settings/policy.go
@@ -41,11 +41,11 @@ func (r *PolicyAgent) Load() (err error) {
 	} else {
 		r.TLS.CA = ServiceCAFile
 	}
-	r.Limit.Worker, err = getEnvLimit(PolicyAgentWorkerLimit, 10)
+	r.Limit.Worker, err = getPositiveEnvLimit(PolicyAgentWorkerLimit, 10)
 	if err != nil {
 		return err
 	}
-	r.SearchInterval, err = getEnvLimit(PolicyAgentSearchInterval, 600)
+	r.SearchInterval, err = getPositiveEnvLimit(PolicyAgentSearchInterval, 600)
 	if err != nil {
 		return err
 	}

--- a/pkg/settings/profiler.go
+++ b/pkg/settings/profiler.go
@@ -27,7 +27,7 @@ type Profiler struct {
 
 // Load settings.
 func (r *Profiler) Load() error {
-	minutes, _ := getEnvLimit(ProfileDuration, 0)
+	minutes, _ := getPositiveEnvLimit(ProfileDuration, 0)
 	r.Duration = time.Duration(minutes) * time.Minute
 	if s, found := os.LookupEnv(ProfilePath); found {
 		r.Path = s

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -1,9 +1,11 @@
 package settings
 
 import (
-	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	"fmt"
 	"os"
 	"strconv"
+
+	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 )
 
 // Global
@@ -69,15 +71,27 @@ func (r *ControllerSettings) Load() error {
 
 // Get positive integer limit from the environment
 // using the specified variable name and default.
-func getEnvLimit(name string, def int) (int, error) {
+func getPositiveEnvLimit(name string, def int) (int, error) {
+	return getEnvLimit(name, def, 1)
+}
+
+// Get non-negative integer limit from the environment
+// using the specified variable name and default.
+func getNonNegativeEnvLimit(name string, def int) (int, error) {
+	return getEnvLimit(name, def, 0)
+}
+
+// Get an integer limit from the environment
+// using the specified variable name and default.
+func getEnvLimit(name string, def, minimum int) (int, error) {
 	limit := 0
 	if s, found := os.LookupEnv(name); found {
 		n, err := strconv.Atoi(s)
 		if err != nil {
 			return 0, liberr.New(name + " must be an integer")
 		}
-		if n < 1 {
-			return 0, liberr.New(name + " must be >= 1")
+		if n < minimum {
+			return 0, liberr.New(fmt.Sprintf(name+" must be >= %d", minimum))
 		}
 		limit = n
 	} else {


### PR DESCRIPTION
This patch will allow the user to configure the filesystem overhead. Currently it defaults to 10%. The overhead is mainly required for ext4 and the root partition.