### PR TITLE
Remove DefaultVirtV2vImage

### DIFF
--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -19,11 +20,6 @@ const (
 	SnapshotStatusCheckRate = "SNAPSHOT_STATUS_CHECK_RATE"
 	CDIExportTokenTTL       = "CDI_EXPORT_TOKEN_TTL"
 	FileSystemOverhead      = "FILESYSTEM_OVERHEAD"
-)
-
-// Default virt-v2v image.
-const (
-	DefaultVirtV2vImage = "quay.io/kubev2v/forklift-virt-v2v:latest"
 )
 
 // Migration settings
@@ -79,9 +75,8 @@ func (r *Migration) Load() (err error) {
 			r.VirtV2vImageCold = virtV2vImage
 			r.VirtV2vImageWarm = virtV2vImage
 		}
-	} else {
-		r.VirtV2vImageCold = DefaultVirtV2vImage
-		r.VirtV2vImageWarm = DefaultVirtV2vImage
+	} else if Settings.Role.Has(MainRole) {
+		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtV2vImage))
 	}
 	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
 	if r.CDIExportTokenTTL, err = getPositiveEnvLimit(CDIExportTokenTTL, 0); err != nil {

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -53,28 +53,22 @@ type Migration struct {
 
 // Load settings.
 func (r *Migration) Load() (err error) {
-	r.MaxInFlight, err = getPositiveEnvLimit(MaxVmInFlight, 20)
-	if err != nil {
+	if r.MaxInFlight, err = getPositiveEnvLimit(MaxVmInFlight, 20); err != nil {
 		return liberr.Wrap(err)
 	}
-	r.HookRetry, err = getPositiveEnvLimit(HookRetry, 3)
-	if err != nil {
+	if r.HookRetry, err = getPositiveEnvLimit(HookRetry, 3); err != nil {
 		return liberr.Wrap(err)
 	}
-	r.ImporterRetry, err = getPositiveEnvLimit(ImporterRetry, 3)
-	if err != nil {
+	if r.ImporterRetry, err = getPositiveEnvLimit(ImporterRetry, 3); err != nil {
 		return liberr.Wrap(err)
 	}
-	r.PrecopyInterval, err = getPositiveEnvLimit(PrecopyInterval, 60)
-	if err != nil {
+	if r.PrecopyInterval, err = getPositiveEnvLimit(PrecopyInterval, 60); err != nil {
 		return liberr.Wrap(err)
 	}
-	r.SnapshotRemovalTimeout, err = getPositiveEnvLimit(SnapshotRemovalTimeout, 120)
-	if err != nil {
+	if r.SnapshotRemovalTimeout, err = getPositiveEnvLimit(SnapshotRemovalTimeout, 120); err != nil {
 		return liberr.Wrap(err)
 	}
-	r.SnapshotStatusCheckRate, err = getPositiveEnvLimit(SnapshotStatusCheckRate, 10)
-	if err != nil {
+	if r.SnapshotStatusCheckRate, err = getPositiveEnvLimit(SnapshotStatusCheckRate, 10); err != nil {
 		return liberr.Wrap(err)
 	}
 	if virtV2vImage, ok := os.LookupEnv(VirtV2vImage); ok {
@@ -90,12 +84,10 @@ func (r *Migration) Load() (err error) {
 		r.VirtV2vImageWarm = DefaultVirtV2vImage
 	}
 	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
-	r.CDIExportTokenTTL, err = getPositiveEnvLimit(CDIExportTokenTTL, 0)
-	if err != nil {
+	if r.CDIExportTokenTTL, err = getPositiveEnvLimit(CDIExportTokenTTL, 0); err != nil {
 		return liberr.Wrap(err)
 	}
-	r.FileSystemOverhead, err = getNonNegativeEnvLimit(FileSystemOverhead, 10)
-	if err != nil {
+	if r.FileSystemOverhead, err = getNonNegativeEnvLimit(FileSystemOverhead, 10); err != nil {
 		return liberr.Wrap(err)
 	}
 


### PR DESCRIPTION
We should never fallback to use hard-coded images but rather fail when
an image is missing. Thus, removing DefaultVirtV2vImage that pointed to
forklift-virt-v2v:latest in quay.io and returning an error when
VIRT_V2V_IMAGE is not specified instead.

Also replace ordinary if-statements with if-with-a-short-statement to reduce
the length of Migration#Load.