### PR TITLE
Keep the populator pod on failure (backport)

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -862,7 +862,7 @@ func (r *KubeVirt) SetPopulatorPodOwnership(vm *plan.VMStatus) (err error) {
 		return
 	}
 	for _, pod := range pods {
-		pvcId := strings.Split(pod.Name, "populate-")[1]
+		pvcId := pod.Name[len(PopulatorPodPrefix):]
 		for _, pvc := range pvcs {
 			if string(pvc.UID) != pvcId {
 				continue
@@ -898,7 +898,7 @@ func (r *KubeVirt) getPopulatorPods() (pods []core.Pod, err error) {
 		return nil, liberr.Wrap(err)
 	}
 	for _, pod := range migrationPods.Items {
-		if strings.HasPrefix(pod.Name, "populate-") {
+		if strings.HasPrefix(pod.Name, PopulatorPodPrefix) {
 			pods = append(pods, pod)
 		}
 	}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -84,7 +84,8 @@ const (
 )
 
 const (
-	TransferCompleted = "Transfer completed."
+	TransferCompleted  = "Transfer completed."
+	PopulatorPodPrefix = "populate-"
 )
 
 var (
@@ -1601,7 +1602,7 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 			continue
 		}
 
-		err = r.isPopulatorFailed(populatorPods, string(pvc.UID))
+		_, err = r.isPopulatorFailed(populatorPods, string(pvc.UID))
 		if err != nil {
 			return
 		}
@@ -1628,17 +1629,18 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 	return
 }
 
-func (r *Migration) isPopulatorFailed(populatorPods []core.Pod, givenPvcId string) error {
+func (r *Migration) isPopulatorFailed(populatorPods []core.Pod, givenPvcId string) (bool, error) {
 	for _, pod := range populatorPods {
-		pvcId := strings.Split(pod.Name, "populate-")[1]
+		pvcId := pod.Name[len(PopulatorPodPrefix):]
 		if givenPvcId != pvcId {
 			continue
 		}
 		if pod.Status.Phase == core.PodFailed {
-			return fmt.Errorf("populator pod %s/%s failed for PVC %s. Please check the pod logs.", pod.Namespace, pod.Name, pvcId)
+			return true, fmt.Errorf("populator pod %s/%s failed for PVC %s. Please check the pod logs.", pod.Namespace, pod.Name, pvcId)
 		}
+		break
 	}
-	return nil
+	return false, nil
 }
 
 func (r *Migration) setPopulatorPodsWithLabels(vm *plan.VMStatus, migrationID string) {
@@ -1647,7 +1649,7 @@ func (r *Migration) setPopulatorPodsWithLabels(vm *plan.VMStatus, migrationID st
 		return
 	}
 	for _, pod := range podList.Items {
-		if strings.HasPrefix(pod.Name, "populate-") {
+		if strings.HasPrefix(pod.Name, PopulatorPodPrefix) {
 			// it's populator pod
 			if _, ok := pod.Labels["migration"]; !ok {
 				// un-labeled pod, we need to set it

--- a/pkg/lib-volume-populator/populator-machinery/BUILD.bazel
+++ b/pkg/lib-volume-populator/populator-machinery/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/forklift/v1beta1",
-        "//pkg/controller/plan",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/api/storage/v1:storage",
         "//vendor/k8s.io/apimachinery/pkg/api/errors",

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
-	"github.com/konveyor/forklift-controller/pkg/controller/plan"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -698,13 +697,6 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 		if corev1.PodSucceeded != pod.Status.Phase {
 			if corev1.PodFailed == pod.Status.Phase {
 				c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPodFailed, "Populator failed: %s", pod.Status.Message)
-				// Delete failed pods so we can try again
-				if !plan.RestartLimitExceeded(pod) {
-					err = c.kubeClient.CoreV1().Pods(populatorNamespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-					if err != nil {
-						return err
-					}
-				}
 			}
 			// We'll get called again later when the pod succeeds
 			return nil


### PR DESCRIPTION
This patch will keep the populator pod existence when failing. It won't restart or recreated. This is in the mind of aligning with v2v pod failure and the thought that once we fail, we will most likely keep failing. This change will allow to get the populator logs in case of failure in a easy way.