### PR TITLE
Add a warning and support of TPM

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -287,6 +287,7 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	r.mapMemory(vm, object)
 	r.mapClock(vm, object)
 	r.mapInput(object)
+	r.mapTpm(vm, object)
 	err = r.mapNetworks(vm, object)
 	if err != nil {
 		return
@@ -502,6 +503,13 @@ func (r *Builder) mapDisks(vm *model.Workload, persistentVolumeClaims []core.Per
 	}
 	object.Template.Spec.Volumes = kVolumes
 	object.Template.Spec.Domain.Devices.Disks = kDisks
+}
+
+func (r *Builder) mapTpm(vm *model.Workload, object *cnv.VirtualMachineSpec) {
+	if vm.OSType == "windows_2022" || vm.OSType == "windows_11" {
+		persistData := true
+		object.Template.Spec.Domain.Devices.TPM = &cnv.TPMDevice{Persistent: &persistData}
+	}
 }
 
 // Build tasks.

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -462,6 +462,7 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	r.mapMemory(vm, object)
 	r.mapClock(host, object)
 	r.mapInput(object)
+	r.mapTpm(vm, object)
 	err = r.mapNetworks(vm, object)
 	if err != nil {
 		return
@@ -637,6 +638,13 @@ func (r *Builder) mapDisks(vm *model.VM, persistentVolumeClaims []core.Persisten
 	}
 	object.Template.Spec.Volumes = kVolumes
 	object.Template.Spec.Domain.Devices.Disks = kDisks
+}
+
+func (r *Builder) mapTpm(vm *model.VM, object *cnv.VirtualMachineSpec) {
+	if vm.TpmEnabled {
+		persistData := true
+		object.Template.Spec.Domain.Devices.TPM = &cnv.TPMDevice{Persistent: &persistData}
+	}
 }
 
 // Build tasks.

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -110,6 +110,7 @@ const (
 	fChangeTracking      = "config.changeTrackingEnabled"
 	fGuestName           = "summary.config.guestFullName"
 	fGuestID             = "summary.guest.guestId"
+	fTpmPresent          = "summary.config.tpmPresent"
 	fBalloonedMemory     = "summary.quickStats.balloonedMemory"
 	fVmIpAddress         = "summary.guest.ipAddress"
 	fStorageUsed         = "summary.storage.committed"
@@ -714,6 +715,7 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 				fExtraConfig,
 				fGuestName,
 				fGuestID,
+				fTpmPresent,
 				fBalloonedMemory,
 				fVmIpAddress,
 				fStorageUsed,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -570,6 +570,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if s, cast := p.Val.(string); cast {
 					v.model.GuestName = s
 				}
+			case fTpmPresent:
+				if b, cast := p.Val.(bool); cast {
+					v.model.TpmEnabled = b
+				}
 			case fGuestID:
 				if s, cast := p.Val.(string); cast {
 					// When the VM isn't powered on, the guest tools don't report

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -256,6 +256,7 @@ type VM struct {
 	Snapshot              Ref       `sql:""`
 	IsTemplate            bool      `sql:""`
 	ChangeTrackingEnabled bool      `sql:""`
+	TpmEnabled            bool      `sql:""`
 	Devices               []Device  `sql:""`
 	NICs                  []NIC     `sql:""`
 	Disks                 []Disk    `sql:""`

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -229,6 +229,7 @@ type VM struct {
 	BalloonedMemory       int32          `json:"balloonedMemory"`
 	IpAddress             string         `json:"ipAddress"`
 	StorageUsed           int64          `json:"storageUsed"`
+	TpmEnabled            bool           `json:"tpmEnabled"`
 	NumaNodeAffinity      []string       `json:"numaNodeAffinity"`
 	Devices               []model.Device `json:"devices"`
 	NICs                  []model.NIC    `json:"nics"`
@@ -255,6 +256,7 @@ func (r *VM) With(m *model.VM) {
 	r.BalloonedMemory = m.BalloonedMemory
 	r.IpAddress = m.IpAddress
 	r.StorageUsed = m.StorageUsed
+	r.TpmEnabled = m.TpmEnabled
 	r.FaultToleranceEnabled = m.FaultToleranceEnabled
 	r.Devices = m.Devices
 	r.NumaNodeAffinity = m.NumaNodeAffinity

--- a/validation/policies/io/konveyor/forklift/ovirt/tpm.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/tpm.rego
@@ -1,0 +1,16 @@
+package io.konveyor.forklift.ovirt
+
+default has_tpm_os = false
+
+has_tpm_os = true {
+    regex.match(`windows_2022|windows_11`, input.osType)
+}
+
+concerns[flag] {
+    has_tpm_os
+    flag := {
+        "category": "Warning",
+        "label": "VM configured with a TPM device",
+        "assessment": "The VM is detected with an operation system that must have a TPM device. TPM data is not transferred during the migration."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/ovirt/tpm_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/tpm_test.rego
@@ -1,0 +1,25 @@
+package io.konveyor.forklift.ovirt
+ 
+test_without_tpm_enabled {
+    mock_vm := { "name": "test",
+                 "osType": "rhel_9x64"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_tpm_enabled_w11 {
+    mock_vm := { "name": "test",
+                 "osType": "windows_11"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_with_tpm_enabled_w2k22 {
+    mock_vm := { "name": "test",
+                 "osType": "windows_2022"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}

--- a/validation/policies/io/konveyor/forklift/vmware/tpm_enabled.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/tpm_enabled.rego
@@ -1,0 +1,16 @@
+package io.konveyor.forklift.vmware
+
+default has_tpm_enabled = false
+
+has_tpm_enabled = true {
+    input.tpmEnabled == true
+}
+
+concerns[flag] {
+    has_tpm_enabled
+    flag := {
+        "category": "Warning",
+        "label": "VM configured with a TPM device",
+        "assessment": "The VM is configured with a TPM device. TPM data is not transferred during the migration."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/vmware/tpm_enabled_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/tpm_enabled_test.rego
@@ -1,0 +1,19 @@
+package io.konveyor.forklift.vmware
+
+test_with_tpm_disabled {
+    mock_vm := {
+        "name": "test",
+        "tpmEnabled": false,
+    }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_cpu_hot_add_enabled {
+    mock_vm := {
+        "name": "test",
+        "tpmEnabled": true
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}


### PR DESCRIPTION
When having a TPM device from the source(oVirt - based on having windows 2022 or windows 11 OS),
create it also for the destination VM.
The data is persist in oVirt. Therefore, if supported by kubevirt the TPM will be persistent TPM,
otherwise the TPM without persistent data.

**A warning will be shown as the data will be lost during the migration**

In order to have the TPM persistent it is required to have kubvirt
v1.0.0 and adding configuration manually as described in:
https://kubevirt.io/user-guide/virtual_machines/persistent_tpm_and_uefi_state/

It is also supported in CNV running on OCP 4.14, and you need to follow:
https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/virtualization/virtual-machines#virt-using-vtpm-devices

https://issues.redhat.com/browse/MTV-378