### PR TITLE
Replace post-vendor.sh with a .gitignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ bazel-*
 
 # deploy env
 hack/deploy/**/deploy.env
+
+# unused Dockerfiles
+vendor/**/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,6 @@ tidy:
 # Run go mod vendor against code
 vendor:
 	go mod vendor
-	./hack/post-vendor.sh
 
 # Generate code
 generate: controller-gen

--- a/hack/post-vendor.sh
+++ b/hack/post-vendor.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-rm vendor/github.com/nxadm/tail/Dockerfile
-rm vendor/github.com/pelletier/go-toml/v2/Dockerfile


### PR DESCRIPTION
It's hard to enforce developers to use `make vendor` so dropping the post-vendor.sh script that removed unused files that introduce warning by code analyze tools and we will use .gitignore rules instead.