### PR TITLE
openstack: add simple test for the openstack-populator

### DIFF
--- a/cmd/openstack-populator/BUILD.bazel
+++ b/cmd/openstack-populator/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
@@ -30,4 +30,10 @@ container_image(
     entrypoint = ["/usr/local/bin/openstack-populator"],
     files = [":openstack-populator"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "openstack-populator_test",
+    srcs = ["openstack-populator_test.go"],
+    embed = [":openstack-populator_lib"],
 )

--- a/cmd/openstack-populator/openstack-populator_test.go
+++ b/cmd/openstack-populator/openstack-populator_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func setupMockServer() (*httptest.Server, string, int, error) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return nil, "", 0, err
+	}
+
+	mux := http.NewServeMux()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	identityServerURL := fmt.Sprintf("http://localhost:%d", port)
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		response := fmt.Sprintf(`{
+            "versions": {
+                "values": [
+                    {
+                        "id": "v3.0",
+                        "links": [
+                            {"rel": "self", "href": "%s/v3/"}
+                        ],
+                        "status": "stable"
+                    }
+                ]
+            }
+        }`, identityServerURL)
+		fmt.Fprint(w, response)
+	})
+
+	mux.HandleFunc("/v2/images/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `mock_data`)
+	})
+
+	mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Subject-Token", "MIIFvgY")
+		w.WriteHeader(http.StatusCreated)
+		identityPublicURL := fmt.Sprintf("http://localhost:%d/v3/", port)
+		identityAdminURL := fmt.Sprintf("http://localhost:%d/v3/", port)
+		identityInternalURL := fmt.Sprintf("http://localhost:%d/v3/", port)
+		imageServiceURL := fmt.Sprintf("http://localhost:%d/v2/images", port)
+
+		response := fmt.Sprintf(`{
+			"token": {
+				"methods": ["password"],
+				"project": {
+					"domain": {
+						"id": "default",
+						"name": "Default"
+					},
+					"id": "8538a3f13f9541b28c2620eb19065e45",
+					"name": "admin"
+				},
+				"catalog": [
+					{
+						"type": "identity",
+						"name": "keystone",
+						"endpoints": [
+							{
+								"url": "%s",
+								"region": "RegionOne",
+								"interface": "public",
+								"id": "identity-public-endpoint-id"
+							},
+							{
+								"url": "%s",
+								"region": "RegionOne",
+								"interface": "admin",
+								"id": "identity-admin-endpoint-id"
+							},
+							{
+								"url": "%s",
+								"region": "RegionOne",
+								"interface": "internal",
+								"id": "identity-internal-endpoint-id"
+							}
+						]
+					},
+					{
+						"type": "image",
+						"name": "glance",
+						"endpoints": [
+							{
+								"url": "%s",
+								"region": "RegionOne",
+								"interface": "public",
+								"id": "image-public-endpoint-id"
+							}
+						]
+					}
+				],
+				"user": {
+					"domain": {
+						"id": "default",
+						"name": "Default"
+					},
+					"id": "3ec3164f750146be97f21559ee4d9c51",
+					"name": "admin"
+				},
+				"issued_at": "201406-10T20:55:16.806027Z"
+			}
+		}`,
+			identityPublicURL,
+			identityAdminURL,
+			identityInternalURL,
+			imageServiceURL)
+
+		fmt.Fprint(w, response)
+	})
+
+	server := httptest.NewUnstartedServer(mux)
+	server.Listener = listener
+
+	server.Start()
+
+	return server, identityServerURL, port, nil
+}
+
+func TestPopulate(t *testing.T) {
+	os.Setenv("username", "testuser")
+	os.Setenv("password", "testpassword")
+	os.Setenv("projectName", "Default")
+	os.Setenv("domainName", "Default")
+	os.Setenv("insecureSkipVerify", "true")
+	os.Setenv("availability", "public")
+	os.Setenv("regionName", "RegionOne")
+	os.Setenv("authType", "password")
+
+	server, identityServerURL, port, err := setupMockServer()
+	if err != nil {
+		t.Fatalf("Failed to start mock server: %v", err)
+	}
+	defer server.Close()
+
+	fmt.Printf("Mock server running on port: %d\n", port)
+
+	fileName := "disk.img"
+	secretName := "test-secret"
+	imageID := "test-image-id"
+
+	fmt.Println("server ", identityServerURL)
+	populate(fileName, identityServerURL, secretName, imageID)
+
+	file, err := os.Open(fileName)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer file.Close() // Ensure the file is closed after reading
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+
+	if string(content) != "mock_data\n" {
+		t.Errorf("Expected %s, got %s", "mock_data\n", string(content))
+	}
+
+	os.Remove(fileName)
+}

--- a/cmd/openstack-populator/openstack-populator_test.go
+++ b/cmd/openstack-populator/openstack-populator_test.go
@@ -19,7 +19,7 @@ func setupMockServer() (*httptest.Server, string, int, error) {
 	mux := http.NewServeMux()
 
 	port := listener.Addr().(*net.TCPAddr).Port
-	identityServerURL := fmt.Sprintf("http://localhost:%d", port)
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -36,7 +36,7 @@ func setupMockServer() (*httptest.Server, string, int, error) {
                     }
                 ]
             }
-        }`, identityServerURL)
+        }`, baseURL)
 		fmt.Fprint(w, response)
 	})
 
@@ -48,11 +48,9 @@ func setupMockServer() (*httptest.Server, string, int, error) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-Subject-Token", "MIIFvgY")
 		w.WriteHeader(http.StatusCreated)
-		identityPublicURL := fmt.Sprintf("http://localhost:%d/v3/", port)
-		identityAdminURL := fmt.Sprintf("http://localhost:%d/v3/", port)
-		identityInternalURL := fmt.Sprintf("http://localhost:%d/v3/", port)
-		imageServiceURL := fmt.Sprintf("http://localhost:%d/v2/images", port)
-
+		identityServer := fmt.Sprintf("%s/v3/", baseURL)
+		imageServiceURL := fmt.Sprintf("%s/v2/images", baseURL)
+		fmt.Println("identityServer ", identityServer)
 		response := fmt.Sprintf(`{
 			"token": {
 				"methods": ["password"],
@@ -113,9 +111,9 @@ func setupMockServer() (*httptest.Server, string, int, error) {
 				"issued_at": "201406-10T20:55:16.806027Z"
 			}
 		}`,
-			identityPublicURL,
-			identityAdminURL,
-			identityInternalURL,
+			identityServer,
+			identityServer,
+			identityServer,
 			imageServiceURL)
 
 		fmt.Fprint(w, response)
@@ -126,7 +124,7 @@ func setupMockServer() (*httptest.Server, string, int, error) {
 
 	server.Start()
 
-	return server, identityServerURL, port, nil
+	return server, baseURL, port, nil
 }
 
 func TestPopulate(t *testing.T) {
@@ -166,7 +164,7 @@ func TestPopulate(t *testing.T) {
 	}
 
 	if string(content) != "mock_data\n" {
-		t.Errorf("Expected %s, got %s", "mock_data\n", string(content))
+		t.Errorf("Expected %s, got %s", "mock_data", string(content))
 	}
 
 	os.Remove(fileName)

--- a/cmd/ovirt-populator/ovirt-populator.go
+++ b/cmd/ovirt-populator/ovirt-populator.go
@@ -159,7 +159,6 @@ func loadEngineConfig(engineURL string) engineConfig {
 	user := os.Getenv("user")
 	pass := os.Getenv("password")
 
-	var insecureSkipVerify string
 	insecureSkipVerify, found := os.LookupEnv("insecureSkipVerify")
 	if !found {
 		insecureSkipVerify = "false"

--- a/cmd/ovirt-populator/ovirt-populator.go
+++ b/cmd/ovirt-populator/ovirt-populator.go
@@ -156,50 +156,28 @@ func populate(engineURL, diskID, volPath string) {
 }
 
 func loadEngineConfig(engineURL string) engineConfig {
-	user, err := os.ReadFile("/etc/secret-volume/user")
-	if err != nil {
-		klog.Fatal(err.Error())
-	}
-	pass, err := os.ReadFile("/etc/secret-volume/password")
-	if err != nil {
-		klog.Fatal(err.Error())
-	}
+	user := os.Getenv("user")
+	pass := os.Getenv("password")
 
-	var insecureSkipVerify []byte
-	_, err = os.Stat("/etc/secret-volume/insecureSkipVerify")
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			insecureSkipVerify = []byte("false")
-		} else {
-			klog.Fatal(err.Error())
-		}
-	} else {
-		insecureSkipVerify, err = os.ReadFile("/etc/secret-volume/insecureSkipVerify")
-		if err != nil {
-			klog.Fatal(err.Error())
-		}
+	var insecureSkipVerify string
+	insecureSkipVerify, found := os.LookupEnv("insecureSkipVerify")
+	if !found {
+		insecureSkipVerify = "false"
 	}
 
 	insecure, err := strconv.ParseBool(string(insecureSkipVerify))
 	if err != nil {
 		klog.Fatal(err.Error())
 	}
+
 	//If the insecure option is set, the ca file field in the secret is not required.
-	var cacert []byte
-	if insecure {
-		cacert = []byte("")
-	} else {
-		cacert, err = os.ReadFile("/etc/secret-volume/cacert")
-		if err != nil {
-			klog.Error(err.Error())
-		}
-	}
+	cacert := os.Getenv("cacert")
 
 	return engineConfig{
 		URL:      engineURL,
-		username: string(user),
-		password: string(pass),
-		cacert:   string(cacert),
+		username: user,
+		password: pass,
+		cacert:   cacert,
 		insecure: insecure,
 	}
 }

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -628,11 +628,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 					},
 				}
 			}
-			con.VolumeMounts = append(con.VolumeMounts, corev1.VolumeMount{
-				Name:      "secret-volume",
-				ReadOnly:  true,
-				MountPath: "/etc/secret-volume",
-			})
+
 			if waitForFirstConsumer {
 				pod.Spec.NodeName = nodeName
 			}
@@ -940,6 +936,15 @@ func makePopulatePodSpec(pvcPrimeName, secretName string) corev1.PodSpec {
 						Drop: []corev1.Capability{"ALL"},
 					},
 				},
+				EnvFrom: []corev1.EnvFromSource{
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: secretName,
+							},
+						},
+					},
+				},
 			},
 		},
 		SecurityContext: &corev1.PodSecurityContext{
@@ -955,14 +960,6 @@ func makePopulatePodSpec(pvcPrimeName, secretName string) corev1.PodSpec {
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: pvcPrimeName,
-					},
-				},
-			},
-			{
-				Name: "secret-volume",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: secretName,
 					},
 				},
 			},


### PR DESCRIPTION
* This PR also changes the populator controller and ovirt-populator to use `envFrom` instead of a file to pass the secret.

This will eventually go into the CDI controller PR, but is also useful here for now