### PR TITLE
OVA: Fix phases display for OVA provider creation

### DIFF
--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -206,10 +206,10 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 					r.handleServerCreationFailure(provider, err)
 					return
 				}
-				provider.Status.Phase = Initializing
+				provider.Status.Phase = Staging
 				provider.Status.SetCondition(
 					libcnd.Condition{
-						Type:     Initializing,
+						Type:     Staging,
 						Status:   True,
 						Category: Required,
 						Message:  "The OVA server being inizialized.",
@@ -386,21 +386,6 @@ func (r *Reconciler) getSecret(provider *api.Provider) (*v1.Secret, error) {
 	}
 
 	return secret, nil
-}
-
-func (r *Reconciler) handleServerCreationFailure(provider *api.Provider, err error) {
-	provider.Status.Phase = ServerCreationFailed
-	msg := fmt.Sprint("The OVA provider server creation failed -", err)
-	provider.Status.SetCondition(
-		libcnd.Condition{
-			Type:     ServerCreationFailed,
-			Status:   True,
-			Category: Critical,
-			Message:  msg,
-		})
-	if updateErr := r.Status().Update(context.TODO(), provider.DeepCopy()); updateErr != nil {
-		log.Error(updateErr, "Failed to update provider status")
-	}
 }
 
 // Provider catalog.

--- a/pkg/controller/provider/ova-setup.go
+++ b/pkg/controller/provider/ova-setup.go
@@ -26,20 +26,20 @@ const (
 	qemuGroup              = 107
 )
 
-func (r Reconciler) CreateOVAServerDeployment(provider *api.Provider, ctx context.Context) {
-	pvName := fmt.Sprintf("%s-pv-%s-%s", ovaServer, provider.Name, provider.Namespace)
-	err := r.createPvForNfs(provider, ctx, pvName)
-	if err != nil {
-		r.Log.Error(err, "Failed to create PV for the OVA server")
-		return
-	}
-
+func (r Reconciler) CreateOVAServerDeployment(provider *api.Provider, ctx context.Context) (err error) {
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "forklift.konveyor.io/v1beta1",
 		Kind:       "Provider",
 		Name:       provider.Name,
 		UID:        provider.UID,
 	}
+	pvName := fmt.Sprintf("%s-pv-%s-%s", ovaServer, provider.Name, provider.Namespace)
+	err = r.createPvForNfs(provider, ctx, pvName)
+	if err != nil {
+		r.Log.Error(err, "Failed to create PV for the OVA server")
+		return
+	}
+
 	pvcName := fmt.Sprintf("%s-pvc-%s", ovaServer, provider.Name)
 	err = r.createPvcForNfs(provider, ctx, ownerReference, pvName, pvcName)
 	if err != nil {
@@ -59,6 +59,7 @@ func (r Reconciler) CreateOVAServerDeployment(provider *api.Provider, ctx contex
 		r.Log.Error(err, "Failed to create OVA server service")
 		return
 	}
+	return
 }
 
 func (r *Reconciler) createPvForNfs(provider *api.Provider, ctx context.Context, pvName string) (err error) {

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -361,11 +361,11 @@ func (r *Reconciler) inventoryCreated(provider *api.Provider) error {
 }
 
 func (r *Reconciler) handleServerCreationFailure(provider *api.Provider, err error) {
-	provider.Status.Phase = ConnectionAuthFailed
-	msg := fmt.Sprint("The OVA provider server creation failed -", err)
+	provider.Status.Phase = ConnectionFailed
+	msg := fmt.Sprint("The OVA provider server creation failed: ", err)
 	provider.Status.SetCondition(
 		libcnd.Condition{
-			Type:     ConnectionAuthFailed,
+			Type:     ConnectionFailed,
 			Status:   True,
 			Category: Critical,
 			Message:  msg,

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -58,12 +58,10 @@ const (
 
 // Phases
 const (
-	ValidationFailed     = "ValidationFailed"
-	ConnectionFailed     = "ConnectionFailed"
-	Ready                = "Ready"
-	Staging              = "Staging"
-	Initializing         = "Initializing"
-	ServerCreationFailed = "ServerCreationFailed"
+	ValidationFailed = "ValidationFailed"
+	ConnectionFailed = "ConnectionFailed"
+	Ready            = "Ready"
+	Staging          = "Staging"
 )
 
 // Statuses
@@ -360,6 +358,21 @@ func (r *Reconciler) inventoryCreated(provider *api.Provider) error {
 	}
 
 	return nil
+}
+
+func (r *Reconciler) handleServerCreationFailure(provider *api.Provider, err error) {
+	provider.Status.Phase = ConnectionAuthFailed
+	msg := fmt.Sprint("The OVA provider server creation failed -", err)
+	provider.Status.SetCondition(
+		libcnd.Condition{
+			Type:     ConnectionAuthFailed,
+			Status:   True,
+			Category: Critical,
+			Message:  msg,
+		})
+	if updateErr := r.Status().Update(context.TODO(), provider.DeepCopy()); updateErr != nil {
+		log.Error(updateErr, "Failed to update provider status")
+	}
 }
 
 func isValidNFSPath(nfsPath string) bool {

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -58,10 +58,12 @@ const (
 
 // Phases
 const (
-	ValidationFailed = "ValidationFailed"
-	ConnectionFailed = "ConnectionFailed"
-	Ready            = "Ready"
-	Staging          = "Staging"
+	ValidationFailed     = "ValidationFailed"
+	ConnectionFailed     = "ConnectionFailed"
+	Ready                = "Ready"
+	Staging              = "Staging"
+	initializing         = "initializing"
+	ServerCreationFailed = "ServerCreationFailed"
 )
 
 // Statuses

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -62,7 +62,7 @@ const (
 	ConnectionFailed     = "ConnectionFailed"
 	Ready                = "Ready"
 	Staging              = "Staging"
-	initializing         = "initializing"
+	Initializing         = "Initializing"
 	ServerCreationFailed = "ServerCreationFailed"
 )
 


### PR DESCRIPTION
While the OVA provider pod is being created, the pod status currently displays `connectionFailed` until the OVA pod is actually up and running, this gives the wrong impression that something went wrong during the OVA provider creation. This fix changes the phases for the OVA provider. Once the provider is added, the status will immediately show `staging`. If there is a failure during the OVA provider creation process, or if the pod is not running after 10 minutes (consider as a timeout), the status will change to `connectionFailed`.
