### PR TITLE
Add 'app' label to the template of the migrated VM

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -319,7 +319,7 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) (err error) {
 		return
 	}
 
-	virtualMachine := &cnv.VirtualMachine{}
+	var virtualMachine *cnv.VirtualMachine
 	if len(list.Items) == 0 {
 		virtualMachine = newVM
 		err = r.Destination.Client.Create(context.TODO(), virtualMachine)
@@ -1075,6 +1075,12 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus) (object *cnv.VirtualMachine
 		object = r.emptyVm(vm)
 	}
 
+	if object.Spec.Template.ObjectMeta.Labels == nil {
+		object.Spec.Template.ObjectMeta.Labels = map[string]string{}
+	}
+	// Set the 'app' label for identification of the virtual machine instance(s)
+	object.Spec.Template.ObjectMeta.Labels["app"] = vm.Name
+
 	//Add the original name and ID info to the VM annotations
 	if len(originalName) > 0 {
 		annotations := make(map[string]string)
@@ -1164,7 +1170,9 @@ func (r *KubeVirt) emptyVm(vm *plan.VMStatus) (virtualMachine *cnv.VirtualMachin
 			Labels:    r.vmLabels(vm.Ref),
 			Name:      vm.Name,
 		},
-		Spec: cnv.VirtualMachineSpec{},
+		Spec: cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{},
+		},
 	}
 	return
 }


### PR DESCRIPTION
This label is used for identification of the virtual machine instance(s) that will be created from the VM, for example for load balancing, see:

https://github.com/rhpds/roadshow_ocpvirt_instructions/blob/d3b008cb5d7855b54ab912dda9f8d174dd93dcbc/workshop/content/08_migrate_vms.adoc#review-and-configure-migrated-virtual-machines

https://issues.redhat.com/browse/MTV-843