### PR TITLE
Set transfer network on the conversion pod

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1230,10 +1230,17 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	if err != nil {
 		return
 	}
+	// pod annotations
+	annotations := map[string]string{}
+	if r.Plan.Spec.TransferNetwork != nil {
+		annotations[AnnDefaultNetwork] = path.Join(
+			r.Plan.Spec.TransferNetwork.Namespace, r.Plan.Spec.TransferNetwork.Name)
+	}
 	// pod
 	pod = &core.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Namespace:    r.Plan.Spec.TargetNamespace,
+			Annotations:  annotations,
 			Labels:       r.conversionLabels(vm.Ref, false),
 			GenerateName: r.getGeneratedName(vm),
 		},


### PR DESCRIPTION
Before version 2.4, the virt-v2v conversion pod operated on a local disk after the disk was retrieved by CDI. CDI considered the transfer network when transfering the data from vSphere.

As from version 2.4, when running a cold-migration to the local cluster, virt-v2v is also responsible to connect to vSphere and retrieve the disk(s) from there, therefore it now needs to consider the transfer network that is selected as well.

This patch adds the transfer network, if set, on the conversion pod in both cases.

https://issues.redhat.com/browse/MTV-846