### PR TITLE
OVA: manually remove PVs attached to ova provider once it deleted.

### DIFF
--- a/pkg/controller/provider/BUILD.bazel
+++ b/pkg/controller/provider/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors",
         "//vendor/k8s.io/apimachinery/pkg/api/resource",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/apimachinery/pkg/labels",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr",
         "//vendor/k8s.io/apiserver/pkg/storage/names",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",


### PR DESCRIPTION
When deleting an OVA provider, the PVs are not automatically deleted. To overcome this issue, as part of the reconciler, we need to perform a manual clean-up. Since the provider is already deleted, we can't query the specific PV by name, so using the PV prefix and labels, we find the matching one. And if the status of it is 'released' (which indicates that the provider was deleted), we remove it from the system.