### PR TITLE
Make the block overhead configurable

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -66,6 +66,8 @@ spec:
           value: ${CDI_EXPORT_TOKEN_TTL}
         - name: FILESYSTEM_OVERHEAD
           value: ${FILESYSTEM_OVERHEAD}
+        - name: BLOCK_OVERHEAD
+          value: ${BLOCK_OVERHEAD}
         - name: POPULATOR_CONTROLLER_IMAGE
           value: ${POPULATOR_CONTROLLER_IMAGE}
         - name: OVIRT_POPULATOR_IMAGE

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -35,6 +35,7 @@ controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_max_vm_inflight: 20
 controller_filesystem_overhead: 10
+controller_block_overhead: 0
 profiler_volume_path: "/var/cache/profiler"
 
 inventory_volume_path: "/var/cache/inventory"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -80,6 +80,10 @@ spec:
         - name: FILESYSTEM_OVERHEAD
           value: "{{ controller_filesystem_overhead }}"
 {% endif %}
+{% if controller_block_overhead is number %}
+        - name: BLOCK_OVERHEAD
+          value: "{{ controller_block_overhead }}"
+{% endif %}
 {% if controller_vsphere_incremental_backup|bool %}
         - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
           value: "true"

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1098,10 +1098,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image, storageC
 		err = liberr.Wrap(err)
 		return
 	}
-
-	if *volumeMode == core.PersistentVolumeFilesystem {
-		virtualSize = utils.CalculateSpaceWithOverhead(virtualSize)
-	}
+	virtualSize = utils.CalculateSpaceWithOverhead(virtualSize, volumeMode)
 
 	// The image might be a VM Snapshot Image and has no volume associated to it
 	if originalVolumeDiskId, ok := image.Properties["forklift_original_volume_id"]; ok {

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -20,6 +20,7 @@ const (
 	SnapshotStatusCheckRate = "SNAPSHOT_STATUS_CHECK_RATE"
 	CDIExportTokenTTL       = "CDI_EXPORT_TOKEN_TTL"
 	FileSystemOverhead      = "FILESYSTEM_OVERHEAD"
+	BlockOverhead           = "BLOCK_OVERHEAD"
 )
 
 // Migration settings
@@ -45,6 +46,8 @@ type Migration struct {
 	CDIExportTokenTTL int
 	// FileSystem overhead in percantage
 	FileSystemOverhead int
+	// Block fixed overhead size
+	BlockOverhead int
 }
 
 // Load settings.
@@ -83,6 +86,9 @@ func (r *Migration) Load() (err error) {
 		return liberr.Wrap(err)
 	}
 	if r.FileSystemOverhead, err = getNonNegativeEnvLimit(FileSystemOverhead, 10); err != nil {
+		return liberr.Wrap(err)
+	}
+	if r.BlockOverhead, err = getNonNegativeEnvLimit(BlockOverhead, 0); err != nil {
 		return liberr.Wrap(err)
 	}
 


### PR DESCRIPTION
This patch will allow the user to configure the block overhead.
Currently it defaults to 0. The overhead is required when migrating to
encrypted Ceph RBD (block). The pod may see less space on the disk and
therefore the migration will fail when it tries to allocate the last
sectors. See more about encrypted Ceph RBD in:
https://docs.ceph.com/en/quincy/rbd/rbd-encryption/

The value needs to be set in the ForkliftController spec under the
value: `controller_block_overhead`. The addition will be the fixed
number provided to the size of the disk.