### PR TITLE
Make the block overhead configurable (backport)

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -66,6 +66,8 @@ spec:
           value: ${CDI_EXPORT_TOKEN_TTL}
         - name: FILESYSTEM_OVERHEAD
           value: ${FILESYSTEM_OVERHEAD}
+        - name: BLOCK_OVERHEAD
+          value: ${BLOCK_OVERHEAD}
         - name: POPULATOR_CONTROLLER_IMAGE
           value: ${POPULATOR_CONTROLLER_IMAGE}
         - name: OVIRT_POPULATOR_IMAGE

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -35,6 +35,7 @@ controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_max_vm_inflight: 20
 controller_filesystem_overhead: 10
+controller_block_overhead: 0
 profiler_volume_path: "/var/cache/profiler"
 
 inventory_volume_path: "/var/cache/inventory"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -80,6 +80,10 @@ spec:
         - name: FILESYSTEM_OVERHEAD
           value: "{{ controller_filesystem_overhead }}"
 {% endif %}
+{% if controller_block_overhead is number %}
+        - name: BLOCK_OVERHEAD
+          value: "{{ controller_block_overhead }}"
+{% endif %}
 {% if controller_vsphere_incremental_backup|bool %}
         - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
           value: "true"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -80,10 +80,8 @@ spec:
         - name: FILESYSTEM_OVERHEAD
           value: "{{ controller_filesystem_overhead }}"
 {% endif %}
-{% if controller_block_overhead is number %}
         - name: BLOCK_OVERHEAD
           value: "{{ controller_block_overhead }}"
-{% endif %}
 {% if controller_vsphere_incremental_backup|bool %}
         - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
           value: "true"

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1100,10 +1100,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image, storageC
 		err = liberr.Wrap(err)
 		return
 	}
-
-	if *volumeMode == core.PersistentVolumeFilesystem {
-		virtualSize = utils.CalculateSpaceWithOverhead(virtualSize)
-	}
+	virtualSize = utils.CalculateSpaceWithOverhead(virtualSize, volumeMode)
 
 	// The image might be a VM Snapshot Image and has no volume associated to it
 	if originalVolumeDiskId, ok := image.Properties["forklift_original_volume_id"]; ok {

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -780,11 +780,7 @@ func (r *Builder) getDefaultVolumeAndAccessMode(storageClassName string) ([]core
 // Build a PersistentVolumeClaim with DataSourceRef for VolumePopulator
 func (r *Builder) persistentVolumeClaimWithSourceRef(diskAttachment model.XDiskAttachment, storageClassName string, populatorName string,
 	annotations map[string]string) (pvc *core.PersistentVolumeClaim, err error) {
-
-	// We add 10% overhead because of the fsOverhead in CDI, around 5% to ext4 and 5% for root partition.
-	// This value is configurable using `FILESYSTEM_OVERHEAD`
 	diskSize := diskAttachment.Disk.ProvisionedSize
-
 	var accessModes []core.PersistentVolumeAccessMode
 	var volumeMode *core.PersistentVolumeMode
 	accessModes, volumeMode, err = r.getDefaultVolumeAndAccessMode(storageClassName)
@@ -792,12 +788,11 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(diskAttachment model.XDiskA
 		err = liberr.Wrap(err)
 		return
 	}
-
-	// Accounting for fsOverhead is only required for `volumeMode: Filesystem`, as we may not have enough space
-	// after creating a filesystem on an underlying block device
-	if *volumeMode == core.PersistentVolumeFilesystem {
-		diskSize = utils.CalculateSpaceWithOverhead(diskSize)
-	}
+	// We add 10% overhead because of the fsOverhead in CDI, around 5% to ext4 and 5% for root partition.
+	// This value is configurable using `FILESYSTEM_OVERHEAD`
+	// Encrypted Ceph RBD makes the pod see less space, this possible overhead needs to be taken into account.
+	// For Block the value is configurable using `BLOCK_OVERHEAD`
+	diskSize = utils.CalculateSpaceWithOverhead(diskSize, volumeMode)
 
 	annotations[AnnImportDiskId] = diskAttachment.ID
 

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -27,7 +27,7 @@ func CalculateSpaceWithOverhead(requestedSpace int64, volumeMode *core.Persisten
 	if *volumeMode == core.PersistentVolumeFilesystem {
 		spaceWithOverhead = int64(math.Ceil(float64(alignedSize) / (1 - float64(settings.Settings.FileSystemOverhead)/100)))
 	} else {
-		spaceWithOverhead = alignedSize + int64(settings.Settings.BlockOverhead)
+		spaceWithOverhead = alignedSize + settings.Settings.BlockOverhead
 	}
 	return spaceWithOverhead
 }

--- a/pkg/settings/BUILD.bazel
+++ b/pkg/settings/BUILD.bazel
@@ -18,5 +18,6 @@ go_library(
     deps = [
         "//pkg/lib/error",
         "//pkg/lib/logging",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource",
     ],
 )

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Environment variables.
@@ -51,7 +52,7 @@ type Migration struct {
 	// FileSystem overhead in percantage
 	FileSystemOverhead int
 	// Block fixed overhead size
-	BlockOverhead int
+	BlockOverhead int64
 }
 
 // Load settings.
@@ -101,8 +102,12 @@ func (r *Migration) Load() (err error) {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	if r.BlockOverhead, err = getNonNegativeEnvLimit(BlockOverhead, 0); err != nil {
-		return liberr.Wrap(err)
+	if overhead, ok := os.LookupEnv(BlockOverhead); ok {
+		if quantity, err := resource.ParseQuantity(overhead); err != nil {
+			return liberr.Wrap(err)
+		} else if r.BlockOverhead, ok = quantity.AsInt64(); !ok {
+			return fmt.Errorf("Block overhead is invalid: %s", overhead)
+		}
 	}
 
 	return

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"fmt"
 	"os"
 	"strings"
 

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -19,6 +19,7 @@ const (
 	SnapshotStatusCheckRate = "SNAPSHOT_STATUS_CHECK_RATE"
 	CDIExportTokenTTL       = "CDI_EXPORT_TOKEN_TTL"
 	FileSystemOverhead      = "FILESYSTEM_OVERHEAD"
+	BlockOverhead           = "BLOCK_OVERHEAD"
 )
 
 // Default virt-v2v image.
@@ -49,6 +50,8 @@ type Migration struct {
 	CDIExportTokenTTL int
 	// FileSystem overhead in percantage
 	FileSystemOverhead int
+	// Block fixed overhead size
+	BlockOverhead int
 }
 
 // Load settings.
@@ -96,6 +99,9 @@ func (r *Migration) Load() (err error) {
 	}
 	r.FileSystemOverhead, err = getNonNegativeEnvLimit(FileSystemOverhead, 10)
 	if err != nil {
+		return liberr.Wrap(err)
+	}
+	if r.BlockOverhead, err = getNonNegativeEnvLimit(BlockOverhead, 0); err != nil {
 		return liberr.Wrap(err)
 	}
 


### PR DESCRIPTION
This patch will allow the user to configure the block overhead. Currently it defaults to 0. The overhead is required when migrating to encrypted Ceph RBD (block). The pod may see less space on the disk and therefore the migration will fail when it tries to allocate the last sectors. See more about encrypted Ceph RBD in:
https://docs.ceph.com/en/quincy/rbd/rbd-encryption/

The value needs to be set in the ForkliftController spec under the value: `controller_block_overhead`. The addition will be the fixed number provided to the size of the disk.