### PR TITLE
Lock bazel in CI build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -86,7 +86,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    env:
+      USE_BAZEL_VERSION: 5.4.0
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checks-out repository under $GITHUB_WORKSPACE


### PR DESCRIPTION
In order to align with the whole project and not failing the CI, this patch will lock bazel to 5.4.0.