### PR TITLE
Change controller_block_overhead to quantity

### DIFF
--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -80,10 +80,8 @@ spec:
         - name: FILESYSTEM_OVERHEAD
           value: "{{ controller_filesystem_overhead }}"
 {% endif %}
-{% if controller_block_overhead is number %}
         - name: BLOCK_OVERHEAD
           value: "{{ controller_block_overhead }}"
-{% endif %}
 {% if controller_vsphere_incremental_backup|bool %}
         - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
           value: "true"

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -27,7 +27,7 @@ func CalculateSpaceWithOverhead(requestedSpace int64, volumeMode *core.Persisten
 	if *volumeMode == core.PersistentVolumeFilesystem {
 		spaceWithOverhead = int64(math.Ceil(float64(alignedSize) / (1 - float64(settings.Settings.FileSystemOverhead)/100)))
 	} else {
-		spaceWithOverhead = alignedSize + int64(settings.Settings.BlockOverhead)
+		spaceWithOverhead = alignedSize + settings.Settings.BlockOverhead
 	}
 	return spaceWithOverhead
 }

--- a/pkg/settings/BUILD.bazel
+++ b/pkg/settings/BUILD.bazel
@@ -18,5 +18,6 @@ go_library(
     deps = [
         "//pkg/lib/error",
         "//pkg/lib/logging",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource",
     ],
 )


### PR DESCRIPTION
When specifying resources like disk sizes, the value is expected to represent a quantity rather than an integer so users can set values like "1Gi". Applying this to controller_block_overhead as well.