### PR TITLE
Keep the cluster CPU

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -137,6 +137,10 @@ spec:
                 - network
                 - storage
                 type: object
+              preserveClusterCpuModel:
+                description: Preserve the CPU model and flags the VM runs with in
+                  its oVirt cluster.
+                type: boolean
               provider:
                 description: Providers.
                 properties:

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -44,6 +44,8 @@ type PlanSpec struct {
 	TransferNetwork *core.ObjectReference `json:"transferNetwork,omitempty"`
 	// Whether this plan should be archived.
 	Archived bool `json:"archived,omitempty"`
+	// Preserve the CPU model and flags the VM runs with in its oVirt cluster.
+	PreserveClusterCPUModel bool `json:"preserveClusterCpuModel,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -394,7 +394,21 @@ func (r *Builder) mapCPU(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 	}
 	if vm.CustomCpuModel != "" {
 		r.setCpuFlags(vm.CustomCpuModel, object)
+	} else if r.Plan.Spec.PreserveClusterCPUModel {
+		r.setCpuFlags(r.getClusterCpu(vm), object)
 	}
+}
+
+func (r *Builder) getClusterCpu(vm *model.Workload) string {
+	var cpuAndFlags string
+	cpus := strings.Split(vm.ServerCpu.SystemOptionValue[0].Value, ";")
+	for _, values := range cpus {
+		if strings.Contains(values, vm.Cluster.CPU.Type) {
+			cpuAndFlags = strings.Split(values, ":")[3]
+			break
+		}
+	}
+	return cpuAndFlags
 }
 
 func (r *Builder) setCpuFlags(fullCpu string, object *cnv.VirtualMachineSpec) {

--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -77,6 +77,9 @@ type Cluster struct {
 		Enabled string `json:"enabled"`
 	} `json:"ksm"`
 	BiosType string `json:"bios_type"`
+	CPU      struct {
+		Type string `json:"type"`
+	} `json:"cpu"`
 }
 
 // Apply to (update) the model.
@@ -87,6 +90,7 @@ func (r *Cluster) ApplyTo(m *model.Cluster) {
 	m.HaReservation = r.bool(r.HaReservation)
 	m.KsmEnabled = r.bool(r.KSM.Enabled)
 	m.BiosType = r.BiosType
+	m.CPU.Type = r.CPU.Type
 }
 
 // Cluster (list).

--- a/pkg/controller/provider/container/ovirt/resource.go
+++ b/pkg/controller/provider/container/ovirt/resource.go
@@ -80,6 +80,10 @@ type Cluster struct {
 	CPU      struct {
 		Type string `json:"type"`
 	} `json:"cpu"`
+	Version struct {
+		Minor string `json:"minor"`
+		Major string `json:"major"`
+	} `json:"version"`
 }
 
 // Apply to (update) the model.
@@ -91,11 +95,26 @@ func (r *Cluster) ApplyTo(m *model.Cluster) {
 	m.KsmEnabled = r.bool(r.KSM.Enabled)
 	m.BiosType = r.BiosType
 	m.CPU.Type = r.CPU.Type
+	m.Version.Minor = r.Version.Minor
+	m.Version.Major = r.Version.Major
 }
 
 // Cluster (list).
 type ClusterList struct {
 	Items []Cluster `json:"cluster"`
+}
+
+// ServerCpu.
+type ServerCpu struct {
+	Base
+	Values struct {
+		SystemOptionValues []SystemOptionValue `json:"system_option_value"`
+	} `json:"values"`
+}
+
+type SystemOptionValue struct {
+	Value   string `json:"value"`
+	Version string `json:"version"`
 }
 
 // Host.

--- a/pkg/controller/provider/model/ovirt/doc.go
+++ b/pkg/controller/provider/model/ovirt/doc.go
@@ -10,6 +10,7 @@ func All() []interface{} {
 		&ocp.Provider{},
 		&DataCenter{},
 		&Cluster{},
+		&ServerCpu{},
 		&NICProfile{},
 		&DiskProfile{},
 		&Network{},

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -52,6 +52,12 @@ type Cluster struct {
 	HaReservation bool   `sql:""`
 	KsmEnabled    bool   `sql:""`
 	BiosType      string `sql:""`
+	CPU           CPU    `sql:""`
+}
+
+type CPU struct {
+	Architecture string `json:"architecture"`
+	Type         string `json:"type"`
 }
 
 type Network struct {

--- a/pkg/controller/provider/model/ovirt/model.go
+++ b/pkg/controller/provider/model/ovirt/model.go
@@ -48,16 +48,33 @@ type DataCenter struct {
 
 type Cluster struct {
 	Base
-	DataCenter    string `sql:"d0,fk(dataCenter +cascade)"`
-	HaReservation bool   `sql:""`
-	KsmEnabled    bool   `sql:""`
-	BiosType      string `sql:""`
-	CPU           CPU    `sql:""`
+	DataCenter    string  `sql:"d0,fk(dataCenter +cascade)"`
+	HaReservation bool    `sql:""`
+	KsmEnabled    bool    `sql:""`
+	BiosType      string  `sql:""`
+	CPU           CPU     `sql:""`
+	Version       Version `sql:""`
+}
+
+type ServerCpu struct {
+	Base
+	DataCenter        string            `sql:"d0,fk(dataCenter +cascade)"`
+	SystemOptionValue SystemOptionValue `sql:""`
+}
+
+type SystemOptionValue struct {
+	Value   string `json:"value"`
+	Version string `json:"version"`
 }
 
 type CPU struct {
 	Architecture string `json:"architecture"`
 	Type         string `json:"type"`
+}
+
+type Version struct {
+	Minor string `json:"minor"`
+	Major string `json:"major"`
 }
 
 type Network struct {

--- a/pkg/controller/provider/model/ovirt/tree.go
+++ b/pkg/controller/provider/model/ovirt/tree.go
@@ -15,6 +15,7 @@ var (
 	StorageKind     = libref.ToKind(StorageDomain{})
 	DiskKind        = "Disk" // TODO: UPDATE WITH MODEL.
 	VmKind          = libref.ToKind(VM{})
+	ServerCPUKind   = libref.ToKind(ServerCpu{})
 )
 
 // Types.

--- a/pkg/controller/provider/web/ovirt/BUILD.bazel
+++ b/pkg/controller/provider/web/ovirt/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "nicprofile.go",
         "provider.go",
         "resource.go",
+        "servercpu.go",
         "storage.go",
         "tree.go",
         "vm.go",

--- a/pkg/controller/provider/web/ovirt/base.go
+++ b/pkg/controller/provider/web/ovirt/base.go
@@ -65,26 +65,26 @@ func (r *PathBuilder) Path(m model.Model) (path string) {
 	if r.cache == nil {
 		r.cache = map[string]string{}
 	}
-	switch m.(type) {
+	switch obj := m.(type) {
 	case *model.DataCenter:
-		path = m.(*model.DataCenter).Name
+		path = obj.Name
 	case *model.Cluster:
-		object := m.(*model.Cluster)
+		object := obj
 		path, err = r.forDataCenter(object.DataCenter, object.Name)
 	case *model.ServerCpu:
-		object := m.(*model.ServerCpu)
+		object := obj
 		path, err = r.forDataCenter(object.DataCenter, object.Name)
 	case *model.Network:
-		object := m.(*model.Network)
+		object := obj
 		path, err = r.forDataCenter(object.DataCenter, object.Name)
 	case *model.StorageDomain:
-		object := m.(*model.StorageDomain)
+		object := obj
 		path, err = r.forDataCenter(object.DataCenter, object.Name)
 	case *model.Host:
-		object := m.(*model.Host)
+		object := obj
 		path, err = r.forCluster(object.Cluster, object.Name)
 	case *model.VM:
-		object := m.(*model.VM)
+		object := obj
 		path, err = r.forCluster(object.Cluster, object.Name)
 	}
 

--- a/pkg/controller/provider/web/ovirt/base.go
+++ b/pkg/controller/provider/web/ovirt/base.go
@@ -1,13 +1,14 @@
 package ovirt
 
 import (
+	pathlib "path"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ovirt"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	libmodel "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
-	pathlib "path"
-	"strings"
 )
 
 // Package logger.
@@ -69,6 +70,9 @@ func (r *PathBuilder) Path(m model.Model) (path string) {
 		path = m.(*model.DataCenter).Name
 	case *model.Cluster:
 		object := m.(*model.Cluster)
+		path, err = r.forDataCenter(object.DataCenter, object.Name)
+	case *model.ServerCpu:
+		object := m.(*model.ServerCpu)
 		path, err = r.forDataCenter(object.DataCenter, object.Name)
 	case *model.Network:
 		object := m.(*model.Network)

--- a/pkg/controller/provider/web/ovirt/client.go
+++ b/pkg/controller/provider/web/ovirt/client.go
@@ -98,7 +98,7 @@ func (r *Finder) With(client base.Client) base.Finder {
 //	NotFoundErr
 //	RefNotUniqueErr
 func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
-	switch resource.(type) {
+	switch res := resource.(type) {
 	case *Network:
 		id := ref.ID
 		if id != "" {
@@ -129,7 +129,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
-			*resource.(*Network) = list[0]
+			*res = list[0]
 		}
 	case *StorageDomain:
 		id := ref.ID
@@ -161,7 +161,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
-			*resource.(*StorageDomain) = list[0]
+			*res = list[0]
 		}
 	case *Host:
 		id := ref.ID
@@ -193,7 +193,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
-			*resource.(*Host) = list[0]
+			*res = list[0]
 		}
 	case *VM:
 		id := ref.ID
@@ -225,7 +225,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
-			*resource.(*VM) = list[0]
+			*res = list[0]
 		}
 	case *Cluster:
 		id := ref.ID
@@ -257,7 +257,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
-			*resource.(*Cluster) = list[0]
+			*res = list[0]
 		}
 	case *ServerCpu:
 		id := ref.ID
@@ -289,7 +289,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
-			*resource.(*ServerCpu) = list[0]
+			*res = list[0]
 		}
 	case *Workload:
 		id := ref.ID
@@ -321,7 +321,7 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 				err = liberr.Wrap(RefNotUniqueError{Ref: ref})
 				break
 			}
-			*resource.(*Workload) = list[0]
+			*res = list[0]
 		}
 	default:
 		err = liberr.Wrap(

--- a/pkg/controller/provider/web/ovirt/cluster.go
+++ b/pkg/controller/provider/web/ovirt/cluster.go
@@ -180,7 +180,10 @@ type Cluster struct {
 	HaReservation bool   `json:"haReservation"`
 	KsmEnabled    bool   `json:"ksmEnabled"`
 	BiosType      string `json:"biosType"`
+	CPU           CPU    `json:"cpu"`
 }
+
+type CPU = model.CPU
 
 // Build the resource using the model.
 func (r *Cluster) With(m *model.Cluster) {
@@ -189,6 +192,7 @@ func (r *Cluster) With(m *model.Cluster) {
 	r.HaReservation = m.HaReservation
 	r.KsmEnabled = m.KsmEnabled
 	r.BiosType = m.BiosType
+	r.CPU = m.CPU
 }
 
 // Build self link (URI).

--- a/pkg/controller/provider/web/ovirt/doc.go
+++ b/pkg/controller/provider/web/ovirt/doc.go
@@ -60,6 +60,11 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 				base.Handler{Container: container},
 			},
 		},
+		&ServerCpuHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
 		&DiskHandler{
 			Handler: Handler{
 				base.Handler{Container: container},

--- a/pkg/controller/provider/web/ovirt/tree.go
+++ b/pkg/controller/provider/web/ovirt/tree.go
@@ -279,6 +279,17 @@ func (r *NodeBuilder) Node(parent *TreeNode, m model.Model) *TreeNode {
 			Kind:   kind,
 			Object: object,
 		}
+	case model.ServerCPUKind:
+		resource := &ServerCpu{}
+		resource.With(m.(*model.ServerCpu))
+		resource.Link(provider)
+		resource.Path = r.pathBuilder.Path(m)
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
 	}
 
 	return node

--- a/pkg/controller/provider/web/ovirt/workload.go
+++ b/pkg/controller/provider/web/ovirt/workload.go
@@ -3,6 +3,7 @@ package ovirt
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
@@ -207,6 +208,7 @@ type Workload struct {
 	Host       *Host      `json:"host"`
 	Cluster    Cluster    `json:"cluster"`
 	DataCenter DataCenter `json:"dataCenter"`
+	ServerCpu  ServerCpu  `json:"serverCpu"`
 }
 
 // Build self link (URI).
@@ -220,6 +222,7 @@ func (r *Workload) Link(p *api.Provider) {
 	r.XVM.Link(p)
 	r.Cluster.Link(p)
 	r.DataCenter.Link(p)
+	r.ServerCpu.Link(p)
 	if r.Host != nil {
 		r.Host.Link(p)
 	}
@@ -262,6 +265,15 @@ func (r *Workload) Expand(db libmodel.DB) (err error) {
 		return err
 	}
 	r.DataCenter.With(dataCenter)
+	// Server CPU
+	serverCpu := &model.ServerCpu{
+		Base: model.Base{ID: strings.Join([]string{cluster.Version.Major, cluster.Version.Minor}, ".")},
+	}
+	err = db.Get(serverCpu)
+	if err != nil {
+		return err
+	}
+	r.ServerCpu.With(serverCpu)
 
 	return
 }


### PR DESCRIPTION
If the user may wish to migrate and preserve the cluster CPU model.
Therefore, in the plan spec it will be possible now to set `PreserveClusterCPUModel` to `true` and forklift
will set the VMs with the source cluster CPU model.