### PR TITLE
openstack: check image is in the inventory before progressing

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1101,8 +1101,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image, storageC
 	}
 
 	var accessModes []core.PersistentVolumeAccessMode
-	var volumeMode *core.PersistentVolumeMode
-	accessModes, volumeMode, err = r.getVolumeAndAccessMode(storageClassName)
+	accessModes, volumeMode, err := r.getVolumeAndAccessMode(storageClassName)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -1116,6 +1115,8 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image, storageC
 	} else if originalImageId, ok := image.Properties["forklift_original_image_id"]; ok {
 		annotations[AnnImportDiskId] = originalImageId.(string)
 		r.Log.Info("the image comes from a vm snapshot", "imageID", originalImageId)
+	} else {
+		r.Log.Error(nil, "the image has no volume or vm snapshot associated to it", "image", image.Name)
 	}
 
 	pvc = &core.PersistentVolumeClaim{

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1113,9 +1113,9 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image, storageC
 	if originalVolumeDiskId, ok := image.Properties["forklift_original_volume_id"]; ok {
 		annotations[AnnImportDiskId] = originalVolumeDiskId.(string)
 		r.Log.Info("the image comes from a volume", "volumeID", originalVolumeDiskId)
-	} else {
-		annotations[AnnImportDiskId] = image.ID
-		r.Log.Info("the image comes from a vm snapshot", "imageID", image.ID)
+	} else if originalImageId, ok := image.Properties["forklift_original_image_id"]; ok {
+		annotations[AnnImportDiskId] = originalImageId.(string)
+		r.Log.Info("the image comes from a vm snapshot", "imageID", originalImageId)
 	}
 
 	pvc = &core.PersistentVolumeClaim{

--- a/pkg/controller/plan/adapter/openstack/client.go
+++ b/pkg/controller/plan/adapter/openstack/client.go
@@ -498,7 +498,7 @@ func (r *Client) createVmSnapshotImage(vm *libclient.VM) (vmImage *libclient.Ima
 		err = liberr.Wrap(err)
 		return
 	}
-	// The vm is image based and we need to create the snapsots of the
+	// The vm is image based and we need to create the snapshots of the
 	// volumes attached to it.
 	if imageID, ok := vm.Image["id"]; ok {
 		// Update property for image based

--- a/pkg/controller/plan/adapter/openstack/common.go
+++ b/pkg/controller/plan/adapter/openstack/common.go
@@ -2,11 +2,13 @@ package openstack
 
 import (
 	"fmt"
+
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 )
 
 const (
 	forkliftPropertyOriginalVolumeID = "forklift_original_volume_id"
+	forkliftPropertyOriginalImageID  = "forklift_original_image_id"
 )
 
 func getMigrationName(ctx *plancontext.Context) string {


### PR DESCRIPTION
Image based migrations can get stuck since there is no check to ensure they were created in the inventory before attempting to progress, this will lead to the migration progressing to the next phase, but the PVC will not be created.

This patch adds the relevant property and checks the snapshot image is in the inventory before progressing