### PR TITLE
Disable TPM gathering from vSphere temporarily

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -715,7 +715,7 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 				fExtraConfig,
 				fGuestName,
 				fGuestID,
-				fTpmPresent,
+				//fTpmPresent,
 				fBalloonedMemory,
 				fVmIpAddress,
 				fStorageUsed,


### PR DESCRIPTION
The addition of the property "summary.config.tpmPresent" breaks compatibility with vSphere 6.5 ("InvalidProperty" error is returned when building the inventory). This patch reverts this part temporarily until we change this to work also with older versions of vSphere.

Related to #665 