### PR TITLE
Support adding an ESXi host as a source provider

### DIFF
--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -160,6 +160,12 @@
       state: present
       definition: "{{ lookup('template', 'api/mutatingwebhookconfiguration-plans.yml.j2') }}"
 
+
+  - name: "Setup providers mutating webhook configuration"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'api/mutatingwebhookconfiguration-providers.yml.j2') }}"
+
   - name: "Setup default provider"
     k8s:
       state: present

--- a/operator/roles/forkliftcontroller/templates/api/mutatingwebhookconfiguration-providers.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/mutatingwebhookconfiguration-providers.yml.j2
@@ -1,0 +1,38 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ api_deployment_name }}-providers
+  namespace: ""
+  annotations:
+{% if k8s_cluster|bool %}
+    cert-manager.io/inject-ca-from: {{ app_namespace }}/{{ api_certificate_name }}
+{% else %}
+    service.beta.openshift.io/inject-cabundle: "true"
+{% endif %}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ api_service_name }}
+      namespace: {{ app_namespace }}
+      path: /provider-mutate
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: plans.forklift.konveyor
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - forklift.konveyor.io
+    resources:
+    - providers
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+  sideEffects: None
+  timeoutSeconds: 30

--- a/operator/roles/forkliftcontroller/templates/api/mutatingwebhookconfiguration-secrets.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/mutatingwebhookconfiguration-secrets.yml.j2
@@ -25,7 +25,7 @@ webhooks:
   namespaceSelector: {}
   objectSelector: 
     matchExpressions:
-    - key: createdForProviderType
+    - key: createdForResourceType
       operator: Exists
   rules:
   - apiGroups:

--- a/pkg/apis/forklift/v1beta1/provider.go
+++ b/pkg/apis/forklift/v1beta1/provider.go
@@ -63,7 +63,10 @@ const (
 
 // Provider settings.
 const (
-	VDDK = "vddkInitImage"
+	VDDK    = "vddkInitImage"
+	SDK     = "sdkEndpoint"
+	VCenter = "vcenter"
+	ESXI    = "esxi"
 )
 
 // Defines the desired state of Provider.

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -204,7 +204,7 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		},
 		core.EnvVar{
 			Name:  "V2V_source",
-			Value: "vCenter",
+			Value: "vSphere",
 		},
 	)
 	return

--- a/pkg/forklift-api/webhooks/mutating-webhook.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook.go
@@ -15,3 +15,7 @@ func ServeSecretMutator(resp http.ResponseWriter, req *http.Request) {
 func ServePlanMutator(resp http.ResponseWriter, req *http.Request, client client.Client) {
 	mutating_webhooks.Serve(resp, req, &mutators.PlanMutator{Client: client})
 }
+
+func ServeProviderMutator(resp http.ResponseWriter, req *http.Request, client client.Client) {
+	mutating_webhooks.Serve(resp, req, &mutators.ProviderMutator{Client: client})
+}

--- a/pkg/forklift-api/webhooks/mutating-webhook.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook.go
@@ -8,8 +8,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ServeSecretMutator(resp http.ResponseWriter, req *http.Request) {
-	mutating_webhooks.Serve(resp, req, &mutators.SecretMutator{})
+func ServeSecretMutator(resp http.ResponseWriter, req *http.Request, client client.Client) {
+	mutating_webhooks.Serve(resp, req, &mutators.SecretMutator{Client: client})
 }
 
 func ServePlanMutator(resp http.ResponseWriter, req *http.Request, client client.Client) {

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "mutators",
     srcs = [
         "plan-mutator.go",
+        "provider-mutator.go",
         "secret-mutator.go",
     ],
     importpath = "github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/mutating-webhook/mutators",

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/provider-mutator.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/provider-mutator.go
@@ -1,0 +1,68 @@
+package mutators
+
+import (
+	"encoding/json"
+
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/util"
+	admissionv1 "k8s.io/api/admission/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ProviderMutator struct {
+	ar       *admissionv1.AdmissionReview
+	provider api.Provider
+	Client   client.Client
+}
+
+func (mutator *ProviderMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	log.Info("provider mutator was called")
+	mutator.ar = ar
+	raw := ar.Request.Object.Raw
+	if err := json.Unmarshal(raw, &mutator.provider); err != nil {
+		log.Error(err, "mutating webhook error, failed to unmarshel provider")
+		return util.ToAdmissionResponseError(err)
+	}
+
+	specChanged := mutator.setSdkEndpointIfNeeded()
+
+	if specChanged {
+		patches := mutator.patchPayload()
+		patchBytes, err := util.GeneratePatchPayload(patches...)
+		if err != nil {
+			log.Error(err, "mutating webhook error, failed to generate payload for patch request")
+			return util.ToAdmissionResponseError(err)
+		}
+
+		jsonPatchType := admissionv1.PatchTypeJSONPatch
+		return &admissionv1.AdmissionResponse{
+			Allowed:   true,
+			Patch:     patchBytes,
+			PatchType: &jsonPatchType,
+		}
+	} else {
+		return util.ToAdmissionResponseAllow()
+	}
+}
+
+func (mutator *ProviderMutator) setSdkEndpointIfNeeded() bool {
+	var providerChanged bool
+
+	if mutator.provider.Type() == api.VSphere {
+		if _, ok := mutator.provider.Spec.Settings[api.SDK]; !ok {
+			log.Info("SDK endpoint type was not specified for a vSphere provider, assuming vCenter")
+			mutator.provider.Spec.Settings[api.SDK] = api.VCenter
+			providerChanged = true
+		}
+	}
+
+	return providerChanged
+}
+
+func (mutator *ProviderMutator) patchPayload() []util.PatchOperation {
+	return []util.PatchOperation{{
+		Op:    "replace",
+		Path:  "/spec",
+		Value: mutator.provider.Spec,
+	}}
+}

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
@@ -112,6 +112,10 @@ func (admitter *SecretAdmitter) validateProviderSecret() *admissionv1.AdmissionR
 
 func (admitter *SecretAdmitter) validateHostSecret() *admissionv1.AdmissionResponse {
 	if hostName, ok := admitter.secret.GetLabels()["createdForResource"]; ok {
+		if _, ok := admitter.secret.Data["user"]; !ok {
+			err := errors.New("Missing credentials on Host secret")
+			return webhookutils.ToAdmissionResponseError(err)
+		}
 		tested, err := admitter.testConnectionToHost(hostName)
 		switch {
 		case tested && err != nil:

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
@@ -125,7 +125,7 @@ func (admitter *SecretAdmitter) validateHostSecret() *admissionv1.AdmissionRespo
 			}
 		case err != nil:
 			log.Info("Couldn't test connection to the host, yet passing", "error", err.Error())
-		default:
+		case tested:
 			log.Info("Test succeeded, passing")
 		}
 		return webhookutils.ToAdmissionResponseAllow()

--- a/pkg/forklift-api/webhooks/webhooks.go
+++ b/pkg/forklift-api/webhooks/webhooks.go
@@ -46,7 +46,7 @@ func RegisterValidatingWebhooks(mux *http.ServeMux, client client.Client) {
 func RegisterMutatingWebhooks(mux *http.ServeMux, client client.Client) {
 	log.Info("register mutation webhook")
 	mux.HandleFunc(SecretMutatorPath, func(w http.ResponseWriter, r *http.Request) {
-		ServeSecretMutator(w, r)
+		ServeSecretMutator(w, r, client)
 	})
 	mux.HandleFunc(PlanMutatorPath, func(w http.ResponseWriter, r *http.Request) {
 		ServePlanMutator(w, r, client)

--- a/pkg/forklift-api/webhooks/webhooks.go
+++ b/pkg/forklift-api/webhooks/webhooks.go
@@ -15,6 +15,7 @@ const SecretMutatorPath = "/secret-mutate"
 const PlanValidatePath = "/plan-validate"
 const PlanMutatorPath = "/plan-mutate"
 const ProviderValidatePath = "/provider-validate"
+const ProviderMutatorPath = "/provider-mutate"
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager) error
@@ -49,5 +50,8 @@ func RegisterMutatingWebhooks(mux *http.ServeMux, client client.Client) {
 	})
 	mux.HandleFunc(PlanMutatorPath, func(w http.ResponseWriter, r *http.Request) {
 		ServePlanMutator(w, r, client)
+	})
+	mux.HandleFunc(ProviderMutatorPath, func(w http.ResponseWriter, r *http.Request) {
+		ServeProviderMutator(w, r, client)
 	})
 }

--- a/tests/suit/BUILD.bazel
+++ b/tests/suit/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo",
         "//vendor/github.com/onsi/gomega",
         "//vendor/k8s.io/api/core/v1:core",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/types",
         "//vendor/kubevirt.io/api/core/v1:core",
     ],

--- a/tests/suit/ova_test.go
+++ b/tests/suit/ova_test.go
@@ -32,6 +32,7 @@ var _ = Describe("[level:component]Migration tests for OVA provider", func() {
 		secret, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(
 			map[string]string{
 				"createdForProviderType": "ova",
+				"createdForResourceType": "providers",
 			}, nil,
 			map[string][]byte{
 				"url": []byte(nfs),

--- a/tests/suit/vsphere_test.go
+++ b/tests/suit/vsphere_test.go
@@ -1,6 +1,7 @@
 package suit_test
 
 import (
+	"context"
 	"time"
 
 	forkliftv1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
@@ -8,6 +9,7 @@ import (
 	"github.com/konveyor/forklift-controller/tests/suit/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -15,10 +17,10 @@ const (
 	vsphereStorageClass = "nfs-csi"
 )
 
-var _ = Describe("[level:component]Migration tests for vSphere provider", func() {
+var _ = Describe("vSphere provider", func() {
 	f := framework.NewFramework("migration-func-test")
 
-	It("[test] should create provider with NetworkMap", func() {
+	It("Migrate VM", func() {
 		namespace := f.Namespace.Name
 		By("Create Secret from Definition")
 		s, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
@@ -71,5 +73,91 @@ var _ = Describe("[level:component]Migration tests for vSphere provider", func()
 		err = utils.WaitForMigrationSucceededWithTimeout(f.CrClient, provider.Namespace, test_migration_name, 300*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 
+	})
+
+	Context("vCenter SDK", func() {
+		var provider *forkliftv1.Provider
+		var namespace string
+
+		BeforeEach(func() {
+			namespace = f.Namespace.Name
+			By("Create Secret from Definition")
+			s, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
+				map[string][]byte{
+					"thumbprint": []byte("52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF"),
+					"password":   []byte("MTIzNDU2Cg=="),
+					"user":       []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
+				}, namespace, "vcenter-provider-secret"))
+			Expect(err).ToNot(HaveOccurred())
+			By("Create vCenter provider")
+			pr := utils.NewProvider(vsphereProviderName, forkliftv1.VSphere, namespace, map[string]string{}, map[string]string{forkliftv1.VDDK: "quay.io/kubev2v/vddk-test-vmdk"}, "https://vcsim.konveyor-forklift:8989/sdk", s)
+			err = utils.CreateProviderFromDefinition(f.CrClient, pr)
+			Expect(err).ToNot(HaveOccurred())
+			provider, err = utils.WaitForProviderReadyWithTimeout(f.CrClient, namespace, vsphereProviderName, 30*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Provider should be set with sdkEndpoint=vcenter by default", func() {
+			Expect(provider.Spec.Settings[forkliftv1.SDK]).To(Equal(forkliftv1.VCenter))
+		})
+		It("Host cannot be defined with empty credentials", func() {
+			labels := map[string]string{
+				"createdForResourceType": "hosts",
+				"createdForResource":     "host-21",
+			}
+			_, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(labels, nil,
+				map[string][]byte{
+					"ip":       []byte("52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF"),
+					"provider": []byte(vsphereProviderName),
+				}, namespace, "esxi-host-secret"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("ESXi SDK", func() {
+		var provider *forkliftv1.Provider
+		var namespace string
+
+		BeforeEach(func() {
+			namespace = f.Namespace.Name
+			By("Create Secret from Definition")
+			s, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
+				map[string][]byte{
+					"thumbprint": []byte("52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF"),
+					"password":   []byte("MTIzNDU2Cg=="),
+					"user":       []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
+				}, namespace, "esxi-provider-secret"))
+			Expect(err).ToNot(HaveOccurred())
+			By("Create ESXi provider")
+			settings := map[string]string{
+				forkliftv1.VDDK: "quay.io/kubev2v/vddk-test-vmdk",
+				forkliftv1.SDK:  forkliftv1.ESXI,
+			}
+			pr := utils.NewProvider(vsphereProviderName, forkliftv1.VSphere, namespace, map[string]string{}, settings, "https://vcsim.konveyor-forklift:8989/sdk", s)
+			err = utils.CreateProviderFromDefinition(f.CrClient, pr)
+			Expect(err).ToNot(HaveOccurred())
+			provider, err = utils.WaitForProviderReadyWithTimeout(f.CrClient, namespace, vsphereProviderName, 30*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Provider should be set with sdkEndpoint=esxi", func() {
+			Expect(provider.Spec.Settings[forkliftv1.SDK]).To(Equal(forkliftv1.ESXI))
+		})
+		It("Credentials are copied from the Provider to the Host", func() {
+			labels := map[string]string{
+				"createdForResourceType": "hosts",
+				"createdForResource":     "host-21",
+			}
+			secret := utils.NewSecretDefinition(labels, nil,
+				map[string][]byte{
+					"ip":       []byte("52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF"),
+					"provider": []byte(vsphereProviderName),
+				}, namespace, "esxi-host-secret",
+			)
+			secret, err := f.K8sClient.CoreV1().Secrets(secret.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			_, found := secret.Data["user"]
+			Expect(found).To(BeTrue())
+		})
 	})
 })

--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -12,7 +12,7 @@ fi
 # This variable is used to build the command with args for virt-v2v.
 args=(virt-v2v -v -x)
 
-if [ "$V2V_source" == "vCenter" ] ; then
+if [ "$V2V_source" == "vSphere" ] ; then
   if [ -z "$V2V_libvirtURL" ] || \
       [ -z "$V2V_secretKey" ] || \
       [ -z "$V2V_vmName" ] ; then
@@ -71,7 +71,7 @@ for disk in /dev/block[0-9]* ; do
 	ln -s "$disk" "$DIR/$V2V_vmName-sd$(gen_name "$((num+1))")"
 done
 
-if [ "$V2V_source" == "vCenter" ] ; then
+if [ "$V2V_source" == "vSphere" ] ; then
   # Store password to file
   echo -n "$V2V_secretKey" > "$DIR/vmware.pw"
   args+=(-ip "$DIR/vmware.pw")


### PR DESCRIPTION
This PR adds the ability to add a vSphere provider that connects to SDK that is served by an ESXi host, instead of that of  vCenter. This allows users to import directly from environments that comprise of ESXi hosts, without vCenter.

We don't add a new type of provider since most of the code is similar in both cases, the SDK that is exposed from ESXi aligns with the one exposed from vCenter. The only difference is that in case we operate with an ESXi host, we need to set the libvirt URL with `esx://` rather than `vpx://` for virt-v2v.

For vSphere providers that interact with an ESXi hosts, the backend doesn't assume clients specify the credentials for the host as these credentials were already specified for the provider - a mutating webhook copies the credentials from the secret of the Provider to the secret of the Host in this case.