### PR TITLE
Fix validation of ESXi network configuration (backport)

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/host.go
+++ b/pkg/controller/plan/adapter/vsphere/host.go
@@ -155,12 +155,12 @@ func (r *EsxHost) thumbprint() string {
 func (r *EsxHost) getInsecureSkipVerifyFlag() bool {
 	insecure, found := r.Secret.Data["insecureSkipVerify"]
 	if !found {
-		return false
+		return true
 	}
 
 	insecureSkipVerify, err := strconv.ParseBool(string(insecure))
 	if err != nil {
-		return false
+		return true
 	}
 
 	return insecureSkipVerify


### PR DESCRIPTION
Currently, all validations fail because we cannot access the hosts with secure connections. In https://github.com/kubev2v/forklift/pull/656 the code has changed to take the configuration of the client connection from the secret, however, the secret of the ESXi hosts is never set with the insecure flag.

This change practically makes the client to the hosts be always insecure. It's not that significant because the data we get from the host does not include data that could be confidential.