### PR TITLE
Enable TPM gathering from vSphere

### DIFF
--- a/pkg/controller/provider/container/vsphere/BUILD.bazel
+++ b/pkg/controller/provider/container/vsphere/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "vsphere",
@@ -30,5 +30,19 @@ go_library(
         "//vendor/github.com/vmware/govmomi/vim25/types",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "vsphere_test",
+    srcs = ["collector_test.go"],
+    embed = [":vsphere"],
+    deps = [
+        "//vendor/github.com/onsi/gomega",
+        "//vendor/github.com/vmware/govmomi",
+        "//vendor/github.com/vmware/govmomi/session",
+        "//vendor/github.com/vmware/govmomi/vim25",
+        "//vendor/github.com/vmware/govmomi/vim25/soap",
+        "//vendor/github.com/vmware/govmomi/vim25/types",
     ],
 )

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -697,39 +697,50 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 			},
 		},
 		{ // VM
-			Type: VirtualMachine,
-			PathSet: []string{
-				fName,
-				fParent,
-				fUUID,
-				fFirmware,
-				fFtInfo,
-				fCpuAffinity,
-				fCpuHotAddEnabled,
-				fCpuHotRemoveEnabled,
-				fMemoryHotAddEnabled,
-				fNumCpu,
-				fNumCoresPerSocket,
-				fMemorySize,
-				fDevices,
-				fExtraConfig,
-				fGuestName,
-				fGuestID,
-				//fTpmPresent,
-				fBalloonedMemory,
-				fVmIpAddress,
-				fStorageUsed,
-				fDatastore,
-				fNetwork,
-				fRuntimeHost,
-				fPowerState,
-				fConnectionState,
-				fIsTemplate,
-				fSnapshot,
-				fChangeTracking,
-			},
+			Type:    VirtualMachine,
+			PathSet: r.vmPathSet(),
 		},
 	}
+}
+
+func (r *Collector) vmPathSet() []string {
+	pathSet := []string{
+		fName,
+		fParent,
+		fUUID,
+		fFirmware,
+		fFtInfo,
+		fCpuAffinity,
+		fCpuHotAddEnabled,
+		fCpuHotRemoveEnabled,
+		fMemoryHotAddEnabled,
+		fNumCpu,
+		fNumCoresPerSocket,
+		fMemorySize,
+		fDevices,
+		fExtraConfig,
+		fGuestName,
+		fGuestID,
+		fBalloonedMemory,
+		fVmIpAddress,
+		fStorageUsed,
+		fDatastore,
+		fNetwork,
+		fRuntimeHost,
+		fPowerState,
+		fConnectionState,
+		fIsTemplate,
+		fSnapshot,
+		fChangeTracking,
+	}
+
+	apiVer := strings.Split(r.client.ServiceContent.About.ApiVersion, ".")
+	majorVal, _ := strconv.Atoi(apiVer[0])
+	minorVal, _ := strconv.Atoi(apiVer[1])
+	if majorVal > 6 || majorVal == 6 && minorVal >= 7 {
+		pathSet = append(pathSet, fTpmPresent)
+	}
+	return pathSet
 }
 
 // Apply updates.

--- a/pkg/controller/provider/container/vsphere/collector_test.go
+++ b/pkg/controller/provider/container/vsphere/collector_test.go
@@ -1,0 +1,39 @@
+package vsphere
+
+import (
+	liburl "net/url"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestTpmCollector(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	collector := Collector{}
+	url, err := liburl.Parse("https://fake.com/sdk")
+	g.Expect(err).To(gomega.BeNil())
+	vimClient := &vim25.Client{
+		Client:         soap.NewClient(url, false),
+		ServiceContent: types.ServiceContent{},
+	}
+	collector.client = &govmomi.Client{
+		SessionManager: session.NewManager(vimClient),
+		Client:         vimClient,
+	}
+	// Verify that we don't collect TPM for unsupported version
+	collector.client.ServiceContent.About.ApiVersion = "6.5"
+	g.Expect(collector.vmPathSet()).ShouldNot(gomega.ContainElement(fTpmPresent))
+
+	// Verify that we don't collect TPM for supported version
+	collector.client.ServiceContent.About.ApiVersion = "6.7"
+	g.Expect(collector.vmPathSet()).Should(gomega.ContainElement(fTpmPresent))
+
+	// Verify that we don't collect TPM for supported version
+	collector.client.ServiceContent.About.ApiVersion = "7.0"
+	g.Expect(collector.vmPathSet()).Should(gomega.ContainElement(fTpmPresent))
+}


### PR DESCRIPTION
Since #694, we disabled the TPM gathering to avoid "InvalidProperty" error.
vSphere started supporting TPM API in 6.7, based on that version we will gather the TPM on supported versions.