### PR TITLE
Enable secure migrations from vSphere

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,6 +31,7 @@ build --action_env=OVA_PROVIDER_SERVER_IMAGE=quay.io/kubev2v/forklift-ova-provid
 # NOTE: Same configuration is in virt-v2v/cold/.bazelrc.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
 build --strategy_regexp="RunAndCommitLayer no-ems-in-fips-layer.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer ca-certificate-from-secret-layer.tar"=processwrapper-sandbox
 
 # For populator images, we need to use processwrapper sandbox as well
 build --strategy_regexp="RunAndCommitLayer cmd/ovirt-populator/ovirt-imageio-layer-run-layer.tar"=processwrapper-sandbox

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kubev2v/forkliftci
-          ref: v11.0
+          ref: v12.0
 
       - name: Build and setup everything with bazel
         id: forkliftci

--- a/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
@@ -151,6 +151,9 @@ spec:
                   - type
                   type: object
                 type: array
+              fingerprint:
+                description: Fingerprint.
+                type: string
               observedGeneration:
                 description: The most recent generation observed by the controller.
                 format: int64

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -51,6 +51,12 @@ inventory_tls_secret_name: "{{ inventory_service_name }}-serving-cert"
 inventory_issuer_name: "{{ inventory_service_name }}-issuer"
 inventory_certificate_name: "{{ inventory_service_name }}-certificate"
 
+services_service_name: "{{ app_name }}-services"
+services_route_name: "{{ services_service_name }}"
+services_tls_secret_name: "{{ services_service_name }}-serving-cert"
+services_issuer_name: "{{ services_service_name }}-issuer"
+services_certificate_name: "{{ services_service_name }}-certificate"
+
 validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VALIDATION') }}"
 validation_configmap_name: "{{ validation_service_name }}-config"
 validation_service_name: "{{ app_name }}-validation"

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -67,6 +67,11 @@
       state: present
       definition: "{{ lookup('template', 'controller/service-inventory.yml.j2') }}"
 
+  - name: "Setup forklift-services service"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'api/service-services.yml.j2') }}"
+
   - name: "Setup controller deployment"
     k8s:
       state : present
@@ -77,6 +82,12 @@
     k8s:
       state: present
       definition: "{{ lookup('template', 'controller/route-inventory.yml.j2') }}"
+    when: not k8s_cluster|bool
+
+  - name: "Setup forklift-services route"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'api/route-services.yml.j2') }}"
     when: not k8s_cluster|bool
 
   - name: "Setup forklift-controller security context constraints"
@@ -102,6 +113,10 @@
       k8s:
         state: present
         definition: "{{ lookup('template', 'api/ca.yml.j2') }}"
+    - name: "Configure forklift-services certificate on K8s"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'api/services-ca.yml.j2') }}"
     - name: "Configure validation certificate on K8s"
       k8s:
         state: present

--- a/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
@@ -42,6 +42,10 @@ spec:
               value: {{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local
             - name: API_PORT
               value: "8443"
+            - name: SERVICES_TLS_CERTIFICATE
+              value: "/var/run/secrets/{{ services_tls_secret_name }}/tls.crt"
+            - name: SERVICES_TLS_KEY
+              value: "/var/run/secrets/{{ services_tls_secret_name }}/tls.key"
           resources:
             limits:
               cpu: {{ api_container_limits_cpu }}
@@ -52,8 +56,14 @@ spec:
           volumeMounts:
             - name: {{ api_tls_secret_name }}
               mountPath: /var/run/secrets/{{ api_tls_secret_name }}
+            - name: {{ services_tls_secret_name }}
+              mountPath: /var/run/secrets/{{ services_tls_secret_name }}
       volumes:
         - name: {{ api_tls_secret_name }}
           secret:
             secretName: {{ api_tls_secret_name }}
+            defaultMode: 420
+        - name: {{ services_tls_secret_name }}
+          secret:
+            secretName: {{ services_tls_secret_name }}
             defaultMode: 420

--- a/operator/roles/forkliftcontroller/templates/api/route-services.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/route-services.yml.j2
@@ -1,0 +1,16 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ services_route_name }}
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+    service: {{ services_service_name }}
+spec:
+  to:
+    kind: Service
+    name: {{ services_service_name }}
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect

--- a/operator/roles/forkliftcontroller/templates/api/service-services.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/service-services.yml.j2
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+{% if not k8s_cluster|bool %}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ services_tls_secret_name }}
+{% endif %}
+  labels:
+    app: {{ app_name }}
+    service: {{ services_service_name }}
+  name: {{ services_service_name }}
+  namespace: {{ app_namespace }}
+spec:
+  ports:
+  - name: api-https
+    port: 8443
+    targetPort: 8444
+    protocol: TCP
+  selector:
+    app: {{ app_name }}
+    service: {{ api_service_name }}

--- a/operator/roles/forkliftcontroller/templates/api/services-ca.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/services-ca.yml.j2
@@ -1,0 +1,20 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ services_certificate_name }}
+  namespace: {{ app_namespace }}
+spec:
+  isCA: true
+  dnsNames:
+  - {{ services_service_name }}.{{ app_namespace }}.svc
+  - {{ services_service_name }}.{{ app_namespace }}.svc.cluster.local
+  commonName: {{ services_certificate_name }}
+  secretName: {{ services_tls_secret_name }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ app_name }}-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
@@ -21,6 +21,13 @@ spec:
         namespace: {{ app_namespace }}
         port: 8443
     - type: Service
+      alias: {{ services_service_name }}
+      authorize: true
+      service:
+        name: {{ services_service_name }}
+        namespace: {{ app_namespace }}
+        port: 8443
+    - type: Service
       alias: {{ must_gather_api_service_name }}
       authorize: true
       service:

--- a/pkg/apis/forklift/v1beta1/provider.go
+++ b/pkg/apis/forklift/v1beta1/provider.go
@@ -58,7 +58,8 @@ func (t ProviderType) String() string {
 
 // Secret fields.
 const (
-	Token = "token"
+	Token    = "token"
+	Insecure = "insecureSkipVerify"
 )
 
 // Provider settings.
@@ -93,6 +94,9 @@ type ProviderStatus struct {
 	// The most recent generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Fingerprint.
+	// +optional
+	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
 // +genclient

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -362,12 +362,14 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 		thumbprint = h.Thumbprint
 	}
 
-	object.StringData = map[string]string{
-		"accessKeyId": string(in.Data["user"]),
-		"secretKey":   string(in.Data["password"]),
-		"thumbprint":  thumbprint,
+	object.Data = map[string][]byte{
+		"accessKeyId": in.Data["user"],
+		"secretKey":   in.Data["password"],
+		"thumbprint":  []byte(thumbprint),
 	}
-
+	if cacert, ok := in.Data["cacert"]; ok {
+		object.Data["cacert"] = cacert
+	}
 	return
 }
 

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -364,10 +364,7 @@ func (r *Client) password() string {
 }
 
 func (r *Client) thumbprint() string {
-	if thumbprint, found := r.Source.Secret.Data["thumbprint"]; found {
-		return string(thumbprint)
-	}
-	return ""
+	return r.Source.Provider.Status.Fingerprint
 }
 
 // getInsecureSkipVerifyFlag gets the insecureSkipVerify boolean flag

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1355,6 +1355,20 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	}
 	if el9 {
 		virtV2vImage = Settings.Migration.VirtV2vImageCold
+		// mount the secret for the password and CA certificate
+		volumes = append(volumes, core.Volume{
+			Name: "secret-volume",
+			VolumeSource: core.VolumeSource{
+				Secret: &core.SecretVolumeSource{
+					SecretName: v2vSecret.Name,
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, core.VolumeMount{
+			Name:      "secret-volume",
+			ReadOnly:  true,
+			MountPath: "/etc/secret",
+		})
 	} else {
 		virtV2vImage = Settings.Migration.VirtV2vImageWarm
 	}

--- a/pkg/controller/provider/container/BUILD.bazel
+++ b/pkg/controller/provider/container/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "container",
-    srcs = ["doc.go"],
+    srcs = [
+        "doc.go",
+        "util.go",
+    ],
     importpath = "github.com/konveyor/forklift-controller/pkg/controller/provider/container",
     visibility = ["//visibility:public"],
     deps = [
@@ -12,6 +15,7 @@ go_library(
         "//pkg/controller/provider/container/ova",
         "//pkg/controller/provider/container/ovirt",
         "//pkg/controller/provider/container/vsphere",
+        "//pkg/lib/error",
         "//pkg/lib/inventory/container",
         "//pkg/lib/inventory/model",
         "//vendor/k8s.io/api/core/v1:core",

--- a/pkg/controller/provider/container/util.go
+++ b/pkg/controller/provider/container/util.go
@@ -1,0 +1,84 @@
+package container
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	liburl "net/url"
+	"strconv"
+
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	core "k8s.io/api/core/v1"
+)
+
+func GetTlsCertificate(url string, secret *core.Secret) (crt *x509.Certificate, err error) {
+	cfg, err := tlsConfig(secret)
+	if err != nil {
+		return
+	}
+
+	if parsedUrl, _ := liburl.Parse(url); parsedUrl.Port() == "" {
+		url = parsedUrl.Host + ":443"
+	} else {
+		url = parsedUrl.Host
+	}
+
+	conn, err := tls.Dial("tcp", url, cfg)
+	if err == nil && len(conn.ConnectionState().PeerCertificates) > 0 {
+		crt = conn.ConnectionState().PeerCertificates[0]
+	} else {
+		err = liberr.Wrap(
+			err,
+			"failed to retrieve TLS certificate",
+			"url",
+			url,
+		)
+	}
+	return
+}
+
+func tlsConfig(secret *core.Secret) (cfg *tls.Config, err error) {
+	cfg = &tls.Config{}
+	if InsecureProvider(secret) {
+		cfg.InsecureSkipVerify = true
+	} else if cacert, ok := secret.Data["cacert"]; ok {
+		cfg.RootCAs = x509.NewCertPool()
+		if ok := cfg.RootCAs.AppendCertsFromPEM(cacert); !ok {
+			err = liberr.New("failed to parse the specified certificate")
+		}
+	} else {
+		if cfg.RootCAs, err = x509.SystemCertPool(); err != nil {
+			err = liberr.Wrap(err, "failed to get system certificate pool")
+		}
+	}
+	return
+}
+
+func Fingerprint(cert *x509.Certificate) string {
+	sum := sha1.Sum(cert.Raw)
+	var buf bytes.Buffer
+	for i, f := range sum {
+		if i > 0 {
+			fmt.Fprintf(&buf, ":")
+		}
+		fmt.Fprintf(&buf, "%02X", f)
+	}
+	return buf.String()
+}
+
+func InsecureProvider(secret *core.Secret) bool {
+	insecure, found := secret.Data[api.Insecure]
+	if !found {
+		return false
+	}
+
+	insecureSkipVerify, err := strconv.ParseBool(string(insecure))
+	if err != nil {
+		return false
+	}
+
+	return insecureSkipVerify
+}

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -543,11 +543,7 @@ func (r *Collector) password() string {
 
 // Thumbprint.
 func (r *Collector) thumbprint() string {
-	if password, found := r.secret.Data["thumbprint"]; found {
-		return string(password)
-	}
-
-	return ""
+	return r.provider.Status.Fingerprint
 }
 
 // getInsecureSkipVerifyFlag gets the insecureSkipVerify boolean flag

--- a/pkg/forklift-api/BUILD.bazel
+++ b/pkg/forklift-api/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/konveyor/forklift-controller/pkg/forklift-api",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/forklift-api/services",
         "//pkg/forklift-api/webhooks",
         "//pkg/lib/logging",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",

--- a/pkg/forklift-api/api.go
+++ b/pkg/forklift-api/api.go
@@ -57,6 +57,10 @@ func NewForkliftApi(client client.Client) ForkliftApi {
 }
 
 func (app *forkliftAPIApp) Execute() {
+	app.serveWebhooks()
+}
+
+func (app *forkliftAPIApp) serveWebhooks() {
 	apiTlsCertificate, found := os.LookupEnv("API_TLS_CERTIFICATE")
 	if !found {
 		log.Info("Failed to find API_TLS_CERTIFICATE")
@@ -76,10 +80,10 @@ func (app *forkliftAPIApp) Execute() {
 		Handler: mux,
 	}
 
-	log.Info("start listening")
+	log.Info("start serving webhooks")
 	err := server.ListenAndServeTLS(apiTlsCertificate, apiTlsKey)
 	if err != nil {
-		log.Info("got error from server")
+		log.Error(err, "stop serving webhooks")
 	}
-	log.Info("stopped listening")
 }
+

--- a/pkg/forklift-api/services/BUILD.bazel
+++ b/pkg/forklift-api/services/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "services",
+    srcs = [
+        "services.go",
+        "tls-certificate.go",
+    ],
+    importpath = "github.com/konveyor/forklift-controller/pkg/forklift-api/services",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/controller/provider/container",
+        "//pkg/lib/logging",
+        "//vendor/k8s.io/api/core/v1:core",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
+    ],
+)

--- a/pkg/forklift-api/services/services.go
+++ b/pkg/forklift-api/services/services.go
@@ -1,0 +1,20 @@
+package services
+
+import (
+	"net/http"
+
+	"github.com/konveyor/forklift-controller/pkg/lib/logging"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const TLS_CERTIFICATE_PATH = "/tls-certificate"
+
+var log = logging.WithName("services")
+
+func RegisterServices(mux *http.ServeMux, client client.Client) {
+	log.Info("register TLS certificate service")
+	mux.HandleFunc(TLS_CERTIFICATE_PATH, func(w http.ResponseWriter, r *http.Request) {
+		serveTlsCertificate(w, r, client)
+	})
+}

--- a/pkg/forklift-api/services/tls-certificate.go
+++ b/pkg/forklift-api/services/tls-certificate.go
@@ -1,0 +1,36 @@
+package services
+
+import (
+	"encoding/pem"
+	"fmt"
+	"net/http"
+
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/container"
+	core "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func serveTlsCertificate(resp http.ResponseWriter, req *http.Request, client client.Client) {
+	if url := req.URL.Query().Get("URL"); url != "" {
+		log.Info("received a request to retrieve certificate", "url", url)
+		secret := &core.Secret{
+			Data: map[string][]byte{"insecureSkipVerify": []byte("true")},
+		}
+		if cacert, err := container.GetTlsCertificate(url, secret); err == nil {
+			encoded := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: cacert.Raw,
+			})
+			if _, err := resp.Write(encoded); err == nil {
+				resp.WriteHeader(http.StatusOK)
+			} else {
+				msg := fmt.Sprintf("failed to write certificate: %s", string(encoded))
+				http.Error(resp, msg, http.StatusInternalServerError)
+			}
+		} else {
+			http.Error(resp, err.Error(), http.StatusInternalServerError)
+		}
+	} else {
+		http.Error(resp, "Required parameter is missing: URL", http.StatusBadRequest)
+	}
+}

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/secret-admitter.go
@@ -72,6 +72,10 @@ func (admitter *SecretAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissio
 }
 
 func (admitter *SecretAdmitter) validateProviderSecret() *admissionv1.AdmissionResponse {
+	if _, ok := admitter.secret.Data["cacert"]; ok && container.InsecureProvider(&admitter.secret) {
+		return webhookutils.ToAdmissionResponseError(fmt.Errorf("received a request to add insecure provider with a CA certificate"))
+	}
+
 	if createdForProviderType, ok := admitter.secret.GetLabels()["createdForProviderType"]; ok {
 		providerType := api.ProviderType(createdForProviderType)
 

--- a/tests/suit/utils/secrets.go
+++ b/tests/suit/utils/secrets.go
@@ -63,3 +63,7 @@ func DeleteSecret(clientSet *kubernetes.Clientset, namespace string, secret v1.S
 	})
 	return e
 }
+
+func GetSecret(clientSet *kubernetes.Clientset, namespace, name string) (*v1.Secret, error) {
+	return clientSet.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}

--- a/tests/suit/vsphere_test.go
+++ b/tests/suit/vsphere_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	forkliftv1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/tests/suit/framework"
 	"github.com/konveyor/forklift-controller/tests/suit/utils"
@@ -25,9 +26,9 @@ var _ = Describe("vSphere provider", func() {
 		By("Create Secret from Definition")
 		s, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
 			map[string][]byte{
-				"thumbprint": []byte("52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF"),
-				"password":   []byte("MTIzNDU2Cg=="),
-				"user":       []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
+				v1beta1.Insecure: []byte("true"),
+				"password":       []byte("MTIzNDU2Cg=="),
+				"user":           []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
 			}, namespace, "provider-test-secret"))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -84,9 +85,9 @@ var _ = Describe("vSphere provider", func() {
 			By("Create Secret from Definition")
 			s, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
 				map[string][]byte{
-					"thumbprint": []byte("52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF"),
-					"password":   []byte("MTIzNDU2Cg=="),
-					"user":       []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
+					v1beta1.Insecure: []byte("true"),
+					"password":       []byte("MTIzNDU2Cg=="),
+					"user":           []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
 				}, namespace, "vcenter-provider-secret"))
 			Expect(err).ToNot(HaveOccurred())
 			By("Create vCenter provider")
@@ -123,9 +124,9 @@ var _ = Describe("vSphere provider", func() {
 			By("Create Secret from Definition")
 			s, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
 				map[string][]byte{
-					"thumbprint": []byte("52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF"),
-					"password":   []byte("MTIzNDU2Cg=="),
-					"user":       []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
+					v1beta1.Insecure: []byte("true"),
+					"password":       []byte("MTIzNDU2Cg=="),
+					"user":           []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
 				}, namespace, "esxi-provider-secret"))
 			Expect(err).ToNot(HaveOccurred())
 			By("Create ESXi provider")

--- a/tests/suit/vsphere_test.go
+++ b/tests/suit/vsphere_test.go
@@ -24,9 +24,11 @@ var _ = Describe("vSphere provider", func() {
 	It("Migrate VM", func() {
 		namespace := f.Namespace.Name
 		By("Create Secret from Definition")
+		simSecret, err := utils.GetSecret(f.K8sClient, "konveyor-forklift", "vcsim-certificate")
+		Expect(err).ToNot(HaveOccurred())
 		s, err := utils.CreateSecretFromDefinition(f.K8sClient, utils.NewSecretDefinition(nil, nil,
 			map[string][]byte{
-				v1beta1.Insecure: []byte("true"),
+				"cacert":         simSecret.Data["ca.crt"],
 				"password":       []byte("MTIzNDU2Cg=="),
 				"user":           []byte("YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs"),
 			}, namespace, "provider-test-secret"))

--- a/virt-v2v/cold/.bazerlc
+++ b/virt-v2v/cold/.bazerlc
@@ -4,3 +4,4 @@
 # NOTE: Same configuration is in .bazelrc in repository root.
 build --strategy_regexp="Action appliance/libguestfs-appliance.tar"=processwrapper-sandbox
 build --strategy_regexp="RunAndCommitLayer no-ems-in-fips-layer.tar"=processwrapper-sandbox
+build --strategy_regexp="RunAndCommitLayer ca-certificate-from-secret-layer.tar"=processwrapper-sandbox

--- a/virt-v2v/cold/BUILD.bazel
+++ b/virt-v2v/cold/BUILD.bazel
@@ -70,11 +70,21 @@ container_run_and_commit_layer(
     image = ":virt-v2v-image.tar",
 )
 
+container_run_and_commit_layer(
+    name = "ca-certificate-from-secret",
+    commands = [
+        "mv /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt.bak",
+        "ln -sf /opt/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt",
+    ],
+    image = ":virt-v2v-image.tar",
+)
+
 container_image(
     name = "virt-v2v-layer",
     base = ":virt-v2v-image",
     layers = [
         ":no-ems-in-fips",
+        ":ca-certificate-from-secret",
     ],
     visibility = ["//visibility:public"],
 )

--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -72,9 +72,16 @@ for disk in /dev/block[0-9]* ; do
 done
 
 if [ "$V2V_source" == "vSphere" ] ; then
-  # Store password to file
-  echo -n "$V2V_secretKey" > "$DIR/vmware.pw"
-  args+=(-ip "$DIR/vmware.pw")
+  if [ -e "/etc/secret/cacert" ]; then
+    # use the specified certificate
+    ln -sf /etc/secret/cacert /opt/ca-bundle.crt
+  else
+    # otherwise, keep system pool certificates
+    ln -sf /etc/pki/tls/certs/ca-bundle.crt.bak /opt/ca-bundle.crt
+  fi
+
+  # password
+  args+=(-ip "/etc/secret/secretKey")
 
   # Use VDDK if present
   if [ -d "/opt/vmware-vix-disklib-distrib" ]; then

--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -81,7 +81,7 @@ if [ "$V2V_source" == "vSphere" ] ; then
       args+=(
           -it vddk
           -io vddk-libdir=/opt/vmware-vix-disklib-distrib
-          -io "vddk-thumbprint=$V2V_thumbprint"
+          -io "vddk-thumbprint=$V2V_fingerprint"
       )
   fi
   args+=(-- "$V2V_vmName")


### PR DESCRIPTION
Since 2.4 we require users to provide fingerprint/thumbprint, also for insecure providers, and secure migrations practically don't work for vSphere providers.

This main contributions in this PR are:
1. We enable secure migrations from vSphere in case the required certificate doesn't exist in the system pool: the forklift-controller and virt-v2v pods use a certificate that is specified in the provider's secret.
2. We drop the fingerprint field for (secure/insecure) vSphere providers

This PR also introduces an additional service that returns the TLS certificate for a given URL. The idea is that clients, and specifically forklift-console-plugins, would use it to simplify the certificate gathering for users (by getting the certificate over an insecure channel, and asking the user to confirm that it's the right certificate to use)