### PR TITLE
Change ovirt-img path

### DIFF
--- a/cmd/ovirt-populator/ovirt-populator.go
+++ b/cmd/ovirt-populator/ovirt-populator.go
@@ -80,7 +80,7 @@ func populate(engineURL, diskID, volPath string) {
 	}
 
 	args := createCommandArguments(&engineConfig, diskID, volPath)
-	cmd := exec.Command("/usr/local/bin/ovirt-img", args...)
+	cmd := exec.Command("ovirt-img", args...)
 	r, _ := cmd.StdoutPipe()
 	cmd.Stderr = cmd.Stdout
 	done := make(chan struct{})


### PR DESCRIPTION
The ovirt-img found in `/usr/local/bin` which is part of `$PATH`. There is no reason to give a full path to the binary which may change on different versions.