### PR TITLE
vsphere: consider parentless folder a terminal node

### DIFF
--- a/pkg/controller/provider/web/vsphere/BUILD.bazel
+++ b/pkg/controller/provider/web/vsphere/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "vsphere",
@@ -33,5 +33,15 @@ go_library(
         "//pkg/lib/logging",
         "//pkg/lib/ref",
         "//vendor/github.com/gin-gonic/gin",
+    ],
+)
+
+go_test(
+    name = "vsphere_test",
+    srcs = ["base_test.go"],
+    embed = [":vsphere"],
+    deps = [
+        "//pkg/controller/provider/model/vsphere",
+        "//vendor/github.com/onsi/gomega",
     ],
 )

--- a/pkg/controller/provider/web/vsphere/base.go
+++ b/pkg/controller/provider/web/vsphere/base.go
@@ -1,12 +1,13 @@
 package vsphere
 
 import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	libmodel "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
-	"strings"
 )
 
 // Package logger.
@@ -81,6 +82,9 @@ Walk:
 				b = &m.Base
 				r.cache[parent] = b
 			}
+			if b.GetParent().Kind == "" {
+				break Walk
+			}
 			parts = append(parts, b.Name)
 			node = b
 		case model.DatacenterKind:
@@ -97,7 +101,6 @@ Walk:
 			}
 			parts = append(parts, b.Name)
 			node = b
-			break Walk
 		case model.ClusterKind:
 			b, cached := r.cache[parent]
 			if !cached {

--- a/pkg/controller/provider/web/vsphere/base_test.go
+++ b/pkg/controller/provider/web/vsphere/base_test.go
@@ -1,0 +1,235 @@
+package vsphere
+
+import (
+	"testing"
+
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	. "github.com/onsi/gomega"
+)
+
+func TestHostPath(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	pb := PathBuilder{
+		cache: make(map[model.Ref]*model.Base),
+	}
+
+	root := model.Folder{
+		Base: model.Base{
+			Name:   "Datacenters",
+			Parent: model.Ref{},
+			ID:     "1",
+		},
+	}
+	rootRef := model.Ref{
+		Kind: model.FolderKind,
+		ID:   "1",
+	}
+	pb.cache[rootRef] = &root.Base
+
+	dc := model.Datacenter{
+		Base: model.Base{
+			Name:   "mydc",
+			Parent: rootRef,
+			ID:     "2",
+		},
+	}
+	dcRef := model.Ref{
+		Kind: model.DatacenterKind,
+		ID:   "2",
+	}
+	pb.cache[dcRef] = &dc.Base
+
+	cluster := model.Cluster{
+		Base: model.Base{
+			Name:   "mycluster",
+			Parent: dcRef,
+			ID:     "3",
+		},
+	}
+	clusterRef := model.Ref{
+		Kind: model.ClusterKind,
+		ID:   "3",
+	}
+	pb.cache[clusterRef] = &cluster.Base
+
+	host := model.Host{
+		Base: model.Base{
+			Name:   "myhost",
+			Parent: clusterRef,
+			ID:     "4",
+		},
+	}
+	hostRef := model.Ref{
+		Kind: model.HostKind,
+		ID:   "4",
+	}
+	pb.cache[hostRef] = &host.Base
+
+	g.Expect(pb.Path(&host)).To(Equal("/mydc/mycluster/myhost"))
+}
+
+func TestHostPathNestedDatacenter(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	pb := PathBuilder{
+		cache: make(map[model.Ref]*model.Base),
+	}
+
+	root := model.Folder{
+		Base: model.Base{
+			Name:   "Datacenters",
+			Parent: model.Ref{},
+			ID:     "1",
+		},
+	}
+	rootRef := model.Ref{
+		Kind: model.FolderKind,
+		ID:   "1",
+	}
+	pb.cache[rootRef] = &root.Base
+
+	folder := model.Folder{
+		Base: model.Base{
+			Name:   "myfolder",
+			Parent: rootRef,
+			ID:     "100",
+		},
+	}
+	folderRef := model.Ref{
+		Kind: model.FolderKind,
+		ID:   "100",
+	}
+	pb.cache[folderRef] = &folder.Base
+
+	dc := model.Datacenter{
+		Base: model.Base{
+			Name:   "mydc",
+			Parent: folderRef,
+			ID:     "2",
+		},
+	}
+	dcRef := model.Ref{
+		Kind: model.DatacenterKind,
+		ID:   "2",
+	}
+	pb.cache[dcRef] = &dc.Base
+
+	cluster := model.Cluster{
+		Base: model.Base{
+			Name:   "mycluster",
+			Parent: dcRef,
+			ID:     "3",
+		},
+	}
+	clusterRef := model.Ref{
+		Kind: model.ClusterKind,
+		ID:   "3",
+	}
+
+	pb.cache[clusterRef] = &cluster.Base
+
+	host := model.Host{
+		Base: model.Base{
+			Name:   "myhost",
+			Parent: clusterRef,
+			ID:     "4",
+		},
+	}
+	hostRef := model.Ref{
+		Kind: model.HostKind,
+		ID:   "4",
+	}
+	pb.cache[hostRef] = &host.Base
+
+	g.Expect(pb.Path(&host)).To(Equal("/myfolder/mydc/mycluster/myhost"))
+}
+
+func TestHostPathNestedDatacenterTwoLevels(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	pb := PathBuilder{
+		cache: make(map[model.Ref]*model.Base),
+	}
+
+	root := model.Folder{
+		Base: model.Base{
+			Name:   "Datacenters",
+			Parent: model.Ref{},
+			ID:     "1",
+		},
+	}
+	rootRef := model.Ref{
+		Kind: model.FolderKind,
+		ID:   "1",
+	}
+	pb.cache[rootRef] = &root.Base
+
+	folder := model.Folder{
+		Base: model.Base{
+			Name:   "myfolder",
+			Parent: rootRef,
+			ID:     "100",
+		},
+	}
+	folderRef := model.Ref{
+		Kind: model.FolderKind,
+		ID:   "100",
+	}
+	pb.cache[folderRef] = &folder.Base
+
+	folder2 := model.Folder{
+		Base: model.Base{
+			Name:   "myfolder2",
+			Parent: folderRef,
+			ID:     "101",
+		},
+	}
+	folder2Ref := model.Ref{
+		Kind: model.FolderKind,
+		ID:   "101",
+	}
+	pb.cache[folder2Ref] = &folder2.Base
+
+	dc := model.Datacenter{
+		Base: model.Base{
+			Name:   "mydc",
+			Parent: folder2Ref,
+			ID:     "2",
+		},
+	}
+	dcRef := model.Ref{
+		Kind: model.DatacenterKind,
+		ID:   "2",
+	}
+	pb.cache[dcRef] = &dc.Base
+
+	cluster := model.Cluster{
+		Base: model.Base{
+			Name:   "mycluster",
+			Parent: dcRef,
+			ID:     "3",
+		},
+	}
+	clusterRef := model.Ref{
+		Kind: model.ClusterKind,
+		ID:   "3",
+	}
+
+	pb.cache[clusterRef] = &cluster.Base
+
+	host := model.Host{
+		Base: model.Base{
+			Name:   "myhost",
+			Parent: clusterRef,
+			ID:     "4",
+		},
+	}
+	hostRef := model.Ref{
+		Kind: model.HostKind,
+		ID:   "4",
+	}
+	pb.cache[hostRef] = &host.Base
+
+	g.Expect(pb.Path(&host)).To(Equal("/myfolder/myfolder2/mydc/mycluster/myhost"))
+}


### PR DESCRIPTION
We used to break when encontering a datacenter while creating a path of a host. That was ok in most cases since Datacenters typically reside within the root folder named "Datacenters" that should not be part of the path that is passed to virt-v2v and libvirt.

However, it is possible to create nested datacenters, which reside within a folder under the aforementioned root folder, and in this case we need to include the parent folder of the datacenter in the path of the host. Therefore, we now don't stop traveling when encountering a datacenter but rather continue and break when we encounter a folder that has an empty parent instead, without adding this folder (the root folder) to the path.