### PR TITLE
Attempting to fix upload coverage report

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Push code coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./go/src/github.com/${{ github.repository }}/cover.out
+          file: ./go/src/github.com/${{ github.repository }}/cover.out
           flags: unittests
-          fail_ci_if_error: false # see https://github.com/codecov/codecov-action/issues/598
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -117,6 +117,9 @@ jobs:
           cd ${GITHUB_WORKSPACE}/go/src/github.com/${GITHUB_REPOSITORY}
           GOPATH=${GITHUB_WORKSPACE}/go make ci
 
+      - name: cat cover.out
+        run: cat ./go/src/github.com/${{ github.repository }}/cover.out
+
       # Push code coverage using Codecov Action
       - name: Push code coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
This PR started with bumping codecov-action to v4 but this version seems to be premature at this point.
Instead, we now set a token for the action and print the cover.out to the log for debugging