### PR TITLE
Validate VDDK

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kubev2v/forkliftci
-          ref: v12.0
+          ref: v13.0
 
       - name: Build and setup everything with bazel
         id: forkliftci

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -39,6 +39,7 @@ controller_ovirt_warm_migration: true
 controller_max_vm_inflight: 20
 controller_filesystem_overhead: 10
 controller_block_overhead: 0
+controller_vddk_job_active_deadline_sec: 300
 profiler_volume_path: "/var/cache/profiler"
 
 inventory_volume_path: "/var/cache/inventory"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -58,6 +58,10 @@ spec:
         - name: PRECOPY_INTERVAL
           value: "{{ controller_precopy_interval }}"
 {% endif %}
+{% if controller_vddk_job_active_deadline_sec is number %}
+        - name: VDDK_JOB_ACTIVE_DEADLINE
+          value: "{{ controller_vddk_job_active_deadline_sec }}"
+{% endif %}
 {% if controller_snapshot_removal_timeout_minuts is number %}
         - name: SNAPSHOT_REMOVAL_TIMEOUT_MINUTES
           value: "{{ controller_snapshot_removal_timeout_minuts }}"

--- a/pkg/controller/plan/BUILD.bazel
+++ b/pkg/controller/plan/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/storage/names",
         "//vendor/k8s.io/client-go/kubernetes",
         "//vendor/k8s.io/client-go/kubernetes/scheme",
+        "//vendor/k8s.io/utils/ptr",
         "//vendor/kubevirt.io/api/core/v1:core",
         "//vendor/kubevirt.io/api/instancetype/v1beta1",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1",

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -20,6 +20,7 @@ import (
 	libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libref "github.com/konveyor/forklift-controller/pkg/lib/ref"
+	"github.com/konveyor/forklift-controller/pkg/settings"
 	batchv1 "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -858,7 +859,7 @@ func createVddkCheckJob(plan *api.Plan, labels map[string]string, el9 bool, vddk
 			},
 		},
 		Spec: batchv1.JobSpec{
-			ActiveDeadlineSeconds: ptr.To[int64](300),
+			ActiveDeadlineSeconds: ptr.To[int64](int64(settings.Settings.Migration.VddkJobActiveDeadline)),
 			BackoffLimit:          ptr.To[int32](2),
 			Completions:           ptr.To[int32](1),
 			Template: core.PodTemplateSpec{

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
@@ -22,8 +22,14 @@ func (admitter *ProviderAdmitter) validateVDDK() error {
 		return nil
 	}
 
-	if _, found := admitter.provider.Spec.Settings[api.VDDK]; found {
-		log.Info("VDDK image found, passing")
+	if image, found := admitter.provider.Spec.Settings[api.VDDK]; found {
+		if image == "" {
+			err := liberr.New("The specified VDDK init image name is empty")
+			log.Error(err, "The specified VDDK init image cannot be empty, failing",
+				"provider", admitter.provider.Name,
+				"namespace", admitter.provider.Namespace)
+			return err
+		}
 		return nil
 	}
 

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
@@ -22,15 +22,8 @@ func (admitter *ProviderAdmitter) validateVDDK() error {
 		return nil
 	}
 
-	if image, found := admitter.provider.Spec.Settings[api.VDDK]; found {
-		if image == "" {
-			err := liberr.New("The specified VDDK init image name is empty")
-			log.Error(err, "The specified VDDK init image cannot be empty, failing",
-				"provider", admitter.provider.Name,
-				"namespace", admitter.provider.Namespace)
-			return err
-		}
-		return nil
+	if err := admitter.validateVddkImage(); err != nil {
+		return err
 	}
 
 	plans := api.PlanList{}
@@ -84,6 +77,19 @@ func (admitter *ProviderAdmitter) validateVDDK() error {
 			log.Error(err, "Plans requiring VDDK are associated with this provider, failing",
 				"plan", plan.Name,
 				"namespace", plan.Namespace)
+			return err
+		}
+	}
+	return nil
+}
+
+func (admitter *ProviderAdmitter) validateVddkImage() error {
+	if image, found := admitter.provider.Spec.Settings[api.VDDK]; found {
+		if image == "" {
+			err := liberr.New("The specified VDDK init image name is empty")
+			log.Error(err, "The specified VDDK init image cannot be empty, failing",
+				"provider", admitter.provider.Name,
+				"namespace", admitter.provider.Namespace)
 			return err
 		}
 	}

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -25,6 +25,7 @@ const (
 	CleanupRetries          = "CLEANUP_RETRIES"
 	OvirtOsConfigMap        = "OVIRT_OS_MAP"
 	VsphereOsConfigMap      = "VSPHERE_OS_MAP"
+	VddkJobActiveDeadline   = "VDDK_JOB_ACTIVE_DEADLINE"
 )
 
 // Migration settings
@@ -58,6 +59,8 @@ type Migration struct {
 	OvirtOsConfigMap string
 	// vSphere OS config map name
 	VsphereOsConfigMap string
+	// Active deadline for VDDK validation job
+	VddkJobActiveDeadline int
 }
 
 // Load settings.
@@ -117,7 +120,9 @@ func (r *Migration) Load() (err error) {
 		r.VsphereOsConfigMap = val
 	} else if Settings.Role.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VsphereOsConfigMap))
-
+	}
+	if r.VddkJobActiveDeadline, err = getPositiveEnvLimit(VddkJobActiveDeadline, 300); err != nil {
+		return liberr.Wrap(err)
 	}
 
 	return

--- a/tests/suit/vsphere_test.go
+++ b/tests/suit/vsphere_test.go
@@ -66,7 +66,7 @@ var _ = Describe("vSphere provider", func() {
 
 		err = utils.CreatePlanFromDefinition(f.CrClient, planDef)
 		Expect(err).ToNot(HaveOccurred())
-		err, _ = utils.WaitForPlanReadyWithTimeout(f.CrClient, namespace, test_plan_name, 15*time.Second)
+		err, _ = utils.WaitForPlanReadyWithTimeout(f.CrClient, namespace, test_plan_name, 1*time.Minute)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Creating migration")


### PR DESCRIPTION
This PR introduces two-step validation of the VDDK init image:
1. The provider's validating webhook fails providers with empty VDDK init image setting. VDDK can be omitted when users don't want to use it (though it's highly recommended to use VDDK to accelerate migrations from vSphere) but it cannot be set with empty value now.
2. The validation of plans in forklift-controller creates a job on the target provider that checks the validity of the specified VDDK image by checking the existence of `/opt/vmware-vix-disklib-distrib/lib64/libvixDiskLib.so`. The job is set with `ActiveDeadlineSeconds` of 300  seconds (which is configurable) so that if the VDDK image cannot be pulled, the job would fail. There can be more than a single job for a plan in case the VDDK image for the provider changes and the jobs are deleted when archiving the plan.