### PR TITLE
Drop dockerfile_image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,13 +26,6 @@ http_archive(
     ],
 )
 
-load("@io_bazel_rules_docker//contrib:dockerfile_build.bzl", "dockerfile_image")
-
-dockerfile_image(
-    name = "ova-provider-server-image-dockerfile",
-    dockerfile = "//:ova_provider_server_containerfile",
-)
-
 load(
     "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
     docker_toolchain_configure = "toolchain_configure",


### PR DESCRIPTION
We no longer build the OVA provider server using a dockerfile so we can drop 'ova-provider-server-image-dockerfile' which is the only place where dockerfile_image is used.