### PR TITLE
Validate incoming EL6 OS

### DIFF
--- a/validation/policies/io/konveyor/forklift/ovirt/vm_os.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/vm_os.rego
@@ -1,0 +1,16 @@
+package io.konveyor.forklift.ovirt
+
+default has_unsupported_os = false
+
+has_unsupported_os = true {
+    regex.match(`rhel_6|rhel_6x64`, input.osType)
+}
+
+concerns[flag] {
+    has_unsupported_os
+    flag := {
+        "category": "Warning",
+        "label": "Unsupported operating system detected",
+        "assessment": "The guest operating system is RHEL6 which is not currently supported by OpenShift Virtualization."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/ovirt/vm_os_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/vm_os_test.rego
@@ -1,0 +1,33 @@
+package io.konveyor.forklift.ovirt
+ 
+test_unsupported_el6_64 {
+    mock_vm := { "name": "test",
+                 "osType": "rhel_6x64"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_supported_el7 {
+    mock_vm := { "name": "test",
+                 "osType": "rhel_7x64"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_unsupported_el6 {
+    mock_vm := { "name": "test",
+                 "osType": "rhel_6"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_supported_windows {
+    mock_vm := { "name": "test",
+                 "osType": "windows_2019x64"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 0
+}

--- a/validation/policies/io/konveyor/forklift/vmware/vm_os.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/vm_os.rego
@@ -1,0 +1,16 @@
+package io.konveyor.forklift.vmware
+
+default has_unsupported_os = false
+
+has_unsupported_os = true {
+    regex.match(`rhel6Guest|rhel6_64Guest`, input.guestId)
+}
+
+concerns[flag] {
+    has_unsupported_os
+    flag := {
+        "category": "Warning",
+        "label": "Unsupported operating system detected",
+        "assessment": "The guest operating system is RHEL6 which is not currently supported by OpenShift Virtualization."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/vmware/vm_os_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/vm_os_test.rego
@@ -1,0 +1,33 @@
+package io.konveyor.forklift.vmware
+ 
+test_unsupported_el6_64 {
+    mock_vm := { "name": "test",
+                 "guestId": "rhel6_64Guest"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_supported_el7 {
+    mock_vm := { "name": "test",
+                 "guestId": "rhel7_64Guest"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_unsupported_el6 {
+    mock_vm := { "name": "test",
+                 "guestId": "rhel6Guest"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_supported_windows {
+    mock_vm := { "name": "test",
+                 "guestId": "windows11_64Guest"
+                }
+    results = concerns with input as mock_vm
+    count(results) == 0
+}


### PR DESCRIPTION
This patch will warn the user if an unsupported OS is being migrated.
Currently only EL6 is being checked.

Fixes https://issues.redhat.com/browse/MTV-413