### PR TITLE
Add VMs validation for OVA provider

### DIFF
--- a/validation/policies/io/konveyor/forklift/ova/cpu_affinity.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_affinity.rego
@@ -1,0 +1,14 @@
+package io.konveyor.forklift.ova
+
+has_cpu_affinity {
+    count(input.cpuAffinity) != 0
+}
+
+concerns[flag] {
+    has_cpu_affinity
+    flag := {
+        "category": "Warning",
+        "label": "CPU affinity detected",
+        "assessment": "CPU affinity is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/ova/cpu_affinity_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_affinity_test.rego
@@ -1,0 +1,13 @@
+package io.konveyor.forklift.ova
+ 
+test_without_cpu_affinity {
+    mock_vm := { "name": "test", "cpuAffinity": [] }
+    results = concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_cpu_affinity {
+    mock_vm := { "name": "test", "cpuAffinity": [0,2] }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}

--- a/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug.rego
@@ -1,0 +1,24 @@
+package io.konveyor.forklift.ova
+
+default has_hotplug_enabled = false
+
+has_hotplug_enabled = true {
+    input.cpuHotAddEnabled == true
+}
+
+has_hotplug_enabled = true {
+    input.cpuHotRemoveEnabled == true
+}
+
+has_hotplug_enabled = true {
+    input.memoryHotAddEnabled == true
+}
+
+concerns[flag] {
+    has_hotplug_enabled
+    flag := {
+        "category": "Warning",
+        "label": "CPU/Memory hotplug detected",
+        "assessment": "Hot pluggable CPU or memory is not currently supported by OpenShift Virtualization. Review CPU or memory configuration after migration."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug_test.rego
@@ -1,0 +1,45 @@
+package io.konveyor.forklift.ova
+
+test_with_hotplug_disabled {
+    mock_vm := {
+        "name": "test",
+        "cpuHotAddEnabled": false,
+        "cpuHotRemoveEnabled": false,
+        "memoryHotAddEnabled": false
+    }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_cpu_hot_add_enabled {
+    mock_vm := {
+        "name": "test",
+        "cpuHotAddEnabled": true,
+        "cpuHotRemoveEnabled": false,
+        "memoryHotAddEnabled": false
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_with_cpu_hot_remove_enabled {
+    mock_vm := {
+        "name": "test",
+        "cpuHotAddEnabled": false,
+        "cpuHotRemoveEnabled": true,
+        "memoryHotAddEnabled": false
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_with_memory_hot_add_enabled {
+    mock_vm := {
+        "name": "test",
+        "cpuHotAddEnabled": false,
+        "cpuHotRemoveEnabled": false,
+        "memoryHotAddEnabled": true
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}

--- a/validation/policies/io/konveyor/forklift/ova/memory_ballooning.rego
+++ b/validation/policies/io/konveyor/forklift/ova/memory_ballooning.rego
@@ -1,0 +1,14 @@
+package io.konveyor.forklift.ova
+
+has_ballooned_memory {
+    input.balloonedMemory > 0
+}
+
+concerns[flag] {
+    has_ballooned_memory
+    flag := {
+        "category": "Warning",
+        "label": "Memory ballooning detected",
+        "assessment": "Memory ballooning is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/ova/memory_ballooning_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/memory_ballooning_test.rego
@@ -1,0 +1,14 @@
+package io.konveyor.forklift.ova
+
+test_without_ballooned_memory {
+    mock_vm := { "name": "test", "balloonedMemory": 0 }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_balloned_memory {
+    mock_vm := { "name": "test", "balloonedMemory": 1024 }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+

--- a/validation/policies/io/konveyor/forklift/ova/name.rego
+++ b/validation/policies/io/konveyor/forklift/ova/name.rego
@@ -1,0 +1,29 @@
+package io.konveyor.forklift.ova
+
+default valid_input   = true
+default valid_vm      = false
+default valid_vm_name = false
+
+valid_input = false {
+    is_null(input)
+}
+
+valid_vm = true {
+    is_string(input.name)
+}
+
+valid_vm_name = true {
+    regex.match("^[a-z0-9][a-z0-9-]*[a-z0-9]$", input.name)
+    count(input.name) < 64
+}
+
+concerns[flag] {
+    valid_input
+    valid_vm
+    not valid_vm_name
+    flag := {
+        "category": "Warning",
+        "label": "Invalid VM Name",
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/ova/name_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/name_test.rego
@@ -1,0 +1,25 @@
+package io.konveyor.forklift.ova
+
+test_valid_vm_name {
+    mock_vm := { "name": "test" }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_vm_name_too_long {
+    mock_vm := { "name": "my-vm-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_vm_name_invalid_char_underscore {
+    mock_vm := { "name": "my_vm" }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_vm_name_invalid_char_slash {
+    mock_vm := { "name": "my/vm" }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}

--- a/validation/policies/io/konveyor/forklift/ova/rules_version.rego
+++ b/validation/policies/io/konveyor/forklift/ova/rules_version.rego
@@ -1,0 +1,7 @@
+package io.konveyor.forklift.ova
+
+RULES_VERSION := 5
+
+rules_version = {
+    "rules_version": RULES_VERSION
+}

--- a/validation/policies/io/konveyor/forklift/ova/uefi_boot.rego
+++ b/validation/policies/io/konveyor/forklift/ova/uefi_boot.rego
@@ -1,0 +1,14 @@
+package io.konveyor.forklift.ova
+
+has_uefi_boot {
+    input.firmware == "efi"
+}
+
+concerns[flag] {
+    has_uefi_boot
+    flag := {
+        "category": "Warning",
+        "label": "UEFI detected",
+        "assessment": "UEFI secure boot will be disabled on OpenShift Virtualization. If the VM was set with UEFI secure boot, manual steps within the guest would be needed for the guest operating system to boot."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/ova/uefi_boot_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/uefi_boot_test.rego
@@ -1,0 +1,13 @@
+package io.konveyor.forklift.ova
+ 
+test_without_uefi_boot {
+    mock_vm := { "name": "test", "firmware": "bios" }
+    results = concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_uefi_boot {
+    mock_vm := { "name": "test", "firmware": "efi" }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}

--- a/validation/policies/io/konveyor/forklift/ova/validate.rego
+++ b/validation/policies/io/konveyor/forklift/ova/validate.rego
@@ -1,0 +1,12 @@
+package io.konveyor.forklift.ova
+
+validate = {
+    "rules_version": RULES_VERSION,
+    "errors": errors,
+    "concerns": concerns
+}
+
+errors[message] {
+    not valid_vm
+    message := "No VM name found in input body"
+}


### PR DESCRIPTION
Adding VMs validations for OVA, since the OVA model is a subset of the vSphere one (using a similar structure and variable names in the inventory) the same validation were used, excluding the one that related to cluster/hosts or running state of the VM or any other configuration that are not relevant for OVA VMs.