### PR TITLE
Follow up on VDDK validation

### DIFF
--- a/pkg/controller/plan/BUILD.bazel
+++ b/pkg/controller/plan/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "metrics.go",
         "migration.go",
         "predicate.go",
+        "util.go",
         "validation.go",
         "vm_name_handler.go",
     ],

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -174,24 +174,15 @@ func (r *KubeVirt) ListVMs() ([]VirtualMachine, error) {
 }
 
 // Ensure the namespace exists on the destination.
-func (r *KubeVirt) EnsureNamespace() (err error) {
-	ns := &core.Namespace{
-		ObjectMeta: meta.ObjectMeta{
-			Name: r.Plan.Spec.TargetNamespace,
-		},
+func (r *KubeVirt) EnsureNamespace() error {
+	err := ensureNamespace(r.Plan, r.Destination.Client)
+	if err == nil {
+		r.Log.Info(
+			"Created namespace.",
+			"import",
+			r.Plan.Spec.TargetNamespace)
 	}
-	err = r.Destination.Client.Create(context.TODO(), ns)
-	if err != nil {
-		if k8serr.IsAlreadyExists(err) {
-			err = nil
-		}
-	}
-	r.Log.Info(
-		"Created namespace.",
-		"import",
-		ns.Name)
-
-	return
+	return err
 }
 
 // Get the importer pod for a PersistentVolumeClaim.

--- a/pkg/controller/plan/util.go
+++ b/pkg/controller/plan/util.go
@@ -1,0 +1,25 @@
+package plan
+
+import (
+	"context"
+
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	core "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Ensure the namespace exists on the destination.
+func ensureNamespace(plan *api.Plan, client client.Client) error {
+	ns := &core.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: plan.Spec.TargetNamespace,
+		},
+	}
+	err := client.Create(context.TODO(), ns)
+	if err != nil && k8serr.IsAlreadyExists(err) {
+		err = nil
+	}
+	return err
+}

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
@@ -26,6 +26,10 @@ func (admitter *ProviderAdmitter) validateVDDK() error {
 		return err
 	}
 
+	if _, found := admitter.provider.Spec.Settings[api.VDDK]; found {
+		return nil
+	}
+
 	plans := api.PlanList{}
 	err := admitter.Client.List(context.TODO(), &plans, &client.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
1. Fix the provider-admitter to allow changing the VDDK init image for a vSphere provider that serves as the source provider for existing plans.
2. Ensure the target namespace exists in the target provider before creating the VDDK validation job.