### PR TITLE
Fix 'make bazel-generate'

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3295,8 +3295,8 @@ go_repository(
 
 go_rules_dependencies()
 
-# NOTE: Keep the version in sync with Go toolchain in GitHub action.
-go_register_toolchains(version = "1.20.10")
+# NOTE: Go version is also set in GitHub action
+go_register_toolchains(version = "1.21.7")
 
 # override rules_docker issue with this dependency
 # rules_docker 0.16 uses 0.1.4, bit since there the checksum changed, which is very weird, going with 0.1.4.1 to

--- a/cmd/forklift-api/BUILD.bazel
+++ b/cmd/forklift-api/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
 go_binary(
     name = "forklift-api",
     embed = [":forklift-api-lib"],
-    static = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/forklift-controller/BUILD.bazel
+++ b/cmd/forklift-controller/BUILD.bazel
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_binary(
     name = "forklift-controller",
     embed = [":forklift-controller_lib"],
-    static = "on",
     #gotags = ["netgo"],
     visibility = ["//visibility:public"],
 )

--- a/virt-v2v/cold/WORKSPACE
+++ b/virt-v2v/cold/WORKSPACE
@@ -132,8 +132,8 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 go_rules_dependencies()
 
-# NOTE: Keep the version in sync with Go toolchain in GitHub action.
-go_register_toolchains(version = "1.20.10")
+# NOTE: Go version is also set in GitHub action
+go_register_toolchains(version = "1.21.7")
 
 # override rules_docker issue with this dependency
 # rules_docker 0.16 uses 0.1.4, bit since there the checksum changed, which is very weird, going with 0.1.4.1 to

--- a/virt-v2v/warm/WORKSPACE
+++ b/virt-v2v/warm/WORKSPACE
@@ -117,8 +117,8 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 go_rules_dependencies()
 
-# NOTE: Keep the version in sync with Go toolchain in GitHub action.
-go_register_toolchains(version = "1.20.10")
+# NOTE: Go version is also set in GitHub action
+go_register_toolchains(version = "1.21.7")
 
 # override rules_docker issue with this dependency
 # rules_docker 0.16 uses 0.1.4, bit since there the checksum changed, which is very weird, going with 0.1.4.1 to


### PR DESCRIPTION
By upgrading the toolchain to Go 1.21.7