### PR TITLE
Drop static linking

### DIFF
--- a/cmd/forklift-api/BUILD.bazel
+++ b/cmd/forklift-api/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
 go_binary(
     name = "forklift-api",
     embed = [":forklift-api-lib"],
-    static = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/forklift-controller/BUILD.bazel
+++ b/cmd/forklift-controller/BUILD.bazel
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_binary(
     name = "forklift-controller",
     embed = [":forklift-controller_lib"],
-    static = "on",
     #gotags = ["netgo"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
We used to enable static linking for forklift-api and forklift-controller which is not needed anymore.