### PR TITLE
OVA: generate random names for NFS pv and PVS used for migration

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2104,7 +2104,7 @@ func (r *KubeVirt) EnsurePersistentVolume(vmRef ref.Ref, persistentVolumes []cor
 	return
 }
 
-func GetOvaPvNfs(dClient client.Client, planID string) (pvs *core.PersistentVolumeList, found bool, err error) {
+func GetOvaPvListNfs(dClient client.Client, planID string) (pvs *core.PersistentVolumeList, found bool, err error) {
 	pvs = &core.PersistentVolumeList{}
 	pvLabels := map[string]string{
 		"plan": planID,
@@ -2128,7 +2128,7 @@ func GetOvaPvNfs(dClient client.Client, planID string) (pvs *core.PersistentVolu
 	return
 }
 
-func GetOvaPvcNfs(dClient client.Client, planID string, planNamespace string) (pvcs *core.PersistentVolumeClaimList, found bool, err error) {
+func GetOvaPvcListNfs(dClient client.Client, planID string, planNamespace string) (pvcs *core.PersistentVolumeClaimList, found bool, err error) {
 	pvcs = &core.PersistentVolumeClaimList{}
 	pvcLabels := map[string]string{
 		"plan": planID,

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1604,12 +1604,14 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.Confi
 
 	switch r.Source.Provider.Type() {
 	case api.Ova:
-		err = r.CreatePvForNfs()
+		var pvName string
+		pvName, err = r.CreatePvForNfs()
 		if err != nil {
 			return
 		}
-		pvcName := getEntityName("pvc", r.Source.Provider.Name, r.Plan.Name)
-		err = r.CreatePvcForNfs(pvcName)
+		pvcNamePrefix := getEntityPrefixName("pvc", r.Source.Provider.Name, r.Plan.Name)
+		var pvcName string
+		pvcName, err = r.CreatePvcForNfs(pvcNamePrefix, pvName)
 		if err != nil {
 			return
 		}
@@ -2107,7 +2109,7 @@ func GetOvaPvNfs(client client.Client, planName string, providerName string) (pv
 	err = client.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name: getEntityName("pv", providerName, planName),
+			Name: getEntityPrefixName("pv", providerName, planName),
 		},
 		pv,
 	)
@@ -2127,7 +2129,7 @@ func GetOvaPvcNfs(client client.Client, planName string, planNamespace string, p
 	err = client.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      getEntityName("pvc", providerName, planName),
+			Name:      getEntityPrefixName("pvc", providerName, planName),
 			Namespace: planNamespace,
 		},
 		pvc,
@@ -2143,28 +2145,18 @@ func GetOvaPvcNfs(client client.Client, planName string, planNamespace string, p
 	return
 }
 
-func (r *KubeVirt) CreatePvForNfs() (err error) {
+func (r *KubeVirt) CreatePvForNfs() (pvName string, err error) {
 	sourceProvider := r.Source.Provider
 	splitted := strings.Split(sourceProvider.Spec.URL, ":")
 	nfsServer := splitted[0]
 	nfsPath := splitted[1]
-
-	_, found, err := GetOvaPvNfs(r.Destination.Client, r.Plan.Name, r.Plan.Provider.Source.Name)
-	if err != nil {
-		r.Log.Error(err, "Failed to get ova PV")
-		return
-	}
-	pvName := getEntityName("pv", r.Source.Provider.Name, r.Plan.Name)
-	if found {
-		r.Log.Info("The PV for OVA NFS exists", "PV", pvName)
-		return
-	}
+	pvcNamePrefix := getEntityPrefixName("pv", r.Source.Provider.Name, r.Plan.Name)
 
 	labels := map[string]string{"provider": r.Plan.Provider.Source.Name, "app": "forklift", "migration": r.Migration.Name, "plan": r.Plan.Name}
 	pv := &core.PersistentVolume{
 		ObjectMeta: meta.ObjectMeta{
-			Name:   pvName,
-			Labels: labels,
+			GenerateName: pvcNamePrefix,
+			Labels:       labels,
 		},
 		Spec: core.PersistentVolumeSpec{
 			Capacity: core.ResourceList{
@@ -2186,28 +2178,18 @@ func (r *KubeVirt) CreatePvForNfs() (err error) {
 		r.Log.Error(err, "Failed to create OVA plan PV")
 		return
 	}
+	pvName = pv.Name
 	return
 }
 
-func (r *KubeVirt) CreatePvcForNfs(pvcName string) (err error) {
-	_, found, err := GetOvaPvcNfs(r.Destination.Client, r.Plan.Name, r.Plan.Spec.TargetNamespace, r.Plan.Provider.Source.Name)
-	if err != nil {
-		r.Log.Error(err, "Failed to get ova PVC")
-		return
-	}
-	if found {
-		r.Log.Info("The PVC for OVA NFS exists", "PVC", pvcName)
-		return
-	}
-
+func (r *KubeVirt) CreatePvcForNfs(pvcNamePrefix string, pvName string) (pvcName string, err error) {
 	sc := ""
-	pvName := getEntityName("pv", r.Source.Provider.Name, r.Plan.Name)
 	labels := map[string]string{"provider": r.Plan.Provider.Source.Name, "app": "forklift", "migration": r.Migration.Name, "plan": r.Plan.Name}
 	pvc := &core.PersistentVolumeClaim{
 		ObjectMeta: meta.ObjectMeta{
-			Name:      pvcName,
-			Namespace: r.Plan.Spec.TargetNamespace,
-			Labels:    labels,
+			GenerateName: pvcNamePrefix,
+			Namespace:    r.Plan.Spec.TargetNamespace,
+			Labels:       labels,
 		},
 		Spec: core.PersistentVolumeClaimSpec{
 			Resources: core.ResourceRequirements{
@@ -2230,7 +2212,7 @@ func (r *KubeVirt) CreatePvcForNfs(pvcName string) (err error) {
 
 	pvcNamespacedName := types.NamespacedName{
 		Namespace: r.Plan.Spec.TargetNamespace,
-		Name:      pvcName,
+		Name:      pvc.Name,
 	}
 
 	if err = wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 45*time.Second, true, func(ctx context.Context) (done bool, err error) {
@@ -2246,11 +2228,12 @@ func (r *KubeVirt) CreatePvcForNfs(pvcName string) (err error) {
 		return
 
 	}
-	return nil
+	pvcName = pvc.Name
+	return
 }
 
-func getEntityName(resourceType, providerName, planName string) string {
-	return fmt.Sprintf("ova-store-%s-%s-%s", resourceType, providerName, planName)
+func getEntityPrefixName(resourceType, providerName, planName string) string {
+	return fmt.Sprintf("ova-store-%s-%s-%s-", resourceType, providerName, planName)
 }
 
 // Ensure the PV exist on the destination.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2104,16 +2104,20 @@ func (r *KubeVirt) EnsurePersistentVolume(vmRef ref.Ref, persistentVolumes []cor
 	return
 }
 
-func GetOvaPvNfs(client client.Client, planName string, providerName string) (pv *core.PersistentVolume, found bool, err error) {
-	pv = &core.PersistentVolume{}
-	err = client.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name: getEntityPrefixName("pv", providerName, planName),
-		},
-		pv,
-	)
+func GetOvaPvNfs(dClient client.Client, planID string) (pvs *core.PersistentVolumeList, found bool, err error) {
+	pvs = &core.PersistentVolumeList{}
+	pvLabels := map[string]string{
+		"plan": planID,
+		"ova":  "nfs-pv",
+	}
 
+	err = dClient.List(
+		context.TODO(),
+		pvs,
+		&client.ListOptions{
+			LabelSelector: labels.SelectorFromSet(pvLabels),
+		},
+	)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			return nil, false, nil
@@ -2124,17 +2128,21 @@ func GetOvaPvNfs(client client.Client, planName string, providerName string) (pv
 	return
 }
 
-func GetOvaPvcNfs(client client.Client, planName string, planNamespace string, providerName string) (pvc *core.PersistentVolumeClaim, found bool, err error) {
-	pvc = &core.PersistentVolumeClaim{}
-	err = client.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      getEntityPrefixName("pvc", providerName, planName),
-			Namespace: planNamespace,
-		},
-		pvc,
-	)
+func GetOvaPvcNfs(dClient client.Client, planID string, planNamespace string) (pvcs *core.PersistentVolumeClaimList, found bool, err error) {
+	pvcs = &core.PersistentVolumeClaimList{}
+	pvcLabels := map[string]string{
+		"plan": planID,
+		"ova":  "nfs-pvc",
+	}
 
+	err = dClient.List(
+		context.TODO(),
+		pvcs,
+		&client.ListOptions{
+			LabelSelector: labels.SelectorFromSet(pvcLabels),
+			Namespace:     planNamespace,
+		},
+	)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			return nil, false, nil
@@ -2152,7 +2160,7 @@ func (r *KubeVirt) CreatePvForNfs() (pvName string, err error) {
 	nfsPath := splitted[1]
 	pvcNamePrefix := getEntityPrefixName("pv", r.Source.Provider.Name, r.Plan.Name)
 
-	labels := map[string]string{"provider": r.Plan.Provider.Source.Name, "app": "forklift", "migration": r.Migration.Name, "plan": r.Plan.Name}
+	labels := map[string]string{"provider": r.Plan.Provider.Source.Name, "app": "forklift", "migration": r.Migration.Name, "plan": string(r.Plan.UID), "ova": "nfs-pv"}
 	pv := &core.PersistentVolume{
 		ObjectMeta: meta.ObjectMeta{
 			GenerateName: pvcNamePrefix,
@@ -2184,7 +2192,7 @@ func (r *KubeVirt) CreatePvForNfs() (pvName string, err error) {
 
 func (r *KubeVirt) CreatePvcForNfs(pvcNamePrefix string, pvName string) (pvcName string, err error) {
 	sc := ""
-	labels := map[string]string{"provider": r.Plan.Provider.Source.Name, "app": "forklift", "migration": r.Migration.Name, "plan": r.Plan.Name}
+	labels := map[string]string{"provider": r.Plan.Provider.Source.Name, "app": "forklift", "migration": r.Migration.Name, "plan": string(r.Plan.UID), "ova": "nfs-pvc"}
 	pvc := &core.PersistentVolumeClaim{
 		ObjectMeta: meta.ObjectMeta{
 			GenerateName: pvcNamePrefix,

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -518,7 +518,7 @@ func (r *Migration) deleteImporterPods(vm *plan.VMStatus) (err error) {
 }
 
 func (r *Migration) deletePvcPvForOva() (err error) {
-	pvcs, _, err := GetOvaPvcNfs(r.Destination.Client, r.Plan.Name, r.Plan.Spec.TargetNamespace)
+	pvcs, _, err := GetOvaPvcListNfs(r.Destination.Client, r.Plan.Name, r.Plan.Spec.TargetNamespace)
 	if err != nil {
 		r.Log.Error(err, "Failed to get the plan PVCs")
 		return
@@ -536,7 +536,7 @@ func (r *Migration) deletePvcPvForOva() (err error) {
 		}
 	}
 
-	pvs, _, err := GetOvaPvNfs(r.Destination.Client, string(r.Plan.UID))
+	pvs, _, err := GetOvaPvListNfs(r.Destination.Client, string(r.Plan.UID))
 	if err != nil {
 		r.Log.Error(err, "Failed to get the plan PVs")
 		return

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -518,36 +518,40 @@ func (r *Migration) deleteImporterPods(vm *plan.VMStatus) (err error) {
 }
 
 func (r *Migration) deletePvcPvForOva() (err error) {
-	pvc, _, err := GetOvaPvcNfs(r.Destination.Client, r.Plan.Name, r.Plan.Spec.TargetNamespace, r.Plan.Provider.Source.Name)
+	pvcs, _, err := GetOvaPvcNfs(r.Destination.Client, r.Plan.Name, r.Plan.Spec.TargetNamespace)
 	if err != nil {
-		r.Log.Error(err, "Failed to get the plan PVC")
+		r.Log.Error(err, "Failed to get the plan PVCs")
 		return
 	}
-	// The PVC was already deleted
-	if pvc == nil {
+	// The PVCs was already deleted
+	if len(pvcs.Items) == 0 {
 		return
 	}
 
-	err = r.Destination.Client.Delete(context.TODO(), pvc)
+	for _, pvc := range pvcs.Items {
+		err = r.Destination.Client.Delete(context.TODO(), &pvc)
+		if err != nil {
+			r.Log.Error(err, "Failed to delete the plan PVC", pvc)
+			return
+		}
+	}
+
+	pvs, _, err := GetOvaPvNfs(r.Destination.Client, string(r.Plan.UID))
 	if err != nil {
-		r.Log.Error(err, "Failed to delete the plan PVC")
+		r.Log.Error(err, "Failed to get the plan PVs")
+		return
+	}
+	// The PVs was already deleted
+	if len(pvs.Items) == 0 {
 		return
 	}
 
-	pv, _, err := GetOvaPvNfs(r.Destination.Client, r.Plan.Name, r.Plan.Provider.Source.Name)
-	if err != nil {
-		r.Log.Error(err, "Failed to get the plan PV")
-		return
-	}
-	// The PV was already deleted
-	if pv == nil {
-		return
-	}
-
-	err = r.Destination.Client.Delete(context.TODO(), pv)
-	if err != nil {
-		r.Log.Error(err, "Failed to delete the plan PV")
-		return
+	for _, pv := range pvs.Items {
+		err = r.Destination.Client.Delete(context.TODO(), &pv)
+		if err != nil {
+			r.Log.Error(err, "Failed to delete the plan PV", pv)
+			return
+		}
 	}
 	return
 }


### PR DESCRIPTION
An issue has been identified where manually constructed names for PVCs lead to migration failures, especially during restarts or when reusing the same plan names. This occurs because of conflicts with existing PVCs. To address this, the implementation now utilizes `GeneratedName` to ensure unique naming and prevent collisions. Correspondingly, the cleanup process has been changed to accommodate these changes.