### PR TITLE
ovirt: fix connection test

### DIFF
--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -132,8 +132,7 @@ func (r *Collector) HasParity() bool {
 func (r *Collector) Test() (status int, err error) {
 	_, status, err = r.client.system()
 	if status != http.StatusOK {
-		err = liberr.New(
-			fmt.Sprintf("status: %d", status))
+		err = liberr.New("got status != 200 from oVirt", "status", status)
 	}
 
 	return

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -3,6 +3,7 @@ package ovirt
 import (
 	"context"
 	"fmt"
+	"net/http"
 	liburl "net/url"
 	libpath "path"
 	"strconv"
@@ -130,6 +131,11 @@ func (r *Collector) HasParity() bool {
 // Test connect/logout.
 func (r *Collector) Test() (status int, err error) {
 	_, status, err = r.client.system()
+	if status != http.StatusOK {
+		err = liberr.New(
+			fmt.Sprintf("status: %d", status))
+	}
+
 	return
 }
 


### PR DESCRIPTION
Currently when the connection test returns 500 we have no error reported which makes the connection test succeed despite failure.

Return an error when the status returned by the connection test is not 200