### PR TITLE
Set resource requests for forklift-operator

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -93,4 +93,7 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: Always
         name: forklift-operator
-        resources: {}
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi


### PR DESCRIPTION
The forklift-operator pod is not CPU intensive, so minimal CPU time should be sufficient. When it comes to memory, in some environments it consumes ~40Mi and in others ~100Mi, so asking for 64Mi seems reasonable.

see [this](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/4079#issuecomment-1959939530)