### PR TITLE
vSphere: URL in the secret is optional

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -263,7 +263,7 @@ func (r *Builder) getSourceDetails(vm *model.VM, sourceSecret *core.Secret) (lib
 			}
 		}
 		var url *liburl.URL
-		if url, err = liburl.Parse(string(sourceSecret.Data["url"])); err != nil {
+		if url, err = liburl.Parse(r.Source.Provider.Spec.URL); err != nil {
 			err = liberr.Wrap(err)
 			return
 		}


### PR DESCRIPTION
Users should specify the URL in the secret in case they like the system to validate the provider configuration using a webhook (additional labels are also required on the secret in this case). But when users ar not interested in such validations, they can omit the URL from the secret and the migration from a valid provider should succeed.

However, recent changes in the builder of vSphere caused the URL we pass to virt-v2v to be taken from the secret and thus virt-v2v was provided with an empty URL in the aforementioned case, causing the migration to fail. Here, we replace that part and rather take the URL from the configuration of the provider (instead of its secret).