### PR TITLE
vSphere: Fix security context of VDDK validation pod

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -882,6 +882,7 @@ func createVddkCheckJob(plan *api.Plan, labels map[string]string, el9 bool, vddk
 				Spec: core.PodSpec{
 					SecurityContext: &core.PodSecurityContext{
 						RunAsNonRoot: ptr.To(true),
+						RunAsUser:    ptr.To(qemuUser),
 						SeccompProfile: &core.SeccompProfile{
 							Type: core.SeccompProfileTypeRuntimeDefault,
 						},


### PR DESCRIPTION
The security context was set with RunAsNonRoot = true while the user wasn't specified, which lead to an error when migrating to the default namespace: container has runAsNonRoot and image will run as root. This issue is fixed by setting the user to the QEMU user (107).