### PR TITLE
Propagate PVC creation error

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -741,7 +741,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 			pvc, err = r.persistentVolumeClaimWithSourceRef(diskAttachment, storageClassName, populatorName, annotations)
 			if err != nil {
 				if !k8serr.IsAlreadyExists(err) {
-					err = liberr.New("couldn't build the PVC", "diskAttachmentID", diskAttachment.DiskAttachment.ID,
+					err = liberr.Wrap(err, "couldn't build the PVC", "diskAttachmentID", diskAttachment.DiskAttachment.ID,
 						"storageClassName", storageClassName, "populatorName", populatorName)
 					return
 				}


### PR DESCRIPTION
When having an error creating a PVC, the real cause wasn't shown in the logs. Now the reason will appear both on the plan status and in the controller logs.

Fixes: [MTV-928](https://issues.redhat.com/browse/MTV-928)