### PR TITLE
Fix validation of plans with an invalid source provider

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -147,15 +147,19 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 	}
 
 	// Validate version only if migration is OCP to OCP
-	err = r.validateOCPVersion(plan)
-	if err != nil {
+	if err := r.validateOpenShiftVersion(plan); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (r *Reconciler) validateOCPVersion(plan *api.Plan) error {
+func (r *Reconciler) validateOpenShiftVersion(plan *api.Plan) error {
+	source := plan.Referenced.Provider.Source
+	if source == nil {
+		return nil
+	}
+
 	if plan.IsSourceProviderOCP() && plan.Provider.Destination.Type() == api.OpenShift {
 		unsupportedVersion := libcnd.Condition{
 			Type:     unsupportedVersion,

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -160,7 +160,12 @@ func (r *Reconciler) validateOpenShiftVersion(plan *api.Plan) error {
 		return nil
 	}
 
-	if plan.IsSourceProviderOCP() && plan.Provider.Destination.Type() == api.OpenShift {
+	destination := plan.Referenced.Provider.Destination
+	if destination == nil {
+		return nil
+	}
+
+	if source.Type() == api.OpenShift && destination.Type() == api.OpenShift {
 		unsupportedVersion := libcnd.Condition{
 			Type:     unsupportedVersion,
 			Status:   True,
@@ -170,7 +175,7 @@ func (r *Reconciler) validateOpenShiftVersion(plan *api.Plan) error {
 			Items:    []string{},
 		}
 
-		restCfg := ocp.RestCfg(plan.Referenced.Provider.Source, plan.Referenced.Secret)
+		restCfg := ocp.RestCfg(source, plan.Referenced.Secret)
 		clientset, err := kubernetes.NewForConfig(restCfg)
 		if err != nil {
 			return liberr.Wrap(err)


### PR DESCRIPTION
When validating a plan we have specific logic that applies for source providers of type OpenShift but the check of the type of the source provider didn't take into consideration that the source provider may be invalid, leading to a sig fault. Here we extend the function that validates the source providers of type OpenShift with nil-check of the source provider as done in other validation function for a plan, and also nil-check of the destination provider.