### PR TITLE
vSphere: Fix security context of VDDK validation pod

### DIFF
--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -50,6 +50,12 @@ spec:
         - name: API_TLS_CA
           value: /var/run/secrets/{{ inventory_tls_secret_name }}/ca.crt
 {% endif %}
+        - name: OpenShift
+{% if k8s_cluster|bool %}
+          value: false
+{% else %}
+          value: true
+{% endif %}
 {% if controller_log_level is defined and controller_log_level is number %}
         - name: LOG_LEVEL
           value: "{{ controller_log_level }}"

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -817,7 +817,7 @@ func (r *Reconciler) ensureVddkImageValidationJob(plan *api.Plan, el9 bool, vddk
 		return nil, err
 	case len(jobs.Items) == 0:
 		job := createVddkCheckJob(ctx.Plan, jobLabels, el9, vddkImage)
-		err = ctx.Destination.Client.Create(context.Background(), job, &client.CreateOptions{})
+		err = ctx.Destination.Client.Create(context.Background(), job)
 		if err != nil {
 			return nil, err
 		}
@@ -901,8 +901,6 @@ func createVddkCheckJob(plan *api.Plan, labels map[string]string, el9 bool, vddk
 			Template: core.PodTemplateSpec{
 				Spec: core.PodSpec{
 					SecurityContext: &core.PodSecurityContext{
-						RunAsNonRoot: ptr.To(true),
-						RunAsUser:    ptr.To(qemuUser),
 						SeccompProfile: &core.SeccompProfile{
 							Type: core.SeccompProfileTypeRuntimeDefault,
 						},

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -11,6 +11,8 @@ import (
 // Global
 var Settings = ControllerSettings{}
 
+const OpenShift = "OpenShift"
+
 // Settings
 type ControllerSettings struct {
 	// Roles.
@@ -29,6 +31,7 @@ type ControllerSettings struct {
 	Profiler
 	// Feature gates.
 	Features
+	OpenShift bool
 }
 
 // Load settings.
@@ -65,6 +68,7 @@ func (r *ControllerSettings) Load() error {
 	if err != nil {
 		return err
 	}
+	r.OpenShift = getEnvBool(OpenShift, false)
 
 	return nil
 }


### PR DESCRIPTION
The previous attempt to fix the execution of the VDDK validation pod didn't succeed - it allowed to run it on the 'default' namespace but its execution failed on other restricted namespaces in which the QEMU user (107) is not included in the allowed range.

In order to fix this properly, we differentiate OpenShift from k8s: in case of OpenShift we don't specify RunAsNonRoot and RunAsUser in order to let the platform choose an appropriate user, and in case of k8s, we specify the QEMU user (107)