### PR TITLE
Add forklift disk ID annotation to DV and PVCs

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -72,12 +72,6 @@ const (
 	Unknown        = "unknown"
 )
 
-// Annotations
-const (
-	// CDI import disk ID annotation on PVC
-	AnnImportDiskId = "cdi.kubevirt.io/storage.import.diskId"
-)
-
 // Map of ovirt guest ids to osinfo ids.
 var osMap = map[string]string{
 	"rhel_6_10_plus_ppc64": "rhel6.10",
@@ -594,7 +588,7 @@ func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
 
 // Return a stable identifier for a PersistentDataVolume.
 func (r *Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVolumeClaim) string {
-	return pvc.Annotations[AnnImportDiskId]
+	return pvc.Annotations[planbase.AnnDiskSource]
 }
 
 // Create PVs specs for the VM LUNs.
@@ -634,10 +628,10 @@ func (r *Builder) LunPersistentVolumes(vmRef ref.Ref) (pvs []core.PersistentVolu
 					Name:      da.Disk.ID,
 					Namespace: r.Plan.Spec.TargetNamespace,
 					Annotations: map[string]string{
-						AnnImportDiskId: da.Disk.ID,
-						"vmID":          vm.ID,
-						"plan":          string(r.Plan.UID),
-						"lun":           "true",
+						planbase.AnnDiskSource: da.Disk.ID,
+						"vmID":                 vm.ID,
+						"plan":                 string(r.Plan.UID),
+						"lun":                  "true",
 					},
 					Labels: map[string]string{
 						"volume": fmt.Sprintf("%v-%v", vm.Name, da.ID),
@@ -677,10 +671,10 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 					Name:      da.Disk.ID,
 					Namespace: r.Plan.Spec.TargetNamespace,
 					Annotations: map[string]string{
-						AnnImportDiskId: da.Disk.ID,
-						"vmID":          vm.ID,
-						"plan":          string(r.Plan.UID),
-						"lun":           "true",
+						planbase.AnnDiskSource: da.Disk.ID,
+						"vmID":                 vm.ID,
+						"plan":                 string(r.Plan.UID),
+						"lun":                  "true",
 					},
 					Labels: map[string]string{"migration": r.Migration.Name},
 				},
@@ -837,7 +831,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(diskAttachment model.XDiskA
 	// For Block the value is configurable using `BLOCK_OVERHEAD`
 	diskSize = utils.CalculateSpaceWithOverhead(diskSize, volumeMode)
 
-	annotations[AnnImportDiskId] = diskAttachment.ID
+	annotations[planbase.AnnDiskSource] = diskAttachment.ID
 
 	pvc = &core.PersistentVolumeClaim{
 		ObjectMeta: meta.ObjectMeta{


### PR DESCRIPTION
In OCP 4.15, CDI dropped their annotation of the import disk ID. We added an annotation `forklift.konveyor.io/disk-source` before to the DataVolumes only which propagates to the PersistentVolumeClaim. Now it will also be included on other non-CDI flows.

This change is made as we used the CDI annotation to be an identifier when importing a disk. Not having it caused an NPE. Now we will use the forklift annotation.