### PR TITLE
OVA: match the correct vm for the firmware value

### DIFF
--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -342,7 +342,7 @@ func (r *Builder) mapFirmware(vm *model.VM, vmRef ref.Ref, object *cnv.VirtualMa
 			}
 		}
 		if virtV2VFirmware == "" {
-			r.Log.Info("failed to match the vm, model VMid is %s, vmRef ID is %s", vm.ID, vmRef.ID)
+			r.Log.Info("failed to match the vm", "model ID", vm.ID, "vmRef ID", vmRef.ID)
 		}
 	} else {
 		virtV2VFirmware = vm.Firmware

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -227,7 +227,7 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 		object.Template = &cnv.VirtualMachineInstanceTemplateSpec{}
 	}
 	r.mapDisks(vm, persistentVolumeClaims, object)
-	r.mapFirmware(vm, object)
+	r.mapFirmware(vm, vmRef, object)
 	r.mapCPU(vm, object)
 	r.mapInput(object)
 	err = r.mapMemory(vm, object)
@@ -332,14 +332,17 @@ func (r *Builder) mapCPU(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	}
 }
 
-func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
+func (r *Builder) mapFirmware(vm *model.VM, vmRef ref.Ref, object *cnv.VirtualMachineSpec) {
 	var virtV2VFirmware string
 	if vm.Firmware == "" {
 		for _, vmConf := range r.Migration.Status.VMs {
-			if vmConf.ID == vm.ID {
+			if vmConf.ID == vmRef.ID {
 				virtV2VFirmware = vmConf.Firmware
 				break
 			}
+		}
+		if virtV2VFirmware == "" {
+			r.Log.Info("failed to match the vm, model VMid is %s, vmRef ID is %s", vm.ID, vmRef.ID)
 		}
 	} else {
 		virtV2VFirmware = vm.Firmware


### PR DESCRIPTION
currently for some cases the vm is not being match correctly in the builder which leads to not fetching the firmware value set by virt-v2v, which lead to that the default firmware value being set for bios VMs.

* need to be verified -  the bug is currently randomly reproducing.