### PR TITLE
Do not override description of wrapped error

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -735,8 +735,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 			pvc, err = r.persistentVolumeClaimWithSourceRef(diskAttachment, storageClassName, populatorName, annotations)
 			if err != nil {
 				if !k8serr.IsAlreadyExists(err) {
-					err = liberr.Wrap(err, "couldn't build the PVC", "diskAttachmentID", diskAttachment.DiskAttachment.ID,
-						"storageClassName", storageClassName, "populatorName", populatorName)
+					err = liberr.Wrap(err, "disk attachment", diskAttachment.DiskAttachment.ID, "storage class", storageClassName, "populator", populatorName)
 					return
 				}
 				err = nil


### PR DESCRIPTION
The liberr.Wrap function should get an odd number of arguments, otherwise the description of the specified error would be overridden (follow-up on #772).