### PR TITLE
Bump kubernetes.core ansible collection

### DIFF
--- a/operator/requirements.yml
+++ b/operator/requirements.yml
@@ -3,6 +3,6 @@ collections:
   - name: operator_sdk.util
     version: "0.5.0"
   - name: kubernetes.core
-    version: "2.4.1"
+    version: "2.4.2"
   - name: cloud.common
     version: "2.1.1"


### PR DESCRIPTION
Version 2.4.2 contains the fix for newer OCP versions.