### PR TITLE
Add root=first to cold v2v command

### DIFF
--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -49,7 +49,7 @@ func main() {
 	fmt.Println("Preparing virt-v2v")
 	switch source {
 	case vSphere:
-		virtV2vArgs = append(virtV2vArgs, "-i", "libvirt", "-ic", os.Getenv("V2V_libvirtURL"))
+		virtV2vArgs = append(virtV2vArgs, "--root", "first", "-i", "libvirt", "-ic", os.Getenv("V2V_libvirtURL"))
 	case OVA:
 		virtV2vArgs = append(virtV2vArgs, "-i", "ova", os.Getenv("V2V_diskPath"))
 	}


### PR DESCRIPTION
When importing from vSphere a multiple-boot operation system v2v will ask the user which one to use. In our case virt-v2v isn't interactively. Therefore, we will default to the first boot device as we done previsouly.