### PR TITLE
Add root first to cold v2v command

### DIFF
--- a/virt-v2v/cold/entrypoint
+++ b/virt-v2v/cold/entrypoint
@@ -21,7 +21,7 @@ if [ "$V2V_source" == "vCenter" ] ; then
       echo "    V2V_libvirtURL, V2V_secretKey, V2V_vmName"
       exit 1
   fi
-  args+=(-i libvirt -ic "$V2V_libvirtURL")
+  args+=(--root first -i libvirt -ic "$V2V_libvirtURL")
 fi
 
 if [ "$V2V_source" == "ova" ] ; then


### PR DESCRIPTION
When importing from vSphere a multiple-boot operation system v2v will ask the user which one to use. In our case virt-v2v isn't interactively. Therefore, we will default to the first boot device as we done previsouly.