### PR TITLE
OVA: workaround for consuming firmware from virt-v2v

### DIFF
--- a/pkg/controller/plan/adapter/ova/ovfparser.go
+++ b/pkg/controller/plan/adapter/ova/ovfparser.go
@@ -3,35 +3,21 @@ package ova
 import (
 	"encoding/xml"
 	"strings"
+
+	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 )
 
 type OvaVmconfig struct {
-	XMLName xml.Name `xml:"domain"`
-	Name    string   `xml:"name"`
-	OS      OS       `xml:"os"`
+	XMLName  xml.Name `xml:"domain"`
+	Firmware Firmware `xml:"firmware"`
 }
 
-type OS struct {
-	Type   OSType `xml:"type"`
-	Loader Loader `xml:"loader"`
-	Nvram  Nvram  `xml:"nvram"`
+type Firmware struct {
+	Bootloader Bootloader `xml:"bootloader"`
 }
 
-type OSType struct {
-	Arch    string `xml:"arch,attr"`
-	Machine string `xml:"machine,attr"`
-	Content string `xml:",chardata"`
-}
-
-type Loader struct {
-	Readonly string `xml:"readonly,attr"`
-	Type     string `xml:"type,attr"`
-	Secure   string `xml:"secure,attr"`
-	Path     string `xml:",chardata"`
-}
-
-type Nvram struct {
-	Template string `xml:"template,attr"`
+type Bootloader struct {
+	Type string `xml:"type,attr"`
 }
 
 func readConfFromXML(xmlData string) (*OvaVmconfig, error) {
@@ -54,9 +40,9 @@ func GetFirmwareFromConfig(vmConfigXML string) (firmware string, err error) {
 		return
 	}
 
-	path := xmlConf.OS.Loader.Path
-	if strings.Contains(path, "OVMF") {
-		return UEFI, nil
+	firmware = xmlConf.Firmware.Bootloader.Type
+	if firmware == "" {
+		err = liberr.New("failed to get the firmware type from virt-v2v config")
 	}
-	return BIOS, nil
+	return
 }

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -941,7 +941,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 		return
 	}
 
-	r.Log.Info("setting the vm firmware to ", firmware, "vmId", vm.ID)
+	r.Log.Info("setting vm firmware", "vmId", vm.ID, "firmware", firmware)
 
 	vm.Firmware = firmware
 

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -913,7 +913,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 		return
 	}
 
-	url := fmt.Sprintf("http://%s:8080/ovf", pod.Status.PodIP)
+	url := fmt.Sprintf("http://%s:8080/vm", pod.Status.PodIP)
 
 	/* Due to the virt-v2v operation, the ovf file is only available after the command's execution,
 	meaning it appears following the copydisks phase.
@@ -940,6 +940,8 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 	if err != nil {
 		return
 	}
+
+	r.Log.Info("setting the vm firmware to ", firmware, "vmId", vm.ID)
 
 	vm.Firmware = firmware
 

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -300,16 +300,9 @@ func isValidSource(source string) bool {
 }
 
 func addFirmwareToXml(filePath string) (err error) {
-	var newFirmwareData string
-	if firmware == "bios" {
-		newFirmwareData = (`  <firmware>
-		<bootloader type='bios'/>
-	</firmware>`)
-	} else {
-		newFirmwareData = (`  <firmware>
-		<bootloader type='efi'/>
-	</firmware>`)
-	}
+	newFirmwareData := fmt.Sprintf(`  <firmware>
+		<bootloader type='%s'/>
+	</firmware>`, firmware)
 
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -330,8 +323,7 @@ func addFirmwareToXml(filePath string) (err error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		_, err = tempFile.WriteString(line + "\n")
-		if err != nil {
+		if _, err = tempFile.WriteString(line + "\n"); err != nil {
 			return
 		}
 

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -223,6 +223,7 @@ func executeVirtV2v(source string, args []string) (err error) {
 			if match := UEFI_RE.FindSubmatch(line); match != nil {
 				fmt.Println("UEFI firmware detected")
 				firmware = "efi"
+				break
 			}
 		}
 
@@ -325,26 +326,19 @@ func addFirmwareToXml(filePath string) (err error) {
 	defer tempFile.Close()
 
 	scanner := bufio.NewScanner(file)
-	domainFound := false
 
 	for scanner.Scan() {
 		line := scanner.Text()
-
-		if strings.Contains(line, "</os>") {
-			domainFound = true
-		}
 
 		_, err = tempFile.WriteString(line + "\n")
 		if err != nil {
 			return
 		}
 
-		if domainFound {
-			_, err = tempFile.WriteString(newFirmwareData + "\n")
-			if err != nil {
+		if strings.Contains(line, "</os>") {
+			if _, err = tempFile.WriteString(newFirmwareData + "\n"); err != nil {
 				return
 			}
-			domainFound = false
 		}
 	}
 
@@ -352,8 +346,7 @@ func addFirmwareToXml(filePath string) (err error) {
 		return
 	}
 
-	err = os.Rename(tempFilePath, filePath)
-	if err != nil {
+	if err = os.Rename(tempFilePath, filePath); err != nil {
 		return
 	}
 


### PR DESCRIPTION
The change to use `-o kubvirt` requires too many adjustments to the virt-v2v pod. For version 2.6, we will continue using -o local and add the firmware type to the created XML after it is detected from the virt-v2v output. Then, this value will be consumed in the controller to determine the missing firmware.