### PR TITLE
Add forklift disk ID annotation to DV and PVCs (backport 2.5)

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 	utils "github.com/konveyor/forklift-controller/pkg/controller/plan/util"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
@@ -47,11 +48,6 @@ const (
 	TemplateFlavorSmall             = "small"
 	TemplateFlavorMedium            = "medium"
 	TemplateFlavorLarge             = "large"
-)
-
-// Annotations
-const (
-	AnnImportDiskId = "cdi.kubevirt.io/storage.import.volumeId"
 )
 
 // OS types
@@ -525,7 +521,7 @@ func (r *Builder) mapDisks(vm *model.Workload, persistentVolumeClaims []core.Per
 			return
 		}
 
-		cnvVolumeName := fmt.Sprintf("vol-%v", pvc.Annotations[AnnImportDiskId])
+		cnvVolumeName := fmt.Sprintf("vol-%v", pvc.Annotations[planbase.AnnDiskSource])
 		cnvVolume := cnv.Volume{
 			Name: cnvVolumeName,
 			VolumeSource: cnv.VolumeSource{
@@ -1104,10 +1100,10 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image, storageC
 
 	// The image might be a VM Snapshot Image and has no volume associated to it
 	if originalVolumeDiskId, ok := image.Properties["forklift_original_volume_id"]; ok {
-		annotations[AnnImportDiskId] = originalVolumeDiskId.(string)
+		annotations[planbase.AnnDiskSource] = originalVolumeDiskId.(string)
 		r.Log.Info("the image comes from a volume", "volumeID", originalVolumeDiskId)
 	} else {
-		annotations[AnnImportDiskId] = image.ID
+		annotations[planbase.AnnDiskSource] = image.ID
 		r.Log.Info("the image comes from a vm snapshot", "imageID", image.ID)
 	}
 

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -71,12 +71,6 @@ const (
 	Unknown        = "unknown"
 )
 
-// Annotations
-const (
-	// CDI import disk ID annotation on PVC
-	AnnImportDiskId = "cdi.kubevirt.io/storage.import.diskId"
-)
-
 // Map of ovirt guest ids to osinfo ids.
 var osMap = map[string]string{
 	"rhel_6_10_plus_ppc64": "rhel6.10",
@@ -555,7 +549,7 @@ func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
 
 // Return a stable identifier for a PersistentDataVolume.
 func (r *Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVolumeClaim) string {
-	return pvc.Annotations[AnnImportDiskId]
+	return pvc.Annotations[planbase.AnnDiskSource]
 }
 
 // Create PVs specs for the VM LUNs.
@@ -580,10 +574,10 @@ func (r *Builder) LunPersistentVolumes(vmRef ref.Ref) (pvs []core.PersistentVolu
 					Name:      da.Disk.ID,
 					Namespace: r.Plan.Spec.TargetNamespace,
 					Annotations: map[string]string{
-						AnnImportDiskId: da.Disk.ID,
-						"vmID":          vm.ID,
-						"plan":          string(r.Plan.UID),
-						"lun":           "true",
+						planbase.AnnDiskSource: da.Disk.ID,
+						"vmID":                 vm.ID,
+						"plan":                 string(r.Plan.UID),
+						"lun":                  "true",
 					},
 					Labels: map[string]string{
 						"volume": fmt.Sprintf("%v-%v", vm.Name, da.ID),
@@ -634,10 +628,10 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 					Name:      da.Disk.ID,
 					Namespace: r.Plan.Spec.TargetNamespace,
 					Annotations: map[string]string{
-						AnnImportDiskId: da.Disk.ID,
-						"vmID":          vm.ID,
-						"plan":          string(r.Plan.UID),
-						"lun":           "true",
+						planbase.AnnDiskSource: da.Disk.ID,
+						"vmID":                 vm.ID,
+						"plan":                 string(r.Plan.UID),
+						"lun":                  "true",
 					},
 					Labels: map[string]string{"migration": r.Migration.Name},
 				},
@@ -794,7 +788,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(diskAttachment model.XDiskA
 	// For Block the value is configurable using `BLOCK_OVERHEAD`
 	diskSize = utils.CalculateSpaceWithOverhead(diskSize, volumeMode)
 
-	annotations[AnnImportDiskId] = diskAttachment.ID
+	annotations[planbase.AnnDiskSource] = diskAttachment.ID
 
 	pvc = &core.PersistentVolumeClaim{
 		ObjectMeta: meta.ObjectMeta{


### PR DESCRIPTION
In OCP 4.15, CDI dropped their annotation of the import disk ID. We added an annotation `forklift.konveyor.io/disk-source` before to the DataVolumes only which propagates to the PersistentVolumeClaim. Now it will also be included on other non-CDI flows.

This change is made as we used the CDI annotation to be an identifier when importing a disk. Not having it caused an NPE. Now we will use the forklift annotation.