### PR TITLE
Shorten the label of the warning on TPM device

### DIFF
--- a/validation/policies/io/konveyor/forklift/ovirt/tpm.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/tpm.rego
@@ -10,7 +10,7 @@ concerns[flag] {
     has_tpm_os
     flag := {
         "category": "Warning",
-        "label": "VM configured with a TPM device",
+        "label": "TPM detected",
         "assessment": "The VM is detected with an operation system that must have a TPM device. TPM data is not transferred during the migration."
     }
 }

--- a/validation/policies/io/konveyor/forklift/vmware/tpm_enabled.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/tpm_enabled.rego
@@ -10,7 +10,7 @@ concerns[flag] {
     has_tpm_enabled
     flag := {
         "category": "Warning",
-        "label": "VM configured with a TPM device",
+        "label": "TPM detected",
         "assessment": "The VM is configured with a TPM device. TPM data is not transferred during the migration."
     }
 }


### PR DESCRIPTION
Replace "VM configured with a TPM device" with "TPM detected", to align it with what we display for UEFI.