### PR TITLE
Add support for instance types

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -318,6 +318,10 @@ spec:
                         vsphere:
                           The managed object ID.
                       type: string
+                    instanceType:
+                      description: Selected InstanceType that will override the VM
+                        properties.
+                      type: string
                     luks:
                       description: Disk decryption LUKS keys
                       properties:

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -373,6 +373,10 @@ spec:
                         vsphere:
                           The managed object ID.
                       type: string
+                    instanceType:
+                      description: Selected InstanceType that will override the VM
+                        properties.
+                      type: string
                     luks:
                       description: Disk decryption LUKS keys
                       properties:
@@ -824,6 +828,10 @@ spec:
                             The object ID.
                             vsphere:
                               The managed object ID.
+                          type: string
+                        instanceType:
+                          description: Selected InstanceType that will override the
+                            VM properties.
                           type: string
                         luks:
                           description: Disk decryption LUKS keys

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -140,6 +140,8 @@ rules:
   resources:
   - virtualmachinepreferences
   - virtualmachineclusterpreferences
+  - virtualmachineinstancetypes
+  - virtualmachineclusterinstancetypes
   verbs:
   - get
   - list

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -145,3 +145,4 @@ rules:
   verbs:
   - get
   - list
+  - watch

--- a/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -36,6 +36,9 @@ type VM struct {
 	// Choose the primary disk the VM boots from
 	// +optional
 	RootDisk string `json:"rootDisk,omitempty"`
+	// Selected InstanceType that will override the VM properties.
+	// +optional
+	InstanceType string `json:"instanceType,omitempty"`
 }
 
 // Find a Hook for the specified step.

--- a/pkg/controller/plan/BUILD.bazel
+++ b/pkg/controller/plan/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//vendor/k8s.io/client-go/kubernetes/scheme",
         "//vendor/k8s.io/utils/ptr",
         "//vendor/kubevirt.io/api/core/v1:core",
+        "//vendor/kubevirt.io/api/instancetype",
         "//vendor/kubevirt.io/api/instancetype/v1beta1",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1",
         "//vendor/libvirt.org/libvirt-go-xml",

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -61,7 +61,7 @@ type Builder interface {
 	// Build DataVolume config map.
 	ConfigMap(vmRef ref.Ref, secret *core.Secret, object *core.ConfigMap) error
 	// Build the Kubevirt VirtualMachine spec.
-	VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim) error
+	VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim, usesInstanceType bool) error
 	// Build DataVolumes.
 	DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume) (dvs []cdi.DataVolume, err error)
 	// Build tasks.

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -243,7 +243,7 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 }
 
 // VirtualMachine implements base.Builder
-func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim) error {
+func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim, usesInstanceType bool) error {
 	vmExport := &export.VirtualMachineExport{}
 	err := r.sourceClient.Get(context.Background(), client.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vmExport)
 	if err != nil {

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -259,7 +259,7 @@ var DefaultProperties = map[string]string{
 }
 
 // Create the destination Kubevirt VM.
-func (r *Builder) VirtualMachine(vmRef ref.Ref, vmSpec *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim) (err error) {
+func (r *Builder) VirtualMachine(vmRef ref.Ref, vmSpec *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim, usesInstanceType bool) (err error) {
 	vm := &model.Workload{}
 	err = r.Source.Inventory.Find(vm, vmRef)
 	if err != nil {
@@ -283,7 +283,7 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, vmSpec *cnv.VirtualMachineSpec, 
 	}
 
 	r.mapFirmware(vm, vmSpec)
-	r.mapResources(vm, vmSpec)
+	r.mapResources(vm, vmSpec, usesInstanceType)
 	r.mapHardwareRng(vm, vmSpec)
 	r.mapInput(vm, vmSpec)
 	r.mapVideo(vm, vmSpec)
@@ -406,10 +406,12 @@ func (r *Builder) mapInput(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 	}
 }
 
-func (r *Builder) mapResources(vm *model.Workload, object *cnv.VirtualMachineSpec) {
-
+func (r *Builder) mapResources(vm *model.Workload, object *cnv.VirtualMachineSpec, usesInstanceType bool) {
 	// KubeVirt supports Q35 or PC-Q35 machine types only.
 	object.Template.Spec.Domain.Machine = &cnv.Machine{Type: Q35}
+	if usesInstanceType {
+		return
+	}
 	object.Template.Spec.Domain.CPU = &cnv.CPU{}
 
 	// Set CPU Policy

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1422,7 +1422,7 @@ func (r *KubeVirt) getVirtualMachinePreference(preferenceName string) (name, kin
 	if err != nil {
 		return
 	}
-	return preferenceName, "VirtualMachinePreference", nil
+	return preferenceName, instancetypeapi.SingularPreferenceResourceName, nil
 }
 
 func (r *KubeVirt) getVirtualMachineClusterPreference(vm *plan.VMStatus, preferenceName string) (name, kind string, err error) {
@@ -1441,7 +1441,7 @@ func (r *KubeVirt) getVirtualMachineClusterPreference(vm *plan.VMStatus, prefere
 		}
 		return
 	}
-	return preferenceName, "VirtualMachineClusterPreference", nil
+	return preferenceName, instancetypeapi.ClusterSingularPreferenceResourceName, nil
 }
 
 // Attempt to find a suitable template and extract a VirtualMachine definition from it.

--- a/pkg/controller/provider/container/ocp/BUILD.bazel
+++ b/pkg/controller/provider/container/ocp/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/api/storage/v1:storage",
         "//vendor/kubevirt.io/api/core/v1:core",
+        "//vendor/kubevirt.io/api/instancetype/v1beta1",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/event",
     ],

--- a/pkg/controller/provider/container/ocp/collection.go
+++ b/pkg/controller/provider/container/ocp/collection.go
@@ -12,6 +12,7 @@ import (
 	core "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	cnv "kubevirt.io/api/core/v1"
+	instancetype "kubevirt.io/api/instancetype/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
@@ -401,5 +402,199 @@ func (r *VM) Delete(e event.DeleteEvent) bool {
 
 // Ignored.
 func (r *VM) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+// InstanceType
+type InstanceType struct {
+	libocp.BaseCollection
+	log logging.LevelLogger
+}
+
+// Get the kubernetes object being collected.
+func (r *InstanceType) Object() client.Object {
+	return &instancetype.VirtualMachineInstancetype{}
+}
+
+// Reconcile.
+// Achieve initial consistency.
+func (r *InstanceType) Reconcile(ctx context.Context) (err error) {
+	pClient := r.Collector.Client()
+	list := &instancetype.VirtualMachineInstancetypeList{}
+	err = pClient.List(context.TODO(), list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	db := r.Collector.DB()
+	tx, err := db.Begin()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	defer tx.End()
+	for _, resource := range list.Items {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			m := &model.InstanceType{}
+			m.With(&resource)
+			r.Collector.UpdateThreshold(m)
+			r.log.Info("Create", libref.ToKind(m), m.String())
+			err = tx.Insert(m)
+			if err != nil {
+				err = liberr.Wrap(err)
+				return
+			}
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	return
+}
+
+// Resource created watch event.
+func (r *InstanceType) Create(e event.CreateEvent) bool {
+	object, cast := e.Object.(*instancetype.VirtualMachineInstancetype)
+	if !cast {
+		return false
+	}
+	m := &model.InstanceType{}
+	m.With(object)
+	r.Collector.Create(m)
+
+	return false
+}
+
+// Resource updated watch event.
+func (r *InstanceType) Update(e event.UpdateEvent) bool {
+	object, cast := e.ObjectNew.(*instancetype.VirtualMachineInstancetype)
+	if !cast {
+		return false
+	}
+	m := &model.InstanceType{}
+	m.With(object)
+	r.Collector.Update(m)
+
+	return false
+}
+
+// Resource deleted watch event.
+func (r *InstanceType) Delete(e event.DeleteEvent) bool {
+	object, cast := e.Object.(*instancetype.VirtualMachineInstancetype)
+	if !cast {
+		return false
+	}
+	m := &model.InstanceType{}
+	m.With(object)
+	r.Collector.Delete(m)
+
+	return false
+}
+
+// Ignored.
+func (r *InstanceType) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+// ClusterInstanceType
+type ClusterInstanceType struct {
+	libocp.BaseCollection
+	log logging.LevelLogger
+}
+
+// Get the kubernetes object being collected.
+func (r *ClusterInstanceType) Object() client.Object {
+	return &instancetype.VirtualMachineClusterInstancetype{}
+}
+
+// Reconcile.
+// Achieve initial consistency.
+func (r *ClusterInstanceType) Reconcile(ctx context.Context) (err error) {
+	pClient := r.Collector.Client()
+	list := &instancetype.VirtualMachineClusterInstancetypeList{}
+	err = pClient.List(context.TODO(), list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	db := r.Collector.DB()
+	tx, err := db.Begin()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	defer tx.End()
+	for _, resource := range list.Items {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			m := &model.ClusterInstanceType{}
+			m.With(&resource)
+			r.Collector.UpdateThreshold(m)
+			r.log.Info("Create", libref.ToKind(m), m.String())
+			err = tx.Insert(m)
+			if err != nil {
+				err = liberr.Wrap(err)
+				return
+			}
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	return
+}
+
+// Resource created watch event.
+func (r *ClusterInstanceType) Create(e event.CreateEvent) bool {
+	object, cast := e.Object.(*instancetype.VirtualMachineClusterInstancetype)
+	if !cast {
+		return false
+	}
+	m := &model.ClusterInstanceType{}
+	m.With(object)
+	r.Collector.Create(m)
+
+	return false
+}
+
+// Resource updated watch event.
+func (r *ClusterInstanceType) Update(e event.UpdateEvent) bool {
+	object, cast := e.ObjectNew.(*instancetype.VirtualMachineClusterInstancetype)
+	if !cast {
+		return false
+	}
+	m := &model.ClusterInstanceType{}
+	m.With(object)
+	r.Collector.Update(m)
+
+	return false
+}
+
+// Resource deleted watch event.
+func (r *ClusterInstanceType) Delete(e event.DeleteEvent) bool {
+	object, cast := e.Object.(*instancetype.VirtualMachineClusterInstancetype)
+	if !cast {
+		return false
+	}
+	m := &model.ClusterInstanceType{}
+	m.With(object)
+	r.Collector.Delete(m)
+
+	return false
+}
+
+// Ignored.
+func (r *ClusterInstanceType) Generic(e event.GenericEvent) bool {
 	return false
 }

--- a/pkg/controller/provider/container/ocp/collection.go
+++ b/pkg/controller/provider/container/ocp/collection.go
@@ -7,6 +7,7 @@ import (
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libocp "github.com/konveyor/forklift-controller/pkg/lib/inventory/container/ocp"
+	m "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
 	libref "github.com/konveyor/forklift-controller/pkg/lib/ref"
 	core "k8s.io/api/core/v1"
@@ -44,7 +45,9 @@ func (r *StorageClass) Reconcile(ctx context.Context) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	defer tx.End()
+	defer func() {
+		err = endTransaction(tx)
+	}()
 	for _, resource := range list.Items {
 		select {
 		case <-ctx.Done():
@@ -141,7 +144,9 @@ func (r *NetworkAttachmentDefinition) Reconcile(ctx context.Context) (err error)
 		err = liberr.Wrap(err)
 		return
 	}
-	defer tx.End()
+	defer func() {
+		err = endTransaction(tx)
+	}()
 	for _, resource := range list.Items {
 		select {
 		case <-ctx.Done():
@@ -238,7 +243,9 @@ func (r *Namespace) Reconcile(ctx context.Context) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	defer tx.End()
+	defer func() {
+		err = endTransaction(tx)
+	}()
 	for _, resource := range list.Items {
 		select {
 		case <-ctx.Done():
@@ -335,7 +342,9 @@ func (r *VM) Reconcile(ctx context.Context) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	defer tx.End()
+	defer func() {
+		err = endTransaction(tx)
+	}()
 	for _, resource := range list.Items {
 		select {
 		case <-ctx.Done():
@@ -432,7 +441,9 @@ func (r *InstanceType) Reconcile(ctx context.Context) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	defer tx.End()
+	defer func() {
+		err = endTransaction(tx)
+	}()
 	for _, resource := range list.Items {
 		select {
 		case <-ctx.Done():
@@ -529,7 +540,9 @@ func (r *ClusterInstanceType) Reconcile(ctx context.Context) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	defer tx.End()
+	defer func() {
+		err = endTransaction(tx)
+	}()
 	for _, resource := range list.Items {
 		select {
 		case <-ctx.Done():
@@ -597,4 +610,12 @@ func (r *ClusterInstanceType) Delete(e event.DeleteEvent) bool {
 // Ignored.
 func (r *ClusterInstanceType) Generic(e event.GenericEvent) bool {
 	return false
+}
+
+func endTransaction(tx *m.Tx) error {
+	err := tx.End()
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
+	return err
 }

--- a/pkg/controller/provider/container/ocp/collector.go
+++ b/pkg/controller/provider/container/ocp/collector.go
@@ -39,6 +39,20 @@ func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) libcontain
 						provider.GetNamespace(),
 						provider.GetName())),
 			},
+			&InstanceType{
+				log: logging.WithName("collection|instancetype").WithValues(
+					"provider",
+					path.Join(
+						provider.GetNamespace(),
+						provider.GetName())),
+			},
+			&ClusterInstanceType{
+				log: logging.WithName("collection|clusterinstancetype").WithValues(
+					"provider",
+					path.Join(
+						provider.GetNamespace(),
+						provider.GetName())),
+			},
 			&VM{
 				log: logging.WithName("collection|vm").WithValues(
 					"provider",

--- a/pkg/controller/provider/model/ocp/BUILD.bazel
+++ b/pkg/controller/provider/model/ocp/BUILD.bazel
@@ -20,5 +20,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/runtime",
         "//vendor/kubevirt.io/api/core/v1:core",
+        "//vendor/kubevirt.io/api/instancetype/v1beta1",
     ],
 )

--- a/pkg/controller/provider/model/ocp/doc.go
+++ b/pkg/controller/provider/model/ocp/doc.go
@@ -7,6 +7,8 @@ func All() []interface{} {
 		&NetworkAttachmentDefinition{},
 		&StorageClass{},
 		&Namespace{},
+		&InstanceType{},
+		&ClusterInstanceType{},
 		&VM{},
 	}
 }

--- a/pkg/controller/provider/model/ocp/model.go
+++ b/pkg/controller/provider/model/ocp/model.go
@@ -13,6 +13,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	cnv "kubevirt.io/api/core/v1"
+	instancetype "kubevirt.io/api/instancetype/v1beta1"
 )
 
 // Errors

--- a/pkg/controller/provider/model/ocp/model.go
+++ b/pkg/controller/provider/model/ocp/model.go
@@ -121,6 +121,28 @@ func (m *NetworkAttachmentDefinition) With(n *net.NetworkAttachmentDefinition) {
 	m.Object = *n
 }
 
+// InstanceTypes
+type InstanceType struct {
+	Base
+	Object instancetype.VirtualMachineInstancetype `sql:""`
+}
+
+func (m *InstanceType) With(i *instancetype.VirtualMachineInstancetype) {
+	m.Base.With(i)
+	m.Object = *i
+}
+
+// ClusterInstanceTypes
+type ClusterInstanceType struct {
+	Base
+	Object instancetype.VirtualMachineClusterInstancetype `sql:""`
+}
+
+func (m *ClusterInstanceType) With(i *instancetype.VirtualMachineClusterInstancetype) {
+	m.Base.With(i)
+	m.Object = *i
+}
+
 // VM
 type VM struct {
 	Base

--- a/pkg/controller/provider/web/ocp/BUILD.bazel
+++ b/pkg/controller/provider/web/ocp/BUILD.bazel
@@ -5,7 +5,9 @@ go_library(
     srcs = [
         "base.go",
         "client.go",
+        "clusterinstancetype.go",
         "doc.go",
+        "instancetype.go",
         "namespace.go",
         "netattachdefinition.go",
         "provider.go",
@@ -31,5 +33,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/api/storage/v1:storage",
         "//vendor/kubevirt.io/api/core/v1:core",
+        "//vendor/kubevirt.io/api/instancetype/v1beta1",
     ],
 )

--- a/pkg/controller/provider/web/ocp/clusterinstancetype.go
+++ b/pkg/controller/provider/web/ocp/clusterinstancetype.go
@@ -1,0 +1,159 @@
+package ocp
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
+	libmodel "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
+	instancetype "kubevirt.io/api/instancetype/v1beta1"
+)
+
+// Routes.
+const (
+	ClusterInstanceParam = "clusterinstancetype"
+	ClusterInstancesRoot = ProviderRoot + "/clusterinstancetypes"
+	ClusterInstanceRoot  = ClusterInstancesRoot + "/:" + ClusterInstanceParam
+)
+
+// ClusterInstanceType handler.
+type ClusterInstanceHandler struct {
+	Handler
+}
+
+// Add routes to the `gin` router.
+func (h *ClusterInstanceHandler) AddRoutes(e *gin.Engine) {
+	e.GET(ClusterInstancesRoot, h.List)
+	e.GET(ClusterInstancesRoot+"/", h.List)
+	e.GET(ClusterInstanceRoot, h.Get)
+}
+
+// List resources in a REST collection.
+// A GET onn the collection that includes the `X-Watch`
+// header will negotiate an upgrade of the connection
+// to a websocket and push watch events.
+func (h ClusterInstanceHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+	db := h.Collector.DB()
+	list := []model.ClusterInstanceType{}
+	err = db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := []interface{}{}
+	for _, m := range list {
+		r := &ClusterInstanceType{}
+		r.With(&m)
+		r.Link(h.Provider)
+		content = append(content, r.Content(h.Detail))
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// Get a specific REST resource.
+func (h ClusterInstanceHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	m := &model.ClusterInstanceType{
+		Base: model.Base{
+			UID: ctx.Param(ClusterInstanceParam),
+		},
+	}
+	db := h.Collector.DB()
+	err = db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r := &ClusterInstanceType{}
+	r.With(m)
+	r.Link(h.Provider)
+	content := r.Content(model.MaxDetail)
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// Watch.
+func (h ClusterInstanceHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.ClusterInstanceType{},
+		func(in libmodel.Model) (r interface{}) {
+			m := in.(*model.ClusterInstanceType)
+			it := &ClusterInstanceType{}
+			it.With(m)
+			it.Link(h.Provider)
+			r = it
+			return
+		})
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+	}
+}
+
+// REST Resource.
+type ClusterInstanceType struct {
+	Resource
+	Object instancetype.VirtualMachineClusterInstancetype `json:"object"`
+}
+
+// Set fields with the specified object.
+func (r *ClusterInstanceType) With(m *model.ClusterInstanceType) {
+	r.Resource.With(&m.Base)
+	r.Object = m.Object
+}
+
+// Build self link (URI).
+func (r *ClusterInstanceType) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		ClusterInstanceRoot,
+		base.Params{
+			base.ProviderParam:  string(p.UID),
+			ClusterInstanceRoot: r.UID,
+		})
+}
+
+// As content.
+func (r *ClusterInstanceType) Content(detail int) interface{} {
+	if detail == 0 {
+		return r.Resource
+	}
+
+	return r
+}

--- a/pkg/controller/provider/web/ocp/doc.go
+++ b/pkg/controller/provider/web/ocp/doc.go
@@ -35,6 +35,16 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 				base.Handler{Container: container},
 			},
 		},
+		&InstanceHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
+		&ClusterInstanceHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
 		&VMHandler{
 			Handler: Handler{
 				base.Handler{Container: container},

--- a/pkg/controller/provider/web/ocp/instancetype.go
+++ b/pkg/controller/provider/web/ocp/instancetype.go
@@ -1,0 +1,159 @@
+package ocp
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/ocp"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
+	libmodel "github.com/konveyor/forklift-controller/pkg/lib/inventory/model"
+	instancetype "kubevirt.io/api/instancetype/v1beta1"
+)
+
+// Routes.
+const (
+	InstanceParam = "instancetype"
+	InstancesRoot = ProviderRoot + "/instancetypes"
+	InstanceRoot  = InstancesRoot + "/:" + InstanceParam
+)
+
+// InstanceType handler.
+type InstanceHandler struct {
+	Handler
+}
+
+// Add routes to the `gin` router.
+func (h *InstanceHandler) AddRoutes(e *gin.Engine) {
+	e.GET(InstancesRoot, h.List)
+	e.GET(InstancesRoot+"/", h.List)
+	e.GET(InstanceRoot, h.Get)
+}
+
+// List resources in a REST collection.
+// A GET onn the collection that includes the `X-Watch`
+// header will negotiate an upgrade of the connection
+// to a websocket and push watch events.
+func (h InstanceHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+	db := h.Collector.DB()
+	list := []model.InstanceType{}
+	err = db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := []interface{}{}
+	for _, m := range list {
+		r := &InstanceType{}
+		r.With(&m)
+		r.Link(h.Provider)
+		content = append(content, r.Content(h.Detail))
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// Get a specific REST resource.
+func (h InstanceHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	m := &model.InstanceType{
+		Base: model.Base{
+			UID: ctx.Param(InstanceParam),
+		},
+	}
+	db := h.Collector.DB()
+	err = db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r := &InstanceType{}
+	r.With(m)
+	r.Link(h.Provider)
+	content := r.Content(model.MaxDetail)
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// Watch.
+func (h InstanceHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.InstanceType{},
+		func(in libmodel.Model) (r interface{}) {
+			m := in.(*model.InstanceType)
+			it := &InstanceType{}
+			it.With(m)
+			it.Link(h.Provider)
+			r = it
+			return
+		})
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+	}
+}
+
+// REST Resource.
+type InstanceType struct {
+	Resource
+	Object instancetype.VirtualMachineInstancetype `json:"object"`
+}
+
+// Set fields with the specified object.
+func (r *InstanceType) With(m *model.InstanceType) {
+	r.Resource.With(&m.Base)
+	r.Object = m.Object
+}
+
+// Build self link (URI).
+func (r *InstanceType) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		InstanceRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			InstanceRoot:       r.UID,
+		})
+}
+
+// As content.
+func (r *InstanceType) Content(detail int) interface{} {
+	if detail == 0 {
+		return r.Resource
+	}
+
+	return r
+}


### PR DESCRIPTION
Setting the `instanceType` to the VM will set the specific VM in
the plan with the selected instance type available in the destination
cluster (if found). This means, the VM won't be set with their original
CPUs and memory they had in the source environment.