### PR TITLE
openstack: avoid NPE when there's only an image attached

### DIFF
--- a/pkg/apis/forklift/v1beta1/doc.go
+++ b/pkg/apis/forklift/v1beta1/doc.go
@@ -21,3 +21,6 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=forklift.konveyor.io
 package v1beta1
+
+// GlanceSource represents an image of which the source is Glance, to be used in storage mapping
+const GlanceSource = "glance"

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1020,13 +1020,14 @@ func (r *Builder) ensureVolumePopulatorPVC(workload *model.Workload, image *mode
 
 		// VM is image based, look for a glance key in the mapping
 		if workload.ImageID != "" {
+			// At this point the StorageMap has been validated, and the VM has to be fully mapped
 			for _, storageMap := range mapList {
 				if storageMap.Source.Name == api.GlanceSource {
 					storageClassName = storageMap.Destination.StorageClass
 				}
 			}
 		} else {
-			// VM is volume based, look for the volume type in the mapping
+			// VM has a volume, look for the volume type in the mapping
 			if volumeType := r.getVolumeType(workload, originalVolumeDiskId); volumeType != "" {
 				storageClassName, err = r.getStorageClassName(workload, volumeType)
 				if err != nil {

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -31,9 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GlanceSource represents an image of which the source is Glance, to be used in storage mapping
-const GlanceSource = "glance"
-
 // Openstack builder.
 type Builder struct {
 	*plancontext.Context
@@ -1024,7 +1021,7 @@ func (r *Builder) ensureVolumePopulatorPVC(workload *model.Workload, image *mode
 		// VM is image based, look for a glance key in the mapping
 		if workload.ImageID != "" {
 			for _, storageMap := range mapList {
-				if storageMap.Source.Name == "glance" {
+				if storageMap.Source.Name == api.GlanceSource {
 					storageClassName = storageMap.Destination.StorageClass
 				}
 			}

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -31,6 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// GlanceSource represents an image of which the source is Glance, to be used in storage mapping
+const GlanceSource = "glance"
+
 // Openstack builder.
 type Builder struct {
 	*plancontext.Context
@@ -1008,14 +1011,34 @@ func (r *Builder) ensureVolumePopulatorPVC(workload *model.Workload, image *mode
 			originalVolumeDiskId = imageProperty.(string)
 		}
 
-		storageClassName := r.Context.Map.Storage.Spec.Map[0].Destination.StorageClass
-		if volumeType := r.getVolumeType(workload, originalVolumeDiskId); volumeType != "" {
-			storageClassName, err = r.getStorageClassName(workload, volumeType)
-			if err != nil {
-				err = liberr.Wrap(err)
-				return
+		mapList := r.Context.Map.Storage.Spec.Map
+
+		// Check if there's a storage map available
+		if len(mapList) == 0 {
+			err = liberr.New("no storage map found in the migration plan")
+			return
+		}
+
+		var storageClassName string
+
+		// VM is image based, look for a glance key in the mapping
+		if workload.ImageID != "" {
+			for _, storageMap := range mapList {
+				if storageMap.Source.Name == "glance" {
+					storageClassName = storageMap.Destination.StorageClass
+				}
+			}
+		} else {
+			// VM is volume based, look for the volume type in the mapping
+			if volumeType := r.getVolumeType(workload, originalVolumeDiskId); volumeType != "" {
+				storageClassName, err = r.getStorageClassName(workload, volumeType)
+				if err != nil {
+					err = liberr.Wrap(err)
+					return
+				}
 			}
 		}
+
 		if pvc, err = r.persistentVolumeClaimWithSourceRef(*image, storageClassName, populatorName, annotations, workload.ID); err != nil {
 			err = liberr.Wrap(err)
 			return

--- a/pkg/controller/plan/adapter/openstack/builder_test.go
+++ b/pkg/controller/plan/adapter/openstack/builder_test.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	v1beta1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -19,6 +20,6 @@ var _ = Describe("OpenStack builder", func() {
 
 var _ = Describe("OpenStack Glance const test", func() {
 	It("GlanceSource should be glance, changing it may break the UI", func() {
-		Expect(GlanceSource).Should(Equal("glance"))
+		Expect(v1beta1.GlanceSource).Should(Equal("glance"))
 	})
 })

--- a/pkg/controller/plan/adapter/openstack/builder_test.go
+++ b/pkg/controller/plan/adapter/openstack/builder_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("vSphere builder", func() {
+var _ = Describe("OpenStack builder", func() {
 	DescribeTable("should", func(os, version, distro, matchPreferenceName string) {
 		Expect(getPreferenceOs(os, version, distro)).Should(Equal(matchPreferenceName))
 	},
@@ -15,4 +15,10 @@ var _ = Describe("vSphere builder", func() {
 		Entry("windows2022", Windows, "2022", Windows, "windows.2k22.virtio"),
 		Entry("ubuntu 22", Ubuntu, "22.04.3", Ubuntu, "ubuntu"),
 	)
+})
+
+var _ = Describe("OpenStack Glance const test", func() {
+	It("GlanceSource should be glance, changing it may break the UI", func() {
+		Expect(GlanceSource).Should(Equal("glance"))
+	})
 })

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -38,7 +38,6 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 
 	// If vm is image based, we need to see glance in the storage map
 	if vm.ImageID != "" && !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{Name: api.GlanceSource}) {
-		err = liberr.New("glance storage not mapped", "vm", vmRef.String())
 		return
 	}
 

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -35,6 +35,14 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 			return
 		}
 	}
+
+	// If vm is image based, we need to see glance in the storage map
+	if vm.ImageID != "" {
+		if !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{Name: "glance"}) {
+			return
+		}
+	}
+
 	ok = true
 	return
 }

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -37,10 +37,9 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	// If vm is image based, we need to see glance in the storage map
-	if vm.ImageID != "" {
-		if !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{Name: "glance"}) {
-			return
-		}
+	if vm.ImageID != "" && !r.plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{Name: api.GlanceSource}) {
+		err = liberr.New("glance storage not mapped", "vm", vmRef.String())
+		return
 	}
 
 	ok = true

--- a/pkg/controller/provider/web/openstack/client.go
+++ b/pkg/controller/provider/web/openstack/client.go
@@ -396,6 +396,10 @@ func (r *Finder) Network(ref *base.Ref) (object interface{}, err error) {
 //	NotFoundErr
 //	RefNotUniqueErr
 func (r *Finder) Storage(ref *base.Ref) (object interface{}, err error) {
+	if ref.Name == "glance" {
+		return
+	}
+
 	volumeType := &VolumeType{}
 	err = r.ByRef(volumeType, *ref)
 	if err == nil {

--- a/pkg/controller/provider/web/openstack/client.go
+++ b/pkg/controller/provider/web/openstack/client.go
@@ -396,7 +396,7 @@ func (r *Finder) Network(ref *base.Ref) (object interface{}, err error) {
 //	NotFoundErr
 //	RefNotUniqueErr
 func (r *Finder) Storage(ref *base.Ref) (object interface{}, err error) {
-	if ref.Name == "glance" {
+	if ref.Name == api.GlanceSource {
 		return
 	}
 

--- a/tests/suit/BUILD.bazel
+++ b/tests/suit/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
     ],
     deps = [
         "//pkg/apis/forklift/v1beta1",
+        "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/lib/client/openstack",
         "//pkg/lib/logging",
         "//tests/suit/framework",

--- a/tests/suit/openstack_test.go
+++ b/tests/suit/openstack_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	forkliftv1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	"github.com/konveyor/forklift-controller/tests/suit/framework"
 	"github.com/konveyor/forklift-controller/tests/suit/utils"
 	. "github.com/onsi/ginkgo"
@@ -62,6 +63,13 @@ var _ = Describe("[level:component]Migration tests for OpenStack provider", func
 
 		//TODO: Add storage-class  pass here
 		storageMapDef := utils.NewStorageMap(namespace, *provider, test_storage_map_name, []string{vmData.GetVolumeId()}, openstackStorageClass)
+		storageMapDef.Spec.Map = append(storageMapDef.Spec.Map,
+			forkliftv1.StoragePair{
+				Source: ref.Ref{Name: forkliftv1.GlanceSource},
+				Destination: forkliftv1.DestinationStorage{
+					StorageClass: openstackStorageClass,
+				},
+			})
 
 		err = utils.CreateStorageMapFromDefinition(f.CrClient, storageMapDef)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/suit/utils/storagemap.go
+++ b/tests/suit/utils/storagemap.go
@@ -47,6 +47,15 @@ func NewStorageMap(namespace string, providerIdentifier forkliftv1.Provider, sto
 		sdPairs = append(sdPairs, pair)
 	}
 
+	if providerIdentifier.Type() == api.OpenStack {
+		sdPairs = append(sdPairs, forkliftv1.StoragePair{
+			Source: ref.Ref{Name: "glance"},
+			Destination: forkliftv1.DestinationStorage{
+				StorageClass: storageClass,
+			},
+		})
+	}
+
 	storageMap := &forkliftv1.StorageMap{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "StorageMap",

--- a/tests/suit/utils/storagemap.go
+++ b/tests/suit/utils/storagemap.go
@@ -49,7 +49,7 @@ func NewStorageMap(namespace string, providerIdentifier forkliftv1.Provider, sto
 
 	if providerIdentifier.Type() == api.OpenStack {
 		sdPairs = append(sdPairs, forkliftv1.StoragePair{
-			Source: ref.Ref{Name: "glance"},
+			Source: ref.Ref{Name: forkliftv1.GlanceSource},
 			Destination: forkliftv1.DestinationStorage{
 				StorageClass: storageClass,
 			},

--- a/tests/suit/utils/storagemap.go
+++ b/tests/suit/utils/storagemap.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	forkliftv1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/provider"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
@@ -38,22 +37,13 @@ func NewStorageMap(namespace string, providerIdentifier forkliftv1.Provider, sto
 		}
 
 		switch providerIdentifier.Type() {
-		case api.Ova:
+		case forkliftv1.Ova:
 			pair.Source = ref.Ref{Name: sd}
 		default:
 			pair.Source = ref.Ref{ID: sd}
 		}
 
 		sdPairs = append(sdPairs, pair)
-	}
-
-	if providerIdentifier.Type() == api.OpenStack {
-		sdPairs = append(sdPairs, forkliftv1.StoragePair{
-			Source: ref.Ref{Name: forkliftv1.GlanceSource},
-			Destination: forkliftv1.DestinationStorage{
-				StorageClass: storageClass,
-			},
-		})
 	}
 
 	storageMap := &forkliftv1.StorageMap{


### PR DESCRIPTION
Since it's possible to create a plan without storage maps, image based VMs that have no volumes attached will crash the controller with an NPE when attempting to fetch the storage map