### PR TITLE
OVA: Remove the break to properly consume stderr

### DIFF
--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -223,7 +223,6 @@ func executeVirtV2v(source string, args []string) (err error) {
 			if match := UEFI_RE.FindSubmatch(line); match != nil {
 				fmt.Println("UEFI firmware detected")
 				firmware = "efi"
-				break
 			}
 		}
 


### PR DESCRIPTION
When breaking the scanner loop for firmware detection, we cause the virt-v2v pod to run indefinitely. The call to virtV2vCmd.Wait() waits for the virtV2vCmd process to exit. However, once its `stdout` or `stderr` is not being consumed—in our case, the consumer, virtV2vMonitorCmd for `stdout`, and the scanning loop for `stderr`—so once we break the loop, the consumption stops, and the main command will wait forever for an action that will not happen.

It was intentionally dropped from the code, and I've missed that part addition in the previous code review.





