### PR TITLE
ovirt: Respect storage mapping

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -192,9 +192,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 		mapped := &dsMapIn[i]
 		ref := mapped.Source
 		sd := &model.StorageDomain{}
-		fErr := r.Source.Inventory.Find(sd, ref)
-		if fErr != nil {
-			err = fErr
+		if err = r.Source.Inventory.Find(sd, ref); err != nil {
 			return
 		}
 		for _, da := range vm.DiskAttachments {
@@ -715,6 +713,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 		return
 	}
 
+	var sdToStorageClass map[string]string
 	for _, diskAttachment := range workload.DiskAttachments {
 		if diskAttachment.Disk.StorageType == "lun" {
 			continue
@@ -732,7 +731,12 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				return
 			}
 			var pvc *core.PersistentVolumeClaim
-			storageClassName := r.Context.Map.Storage.Spec.Map[0].Destination.StorageClass
+			if sdToStorageClass == nil {
+				if sdToStorageClass, err = r.mapStorageDomainToStorageClass(); err != nil {
+					return
+				}
+			}
+			storageClassName := sdToStorageClass[diskAttachment.Disk.StorageDomain]
 			pvc, err = r.persistentVolumeClaimWithSourceRef(diskAttachment, storageClassName, populatorName, annotations, vmRef.ID)
 			if err != nil {
 				if !k8serr.IsAlreadyExists(err) {
@@ -746,6 +750,18 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 		}
 	}
 	return
+}
+
+func (r *Builder) mapStorageDomainToStorageClass() (map[string]string, error) {
+	sdToStorageClass := make(map[string]string)
+	for _, mapped := range r.Context.Map.Storage.Spec.Map {
+		sd := &model.StorageDomain{}
+		if err := r.Source.Inventory.Find(sd, mapped.Source); err != nil {
+			return nil, liberr.Wrap(err)
+		}
+		sdToStorageClass[sd.ID] = mapped.Destination.StorageClass
+	}
+	return sdToStorageClass, nil
 }
 
 // Get the OvirtVolumePopulator CustomResource based on the disk ID.


### PR DESCRIPTION
Previously, when migrating to the cluster Forklift is deployed on using a cold migration, all disks of the migrated VM were transferred to the same storage class, which is one of the target storage class that appear in the storage mapping that is set for the migration plan.

With these changes, each disk will be mapped to a target storage class based on its original storage domain and the storage mapping that is defined for the migration plan.