### PR TITLE
Backport: Do not deploy OVA server pod when the provider is being deleted

### DIFF
--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -190,7 +190,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		}
 	}
 
-	if provider.Type() == api.Ova {
+	if provider.Type() == api.Ova && provider.DeletionTimestamp == nil {
 
 		deploymentName := fmt.Sprintf("%s-deployment-%s", ovaServer, provider.Name)
 


### PR DESCRIPTION
If the OVA provider server fails to be created for any reason, we keep hitting the timeout check in the reconcile and return from there, so we do not reach the cleanup. To solve this issue, a check was added for the provider query to perform only when the provider has not started the deletion process.