### PR TITLE
Set guest memory

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -440,6 +440,7 @@ func (r *Builder) mapResources(vm *model.Workload, object *cnv.VirtualMachineSpe
 	memory := resource.NewQuantity(int64(vm.Flavor.RAM)*1024*1024, resource.BinarySI)
 	resourceRequests := map[core.ResourceName]resource.Quantity{}
 	resourceRequests[core.ResourceMemory] = *memory
+	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: memory}
 
 	object.Template.Spec.Domain.Resources.Requests = resourceRequests
 }

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -318,6 +318,7 @@ func (r *Builder) mapMemory(vm *model.VM, object *cnv.VirtualMachineSpec) error 
 			core.ResourceMemory: *reservation,
 		},
 	}
+	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: reservation}
 	return nil
 }
 

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -366,6 +366,7 @@ func (r *Builder) mapMemory(vm *model.Workload, object *cnv.VirtualMachineSpec) 
 			core.ResourceMemory: *reservation,
 		},
 	}
+	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: reservation}
 }
 func (r *Builder) mapCPU(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 	object.Template.Spec.Domain.Machine = &cnv.Machine{Type: "q35"}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -564,6 +564,7 @@ func (r *Builder) mapMemory(vm *model.VM, object *cnv.VirtualMachineSpec) {
 			core.ResourceMemory: *reservation,
 		},
 	}
+	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: reservation}
 }
 
 func (r *Builder) mapCPU(vm *model.VM, object *cnv.VirtualMachineSpec) {


### PR DESCRIPTION
Previously we didn't set the guest memory but only memory request, since the guest memory property is optional and according to the documentation it "Defaults to the requested memory in the resources section if not specified.". However, if we don't set it and the migrated VM is based on a template/instancetypepreference, the value of this field would be retrieved from the template/instancetypepreference, which may be different than what the VM had on the source and this could lead to various issues, e.g., starting with insufficient memory for booting.