### PR TITLE
Let the os maps be fully customized (backport)

### DIFF
--- a/operator/roles/forkliftcontroller/templates/controller/configmap-osmap-ovirt.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/configmap-osmap-ovirt.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ ovirt_osmap_configmap_name }}
+  name: "forklift-ovirt-osmap"
   namespace: {{ app_namespace }}
   labels:
     app: {{ app_name }}

--- a/operator/roles/forkliftcontroller/templates/controller/configmap-osmap-vsphere.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/configmap-osmap-vsphere.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ vsphere_osmap_configmap_name }}
+  name: "forklift-vsphere-osmap"
   namespace: {{ app_namespace }}
   labels:
     app: {{ app_name }}


### PR DESCRIPTION
Until now, if the user wished to create his own OS map for preferences the operator would think his new config map is managed by itself. This will cause the operator to add mappings for which the keys don't exist.

Backport of #843