### PR TITLE
Log a non-nil error from findTemplate

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1355,7 +1355,7 @@ func (r *KubeVirt) getVirtualMachineClusterPreference(vm *plan.VMStatus, prefere
 func (r *KubeVirt) vmTemplate(vm *plan.VMStatus) (virtualMachine *cnv.VirtualMachine, ok bool) {
 	tmpl, err := r.findTemplate(vm)
 	if err != nil {
-		r.Log.Info("could not find template for destination VM.",
+		r.Log.Error(err, "could not find template for destination VM.",
 			"vm",
 			vm.String())
 		return


### PR DESCRIPTION
In 98b06ec we switched an Error log to Info and by that we lost the trace from the code that tries to find a template in KubeVirt in case it raises an error. Switching that log to Error again in order to restore this information.

backport of #842 