### PR TITLE
Sanitize datastore identifiers from ESXi providers

### DIFF
--- a/pkg/controller/provider/container/vsphere/BUILD.bazel
+++ b/pkg/controller/provider/container/vsphere/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "collector.go",
         "doc.go",
         "model.go",
+        "utils.go",
         "watch.go",
     ],
     importpath = "github.com/konveyor/forklift-controller/pkg/controller/provider/container/vsphere",

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -688,18 +688,20 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 			switch disk.Backing.(type) {
 			case *types.VirtualDiskFlatVer1BackingInfo:
 				backing := disk.Backing.(*types.VirtualDiskFlatVer1BackingInfo)
+				datastoreId, _ := sanitize(backing.Datastore.Value)
 				md := model.Disk{
 					Key:      disk.Key,
 					File:     backing.FileName,
 					Capacity: disk.CapacityInBytes,
 					Datastore: model.Ref{
 						Kind: model.DsKind,
-						ID:   backing.Datastore.Value,
+						ID:   datastoreId,
 					},
 				}
 				disks = append(disks, md)
 			case *types.VirtualDiskFlatVer2BackingInfo:
 				backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+				datastoreId, _ := sanitize(backing.Datastore.Value)
 				md := model.Disk{
 					Key:      disk.Key,
 					File:     backing.FileName,
@@ -707,12 +709,13 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 					Shared:   backing.Sharing != "sharingNone",
 					Datastore: model.Ref{
 						Kind: model.DsKind,
-						ID:   backing.Datastore.Value,
+						ID:   datastoreId,
 					},
 				}
 				disks = append(disks, md)
 			case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
 				backing := disk.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo)
+				datastoreId, _ := sanitize(backing.Datastore.Value)
 				md := model.Disk{
 					Key:      disk.Key,
 					File:     backing.FileName,
@@ -720,7 +723,7 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 					Shared:   backing.Sharing != "sharingNone",
 					Datastore: model.Ref{
 						Kind: model.DsKind,
-						ID:   backing.Datastore.Value,
+						ID:   datastoreId,
 					},
 					RDM: true,
 				}

--- a/pkg/controller/provider/container/vsphere/utils.go
+++ b/pkg/controller/provider/container/vsphere/utils.go
@@ -1,0 +1,17 @@
+package vsphere
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"net/url"
+)
+
+func sanitize(datastoreId string) (sanitizedId string, changed bool) {
+	sanitizedId = url.PathEscape(datastoreId)
+	if sanitizedId != datastoreId {
+		sum := md5.Sum([]byte(datastoreId))
+		sanitizedId = hex.EncodeToString(sum[:])
+		changed = true
+	}
+	return
+}


### PR DESCRIPTION
when we get datastores from the ESXi SDK, their identifier may be in the form of '10.11.12.13:/vol/virtv2v/function' which leads to invalid endpoints in the inventory so we sanitize such identifiers

backport of #849 