### PR TITLE
Don't set time within clock (backport)

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -350,9 +350,7 @@ func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {
 
 func (r *Builder) mapClock(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 	if object.Template.Spec.Domain.Clock == nil {
-		object.Template.Spec.Domain.Clock = &cnv.Clock{
-			Timer: &cnv.Timer{},
-		}
+		object.Template.Spec.Domain.Clock = &cnv.Clock{}
 	}
 
 	timezone := cnv.ClockOffsetTimezone(vm.Timezone)

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -547,9 +547,7 @@ func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {
 func (r *Builder) mapClock(host *model.Host, object *cnv.VirtualMachineSpec) {
 	if host.Timezone != "" {
 		if object.Template.Spec.Domain.Clock == nil {
-			object.Template.Spec.Domain.Clock = &cnv.Clock{
-				Timer: &cnv.Timer{},
-			}
+			object.Template.Spec.Domain.Clock = &cnv.Clock{}
 		}
 		tz := cnv.ClockOffsetTimezone(host.Timezone)
 		object.Template.Spec.Domain.Clock.ClockOffset.Timezone = &tz


### PR DESCRIPTION
When using preferences the timer configuration may conflict with the empty timer we used to set. That would lead windows VMs to fail running. Since `Time` is optional and we used to have it empty - this patch will drop it.

Backport of #853 