### PR TITLE
Drop retainAfterCompletion

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1152,7 +1152,7 @@ func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap
 	}
 
 	annotations := r.vmLabels(vm.Ref)
-	if !r.Plan.Spec.Warm || Settings.RetainPrecopyImporterPods {
+	if Settings.RetainPrecopyImporterPods {
 		annotations[planbase.AnnRetainAfterCompletion] = "true"
 	}
 	if r.Plan.Spec.TransferNetwork != nil {

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -21,7 +21,7 @@ type Features struct {
 // Load settings.
 func (r *Features) Load() (err error) {
 	r.OvirtWarmMigration = getEnvBool(FeatureOvirtWarmMigration, false)
-	r.RetainPrecopyImporterPods = getEnvBool(FeatureRetainPrecopyImporterPods, true)
+	r.RetainPrecopyImporterPods = getEnvBool(FeatureRetainPrecopyImporterPods, false)
 	r.VsphereIncrementalBackup = getEnvBool(FeatureVsphereIncrementalBackup, false)
 	return
 }


### PR DESCRIPTION
Removed the retainAfterCompletion annotation from DataVolumes.
This is still configurable by setting `FEATURE_RETAIN_PRECOPY_IMPORTER_PODS`.