### PR TITLE
vSphere: skip immediate binding when using virt-v2v on el9

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1159,8 +1159,12 @@ func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap
 		annotations[AnnDefaultNetwork] = path.Join(
 			r.Plan.Spec.TransferNetwork.Namespace, r.Plan.Spec.TransferNetwork.Name)
 	}
-	// Set annotation for WFFC storage classes
-	annotations[planbase.AnnBindImmediate] = "true"
+	if r.Plan.Spec.Warm || !r.Destination.Provider.IsHost() || r.Plan.IsSourceProviderOCP() {
+		// Set annotation for WFFC storage classes. Note that we create data volumes while
+		// running a cold migration to the local cluster only when the source is either OpenShift
+		// or vSphere, and in the latter case the conversion pod acts as the first-consumer
+		annotations[planbase.AnnBindImmediate] = "true"
+	}
 	// Do not delete the DV when the import completes as we check the DV to get the current
 	// disk transfer status.
 	annotations[AnnDeleteAfterCompletion] = "false"


### PR DESCRIPTION
In b0d0a68, we incorrectly dropped a check that skips setting the "cdi.kubevirt.io/storage.bind.immediate.requested" annotation when using virt-v2v on el9 - in that case, the conversion pod acts as the first-consumer of the data volume and thus, there is no need in artificial first-consumer pod.

See https://issues.redhat.com/browse/CNV-40266