### PR TITLE
Skip querying preference if OS is empty

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1272,6 +1272,10 @@ func (r *KubeVirt) vmPreference(vm *plan.VMStatus) (virtualMachine *cnv.VirtualM
 	if err != nil {
 		return
 	}
+	if preferenceName == "" {
+		err = liberr.New("couldn't find a corresponding preference", "vm", vm)
+		return
+	}
 
 	preferenceName, kind, err := r.getPreference(vm, preferenceName)
 	if err != nil {


### PR DESCRIPTION
We may have VM without OS set. In such case we get an empty string from the map. This patch will prevent querying and erroring when we hit this case.