### PR TITLE
operator: change matchLabels of operator deployment

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -10,19 +10,17 @@ kind: Deployment
 metadata:
   name: forklift-operator
   namespace: system
-  labels:
-    control-plane: controller-manager
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: forklift
-      name: controller-manager
+      name: forklift-operator
   template:
     metadata:
       labels:
         app: forklift
-        name: controller-manager
+        name: forklift-operator
     spec:
       serviceAccountName: forklift-operator
       containers:


### PR DESCRIPTION
The matcher includes the label "name: controller-manager". This differs from what we set in MTV (there 'name' is mapped to 'forklift-operator') and this can lead to errors when creating a new release of MTV.

Here we change the aforementioned label to match that of MTV. This change would break upgradea to Forklift 2.7.0, however, there is an easy workaround for this by removing the custom resource 'forklift-controller' of type ForkliftController from the namespace the operator is deployed on.