### PR TITLE
backport: fix virt-v2v disk name generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ all: test forklift-controller
 
 # Run tests
 test: generate fmt vet manifests validation-test
-	go test -coverprofile=cover.out ./pkg/... ./cmd/...
+	go test -coverprofile=cover.out ./pkg/... ./cmd/... ./virt-v2v/cold/...
 
 # Experimental e2e target
 e2e-sanity: e2e-sanity-ovirt e2e-sanity-vsphere

--- a/virt-v2v/cold/BUILD.bazel
+++ b/virt-v2v/cold/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
@@ -477,4 +477,10 @@ rpmtree(
         "@zlib-0__1.2.11-41.el9.x86_64//rpm",
     ],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "cold_test",
+    srcs = ["cold_test.go"],
+    embed = [":cold_lib"],
 )

--- a/virt-v2v/cold/cold_test.go
+++ b/virt-v2v/cold/cold_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGenName(t *testing.T) {
+	cases := []struct {
+		diskNum  int
+		expected string
+	}{
+		{1, "a"},
+		{26, "z"},
+		{27, "aa"},
+		{28, "ab"},
+		{52, "az"},
+		{53, "ba"},
+		{55, "bc"},
+		{702, "zz"},
+		{754, "abz"},
+	}
+
+	for _, c := range cases {
+		got := genName(c.diskNum)
+		if got != c.expected {
+			t.Errorf("genName(%d) = %s; want %s", c.diskNum, got, c.expected)
+		}
+	}
+}

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -142,11 +142,15 @@ func genName(diskNum int) string {
 		return ""
 	}
 
-	letters := []int32("abcdefghijklmnopqrstuvwxyz")
+	letters := "abcdefghijklmnopqrstuvwxyz"
 	index := (diskNum - 1) % len(letters)
-	cycels := (diskNum - 1) % len(letters)
+	cycles := (diskNum - 1) / len(letters)
 
-	return genName(cycels) + string(letters[index])
+	if cycles == 0 {
+		return string(letters[index])
+	} else {
+		return genName(cycles) + string(letters[index])
+	}
 }
 
 func LinkDisks(diskKind string, num int) (err error) {


### PR DESCRIPTION
Currently, the function generating the disk names didn't work as expected, and instead of matching the disk number with the corresponding letter, it caused the letters to be attached from the previous disk. This resulted in only the first disk being properly copied due to incorrect linking. With these changes, the disk name generation works as expected.

backport: https://github.com/kubev2v/forklift/pull/872