### PR TITLE
drop trusted-ca config map

### DIFF
--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -30,23 +30,6 @@
       set_fact:
         k8s_cluster_version: "{{ lookup('k8s', cluster_info='version').kubernetes.gitVersion }}"
 
-  - when: not k8s_cluster|bool
-    block:
-    - name: "Get cluster proxy object"
-      set_fact:
-        proxy_cluster: "{{ lookup('k8s', api_version='config.openshift.io/v1', kind='Proxy', resource_name='cluster') }}"
-
-    - when: proxy_cluster.spec.trustedCA.name|length > 0
-      block:
-      - name: "Enable trusted CA environment"
-        set_fact:
-          trusted_ca_enabled: true
-
-      - name: "Create an empty ConfigMap that will hold the trusted CA"
-        k8s:
-          state: present
-          definition: "{{ lookup('template', 'configmap-trusted-ca.yml.j2') }}"
-
   - name: "Setup controller config map"
     k8s:
       state : present

--- a/operator/roles/forkliftcontroller/templates/configmap-trusted-ca.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/configmap-trusted-ca.yml.j2
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: trusted-ca
-  namespace: {{ app_namespace }}
-  labels:
-    app: {{ app_name }}
-    config.openshift.io/inject-trusted-cabundle: "true"


### PR DESCRIPTION
apparently, recent versions of OpenShift doesn't set the 'trustedCA' property in the cluster's Proxy, leading to our operator failing on checking "proxy_cluster.spec.trustedCA.name|length > 0". we no longer need the config map as we dropped the old, standadlone, UI.