### PR TITLE
v2v: add extra args

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -110,5 +110,6 @@ must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') or lookup( 'env'
 virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V') }}"
 virt_v2v_warm_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_WARM_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V_WARM') }}"
 virt_v2v_dont_request_kvm: "{{ lookup( 'env', 'VIRT_V2V_DONT_REQUEST_KVM') }}"
+virt_v2v_extra_args: "{{ lookup( 'env', 'VIRT_V2V_EXTRA_ARGS') }}"
 
 ova_provider_server_fqin: "{{ lookup( 'env', 'OVA_PROVIDER_SERVER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_OVA_PROVIDER_SERVER') }}"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -122,6 +122,8 @@ spec:
         - name: VIRT_V2V_DONT_REQUEST_KVM
           value: "true"
 {% endif %}
+        - name: VIRT_V2V_EXTRA_ARGS
+          value: "{{ virt_v2v_extra_args }}"
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -24,6 +24,7 @@ import (
 	libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libitr "github.com/konveyor/forklift-controller/pkg/lib/itinerary"
+	"github.com/konveyor/forklift-controller/pkg/settings"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
 	core "k8s.io/api/core/v1"
@@ -207,6 +208,10 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		core.EnvVar{
 			Name:  "V2V_fingerprint",
 			Value: fingerprint,
+		},
+		core.EnvVar{
+			Name:  "V2V_extra_args",
+			Value: settings.Settings.Migration.VirtV2vExtraArgs,
 		},
 	)
 	return

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -26,6 +27,7 @@ const (
 	OvirtOsConfigMap        = "OVIRT_OS_MAP"
 	VsphereOsConfigMap      = "VSPHERE_OS_MAP"
 	VddkJobActiveDeadline   = "VDDK_JOB_ACTIVE_DEADLINE"
+	VirtV2vExtraArgs        = "VIRT_V2V_EXTRA_ARGS"
 )
 
 // Migration settings
@@ -61,6 +63,8 @@ type Migration struct {
 	VsphereOsConfigMap string
 	// Active deadline for VDDK validation job
 	VddkJobActiveDeadline int
+	// Additional arguments for virt-v2v
+	VirtV2vExtraArgs string
 }
 
 // Load settings.
@@ -125,6 +129,14 @@ func (r *Migration) Load() (err error) {
 	}
 	if r.VddkJobActiveDeadline, err = getPositiveEnvLimit(VddkJobActiveDeadline, 300); err != nil {
 		return liberr.Wrap(err)
+	}
+	r.VirtV2vExtraArgs = "[]"
+	if val, found := os.LookupEnv(VirtV2vExtraArgs); found && len(val) > 0 {
+		if encoded, jsonErr := json.Marshal(strings.Fields(val)); jsonErr == nil {
+			r.VirtV2vExtraArgs = string(encoded)
+		} else {
+			return liberr.Wrap(err)
+		}
 	}
 
 	return

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -97,6 +98,15 @@ func main() {
 				"-io", fmt.Sprintf("vddk-thumbprint=%s", os.Getenv("V2V_fingerprint")),
 			)
 		}
+		var extraArgs []string
+		if envExtraArgs := os.Getenv("V2V_extra_args"); envExtraArgs != "" {
+			if err := json.Unmarshal([]byte(envExtraArgs), &extraArgs); err != nil {
+				fmt.Println("Error parsing extra arguments ", err)
+				os.Exit(1)
+			}
+		}
+		virtV2vArgs = append(virtV2vArgs, extraArgs...)
+
 		virtV2vArgs = append(virtV2vArgs, "--", os.Getenv("V2V_vmName"))
 	}
 


### PR DESCRIPTION
Add an argument for extending the virt-v2v command with additional arguments that are taken from ForkliftController. This allows to modify the virt-v2v command, without creating new images.