### PR TITLE
Set content-type of tls-certificate response

### DIFF
--- a/pkg/forklift-api/services/tls-certificate.go
+++ b/pkg/forklift-api/services/tls-certificate.go
@@ -23,6 +23,7 @@ func serveTlsCertificate(resp http.ResponseWriter, req *http.Request, client cli
 				Bytes: cacert.Raw,
 			})
 			if _, err := resp.Write(encoded); err == nil {
+				resp.Header().Set("Content-Type", "text/plain")
 				resp.WriteHeader(http.StatusOK)
 			} else {
 				msg := fmt.Sprintf("failed to write certificate: %s", string(encoded))

--- a/pkg/lib/util/util.go
+++ b/pkg/lib/util/util.go
@@ -27,7 +27,7 @@ func GetTlsCertificate(url *liburl.URL, secret *core.Secret) (crt *x509.Certific
 
 	conn, err := tls.Dial("tcp", host, cfg)
 	if err == nil && len(conn.ConnectionState().PeerCertificates) > 0 {
-		crt, err = x509.ParseCertificate(conn.ConnectionState().PeerCertificates[0].Raw)
+		crt = conn.ConnectionState().PeerCertificates[0]
 	} else {
 		err = liberr.Wrap(err, "url", url)
 	}


### PR DESCRIPTION
The content-type of the response that included the TLS certificate wasn't set, and therefore static analysis tools could have thought we intend to return text/html that wasn't sanitized. However, in this case the return value is not in the form of text/html but text/plain. Now the content-type is set accordingly to avoid that and so that clients won't treat the output as HTML.

This commit also reverts 3848777a.