### PR TITLE
operator: remove must-gather-api deployment on upgrade

### DIFF
--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -245,3 +245,11 @@
       loop_var: resource_kind
     vars:
       feature_label: "{{ validation_service_name }}"
+
+  - name: "Delete must-gather-api deployment"
+    k8s:
+      api_version: apps/v1
+      kind: deployment
+      namespace: "{{ app_namespace }}"
+      name: forklift-must-gather-api
+      state: absent


### PR DESCRIPTION
We no longer deploy must-gather-api but we haven't made sure that we remove the deployment when it already exists and therefore the must-gather-api pod remains running when upgrading from a version in which must-gather-api is deployed.

backport of #899 