### PR TITLE
Fix virt-v2v progress after using go wrapper

### DIFF
--- a/cmd/virt-v2v-monitor/BUILD.bazel
+++ b/cmd/virt-v2v-monitor/BUILD.bazel
@@ -15,6 +15,5 @@ go_library(
         "//vendor/github.com/prometheus/client_golang/prometheus",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp",
         "//vendor/github.com/prometheus/client_model/go",
-        "//vendor/k8s.io/klog/v2:klog",
     ],
 )

--- a/cmd/virt-v2v-monitor/virt-v2v-monitor.go
+++ b/cmd/virt-v2v-monitor/virt-v2v-monitor.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -12,7 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
-	"k8s.io/klog/v2"
 )
 
 var COPY_DISK_RE = regexp.MustCompile(`^.*Copying disk (\d+)/(\d+)`)
@@ -52,28 +50,15 @@ func updateProgress(progressCounter *prometheus.CounterVec, disk, progress uint6
 
 	change := float64(progress) - previous_progress
 	if change > 0 {
-		klog.Infof("Progress changed for disk %d about %v", disk, change)
+		fmt.Printf("virt-v2v monitoring: Progress changed for disk %d about %v\n", disk, change)
 		progressCounter.WithLabelValues(label).Add(change)
 	}
 	return
 }
 
-func NewBufferedScanner(r *bufio.Reader, bufferSize int) *bufio.Scanner {
-	scanner := bufio.NewScanner(r)
-	buf := make([]byte, bufferSize)
-	scanner.Buffer(buf, bufferSize)
-	scanner.Split(LimitedScanLines)
-	return scanner
-}
-
 func main() {
-	klog.InitFlags(nil)
-	defer klog.Flush()
-	flag.Parse()
-
 	// Start prometheus metrics HTTP handler
-	klog.Info("Setting up prometheus endpoint :2112/metrics")
-	klog.Info("this is Bella test")
+	fmt.Println("virt-v2v monitoring: Setting up prometheus endpoint :2112/metrics")
 	http.Handle("/metrics", promhttp.Handler())
 	go http.ListenAndServe(":2112", nil)
 
@@ -88,62 +73,52 @@ func main() {
 	if err := prometheus.Register(progressCounter); err != nil {
 		// Exit gracefully if we fail here. We don't need monitoring
 		// failures to hinder guest conversion.
-		klog.Error("Prometheus progress counter not registered:", err)
+		fmt.Println("virt-v2v monitoring: Prometheus progress counter not registered:", err)
 		return
 	}
-	klog.Info("Prometheus progress counter registered.")
+	fmt.Println("virt-v2v monitoring: Prometheus progress counter registered.")
 
 	var diskNumber uint64 = 0
 	var disks uint64 = 0
 	var progress uint64 = 0
 
-	reader := bufio.NewReader(os.Stdin)
-	scanner := NewBufferedScanner(reader, 1*1024*1024)
-	fmt.Println("Arik")
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Split(LimitedScanLines)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		os.Stdout.Write(line)
 		os.Stdout.Write([]byte("\n"))
 		err := scanner.Err()
 		if err != nil {
-			klog.Fatal("Output monitoring failed! ", err)
+			fmt.Println("virt-v2v monitoring: Output monitoring failed! ", err)
 		}
-
-		//fmt.Println("this is the line we scanning now ", string(line))
 
 		if match := COPY_DISK_RE.FindSubmatch(line); match != nil {
 			diskNumber, _ = strconv.ParseUint(string(match[1]), 10, 0)
 			disks, _ = strconv.ParseUint(string(match[2]), 10, 0)
-			//klog.Infof("Copying disk %d out of %d", diskNumber, disks)
-			fmt.Printf("Copying disk %d out of %d", diskNumber, disks)
+			fmt.Printf("virt-v2v monitoring: Copying disk %d out of %d\n", diskNumber, disks)
 			progress = 0
 			err = updateProgress(progressCounter, diskNumber, progress)
 		} else if match := DISK_PROGRESS_RE.FindSubmatch(line); match != nil {
-			//klog.Info("we are here at progress ", line)
-			fmt.Printf("we are here at progress line=%s match-0=%s match-1=%s\n", string(line), string(match[0]), string(match[1]))
 			progress, _ = strconv.ParseUint(string(match[1]), 10, 0)
-			//klog.Infof("Progress update, completed %d %%", progress)
-			fmt.Printf("Progress update, completed %d %%\n", progress)
+			fmt.Printf("virt-v2v monitoring: Progress update, completed %d %%\n", progress)
 			err = updateProgress(progressCounter, diskNumber, progress)
 		} else if match := FINISHED_RE.Find(line); match != nil {
 			// Make sure we flag conversion as finished. This is
 			// just in case we miss the last progress update for some reason.
-			//klog.Infof("Finished")
-			fmt.Printf("Finished\n")
+			fmt.Println("virt-v2v monitoring: Finished")
 			for disk := uint64(0); disk < disks; disk++ {
 				err = updateProgress(progressCounter, disk, 100)
 			}
-		} else {
-			klog.Infof("Ignoring line: ", string(line))
 		}
 		if err != nil {
 			// Don't make processing errors fatal.
-			klog.Error("Error updating progress: ", err)
+			fmt.Println("virt-v2v monitoring: Error updating progress: ", err)
 			err = nil
 		}
 	}
 	err := scanner.Err()
 	if err != nil {
-		klog.Fatal("Output monitoring failed! ", err)
+		fmt.Println("virt-v2v monitoring: Output monitoring failed! ", err)
 	}
 }

--- a/cmd/virt-v2v-monitor/virt-v2v-monitor.go
+++ b/cmd/virt-v2v-monitor/virt-v2v-monitor.go
@@ -16,7 +16,7 @@ import (
 )
 
 var COPY_DISK_RE = regexp.MustCompile(`^.*Copying disk (\d+)/(\d+)`)
-var DISK_PROGRESS_RE = regexp.MustCompile(`\s+\((\d+).*|.+ (\d+)% \[[*-]+\]`)
+var DISK_PROGRESS_RE = regexp.MustCompile(`.+ (\d+)% \[[*-]+\]`)
 var FINISHED_RE = regexp.MustCompile(`^\[[ .0-9]*\] Finishing off`)
 
 // Here is a scan function that imposes limit on returned line length. virt-v2v
@@ -29,7 +29,7 @@ func LimitedScanLines(data []byte, atEOF bool) (advance int, token []byte, err e
 	if token != nil || err != nil {
 		return
 	}
-	if len(data) == 1*1024*1024 {
+	if len(data) == bufio.MaxScanTokenSize {
 		// Line is too long for the buffer. Trim it.
 		advance = len(data)
 		token = data
@@ -99,7 +99,7 @@ func main() {
 
 	reader := bufio.NewReader(os.Stdin)
 	scanner := NewBufferedScanner(reader, 1*1024*1024)
-
+	fmt.Println("Arik")
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		os.Stdout.Write(line)
@@ -109,23 +109,27 @@ func main() {
 			klog.Fatal("Output monitoring failed! ", err)
 		}
 
-		fmt.Println("this is the line we scanning now ", string(line))
+		//fmt.Println("this is the line we scanning now ", string(line))
 
 		if match := COPY_DISK_RE.FindSubmatch(line); match != nil {
 			diskNumber, _ = strconv.ParseUint(string(match[1]), 10, 0)
 			disks, _ = strconv.ParseUint(string(match[2]), 10, 0)
-			klog.Infof("Copying disk %d out of %d", diskNumber, disks)
+			//klog.Infof("Copying disk %d out of %d", diskNumber, disks)
+			fmt.Printf("Copying disk %d out of %d", diskNumber, disks)
 			progress = 0
 			err = updateProgress(progressCounter, diskNumber, progress)
 		} else if match := DISK_PROGRESS_RE.FindSubmatch(line); match != nil {
-			klog.Info("we are here at progress ", line)
+			//klog.Info("we are here at progress ", line)
+			fmt.Printf("we are here at progress line=%s match-0=%s match-1=%s\n", string(line), string(match[0]), string(match[1]))
 			progress, _ = strconv.ParseUint(string(match[1]), 10, 0)
-			klog.Infof("Progress update, completed %d %%", progress)
+			//klog.Infof("Progress update, completed %d %%", progress)
+			fmt.Printf("Progress update, completed %d %%\n", progress)
 			err = updateProgress(progressCounter, diskNumber, progress)
 		} else if match := FINISHED_RE.Find(line); match != nil {
 			// Make sure we flag conversion as finished. This is
 			// just in case we miss the last progress update for some reason.
-			klog.Infof("Finished")
+			//klog.Infof("Finished")
+			fmt.Printf("Finished\n")
 			for disk := uint64(0); disk < disks; disk++ {
 				err = updateProgress(progressCounter, disk, 100)
 			}

--- a/cmd/virt-v2v-monitor/virt-v2v-monitor.go
+++ b/cmd/virt-v2v-monitor/virt-v2v-monitor.go
@@ -91,6 +91,7 @@ func main() {
 		err := scanner.Err()
 		if err != nil {
 			fmt.Println("virt-v2v monitoring: Output monitoring failed! ", err)
+			os.Exit(1)
 		}
 
 		if match := COPY_DISK_RE.FindSubmatch(line); match != nil {
@@ -120,5 +121,6 @@ func main() {
 	err := scanner.Err()
 	if err != nil {
 		fmt.Println("virt-v2v monitoring: Output monitoring failed! ", err)
+		os.Exit(1)
 	}
 }

--- a/cmd/virt-v2v-monitor/virt-v2v-monitor.go
+++ b/cmd/virt-v2v-monitor/virt-v2v-monitor.go
@@ -58,7 +58,7 @@ func updateProgress(progressCounter *prometheus.CounterVec, disk, progress uint6
 
 func main() {
 	// Start prometheus metrics HTTP handler
-	fmt.Println("virt-v2v monitoring: Setting up prometheus endpoint :2112/metrics")
+	fmt.Println("virt-v2v monitoring: Bella Setting up prometheus endpoint :2112/metrics")
 	http.Handle("/metrics", promhttp.Handler())
 	go http.ListenAndServe(":2112", nil)
 

--- a/cmd/virt-v2v-monitor/virt-v2v-monitor.go
+++ b/cmd/virt-v2v-monitor/virt-v2v-monitor.go
@@ -58,7 +58,7 @@ func updateProgress(progressCounter *prometheus.CounterVec, disk, progress uint6
 
 func main() {
 	// Start prometheus metrics HTTP handler
-	fmt.Println("virt-v2v monitoring: Bella Setting up prometheus endpoint :2112/metrics")
+	fmt.Println("virt-v2v monitoring: Setting up prometheus endpoint :2112/metrics")
 	http.Handle("/metrics", promhttp.Handler())
 	go http.ListenAndServe(":2112", nil)
 
@@ -114,7 +114,7 @@ func main() {
 		}
 		if err != nil {
 			// Don't make processing errors fatal.
-			fmt.Println("virt-v2v monitoring: Error updating progress: ", err)
+			fmt.Println("virt-v2v monitoring: Error updating progress:", err)
 			err = nil
 		}
 	}

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -198,6 +198,7 @@ func executeVirtV2v(source string, args []string) (err error) {
 	virtV2vCmd.Stdout = w
 	virtV2vCmd.Stderr = w
 
+	fmt.Println("exec ", virtV2vCmd)
 	if err = virtV2vCmd.Start(); err != nil {
 		fmt.Printf("Error executing command: %v\n", err)
 		return
@@ -205,8 +206,6 @@ func executeVirtV2v(source string, args []string) (err error) {
 
 	virtV2vMonitorCmd := exec.Command("/usr/local/bin/virt-v2v-monitor")
 	virtV2vMonitorCmd.Stdin = r
-	//k, _ := virtV2vMonitorCmd.StderrPipe()
-	//r2 := io.TeeReader(k, os.Stderr)
 	virtV2vMonitorCmd.Stdout = os.Stdout
 
 	if err = virtV2vMonitorCmd.Start(); err != nil {
@@ -215,7 +214,7 @@ func executeVirtV2v(source string, args []string) (err error) {
 	}
 
 	if source == OVA {
-		scanner := bufio.NewScanner(nil)
+		scanner := bufio.NewScanner(r)
 		const maxCapacity = 1024 * 1024
 		buf := make([]byte, 0, 64*1024)
 		scanner.Buffer(buf, maxCapacity)

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -206,17 +206,16 @@ func executeVirtV2v(source string, args []string) (err error) {
 
 	virtV2vMonitorCmd := exec.Command("/usr/local/bin/virt-v2v-monitor")
 	virtV2vMonitorCmd.Stdin = r
-	virtV2vMonitorCmd.Stdout = os.Stdout
 	virtV2vMonitorCmd.Stderr = os.Stderr
 
-	var teeErr io.Reader
+	var teeOut io.Reader
 	if source == OVA {
-		virtV2vStderrPipe, err := virtV2vMonitorCmd.StderrPipe()
+		virtV2vStdoutPipe, err := virtV2vMonitorCmd.StdoutPipe()
 		if err != nil {
 			fmt.Printf("Error setting up stdout pipe: %v\n", err)
 			return err
 		}
-		teeErr = io.TeeReader(virtV2vStderrPipe, os.Stdout)
+		teeOut = io.TeeReader(virtV2vStdoutPipe, os.Stdout)
 	}
 
 	if err = virtV2vMonitorCmd.Start(); err != nil {
@@ -225,7 +224,7 @@ func executeVirtV2v(source string, args []string) (err error) {
 	}
 
 	if source == OVA {
-		scanner := bufio.NewScanner(teeErr)
+		scanner := bufio.NewScanner(teeOut)
 		const maxCapacity = 1024 * 1024
 		buf := make([]byte, 0, 64*1024)
 		scanner.Buffer(buf, maxCapacity)

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -209,45 +209,46 @@ func executeVirtV2v(source string, args []string) (err error) {
 	virtV2vMonitorCmd.Stdout = os.Stdout
 	virtV2vMonitorCmd.Stderr = os.Stderr
 
+	var teeErr io.Reader
+	if source == OVA {
+		virtV2vStderrPipe, err := virtV2vMonitorCmd.StderrPipe()
+		if err != nil {
+			fmt.Printf("Error setting up stdout pipe: %v\n", err)
+			return err
+		}
+		teeErr = io.TeeReader(virtV2vStderrPipe, os.Stdout)
+	}
+
 	if err = virtV2vMonitorCmd.Start(); err != nil {
 		fmt.Printf("Error executing monitor command: %v\n", err)
 		return
 	}
 
-	done := make(chan error, 1)
-	go func() {
-		if source == OVA {
-			scanner := bufio.NewScanner(r)
-			const maxCapacity = 1024 * 1024
-			buf := make([]byte, 0, 64*1024)
-			scanner.Buffer(buf, maxCapacity)
+	if source == OVA {
+		scanner := bufio.NewScanner(teeErr)
+		const maxCapacity = 1024 * 1024
+		buf := make([]byte, 0, 64*1024)
+		scanner.Buffer(buf, maxCapacity)
 
-			for scanner.Scan() {
-				line := scanner.Bytes()
-				if match := UEFI_RE.FindSubmatch(line); match != nil {
-					fmt.Println("UEFI firmware detected")
-					firmware = "efi"
-				}
-			}
-
-			if err := scanner.Err(); err != nil {
-				fmt.Println("Output query failed:", err)
-				done <- err
-				return
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if match := UEFI_RE.FindSubmatch(line); match != nil {
+				fmt.Println("UEFI firmware detected")
+				firmware = "efi"
 			}
 		}
-		done <- nil
-	}()
+
+		if err = scanner.Err(); err != nil {
+			fmt.Println("Output query failed:", err)
+			return
+		}
+	}
 
 	if err = virtV2vCmd.Wait(); err != nil {
 		fmt.Printf("Error waiting for virt-v2v to finish: %v\n", err)
 		return
 	}
 	w.Close()
-
-	if err = <-done; err != nil {
-		return err
-	}
 	return
 }
 

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -197,6 +197,7 @@ func executeVirtV2v(source string, args []string) (err error) {
 	r, w := io.Pipe()
 	virtV2vCmd.Stdout = w
 	virtV2vCmd.Stderr = w
+	defer w.Close()
 
 	fmt.Println("exec ", virtV2vCmd)
 	if err = virtV2vCmd.Start(); err != nil {
@@ -224,6 +225,7 @@ func executeVirtV2v(source string, args []string) (err error) {
 	}
 
 	if source == OVA {
+		fmt.Println("we are in the ova scanner")
 		scanner := bufio.NewScanner(teeOut)
 		const maxCapacity = 1024 * 1024
 		buf := make([]byte, 0, 64*1024)
@@ -231,12 +233,14 @@ func executeVirtV2v(source string, args []string) (err error) {
 
 		for scanner.Scan() {
 			line := scanner.Bytes()
+			fmt.Println("this is the line", string(line))
 			if match := UEFI_RE.FindSubmatch(line); match != nil {
 				fmt.Println("UEFI firmware detected")
 				firmware = "efi"
 			}
 		}
 
+		fmt.Println("we are here - after the loop")
 		if err = scanner.Err(); err != nil {
 			fmt.Println("Output query failed:", err)
 			return
@@ -247,7 +251,6 @@ func executeVirtV2v(source string, args []string) (err error) {
 		fmt.Printf("Error waiting for virt-v2v to finish: %v\n", err)
 		return
 	}
-	w.Close()
 	return
 }
 


### PR DESCRIPTION
After switching to use a Go wrapper, not all the information was redirected to the virt-v2v monitor command. Additionally, with changes done in the virt-v2v progress display, the progress was not reported to the controller. This patch fixes the piping to the virt-v2v monitoring command and the regex used to determine the copy disk progress of the migration.