### PR TITLE
Fix direct LUN migrations (backport)

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -627,12 +627,13 @@ func (r *Builder) LunPersistentVolumes(vmRef ref.Ref) (pvs []core.PersistentVolu
 					Namespace: r.Plan.Spec.TargetNamespace,
 					Annotations: map[string]string{
 						planbase.AnnDiskSource: da.Disk.ID,
-						"vmID":                 vm.ID,
-						"plan":                 string(r.Plan.UID),
 						"lun":                  "true",
 					},
 					Labels: map[string]string{
-						"volume": fmt.Sprintf("%v-%v", vm.Name, da.ID),
+						"volume":    fmt.Sprintf("%v-%v", vm.Name, da.ID),
+						"vmID":      vm.ID,
+						"plan":      string(r.Plan.UID),
+						"migration": string(r.Migration.UID),
 					},
 				},
 				Spec: core.PersistentVolumeSpec{
@@ -670,11 +671,13 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 					Namespace: r.Plan.Spec.TargetNamespace,
 					Annotations: map[string]string{
 						planbase.AnnDiskSource: da.Disk.ID,
-						"vmID":                 vm.ID,
-						"plan":                 string(r.Plan.UID),
 						"lun":                  "true",
 					},
-					Labels: map[string]string{"migration": r.Migration.Name},
+					Labels: map[string]string{
+						"vmID":      vm.ID,
+						"plan":      string(r.Plan.UID),
+						"migration": string(r.Migration.UID),
+					},
 				},
 				Spec: core.PersistentVolumeClaimSpec{
 					AccessModes: []core.PersistentVolumeAccessMode{

--- a/pkg/controller/provider/container/ovirt/BUILD.bazel
+++ b/pkg/controller/provider/container/ovirt/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "ovirt",
@@ -27,5 +27,20 @@ go_library(
         "//pkg/settings",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+    ],
+)
+
+go_test(
+    name = "ovirt_test",
+    srcs = [
+        "collector_suite_test.go",
+        "collector_test.go",
+    ],
+    embed = [":ovirt"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo",
+        "//vendor/github.com/onsi/ginkgo/extensions/table",
+        "//vendor/github.com/onsi/gomega",
+        "//vendor/github.com/onsi/gomega/types",
     ],
 )

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -146,15 +146,16 @@ func (r *Collector) Version() (major, minor, build, revision string, err error) 
 	version := strings.Split(system.Product.Version.FullVersion, ".")
 	major = version[0]
 	minor = version[1]
-	build = version[2]
-	revision = "0"
-	if strings.Contains(build, "-") {
-		build = strings.Split(version[2], "-")[0]
-		revision = strings.Split(version[2], "-")[1]
-	} else {
-		if len(version) > 3 {
-			revision = strings.Split(version[3], "-")[0]
-		}
+
+	split := strings.SplitN(version[2], "-", 2)
+	build = split[0]
+	switch {
+	case len(split) > 1:
+		revision = split[1]
+	case len(version) > 3:
+		revision = strings.Split(version[3], "-")[0]
+	default:
+		revision = "0"
 	}
 
 	return

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -148,9 +148,15 @@ func (r *Collector) Version() (major, minor, build, revision string, err error) 
 	minor = version[1]
 	build = version[2]
 	revision = "0"
-	if len(version) > 3 {
-		revision = strings.Split(version[3], "-")[0]
+	if strings.Contains(build, "-") {
+		build = strings.Split(version[2], "-")[0]
+		revision = strings.Split(version[2], "-")[1]
+	} else {
+		if len(version) > 3 {
+			revision = strings.Split(version[3], "-")[0]
+		}
 	}
+
 	return
 }
 

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -143,7 +143,12 @@ func (r *Collector) Version() (major, minor, build, revision string, err error) 
 	if err != nil {
 		return
 	}
-	version := strings.Split(system.Product.Version.FullVersion, ".")
+	major, minor, build, revision = parseVersion(system.Product.Version.FullVersion)
+	return
+}
+
+func parseVersion(fullVersion string) (major, minor, build, revision string) {
+	version := strings.Split(fullVersion, ".")
 	major = version[0]
 	minor = version[1]
 
@@ -157,7 +162,6 @@ func (r *Collector) Version() (major, minor, build, revision string, err error) 
 	default:
 		revision = "0"
 	}
-
 	return
 }
 

--- a/pkg/controller/provider/container/ovirt/collector_suite_test.go
+++ b/pkg/controller/provider/container/ovirt/collector_suite_test.go
@@ -1,0 +1,22 @@
+package ovirt
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// forkliftFailHandler call ginkgo.Fail with printing the additional information
+func forkliftFailHandler(message string, callerSkip ...int) {
+	if len(callerSkip) > 0 {
+		callerSkip[0]++
+	}
+	ginkgo.Fail(message, callerSkip...)
+}
+
+func TestTests(t *testing.T) {
+	defer ginkgo.GinkgoRecover()
+	RegisterFailHandler(forkliftFailHandler)
+	ginkgo.RunSpecs(t, "ovirt collector")
+}

--- a/pkg/controller/provider/container/ovirt/collector_test.go
+++ b/pkg/controller/provider/container/ovirt/collector_test.go
@@ -1,0 +1,20 @@
+package ovirt
+
+import (
+	"strings"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	gtypes "github.com/onsi/gomega/types"
+)
+
+var _ = ginkgo.Describe("ovirt collector", func() {
+	table.DescribeTable("should", func(version string, matchVersion gtypes.GomegaMatcher) {
+		major, minor, build, revision := parseVersion(version)
+		Expect(strings.Join([]string{major, minor, build, revision}, ".")).Should(matchVersion)
+	},
+		table.Entry("get version when revision is in the 3rd element", "4.5.5-1.el8", Equal("4.5.5.1")),
+		table.Entry("get version when revision is in the 4th element", "4.5.3.4-1.el8ev", Equal("4.5.3.4")),
+	)
+})


### PR DESCRIPTION
Since
https://github.com/kubev2v/forklift/commit/0e9edd7f45ebe54aac80fa35278e359d144da4e0, the way we get PVCs associated with VMs has changed. This patch adds the relevant labels to the LUN PVCs, so we can get them correctly.

Also, there is a difference of versioning between ovirt to rhv. Now we can use them both in the version validation.

Backport of #897 