### PR TITLE
Fix virt-v2v progress update

### DIFF
--- a/cmd/virt-v2v-monitor/BUILD.bazel
+++ b/cmd/virt-v2v-monitor/BUILD.bazel
@@ -15,6 +15,5 @@ go_library(
         "//vendor/github.com/prometheus/client_golang/prometheus",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp",
         "//vendor/github.com/prometheus/client_model/go",
-        "//vendor/k8s.io/klog/v2:klog",
     ],
 )

--- a/cmd/virt-v2v-monitor/virt-v2v-monitor.go
+++ b/cmd/virt-v2v-monitor/virt-v2v-monitor.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bufio"
-	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"regexp"
@@ -11,11 +11,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
-	"k8s.io/klog/v2"
 )
 
 var COPY_DISK_RE = regexp.MustCompile(`^.*Copying disk (\d+)/(\d+)`)
-var DISK_PROGRESS_RE = regexp.MustCompile(`^..\s*(\d+)% \[.*\]`)
+var DISK_PROGRESS_RE = regexp.MustCompile(`.+ (\d+)% \[[*-]+\]`)
 var FINISHED_RE = regexp.MustCompile(`^\[[ .0-9]*\] Finishing off`)
 
 // Here is a scan function that imposes limit on returned line length. virt-v2v
@@ -51,19 +50,15 @@ func updateProgress(progressCounter *prometheus.CounterVec, disk, progress uint6
 
 	change := float64(progress) - previous_progress
 	if change > 0 {
-		klog.Infof("Progress changed for disk %d about %v", disk, change)
+		fmt.Printf("virt-v2v monitoring: Progress changed for disk %d about %v\n", disk, change)
 		progressCounter.WithLabelValues(label).Add(change)
 	}
 	return
 }
 
 func main() {
-	klog.InitFlags(nil)
-	defer klog.Flush()
-	flag.Parse()
-
 	// Start prometheus metrics HTTP handler
-	klog.Info("Setting up prometheus endpoint :2112/metrics")
+	fmt.Println("virt-v2v monitoring: Setting up prometheus endpoint :2112/metrics")
 	http.Handle("/metrics", promhttp.Handler())
 	go http.ListenAndServe(":2112", nil)
 
@@ -78,10 +73,10 @@ func main() {
 	if err := prometheus.Register(progressCounter); err != nil {
 		// Exit gracefully if we fail here. We don't need monitoring
 		// failures to hinder guest conversion.
-		klog.Error("Prometheus progress counter not registered:", err)
+		fmt.Println("virt-v2v monitoring: Prometheus progress counter not registered:", err)
 		return
 	}
-	klog.Info("Prometheus progress counter registered.")
+	fmt.Println("virt-v2v monitoring: Prometheus progress counter registered.")
 
 	var diskNumber uint64 = 0
 	var disks uint64 = 0
@@ -95,37 +90,38 @@ func main() {
 		os.Stdout.Write([]byte("\n"))
 		err := scanner.Err()
 		if err != nil {
-			klog.Fatal("Output monitoring failed! ", err)
+			fmt.Println("virt-v2v monitoring: Output monitoring failed! ", err)
+			os.Exit(1)
 		}
 
 		if match := COPY_DISK_RE.FindSubmatch(line); match != nil {
 			diskNumber, _ = strconv.ParseUint(string(match[1]), 10, 0)
 			disks, _ = strconv.ParseUint(string(match[2]), 10, 0)
-			klog.Infof("Copying disk %d out of %d", diskNumber, disks)
+			fmt.Printf("virt-v2v monitoring: Copying disk %d out of %d\n", diskNumber, disks)
 			progress = 0
 			err = updateProgress(progressCounter, diskNumber, progress)
 		} else if match := DISK_PROGRESS_RE.FindSubmatch(line); match != nil {
 			progress, _ = strconv.ParseUint(string(match[1]), 10, 0)
-			klog.Infof("Progress update, completed %d %%", progress)
+			fmt.Printf("virt-v2v monitoring: Progress update, completed %d %%\n", progress)
 			err = updateProgress(progressCounter, diskNumber, progress)
 		} else if match := FINISHED_RE.Find(line); match != nil {
 			// Make sure we flag conversion as finished. This is
 			// just in case we miss the last progress update for some reason.
-			klog.Infof("Finished")
+			fmt.Println("virt-v2v monitoring: Finished")
 			for disk := uint64(0); disk < disks; disk++ {
 				err = updateProgress(progressCounter, disk, 100)
 			}
-		} else {
-			klog.V(1).Info("Ignoring line: ", string(line))
 		}
+
 		if err != nil {
 			// Don't make processing errors fatal.
-			klog.Error("Error updating progress: ", err)
+			fmt.Println("virt-v2v monitoring: Error updating progress: ", err)
 			err = nil
 		}
 	}
 	err := scanner.Err()
 	if err != nil {
-		klog.Fatal("Output monitoring failed! ", err)
+		fmt.Println("virt-v2v monitoring: Output monitoring failed! ", err)
+		os.Exit(1)
 	}
 }

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -197,14 +197,9 @@ func LinkDisks(diskKind string, num int) (err error) {
 
 func executeVirtV2v(args []string) (err error) {
 	virtV2vCmd := exec.Command(args[0], args[1:]...)
-	virtV2vStdoutPipe, err := virtV2vCmd.StdoutPipe()
-	if err != nil {
-		fmt.Printf("Error setting up stdout pipe: %v\n", err)
-		return
-	}
-
-	tee := io.TeeReader(virtV2vStdoutPipe, os.Stdout)
-	virtV2vCmd.Stderr = os.Stderr
+	r, w := io.Pipe()
+	virtV2vCmd.Stdout = w
+	virtV2vCmd.Stderr = w
 
 	fmt.Println("exec ", virtV2vCmd)
 	if err = virtV2vCmd.Start(); err != nil {
@@ -213,7 +208,7 @@ func executeVirtV2v(args []string) (err error) {
 	}
 
 	virtV2vMonitorCmd := exec.Command("/usr/local/bin/virt-v2v-monitor")
-	virtV2vMonitorCmd.Stdin = tee
+	virtV2vMonitorCmd.Stdin = r
 	virtV2vMonitorCmd.Stdout = os.Stdout
 	virtV2vMonitorCmd.Stderr = os.Stderr
 


### PR DESCRIPTION
After switching to use a Go wrapper, not all the information was redirected to the virt-v2v monitor command. Additionally, with changes done in the virt-v2v progress display, the progress was not reported to the controller. This patch fixes the piping to the virt-v2v monitoring command and the regex used to determine the copy disk progress of the migration.
https://github.com/kubev2v/forklift/pull/901