### PR TITLE
Map vSphere static IPs (backport)

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -141,6 +141,9 @@ spec:
                 description: Preserve the CPU model and flags the VM runs with in
                   its oVirt cluster.
                 type: boolean
+              preserveStaticIPs:
+                description: Preserve static IPs of VMs in vSphere (Windows only)
+                type: boolean
               provider:
                 description: Providers.
                 properties:

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -46,6 +46,8 @@ type PlanSpec struct {
 	Archived bool `json:"archived,omitempty"`
 	// Preserve the CPU model and flags the VM runs with in its oVirt cluster.
 	PreserveClusterCPUModel bool `json:"preserveClusterCpuModel,omitempty"`
+	// Preserve static IPs of VMs in vSphere (Windows only)
+	PreserveStaticIPs bool `json:"preserveStaticIPs,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -135,6 +135,8 @@ type Validator interface {
 	WarmMigration() bool
 	// Validate that no more than one of a VM's networks is mapped to the pod network.
 	PodNetwork(vmRef ref.Ref) (bool, error)
+	// Validate that we have information about static IPs for every virtual NIC
+	StaticIPs(vmRef ref.Ref) (bool, error)
 }
 
 // DestinationClient API.

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -186,3 +186,8 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 func (r *Validator) DirectStorage(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -109,3 +109,9 @@ func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
 func (r *Validator) DirectStorage(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
+	// the guest operating system is not modified during the migration so static IPs should be preserved
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -100,3 +100,8 @@ func (r *Validator) MaintenanceMode(vmRef ref.Ref) (ok bool, err error) {
 func (r *Validator) DirectStorage(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -165,3 +165,9 @@ func (r *Validator) MaintenanceMode(_ ref.Ref) (ok bool, err error) {
 	ok = true
 	return
 }
+
+// NO-OP
+func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
+	// the guest operating system is not modified during the migration so static IPs should be preserved
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/vsphere/BUILD.bazel
+++ b/pkg/controller/plan/adapter/vsphere/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "vsphere",
@@ -41,5 +41,25 @@ go_library(
         "//vendor/kubevirt.io/api/core/v1:core",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
+    ],
+)
+
+go_test(
+    name = "vsphere_test",
+    srcs = [
+        "validator_test.go",
+        "vsphere_suite_test.go",
+    ],
+    embed = [":vsphere"],
+    deps = [
+        "//pkg/apis/forklift/v1beta1",
+        "//pkg/apis/forklift/v1beta1/plan",
+        "//pkg/apis/forklift/v1beta1/ref",
+        "//pkg/controller/provider/model/vsphere",
+        "//pkg/controller/provider/web",
+        "//pkg/controller/provider/web/vsphere",
+        "//vendor/github.com/onsi/ginkgo/v2:ginkgo",
+        "//vendor/github.com/onsi/gomega",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
     ],
 )

--- a/pkg/controller/plan/adapter/vsphere/BUILD.bazel
+++ b/pkg/controller/plan/adapter/vsphere/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
 go_test(
     name = "vsphere_test",
     srcs = [
+        "builder_test.go",
         "validator_test.go",
         "vsphere_suite_test.go",
     ],
@@ -55,11 +56,17 @@ go_test(
         "//pkg/apis/forklift/v1beta1",
         "//pkg/apis/forklift/v1beta1/plan",
         "//pkg/apis/forklift/v1beta1/ref",
+        "//pkg/controller/plan/context",
         "//pkg/controller/provider/model/vsphere",
         "//pkg/controller/provider/web",
         "//pkg/controller/provider/web/vsphere",
+        "//pkg/lib/logging",
         "//vendor/github.com/onsi/ginkgo/v2:ginkgo",
         "//vendor/github.com/onsi/gomega",
+        "//vendor/github.com/vmware/govmomi/vim25/types",
+        "//vendor/k8s.io/api/apps/v1:apps",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/apimachinery/pkg/runtime",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake",
     ],
 )

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -66,6 +66,7 @@ const (
 	DefaultWindows = "win10"
 	DefaultLinux   = "rhel8.1"
 	Unknown        = "unknown"
+	WindowsPrefix  = "win"
 )
 
 // Annotations
@@ -224,6 +225,9 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 }
 
 func (r *Builder) mapMacStaticIps(vm *model.VM) string {
+	if !isWindows(vm) {
+		return ""
+	}
 	configurations := []string{}
 	for _, guestNetwork := range vm.GuestNetworks {
 		if guestNetwork.Origin == string(types.NetIpConfigInfoIpAddressOriginManual) {
@@ -231,6 +235,10 @@ func (r *Builder) mapMacStaticIps(vm *model.VM) string {
 		}
 	}
 	return strings.Join(configurations, "_")
+}
+
+func isWindows(vm *model.VM) bool {
+	return strings.Contains(vm.GuestID, WindowsPrefix) || strings.Contains(vm.GuestName, WindowsPrefix)
 }
 
 func (r *Builder) getSourceDetails(vm *model.VM, sourceSecret *core.Secret) (libvirtURL liburl.URL, fingerprint string, err error) {
@@ -721,7 +729,7 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 		os = osMap[vm.GuestID]
 	} else if strings.Contains(vm.GuestName, "linux") || strings.Contains(vm.GuestName, "rhel") {
 		os = DefaultLinux
-	} else if strings.Contains(vm.GuestName, "win") {
+	} else if strings.Contains(vm.GuestName, WindowsPrefix) {
 		os = DefaultWindows
 	} else {
 		os = Unknown

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -183,7 +183,10 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		return
 	}
 
-	macsToIps := r.mapMacStaticIps(vm)
+	macsToIps := ""
+	if r.Plan.Spec.PreserveStaticIPs {
+		macsToIps = r.mapMacStaticIps(vm)
+	}
 
 	libvirtURL, fingerprint, err := r.getSourceDetails(vm, sourceSecret)
 	if err != nil {

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -23,9 +23,9 @@ var _ = Describe("vSphere builder", func() {
 	DescribeTable("should", func(vm *model.VM, outputMap string) {
 		Expect(builder.mapMacStaticIps(vm)).Should(Equal(outputMap))
 	},
-		Entry("no static ips", &model.VM{}, ""),
-		Entry("single static ip", &model.VM{GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, "00:50:56:83:25:47:ip:172.29.3.193"),
-		Entry("multiple static ips", &model.VM{GuestNetworks: []vsphere.GuestNetwork{
+		Entry("no static ips", &model.VM{GuestID: "windows9Guest"}, ""),
+		Entry("single static ip", &model.VM{GuestID: "windows9Guest", GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, "00:50:56:83:25:47:ip:172.29.3.193"),
+		Entry("multiple static ips", &model.VM{GuestID: "windows9Guest", GuestNetworks: []vsphere.GuestNetwork{
 			{
 				MAC:    "00:50:56:83:25:47",
 				IP:     "172.29.3.193",
@@ -38,7 +38,9 @@ var _ = Describe("vSphere builder", func() {
 			},
 		},
 		}, "00:50:56:83:25:47:ip:172.29.3.193_00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097"),
-		Entry("non-static ip", &model.VM{GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: string(types.NetIpConfigInfoIpAddressOriginDhcp)}}}, ""),
+		Entry("non-static ip", &model.VM{GuestID: "windows9Guest", GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: string(types.NetIpConfigInfoIpAddressOriginDhcp)}}}, ""),
+		Entry("non windows vm", &model.VM{GuestID: "other", GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, ""),
+		Entry("no OS vm", &model.VM{GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, ""),
 	)
 })
 

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -1,0 +1,65 @@
+package vsphere
+
+import (
+	v1beta1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
+	"github.com/konveyor/forklift-controller/pkg/lib/logging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/vim25/types"
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var builderLog = logging.WithName("vsphere-builder-test")
+
+const ManualOrigin = string(types.NetIpConfigInfoIpAddressOriginManual)
+
+var _ = Describe("vSphere builder", func() {
+	builder := createBuilder()
+	DescribeTable("should", func(vm *model.VM, outputMap string) {
+		Expect(builder.mapMacStaticIps(vm)).Should(Equal(outputMap))
+	},
+		Entry("no static ips", &model.VM{}, ""),
+		Entry("single static ip", &model.VM{GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, "00:50:56:83:25:47:ip:172.29.3.193"),
+		Entry("multiple static ips", &model.VM{GuestNetworks: []vsphere.GuestNetwork{
+			{
+				MAC:    "00:50:56:83:25:47",
+				IP:     "172.29.3.193",
+				Origin: ManualOrigin,
+			},
+			{
+				MAC:    "00:50:56:83:25:47",
+				IP:     "fe80::5da:b7a5:e0a2:a097",
+				Origin: ManualOrigin,
+			},
+		},
+		}, "00:50:56:83:25:47:ip:172.29.3.193_00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097"),
+		Entry("non-static ip", &model.VM{GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: string(types.NetIpConfigInfoIpAddressOriginDhcp)}}}, ""),
+	)
+})
+
+func createBuilder(objs ...runtime.Object) *Builder {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	v1beta1.SchemeBuilder.AddToScheme(scheme)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objs...).
+		Build()
+	return &Builder{
+		Context: &plancontext.Context{
+			Destination: plancontext.Destination{
+				Client: client,
+			},
+			Plan: createPlan(),
+			Log:  builderLog,
+
+			// To make sure r.Scheme is not nil
+			Client: client,
+		},
+	}
+}

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -42,6 +42,7 @@ var _ = Describe("vSphere builder", func() {
 	)
 })
 
+//nolint:errcheck
 func createBuilder(objs ...runtime.Object) *Builder {
 	scheme := runtime.NewScheme()
 	_ = v1.AddToScheme(scheme)

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -139,6 +139,10 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 		err = liberr.Wrap(err, "vm", vmRef)
 		return
 	}
+	if !isWindows(&vm.VM) {
+		return true, nil
+	}
+
 	for _, nic := range vm.NICs {
 		found := false
 		for _, guestNetwork := range vm.GuestNetworks {

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -27,10 +27,14 @@ func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 				},
 				GuestNetworks: []vsphere.GuestNetwork{
 					{MAC: "mac1"},
-				}},
+				},
+				GuestID: "windows7Guest"},
 		}
 		if ref.Name == "full_guest_network" {
 			res.VM.GuestNetworks = append(res.VM.GuestNetworks, vsphere.GuestNetwork{MAC: "mac2"})
+		}
+		if ref.Name == "not_windows_guest" {
+			res.VM.GuestID = "rhel8_64Guest"
 		}
 	}
 	return nil
@@ -97,6 +101,7 @@ var _ = Describe("vsphere validation tests", func() {
 			Entry("when the vm doesn't have static ips, and the plan set without static ip", "test", false, false),
 			Entry("when the vm have static ips, and the plan set with static ip", "full_guest_network", true, false),
 			Entry("when the vm have static ips, and the plan set without static ip", "test", false, false),
+			Entry("when the vm doesn't have static ips, and the plan set without static ip, vm is non-windows", "not_windows_guest", true, false),
 		)
 	})
 })

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -1,0 +1,115 @@
+//nolint:errcheck
+package vsphere
+
+import (
+	v1beta1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
+	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Mock inventory struct and methods for testing
+type mockInventory struct{}
+
+func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
+	switch res := resource.(type) {
+	case *model.Workload:
+		*res = model.Workload{
+			VM: model.VM{
+				NICs: []vsphere.NIC{
+					{MAC: "mac1"},
+					{MAC: "mac2"},
+				},
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "mac1"},
+				}},
+		}
+		if ref.Name == "full_guest_network" {
+			res.VM.GuestNetworks = append(res.VM.GuestNetworks, vsphere.GuestNetwork{MAC: "mac2"})
+		}
+	}
+	return nil
+}
+
+func (m *mockInventory) Finder() web.Finder {
+	return nil
+}
+
+func (m *mockInventory) Get(resource interface{}, id string) error {
+	return nil
+}
+
+func (m *mockInventory) Host(ref *ref.Ref) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *mockInventory) List(list interface{}, param ...web.Param) error {
+	return nil
+}
+
+func (m *mockInventory) Network(ref *ref.Ref) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *mockInventory) Storage(ref *ref.Ref) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *mockInventory) VM(ref *ref.Ref) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *mockInventory) Watch(resource interface{}, h web.EventHandler) (*web.Watch, error) {
+	return nil, nil
+}
+
+func (m *mockInventory) Workload(ref *ref.Ref) (interface{}, error) {
+	return nil, nil
+}
+
+var _ = Describe("vsphere validation tests", func() {
+	Describe("validateStaticIPs", func() {
+		DescribeTable("should validate Static IPs correctly",
+			func(vmName string, staticIPs, shouldError bool) {
+				plan := createPlan()
+				plan.Spec.PreserveStaticIPs = staticIPs
+				validator := &Validator{
+					plan:      plan,
+					inventory: &mockInventory{},
+				}
+				ok, err := validator.StaticIPs(ref.Ref{Name: vmName})
+				if shouldError {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ok).To(BeFalse())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ok).To(BeTrue())
+				}
+			},
+
+			// Directly declare entries here
+			Entry("when the vm doesn't have static ips, and the plan set with static ip", "test", true, true),
+			Entry("when the vm doesn't have static ips, and the plan set without static ip", "test", false, false),
+			Entry("when the vm have static ips, and the plan set with static ip", "full_guest_network", true, false),
+			Entry("when the vm have static ips, and the plan set without static ip", "test", false, false),
+		)
+	})
+})
+
+func createPlan() *v1beta1.Plan {
+	return &v1beta1.Plan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1beta1.PlanSpec{
+			TargetNamespace: "test",
+			VMs:             []plan.VM{{Ref: ref.Ref{Name: "test"}}},
+		},
+	}
+}

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -1,4 +1,4 @@
-//nolint:errcheck
+//nolint:nilnil
 package vsphere
 
 import (

--- a/pkg/controller/plan/adapter/vsphere/vsphere_suite_test.go
+++ b/pkg/controller/plan/adapter/vsphere/vsphere_suite_test.go
@@ -1,4 +1,4 @@
-package vsphere_test
+package vsphere
 
 import (
 	"testing"

--- a/pkg/controller/plan/adapter/vsphere/vsphere_suite_test.go
+++ b/pkg/controller/plan/adapter/vsphere/vsphere_suite_test.go
@@ -1,0 +1,13 @@
+package vsphere_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVsphere(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "vSphere Suite")
+}

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -322,9 +322,9 @@ func (r *Reconciler) archive(plan *api.Plan) {
 //  5. If a new migration is being started, update the context and snapshot.
 //  6. Run the migration.
 func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
-	validatingVDDK := plan.Status.HasCondition(ValidatingVDDK)
-	if plan.Status.HasBlockerCondition() || plan.Status.HasCondition(Archived) || validatingVDDK {
-		if validatingVDDK {
+	conditionRequiresReQ := plan.Status.HasReQCondition()
+	if plan.Status.HasBlockerCondition() || plan.Status.HasCondition(Archived) || conditionRequiresReQ {
+		if conditionRequiresReQ {
 			reQ = base.SlowReQ
 		}
 		return

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -119,6 +119,7 @@ const (
 	fConnectionState     = "runtime.connectionState"
 	fSnapshot            = "snapshot"
 	fIsTemplate          = "config.template"
+	fGuestNet            = "guest.net"
 )
 
 // Selections
@@ -720,6 +721,7 @@ func (r *Collector) vmPathSet() []string {
 		fNumCoresPerSocket,
 		fMemorySize,
 		fDevices,
+		fGuestNet,
 		fExtraConfig,
 		fGuestName,
 		fGuestID,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -613,6 +613,26 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 						}
 					}
 				}
+			case fGuestNet:
+				if nics, cast := p.Val.(types.ArrayOfGuestNicInfo); cast {
+					guestNetworksList := []model.GuestNetwork{}
+					for _, info := range nics.GuestNicInfo {
+						if info.IpConfig == nil {
+							continue
+						}
+						for _, ip := range info.IpConfig.IpAddress {
+							guestNetworksList = append(guestNetworksList, model.GuestNetwork{
+								MAC:    info.MacAddress,
+								IP:     ip.IpAddress,
+								Origin: ip.Origin,
+							})
+						}
+					}
+					// when the vm goes down, we get an update with empty values - the following check keeps the previously reported data.
+					if len(guestNetworksList) > 0 {
+						v.model.GuestNetworks = guestNetworksList
+					}
+				}
 			case fDevices:
 				if devArray, cast := p.Val.(types.ArrayOfVirtualDevice); cast {
 					devList := []model.Device{}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -231,37 +231,38 @@ type Datastore struct {
 
 type VM struct {
 	Base
-	Folder                string    `sql:"d0,index(folder)"`
-	Host                  string    `sql:"d0,index(host)"`
-	RevisionValidated     int64     `sql:"d0,index(revisionValidated)"`
-	PolicyVersion         int       `sql:"d0,index(policyVersion)"`
-	UUID                  string    `sql:""`
-	Firmware              string    `sql:""`
-	PowerState            string    `sql:""`
-	ConnectionState       string    `sql:""`
-	CpuAffinity           []int32   `sql:""`
-	CpuHotAddEnabled      bool      `sql:""`
-	CpuHotRemoveEnabled   bool      `sql:""`
-	MemoryHotAddEnabled   bool      `sql:""`
-	FaultToleranceEnabled bool      `sql:""`
-	CpuCount              int32     `sql:""`
-	CoresPerSocket        int32     `sql:""`
-	MemoryMB              int32     `sql:""`
-	GuestName             string    `sql:""`
-	GuestID               string    `sql:""`
-	BalloonedMemory       int32     `sql:""`
-	IpAddress             string    `sql:""`
-	NumaNodeAffinity      []string  `sql:""`
-	StorageUsed           int64     `sql:""`
-	Snapshot              Ref       `sql:""`
-	IsTemplate            bool      `sql:""`
-	ChangeTrackingEnabled bool      `sql:""`
-	TpmEnabled            bool      `sql:""`
-	Devices               []Device  `sql:""`
-	NICs                  []NIC     `sql:""`
-	Disks                 []Disk    `sql:""`
-	Networks              []Ref     `sql:""`
-	Concerns              []Concern `sql:""`
+	Folder                string         `sql:"d0,index(folder)"`
+	Host                  string         `sql:"d0,index(host)"`
+	RevisionValidated     int64          `sql:"d0,index(revisionValidated)"`
+	PolicyVersion         int            `sql:"d0,index(policyVersion)"`
+	UUID                  string         `sql:""`
+	Firmware              string         `sql:""`
+	PowerState            string         `sql:""`
+	ConnectionState       string         `sql:""`
+	CpuAffinity           []int32        `sql:""`
+	CpuHotAddEnabled      bool           `sql:""`
+	CpuHotRemoveEnabled   bool           `sql:""`
+	MemoryHotAddEnabled   bool           `sql:""`
+	FaultToleranceEnabled bool           `sql:""`
+	CpuCount              int32          `sql:""`
+	CoresPerSocket        int32          `sql:""`
+	MemoryMB              int32          `sql:""`
+	GuestName             string         `sql:""`
+	GuestID               string         `sql:""`
+	BalloonedMemory       int32          `sql:""`
+	IpAddress             string         `sql:""`
+	NumaNodeAffinity      []string       `sql:""`
+	StorageUsed           int64          `sql:""`
+	Snapshot              Ref            `sql:""`
+	IsTemplate            bool           `sql:""`
+	ChangeTrackingEnabled bool           `sql:""`
+	TpmEnabled            bool           `sql:""`
+	Devices               []Device       `sql:""`
+	NICs                  []NIC          `sql:""`
+	Disks                 []Disk         `sql:""`
+	Networks              []Ref          `sql:""`
+	Concerns              []Concern      `sql:""`
+	GuestNetworks         []GuestNetwork `sql:""`
 }
 
 // Determine if current revision has been validated.
@@ -289,4 +290,11 @@ type Device struct {
 type NIC struct {
 	Network Ref    `json:"network"`
 	MAC     string `json:"mac"`
+}
+
+// Guest network.
+type GuestNetwork struct {
+	MAC    string `json:"mac"`
+	IP     string `json:"ip"`
+	Origin string `json:"origin"`
 }

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -210,29 +210,30 @@ func (r *VM1) Content(detail int) interface{} {
 // VM full detail.
 type VM struct {
 	VM1
-	PolicyVersion         int            `json:"policyVersion"`
-	UUID                  string         `json:"uuid"`
-	Firmware              string         `json:"firmware"`
-	ConnectionState       string         `json:"connectionState"`
-	Snapshot              model.Ref      `json:"snapshot"`
-	ChangeTrackingEnabled bool           `json:"changeTrackingEnabled"`
-	CpuAffinity           []int32        `json:"cpuAffinity"`
-	CpuHotAddEnabled      bool           `json:"cpuHotAddEnabled"`
-	CpuHotRemoveEnabled   bool           `json:"cpuHotRemoveEnabled"`
-	MemoryHotAddEnabled   bool           `json:"memoryHotAddEnabled"`
-	FaultToleranceEnabled bool           `json:"faultToleranceEnabled"`
-	CpuCount              int32          `json:"cpuCount"`
-	CoresPerSocket        int32          `json:"coresPerSocket"`
-	MemoryMB              int32          `json:"memoryMB"`
-	GuestName             string         `json:"guestName"`
-	GuestID               string         `json:"guestId"`
-	BalloonedMemory       int32          `json:"balloonedMemory"`
-	IpAddress             string         `json:"ipAddress"`
-	StorageUsed           int64          `json:"storageUsed"`
-	TpmEnabled            bool           `json:"tpmEnabled"`
-	NumaNodeAffinity      []string       `json:"numaNodeAffinity"`
-	Devices               []model.Device `json:"devices"`
-	NICs                  []model.NIC    `json:"nics"`
+	PolicyVersion         int                  `json:"policyVersion"`
+	UUID                  string               `json:"uuid"`
+	Firmware              string               `json:"firmware"`
+	ConnectionState       string               `json:"connectionState"`
+	Snapshot              model.Ref            `json:"snapshot"`
+	ChangeTrackingEnabled bool                 `json:"changeTrackingEnabled"`
+	CpuAffinity           []int32              `json:"cpuAffinity"`
+	CpuHotAddEnabled      bool                 `json:"cpuHotAddEnabled"`
+	CpuHotRemoveEnabled   bool                 `json:"cpuHotRemoveEnabled"`
+	MemoryHotAddEnabled   bool                 `json:"memoryHotAddEnabled"`
+	FaultToleranceEnabled bool                 `json:"faultToleranceEnabled"`
+	CpuCount              int32                `json:"cpuCount"`
+	CoresPerSocket        int32                `json:"coresPerSocket"`
+	MemoryMB              int32                `json:"memoryMB"`
+	GuestName             string               `json:"guestName"`
+	GuestID               string               `json:"guestId"`
+	BalloonedMemory       int32                `json:"balloonedMemory"`
+	IpAddress             string               `json:"ipAddress"`
+	StorageUsed           int64                `json:"storageUsed"`
+	TpmEnabled            bool                 `json:"tpmEnabled"`
+	NumaNodeAffinity      []string             `json:"numaNodeAffinity"`
+	Devices               []model.Device       `json:"devices"`
+	NICs                  []model.NIC          `json:"nics"`
+	GuestNetworks         []model.GuestNetwork `json:"guestNetworks"`
 }
 
 // Build the resource using the model.
@@ -261,6 +262,7 @@ func (r *VM) With(m *model.VM) {
 	r.Devices = m.Devices
 	r.NumaNodeAffinity = m.NumaNodeAffinity
 	r.NICs = m.NICs
+	r.GuestNetworks = m.GuestNetworks
 }
 
 // Build self link (URI).

--- a/pkg/lib/condition/condition.go
+++ b/pkg/lib/condition/condition.go
@@ -31,6 +31,10 @@ const (
 	Required = "Required"
 	// An advisory condition.
 	Advisory = "Advisory"
+	// VDDK pending condition
+	ValidatingVDDK = "ValidatingVDDK"
+	// Missing IPs on vm pending condition
+	VMMissingGuestIPs = "VMMissingGuestIPs"
 )
 
 // Condition
@@ -311,6 +315,11 @@ func (r *Conditions) HasWarnCondition(category ...string) bool {
 // The collection contains a `Ready` blocker condition.
 func (r *Conditions) HasBlockerCondition() bool {
 	return r.HasConditionCategory(Critical, Error)
+}
+
+// The collection contains blocker conditions that keep the plan reconciling.
+func (r *Conditions) HasReQCondition() bool {
+	return r.HasCondition(ValidatingVDDK) || r.HasCondition(VMMissingGuestIPs)
 }
 
 // The collection contains the `Ready` condition.

--- a/virt-v2v/cold/cold_test.go
+++ b/virt-v2v/cold/cold_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,34 @@ func TestGenName(t *testing.T) {
 		got := genName(c.diskNum)
 		if got != c.expected {
 			t.Errorf("genName(%d) = %s; want %s", c.diskNum, got, c.expected)
+		}
+	}
+}
+
+func TestStaticIPs(t *testing.T) {
+	t.Setenv("V2V_source", vSphere)
+	t.Setenv("V2V_libvirtURL", "http://fake.com")
+	t.Setenv("V2V_secretKey", "fake")
+	t.Setenv("V2V_vmName", "test")
+
+	cases := []struct {
+		inputConfig string
+		outputArgs  []string
+	}{
+		{"", []string{""}},
+		{"00:50:56:83:25:47:ip:172.29.3.193", []string{"--mac 00:50:56:83:25:47:ip:172.29.3.193"}},
+		{"00:50:56:83:25:47:ip:172.29.3.193_00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097", []string{"--mac 00:50:56:83:25:47:ip:172.29.3.193", "--mac 00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097"}},
+	}
+
+	for _, c := range cases {
+		if c.inputConfig != "" {
+			t.Setenv("V2V_staticIPs", c.inputConfig)
+		}
+		command := strings.Join(buildCommand(), " ")
+		for _, outputArg := range c.outputArgs {
+			if !strings.Contains(command, outputArg) {
+				t.Errorf("The command is: %s. Excpected to contain '%s'", command, outputArg)
+			}
 		}
 	}
 }

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -93,6 +93,12 @@ func main() {
 		}
 		virtV2vArgs = append(virtV2vArgs, "-ip", "/etc/secret/secretKey")
 
+		if envStaticIPs := os.Getenv("V2V_staticIPs"); envStaticIPs != "" {
+			for _, macToIp := range strings.Split(envStaticIPs, "_") {
+				virtV2vArgs = append(virtV2vArgs, "--mac", macToIp)
+			}
+		}
+
 		if info, err := os.Stat(VDDK); err == nil && info.IsDir() {
 			virtV2vArgs = append(virtV2vArgs,
 				"-it", "vddk",

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -32,6 +32,51 @@ var UEFI_RE = regexp.MustCompile(`(?i)UEFI\s+bootloader?`)
 var firmware = "bios"
 
 func main() {
+	source := os.Getenv("V2V_source")
+	if source == vSphere {
+		if _, err := os.Stat("/etc/secret/cacert"); err == nil {
+			// use the specified certificate
+			err = os.Symlink("/etc/secret/cacert", "/opt/ca-bundle.crt")
+			if err != nil {
+				fmt.Println("Error creating ca cert link ", err)
+				os.Exit(1)
+			}
+		} else {
+			// otherwise, keep system pool certificates
+			err := os.Symlink("/etc/pki/tls/certs/ca-bundle.crt.bak", "/opt/ca-bundle.crt")
+			if err != nil {
+				fmt.Println("Error creating ca cert link ", err)
+				os.Exit(1)
+			}
+		}
+	}
+
+	if err := executeVirtV2v(source, buildCommand()); err != nil {
+		fmt.Println("Error executing virt-v2v command ", err)
+		os.Exit(1)
+	}
+
+	if source == OVA {
+		var err error
+		xmlFilePath, err = getXMLFile(DIR, "xml")
+		if err != nil {
+			fmt.Println("Error gettin XML file:", err)
+			os.Exit(1)
+		}
+
+		http.HandleFunc("/vm", vmHandler)
+		http.HandleFunc("/shutdown", shutdownHandler)
+		server = &http.Server{Addr: ":8080"}
+
+		fmt.Println("Starting server on :8080")
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
+			fmt.Printf("Error starting server: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func buildCommand() []string {
 	virtV2vArgs := []string{"virt-v2v", "-v", "-x"}
 	source := os.Getenv("V2V_source")
 
@@ -76,21 +121,6 @@ func main() {
 	}
 
 	if source == vSphere {
-		if _, err := os.Stat("/etc/secret/cacert"); err == nil {
-			// use the specified certificate
-			err = os.Symlink("/etc/secret/cacert", "/opt/ca-bundle.crt")
-			if err != nil {
-				fmt.Println("Error creating ca cert link ", err)
-				os.Exit(1)
-			}
-		} else {
-			// otherwise, keep system pool certificates
-			err := os.Symlink("/etc/pki/tls/certs/ca-bundle.crt.bak", "/opt/ca-bundle.crt")
-			if err != nil {
-				fmt.Println("Error creating ca cert link ", err)
-				os.Exit(1)
-			}
-		}
 		virtV2vArgs = append(virtV2vArgs, "-ip", "/etc/secret/secretKey")
 
 		if envStaticIPs := os.Getenv("V2V_staticIPs"); envStaticIPs != "" {
@@ -108,30 +138,7 @@ func main() {
 		}
 		virtV2vArgs = append(virtV2vArgs, "--", os.Getenv("V2V_vmName"))
 	}
-
-	if err := executeVirtV2v(source, virtV2vArgs); err != nil {
-		fmt.Println("Error executing virt-v2v command ", err)
-		os.Exit(1)
-	}
-
-	if source == OVA {
-		var err error
-		xmlFilePath, err = getXMLFile(DIR, "xml")
-		if err != nil {
-			fmt.Println("Error gettin XML file:", err)
-			os.Exit(1)
-		}
-
-		http.HandleFunc("/vm", vmHandler)
-		http.HandleFunc("/shutdown", shutdownHandler)
-		server = &http.Server{Addr: ":8080"}
-
-		fmt.Println("Starting server on :8080")
-		if err := server.ListenAndServe(); err != http.ErrServerClosed {
-			fmt.Printf("Error starting server: %v\n", err)
-			os.Exit(1)
-		}
-	}
+	return virtV2vArgs
 }
 
 func checkEnvVariablesSet(envVars ...string) bool {


### PR DESCRIPTION
This patch will get the static IPs configurations from the vSphere provider to each guest and will propagate it to virt-v2v to set it up while converting the VM.

Backport https://github.com/kubev2v/forklift/pull/852