### PR TITLE
Always take fingerprint from ESXi provider

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -265,7 +265,13 @@ func (r *Builder) getSourceDetails(vm *model.VM, sourceSecret *core.Secret) (lib
 			Path:     "",
 			RawQuery: sslVerify,
 		}
-		fingerprint = host.Thumbprint
+		if r.Source.Provider.Spec.Settings[api.SDK] == api.ESXI {
+			// the SDK of ESXi doesn't return a fingerprint/thumbprint for the host
+			// so we take it from the provider instead
+			fingerprint = r.Source.Provider.Status.Fingerprint
+		} else {
+			fingerprint = host.Thumbprint
+		}
 	} else if r.Source.Provider.Spec.Settings[api.SDK] == api.ESXI {
 		libvirtURL = liburl.URL{
 			Scheme:   "esx",


### PR DESCRIPTION
When migrating from an ESXi provider, always take the fingerprint from the status of the provider, even when there is a transfer network configured for the host since the SDK of ESXi doesn't return the fingerprint of the host as vCenter does.

backport of #919 