### PR TITLE
Fixes for vSphere providers

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/BUILD.bazel
+++ b/pkg/controller/plan/adapter/vsphere/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/lib/condition",
         "//pkg/lib/error",
         "//pkg/lib/itinerary",
+        "//pkg/lib/ref",
         "//pkg/settings",
         "//vendor/github.com/vmware/govmomi",
         "//vendor/github.com/vmware/govmomi/find",

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -24,6 +24,7 @@ import (
 	libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libitr "github.com/konveyor/forklift-controller/pkg/lib/itinerary"
+	libref "github.com/konveyor/forklift-controller/pkg/lib/ref"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
@@ -792,6 +793,10 @@ func (r *Builder) loadHosts() (err error) {
 	for i := range list.Items {
 		host := &list.Items[i]
 		ref := host.Spec.Ref
+		if !libref.Equals(&host.Spec.Provider, &r.Plan.Spec.Provider.Source) {
+			continue
+		}
+
 		if !host.Status.HasCondition(libcnd.Ready) {
 			continue
 		}

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -127,6 +127,11 @@ func (r *Scheduler) buildInFlight() (err error) {
 			continue
 		}
 
+		// skip archived plans
+		if p.Spec.Archived {
+			continue
+		}
+
 		// skip plans that aren't being executed
 		snapshot := p.Status.Migration.ActiveSnapshot()
 		if !snapshot.HasCondition("Executing") {

--- a/pkg/lib/ref/ref.go
+++ b/pkg/lib/ref/ref.go
@@ -33,10 +33,19 @@ func RefSet(ref *v1.ObjectReference) bool {
 
 // Equals comparison.
 // May be used with `nil` pointers.
-func Equals(refA, refB *v1.ObjectReference) bool {
+func DeepEquals(refA, refB *v1.ObjectReference) bool {
 	if refA == nil || refB == nil {
 		return false
 	}
 
 	return reflect.DeepEqual(refA, refB)
+}
+
+// Determind if both refs have the same name and namespace
+func Equals(refA, refB *v1.ObjectReference) bool {
+	if refA == nil || refB == nil {
+		return refA == refB
+	}
+
+	return refA.Name == refB.Name && refA.Namespace == refB.Namespace
 }


### PR DESCRIPTION
1. load hosts per source provider
    
When looking for the configuration of an ESXi host that a certain VM resides on, we query all the hosts in the namespace and then looking for the host by its MOR (Managed Object Reference). This almost always works but it could be wrong when there are several providers within the same namespace that refer to the same host. This is more likely to happen during tests where we define two providers with different propreties for the same vSphere environment. Therefore, adding another check that ensures the host refers to the provider which is the source provider on the plan of the migrated VM, otherwise skip that host.


2. skip archived plans when counting inflight vms
    
It could be that we have VMs for which the migration is marked as started and not marked as completed in archived plans. From now on, we will not take such VMs into account when counting the inflight VMs.