### PR TITLE
vsphere: perform CBT operations on hosts when needed

### DIFF
--- a/pkg/controller/plan/BUILD.bazel
+++ b/pkg/controller/plan/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/controller/plan/handler",
         "//pkg/controller/plan/scheduler",
         "//pkg/controller/provider/web",
+        "//pkg/controller/provider/web/vsphere",
         "//pkg/controller/validation",
         "//pkg/lib/client/openshift",
         "//pkg/lib/condition",

--- a/pkg/controller/plan/adapter/base/BUILD.bazel
+++ b/pkg/controller/plan/adapter/base/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1/plan",
         "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/controller/plan/context",
+        "//pkg/controller/plan/util",
         "//pkg/lib/error",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/kubevirt.io/api/core/v1:core",

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -5,6 +5,7 @@ import (
 	planapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/plan/util"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	core "k8s.io/api/core/v1"
 	cnv "kubevirt.io/api/core/v1"
@@ -103,13 +104,13 @@ type Client interface {
 	// Return whether the source VM is powered off.
 	PoweredOff(vmRef ref.Ref) (bool, error)
 	// Create a snapshot of the source VM.
-	CreateSnapshot(vmRef ref.Ref) (string, error)
+	CreateSnapshot(vmRef ref.Ref, hostsFunc util.HostsFunc) (string, error)
 	// Remove all warm migration snapshots.
-	RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy) error
+	RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy, hostsFunc util.HostsFunc) error
 	// Check if a snapshot is ready to transfer.
 	CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, err error)
 	// Set DataVolume checkpoints.
-	SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool) (err error)
+	SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool, hostsFunc util.HostsFunc) (err error)
 	// Close connections to the provider API.
 	Close()
 	// Finalize migrations

--- a/pkg/controller/plan/adapter/ocp/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ocp/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/controller/plan/adapter/base",
         "//pkg/controller/plan/context",
+        "//pkg/controller/plan/util",
         "//pkg/controller/provider/web",
         "//pkg/lib/client/openshift",
         "//pkg/lib/error",

--- a/pkg/controller/plan/adapter/ocp/client.go
+++ b/pkg/controller/plan/adapter/ocp/client.go
@@ -7,6 +7,7 @@ import (
 	planapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/plan/util"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	core "k8s.io/api/core/v1"
@@ -34,7 +35,7 @@ func (r *Client) Close() {
 }
 
 // CreateSnapshot implements base.Client
-func (r *Client) CreateSnapshot(vmRef ref.Ref) (string, error) {
+func (r *Client) CreateSnapshot(vmRef ref.Ref, hostsFunc util.HostsFunc) (string, error) {
 	return "", nil
 }
 
@@ -123,12 +124,12 @@ func (r *Client) PoweredOff(vmRef ref.Ref) (bool, error) {
 }
 
 // RemoveSnapshots implements base.Client
-func (r *Client) RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy) error {
+func (r *Client) RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy, hostsFunc util.HostsFunc) error {
 	return nil
 }
 
 // SetCheckpoints implements base.Client
-func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool) (err error) {
+func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool, hostsFunc util.HostsFunc) (err error) {
 	return nil
 }
 

--- a/pkg/controller/plan/adapter/openstack/client.go
+++ b/pkg/controller/plan/adapter/openstack/client.go
@@ -8,6 +8,7 @@ import (
 	planapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/plan/util"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/openstack"
 	libclient "github.com/konveyor/forklift-controller/pkg/lib/client/openstack"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
@@ -109,12 +110,12 @@ func (r *Client) PoweredOff(vmRef ref.Ref) (off bool, err error) {
 }
 
 // Create a snapshot of the source VM.
-func (r *Client) CreateSnapshot(vmRef ref.Ref) (imageID string, err error) {
+func (r *Client) CreateSnapshot(vmRef ref.Ref, hostsFunc util.HostsFunc) (imageID string, err error) {
 	return
 }
 
 // Remove all warm migration snapshots.
-func (r *Client) RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy) (err error) {
+func (r *Client) RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy, hostsFunc util.HostsFunc) (err error) {
 	return
 }
 
@@ -124,7 +125,7 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, imageID string) (ready bool, 
 }
 
 // Set DataVolume checkpoints.
-func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool) error {
+func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool, hostsFunc util.HostsFunc) error {
 	return nil
 }
 

--- a/pkg/controller/plan/adapter/ova/BUILD.bazel
+++ b/pkg/controller/plan/adapter/ova/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/controller/plan/adapter/base",
         "//pkg/controller/plan/context",
+        "//pkg/controller/plan/util",
         "//pkg/controller/provider/model/ova",
         "//pkg/controller/provider/web",
         "//pkg/controller/provider/web/base",

--- a/pkg/controller/plan/adapter/ova/client.go
+++ b/pkg/controller/plan/adapter/ova/client.go
@@ -9,6 +9,7 @@ import (
 	planapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/plan/util"
 	libweb "github.com/konveyor/forklift-controller/pkg/lib/inventory/web"
 	core "k8s.io/api/core/v1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -45,12 +46,12 @@ func (r *Client) connect() (err error) {
 }
 
 // Create a VM snapshot and return its ID.
-func (r *Client) CreateSnapshot(vmRef ref.Ref) (snapshot string, err error) {
+func (r *Client) CreateSnapshot(vmRef ref.Ref, hostsFunc util.HostsFunc) (snapshot string, err error) {
 	return
 }
 
 // Remove all warm migration snapshots.
-func (r *Client) RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy) (err error) {
+func (r *Client) RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy, hostsFunc util.HostsFunc) (err error) {
 	return
 }
 
@@ -60,7 +61,7 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool,
 }
 
 // Set DataVolume checkpoints.
-func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool) (err error) {
+func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool, hostsFunc util.HostsFunc) (err error) {
 	return
 }
 

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -11,6 +11,7 @@ import (
 	planapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	"github.com/konveyor/forklift-controller/pkg/controller/plan/util"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/ovirt"
@@ -39,7 +40,7 @@ type Client struct {
 }
 
 // Create a VM snapshot and return its ID.
-func (r *Client) CreateSnapshot(vmRef ref.Ref) (snapshot string, err error) {
+func (r *Client) CreateSnapshot(vmRef ref.Ref, hostsFunc util.HostsFunc) (snapshot string, err error) {
 	_, vmService, err := r.getVM(vmRef)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -74,7 +75,7 @@ func (r *Client) CreateSnapshot(vmRef ref.Ref) (snapshot string, err error) {
 }
 
 // Remove all warm migration snapshots.
-func (r *Client) RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy) (err error) {
+func (r *Client) RemoveSnapshots(vmRef ref.Ref, precopies []planapi.Precopy, hostsFunc util.HostsFunc) (err error) {
 	// Snapshot removal is done in Finalize to avoid race conditions
 	return
 }
@@ -110,7 +111,7 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool,
 }
 
 // Set DataVolume checkpoints.
-func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool) (err error) {
+func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool, hostsFunc util.HostsFunc) (err error) {
 	n := len(precopies)
 	previous := ""
 	current := precopies[n-1].Snapshot

--- a/pkg/controller/plan/adapter/vsphere/BUILD.bazel
+++ b/pkg/controller/plan/adapter/vsphere/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/controller/plan/adapter/base",
         "//pkg/controller/plan/context",
+        "//pkg/controller/plan/util",
         "//pkg/controller/provider/container/vsphere",
         "//pkg/controller/provider/model/vsphere",
         "//pkg/controller/provider/web",

--- a/pkg/controller/plan/adapter/vsphere/BUILD.bazel
+++ b/pkg/controller/plan/adapter/vsphere/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//vendor/github.com/vmware/govmomi/vim25/types",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/api/resource",
+        "//vendor/k8s.io/utils/ptr",
         "//vendor/kubevirt.io/api/core/v1:core",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/utils/ptr"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
@@ -275,8 +276,7 @@ func (r *Client) getVM(vmRef ref.Ref) (vsphereVm *object.VirtualMachine, err err
 	}
 
 	searchIndex := object.NewSearchIndex(r.client.Client)
-	instanceUUID := false
-	vsphereRef, err := searchIndex.FindByUuid(context.TODO(), nil, vm.UUID, true, &instanceUUID)
+	vsphereRef, err := searchIndex.FindByUuid(context.TODO(), nil, vm.UUID, true, ptr.To(false))
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -318,9 +318,7 @@ func (r *Client) connect() error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	url.User = liburl.UserPassword(
-		r.user(),
-		r.password())
+	url.User = liburl.UserPassword(r.user(), r.password())
 	soapClient := soap.NewClient(url, r.getInsecureSkipVerifyFlag())
 	soapClient.SetThumbprint(url.Host, r.thumbprint())
 	vimClient, err := vim25.NewClient(context.TODO(), soapClient)

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -19,9 +19,11 @@ import (
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 	"github.com/konveyor/forklift-controller/pkg/controller/plan/scheduler"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
 	libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libitr "github.com/konveyor/forklift-controller/pkg/lib/itinerary"
+	libref "github.com/konveyor/forklift-controller/pkg/lib/ref"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	batchv1 "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
@@ -490,7 +492,7 @@ func (r *Migration) removeWarmSnapshots(vm *plan.VMStatus) {
 	if vm.Warm == nil {
 		return
 	}
-	if err := r.provider.RemoveSnapshots(vm.Ref, vm.Warm.Precopies); err != nil {
+	if err := r.provider.RemoveSnapshots(vm.Ref, vm.Warm.Precopies, r.loadHosts); err != nil {
 		r.Log.Error(
 			err,
 			"Failed to clean up warm migration snapshots.",
@@ -789,7 +791,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				}
 			}
 			if vm.Warm != nil {
-				err = r.provider.SetCheckpoints(vm.Ref, vm.Warm.Precopies, dataVolumes, false)
+				err = r.provider.SetCheckpoints(vm.Ref, vm.Warm.Precopies, dataVolumes, false, r.loadHosts)
 				if err != nil {
 					step.AddError(err.Error())
 					err = nil
@@ -961,8 +963,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			break
 		}
 		var snapshot string
-		snapshot, err = r.provider.CreateSnapshot(vm.Ref)
-		if err != nil {
+		if snapshot, err = r.provider.CreateSnapshot(vm.Ref, r.loadHosts); err != nil {
 			if errors.As(err, &web.ProviderNotReadyError{}) || errors.As(err, &web.ConflictError{}) {
 				return
 			}
@@ -1078,7 +1079,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			return
 		}
 		if step.MarkedCompleted() {
-			err = r.provider.RemoveSnapshots(vm.Ref, vm.Warm.Precopies)
+			err = r.provider.RemoveSnapshots(vm.Ref, vm.Warm.Precopies, r.loadHosts)
 			if err != nil {
 				r.Log.Info(
 					"Failed to clean up warm migration snapshots.",
@@ -1196,6 +1197,53 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				Durable:  true,
 			})
 	}
+
+	return
+}
+
+// Load host CRs.
+func (r *Migration) loadHosts() (hosts map[string]*v1beta1.Host, err error) {
+	list := &v1beta1.HostList{}
+	err = r.List(
+		context.TODO(),
+		list,
+		&client.ListOptions{
+			Namespace: r.Source.Provider.Namespace,
+		},
+	)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	hostMap := map[string]*v1beta1.Host{}
+	for i := range list.Items {
+		host := &list.Items[i]
+		ref := host.Spec.Ref
+		if !libref.Equals(&host.Spec.Provider, &r.Plan.Spec.Provider.Source) {
+			continue
+		}
+
+		if !host.Status.HasCondition(libcnd.Ready) {
+			continue
+		}
+		// it's not that great to have a vSphere-specific entity here but as we don't
+		// intend to do the same for other providers, doing it here for simplicity
+		m := &model.Host{}
+		pErr := r.Source.Inventory.Find(m, ref)
+		if pErr != nil {
+			if errors.As(pErr, &web.NotFoundError{}) {
+				continue
+			} else {
+				err = pErr
+				return
+			}
+		}
+		ref.ID = m.ID
+		ref.Name = m.Name
+		hostMap[ref.ID] = host
+	}
+
+	hosts = hostMap
 
 	return
 }
@@ -1715,7 +1763,7 @@ func (r *Migration) setDataVolumeCheckpoints(vm *plan.VMStatus) (err error) {
 	for _, disk := range disks {
 		dvs = append(dvs, *disk.DataVolume)
 	}
-	err = r.provider.SetCheckpoints(vm.Ref, vm.Warm.Precopies, dvs, vm.Phase == AddFinalCheckpoint)
+	err = r.provider.SetCheckpoints(vm.Ref, vm.Warm.Precopies, dvs, vm.Phase == AddFinalCheckpoint, r.loadHosts)
 	if err != nil {
 		return
 	}

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -3,6 +3,7 @@ package util
 import (
 	"math"
 
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	core "k8s.io/api/core/v1"
 )
@@ -31,3 +32,5 @@ func CalculateSpaceWithOverhead(requestedSpace int64, volumeMode *core.Persisten
 	}
 	return spaceWithOverhead
 }
+
+type HostsFunc func() (map[string]*api.Host, error)


### PR DESCRIPTION
Previously, when running warm migrations from a vSphere provider with vCenter as its SDK endpoint, we ran create snapshot, set-checkpoints and remove-snapshots on vCenter, even when there was a network defined for an ESXi host. That cause CDI to fail: the identifier of a snapshot that was recievd from vCenter was different than the identifier of the same snapshot in ESXi and therefore CDI, that interacts with ESXi hosts in this scenario, failed to find the snapshot.

Now, when running CBT operations we check whether the disk(s) will be transferred from vCenter or ESXi, and perform the aforementioned CBT operations on the corresponding component.