### PR TITLE
configmap for user-provided v2v configuration files

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -111,6 +111,7 @@ virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') or lookup( 'env', 'REL
 virt_v2v_warm_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_WARM_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V_WARM') }}"
 virt_v2v_dont_request_kvm: "{{ lookup( 'env', 'VIRT_V2V_DONT_REQUEST_KVM') }}"
 virt_v2v_extra_args: "{{ lookup( 'env', 'VIRT_V2V_EXTRA_ARGS') }}"
+virt_v2v_extra_conf_config_map: "{{ lookup( 'env', 'VIRT_V2V_EXTRA_CONF_CONFIG_MAP') }}"
 
 ova_provider_server_fqin: "{{ lookup( 'env', 'OVA_PROVIDER_SERVER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_OVA_PROVIDER_SERVER') }}"
 

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -125,6 +125,8 @@ spec:
 {% endif %}
         - name: VIRT_V2V_EXTRA_ARGS
           value: "{{ virt_v2v_extra_args }}"
+        - name: VIRT_V2V_EXTRA_CONF_CONFIG_MAP
+          value: "{{ virt_v2v_extra_conf_config_map }}"
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -98,6 +98,8 @@ const (
 	OvaPVLabel  = "nfs-pv"
 )
 
+const ExtraV2vConf = "extra-v2v-conf"
+
 // Map of VirtualMachines keyed by vmID.
 type VirtualMachineMap map[string]VirtualMachine
 
@@ -224,7 +226,7 @@ func (r *KubeVirt) EnsureExtraV2vConfConfigMap() error {
 }
 
 func genExtraV2vConfConfigMapName(plan *api.Plan) string {
-	return fmt.Sprintf("%s-extra-v2v-conf", plan.Name)
+	return fmt.Sprintf("%s-%s", plan.Name, ExtraV2vConf)
 }
 
 // Get the importer pod for a PersistentVolumeClaim.
@@ -1834,7 +1836,7 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.Confi
 	extraConfigMapExists := len(Settings.Migration.VirtV2vExtraConfConfigMap) > 0
 	if extraConfigMapExists {
 		volumes = append(volumes, core.Volume{
-			Name: "extra-v2v-conf",
+			Name: ExtraV2vConf,
 			VolumeSource: core.VolumeSource{
 				ConfigMap: &core.ConfigMapVolumeSource{
 					LocalObjectReference: core.LocalObjectReference{
@@ -1896,8 +1898,8 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.Confi
 		if extraConfigMapExists {
 			mounts = append(mounts,
 				core.VolumeMount{
-					Name:      "extra-v2v-conf",
-					MountPath: "/mnt/extra-v2v-conf",
+					Name:      ExtraV2vConf,
+					MountPath: fmt.Sprintf("/mnt/%s", ExtraV2vConf),
 				},
 			)
 		}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -269,6 +269,11 @@ func (r *Migration) begin() (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	err = r.kubevirt.EnsureExtraV2vConfConfigMap()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
 	//
 	// Delete
 	kept := []*plan.VMStatus{}

--- a/pkg/controller/plan/util.go
+++ b/pkg/controller/plan/util.go
@@ -23,3 +23,16 @@ func ensureNamespace(plan *api.Plan, client client.Client) error {
 	}
 	return err
 }
+
+// Ensure the config map exists on the destination
+func ensureConfigMap(cm *core.ConfigMap, name func(plan *api.Plan) string, plan *api.Plan, client client.Client) error {
+	cm.ObjectMeta = meta.ObjectMeta{
+		Name:      name(plan),
+		Namespace: plan.Spec.TargetNamespace,
+	}
+	err := client.Create(context.TODO(), cm)
+	if err != nil && k8serr.IsAlreadyExists(err) {
+		err = nil
+	}
+	return err
+}

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -12,22 +12,23 @@ import (
 
 // Environment variables.
 const (
-	MaxVmInFlight           = "MAX_VM_INFLIGHT"
-	HookRetry               = "HOOK_RETRY"
-	ImporterRetry           = "IMPORTER_RETRY"
-	VirtV2vImage            = "VIRT_V2V_IMAGE"
-	PrecopyInterval         = "PRECOPY_INTERVAL"
-	VirtV2vDontRequestKVM   = "VIRT_V2V_DONT_REQUEST_KVM"
-	SnapshotRemovalTimeout  = "SNAPSHOT_REMOVAL_TIMEOUT"
-	SnapshotStatusCheckRate = "SNAPSHOT_STATUS_CHECK_RATE"
-	CDIExportTokenTTL       = "CDI_EXPORT_TOKEN_TTL"
-	FileSystemOverhead      = "FILESYSTEM_OVERHEAD"
-	BlockOverhead           = "BLOCK_OVERHEAD"
-	CleanupRetries          = "CLEANUP_RETRIES"
-	OvirtOsConfigMap        = "OVIRT_OS_MAP"
-	VsphereOsConfigMap      = "VSPHERE_OS_MAP"
-	VddkJobActiveDeadline   = "VDDK_JOB_ACTIVE_DEADLINE"
-	VirtV2vExtraArgs        = "VIRT_V2V_EXTRA_ARGS"
+	MaxVmInFlight             = "MAX_VM_INFLIGHT"
+	HookRetry                 = "HOOK_RETRY"
+	ImporterRetry             = "IMPORTER_RETRY"
+	VirtV2vImage              = "VIRT_V2V_IMAGE"
+	PrecopyInterval           = "PRECOPY_INTERVAL"
+	VirtV2vDontRequestKVM     = "VIRT_V2V_DONT_REQUEST_KVM"
+	SnapshotRemovalTimeout    = "SNAPSHOT_REMOVAL_TIMEOUT"
+	SnapshotStatusCheckRate   = "SNAPSHOT_STATUS_CHECK_RATE"
+	CDIExportTokenTTL         = "CDI_EXPORT_TOKEN_TTL"
+	FileSystemOverhead        = "FILESYSTEM_OVERHEAD"
+	BlockOverhead             = "BLOCK_OVERHEAD"
+	CleanupRetries            = "CLEANUP_RETRIES"
+	OvirtOsConfigMap          = "OVIRT_OS_MAP"
+	VsphereOsConfigMap        = "VSPHERE_OS_MAP"
+	VddkJobActiveDeadline     = "VDDK_JOB_ACTIVE_DEADLINE"
+	VirtV2vExtraArgs          = "VIRT_V2V_EXTRA_ARGS"
+	VirtV2vExtraConfConfigMap = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
 )
 
 // Migration settings
@@ -65,6 +66,8 @@ type Migration struct {
 	VddkJobActiveDeadline int
 	// Additional arguments for virt-v2v
 	VirtV2vExtraArgs string
+	// Additional configuration for virt-v2v
+	VirtV2vExtraConfConfigMap string
 }
 
 // Load settings.
@@ -138,6 +141,8 @@ func (r *Migration) Load() (err error) {
 			return liberr.Wrap(err)
 		}
 	}
-
+	if val, found := os.LookupEnv(VirtV2vExtraConfConfigMap); found {
+		r.VirtV2vExtraConfConfigMap = val
+	}
 	return
 }


### PR DESCRIPTION
Add an optional configuration for a config map in which users can specify configuration files, that should be accessible from within the conversion pod, for virt-v2v.