### PR TITLE
Switch CentOS stream8 repos

### DIFF
--- a/virt-v2v/warm/BUILD.bazel
+++ b/virt-v2v/warm/BUILD.bazel
@@ -28,6 +28,7 @@ container_run_and_extract(
     name = "appliance",
     commands = [
         "set -x",
+        "sed -i 's|^#baseurl=http://mirror.centos.org/\\(.*\\)$|baseurl=http://vault.centos.org/\001|' /etc/yum.repos.d/*",
         "dnf -y update",
         "dnf -y install libguestfs-devel libguestfs-appliance libguestfs-xfs libguestfs-winsupport supermin",
         "depmod \\$(ls /lib/modules/ |tail -n1)",


### PR DESCRIPTION
Since we still use it and the mirrorlist isn't pointing to the `vault` repos. A command added to switch the repos. Now they will point `vault`, letting us use `dnf` commands later on.