### PR TITLE
Build operator with rules_docker instead of containerfile

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,3 +33,5 @@ build --strategy_regexp="RunAndCommitLayer ca-certificate-from-secret-layer.tar"
 
 # For populator images, we need to use processwrapper sandbox as well
 build --strategy_regexp="RunAndCommitLayer cmd/ovirt-populator/ovirt-imageio-layer-run-layer.tar"=processwrapper-sandbox
+
+build --strategy_regexp="RunAndCommitLayer operator/forklift-operator-image-layer-run-layer.tar"=processwrapper-sandbox

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,12 +30,6 @@ load(
     "@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
     docker_toolchain_configure = "toolchain_configure",
 )
-load("@io_bazel_rules_docker//contrib:dockerfile_build.bzl", "dockerfile_image")
-
-dockerfile_image(
-    name = "forklift-operator-image-containerfile",
-    dockerfile = "//operator:Containerfile",
-)
 
 docker_toolchain_configure(
     name = "docker_config",
@@ -3343,6 +3337,13 @@ container_pull(
     registry = "registry.access.redhat.com",
     repository = "ubi9/ubi-minimal",
     tag = "latest",
+)
+
+container_pull(
+    name = "ansible-operator",
+    registry = "quay.io",
+    repository = "operator-framework/ansible-operator",
+    tag = "main",
 )
 
 container_pull(

--- a/operator/BUILD.bazel
+++ b/operator/BUILD.bazel
@@ -2,6 +2,7 @@ load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
 )
+load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit_layer")
 
 genrule(
     name = "kustomize_bin",
@@ -14,8 +15,33 @@ genrule(
 # 1. Build the oprator image with ansible dependencies and with roles.
 
 container_image(
+    name = "forklift-operator-base-image",
+    base = "@ansible-operator//image",
+    directory = "/opt/ansible",
+    files = [
+        "requirements.yml",
+        "roles",
+        "watches.yaml",
+    ],
+)
+
+container_run_and_commit_layer(
+    name = "forklift-operator-image-layer-run",
+    commands = [
+        "ansible-galaxy collection install -r /opt/ansible/requirements.yml && chmod -R ug+rwx /opt/ansible/.ansible",
+    ],
+    docker_run_flags = ["--entrypoint=''"],
+    image = ":forklift-operator-base-image.tar",
+)
+
+container_image(
     name = "forklift-operator-image",
-    base = "@forklift-operator-image-containerfile//image:dockerfile_image.tar",
+    base = ":forklift-operator-base-image",
+    directory = "/opt/ansible",
+    layers = [
+        ":forklift-operator-image-layer-run",
+    ],
+    user = "1001",
     visibility = ["//visibility:public"],
 )
 

--- a/operator/Containerfile
+++ b/operator/Containerfile
@@ -1,8 +1,0 @@
-FROM quay.io/operator-framework/ansible-operator:main
-
-COPY requirements.yml ${HOME}/requirements.yml
-COPY watches.yaml ${HOME}/watches.yaml
-COPY roles ${HOME}/roles
-
-RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
- && chmod -R ug+rwx ${HOME}/.ansible


### PR DESCRIPTION
We cannot push the operator image with recent images of Ubuntu in GitHub actions because recent versions of Docker create the image differently and as a result, they cannot be pushed to quay.io. Thus, replacing the way we build the operator image to match how other images are built and this way, we are able to push the image to quay.io.