### PR TITLE
Replace dots with dashes when renaming VMs

### DIFF
--- a/pkg/controller/plan/vm_name_handler.go
+++ b/pkg/controller/plan/vm_name_handler.go
@@ -33,7 +33,7 @@ func (r *KubeVirt) changeVmNameDNS1123(vmName string, vmNamespace string) (gener
 
 // changes VM name to match DNS1123 RFC convention.
 func changeVmName(currName string) string {
-	var underscoreExcluded = regexp.MustCompile("[_]")
+	var underscoreExcluded = regexp.MustCompile("[_.]")
 	var nameExcludeChars = regexp.MustCompile("[^a-z0-9-]")
 
 	newName := strings.ToLower(currName)

--- a/pkg/controller/plan/vm_name_handler_test.go
+++ b/pkg/controller/plan/vm_name_handler_test.go
@@ -10,8 +10,8 @@ func TestVmNameHandler(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	//Test all cases in name adjustments
-	originalVmName := "----------------Vm!@#$%^&*()_+-Name/.,';[]-CorREct-<>123----------------------"
-	newVmName := "vm--name-correct-123"
+	originalVmName := "----------------Vm!@#$%^&*()_+-Name/.is,';[]-CorREct-<>123----------------------"
+	newVmName := "vm--name-is-correct-123"
 	g.Expect(changeVmName(originalVmName)).To(gomega.Equal(newVmName))
 
 	//Test the case that the VM name is empty after all removals


### PR DESCRIPTION
backport of #961 