### PR TITLE
Fix migration of OVA to WFFC storage classes

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1511,7 +1511,9 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 			if !found {
 				continue
 			}
-			if dv.Status.Phase == cdi.PendingPopulation && r.Source.Provider.Type() == v1beta1.VSphere {
+			if dv.Status.Phase == cdi.PendingPopulation && r.Source.Provider.RequiresConversion() {
+				// in migrations that involve conversion, the conversion pod serves as the
+				// first consumer of the PVCs so we can treat PendingPopulation as Succeeded
 				dv.Status.Phase = cdi.Succeeded
 			}
 			conditions := dv.Conditions()


### PR DESCRIPTION
In a2170ea we've added the following logic: when using storage classes that are set with WaitForFirstConsumer in migrations from vSphere, we treat the PendingPopulation status as Succeeded since the conversion pod would be the first consumer of the PVCs. This PR applies the same logic also to migrations from OVA providers.