### PR TITLE
ovirt: preserve disk's serial

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -487,6 +487,7 @@ func (r *Builder) mapDisks(vm *model.Workload, persistentVolumeClaims []*core.Pe
 						Bus: cnv.DiskBus(bus),
 					},
 				},
+				Serial: da.Disk.ID,
 			}
 		}
 		volume := cnv.Volume{


### PR DESCRIPTION
In oVirt, the 'serial' of disks is set to their disk ID. We have noticed that it could be useful for users to preserve the serial that is set in oVirt in order to maintain correlations between disks and their configuration within the guest operating system so we now provide the 'serial' as an input to KubeVirt to achieve this.

[1] https://github.com/oVirt/ovirt-engine/blame/ovirt-engine-4.5.3.z/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java#L2215