### PR TITLE
Bump consoleplugin cr to console.openshift.io/v1

### DIFF
--- a/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
@@ -1,29 +1,35 @@
 ---
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: {{ ui_plugin_console_name }}
   annotations:
     console.openshift.io/use-i18n: "true" 
 spec:
+  backend:
+    service:
+      name: {{ ui_plugin_service_name }}
+      port: 9443
+      basePath: '/'
+      namespace: {{ app_namespace }}
+    type: Service
   displayName: {{ ui_plugin_display_name }}
-  service:
-    name: {{ ui_plugin_service_name }}
-    port: 9443
-    basePath: '/'
-    namespace: {{ app_namespace }}
+  i18n:
+    loadType: Preload
   proxy:
-    - type: Service
-      alias: {{ inventory_service_name }}
-      authorize: true
-      service:
-        name: {{ inventory_service_name }}
-        namespace: {{ app_namespace }}
-        port: 8443
-    - type: Service
-      alias: {{ services_service_name }}
-      authorize: true
-      service:
-        name: {{ services_service_name }}
-        namespace: {{ app_namespace }}
-        port: 8443
+    - alias: {{ inventory_service_name }}
+      authorization: UserToken
+      type: Service
+      endpoint:
+        service:
+          name: {{ inventory_service_name }}
+          namespace: {{ app_namespace }}
+          port: 8443
+    - alias: {{ services_service_name }}
+      authorization: UserToken
+      endpoint:
+        type: Service
+        service:
+          name: {{ services_service_name }}
+          namespace: {{ app_namespace }}
+          port: 8443


### PR DESCRIPTION
Ref:
https://github.com/openshift/api/pull/1856
https://issues.redhat.com//browse/OCPBUGS-36213

Issue:
Openshift console operator will stop supporting `v1alpha1` version in 4.17.0

Fix:
This PR convert the consoleplugin `v1alpha1` CR to `v1` format

