### PR TITLE
[MTV-595] Add V2V_preserveStaticIPs env var for virt-v2v pod

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -200,6 +200,11 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		if err != nil {
 			return
 		}
+
+		env = append(env, core.EnvVar{
+			Name:  "V2V_preserveStaticIPs",
+			Value: "true",
+		})
 	}
 
 	libvirtURL, fingerprint, err := r.getSourceDetails(vm, sourceSecret)


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-595

**Issue**:
When migrating a simple RHEL8 VM from VMware 7 to OCPv 4.13 the name of the network interfaces changes and the static IP configuration for the VM no longer works

**Why we need this change**:
in MTV-595 we plan to introduce code that will support static IP defined using RHEL7 and above NetworkManager, we will need an indicator for user selecting preserveStaticIPs

**Why this is safe:**
We add a new env var, no other change needed


