### PR TITLE
[MTV-595] Send mac to ip mappings for linux

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/BUILD.bazel
+++ b/pkg/controller/plan/adapter/vsphere/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//pkg/controller/plan/context",
         "//pkg/controller/provider/model/vsphere",
         "//pkg/controller/provider/web",
+        "//pkg/controller/provider/web/base",
         "//pkg/controller/provider/web/vsphere",
         "//pkg/lib/logging",
         "//vendor/github.com/onsi/ginkgo/v2:ginkgo",

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -67,8 +67,8 @@ var _ = Describe("vSphere builder", func() {
 			},
 		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,16,8.8.8.8_00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097,,64,fec0:0:0:ffff::1,fec0:0:0:ffff::2,fec0:0:0:ffff::3"),
 		Entry("non-static ip", &model.VM{GuestID: "windows9Guest", GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: string(types.NetIpConfigInfoIpAddressOriginDhcp)}}}, ""),
-		Entry("non windows vm", &model.VM{GuestID: "other", GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, ""),
-		Entry("no OS vm", &model.VM{GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, ""),
+		Entry("non windows vm", &model.VM{GuestID: "other", GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, "00:50:56:83:25:47:ip:172.29.3.193,,0"),
+		Entry("no OS vm", &model.VM{GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, "00:50:56:83:25:47:ip:172.29.3.193,,0"),
 		Entry("multiple nics static ips", &model.VM{
 			GuestID: "windows9Guest",
 			GuestNetworks: []vsphere.GuestNetwork{
@@ -116,6 +116,20 @@ var _ = Describe("vSphere builder", func() {
 				},
 			},
 		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,16,8.8.8.8_00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097,,64,fec0:0:0:ffff::1,fec0:0:0:ffff::2,fec0:0:0:ffff::3_00:50:56:83:25:48:ip:172.29.3.192,,24,4.4.4.4_00:50:56:83:25:48:ip:fe80::5da:b7a5:e0a2:a090,,32,fec0:0:0:ffff::4,fec0:0:0:ffff::5,fec0:0:0:ffff::6"),
+		Entry("single static ip without DNS", &model.VM{
+			GuestID: "windows9Guest",
+			GuestNetworks: []vsphere.GuestNetwork{
+				{
+					MAC:          "00:50:56:83:25:47",
+					IP:           "172.29.3.193",
+					Origin:       ManualOrigin,
+					PrefixLength: 16,
+				}},
+			GuestIpStacks: []vsphere.GuestIpStack{
+				{
+					Gateway: "172.29.3.1",
+				}},
+		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,16"),
 	)
 })
 

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -139,9 +139,6 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 		err = liberr.Wrap(err, "vm", vmRef)
 		return
 	}
-	if !isWindows(&vm.VM) {
-		return true, nil
-	}
 
 	for _, nic := range vm.NICs {
 		found := false

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,6 +36,9 @@ func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 		}
 		if ref.Name == "not_windows_guest" {
 			res.VM.GuestID = "rhel8_64Guest"
+		}
+		if ref.Name == "missing_from_invetory" {
+			return base.NotFoundError{}
 		}
 	}
 	return nil
@@ -88,7 +92,6 @@ var _ = Describe("vsphere validation tests", func() {
 				}
 				ok, err := validator.StaticIPs(ref.Ref{Name: vmName})
 				if shouldError {
-					Expect(err).NotTo(HaveOccurred())
 					Expect(ok).To(BeFalse())
 				} else {
 					Expect(err).NotTo(HaveOccurred())
@@ -101,7 +104,9 @@ var _ = Describe("vsphere validation tests", func() {
 			Entry("when the vm doesn't have static ips, and the plan set without static ip", "test", false, false),
 			Entry("when the vm have static ips, and the plan set with static ip", "full_guest_network", true, false),
 			Entry("when the vm have static ips, and the plan set without static ip", "test", false, false),
-			Entry("when the vm doesn't have static ips, and the plan set without static ip, vm is non-windows", "not_windows_guest", true, false),
+			Entry("when the vm doesn't have static ips, and the plan set without static ip, vm is non-windows", "not_windows_guest", false, false),
+			Entry("when the vm doesn't have static ips, and the plan set with static ip, vm is non-windows", "not_windows_guest", true, true),
+			Entry("when the vm doesn't exist", "missing_from_invetory", true, true),
 		)
 	})
 })


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-595

**Issue:**
When migrating a simple RHEL8 VM from VMware 7 to OCPv 4.13 the name of the network interfaces changes and the static IP configuration for the VM no longer works

**What this PR do:**
This PR check if the OS is not Windows, in this case it collects the mac to static IP map, and send it to the `virt-v2v` pod.

Notes:
  - On linux we don't check for `origin=manual` because this information is missing on linux. 
  - We only send this information when user choose to force static IPs
  - The user must run the VM while MTV inventory server is running to create the mapping, IP information is added to the inventory MTV is collecting only when the VM is running, once the IP data is collected, user can power down the VM and MTV will persist this information.
  - If user choose to force static IP and mapping is missing, validation will fail.

**Why this change is safe:**
Our virt-v2v pod check if we have `V2V_staticIPs` and adds it to the `virt-v2v` CLI tool as `--mac` argument, on non Windows OS, `virt-v2v` tool ignore this CLI argument, see: https://libguestfs.org/virt-v2v.1.html

_... It is currently ignored for Linux guests since they do not have this problem. ..._ 

**Run example:**

```
Preparing virt-v2v
exec: /usr/bin/virt-v2v -v -x --root first -i libvirt -ic vpx://administrator%40vsphere.local@rhev-node-05.rdu2.scalelab.redhat.com/Datacenter/host/auto-test/MTV/f01-h06-000-r640.rdu2.scalelab.redhat.com?no_verify=1 -o local -os /var/tmp/v2v -ip /etc/secret/secretKey --mac 00:50:56:83:f9:7f:ip:172.29.97.122,,32 -it vddk -io vddk-libdir=/opt/vmware-vix-disklib-distrib -io vddk-thumbprint=31:14:EB:9E:F1:78:68:10:A5:78:D1:A7:DF:BB:54:B7:1B:91:9F:30 -- yzamir-03
virt-v2v monitoring: Setting up prometheus endpoint :2112/metrics
virt-v2v monitoring: Prometheus progress counter registered.
info: virt-v2v: virt-v2v 2.5.6rhel=9,release=3.el9 (x86_64)
info: libvirt version: 10.5.0
```