### PR TITLE
[MTV-595] Refactor run virt-customize for linux on any non windows

### DIFF
--- a/virt-v2v/cold/customize-rhel.go
+++ b/virt-v2v/cold/customize-rhel.go
@@ -13,7 +13,7 @@ type FileSystemTool interface {
 
 type DomainExecFunc func(args ...string) error
 
-func CustomizeRHEL(execFunc DomainExecFunc, disks []string, dir string, t FileSystemTool) error {
+func CustomizeLinux(execFunc DomainExecFunc, disks []string, dir string, t FileSystemTool) error {
 	fmt.Printf("Customizing disks '%v'\n", disks)
 
 	var extraArgs []string

--- a/virt-v2v/cold/customize-rhel_test.go
+++ b/virt-v2v/cold/customize-rhel_test.go
@@ -68,7 +68,7 @@ func TestCustomizeRHELWithMock(t *testing.T) {
 
 	// Run the CustomizeRHEL function
 	disks := []string{"disk1", "disk2"}
-	err := CustomizeRHEL(mockCustomizeDomainExec, disks, tempDir, mockTool)
+	err := CustomizeLinux(mockCustomizeDomainExec, disks, tempDir, mockTool)
 	if err != nil {
 		t.Fatalf("CustomizeRHEL returned an error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestCustomizeRHEL_CreateFilesFromFSFails(t *testing.T) {
 
 	// Run the CustomizeRHEL function
 	disks := []string{"disk1", "disk2"}
-	err := CustomizeRHEL(mockCustomizeDomainExec, disks, t.TempDir(), mockTool)
+	err := CustomizeLinux(mockCustomizeDomainExec, disks, t.TempDir(), mockTool)
 	if err == nil {
 		t.Fatalf("Expected error in CustomizeRHEL due to CreateFilesFromFS failure, got nil")
 	}

--- a/virt-v2v/cold/entrypoint.go
+++ b/virt-v2v/cold/entrypoint.go
@@ -135,11 +135,11 @@ func customizeVM(source string, xmlFilePath string) error {
 			}
 		}
 
-		// RHEL
-		if strings.Contains(operatingSystem, "rhel") {
+		// Linux
+		if !strings.Contains(operatingSystem, "win") {
 			t := EmbedTool{filesystem: &scriptFS}
 
-			err = CustomizeRHEL(CustomizeDomainExec, disks, DIR, &t)
+			err = CustomizeLinux(CustomizeDomainExec, disks, DIR, &t)
 			if err != nil {
 				fmt.Println("Error customizing disk image:", err)
 				return err


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-595

Issue:
The original issue was reported on RHEL8, after discussions with reporter we found out that this fix may be helpful for other distributions.

Concerns:
The fix will work for machines that use network manager, but will no nothing in other cases.

