### PR TITLE
MTV-1354 | virt-v2v add pod anti affinity to the guest conversion pod

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/library-go/pkg/template/templateprocessing"
 	batch "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -1742,6 +1743,29 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 				RunAsNonRoot: &nonRoot,
 				SeccompProfile: &core.SeccompProfile{
 					Type: core.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Affinity: &core.Affinity{
+				PodAntiAffinity: &core.PodAntiAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []core.WeightedPodAffinityTerm{
+						{
+							Weight: 100,
+							PodAffinityTerm: core.PodAffinityTerm{
+								TopologyKey: "kubernetes.io/hostname",
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key: kApp,
+											Values: []string{
+												"virt-v2v",
+											},
+											Operator: metav1.LabelSelectorOpIn,
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			RestartPolicy:  core.RestartPolicyNever,


### PR DESCRIPTION
Issue: Right now we leave the placement of the conversion pod up to the kubernetes scheduler. But it can cause issues in large scale enviroments as the scheduler can place all migration pods on one node. This can cause the node to run out of the resources and can slow down the migration.

Fix: Add pod anti affinity which will distribute the migration pods evenly across the nodes.