### PR TITLE
Allow more text after ip

### DIFF
--- a/virt-v2v/cold/scripts/rhel/run/network_config_util.sh
+++ b/virt-v2v/cold/scripts/rhel/run/network_config_util.sh
@@ -18,19 +18,13 @@ if [ -f "$UDEV_RULES_FILE" ]; then
     exit 0
 fi
 
-# Add log file descriptot and dump it to stdout
-exec 3>&1
-log() {
-    echo $@ >&3
-}
-
 # Validate MAC address and IPv4 address and extract them
 extract_mac_ip() {
     S_HW=""
     S_IP=""
-    if echo "$1" | grep -qE '^([0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}):ip:([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$'; then
+    if echo "$1" | grep -qE '^([0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}):ip:([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}).*$'; then
         S_HW=$(echo "$1" | sed -nE 's/^([0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}):ip:.*$/\1/p')
-        S_IP=$(echo "$1" | sed -nE 's/^.*:ip:([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$/\1/p')
+        S_IP=$(echo "$1" | sed -nE 's/^.*:ip:([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}).*$/\1/p')
     fi
 }
 

--- a/virt-v2v/cold/scripts/rhel/run/network_config_util_test
+++ b/virt-v2v/cold/scripts/rhel/run/network_config_util_test
@@ -17,7 +17,7 @@ rm -rf "$NETWORK_SCRIPTS_DIR" "$NETWORK_CONNECTIONS_DIR"
 mkdir -p "$NETWORK_SCRIPTS_DIR" "$NETWORK_CONNECTIONS_DIR"
 
 # Create mock data
-printf "aa:bb:cc:dd:ee:ff:ip:192.168.1.10\naa:bb:cc:dd:ee:fe:ip:192.168.1.11\naa:bb:cc:dd:ee:fd:ip:2001:0db8:85a3:0000:0000:8a2e:0370:7334\n" > "$V2V_MAP_FILE"
+printf "aa:bb:cc:dd:ee:ff:ip:192.168.1.10,things,more\naa:bb:cc:dd:ee:fe:ip:192.168.1.11,hello,world\naa:bb:cc:dd:ee:fd:ip:2001:0db8:85a3:0000:0000:8a2e:0370:7334\n" > "$V2V_MAP_FILE"
 printf "DEVICE=eth0\nIPADDR=192.168.1.10\n" > "$NETWORK_SCRIPTS_DIR/ifcfg-eth0"
 printf "[connection]\ninterface-name=eth3\naddress1=192.168.1.11/24\n" > "$NETWORK_CONNECTIONS_DIR/eth1 but with spaces.nmconnection"
 


### PR DESCRIPTION
**Issue:**
a mac to ip line looks like` --mac aa:bb:cc:dd:ee:ff:ip:ipaddr[,gw[,len[,ns,ns,...]]]`
aa:bb:cc:dd:ee:ff:ip:192.168.1.10,192.168.1.245,23,,

but in the tests we tested the format:
aa:bb:cc:dd:ee:ff:ip:192.168.1.10

**What happen:**
tests pass with wrong input

**What should happen:**
use currect input for tests, and tests should fail

**Fix:**
fix tests and error in the script