### PR TITLE
MTV-1354 | Ignore namespaces when choosing the v2v pod on the nodes

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1751,7 +1751,8 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 						{
 							Weight: 100,
 							PodAffinityTerm: core.PodAffinityTerm{
-								TopologyKey: "kubernetes.io/hostname",
+								NamespaceSelector: &metav1.LabelSelector{},
+								TopologyKey:       "kubernetes.io/hostname",
 								LabelSelector: &metav1.LabelSelector{
 									MatchExpressions: []metav1.LabelSelectorRequirement{
 										{


### PR DESCRIPTION
Issue: When a user has a plans across many namespaces the v2v anti-affinity does not look for the other pods in different namespaces when using the anti-affinity.

Fix: This PR disables the namespace selector so it looks across whole cluster for the pods and distributes the pods evenly.