### PR TITLE
[MTV-595] Add a flush disk step after virt-customize in virt-v2v pod

### DIFF
--- a/virt-v2v/cold/customize-image.go
+++ b/virt-v2v/cold/customize-image.go
@@ -92,3 +92,23 @@ func CustomizeDomainExec(extraArgs ...string) error {
 	}
 	return nil
 }
+
+// SyncDisks takes a slice of disk filenames and syncs each one, returning an error if any operation fails.
+func SyncDisks(disks []string) error {
+	for _, disk := range disks {
+		// Open the disk file in read-only mode
+		file, err := os.Open(disk)
+		if err != nil {
+			return fmt.Errorf("failed to open disk file %s: %w", disk, err)
+		}
+		defer file.Close()
+
+		// Sync the file to ensure all data is written to disk
+		if err := file.Sync(); err != nil {
+			return fmt.Errorf("failed to sync disk file %s: %w", disk, err)
+		}
+	}
+
+	// If we get here, all files were synced successfully
+	return nil
+}

--- a/virt-v2v/cold/customize-rhel.go
+++ b/virt-v2v/cold/customize-rhel.go
@@ -49,6 +49,11 @@ func CustomizeLinux(execFunc DomainExecFunc, disks []string, dir string, t FileS
 		return fmt.Errorf("failed to execute domain customization: %w", err)
 	}
 
+	// Step 7: flush page cache for the disk files
+	if err := SyncDisks(disks); err != nil {
+		return fmt.Errorf("failed to execute domain customization: %w", err)
+	}
+
 	return nil
 }
 

--- a/virt-v2v/cold/customize-rhel.go
+++ b/virt-v2v/cold/customize-rhel.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -52,6 +53,14 @@ func CustomizeLinux(execFunc DomainExecFunc, disks []string, dir string, t FileS
 	// Step 7: flush page cache for the disk files
 	if err := SyncDisks(disks); err != nil {
 		return fmt.Errorf("failed to execute domain customization: %w", err)
+	}
+
+	// Step 7.5: Flush all fs, just becasue why not ...
+	syncCmd := exec.Command("sync")
+
+	fmt.Println("exec:", syncCmd)
+	if err := syncCmd.Run(); err != nil {
+		return fmt.Errorf("error executing sync command: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Issue:
`virt-customize` uses regular disk calls, `kubevirt` execute `qemu` using `cache.direct=true` to access disks.
In cases where the disk image if not flushed after running `virt-customize`, `kubevirt` may use currpted disk image file.

Fix:
Flush all the disk files after using `virt-customize`