### PR TITLE
[MTV-595] Add --format raw to virt-customize call

### DIFF
--- a/virt-v2v/cold/customize-image.go
+++ b/virt-v2v/cold/customize-image.go
@@ -79,7 +79,7 @@ func getScriptArgs(argName string, values ...string) []string {
 // Returns:
 //   - error: An error if something goes wrong during the process, or nil if successful.
 func CustomizeDomainExec(extraArgs ...string) error {
-	args := []string{"--verbose"}
+	args := []string{"--verbose", "--format", "raw"}
 	args = append(args, extraArgs...)
 
 	customizeCmd := exec.Command("virt-customize", args...)


### PR DESCRIPTION
Issue:
When running `virt-customize` we get a warning:
```
WARNING: Image format was not specified for '/dev/block0' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.
\x1bc\x1b[?7l\x1b[2J\x1b[0mSeaBIOS (version 1.16.3-2.el9)
```

Fix:
Specifying the format explicitly as raw