### PR TITLE
Remove double quates from network config files

### DIFF
--- a/virt-v2v/cold/scripts/rhel/run/network_config_util.sh
+++ b/virt-v2v/cold/scripts/rhel/run/network_config_util.sh
@@ -18,6 +18,11 @@ if [ -f "$UDEV_RULES_FILE" ]; then
     exit 0
 fi
 
+# Clean strigs in case they have quates
+remove_quotes() {
+    echo "$1" | tr -d '"'
+}
+
 # Validate MAC address and IPv4 address and extract them
 extract_mac_ip() {
     S_HW=""
@@ -58,7 +63,7 @@ udev_from_ifcfg() {
             continue
         fi
 
-        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$S_HW\",NAME=\"$DEVICE\""
+        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"$(remove_quotes "$DEVICE")\""
     done < "$V2V_MAP_FILE"
 }
 
@@ -92,7 +97,7 @@ udev_from_nm() {
             continue
         fi
 
-        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$S_HW\",NAME=\"$DEVICE\""
+        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"$(remove_quotes "$DEVICE")\""
     done < "$V2V_MAP_FILE"
 }
 

--- a/virt-v2v/cold/scripts/rhel/run/network_config_util_test
+++ b/virt-v2v/cold/scripts/rhel/run/network_config_util_test
@@ -18,7 +18,7 @@ mkdir -p "$NETWORK_SCRIPTS_DIR" "$NETWORK_CONNECTIONS_DIR"
 
 # Create mock data
 printf "aa:bb:cc:dd:ee:ff:ip:192.168.1.10,things,more\naa:bb:cc:dd:ee:fe:ip:192.168.1.11,hello,world\naa:bb:cc:dd:ee:fd:ip:2001:0db8:85a3:0000:0000:8a2e:0370:7334\n" > "$V2V_MAP_FILE"
-printf "DEVICE=eth0\nIPADDR=192.168.1.10\n" > "$NETWORK_SCRIPTS_DIR/ifcfg-eth0"
+printf "DEVICE=\"eth0\"\nIPADDR=192.168.1.10\n" > "$NETWORK_SCRIPTS_DIR/ifcfg-eth0"
 printf "[connection]\ninterface-name=eth3\naddress1=192.168.1.11/24\n" > "$NETWORK_CONNECTIONS_DIR/eth1 but with spaces.nmconnection"
 
 # Source the script under test


### PR DESCRIPTION
**Issue:**
If network configuration file has quotes the name, this quotes will be transferred to the udev config file.

**Fix:**
Remove quotes. 

**Tests:**
`shellcheck virt-v2v/cold/scripts/rhel/run/network_config_util.sh` - pass

``` sh
bash virt-v2v/cold/scripts/rhel/run/network_config_util_test 

Test output:
SUBSYSTEM=="net",ACTION=="add",ATTR{address}=="aa:bb:cc:dd:ee:ff",NAME="eth0"
SUBSYSTEM=="net",ACTION=="add",ATTR{address}=="aa:bb:cc:dd:ee:fe",NAME="eth3"
All tests passed successfully.
```