### PR TITLE
MTV-1377 | Fix the auth to return 401 instead of 403

### DIFF
--- a/pkg/controller/provider/web/base/auth.go
+++ b/pkg/controller/provider/web/base/auth.go
@@ -64,7 +64,7 @@ func (r *Auth) Permit(ctx *gin.Context, p *api.Provider) (status int, err error)
 		ns = q.Get(NsParam)
 	}
 	allowed, err := r.permit(token, ns, p)
-	if allowed && err != nil {
+	if err != nil {
 		log.Error(err, "Authorization failed.")
 		status = http.StatusInternalServerError
 		return
@@ -85,7 +85,6 @@ func (r *Auth) Permit(ctx *gin.Context, p *api.Provider) (status int, err error)
 
 // Authenticate token.
 func (r *Auth) permit(token string, ns string, p *api.Provider) (allowed bool, err error) {
-	allowed = true
 	tr := &auth.TokenReview{
 		Spec: auth.TokenReviewSpec{
 			Token: token,


### PR DESCRIPTION
### First issue
Issue: When we request the inventory web endpoint the auth functions
allows the user to get the endpoint even with the incorrect token.

Fix: Change the permit function logic so we do not set the auth=true.

### Second issue
Issue: Right now the request with an invalid token returns 403 instead of
the expected 401.

Fix: Change the `permit` function to return the status code instead of
Boolean.