### PR TITLE
MTV-1353 | Fix NPE when conversion pod does not exists

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1138,7 +1138,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				return err
 			}
 
-			if pod.Status.Phase != core.PodSucceeded {
+			if pod != nil && pod.Status.Phase != core.PodSucceeded {
 				err := r.kubevirt.UpdateVmByConvertedConfig(vm, pod, step)
 				if err != nil {
 					return err


### PR DESCRIPTION
Issue: The controller gets into a specific setup when it's waiting for the conversion pod put it is not created yet due to some other reasons. This causes the pod to crash and entry crashloopbackoff and if the pod won't be created the controller can't get out of it.


I was also able to find this issue in my testing this is my log:
```
{"level":"info","ts":"2024-09-03 12:25:25.653","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","controller":"plan","object":{"name":"copy-of-test-centos-7","namespace":"openshift-mtv"},"namespace":"openshift-mtv","name":"copy-of-test-centos-7","reconcileID":"3d0f9cfb-56e7-43b0-b1ad-2623496bd41c"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x330 pc=0x26b33d2]
goroutine 301 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:116 +0x1e5
panic({0x2c39780?, 0x4fa1b70?})
/usr/lib/golang/src/runtime/panic.go:914 +0x21f
github.com/konveyor/forklift-controller/pkg/controller/plan.(*Migration).execute(0xc000246fc0, 0xc000aec9c0)
/remote-source/app/pkg/controller/plan/migration.go:1136 +0x12312
github.com/konveyor/forklift-controller/pkg/controller/plan.(*Migration).Run(0xc000246fc0)
/remote-source/app/pkg/controller/plan/migration.go:195 +0x285
github.com/konveyor/forklift-controller/pkg/controller/plan.(*Reconciler).execute(0xc000f409c0, 0xc000f48000)
/remote-source/app/pkg/controller/plan/controller.go:428 +0x98b
github.com/konveyor/forklift-controller/pkg/controller/plan.Reconciler.Reconcile({{{0x3697198, 0xc0008465c0}, {0x36b2f60, 0xc000588510}, {0x36a9c98, 0xc0007fc280}}}, {0x36c23c0?, 0xc000917ce8?}, {{{0xc000b033d0, 0xd}, ...}})
/remote-source/app/pkg/controller/plan/controller.go:257 +0x9de
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x36a7f68?, {0x36a4858?, 0xc000f40990?}, {{{0xc000b033d0?, 0xb?}, {0xc000702540?, 0x0?}}})
/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:119 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00083afa0, {0x36a4890, 0xc0006e3a40}, {0x2e5f7a0?, 0xc00014b360?})
/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:316 +0x3cc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00083afa0, {0x36a4890, 0xc0006e3a40})
/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266 +0x1c9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 114
/remote-source/app/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:223 +0x565
```