### PR TITLE
MTV-446 | Warm: Add cbt check before migration

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -138,6 +138,8 @@ type Validator interface {
 	PodNetwork(vmRef ref.Ref) (bool, error)
 	// Validate that we have information about static IPs for every virtual NIC
 	StaticIPs(vmRef ref.Ref) (bool, error)
+	// Validate that the vm has the change tracking enabled
+	ChangeTrackingEnabled(vmRef ref.Ref) (bool, error)
 }
 
 // DestinationClient API.

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -192,3 +192,8 @@ func (r *Validator) DirectStorage(vmRef ref.Ref) (bool, error) {
 func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -115,3 +115,8 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
 	// the guest operating system is not modified during the migration so static IPs should be preserved
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -105,3 +105,9 @@ func (r *Validator) DirectStorage(vmRef ref.Ref) (bool, error) {
 func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
+	// Validate that the vm has the change tracking enabled
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -171,3 +171,9 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
 	// the guest operating system is not modified during the migration so static IPs should be preserved
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
+	// Validate that the vm has the change tracking enabled
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -155,3 +155,16 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 	ok = true
 	return
 }
+
+// Validate that the vm has the change tracking enabled
+func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
+	if !r.plan.Spec.Warm {
+		return true, nil
+	}
+	vm := &model.Workload{}
+	err := r.inventory.Find(vm, vmRef)
+	if err != nil {
+		return false, liberr.Wrap(err, "vm", vmRef)
+	}
+	return vm.ChangeTrackingEnabled, nil
+}


### PR DESCRIPTION
Issue:
Right now we have a check to fail the migration when we start to create the VM which does not have the CBT enabled. We should throw error much earlier before the customer even start the migration.

Fix:
Add a CBT check to the plan validation. This fix right now affects only VMware migrations.