### PR TITLE
Support old ubuntu netplan

### DIFF
--- a/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
+++ b/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
@@ -182,7 +182,7 @@ udev_from_netplan() {
     # netplan with root dir
     netplan_get() {
         if netplan_supports_get; then
-            netplan get --root-dir "$NETPLAN_DIR" "$@" 2>&3
+            netplan get --root-dir "$NETPLAN_DIR" "$@" 2>&3 
         else
             log 'Info: netplan not supporting get subcomment, using python'
             netplan_get_py "$@" 2>&3

--- a/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
+++ b/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
@@ -110,7 +110,7 @@ udev_from_ifcfg() {
         fi
 
         # Find the matching network script file
-        IFCFG=$(grep -l "IPADDR=$S_IP" "$NETWORK_SCRIPTS_DIR"/*)
+        IFCFG=$(grep -l "IPADDR=.*$S_IP.*$" "$NETWORK_SCRIPTS_DIR"/*)
         if [ -z "$IFCFG" ]; then
             log "Info: no ifcg config file name foud for $S_IP."
             continue
@@ -148,7 +148,7 @@ udev_from_nm() {
         fi
 
         # Find the matching NetworkManager connection file
-        NM_FILE=$(grep -El "address[0-9]*=$S_IP" "$NETWORK_CONNECTIONS_DIR"/*)
+        NM_FILE=$(grep -El "address[0-9]*=.*$S_IP.*$" "$NETWORK_CONNECTIONS_DIR"/*)
         if [ -z "$NM_FILE" ]; then
             log "Info: no nm config file name foud for $S_IP."
             continue

--- a/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
+++ b/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
@@ -46,6 +46,10 @@ extract_mac_ip() {
     fi
 }
 
+# Get a netplan setting by specifying a nested key like "ethernets.eth0.addresses"
+# For example:
+#    netplan_get_py ethernets
+# Will return the yaml struct of all the thernet interfaces.
 netplan_get_py() {
     python -c "
 import os

--- a/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
+++ b/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
@@ -175,7 +175,7 @@ udev_from_netplan() {
 
     # Function to check if netplan supports the 'get' subcommand
     netplan_supports_get() {
-        netplan get 2>/dev/null
+        netplan get 2>&3
         return $?
     }
 

--- a/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
+++ b/virt-v2v/pkg/customize/scripts/rhel/run/network_config_util.sh
@@ -182,9 +182,10 @@ udev_from_netplan() {
     # netplan with root dir
     netplan_get() {
         if netplan_supports_get; then
-            netplan get --root-dir "$NETPLAN_DIR" "$@" 2>/dev/null
+            netplan get --root-dir "$NETPLAN_DIR" "$@" 2>&3
         else
-            netplan_get_py "$@" 2>/dev/null
+            log 'Info: netplan not supporting get subcomment, using python'
+            netplan_get_py "$@" 2>&3
         fi
     }
 


### PR DESCRIPTION
Support old ubuntu netplan

Issue:
Ubuntu 18 uses vertion of netplan that does not support the get subcommand

Fix:
a. add a python script that mimics netplan get command
b. check if current version of netplan support get
c. run the python script in cases netplan does not support get