### PR TITLE
Operator | Fix console-plugin template

### DIFF
--- a/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/console-plugin.yml.j2
@@ -19,8 +19,8 @@ spec:
   proxy:
     - alias: {{ inventory_service_name }}
       authorization: UserToken
-      type: Service
       endpoint:
+        type: Service
         service:
           name: {{ inventory_service_name }}
           namespace: {{ app_namespace }}


### PR DESCRIPTION
Issue:
The latest operator fails with error:
`forklift-console-plugin is invalid: spec.proxy[0].endpoint.type: Required value`