### PR TITLE
chore: add Dockerfile for oVirt populator

### DIFF
--- a/build/ovirt-populator/Containerfile
+++ b/build/ovirt-populator/Containerfile
@@ -1,0 +1,27 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:1.21.11-8.1724662611 AS builder
+ENV GOPATH=$APP_ROOT
+WORKDIR /app
+COPY --chown=1001:0 ./ ./
+ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT strictfipsruntime
+
+RUN GOOS=linux GOARCH=amd64 go build -o ovirt-populator github.com/konveyor/forklift-controller/cmd/ovirt-populator
+
+FROM registry.access.redhat.com/ubi8-minimal:8.10-1052.1724178568
+COPY --from=builder /app/ovirt-populator /usr/local/bin/ovirt-populator
+# RUN microdnf install -y python3-ovirt-engine-sdk4 ovirt-imageio-client && microdnf clean all
+RUN microdnf install -y python3 python3-devel libcurl-devel gcc openssl-devel libxml2-devel
+
+RUN pip3 install ovirt-engine-sdk-python ovirt-imageio
+
+ENTRYPOINT ["/usr/local/bin/ovirt-populator"]
+LABEL \
+        com.redhat.component="forklift-ovirt-populator-container" \
+        name="forklift/forklift-ovirt-populator-rhel8" \
+        license="Apache License 2.0" \
+        io.k8s.display-name="Forklift" \
+        io.k8s.description="oVirt populator pod facilitates data import from oVirt environments to PVCs" \
+        io.openshift.tags="migration,mtv,forklift" \
+        summary="Forklift - oVirt Populator" \
+        description="Forklift - oVirt Populator" \
+        maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"


### PR DESCRIPTION
I based the creation of the Dockerfile on this [file](https://github.com/kubev2v/forklift/blob/main/cmd/ovirt-populator/BUILD.bazel) and that is why I'm using `pip install` to install those dependencies. There is another way by using this [copr repo](https://copr.fedorainfracloud.org/coprs/ovirt/ovirt-master-snapshot/) @mnecas @yaacov LMK what you guys prefer