### PR TITLE
MTV-1482 | Fix main pod inventory watch NPE

### DIFF
--- a/pkg/lib/inventory/web/client.go
+++ b/pkg/lib/inventory/web/client.go
@@ -255,6 +255,7 @@ func (r *Client) Watch(url string, resource interface{}, h EventHandler) (status
 	post := func(w *WatchReader) (pStatus int, pErr error) {
 		socket, response, pErr := dialer.Dial(url, header)
 		if response != nil {
+			defer response.Body.Close()
 			pStatus = response.StatusCode
 			switch pStatus {
 			case http.StatusOK,
@@ -265,9 +266,6 @@ func (r *Client) Watch(url string, resource interface{}, h EventHandler) (status
 				return
 			}
 		}
-
-		defer response.Body.Close()
-
 		if pErr != nil {
 			pErr = liberr.Wrap(
 				pErr,


### PR DESCRIPTION
Issue: When the request from main to the inventory pod fails the main pod crashes due to nil pointer.

Fix: Move the request close to case when we get the response body.