### PR TITLE
MTV-1483 | Fix virtio-win driver version

### DIFF
--- a/virt-v2v/BUILD.bazel
+++ b/virt-v2v/BUILD.bazel
@@ -451,7 +451,7 @@ rpmtree(
         "@util-linux-core-0__2.37.4-20.el9.x86_64//rpm",
         "@vim-minimal-2__8.2.2637-21.el9.x86_64//rpm",
         "@virt-v2v-1__2.5.6-4.el9.x86_64//rpm",
-        "@virtio-win-0__1.9.15-4.el9.x86_64//rpm",
+        "@virtio-win-1.9.40-1.el9.noarch//rpm",
         "@which-0__2.21-29.el9.x86_64//rpm",
         "@xfsprogs-0__6.4.0-4.el9.x86_64//rpm",
         "@xz-0__5.2.5-8.el9.x86_64//rpm",

--- a/virt-v2v/WORKSPACE
+++ b/virt-v2v/WORKSPACE
@@ -2931,10 +2931,10 @@ rpm(
 )
 
 rpm(
-    name = "virtio-win-0__1.9.15-4.el9.x86_64",
-    sha256 = "6673ae4cb0f24fdc75b12b68aa37533c29eae2a98eaa60d1ee7c8390f7edd20b",
+    name = "virtio-win-1.9.40-1.el9.noarch",
+    sha256 = "7baa1bddc62a72798b00f1ccd7ba46e3a79d7cd8224d3aabae328719f4d604bc",
     urls = [
-        "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/AppStream/x86_64/os/Packages/virtio-win-1.9.15-4.el9.noarch.rpm",
+        "https://kojihub.stream.rdu2.redhat.com/kojifiles/packages/virtio-win/1.9.40/1.el9/noarch/virtio-win-1.9.40-1.el9.noarch.rpm",
     ],
 )
 


### PR DESCRIPTION
Issue:
The Centos 9 AppStream repo has an outdated Windows virtio driver which does not support Windows 2022 and has issues with 2019. This change updates the rpm to the fedora package.

This is not a proper fix but WA as the base image is ubi9 and we should not mix the packages.

Fixes: https://github.com/kubev2v/forklift/issues/982
Fixes: https://github.com/kubev2v/forklift/issues/1029
Fixes: https://issues.redhat.com/browse/MTV-1483