### PR TITLE
Fix migration to remote cluster

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1748,7 +1748,12 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 				Value: vm.NewName,
 			})
 	}
-
+	environment = append(environment,
+		core.EnvVar{
+			Name:  "LOCAL_MIGRATION",
+			Value: strconv.FormatBool(r.Destination.Provider.IsHost()),
+		},
+	)
 	// pod annotations
 	annotations := map[string]string{}
 	if r.Plan.Spec.TransferNetwork != nil {


### PR DESCRIPTION
Issue:
During the refactoring I have enabled the server, via which we expose the virt-v2v gathered information to the controller, to both migraiton types. The flow is that we request all nessasry information form pod and then manually kill it from the controller. But right now we can't reuqest the server which are in remote clusters.

Fix:
Disable the server in the remote migrations. This will cause the pod to be terminated and the controller will check the pod status and will continue if the pod succeded.

Note:
Because of this we can't get the OS nor Firmware form the remote migrations. This should not be a large issue as we use them right now only for prefenrace in kubevirt.