### PR TITLE
Fix warm migration windows static ip

### DIFF
--- a/virt-v2v/cmd/entrypoint.go
+++ b/virt-v2v/cmd/entrypoint.go
@@ -81,6 +81,11 @@ func runVirtV2vInPlace() error {
 	} else {
 		args = append(args, "first")
 	}
+	if envStaticIPs := os.Getenv("V2V_staticIPs"); envStaticIPs != "" {
+		for _, macToIp := range strings.Split(envStaticIPs, "_") {
+			args = append(args, "--mac", macToIp)
+		}
+	}
 	args = append(args, "/mnt/v2v/input.xml")
 	v2vCmd := exec.Command("/usr/libexec/virt-v2v-in-place", args...)
 	v2vCmd.Stdout = os.Stdout


### PR DESCRIPTION
Issue: 
The windows is missing the static IP address mapping.

Fix:
Add the `--mac` mapping so the virt-v2v-in-place flow.