### PR TITLE
fix: add vendor label to Containerfiles

### DIFF
--- a/build/forklift-api/Containerfile
+++ b/build/forklift-api/Containerfile
@@ -19,4 +19,5 @@ LABEL \
         io.openshift.tags="migration,forklift,mtv" \
         summary="Forklift- API" \
         description="Forklift - API" \
+        vendor="Red Hat, Inc." \
         maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"

--- a/build/forklift-controller/Containerfile
+++ b/build/forklift-controller/Containerfile
@@ -23,4 +23,5 @@ LABEL \
         summary="Forklift - Controller" \
         description="Forklift controller pod orchestrates migrations and \
         maintains an up-to-date inventory of the source providers." \
+        vendor="Red Hat, Inc." \
         maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>"

--- a/build/forklift-operator/Containerfile
+++ b/build/forklift-operator/Containerfile
@@ -19,4 +19,5 @@ LABEL \
         io.openshift.tags="migration,mtv,forklift" \
         summary="Forklift - Operator" \
         description="Forklift - Operator" \
+        vendor="Red Hat, Inc." \
         maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"

--- a/build/openstack-populator/Containerfile
+++ b/build/openstack-populator/Containerfile
@@ -19,4 +19,5 @@ LABEL \
         io.openshift.tags="migration,forklift,mtv" \
         summary="Forklift - openstack-populator" \
         description="Forklift - openstack-populator" \
+        vendor="Red Hat, Inc." \
         maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"

--- a/build/ova-provider-server/Containerfile
+++ b/build/ova-provider-server/Containerfile
@@ -22,4 +22,5 @@ LABEL \
         io.openshift.tags="migration,mtv,forklift" \
         summary="Forklift - OVA Provider Server" \
         description="Forklift - OVA Provider Server" \
+        vendor="Red Hat, Inc." \
         maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"

--- a/build/ovirt-populator/Containerfile
+++ b/build/ovirt-populator/Containerfile
@@ -24,4 +24,5 @@ LABEL \
         io.openshift.tags="migration,mtv,forklift" \
         summary="Forklift - oVirt Populator" \
         description="Forklift - oVirt Populator" \
+        vendor="Red Hat, Inc." \
         maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"

--- a/build/populator-controller/Containerfile
+++ b/build/populator-controller/Containerfile
@@ -22,4 +22,5 @@ LABEL \
         io.openshift.tags="migration,mtv,forklift" \
         summary="Forklift - Populator Controller" \
         description="Forklift - Populator Controller" \
+        vendor="Red Hat, Inc." \
         maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"

--- a/build/validation/Containerfile
+++ b/build/validation/Containerfile
@@ -14,4 +14,5 @@ LABEL \
         io.openshift.tags="migration,mtv,forklift" \
         summary="Forklift - Validation Service" \
         description="Forklift - Validation Service" \
+        vendor="Red Hat, Inc." \
         maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"

--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -53,4 +53,5 @@ LABEL \
         io.openshift.tags="migration,mtv,forklift" \
         summary="Forklift - Virt-V2V" \
         io.k8s.description="Forklift - Virt-V2V" \
+        vendor="Red Hat, Inc." \
         maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"


### PR DESCRIPTION
Needed because we were encountering [this issue](https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/getting-started/passing-ec.md#missing-red-hat-manifests-or-sbom) in the EC policy