### PR TITLE
MTV-1497 | Pass all gateways to the virt-v2v

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -65,7 +65,7 @@ var _ = Describe("vSphere builder", func() {
 					Gateway: "fe80::5da:b7a5:e0a2:a095",
 				},
 			},
-		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,16,8.8.8.8_00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097,,64,fec0:0:0:ffff::1,fec0:0:0:ffff::2,fec0:0:0:ffff::3"),
+		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,16,8.8.8.8_00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097,fe80::5da:b7a5:e0a2:a095,64,fec0:0:0:ffff::1,fec0:0:0:ffff::2,fec0:0:0:ffff::3"),
 		Entry("non-static ip", &model.VM{GuestID: "windows9Guest", GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: string(types.NetIpConfigInfoIpAddressOriginDhcp)}}}, ""),
 		Entry("non windows vm", &model.VM{GuestID: "other", GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, "00:50:56:83:25:47:ip:172.29.3.193,,0"),
 		Entry("no OS vm", &model.VM{GuestNetworks: []vsphere.GuestNetwork{{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin}}}, "00:50:56:83:25:47:ip:172.29.3.193,,0"),
@@ -115,7 +115,7 @@ var _ = Describe("vSphere builder", func() {
 					Gateway: "fe80::5da:b7a5:e0a2:a095",
 				},
 			},
-		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,16,8.8.8.8_00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097,,64,fec0:0:0:ffff::1,fec0:0:0:ffff::2,fec0:0:0:ffff::3_00:50:56:83:25:48:ip:172.29.3.192,,24,4.4.4.4_00:50:56:83:25:48:ip:fe80::5da:b7a5:e0a2:a090,,32,fec0:0:0:ffff::4,fec0:0:0:ffff::5,fec0:0:0:ffff::6"),
+		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,16,8.8.8.8_00:50:56:83:25:47:ip:fe80::5da:b7a5:e0a2:a097,fe80::5da:b7a5:e0a2:a095,64,fec0:0:0:ffff::1,fec0:0:0:ffff::2,fec0:0:0:ffff::3_00:50:56:83:25:48:ip:172.29.3.192,172.29.3.1,24,4.4.4.4_00:50:56:83:25:48:ip:fe80::5da:b7a5:e0a2:a090,fe80::5da:b7a5:e0a2:a095,32,fec0:0:0:ffff::4,fec0:0:0:ffff::5,fec0:0:0:ffff::6"),
 		Entry("single static ip without DNS", &model.VM{
 			GuestID: "windows9Guest",
 			GuestNetworks: []vsphere.GuestNetwork{


### PR DESCRIPTION
Issue:
We are not passing the gateway to the `virt-v2v` when there are multiple interfaces.

Fix:
Remove the limitation to have just one gateway and pass everything to the `virt-v2v`.
The MTV should not touch the configuration the VM should be the same after migration as it was before.

Test log:
```
exec: /usr/bin/virt-v2v -v -x -o kubevirt -os /var/tmp/v2v --root first -i libvirt -ic vpx://administrator%40vsphere.local@10.73.213.102/data/host/10.73.212.38?no_verify=1 -ip /etc/secret/secretKey --mac 00:50:56:92:ee:06:ip:10.73.100.100,10.73.100.10,24,10.73.100.1 --mac 00:50:56:92:25:f0:ip:192.168.24.50,192.168.24.1,24,192.168.24.10 -it vddk -io vddk-libdir=/opt/vmware-vix-disklib-distrib -io vddk-thumbprint=86:25:2F:5E:74:5C:43:D9:28:62:31:E0:1F:BB:1F:FD:AC:18:A5:93 -- mtv-esx7-win2022-2nics-2disks
```

This contains all IPAM configuraiton needed:
```
--mac 00:50:56:92:ee:06:ip:10.73.100.100,10.73.100.10,24,10.73.100.1
--mac 00:50:56:92:25:f0:ip:192.168.24.50,192.168.24.1,24,192.168.24.10
```
