### PR TITLE
add a description label to Virt-v2v

### DIFF
--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -52,6 +52,8 @@ LABEL \
         io.k8s.description="Forklift - Virt-V2V" \
         io.openshift.tags="migration,mtv,forklift" \
         summary="Forklift - Virt-V2V" \
+        description="Forklift - Virt-V2V" \
         io.k8s.description="Forklift - Virt-V2V" \
         vendor="Red Hat, Inc." \
         maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"
+


### PR DESCRIPTION
Konflux tests are currently failing because virt v2v component is missing the description label 