### PR TITLE
MTV-1555 | Fix virt-v2v with new name

### DIFF
--- a/virt-v2v/cmd/entrypoint.go
+++ b/virt-v2v/cmd/entrypoint.go
@@ -134,12 +134,6 @@ func virtV2vBuildCommand() (args []string, err error) {
 		args = append(args, "-i", "ova", os.Getenv("V2V_diskPath"))
 	}
 
-	// When converting VM with name that do not meet DNS1123 RFC requirements,
-	// it should be changed to supported one to ensure the conversion does not fail.
-	if utils.CheckEnvVariablesSet("V2V_NewName") {
-		args = append(args, "-on", os.Getenv("V2V_NewName"))
-	}
-
 	return args, nil
 }
 
@@ -156,6 +150,12 @@ func virtV2vVsphereArgs() (args []string, err error) {
 			"-io", fmt.Sprintf("vddk-libdir=%s", global.VDDK),
 			"-io", fmt.Sprintf("vddk-thumbprint=%s", os.Getenv("V2V_fingerprint")),
 		)
+	}
+
+	// When converting VM with name that do not meet DNS1123 RFC requirements,
+	// it should be changed to supported one to ensure the conversion does not fail.
+	if utils.CheckEnvVariablesSet("V2V_NewName") {
+		args = append(args, "-on", os.Getenv("V2V_NewName"))
 	}
 
 	args = append(args, "--", os.Getenv("V2V_vmName"))


### PR DESCRIPTION
Issue:
The MTV specifies the `-on` argument in the wrong place /usr/bin/virt-v2v [...] -- epassaroMigrate-2 -on epassaromigrate-2

Fix:
/usr/bin/virt-v2v [...] -on newname -- oldname