### PR TITLE
MTV-1573 | Allow scheduler to migrate VMs with more disks

### DIFF
--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -204,6 +204,11 @@ func (r *Scheduler) schedulable() (schedulable map[string][]*pendingVM) {
 			if vms[i].cost+r.inFlight[host] <= r.MaxInFlight {
 				schedulable[host] = append(schedulable[host], vms[i])
 			}
+			// In case there is VM with more disks than the MaxInFlight MTV will migrate it, if there are no other VMs
+			// being migrated at that time.
+			if vms[i].cost > r.MaxInFlight && r.inFlight[host] == 0 {
+				schedulable[host] = append(schedulable[host], vms[i])
+			}
 		}
 	}
 


### PR DESCRIPTION
Issue:
When migrating the VM using the warm migration with more disks than the MAX_VM_INFLIGHT the VM won't get scheduled and won't start the migration.

Fix:
Once the scheduler is empty the controller will start the migration of the large VMs.