### PR TITLE
MTV-1477 | Add DataVolume deletion when archiving

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -661,7 +661,7 @@ func (r *KubeVirt) getDVs(vm *plan.VMStatus) (edvs []ExtendedDataVolume, err err
 		context.TODO(),
 		dvsList,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.vmLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.vmAllButMigrationLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		})
 

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -458,6 +458,9 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool) error
 		if err := r.deletePopulatorPVCs(vm); failOnErr(err) {
 			return err
 		}
+		if err := r.kubevirt.DeleteDataVolumes(vm); failOnErr(err) {
+			return err
+		}
 	}
 	if err := r.deleteImporterPods(vm); failOnErr(err) {
 		return err


### PR DESCRIPTION
Issue:
When running the migration archive we do not delete the DataVolumes.

Fix:
Add deletion of the DataVolumes when running the archive and the VM migration failed.
At some cases the migration in the context is missing the migration ID so we can use the plan instead to find the DataVolume.

Fixes: https://issues.redhat.com/browse/MTV-1477