### PR TITLE
Fix VMware scheduler test

### DIFF
--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -226,9 +226,9 @@ func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {
 func (r *Scheduler) finishedDisks(vmStatus *plan.VMStatus) int {
 	var resp = 0
 	for _, step := range vmStatus.Pipeline {
-		if step.Name == "DiskTransfer" {
+		if step.Name == DiskTransfer {
 			for _, task := range step.Tasks {
-				if task.Phase == "Completed" {
+				if task.Phase == Completed {
 					resp += 1
 				}
 			}

--- a/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
@@ -84,6 +84,9 @@ func TestScheduler(t *testing.T) {
 		},
 		hostC: {
 			{
+				cost: 11,
+			},
+			{
 				cost: 1,
 			},
 			{


### PR DESCRIPTION
Now we allow migrating with more disks than the MaxInFlight in case there is no VM being migrated at that time. This is done for the user's convenience.

Related to: https://github.com/kubev2v/forklift/pull/1087