### PR TITLE
MTV-1576 | VMware apply CBT from extra args

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
@@ -609,6 +610,14 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 						case "numa.nodeAffinity":
 							if s, cast := opt.Value.(string); cast {
 								v.model.NumaNodeAffinity = strings.Split(s, ",")
+							}
+						case "ctkEnabled":
+							if s, cast := opt.Value.(string); cast {
+								boolVal, err := strconv.ParseBool(s)
+								if err != nil {
+									return
+								}
+								v.model.ChangeTrackingEnabled = boolVal
 							}
 						}
 					}

--- a/pkg/lib/condition/condition.go
+++ b/pkg/lib/condition/condition.go
@@ -35,6 +35,8 @@ const (
 	ValidatingVDDK = "ValidatingVDDK"
 	// Missing IPs on vm pending condition
 	VMMissingGuestIPs = "VMMissingGuestIPs"
+	// Missing Changed Block
+	VMMissingChangedBlockTracking = "VMMissingChangedBlockTracking"
 )
 
 // Condition
@@ -319,7 +321,7 @@ func (r *Conditions) HasBlockerCondition() bool {
 
 // The collection contains blocker conditions that keep the plan reconciling.
 func (r *Conditions) HasReQCondition() bool {
-	return r.HasCondition(ValidatingVDDK) || r.HasCondition(VMMissingGuestIPs)
+	return r.HasCondition(ValidatingVDDK) || r.HasCondition(VMMissingGuestIPs) || r.HasCondition(VMMissingChangedBlockTracking)
 }
 
 // The collection contains the `Ready` condition.


### PR DESCRIPTION
Issue:
When customer applies the CBT on running VM by:
`govc vm.change -vm VM_NAME -e "ctkEnabled=TRUE"`
The customer gets a critical conidtion which does not allow them to migrate the VM.

Fix:
The changes are not propagated to the VM config but to the extra arguments which we need to query.

Fixes: https://issues.redhat.com/browse/MTV-1576