### PR TITLE
Add Always pull policy for virt-v2v

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1805,8 +1805,9 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 			InitContainers: initContainers,
 			Containers: []core.Container{
 				{
-					Name: "virt-v2v",
-					Env:  environment,
+					Name:            "virt-v2v",
+					Env:             environment,
+					ImagePullPolicy: core.PullAlways,
 					EnvFrom: []core.EnvFromSource{
 						{
 							Prefix: "V2V_",


### PR DESCRIPTION
Issue:
When running the virt-v2v with the latest tag it does not pull the updated image.