### PR TITLE
Add offload plugin implmentation

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
@@ -60,6 +60,21 @@ spec:
                           - ReadWriteMany
                           - ReadOnlyMany
                           type: string
+                        offloadPlugin:
+                          description: Offload plugin.
+                          properties:
+                            image:
+                              description: Offload plugin.
+                              type: string
+                            vars:
+                              additionalProperties:
+                                type: string
+                              description: Offload plugin variables passed to the
+                                job
+                              type: object
+                          required:
+                          - image
+                          type: object
                         storageClass:
                           description: A storage class.
                           type: string

--- a/pkg/apis/forklift/v1beta1/BUILD.bazel
+++ b/pkg/apis/forklift/v1beta1/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/apis/forklift/v1beta1/provider",
         "//pkg/apis/forklift/v1beta1/ref",
         "//pkg/lib/condition",
-        "//pkg/lib/error",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/runtime",

--- a/pkg/apis/forklift/v1beta1/mapping.go
+++ b/pkg/apis/forklift/v1beta1/mapping.go
@@ -57,12 +57,20 @@ type StoragePair struct {
 type DestinationStorage struct {
 	// A storage class.
 	StorageClass string `json:"storageClass"`
+	// Offload plugin.
+	OffloadPlugin *OffloadPlugin `json:"offloadPlugin,omitempty"`
 	// Volume mode.
 	// +kubebuilder:validation:Enum=Filesystem;Block
 	VolumeMode core.PersistentVolumeMode `json:"volumeMode,omitempty"`
 	// Access mode.
 	// +kubebuilder:validation:Enum=ReadWriteOnce;ReadWriteMany;ReadOnlyMany
 	AccessMode core.PersistentVolumeAccessMode `json:"accessMode,omitempty"`
+}
+type OffloadPlugin struct {
+	// Offload plugin.
+	Image string `json:"image"`
+	// Offload plugin variables passed to the job
+	Vars map[string]string `json:"vars,omitempty"`
 }
 
 // Network map spec.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -118,3 +118,12 @@ func (r *Plan) IsSourceProviderOCP() bool {
 func (r *Plan) IsSourceProviderOVA() bool {
 	return r.Provider.Source.Type() == Ova
 }
+
+func (r *Plan) HasOffloadPlugin() bool {
+	for _, storageMap := range r.Map.Storage.Spec.Map {
+		if storageMap.Destination.OffloadPlugin != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -21,7 +21,6 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/provider"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
-	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -93,30 +92,6 @@ type Plan struct {
 	Referenced `json:"-"`
 }
 
-// If the plan calls for the vm to be cold migrated to the local cluster, we can
-// just use virt-v2v directly to convert the vm while copying data over. In other
-// cases, we use CDI to transfer disks to the destination cluster and then use
-// virt-v2v-in-place to convert these disks after cutover.
-func (p *Plan) VSphereColdLocal() (bool, error) {
-	source := p.Referenced.Provider.Source
-	if source == nil {
-		return false, liberr.New("Cannot analyze plan, source provider is missing.")
-	}
-	destination := p.Referenced.Provider.Destination
-	if destination == nil {
-		return false, liberr.New("Cannot analyze plan, destination provider is missing.")
-	}
-
-	switch source.Type() {
-	case VSphere:
-		return !p.Spec.Warm && destination.IsHost(), nil
-	case Ova:
-		return true, nil
-	default:
-		return false, nil
-	}
-}
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type PlanList struct {
 	meta.TypeMeta `json:",inline"`
@@ -138,4 +113,8 @@ func (r *Plan) IsSourceProviderOvirt() bool {
 
 func (r *Plan) IsSourceProviderOCP() bool {
 	return r.Provider.Source.Type() == OpenShift
+}
+
+func (r *Plan) IsSourceProviderOVA() bool {
+	return r.Provider.Source.Type() == Ova
 }

--- a/pkg/controller/plan/BUILD.bazel
+++ b/pkg/controller/plan/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "hook.go",
         "kubevirt.go",
         "migration.go",
+        "offloadplugin.go",
         "predicate.go",
         "util.go",
         "validation.go",

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -80,6 +80,8 @@ type Builder interface {
 	LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.PersistentVolumeClaim, err error)
 	// check whether the builder supports Volume Populators
 	SupportsVolumePopulators() bool
+	// check whether the builder supports offload plugin
+	SupportsOffloadPlugin() bool
 	// Build populator volumes
 	PopulatorVolumes(vmRef ref.Ref, annotations map[string]string, secretName string) ([]*core.PersistentVolumeClaim, error)
 	// Transferred bytes

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -609,6 +609,9 @@ func pvcSourceName(namespace, name string) string {
 func (r *Builder) SupportsVolumePopulators() bool {
 	return false
 }
+func (r *Builder) SupportsOffloadPlugin() bool {
+	return false
+}
 
 func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string, secretName string) (pvcs []*core.PersistentVolumeClaim, err error) {
 	err = planbase.VolumePopulatorNotSupportedError

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -936,6 +936,9 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 func (r *Builder) SupportsVolumePopulators() bool {
 	return true
 }
+func (r *Builder) SupportsOffloadPlugin() bool {
+	return false
+}
 
 func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string, secretName string) (pvcs []*core.PersistentVolumeClaim, err error) {
 	workload := &model.Workload{}

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -543,6 +543,9 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 func (r *Builder) SupportsVolumePopulators() bool {
 	return false
 }
+func (r *Builder) SupportsOffloadPlugin() bool {
+	return false
+}
 
 func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string, secretName string) (pvcs []*core.PersistentVolumeClaim, err error) {
 	err = planbase.VolumePopulatorNotSupportedError

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -715,6 +715,9 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 func (r *Builder) SupportsVolumePopulators() bool {
 	return !r.Context.Plan.Spec.Warm && r.Context.Plan.Provider.Destination.IsHost()
 }
+func (r *Builder) SupportsOffloadPlugin() bool {
+	return false
+}
 
 func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string, secretName string) (pvcs []*core.PersistentVolumeClaim, err error) {
 	workload := &model.Workload{}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -434,28 +434,16 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 			if disk.Datastore.ID == ds.ID {
 				storageClass := mapped.Destination.StorageClass
 				var dvSource cdi.DataVolumeSource
-				coldLocal, vErr := r.Context.Plan.VSphereColdLocal()
-				if vErr != nil {
-					err = vErr
-					return
-				}
-				if coldLocal {
-					// Let virt-v2v do the copying
-					dvSource = cdi.DataVolumeSource{
-						Blank: &cdi.DataVolumeBlankImage{},
-					}
-				} else {
-					// Let CDI do the copying
-					dvSource = cdi.DataVolumeSource{
-						VDDK: &cdi.DataVolumeSourceVDDK{
-							BackingFile:  r.baseVolume(disk.File),
-							UUID:         vm.UUID,
-							URL:          url,
-							SecretRef:    secret.Name,
-							Thumbprint:   thumbprint,
-							InitImageURL: r.Source.Provider.Spec.Settings[api.VDDK],
-						},
-					}
+				// Let CDI do the copying
+				dvSource = cdi.DataVolumeSource{
+					VDDK: &cdi.DataVolumeSourceVDDK{
+						BackingFile:  r.baseVolume(disk.File),
+						UUID:         vm.UUID,
+						URL:          url,
+						SecretRef:    secret.Name,
+						Thumbprint:   thumbprint,
+						InitImageURL: r.Source.Provider.Spec.Settings[api.VDDK],
+					},
 				}
 				dvSpec := cdi.DataVolumeSpec{
 					Source: &dvSource,

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -277,13 +277,6 @@ func (r *Client) getChangeIds(vmRef ref.Ref, snapshotId string, hosts util.Hosts
 }
 
 func (r *Client) getClient(vm *model.VM, hosts util.HostsFunc) (client *vim25.Client, err error) {
-	if coldLocal, vErr := r.Plan.VSphereColdLocal(); vErr == nil && coldLocal {
-		// when virt-v2v runs the migration, forklift-controller should interact only
-		// with the component that serves the SDK endpoint of the provider
-		client = r.client.Client
-		return
-	}
-
 	if r.Source.Provider.Spec.Settings[v1beta1.SDK] == v1beta1.ESXI {
 		// when migrating from ESXi host, we use the client of the SDK endpoint of the provider,
 		// there's no need in a different client (the ESXi host is the only component involved in the migration)

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -824,18 +824,12 @@ func (r *KubeVirt) getListOptionsNamespaced() (listOptions *client.ListOptions) 
 
 // Ensure the guest conversion (virt-v2v) pod exists on the destination.
 func (r *KubeVirt) EnsureGuestConversionPod(vm *plan.VMStatus, vmCr *VirtualMachine, pvcs []*core.PersistentVolumeClaim) (err error) {
-	labels := r.vmLabels(vm.Ref)
-	v2vSecret, err := r.ensureSecret(vm.Ref, r.secretDataSetterForCDI(vm.Ref), labels)
-	if err != nil {
-		return
-	}
-
 	configMap, err := r.ensureLibvirtConfigMap(vm.Ref, vmCr, pvcs)
 	if err != nil {
 		return
 	}
 
-	newPod, err := r.guestConversionPod(vm, vmCr.Spec.Template.Spec.Volumes, configMap, pvcs, v2vSecret)
+	newPod, err := r.guestConversionPod(vm, vmCr.Spec.Template.Spec.Volumes, configMap, pvcs)
 	if err != nil {
 		return
 	}
@@ -1667,7 +1661,7 @@ func (r *KubeVirt) findTemplate(vm *plan.VMStatus) (tmpl *template.Template, err
 	return
 }
 
-func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, configMap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, v2vSecret *core.Secret) (pod *core.Pod, err error) {
+func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, configMap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim) (pod *core.Pod, err error) {
 	volumes, volumeMounts, volumeDevices, err := r.podVolumeMounts(vmVolumes, configMap, pvcs, vm)
 	if err != nil {
 		return
@@ -1684,34 +1678,6 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	user := qemuUser
 	nonRoot := true
 	allowPrivilageEscalation := false
-	// virt-v2v image
-	coldLocal, vErr := r.Context.Plan.VSphereColdLocal()
-	if vErr != nil {
-		err = vErr
-		return
-	}
-	if coldLocal {
-		// mount the secret for the password and CA certificate
-		volumes = append(volumes, core.Volume{
-			Name: "secret-volume",
-			VolumeSource: core.VolumeSource{
-				Secret: &core.SecretVolumeSource{
-					SecretName: v2vSecret.Name,
-				},
-			},
-		})
-		volumeMounts = append(volumeMounts, core.VolumeMount{
-			Name:      "secret-volume",
-			ReadOnly:  true,
-			MountPath: "/etc/secret",
-		})
-	} else {
-		environment = append(environment,
-			core.EnvVar{
-				Name:  "V2V_inPlace",
-				Value: "1",
-			})
-	}
 	// VDDK image
 	var initContainers []core.Container
 	if vddkImage, found := r.Source.Provider.Spec.Settings[api.VDDK]; found {
@@ -1808,19 +1774,9 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 					Name:            "virt-v2v",
 					Env:             environment,
 					ImagePullPolicy: core.PullAlways,
-					EnvFrom: []core.EnvFromSource{
-						{
-							Prefix: "V2V_",
-							SecretRef: &core.SecretEnvSource{
-								LocalObjectReference: core.LocalObjectReference{
-									Name: v2vSecret.Name,
-								},
-							},
-						},
-					},
-					Image:         Settings.Migration.VirtV2vImage,
-					VolumeMounts:  volumeMounts,
-					VolumeDevices: volumeDevices,
+					Image:           Settings.Migration.VirtV2vImage,
+					VolumeMounts:    volumeMounts,
+					VolumeDevices:   volumeDevices,
 					Ports: []core.ContainerPort{
 						{
 							Name:          "metrics",

--- a/pkg/controller/plan/offloadplugin.go
+++ b/pkg/controller/plan/offloadplugin.go
@@ -1,0 +1,195 @@
+package plan
+
+import (
+	"context"
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	planapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
+	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	batch "k8s.io/api/batch/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes/scheme"
+	"path"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"strings"
+)
+
+const retry int = 5
+
+// OffloadPluginRunner
+type OffloadPluginRunner struct {
+	*plancontext.Context
+	// VM.
+	vm       *planapi.VMStatus
+	kubevirt KubeVirt
+}
+
+// Run.
+func (r *OffloadPluginRunner) Run(vm *planapi.VMStatus) (*batch.Job, error) {
+	r.vm = vm
+	return r.ensureJob()
+}
+
+// Ensure the job.
+func (r *OffloadPluginRunner) ensureJob() (job *batch.Job, err error) {
+	list := batch.JobList{}
+	err = r.Destination.Client.List(
+		context.TODO(),
+		&list,
+		&client.ListOptions{
+			LabelSelector: labels.SelectorFromSet(r.labels()),
+			Namespace:     r.Plan.Namespace,
+		})
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if len(list.Items) == 0 {
+		job, err = r.job()
+		if err != nil {
+			return
+		}
+		err = r.Destination.Client.Create(context.TODO(), job)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		r.Log.Info(
+			"Created (offload plugin) job.",
+			"job",
+			path.Join(
+				job.Namespace,
+				job.Name))
+	} else {
+		job = &list.Items[0]
+		r.Log.V(1).Info(
+			"Found (offload plugin) job.",
+			"job",
+			path.Join(
+				job.Namespace,
+				job.Name))
+	}
+
+	return
+}
+
+// Build the Job.
+func (r *OffloadPluginRunner) job() (job *batch.Job, err error) {
+	secret, err := r.kubevirt.ensureSecret(r.vm.Ref, r.kubevirt.secretDataSetterForCDI(r.vm.Ref), r.labels())
+	template := r.template(secret)
+	backOff := int32(1)
+	job = &batch.Job{
+		Spec: batch.JobSpec{
+			Template:     *template,
+			BackoffLimit: &backOff,
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Namespace: r.Plan.Namespace,
+			GenerateName: strings.ToLower(
+				strings.Join([]string{
+					r.vm.ID,
+					"offloadplugin"},
+					"-") + "-"),
+			Labels: r.labels(),
+		},
+	}
+	err = k8sutil.SetOwnerReference(r.Plan, job, scheme.Scheme)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	return
+}
+
+// FIXME: This is just a tmp before we settle on the design in the end we could have multiple maps with multiple images
+// we might even have multiple jobs with multiple offload plugins... depends on the mapping and design
+func (r *OffloadPluginRunner) getOffloadPluginFromStorageMap() *api.OffloadPlugin {
+	for _, storageMap := range r.Context.Plan.Map.Storage.Spec.Map {
+		if storageMap.Destination.OffloadPlugin != nil {
+			return storageMap.Destination.OffloadPlugin
+		}
+	}
+	return nil
+}
+
+// Build pod template.
+func (r *OffloadPluginRunner) template(secret *core.Secret) (template *core.PodTemplateSpec) {
+	offloadPlugin := r.getOffloadPluginFromStorageMap()
+	volumes, mounts := r.getVolumesAndMounts(secret)
+	template = &core.PodTemplateSpec{
+		Spec: core.PodSpec{
+			RestartPolicy: core.RestartPolicyNever,
+			Containers: []core.Container{
+				{
+					Name:         "offloadplugin",
+					Image:        offloadPlugin.Image,
+					Env:          r.getEnvironments(offloadPlugin),
+					VolumeMounts: mounts,
+				},
+			},
+			Volumes: volumes,
+		},
+	}
+
+	return
+}
+
+// Labels for created resources.
+func (r *OffloadPluginRunner) labels() map[string]string {
+	return map[string]string{
+		kPlan:      string(r.Plan.UID),
+		kMigration: string(r.Migration.UID),
+		kVM:        r.vm.ID,
+		kStep:      r.vm.Phase,
+	}
+}
+
+func (r *OffloadPluginRunner) getEnvironments(offloadPlugin *api.OffloadPlugin) (environments []core.EnvVar) {
+	environments = append(environments,
+		core.EnvVar{
+			Name:  "HOST",
+			Value: r.Context.Source.Provider.Spec.URL,
+		},
+		core.EnvVar{
+			Name:  "PLAN_NAME",
+			Value: r.Context.Plan.Name,
+		},
+		core.EnvVar{
+			Name:  "NAMESPACE",
+			Value: r.Context.Plan.Namespace,
+		},
+	)
+	for key, val := range offloadPlugin.Vars {
+		environments = append(environments,
+			core.EnvVar{
+				Name:  key,
+				Value: val,
+			})
+	}
+	return environments
+}
+
+func (r *OffloadPluginRunner) getVolumesAndMounts(secret *core.Secret) (volumes []core.Volume, mounts []core.VolumeMount) {
+	var secretVolumeName = "secret-volume"
+	volumes = append(volumes,
+		core.Volume{
+			Name: secretVolumeName,
+			VolumeSource: core.VolumeSource{
+				Secret: &core.SecretVolumeSource{
+					SecretName: secret.Name,
+				},
+			},
+		},
+	)
+	mounts = append(mounts,
+		core.VolumeMount{
+			Name:      secretVolumeName,
+			MountPath: "/etc/secret",
+			ReadOnly:  true,
+		})
+	return volumes, mounts
+}

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -197,27 +197,15 @@ func (r *Scheduler) buildPending() (err error) {
 }
 
 func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {
-	coldLocal, _ := r.Plan.VSphereColdLocal()
-	if coldLocal {
-		switch vmStatus.Phase {
-		case CreateVM, PostHook, Completed:
-			// In these phases we already have the disk transferred and are left only to create the VM
-			// By setting the cost to 0 other VMs can start migrating
-			return 0
-		default:
-			return 1
-		}
-	} else {
-		switch vmStatus.Phase {
-		case CreateVM, PostHook, Completed, CopyingPaused, ConvertGuest, CreateGuestConversionPod:
-			// The warm/remote migrations this is done on already transferred disks,
-			// and we can start other VM migrations at these point.
-			// By setting the cost to 0 other VMs can start migrating
-			return 0
-		default:
-			// CDI transfers the disks in parallel by different pods
-			return len(vm.Disks) - r.finishedDisks(vmStatus)
-		}
+	switch vmStatus.Phase {
+	case CreateVM, PostHook, Completed, CopyingPaused, ConvertGuest, CreateGuestConversionPod:
+		// The warm/remote migrations this is done on already transferred disks,
+		// and we can start other VM migrations at these point.
+		// By setting the cost to 0 other VMs can start migrating
+		return 0
+	default:
+		// CDI transfers the disks in parallel by different pods
+		return len(vm.Disks) - r.finishedDisks(vmStatus)
 	}
 }
 

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -893,6 +893,7 @@ func (r *Reconciler) cancelOtherActiveVddkCheckJobs(plan *api.Plan) (err error) 
 
 	queryLabels := make(map[string]string, 1)
 	queryLabels["plan"] = jobLabels["plan"]
+	queryLabels["vddk-validation"] = "vddk-validation"
 	delete(queryLabels, "vddk")
 
 	jobs := &batchv1.JobList{}
@@ -976,6 +977,7 @@ func getVddkImageValidationJobLabels(plan *api.Plan) map[string]string {
 	sum := md5.Sum([]byte(image))
 	return map[string]string{
 		"plan": string(plan.ObjectMeta.UID),
+		"step": "vddk-validation",
 		"vddk": hex.EncodeToString(sum[:]),
 	}
 }

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
@@ -108,17 +108,6 @@ func (admitter *PlanAdmitter) validateLUKS() error {
 		log.Error(err, "Provider type (non-VSphere & non-OVA) does not support LUKS")
 		return err
 	}
-
-	coldLocal, vErr := admitter.plan.VSphereColdLocal()
-	if vErr != nil {
-		log.Error(vErr, "Could not analyze plan, failing")
-		return vErr
-	}
-	if !coldLocal {
-		err := liberr.New("migration of encrypted disks is not supported for warm migrations or migrations to remote providers")
-		log.Error(err, "Warm migration does not support LUKS")
-		return err
-	}
 	return nil
 }
 

--- a/virt-v2v/cmd/entrypoint.go
+++ b/virt-v2v/cmd/entrypoint.go
@@ -23,11 +23,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	// virt-v2v or virt-v2v-in-place
-	if _, found := os.LookupEnv("V2V_inPlace"); found {
-		err = runVirtV2vInPlace()
+	// virt-v2v-in-place
+	if source := os.Getenv("V2V_source"); source == global.OVA {
+		err = runVirtV2vOVA()
 	} else {
-		err = runVirtV2v()
+		err = runVirtV2vInPlace()
 	}
 	if err != nil {
 		fmt.Println("Failed to execute virt-v2v command:", err)
@@ -101,102 +101,7 @@ func runVirtV2vInPlace() error {
 	return v2vCmd.Run()
 }
 
-func virtV2vBuildCommand() (args []string, err error) {
-	args = []string{"-v", "-x"}
-	source := os.Getenv("V2V_source")
-
-	requiredEnvVars := map[string][]string{
-		global.VSPHERE: {"V2V_libvirtURL", "V2V_secretKey", "V2V_vmName"},
-		global.OVA:     {"V2V_diskPath", "V2V_vmName"},
-	}
-
-	if envVars, ok := requiredEnvVars[source]; ok {
-		if !utils.CheckEnvVariablesSet(envVars...) {
-			return nil, fmt.Errorf("Following environment variables need to be defined: %v\n", envVars)
-		}
-	} else {
-		providers := make([]string, len(requiredEnvVars))
-		for key := range requiredEnvVars {
-			providers = append(providers, key)
-		}
-		return nil, fmt.Errorf("virt-v2v supports the following providers: {%v}. Provided: %s\n", strings.Join(providers, ", "), source)
-	}
-	args = append(args, "-o", "kubevirt", "-os", global.DIR)
-
-	switch source {
-	case global.VSPHERE:
-		vsphereArgs, err := virtV2vVsphereArgs()
-		if err != nil {
-			return nil, err
-		}
-		args = append(args, vsphereArgs...)
-	case global.OVA:
-		args = append(args, "-i", "ova", os.Getenv("V2V_diskPath"))
-	}
-
-	return args, nil
-}
-
-func virtV2vVsphereArgs() (args []string, err error) {
-	args = append(args, "-i", "libvirt", "-ic", os.Getenv("V2V_libvirtURL"))
-	args = append(args, "-ip", "/etc/secret/secretKey")
-	args, err = addCommonArgs(args)
-	if err != nil {
-		return nil, err
-	}
-	if info, err := os.Stat(global.VDDK); err == nil && info.IsDir() {
-		args = append(args,
-			"-it", "vddk",
-			"-io", fmt.Sprintf("vddk-libdir=%s", global.VDDK),
-			"-io", fmt.Sprintf("vddk-thumbprint=%s", os.Getenv("V2V_fingerprint")),
-		)
-	}
-
-	// When converting VM with name that do not meet DNS1123 RFC requirements,
-	// it should be changed to supported one to ensure the conversion does not fail.
-	if utils.CheckEnvVariablesSet("V2V_NewName") {
-		args = append(args, "-on", os.Getenv("V2V_NewName"))
-	}
-
-	args = append(args, "--", os.Getenv("V2V_vmName"))
-	return args, nil
-}
-
-// addCommonArgs adds a v2v arguments which is used for both virt-v2v and virt-v2v-in-place
-func addCommonArgs(args []string) ([]string, error) {
-	// Allow specifying which disk should be the bootable disk
-	args = append(args, "--root")
-	if utils.CheckEnvVariablesSet("V2V_RootDisk") {
-		args = append(args, os.Getenv("V2V_RootDisk"))
-	} else {
-		args = append(args, "first")
-	}
-
-	// Add the mapping to the virt-v2v, used mainly in the windows when migrating VMs with static IP
-	if envStaticIPs := os.Getenv("V2V_staticIPs"); envStaticIPs != "" {
-		for _, macToIp := range strings.Split(envStaticIPs, "_") {
-			args = append(args, "--mac", macToIp)
-		}
-	}
-
-	// Adds LUKS keys, if they exist
-	luksArgs, err := utils.AddLUKSKeys()
-	if err != nil {
-		return nil, fmt.Errorf("Error adding LUKS keys: %v", err)
-	}
-	args = append(args, luksArgs...)
-
-	var extraArgs []string
-	if envExtraArgs := os.Getenv("V2V_extra_args"); envExtraArgs != "" {
-		if err := json.Unmarshal([]byte(envExtraArgs), &extraArgs); err != nil {
-			return nil, fmt.Errorf("Error parsing extra arguments %v", err)
-		}
-	}
-	args = append(args, extraArgs...)
-	return args, nil
-}
-
-func runVirtV2v() error {
+func runVirtV2vOVA() error {
 	args, err := virtV2vBuildCommand()
 	if err != nil {
 		return err
@@ -235,28 +140,67 @@ func runVirtV2v() error {
 	return nil
 }
 
+func virtV2vBuildCommand() (args []string, err error) {
+	args = []string{"-v", "-x"}
+	source := os.Getenv("V2V_source")
+
+	requiredEnvVars := map[string][]string{
+		global.OVA: {"V2V_diskPath", "V2V_vmName"},
+	}
+
+	if envVars, ok := requiredEnvVars[source]; ok {
+		if !utils.CheckEnvVariablesSet(envVars...) {
+			return nil, fmt.Errorf("Following environment variables need to be defined: %v\n", envVars)
+		}
+	} else {
+		providers := make([]string, len(requiredEnvVars))
+		for key := range requiredEnvVars {
+			providers = append(providers, key)
+		}
+		return nil, fmt.Errorf("virt-v2v supports the following providers: {%v}. Provided: %s\n", strings.Join(providers, ", "), source)
+	}
+	args = append(args, "-o", "kubevirt", "-os", global.DIR, "-i", "ova", os.Getenv("V2V_diskPath"))
+
+	return args, nil
+}
+
+// addCommonArgs adds a v2v arguments which is used for both virt-v2v and virt-v2v-in-place
+func addCommonArgs(args []string) ([]string, error) {
+	// Allow specifying which disk should be the bootable disk
+	args = append(args, "--root")
+	if utils.CheckEnvVariablesSet("V2V_RootDisk") {
+		args = append(args, os.Getenv("V2V_RootDisk"))
+	} else {
+		args = append(args, "first")
+	}
+
+	// Add the mapping to the virt-v2v, used mainly in the windows when migrating VMs with static IP
+	if envStaticIPs := os.Getenv("V2V_staticIPs"); envStaticIPs != "" {
+		for _, macToIp := range strings.Split(envStaticIPs, "_") {
+			args = append(args, "--mac", macToIp)
+		}
+	}
+
+	// Adds LUKS keys, if they exist
+	luksArgs, err := utils.AddLUKSKeys()
+	if err != nil {
+		return nil, fmt.Errorf("Error adding LUKS keys: %v", err)
+	}
+	args = append(args, luksArgs...)
+
+	var extraArgs []string
+	if envExtraArgs := os.Getenv("V2V_extra_args"); envExtraArgs != "" {
+		if err := json.Unmarshal([]byte(envExtraArgs), &extraArgs); err != nil {
+			return nil, fmt.Errorf("Error parsing extra arguments %v", err)
+		}
+	}
+	args = append(args, extraArgs...)
+	return args, nil
+}
+
 // VirtV2VPrepEnvironment used in the cold migration.
 // It creates a links between the downloaded guest image from virt-v2v and mounted PVC.
 func virtV2VPrepEnvironment() (err error) {
-	source := os.Getenv("V2V_source")
-	_, inplace := os.LookupEnv("V2V_inPlace")
-	if source == global.VSPHERE && !inplace {
-		if _, err := os.Stat("/etc/secret/cacert"); err == nil {
-			// use the specified certificate
-			err = os.Symlink("/etc/secret/cacert", "/opt/ca-bundle.crt")
-			if err != nil {
-				fmt.Println("Error creating ca cert link ", err)
-				os.Exit(1)
-			}
-		} else {
-			// otherwise, keep system pool certificates
-			err := os.Symlink("/etc/pki/tls/certs/ca-bundle.crt.bak", "/opt/ca-bundle.crt")
-			if err != nil {
-				fmt.Println("Error creating ca cert link ", err)
-				os.Exit(1)
-			}
-		}
-	}
 	if err = os.MkdirAll(global.DIR, os.ModePerm); err != nil {
 		return fmt.Errorf("Error creating directory: %v", err)
 	}


### PR DESCRIPTION
## Issue:
when migrating the VMs the VM disks need to be transfered over the network.
This is inefficient, takes additional storage and is slow. We need
an alternative way for the disk transfer.

## Design:
This PR is PoC of adding an offload plugin for the disk transfer.
The offload plugin is a specific tool that needs to be implemented
by the CSI provider. To specify the storage offload plugin the user will
need to specify it in the StorageMap destination. This will allow the
users to migrate the VM even with disks across multiple data store types.
For example, some could be managed by the offloadPlugin and some would
still go over the network if needed.

Example of the storage map with offload plugin:
```yaml
spec:
  map:
    - destination:
        offloadPlugin:
          image: 'quay.io/mnecas0/offload:latest'
          vars:
            test1: test1
            test2: test2
        storageClass: nfs-csi
      source:
        id: datastore-30
...
```
The offload plugin is started right after the CreateDataVolumes, this
the way the Kubernetes CSI will create empty PVs into which the disks can be
transfered.

### Variables
The OffloadPlugin step creates a job on the destination cluster. The job
provided offload plugin image and user-defined variables which are 
passed from the storagemap to the job. The job is started with the
following parameters:
- `HOST` = url to the esxi host
- `PLAN_NAME` = plane name
- `NAMESPACE` = namepsace where the migration is running

In addition to these variables, it also mounts the secrets to the vCenter.
The secrets are in the path `/etc/secret` and the files are:
- `accessKeyId` with a username
- `secretKey` with a password

## Note:
This change additionally requires https://github.com/kubev2v/forklift/pull/1109, because right now the
cold migration transfer is managed by the virt-v2v. The https://github.com/kubev2v/forklift/pull/1109 removes
this dependency and moves it out to the CNV CDI. This allows us to split
the transfer and conversion steps which were in the same step from the
forklift perspective. Once the disks are transferred the Forklift does the
`virt-v2v-in-place` on the disks and starts the VM.
In the same way, this step will be done also on the offload plugin as we
will transfer the disks using the offload plugin and then start
`virt-v2v-in-place` on the disks.

## TODO:
- [ ] Add design doc showing larger details, this is just PoC
- [ ] Add check if OffloadPlugin image exists
- [ ] Add check of the offload plugin disk transfer status
- [ ] Allow storage map with OffloadPlugin and without combination
- [ ] Improve the name of the offload pugin job, right now its the VM ID