### PR TITLE
Fix crash in 'concurrent map read and write' in v2.6

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -146,7 +146,7 @@ func Add(mgr manager.Manager) error {
 	}
 
 	// Gather migration Plan metrics
-	metrics.RecordMigrationMetrics(mgr.GetClient())
+	metrics.RecordPlanMetrics(mgr.GetClient())
 
 	return nil
 }


### PR DESCRIPTION
Commit 0f92c03 backported a patch to add metrics collection to the
controllers, but it was backported incorrectly. The migration controller
and the plan controller both called `RecordMigrationMetrics()`, which
starts the same a goroutine and accesses the same data without
synchronization. The Plan controller should have instead called
`RecordPlanMetrics()` as it does in the upstream code.

Fixes: https://issues.redhat.com/browse/MTV-1530

Signed-off-by: Jonathon Jongsma <jjongsma@redhat.com>
