### PR TITLE
MTV-1220 | Add lock to the inventory handler

### DIFF
--- a/pkg/lib/inventory/web/handler.go
+++ b/pkg/lib/inventory/web/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -152,6 +153,8 @@ type WatchWriter struct {
 	log logging.LevelLogger
 	// Done.
 	done bool
+	// Mutex lock
+	mu sync.Mutex
 }
 
 // Watch options.
@@ -257,6 +260,8 @@ func (r *WatchWriter) End() {
 
 // Write event to the socket.
 func (r *WatchWriter) send(e model.Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.done {
 		return
 	}


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-1220

Issue:
When having lot of VMs in the inventory the controller can fail with:
```
panic: concurrent write to websocket connection
        panic: concurrent write to websocket connection
goroutine 4943150 [running]:
github.com/gorilla/websocket.(*messageWriter).flushFrame(0xc004688300, 0x1, {0x0?, 0x29b1560?, 0xc00824b808?})
        /remote-source/app/vendor/github.com/gorilla/websocket/conn.go:632 +0x4b8
github.com/gorilla/websocket.(*messageWriter).Close(0x30?)
        /remote-source/app/vendor/github.com/gorilla/websocket/conn.go:746 +0x35
github.com/gorilla/websocket.(*Conn).beginMessage(0xc00aa1fce0, 0xc0044ec870, 0x1)
        /remote-source/app/vendor/github.com/gorilla/websocket/conn.go:493 +0x47
```
This is caused by the concurrent write to websocket connection this fix adds a lock so the goroutines wait before sending the response.