### PR TITLE
MTV-1458 | Make Guest information on vNICs is missing a warning

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -326,6 +326,13 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	conditionRequiresReQ := plan.Status.HasReQCondition()
 	if plan.Status.HasBlockerCondition() || plan.Status.HasCondition(Archived) || conditionRequiresReQ {
 		if conditionRequiresReQ {
+			r.Log.Info(
+				"Found a condition requiring re-reconcile.",
+				"plan",
+				path.Join(
+					plan.GetNamespace(),
+					plan.GetName()))
+
 			reQ = base.SlowReQ
 		}
 		return

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -440,8 +440,8 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     VMMissingGuestIPs,
 		Status:   True,
 		Reason:   MissingGuestInfo,
-		Category: Critical,
-		Message:  "Guest information on vNICs is missing, cannot preserve static IPs. Make sure VMware tools are installed and the VM is running.",
+		Category: Warn,
+		Message:  "Guest information on vNICs is missing, cannot preserve static IPs. If this machine has static IP, make sure VMware tools are installed and the VM is running.",
 		Items:    []string{},
 	}
 	missingCbtForWarm := libcnd.Condition{

--- a/pkg/lib/condition/condition.go
+++ b/pkg/lib/condition/condition.go
@@ -321,7 +321,7 @@ func (r *Conditions) HasBlockerCondition() bool {
 
 // The collection contains blocker conditions that keep the plan reconciling.
 func (r *Conditions) HasReQCondition() bool {
-	return r.HasCondition(ValidatingVDDK) || r.HasCondition(VMMissingGuestIPs) || r.HasCondition(VMMissingChangedBlockTracking)
+	return r.HasCondition(ValidatingVDDK) || r.HasCondition(VMMissingChangedBlockTracking)
 }
 
 // The collection contains the `Ready` condition.


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-1458

When selecting "preserve static IP" and migrating a VM without a static IP configuration, then the backend is reporting that the VM was not run. But thi sis incorrect, the VM was run, but it just does not have a static IP configuration (nt inside, and also not repoetred by the VMw API).

Issue:
Currently if a VM does not have static IP, and we set "preserve static IP" the plan is blocked,

Fix:
Changing the condition from "critical" to "warn" will unblock the plan, while still warning the user we may have an issue.