### PR TITLE
MTV-1627 | Fix the PVC search for the progress

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1582,8 +1582,23 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 							path.Join(dv.Namespace, dv.Name))
 						continue
 					}
+					primePvc := &core.PersistentVolumeClaim{}
+					err = r.Destination.Client.Get(context.TODO(), types.NamespacedName{
+						Namespace: r.Plan.Spec.TargetNamespace,
+						Name:      fmt.Sprintf("prime-%s", pvc.UID),
+					}, primePvc)
+					if err != nil {
+						log.Error(
+							err,
+							"Could not get prime PVC for DataVolume.",
+							"vm",
+							vm.String(),
+							"dv",
+							path.Join(dv.Namespace, dv.Name))
+						continue
+					}
 
-					importer, found, kErr = r.kubevirt.GetImporterPod(*pvc)
+					importer, found, kErr = r.kubevirt.GetImporterPod(*primePvc)
 				}
 
 				if kErr != nil {


### PR DESCRIPTION
Issue:
When monitoring the migration process the forklift requests the PVC from DV ClaimName. On top of that the forklift checks the Annotation "cdi.kubevirt.io/storage.import.importPodName". But this annotation is missing in the main PVC but is present in the prime pvc, whose format is "prime-$UID_MAINPVC". This annotation points to the created pod which imports the volume.

Fix:
Search the prime PVC instead of the main PVC, so the forklift is able to check the importer pod status.

Ref: https://issues.redhat.com/browse/MTV-1627