### PR TITLE
Add recording rule to collect migrations data to telemetry.

### DIFF
--- a/operator/config/rbac/leader_election_role.yaml
+++ b/operator/config/rbac/leader_election_role.yaml
@@ -37,6 +37,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - servicemonitors
+  - prometheusrules
   verbs:
   - get
   - create

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -119,4 +119,5 @@ metric_service_name: "{{ app_name }}-metrics"
 metric_servicemonitor_name: "{{ app_name }}-metrics"
 metric_interval: "30s"
 metric_port_name: "metrics"
+metrics_rule_name: "{{app_name}}-migration-rules"
 

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -90,6 +90,11 @@
       k8s:
         state: present
         definition: "{{ lookup('template', 'monitor/servicemonitor-metrics.yml.j2') }}"
+
+    - name: "Setup migration recording rules"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'monitor/recordingrole-migrations.yml.j2') }}"
     
     - name: "Add monitoring label to namespace"
       k8s:

--- a/operator/roles/forkliftcontroller/templates/monitor/recordingrole-migrations.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/monitor/recordingrole-migrations.yml.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ metrics_rule_name }}
+  namespace: {{ app_namespace }}
+spec:
+  groups:
+  - name: mtv-migrations
+    rules:
+    - record: cluster:mtv_migrations_status_total:max
+      expr: max by(status, provider, mode, target) (mtv_migrations_status_total)
+      labels:
+        app: {{ app_name }}


### PR DESCRIPTION
Following the request of adding recording rule in https://github.com/openshift/cluster-monitoring-operator/pull/2461