### PR TITLE
MTV-1645 Change default network annotation.

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -54,7 +54,7 @@ import (
 // Annotations
 const (
 	// Transfer network annotation (value=network-attachment-definition name)
-	AnnDefaultNetwork = "v1.multus-cni.io/default-network"
+	AnnDefaultNetwork = "k8s.v1.cni.cncf.io/networks"
 	// Contains validations for a Kubevirt VM. Needs to be removed when
 	// creating a VM from a template.
 	AnnKubevirtValidations = "vm.kubevirt.io/validations"

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -54,7 +54,7 @@ import (
 // Annotations
 const (
 	// Transfer network annotation (value=network-attachment-definition name)
-	AnnDefaultNetwork = "k8s.v1.cni.cncf.io/networks"
+	AnnTransferNetwork = "k8s.v1.cni.cncf.io/networks"
 	// Contains validations for a Kubevirt VM. Needs to be removed when
 	// creating a VM from a template.
 	AnnKubevirtValidations = "vm.kubevirt.io/validations"
@@ -1227,7 +1227,7 @@ func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap
 		annotations[planbase.AnnRetainAfterCompletion] = "true"
 	}
 	if r.Plan.Spec.TransferNetwork != nil {
-		annotations[AnnDefaultNetwork] = path.Join(
+		annotations[AnnTransferNetwork] = path.Join(
 			r.Plan.Spec.TransferNetwork.Namespace, r.Plan.Spec.TransferNetwork.Name)
 	}
 	if r.Plan.Spec.Warm || !r.Destination.Provider.IsHost() || r.Plan.IsSourceProviderOCP() {
@@ -1757,7 +1757,7 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	// pod annotations
 	annotations := map[string]string{}
 	if r.Plan.Spec.TransferNetwork != nil {
-		annotations[AnnDefaultNetwork] = path.Join(
+		annotations[AnnTransferNetwork] = path.Join(
 			r.Plan.Spec.TransferNetwork.Namespace, r.Plan.Spec.TransferNetwork.Name)
 	}
 	// pod

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -75,7 +75,7 @@ const (
 	reasonPodFinished        = "PopulatorFinished"
 	reasonPVCCreationError   = "PopulatorPVCCreationError"
 	reasonPopulatorProgress  = "PopulatorProgress"
-	AnnDefaultNetwork        = "k8s.v1.cni.cncf.io/networks"
+	AnnTransferNetwork       = "k8s.v1.cni.cncf.io/networks"
 	AnnPopulatorReCreations  = "recreations"
 
 	qemuGroup = 107
@@ -594,7 +594,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 			annotations := make(map[string]string)
 			if found {
 				// Join the transfer network namespace and name
-				annotations[AnnDefaultNetwork] = fmt.Sprintf("%s/%s", transferNetwork["namespace"], transferNetwork["name"])
+				annotations[AnnTransferNetwork] = fmt.Sprintf("%s/%s", transferNetwork["namespace"], transferNetwork["name"])
 			}
 			migration, found, err := unstructured.NestedString(crInstance.Object, "metadata", "labels", "migration")
 			if err != nil {

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -75,7 +75,7 @@ const (
 	reasonPodFinished        = "PopulatorFinished"
 	reasonPVCCreationError   = "PopulatorPVCCreationError"
 	reasonPopulatorProgress  = "PopulatorProgress"
-	AnnDefaultNetwork        = "v1.multus-cni.io/default-network"
+	AnnDefaultNetwork        = "k8s.v1.cni.cncf.io/networks"
 	AnnPopulatorReCreations  = "recreations"
 
 	qemuGroup = 107


### PR DESCRIPTION
The importer pod can get stuck creating if there are multiple networks and the wrong default network override annotation is configured. This changes the annotation as requested in [MTV-1645](https://issues.redhat.com/browse/MTV-1645).

I reproduced the bug without the change, and managed a successful transfer with the change applied.