### PR TITLE
Fix duplicated network interfaces on ESXi provider

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -283,6 +283,7 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 			case fVSwitch:
 				if array, cast := p.Val.(types.ArrayOfHostVirtualSwitch); cast {
 					network := &v.model.Network
+					network.Switches = nil
 					for _, vSwitch := range array.HostVirtualSwitch {
 						network.Switches = append(
 							network.Switches,
@@ -297,6 +298,7 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 			case fPortGroup:
 				if array, cast := p.Val.(types.ArrayOfHostPortGroup); cast {
 					network := &v.model.Network
+					network.PortGroups = nil
 					for _, portGroup := range array.HostPortGroup {
 						network.PortGroups = append(
 							network.PortGroups,
@@ -310,6 +312,7 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 			case fPNIC:
 				if array, cast := p.Val.(types.ArrayOfPhysicalNic); cast {
 					network := &v.model.Network
+					network.PNICs = nil
 					for _, nic := range array.PhysicalNic {
 						linkSpeed := int32(0)
 						if nic.LinkSpeed != nil {
@@ -331,6 +334,7 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 			case fVNIC:
 				if array, cast := p.Val.(types.ArrayOfHostVirtualNic); cast {
 					network := &v.model.Network
+					network.VNICs = nil
 					for _, nic := range array.HostVirtualNic {
 						dGroup := func() (key string) {
 							dp := nic.Spec.DistributedVirtualPort


### PR DESCRIPTION
Bug MTV-1291 describes an issue where, on ESXi providers, opening the modal dialog for changing the migration network for a host may display a list with multiple copies of the same network listed as options. This same issue was not observed with the vCenter endpoint type for the same provider.

I managed to reproduce this behavior by simply starting a vm on the host. After the VM boots up, the ESXi provider will emit an ObjectUpdate for the host object which contains ChangeSets that assign new values to the list of PNICs, VNICs, portgroups, and vswitches for that host. It doesn't appear that these values have changed, so it's unclear why we're getting change notifications for them. But, the end result is that every time a vm is started, a duplicate list of networks is being appended to the current list of networks for the host. So when I started a VM 5 times on the host, the list of networks ended up with 5 duplicates of each network interface.

When getting object updates from the ESXi server, object values that are array types (such as vswitch, portgroup, pnic, vnic), were being appended to our current list of values for those properties. But since the object update contains the entire list of values for those properties, this ended up adding duplicate values to our list. The solution to the issue is to *replace* our current array of networks with the values that we receive from the object update event rather than appending them to our current array.

As far as I can tell, the vCenter provider doesn't seem to trigger the host object update event when a vm starts, which is why the same behavior was not seen for this provider type. But it seems that it would also be susceptible to the same bug if the update did ever occur.

Fixes: https://issues.redhat.com/browse/MTV-1291
