### PR TITLE
VMware warm migration - Fix snapshot cleanup

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -986,7 +986,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		if r.Migration.Spec.Cutover != nil && !r.Migration.Spec.Cutover.After(time.Now()) {
 			vm.Phase = StorePowerState
 		} else if vm.Warm.NextPrecopyAt != nil && !vm.Warm.NextPrecopyAt.After(time.Now()) {
-			vm.Phase = CreateSnapshot
+			vm.Phase = r.next(vm.Phase)
 		}
 	case RemovePreviousSnapshot, RemovePenultimateSnapshot, RemoveFinalSnapshot:
 		step, found := vm.FindStep(r.step(vm))


### PR DESCRIPTION
Issue:
The `CreateSnapshot` is after `RemovePreviousSnapshot` so with the warm migration, we always skipped the snapshot cleanup step. 

Fix:
Get the next migration phase dynamically. This way the VMware migration will run `RemovePreviousSnapshot` and the other migrations will run `CreateSnapshot``.

Ref:
https://issues.redhat.com/browse/MTV-1656