### PR TITLE
Add WaitForResult when removing the vmware snapshot

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -381,11 +381,17 @@ func (r *Client) removeSnapshot(vmRef ref.Ref, snapshot string, children bool, h
 	if err != nil {
 		return
 	}
-	_, err = vm.RemoveSnapshot(context.TODO(), snapshot, children, &consolidate)
+	task, err := vm.RemoveSnapshot(context.TODO(), snapshot, children, &consolidate)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
+	res, err := task.WaitForResult(context.TODO(), nil)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	r.Log.Info("Deleted snapshot", "vmRef", vmRef, "state", res.State)
 	return
 }
 


### PR DESCRIPTION
This PR adds a WaitForResults when removing the VMware snapshots so we will get actual results in case something breaks we will be able to see it in the logs. 