### PR TITLE
warm migration: remove prev snapshot before pause

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -82,7 +82,6 @@ const (
 	StoreSnapshotDeltas        = "StoreSnapshotDeltas"
 	StoreInitialSnapshotDeltas = "StoreInitialSnapshotDeltas"
 	RemovePreviousSnapshot     = "RemovePreviousSnapshot"
-	RemovePenultimateSnapshot  = "RemovePenultimateSnapshot"
 	RemoveFinalSnapshot        = "RemoveFinalSnapshot"
 )
 
@@ -134,8 +133,8 @@ var (
 			{Name: StoreInitialSnapshotDeltas, All: VSphere},
 			{Name: CreateDataVolumes},
 			{Name: CopyDisks},
-			{Name: CopyingPaused},
 			{Name: RemovePreviousSnapshot, All: VSphere},
+			{Name: CopyingPaused},
 			{Name: CreateSnapshot},
 			{Name: WaitForSnapshot},
 			{Name: StoreSnapshotDeltas, All: VSphere},
@@ -143,7 +142,6 @@ var (
 			{Name: StorePowerState},
 			{Name: PowerOffSource},
 			{Name: WaitForPowerOff},
-			{Name: RemovePenultimateSnapshot, All: VSphere},
 			{Name: CreateFinalSnapshot},
 			{Name: WaitForFinalSnapshot},
 			{Name: AddFinalCheckpoint},
@@ -663,7 +661,7 @@ func (r *Migration) step(vm *plan.VMStatus) (step string) {
 		step = DiskAllocation
 	case CopyDisks, CopyingPaused, RemovePreviousSnapshot, CreateSnapshot, WaitForSnapshot, StoreSnapshotDeltas, AddCheckpoint, ConvertOpenstackSnapshot:
 		step = DiskTransfer
-	case RemovePenultimateSnapshot, CreateFinalSnapshot, WaitForFinalSnapshot, AddFinalCheckpoint, Finalize, RemoveFinalSnapshot:
+	case CreateFinalSnapshot, WaitForFinalSnapshot, AddFinalCheckpoint, Finalize, RemoveFinalSnapshot:
 		step = Cutover
 	case CreateGuestConversionPod, ConvertGuest:
 		step = ImageConversion
@@ -988,7 +986,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		} else if vm.Warm.NextPrecopyAt != nil && !vm.Warm.NextPrecopyAt.After(time.Now()) {
 			vm.Phase = r.next(vm.Phase)
 		}
-	case RemovePreviousSnapshot, RemovePenultimateSnapshot, RemoveFinalSnapshot:
+	case RemovePreviousSnapshot, RemoveFinalSnapshot:
 		step, found := vm.FindStep(r.step(vm))
 		if !found {
 			vm.AddError(fmt.Sprintf("Step '%s' not found", r.step(vm)))


### PR DESCRIPTION
The migration controller currently waits until the next precopy phase starts to remove the old snapshot.
Deleting the previous snapshot prior to pausing should speed the process up.