### PR TITLE
feat: add ova ProductSection to ova provider server resp

### DIFF
--- a/cmd/ova-provider-server/ova-provider-server.go
+++ b/cmd/ova-provider-server/ova-provider-server.go
@@ -109,6 +109,7 @@ type VirtualSystem struct {
 		OsType      string `xml:"osType,attr"`
 	} `xml:"OperatingSystemSection"`
 	HardwareSection VirtualHardwareSection `xml:"VirtualHardwareSection"`
+	Product         ProductSection         `xml:"ProductSection"`
 }
 
 type Envelope struct {
@@ -117,6 +118,28 @@ type Envelope struct {
 	DiskSection    DiskSection     `xml:"DiskSection"`
 	NetworkSection NetworkSection  `xml:"NetworkSection"`
 	References     References      `xml:"References"`
+}
+
+type ProductSection struct {
+	Property []Property `xml:"Property"`
+}
+
+type Property struct {
+	Key              string  `xml:"key,attr"`
+	Type             string  `xml:"type,attr"`
+	Qualifiers       *string `xml:"qualifiers,attr"`
+	UserConfigurable *bool   `xml:"userConfigurable,attr"`
+	Default          *string `xml:"value,attr"`
+	Password         *bool   `xml:"password,attr"`
+
+	Label       *string `xml:"Label"`
+	Description *string `xml:"Description"`
+
+	Values []PropertyConfigurationValue `xml:"Value"`
+}
+
+type PropertyConfigurationValue struct {
+	Value string `xml:"value,attr"`
 }
 
 // vm struct
@@ -147,6 +170,7 @@ type VM struct {
 	NICs                  []NIC
 	Disks                 []VmDisk
 	Networks              []VmNetwork
+	Product               ProductSection
 }
 
 // Virtual Disk.
@@ -440,6 +464,7 @@ func convertToVmStruct(envelope []Envelope, ovaPath []string) ([]VM, error) {
 				OvaPath: ovaPath[i],
 				Name:    virtualSystem.Name,
 				OsType:  virtualSystem.OperatingSystemSection.OsType,
+				Product: virtualSystem.Product,
 			}
 
 			for _, item := range virtualSystem.HardwareSection.Items {

--- a/pkg/controller/provider/container/ova/resource.go
+++ b/pkg/controller/provider/container/ova/resource.go
@@ -61,6 +61,21 @@ type VM struct {
 		Name        string `json:"Name"`
 		Description string `json:"Description"`
 	} `json:"Networks"`
+	Product struct {
+		Property []struct {
+			Key              string  `json:"Key"`
+			Type             string  `json:"Type"`
+			Qualifiers       *string `json:"Qualifiers"`
+			UserConfigurable *bool   `json:"UserConfigurable"`
+			Default          *string `json:"Default"`
+			Password         *bool   `json:"Password"`
+			Label            *string `json:"Label"`
+			Description      *string `json:"Description"`
+			Values           []struct {
+				Value string `json:"Value"`
+			} `json:"Values"`
+		} `json:"Property"`
+	} `json:"Product"`
 }
 
 // Apply to (update) the model.
@@ -91,6 +106,7 @@ func (r *VM) ApplyTo(m *model.VM) {
 	r.addDisks(m)
 	r.addDevices(m)
 	r.addNetworks(m)
+	r.addProduct(m)
 }
 
 func (r *VM) addNICs(m *model.VM) {
@@ -159,6 +175,27 @@ func (r *VM) addNetworks(m *model.VM) {
 					ID:   network.ID,
 				},
 			})
+	}
+}
+
+func (r *VM) addProduct(m *model.VM) {
+	m.Product = model.Product{}
+	for _, property := range r.Product.Property {
+		values := []model.PropertyConfigurationValue{}
+		for _, value := range property.Values {
+			values = append(values, model.PropertyConfigurationValue{Value: value.Value})
+		}
+		m.Product.Property = append(m.Product.Property, model.Property{
+			Key:              property.Key,
+			Type:             property.Type,
+			Qualifiers:       property.Qualifiers,
+			UserConfigurable: property.UserConfigurable,
+			Default:          property.Default,
+			Password:         property.Password,
+			Label:            property.Label,
+			Description:      property.Description,
+			Values:           values,
+		})
 	}
 }
 

--- a/pkg/controller/provider/model/ova/model.go
+++ b/pkg/controller/provider/model/ova/model.go
@@ -93,6 +93,29 @@ type VM struct {
 	Disks                 []Disk    `sql:""`
 	Networks              []Network `sql:""`
 	Concerns              []Concern `sql:""`
+	Product               Product   `sql:""`
+}
+
+type Product struct {
+	Property []Property `sql:""`
+}
+
+type Property struct {
+	Key              string  `sql:""`
+	Type             string  `sql:""`
+	Qualifiers       *string `sql:""`
+	UserConfigurable *bool   `sql:""`
+	Default          *string `sql:""`
+	Password         *bool   `sql:""`
+
+	Label       *string `sql:""`
+	Description *string `sql:""`
+
+	Values []PropertyConfigurationValue `sql:""`
+}
+
+type PropertyConfigurationValue struct {
+	Value string `sql:""`
 }
 
 // Virtual Disk.

--- a/pkg/controller/provider/web/ova/vm.go
+++ b/pkg/controller/provider/web/ova/vm.go
@@ -227,6 +227,7 @@ type VM struct {
 	NICs                  []model.NIC     `json:"nics"`
 	Disks                 []model.Disk    `json:"disks"`
 	Networks              []model.Network `json:"networks"`
+	Product               model.Product   `json:"product"`
 }
 
 // Build the resource using the model.
@@ -255,6 +256,7 @@ func (r *VM) With(m *model.VM) {
 	r.OvaPath = m.OvaPath
 	r.Disks = m.Disks
 	r.Networks = m.Networks
+	r.Product = m.Product
 }
 
 // Build self link (URI).


### PR DESCRIPTION
This PR extends the Inventory service and OVA provider server to also return the ProductSection as part of the VM payload. ProductSection can contain user configurable fields that need to be set in order for the VM to run properly. Only the relevant subset of the original [ProductSection](https://github.com/vmware/govmomi/blob/main/ovf/envelope.go#L77) is added.

Example response:
```json
"product": {
        "Property": [
            {
                "Key": "va-ssh-public-key",
                "Type": "string",
                "Qualifiers": null,
                "UserConfigurable": true,
                "Default": null,
                "Password": null,
                "Label": "Set the SSH public key allowed to access the appliance",
                "Description": "This will enable the SSHD service and configure the specified public key for the user 'bitnami'",
                "Values": null
            },
            {
                "Key": "user-data",
                "Type": "string",
                "Qualifiers": null,
                "UserConfigurable": true,
                "Default": null,
                "Password": null,
                "Label": "User data to be made available inside the instance",
                "Description": "This allows to pass any text to the appliance. It will be executed if it starts with a shebang (\"#!\"). The value should be encoded in base64",
                "Values": null
            }
        ]
    }
```
