### PR TITLE
fix: switch to working virtio-win driver link

### DIFF
--- a/virt-v2v/BUILD.bazel
+++ b/virt-v2v/BUILD.bazel
@@ -451,7 +451,7 @@ rpmtree(
         "@util-linux-core-0__2.37.4-20.el9.x86_64//rpm",
         "@vim-minimal-2__8.2.2637-21.el9.x86_64//rpm",
         "@virt-v2v-1__2.5.6-4.el9.x86_64//rpm",
-        "@virtio-win-1.9.40-1.el9.noarch//rpm",
+        "@virtio-win-0.1.266-1.noarch//rpm",
         "@which-0__2.21-29.el9.x86_64//rpm",
         "@xfsprogs-0__6.4.0-4.el9.x86_64//rpm",
         "@xz-0__5.2.5-8.el9.x86_64//rpm",

--- a/virt-v2v/WORKSPACE
+++ b/virt-v2v/WORKSPACE
@@ -2931,10 +2931,10 @@ rpm(
 )
 
 rpm(
-    name = "virtio-win-1.9.40-1.el9.noarch",
-    sha256 = "7baa1bddc62a72798b00f1ccd7ba46e3a79d7cd8224d3aabae328719f4d604bc",
+    name = "virtio-win-0.1.266-1.noarch",
+    sha256 = "ea94b41acff28aebc90e100e9b4e6042ff85b170b9dfe397700a4c87403255c9",
     urls = [
-        "https://kojihub.stream.rdu2.redhat.com/kojifiles/packages/virtio-win/1.9.40/1.el9/noarch/virtio-win-1.9.40-1.el9.noarch.rpm",
+        "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.266-1/virtio-win-0.1.266-1.noarch.rpm",
     ],
 )
 


### PR DESCRIPTION
Following up on https://github.com/kubev2v/forklift/pull/1048#issuecomment-2492004285, the virtio-win driver link currently used in the Bazel build does not seem to work. `quay.io/kubev2v/forklift-virt-v2v:latest` still contains the old 1.9.15 version. This is causing Windows 2022 VMs to boot to blue screen after migration.

This PR swaps to a different, working, virtio-win package link. This is a fedora package, but it seems to be compatible with the CentOS image being used for virt-v2v. Tested with Win22, the machine successfully boots up and is usable.

This is hopefully a temporary solution while a working download for the CentOS package is being resolved.