### PR TITLE
MTV-1695 | Add missing NIC for opaque network

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -578,7 +578,7 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 		needed := []vsphere.NIC{}
 		for _, nic := range vm.NICs {
 			switch network.Variant {
-			case vsphere.NetDvPortGroup:
+			case vsphere.NetDvPortGroup, vsphere.OpaqueNetwork:
 				if nic.Network.ID == network.Key {
 					needed = append(needed, nic)
 				}

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -42,6 +42,7 @@ const (
 	ComputeResource = "ComputeResource"
 	Host            = "HostSystem"
 	Network         = "Network"
+	OpaqueNetwork   = "OpaqueNetwork"
 	DVPortGroup     = "DistributedVirtualPortgroup"
 	DVSwitch        = "VmwareDistributedVirtualSwitch"
 	Datastore       = "Datastore"
@@ -83,7 +84,8 @@ const (
 	fThumbprint     = "summary.config.sslThumbprint"
 	fMgtServerIp    = "summary.managementServerIp"
 	// Network
-	fTag = "tag"
+	fTag     = "tag"
+	fSummary = "summary"
 	// PortGroup
 	fDVSwitch = "config.distributedVirtualSwitch"
 	fKey      = "key"
@@ -672,6 +674,15 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 			},
 		},
 		{
+			Type: OpaqueNetwork,
+			PathSet: []string{
+				fName,
+				fParent,
+				fTag,
+				fSummary,
+			},
+		},
+		{
 			Type: DVPortGroup,
 			PathSet: []string{
 				fName,
@@ -819,6 +830,15 @@ func (r *Collector) selectAdapter(u types.ObjectUpdate) (Adapter, bool) {
 			model: model.Network{
 				Base: model.Base{
 					Variant: model.NetStandard,
+					ID:      u.Obj.Value,
+				},
+			},
+		}
+	case OpaqueNetwork:
+		adapter = &NetworkAdapter{
+			model: model.Network{
+				Base: model.Base{
+					Variant: model.OpaqueNetwork,
 					ID:      u.Obj.Value,
 				},
 			},

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -390,6 +390,10 @@ func (v *NetworkAdapter) Apply(u types.ObjectUpdate) {
 				}
 			case fDVSwitch:
 				v.model.DVSwitch = v.Ref(p.Val)
+			case fSummary:
+				if s, cast := p.Val.(types.OpaqueNetworkSummary); cast {
+					v.model.Key = s.OpaqueNetworkId
+				}
 			}
 		}
 	}
@@ -704,6 +708,8 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 								}
 							case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
 								network = backing.Port.PortgroupKey
+							case *types.VirtualEthernetCardOpaqueNetworkBackingInfo:
+								network = backing.OpaqueNetworkId
 							}
 
 							devList = append(

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -10,6 +10,7 @@ const (
 	// Network.
 	NetStandard    = "Standard"
 	NetDvPortGroup = "DvPortGroup"
+	OpaqueNetwork  = "OpaqueNetwork"
 	NetDvSwitch    = "DvSwitch"
 	// Cluster.
 	ComputeResource = "ComputeResource"

--- a/pkg/controller/provider/web/vsphere/network.go
+++ b/pkg/controller/provider/web/vsphere/network.go
@@ -191,6 +191,8 @@ func (r *Network) With(m *model.Network) {
 	case model.NetDvPortGroup:
 		r.DVSwitch = &m.DVSwitch
 		r.Key = m.Key
+	case model.OpaqueNetwork:
+		r.Key = m.Key
 	case model.NetDvSwitch:
 		r.Host = m.Host
 	}


### PR DESCRIPTION
Issue: When user has NSXT managed network it is represented as opaque network and the VM has opaque nic.

Fix: Add opaque network model mapping to inventory

Ref: https://issues.redhat.com/browse/MTV-1695