### PR TITLE
Expose FEATURE_RETAIN_PRECOPY_IMPORTER_PODS

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -36,6 +36,7 @@ controller_snapshot_status_check_rate_seconds: 10
 controller_cleanup_retries: 10
 controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
+controller_retain_precopy_importer_pods: false
 controller_max_vm_inflight: 20
 controller_filesystem_overhead: 10
 controller_block_overhead: 0

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -103,6 +103,10 @@ spec:
         - name: FEATURE_OVIRT_WARM_MIGRATION
           value: "true"
 {% endif %}
+{% if controller_retain_precopy_importer_pods|bool %}
+        - name: FEATURE_RETAIN_PRECOPY_IMPORTER_PODS
+          value: "true"
+{% endif %}
 {% if ovirt_osmap_configmap_name is defined %}
         - name: OVIRT_OS_MAP
           value: {{ ovirt_osmap_configmap_name }}


### PR DESCRIPTION
This change exposes the feature flag to retain the CDI importer pods on the controller CR. Disabled by default.