### PR TITLE
Fix regression virtio win driver for v2v

### DIFF
--- a/virt-v2v/BUILD.bazel
+++ b/virt-v2v/BUILD.bazel
@@ -437,7 +437,7 @@ rpmtree(
         "@util-linux-core-0__2.37.4-20.el9.x86_64//rpm",
         "@vim-minimal-2__8.2.2637-21.el9.x86_64//rpm",
         "@virt-v2v-1__2.7.1-1.el9.x86_64//rpm",
-        "@virtio-win-0__1.9.15-4.el9.x86_64//rpm",
+        "@virtio-win-1.9.40-1.el9.noarch//rpm",
         "@which-0__2.21-29.el9.x86_64//rpm",
         "@xfsprogs-0__6.4.0-4.el9.x86_64//rpm",
         "@xz-0__5.2.5-8.el9.x86_64//rpm",

--- a/virt-v2v/WORKSPACE
+++ b/virt-v2v/WORKSPACE
@@ -2819,10 +2819,10 @@ rpm(
 )
 
 rpm(
-    name = "virtio-win-0__1.9.15-4.el9.x86_64",
-    sha256 = "6673ae4cb0f24fdc75b12b68aa37533c29eae2a98eaa60d1ee7c8390f7edd20b",
+    name = "virtio-win-1.9.40-1.el9.noarch",
+    sha256 = "7baa1bddc62a72798b00f1ccd7ba46e3a79d7cd8224d3aabae328719f4d604bc",
     urls = [
-        "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/AppStream/x86_64/os/Packages/virtio-win-1.9.15-4.el9.noarch.rpm",
+        "https://kojihub.stream.centos.org/kojifiles/packages/virtio-win/1.9.40/1.el9/noarch/virtio-win-1.9.40-1.el9.noarch.rpm",
     ],
 )
 


### PR DESCRIPTION
Regression introduced by: https://github.com/kubev2v/forklift/pull/1214 
When running the `./hack/virt-v2v-rpm-deps.sh` it will automatically replace the newer driver with the older available drivers. 