### PR TITLE
Support specifying the transfer net by configmap

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -107,7 +107,8 @@ const (
 
 // Kinds
 const (
-	ConfigMap = "ConfigMap"
+	ConfigMap                   = "ConfigMap"
+	NetworkAttachmentDefinition = "NetworkAttachmentDefinition"
 )
 
 // Validate the plan resource.
@@ -713,8 +714,17 @@ func (r *Reconciler) validateTransferNetwork(plan *api.Plan) (err error) {
 	switch plan.Spec.TransferNetwork.Kind {
 	case ConfigMap:
 		err = r.validateTransferNetworkConfigMap(plan, key)
-	default:
+	case "", NetworkAttachmentDefinition:
 		err = r.validateTransferNetworkAttachmentDefinition(plan, key)
+	default:
+		unsupported := libcnd.Condition{
+			Type:     TransferNetNotValid,
+			Status:   True,
+			Category: Critical,
+			Reason:   NotSupported,
+			Message:  "Unsupported transfer network reference Kind.",
+		}
+		plan.Status.SetCondition(unsupported)
 	}
 	if err != nil {
 		err = liberr.Wrap(err)


### PR DESCRIPTION
The `k8s.v1.cni.cncf.org/networks` annotation supports a json value with a list of [NetworkSelectionElements](https://pkg.go.dev/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1#NetworkSelectionElement) that contain additional configuration for the secondary network attachment, including a default route.

This change allows the user to specify the transfer network by referencing a ConfigMap that contains a `NetworkSelectionElement`. The Plan CR already uses an ObjectReference type for the `transferNetwork` field, so we can take advantage of the `kind` field on the ObjectReference to specify that a ConfigMap is being used without having to make any changes to the Plan CR. The transfer network validation has been expanded to check that the ConfigMap is in the correct format and that the NAD the ConfigMap refers to exists.

To maintain compatibility with previous versions of Forklift, the original behavior (using the `v1.multus-cni.io/default-network` annotation) is preserved if a ConfigMap is not specified in the Plan.

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: secondary-net-config
  namespace: default
data:
  interface: net2
  name: secondary-net
  namespace: default
  default-route: [...]
```

```yaml
spec:
  targetNamespace: default
  transferNetwork:
    kind: ConfigMap
    name: secondary-net-config
    namespace: default
  vms:
    - id: vm-1074
      name: slucidi-mtv
```