### PR TITLE
MTV-1717 | Wait for DV status to not be paused

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -34,6 +34,7 @@ controller_precopy_interval: 60
 controller_snapshot_removal_timeout_minuts: 120
 controller_snapshot_status_check_rate_seconds: 10
 controller_cleanup_retries: 10
+controller_dv_status_check_retries: 10
 controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_max_vm_inflight: 20

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -81,6 +81,10 @@ spec:
         - name: CLEANUP_RETRIES
           value: "{{ controller_cleanup_retries }}"
 {% endif %}
+{% if controller_dv_status_check_retries is number %}
+        - name: DV_STATUS_CHECK_RETRIES
+          value: "{{ controller_dv_status_check_retries }}"
+{% endif %}
 {% if controller_max_vm_inflight is number %}
         - name: MAX_VM_INFLIGHT
           value: "{{ controller_max_vm_inflight }}"

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -24,6 +24,7 @@ const (
 	FileSystemOverhead        = "FILESYSTEM_OVERHEAD"
 	BlockOverhead             = "BLOCK_OVERHEAD"
 	CleanupRetries            = "CLEANUP_RETRIES"
+	DvStatusCheckRetries      = "DV_STATUS_CHECK_RETRIES"
 	OvirtOsConfigMap          = "OVIRT_OS_MAP"
 	VsphereOsConfigMap        = "VSPHERE_OS_MAP"
 	VirtCustomizeConfigMap    = "VIRT_CUSTOMIZE_MAP"
@@ -58,6 +59,8 @@ type Migration struct {
 	BlockOverhead int64
 	// Cleanup retries
 	CleanupRetries int
+	// DvStatusCheckRetries retries
+	DvStatusCheckRetries int
 	// oVirt OS config map name
 	OvirtOsConfigMap string
 	// vSphere OS config map name
@@ -98,6 +101,9 @@ func (r *Migration) Load() (err error) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtCustomizeConfigMap))
 	}
 	if r.CleanupRetries, err = getPositiveEnvLimit(CleanupRetries, 10); err != nil {
+		return liberr.Wrap(err)
+	}
+	if r.DvStatusCheckRetries, err = getPositiveEnvLimit(DvStatusCheckRetries, 10); err != nil {
 		return liberr.Wrap(err)
 	}
 	if virtV2vImage, ok := os.LookupEnv(VirtV2vImage); ok {


### PR DESCRIPTION
Issue: When CDI is managing lot of DVs at once it can take some time before the CDI reconciles the DVs status and start the import. In the function `updateCopyProgress` we check the DV status and if it is paused we do continue and as next phase we have snapshot removal. So if the DV is still in paused state and we start the cutover and MTV skips over the phase thinking it already finished as the DV is in paused.

Fix: Add WaitForDataVolumesStatus phase to wait until the DVs do not have the paused status.

Ref: https://issues.redhat.com/browse/MTV-1717

https://github.com/kubev2v/forklift/blob/ea83264881b3dcd4a88dd627c1ca75da2483f408/pkg/controller/plan/migration.go#L1573-L1575