### PR TITLE
MTV-1753 | Add wait for snapshot removal timeout

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -35,6 +35,7 @@ controller_snapshot_removal_timeout_minuts: 120
 controller_snapshot_status_check_rate_seconds: 10
 controller_cleanup_retries: 10
 controller_dv_status_check_retries: 10
+controller_snapshot_removal_check_retries: 20
 controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_retain_precopy_importer_pods: false

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -85,6 +85,10 @@ spec:
         - name: DV_STATUS_CHECK_RETRIES
           value: "{{ controller_dv_status_check_retries }}"
 {% endif %}
+{% if controller_snapshot_removal_check_retries is number %}
+        - name: SNAPSHOT_REMOVAL_CHECK_RETRIES
+          value: "{{ controller_snapshot_removal_check_retries }}"
+{% endif %}
 {% if controller_max_vm_inflight is number %}
         - name: MAX_VM_INFLIGHT
           value: "{{ controller_max_vm_inflight }}"

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -12,25 +12,26 @@ import (
 
 // Environment variables.
 const (
-	MaxVmInFlight             = "MAX_VM_INFLIGHT"
-	HookRetry                 = "HOOK_RETRY"
-	ImporterRetry             = "IMPORTER_RETRY"
-	VirtV2vImage              = "VIRT_V2V_IMAGE"
-	PrecopyInterval           = "PRECOPY_INTERVAL"
-	VirtV2vDontRequestKVM     = "VIRT_V2V_DONT_REQUEST_KVM"
-	SnapshotRemovalTimeout    = "SNAPSHOT_REMOVAL_TIMEOUT"
-	SnapshotStatusCheckRate   = "SNAPSHOT_STATUS_CHECK_RATE"
-	CDIExportTokenTTL         = "CDI_EXPORT_TOKEN_TTL"
-	FileSystemOverhead        = "FILESYSTEM_OVERHEAD"
-	BlockOverhead             = "BLOCK_OVERHEAD"
-	CleanupRetries            = "CLEANUP_RETRIES"
-	DvStatusCheckRetries      = "DV_STATUS_CHECK_RETRIES"
-	OvirtOsConfigMap          = "OVIRT_OS_MAP"
-	VsphereOsConfigMap        = "VSPHERE_OS_MAP"
-	VirtCustomizeConfigMap    = "VIRT_CUSTOMIZE_MAP"
-	VddkJobActiveDeadline     = "VDDK_JOB_ACTIVE_DEADLINE"
-	VirtV2vExtraArgs          = "VIRT_V2V_EXTRA_ARGS"
-	VirtV2vExtraConfConfigMap = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
+	MaxVmInFlight               = "MAX_VM_INFLIGHT"
+	HookRetry                   = "HOOK_RETRY"
+	ImporterRetry               = "IMPORTER_RETRY"
+	VirtV2vImage                = "VIRT_V2V_IMAGE"
+	PrecopyInterval             = "PRECOPY_INTERVAL"
+	VirtV2vDontRequestKVM       = "VIRT_V2V_DONT_REQUEST_KVM"
+	SnapshotRemovalTimeout      = "SNAPSHOT_REMOVAL_TIMEOUT"
+	SnapshotStatusCheckRate     = "SNAPSHOT_STATUS_CHECK_RATE"
+	CDIExportTokenTTL           = "CDI_EXPORT_TOKEN_TTL"
+	FileSystemOverhead          = "FILESYSTEM_OVERHEAD"
+	BlockOverhead               = "BLOCK_OVERHEAD"
+	CleanupRetries              = "CLEANUP_RETRIES"
+	DvStatusCheckRetries        = "DV_STATUS_CHECK_RETRIES"
+	SnapshotRemovalCheckRetries = "SNAPSHOT_REMOVAL_CHECK_RETRIES"
+	OvirtOsConfigMap            = "OVIRT_OS_MAP"
+	VsphereOsConfigMap          = "VSPHERE_OS_MAP"
+	VirtCustomizeConfigMap      = "VIRT_CUSTOMIZE_MAP"
+	VddkJobActiveDeadline       = "VDDK_JOB_ACTIVE_DEADLINE"
+	VirtV2vExtraArgs            = "VIRT_V2V_EXTRA_ARGS"
+	VirtV2vExtraConfConfigMap   = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
 )
 
 // Migration settings
@@ -61,6 +62,8 @@ type Migration struct {
 	CleanupRetries int
 	// DvStatusCheckRetries retries
 	DvStatusCheckRetries int
+	// SnapshotRemovalCheckRetries retries
+	SnapshotRemovalCheckRetries int
 	// oVirt OS config map name
 	OvirtOsConfigMap string
 	// vSphere OS config map name
@@ -104,6 +107,9 @@ func (r *Migration) Load() (err error) {
 		return liberr.Wrap(err)
 	}
 	if r.DvStatusCheckRetries, err = getPositiveEnvLimit(DvStatusCheckRetries, 10); err != nil {
+		return liberr.Wrap(err)
+	}
+	if r.SnapshotRemovalCheckRetries, err = getPositiveEnvLimit(SnapshotRemovalCheckRetries, 20); err != nil {
 		return liberr.Wrap(err)
 	}
 	if virtV2vImage, ok := os.LookupEnv(VirtV2vImage); ok {


### PR DESCRIPTION
Issue: The migration fails with `Another task is already in progress`. This is caused because of the snapshot creation is started right after snapshot removal and the snapshot removal did not finish due to the consolidation.

Fix: I have added a timeout which users can control using the `controller_snapshot_removal_check_retries` variable. This will wait some time right after snapshot removal. This is just a temporary solution to unblock the users. I'll fix it properly using the VM events and tasks, but that will require a lot of changes in the controller inventory and main.

Ref: https://issues.redhat.com/browse/MTV-1753