### PR TITLE
MTV-1632 | Add secureboot to vsphere

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -668,15 +668,9 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	}
 	switch vm.Firmware {
 	case Efi:
-		// We don't distinguish between UEFI and UEFI with secure boot, but we anyway would have
-		// disabled secure boot, even if we knew it was enabled on the source, because the guest
-		// OS won't be able to boot without getting the NVRAM data. By starting the VM without
-		// secure boot we ease the procedure users need to do in order to make a guest OS that
-		// was previously configured with secure boot bootable.
-		secureBootEnabled := false
 		firmware.Bootloader = &cnv.Bootloader{
 			EFI: &cnv.EFI{
-				SecureBoot: &secureBootEnabled,
+				SecureBoot: &vm.SecureBoot,
 			}}
 	default:
 		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -101,6 +101,7 @@ const (
 	fUUID                = "config.uuid"
 	fFirmware            = "config.firmware"
 	fFtInfo              = "config.ftInfo"
+	fBootOptions         = "config.bootOptions"
 	fCpuAffinity         = "config.cpuAffinity"
 	fCpuHotAddEnabled    = "config.cpuHotAddEnabled"
 	fCpuHotRemoveEnabled = "config.cpuHotRemoveEnabled"
@@ -729,6 +730,7 @@ func (r *Collector) vmPathSet() []string {
 		fFirmware,
 		fFtInfo,
 		fCpuAffinity,
+		fBootOptions,
 		fCpuHotAddEnabled,
 		fCpuHotRemoveEnabled,
 		fMemoryHotAddEnabled,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -565,6 +565,12 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if a, cast := p.Val.(types.VirtualMachineAffinityInfo); cast {
 					v.model.CpuAffinity = a.AffinitySet
 				}
+			case fBootOptions:
+				if a, cast := p.Val.(types.VirtualMachineBootOptions); cast {
+					if a.EfiSecureBootEnabled != nil {
+						v.model.SecureBoot = *a.EfiSecureBootEnabled
+					}
+				}
 			case fCpuHotAddEnabled:
 				if b, cast := p.Val.(bool); cast {
 					v.model.CpuHotAddEnabled = b

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -268,6 +268,7 @@ type VM struct {
 	Concerns              []Concern      `sql:""`
 	GuestNetworks         []GuestNetwork `sql:""`
 	GuestIpStacks         []GuestIpStack `sql:""`
+	SecureBoot            bool           `sql:""`
 }
 
 // Determine if current revision has been validated.

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -235,6 +235,7 @@ type VM struct {
 	NICs                  []model.NIC          `json:"nics"`
 	GuestNetworks         []model.GuestNetwork `json:"guestNetworks"`
 	GuestIpStacks         []model.GuestIpStack `json:"guestIpStacks"`
+	SecureBoot            bool                 `json:"secureBoot"`
 }
 
 // Build the resource using the model.
@@ -265,6 +266,7 @@ func (r *VM) With(m *model.VM) {
 	r.NICs = m.NICs
 	r.GuestNetworks = m.GuestNetworks
 	r.GuestIpStacks = m.GuestIpStacks
+	r.SecureBoot = m.SecureBoot
 }
 
 // Build self link (URI).


### PR DESCRIPTION

Issue: When creating the VM from vSphere on kubevirt the MTV always
defaulted the secureboot to false.

Fix: Add the secureboot to the inventory and to main controller to pass
it to the KubeVirt.

Ref: https://issues.redhat.com/browse/MTV-1632

Signed-off-by: Martin Necas <mnecas@redhat.com>
