### PR TITLE
MTV-1774 | Start all available VMs from scheduler

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -222,15 +222,21 @@ func (r *Migration) Run() (reQ time.Duration, err error) {
 			return
 		}
 	}
-
-	vm, hasNext, err := r.scheduler.Next()
-	if err != nil {
-		return
-	}
-	if hasNext {
-		err = r.execute(vm)
+	for {
+		var hasNext bool
+		var vm *plan.VMStatus
+		vm, hasNext, err = r.scheduler.Next()
 		if err != nil {
 			return
+		}
+		if hasNext {
+			err = r.execute(vm)
+			if err != nil {
+				return
+			}
+		} else {
+			r.Log.Info("The scheduler does not have any additional VMs.")
+			break
 		}
 	}
 


### PR DESCRIPTION
Issue:
This issue is visible with a combination of two problems. The first problem is if there is some step/phase that takes some time to finish and halts the process. An example of such an issue MTV-1775. This causes the VM migration startup to take some time as we don't start all available VMs at once but we add VMs one by one in the reconcile. This in large-scale migration can take a long time. For example on the scale of 200 VMs in best case scenario it would take 10 minutes to start all VMs as we have 3s reconciled.

Fix:
Start all available VMs from the scheduler at once.

Ref: https://issues.redhat.com/browse/MTV-1774