### PR TITLE
Revert: Move waiting for tasks to separate phase to unblock process

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -35,6 +35,7 @@ controller_snapshot_removal_timeout_minuts: 120
 controller_snapshot_status_check_rate_seconds: 10
 controller_cleanup_retries: 10
 controller_dv_status_check_retries: 10
+controller_snapshot_removal_check_retries: 20
 controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_retain_precopy_importer_pods: false

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -85,6 +85,10 @@ spec:
         - name: DV_STATUS_CHECK_RETRIES
           value: "{{ controller_dv_status_check_retries }}"
 {% endif %}
+{% if controller_snapshot_removal_check_retries is number %}
+        - name: SNAPSHOT_REMOVAL_CHECK_RETRIES
+          value: "{{ controller_snapshot_removal_check_retries }}"
+{% endif %}
 {% if controller_max_vm_inflight is number %}
         - name: MAX_VM_INFLIGHT
           value: "{{ controller_max_vm_inflight }}"

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -108,9 +108,7 @@ type Client interface {
 	// Remove a snapshot.
 	RemoveSnapshot(vmRef ref.Ref, snapshot string, hostsFunc util.HostsFunc) error
 	// Check if a snapshot is ready to transfer.
-	CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, snapshotId string, err error)
-	// Check if a snapshot is removed.
-	CheckSnapshotRemoved(vmRef ref.Ref, snapshot string) (ready bool, err error)
+	CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, err error)
 	// Set DataVolume checkpoints.
 	SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool, hostsFunc util.HostsFunc) (err error)
 	// Close connections to the provider API.

--- a/pkg/controller/plan/adapter/ocp/client.go
+++ b/pkg/controller/plan/adapter/ocp/client.go
@@ -25,12 +25,7 @@ type Client struct {
 }
 
 // CheckSnapshotReady implements base.Client
-func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, snapshotId string, err error) {
-	return
-}
-
-// CheckSnapshotRemoved implements base.Client
-func (r *Client) CheckSnapshotRemoved(vmRef ref.Ref, snapshot string) (bool, error) {
+func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/controller/plan/adapter/openstack/client.go
+++ b/pkg/controller/plan/adapter/openstack/client.go
@@ -115,13 +115,8 @@ func (r *Client) CreateSnapshot(vmRef ref.Ref, hostsFunc util.HostsFunc) (imageI
 }
 
 // Check if a snapshot is ready to transfer.
-func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, snapshotId string, err error) {
+func (r *Client) CheckSnapshotReady(vmRef ref.Ref, imageID string) (ready bool, err error) {
 	return
-}
-
-// CheckSnapshotRemoved implements base.Client
-func (r *Client) CheckSnapshotRemoved(vmRef ref.Ref, snapshot string) (bool, error) {
-	return false, nil
 }
 
 // Set DataVolume checkpoints.

--- a/pkg/controller/plan/adapter/ova/client.go
+++ b/pkg/controller/plan/adapter/ova/client.go
@@ -61,13 +61,8 @@ func (r *Client) GetSnapshotDeltas(vmRef ref.Ref, snapshot string, hostsFunc uti
 }
 
 // Check if a snapshot is ready to transfer, to avoid importer restarts.
-func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, snapshotId string, err error) {
+func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, err error) {
 	return
-}
-
-// CheckSnapshotRemoved implements base.Client
-func (r *Client) CheckSnapshotRemoved(vmRef ref.Ref, snapshot string) (bool, error) {
-	return false, nil
 }
 
 // Set DataVolume checkpoints.

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -75,7 +75,7 @@ func (r *Client) CreateSnapshot(vmRef ref.Ref, hostsFunc util.HostsFunc) (snapsh
 }
 
 // Check if a snapshot is ready to transfer, to avoid importer restarts.
-func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, snapshotId string, err error) {
+func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool, err error) {
 	correlationID, err := r.getSnapshotCorrelationID(vmRef, &snapshot)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -102,11 +102,6 @@ func (r *Client) CheckSnapshotReady(vmRef ref.Ref, snapshot string) (ready bool,
 		}
 	}
 	return
-}
-
-// CheckSnapshotRemoved implements base.Client
-func (r *Client) CheckSnapshotRemoved(vmRef ref.Ref, snapshot string) (bool, error) {
-	return false, nil
 }
 
 // Remove a VM snapshot. No-op for this provider.

--- a/pkg/controller/plan/adapter/vsphere/BUILD.bazel
+++ b/pkg/controller/plan/adapter/vsphere/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
         "//vendor/github.com/vmware/govmomi/find",
         "//vendor/github.com/vmware/govmomi/object",
         "//vendor/github.com/vmware/govmomi/session",
-        "//vendor/github.com/vmware/govmomi/task",
         "//vendor/github.com/vmware/govmomi/vim25",
         "//vendor/github.com/vmware/govmomi/vim25/mo",
         "//vendor/github.com/vmware/govmomi/vim25/soap",

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -108,6 +108,7 @@ const (
 	TransferCompleted              = "Transfer completed."
 	PopulatorPodPrefix             = "populate-"
 	DvStatusCheckRetriesAnnotation = "dvStatusCheckRetries"
+	SnapshotRemovalCheckRetries    = "snapshotRemovalCheckRetries"
 )
 
 var (
@@ -1026,15 +1027,27 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			vm.AddError(fmt.Sprintf("Step '%s' not found", r.step(vm)))
 			break
 		}
-		snapshot := vm.Warm.Precopies[len(vm.Warm.Precopies)-1].Snapshot
-		ready, err := r.provider.CheckSnapshotRemoved(vm.Ref, snapshot)
-		if err != nil {
-			step.AddError(err.Error())
-			err = nil
-			break
-		}
-		if ready {
-			vm.Phase = r.next(vm.Phase)
+		// FIXME: This is just temporary timeout to unblock the migrations which get stuck on issue https://issues.redhat.com/browse/MTV-1753
+		// This should be fixed properly by adding the task manager inside the inventory and monitor the task status
+		// from the main controller.
+		var retries int
+		retriesAnnotation := step.Annotations[SnapshotRemovalCheckRetries]
+		if retriesAnnotation == "" {
+			step.Annotations[SnapshotRemovalCheckRetries] = "1"
+		} else {
+			retries, err = strconv.Atoi(retriesAnnotation)
+			if err != nil {
+				step.AddError(err.Error())
+				err = nil
+				break
+			}
+			if retries >= settings.Settings.SnapshotRemovalCheckRetries {
+				vm.Phase = r.next(vm.Phase)
+				// Reset for next precopy
+				step.Annotations[SnapshotRemovalCheckRetries] = "1"
+			} else {
+				step.Annotations[SnapshotRemovalCheckRetries] = strconv.Itoa(retries + 1)
+			}
 		}
 	case CreateInitialSnapshot, CreateSnapshot, CreateFinalSnapshot:
 		step, found := vm.FindStep(r.step(vm))
@@ -1063,17 +1076,11 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			break
 		}
 		snapshot := vm.Warm.Precopies[len(vm.Warm.Precopies)-1].Snapshot
-		ready, snapshotId, err := r.provider.CheckSnapshotReady(vm.Ref, snapshot)
+		ready, err := r.provider.CheckSnapshotReady(vm.Ref, snapshot)
 		if err != nil {
 			step.AddError(err.Error())
 			err = nil
 			break
-		}
-		// If the provider does not directly create the snapshot, but we need to wait for the snapshot to be created
-		// We start the creation task in CreateSnapshot, set the task ID as a snapshot id which needs to be replaced
-		// by the snapshot id after the task finishes.
-		if snapshotId != "" {
-			vm.Warm.Precopies[len(vm.Warm.Precopies)-1].Snapshot = snapshotId
 		}
 		if ready {
 			vm.Phase = r.next(vm.Phase)

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -12,25 +12,26 @@ import (
 
 // Environment variables.
 const (
-	MaxVmInFlight             = "MAX_VM_INFLIGHT"
-	HookRetry                 = "HOOK_RETRY"
-	ImporterRetry             = "IMPORTER_RETRY"
-	VirtV2vImage              = "VIRT_V2V_IMAGE"
-	PrecopyInterval           = "PRECOPY_INTERVAL"
-	VirtV2vDontRequestKVM     = "VIRT_V2V_DONT_REQUEST_KVM"
-	SnapshotRemovalTimeout    = "SNAPSHOT_REMOVAL_TIMEOUT"
-	SnapshotStatusCheckRate   = "SNAPSHOT_STATUS_CHECK_RATE"
-	CDIExportTokenTTL         = "CDI_EXPORT_TOKEN_TTL"
-	FileSystemOverhead        = "FILESYSTEM_OVERHEAD"
-	BlockOverhead             = "BLOCK_OVERHEAD"
-	CleanupRetries            = "CLEANUP_RETRIES"
-	DvStatusCheckRetries      = "DV_STATUS_CHECK_RETRIES"
-	OvirtOsConfigMap          = "OVIRT_OS_MAP"
-	VsphereOsConfigMap        = "VSPHERE_OS_MAP"
-	VirtCustomizeConfigMap    = "VIRT_CUSTOMIZE_MAP"
-	VddkJobActiveDeadline     = "VDDK_JOB_ACTIVE_DEADLINE"
-	VirtV2vExtraArgs          = "VIRT_V2V_EXTRA_ARGS"
-	VirtV2vExtraConfConfigMap = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
+	MaxVmInFlight               = "MAX_VM_INFLIGHT"
+	HookRetry                   = "HOOK_RETRY"
+	ImporterRetry               = "IMPORTER_RETRY"
+	VirtV2vImage                = "VIRT_V2V_IMAGE"
+	PrecopyInterval             = "PRECOPY_INTERVAL"
+	VirtV2vDontRequestKVM       = "VIRT_V2V_DONT_REQUEST_KVM"
+	SnapshotRemovalTimeout      = "SNAPSHOT_REMOVAL_TIMEOUT"
+	SnapshotStatusCheckRate     = "SNAPSHOT_STATUS_CHECK_RATE"
+	CDIExportTokenTTL           = "CDI_EXPORT_TOKEN_TTL"
+	FileSystemOverhead          = "FILESYSTEM_OVERHEAD"
+	BlockOverhead               = "BLOCK_OVERHEAD"
+	CleanupRetries              = "CLEANUP_RETRIES"
+	DvStatusCheckRetries        = "DV_STATUS_CHECK_RETRIES"
+	SnapshotRemovalCheckRetries = "SNAPSHOT_REMOVAL_CHECK_RETRIES"
+	OvirtOsConfigMap            = "OVIRT_OS_MAP"
+	VsphereOsConfigMap          = "VSPHERE_OS_MAP"
+	VirtCustomizeConfigMap      = "VIRT_CUSTOMIZE_MAP"
+	VddkJobActiveDeadline       = "VDDK_JOB_ACTIVE_DEADLINE"
+	VirtV2vExtraArgs            = "VIRT_V2V_EXTRA_ARGS"
+	VirtV2vExtraConfConfigMap   = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
 )
 
 // Migration settings
@@ -61,6 +62,8 @@ type Migration struct {
 	CleanupRetries int
 	// DvStatusCheckRetries retries
 	DvStatusCheckRetries int
+	// SnapshotRemovalCheckRetries retries
+	SnapshotRemovalCheckRetries int
 	// oVirt OS config map name
 	OvirtOsConfigMap string
 	// vSphere OS config map name
@@ -104,6 +107,9 @@ func (r *Migration) Load() (err error) {
 		return liberr.Wrap(err)
 	}
 	if r.DvStatusCheckRetries, err = getPositiveEnvLimit(DvStatusCheckRetries, 10); err != nil {
+		return liberr.Wrap(err)
+	}
+	if r.SnapshotRemovalCheckRetries, err = getPositiveEnvLimit(SnapshotRemovalCheckRetries, 20); err != nil {
 		return liberr.Wrap(err)
 	}
 	if virtV2vImage, ok := os.LookupEnv(VirtV2vImage); ok {


### PR DESCRIPTION
Revert of:  #1262

Reverting due to deeper testing on larger scale, this solution does not support ha tasks.
`haTask-2330-vim.VirtualMachine.createSnapshot-2994898`