### PR TITLE
MTV-1632 | Enable SMM for the uefi secureboot

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -672,6 +672,13 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 			EFI: &cnv.EFI{
 				SecureBoot: &vm.SecureBoot,
 			}}
+		if vm.SecureBoot {
+			object.Template.Spec.Domain.Features = &cnv.Features{
+				SMM: &cnv.FeatureState{
+					Enabled: &vm.SecureBoot,
+				},
+			}
+		}
 	default:
 		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	}


### PR DESCRIPTION
Issue: When the VM has a secureboot the migration fails due to missing SSM

Fix: Enable the SMM for UEFI secureboot
https://kubevirt.io/user-guide/compute/virtual_hardware/

Ref: https://issues.redhat.com/browse/MTV-1632