### PR TITLE
MTV-1804 | Implement VDDK AIO buffer configuration

### DIFF
--- a/pkg/apis/forklift/v1beta1/provider.go
+++ b/pkg/apis/forklift/v1beta1/provider.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"strconv"
+
 	libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,10 +61,12 @@ const (
 
 // Provider settings.
 const (
-	VDDK    = "vddkInitImage"
-	SDK     = "sdkEndpoint"
-	VCenter = "vcenter"
-	ESXI    = "esxi"
+	VDDK                   = "vddkInitImage"
+	SDK                    = "sdkEndpoint"
+	VCenter                = "vcenter"
+	ESXI                   = "esxi"
+	UseVddkAioOptimization = "useVddkAioOptimization"
+	VddkConfig             = "vddkConfig"
 )
 
 const OvaProviderFinalizer = "forklift/ova-provider"
@@ -146,4 +150,17 @@ func (p *Provider) HasReconciled() bool {
 // This provider requires VM guest conversion.
 func (p *Provider) RequiresConversion() bool {
 	return p.Type() == VSphere || p.Type() == Ova
+}
+
+// This provider support the vddk aio parameters.
+func (p *Provider) UseVddkAioOptimization() bool {
+	useVddkAioOptimization := p.Spec.Settings[UseVddkAioOptimization]
+	if useVddkAioOptimization == "" {
+		return false
+	}
+	parseBool, err := strconv.ParseBool(useVddkAioOptimization)
+	if err != nil {
+		return false
+	}
+	return parseBool
 }

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -35,6 +35,10 @@ const (
 
 	// DV immediate bind to WaitForFirstConsumer storage class
 	AnnBindImmediate = "cdi.kubevirt.io/storage.bind.immediate.requested"
+
+	// Add extra vddk configmap, in the Forklift used to pass AIO configuration to the VDDK.
+	// Related to https://github.com/kubevirt/containerized-data-importer/pull/3572
+	AnnVddkExtraArgs = "cdi.kubevirt.io/storage.pod.vddk.extraargs"
 )
 
 var VolumePopulatorNotSupportedError = liberr.New("provider does not support volume populators")
@@ -64,7 +68,7 @@ type Builder interface {
 	// Build the Kubevirt VirtualMachine spec.
 	VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim, usesInstanceType bool) error
 	// Build DataVolumes.
-	DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume) (dvs []cdi.DataVolume, err error)
+	DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) (dvs []cdi.DataVolume, err error)
 	// Build tasks.
 	Tasks(vmRef ref.Ref) ([]*planapi.Task, error)
 	// Build template labels.

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -65,7 +65,7 @@ func (r *Builder) ConfigMap(vmRef ref.Ref, secret *core.Secret, object *core.Con
 }
 
 // DataVolumes implements base.Builder
-func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume) (dvs []cdi.DataVolume, err error) {
+func (r *Builder) DataVolumes(vmRef ref.Ref, secret *v1.Secret, configMap *v1.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *v1.ConfigMap) (dvs []cdi.DataVolume, err error) {
 	vmExport := &export.VirtualMachineExport{}
 	key := client.ObjectKey{
 		Namespace: vmRef.Namespace,

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -748,7 +748,7 @@ func (r *Builder) ConfigMap(_ ref.Ref, in *core.Secret, object *core.ConfigMap) 
 	return
 }
 
-func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume) (dvs []cdi.DataVolume, err error) {
+func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) (dvs []cdi.DataVolume, err error) {
 	return nil, nil
 }
 

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -146,7 +146,7 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 }
 
 // Create DataVolume specs for the VM.
-func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.ConfigMap, dvTemplate *cdi.DataVolume) (dvs []cdi.DataVolume, err error) {
+func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) (dvs []cdi.DataVolume, err error) {
 	vm := &model.VM{}
 	err = r.Source.Inventory.Find(vm, vmRef)
 	if err != nil {

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -178,7 +178,7 @@ func (r *Builder) Secret(_ ref.Ref, in, object *core.Secret) (err error) {
 }
 
 // Create DataVolume specs for the VM.
-func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume) (dvs []cdi.DataVolume, err error) {
+func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) (dvs []cdi.DataVolume, err error) {
 	vm := &model.Workload{}
 	err = r.Source.Inventory.Find(vm, vmRef)
 	if err != nil {

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -391,7 +391,7 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 }
 
 // Create DataVolume specs for the VM.
-func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.ConfigMap, dvTemplate *cdi.DataVolume) (dvs []cdi.DataVolume, err error) {
+func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) (dvs []cdi.DataVolume, err error) {
 	vm := &model.VM{}
 	err = r.Source.Inventory.Find(vm, vmRef)
 	if err != nil {
@@ -516,6 +516,9 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 					}
 				}
 
+				if !useV2vForTransfer && vddkConfigMap != nil {
+					dv.ObjectMeta.Annotations[planbase.AnnVddkExtraArgs] = vddkConfigMap.Name
+				}
 				dvs = append(dvs, *dv)
 			}
 		}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -95,6 +95,8 @@ const (
 	kApp = "forklift.app"
 	// LUKS
 	kLUKS = "isLUKS"
+	// Use
+	kUse = "use"
 )
 
 // User
@@ -111,7 +113,14 @@ const (
 	OvaPVLabel  = "nfs-pv"
 )
 
-const ExtraV2vConf = "extra-v2v-conf"
+// Vddk v2v conf
+const (
+	ExtraV2vConf = "extra-v2v-conf"
+	VddkConf     = "vddk-conf"
+
+	VddkAioBufSizeDefault  = "16"
+	VddkAioBufCountDefault = "4"
+)
 
 // Map of VirtualMachines keyed by vmID.
 type VirtualMachineMap map[string]VirtualMachine
@@ -240,6 +249,10 @@ func (r *KubeVirt) EnsureExtraV2vConfConfigMap() error {
 
 func genExtraV2vConfConfigMapName(plan *api.Plan) string {
 	return fmt.Sprintf("%s-%s", plan.Name, ExtraV2vConf)
+}
+
+func genVddkConfConfigMapName(plan *api.Plan) string {
+	return fmt.Sprintf("%s-%s-", plan.Name, VddkConf)
 }
 
 // Get the importer pod for a PersistentVolumeClaim.
@@ -583,8 +596,15 @@ func (r *KubeVirt) DataVolumes(vm *plan.VMStatus) (dataVolumes []cdi.DataVolume,
 	if err != nil {
 		return
 	}
+	var vddkConfigMap *core.ConfigMap
+	if r.Source.Provider.UseVddkAioOptimization() {
+		vddkConfigMap, err = r.ensureVddkConfigMap()
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	dataVolumes, err = r.dataVolumes(vm, secret, configMap)
+	dataVolumes, err = r.dataVolumes(vm, secret, configMap, vddkConfigMap)
 	if err != nil {
 		return
 	}
@@ -637,6 +657,80 @@ func (r *KubeVirt) EnsureDataVolumes(vm *plan.VMStatus, dataVolumes []cdi.DataVo
 				"vm",
 				vm.String())
 		}
+	}
+	return
+}
+
+func (r *KubeVirt) vddkConfigMap(labels map[string]string) (*core.ConfigMap, error) {
+	data := make(map[string]string)
+	if r.Source.Provider.UseVddkAioOptimization() {
+		vddkConfig := r.Source.Provider.Spec.Settings[api.VddkConfig]
+		if vddkConfig != "" {
+			data["vddk-config-file"] = vddkConfig
+		} else {
+			data["vddk-config-file"] =
+				"VixDiskLib.nfcAio.Session.BufSizeIn64K=16\n" +
+					"VixDiskLib.nfcAio.Session.BufCount=4"
+		}
+	}
+	configMap := core.ConfigMap{
+		Data: data,
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: genVddkConfConfigMapName(r.Plan),
+			Namespace:    r.Plan.Spec.TargetNamespace,
+			Labels:       labels,
+		},
+	}
+	return &configMap, nil
+}
+
+func (r *KubeVirt) ensureVddkConfigMap() (configMap *core.ConfigMap, err error) {
+	labels := r.vddkLabels()
+	newConfigMap, err := r.vddkConfigMap(labels)
+	if err != nil {
+		return
+	}
+
+	list := &core.ConfigMapList{}
+	err = r.Destination.Client.List(
+		context.TODO(),
+		list,
+		&client.ListOptions{
+			LabelSelector: k8slabels.SelectorFromSet(labels),
+			Namespace:     r.Plan.Spec.TargetNamespace,
+		},
+	)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if len(list.Items) > 0 {
+		configMap = &list.Items[0]
+		configMap.Data = newConfigMap.Data
+		err = r.Destination.Client.Update(context.TODO(), configMap)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		r.Log.V(1).Info(
+			"VDDK extra args configmap updated.",
+			"configmap",
+			path.Join(
+				configMap.Namespace,
+				configMap.Name))
+	} else {
+		configMap = newConfigMap
+		err = r.Destination.Client.Create(context.TODO(), configMap)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		r.Log.V(1).Info(
+			"VDDK extra args configmap created.",
+			"configmap",
+			path.Join(
+				configMap.Namespace,
+				configMap.Name))
 	}
 	return
 }
@@ -850,12 +944,20 @@ func (r *KubeVirt) EnsureGuestConversionPod(vm *plan.VMStatus, vmCr *VirtualMach
 		return
 	}
 
-	configMap, err := r.ensureLibvirtConfigMap(vm.Ref, vmCr, pvcs)
+	libvirtConfigMap, err := r.ensureLibvirtConfigMap(vm.Ref, vmCr, pvcs)
 	if err != nil {
 		return
 	}
 
-	newPod, err := r.guestConversionPod(vm, vmCr.Spec.Template.Spec.Volumes, configMap, pvcs, v2vSecret)
+	var vddkConfigMap *core.ConfigMap
+	if r.Source.Provider.UseVddkAioOptimization() {
+		vddkConfigMap, err = r.ensureVddkConfigMap()
+		if err != nil {
+			return err
+		}
+	}
+
+	newPod, err := r.guestConversionPod(vm, vmCr.Spec.Template.Spec.Volumes, libvirtConfigMap, vddkConfigMap, pvcs, v2vSecret)
 	if err != nil {
 		return
 	}
@@ -1236,7 +1338,7 @@ func (r *KubeVirt) getPopulatorPods() (pods []core.Pod, err error) {
 }
 
 // Build the DataVolume CRs.
-func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap *core.ConfigMap) (dataVolumes []cdi.DataVolume, err error) {
+func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap *core.ConfigMap, vddkConfigMap *core.ConfigMap) (dataVolumes []cdi.DataVolume, err error) {
 	_, err = r.Source.Inventory.VM(&vm.Ref)
 	if err != nil {
 		return
@@ -1271,7 +1373,7 @@ func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap
 	}
 	dvTemplate.Labels = r.vmLabels(vm.Ref)
 
-	dataVolumes, err = r.Builder.DataVolumes(vm.Ref, secret, configMap, &dvTemplate)
+	dataVolumes, err = r.Builder.DataVolumes(vm.Ref, secret, configMap, &dvTemplate, vddkConfigMap)
 	if err != nil {
 		return
 	}
@@ -1690,8 +1792,8 @@ func (r *KubeVirt) findTemplate(vm *plan.VMStatus) (tmpl *template.Template, err
 	return
 }
 
-func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, configMap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, v2vSecret *core.Secret) (pod *core.Pod, err error) {
-	volumes, volumeMounts, volumeDevices, err := r.podVolumeMounts(vmVolumes, configMap, pvcs, vm)
+func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, libvirtConfigMap *core.ConfigMap, vddkConfigmap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, v2vSecret *core.Secret) (pod *core.Pod, err error) {
+	volumes, volumeMounts, volumeDevices, err := r.podVolumeMounts(vmVolumes, libvirtConfigMap, vddkConfigmap, pvcs, vm)
 	if err != nil {
 		return
 	}
@@ -1892,7 +1994,7 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	return
 }
 
-func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, vm *plan.VMStatus) (volumes []core.Volume, mounts []core.VolumeMount, devices []core.VolumeDevice, err error) {
+func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, libvirtConfigMap *core.ConfigMap, vddkConfigmap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, vm *plan.VMStatus) (volumes []core.Volume, mounts []core.VolumeMount, devices []core.VolumeDevice, err error) {
 	pvcsByName := make(map[string]*core.PersistentVolumeClaim)
 	for _, pvc := range pvcs {
 		pvcsByName[pvc.Name] = pvc
@@ -1939,7 +2041,7 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.Confi
 		VolumeSource: core.VolumeSource{
 			ConfigMap: &core.ConfigMapVolumeSource{
 				LocalObjectReference: core.LocalObjectReference{
-					Name: configMap.Name,
+					Name: libvirtConfigMap.Name,
 				},
 			},
 		},
@@ -1953,6 +2055,18 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.Confi
 				ConfigMap: &core.ConfigMapVolumeSource{
 					LocalObjectReference: core.LocalObjectReference{
 						Name: genExtraV2vConfConfigMapName(r.Plan),
+					},
+				},
+			},
+		})
+	}
+	if vddkConfigmap != nil {
+		volumes = append(volumes, core.Volume{
+			Name: VddkConf,
+			VolumeSource: core.VolumeSource{
+				ConfigMap: &core.ConfigMapVolumeSource{
+					LocalObjectReference: core.LocalObjectReference{
+						Name: vddkConfigmap.Name,
 					},
 				},
 			},
@@ -2012,6 +2126,14 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.Confi
 				core.VolumeMount{
 					Name:      ExtraV2vConf,
 					MountPath: fmt.Sprintf("/mnt/%s", ExtraV2vConf),
+				},
+			)
+		}
+		if vddkConfigmap != nil {
+			mounts = append(mounts,
+				core.VolumeMount{
+					Name:      VddkConf,
+					MountPath: fmt.Sprintf("/mnt/%s", VddkConf),
 				},
 			)
 		}
@@ -2404,6 +2526,14 @@ func (r *KubeVirt) conversionLabels(vmRef ref.Ref, filterOutMigrationLabel bool)
 func (r *KubeVirt) vmLabels(vmRef ref.Ref) (labels map[string]string) {
 	labels = r.planLabels()
 	labels[kVM] = vmRef.ID
+	return
+}
+
+// Labels for a vddk config
+// We need to distinguish between the libvirt configmap which uses also the plan labels and the vddk configmap
+func (r *KubeVirt) vddkLabels() (labels map[string]string) {
+	labels = r.planLabels()
+	labels[kUse] = VddkConf
 	return
 }
 

--- a/pkg/virt-v2v/global/variables.go
+++ b/pkg/virt-v2v/global/variables.go
@@ -3,14 +3,15 @@ package global
 type MountPath string
 
 const (
-	OVA                  = "ova"
-	VSPHERE              = "vSphere"
-	DIR                  = "/var/tmp/v2v"
-	INSPECTION           = "/var/tmp/v2v/inspection.xml"
-	FS         MountPath = "/mnt/disks/disk[0-9]*"
-	BLOCK      MountPath = "/dev/block[0-9]*"
-	VDDK                 = "/opt/vmware-vix-disklib-distrib"
-	LUKSDIR              = "/etc/luks"
+	OVA                      = "ova"
+	VSPHERE                  = "vSphere"
+	DIR                      = "/var/tmp/v2v"
+	INSPECTION               = "/var/tmp/v2v/inspection.xml"
+	FS             MountPath = "/mnt/disks/disk[0-9]*"
+	BLOCK          MountPath = "/dev/block[0-9]*"
+	VDDK_LIB                 = "/opt/vmware-vix-disklib-distrib"
+	LUKSDIR                  = "/etc/luks"
+	VDDK_CONF_FILE           = "/mnt/vddk-conf/vddk-config-file"
 
 	WIN_FIRSTBOOT_PATH         = "/Program Files/Guestfs/Firstboot"
 	WIN_FIRSTBOOT_SCRIPTS_PATH = "/Program Files/Guestfs/Firstboot/scripts"


### PR DESCRIPTION
Issue:
The scale and perf team found a way how to improve the transfer speeds. Right now the only way to enable this feature is to set the v2v extra vars. The v2v extra vars pass the configuration to the virt-v2v and virt-v2v-in-place. The v2v extra vars configuration is general and not specific for VDDK. This causes the warm migration which uses the virt-v2v-in-place to fail as it does not use any VDDK parameters. Those parameters should be passed to the CNV CDI instead.

Fix:
Add a way to easily enable and configure the AIO.
This feature is VDDK and provider-specific as it requires to have specific vSphere and VDDK versions. So we can't enable this feature globally nor by default. So this PR adds the configuration to the Provider spec settings and create a configmap with the necessary configuration and either mounts the configmap to the guest conversion pod for cold migration or passes the configmap name to the CDI DV annotation.

Example:
```
apiVersion: forklift.konveyor.io/v1beta1
kind: Provider
metadata:
  name: vsphere
  namespace: forklift
spec:
  settings:
    sdkEndpoint: vcenter
    vddkInitImage: 'vddk'
    useVddkAioOptimization: 'true'
    vddkConfig: |
      VixDiskLib.nfcAio.Session.BufSizeIn64K=16
      VixDiskLib.nfcAio.Session.BufCount=4
  type: vsphere
```

Ref:
- https://issues.redhat.com/browse/MTV-1804
- https://github.com/kubevirt/containerized-data-importer/pull/3572
- https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-aio-buffer_mtv