### PR TITLE
MTV-1744 | Allow dots in the VM names

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -773,7 +773,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			err = nil
 			break
 		}
-		if errs := k8svalidation.IsDNS1123Label(vm.Name); len(errs) > 0 {
+		if errs := k8svalidation.IsDNS1123Subdomain(vm.Name); len(errs) > 0 {
 			vm.NewName, err = r.kubevirt.changeVmNameDNS1123(vm.Name, r.Plan.Spec.TargetNamespace)
 			if err != nil {
 				r.Log.Error(err, "Failed to update the VM name to meet DNS1123 protocol requirements.")

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -323,7 +323,7 @@ func (r *Reconciler) validateTargetNamespace(plan *api.Plan) (err error) {
 		plan.Status.SetCondition(newCnd)
 		return
 	}
-	if len(k8svalidation.IsDNS1123Label(plan.Spec.TargetNamespace)) > 0 {
+	if len(k8svalidation.IsDNS1123Subdomain(plan.Spec.TargetNamespace)) > 0 {
 		newCnd.Reason = NotValid
 		plan.Status.SetCondition(newCnd)
 	}
@@ -577,7 +577,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 			}
 			return liberr.Wrap(pErr)
 		}
-		if len(k8svalidation.IsDNS1123Label(ref.Name)) > 0 {
+		if len(k8svalidation.IsDNS1123Subdomain(ref.Name)) > 0 {
 			nameNotValid.Items = append(nameNotValid.Items, ref.String())
 		}
 		if _, found := setOf[ref.ID]; found {

--- a/pkg/controller/plan/vm_name_handler.go
+++ b/pkg/controller/plan/vm_name_handler.go
@@ -33,8 +33,8 @@ func (r *KubeVirt) changeVmNameDNS1123(vmName string, vmNamespace string) (gener
 
 // changes VM name to match DNS1123 RFC convention.
 func changeVmName(currName string) string {
-	var underscoreExcluded = regexp.MustCompile("[_.]")
-	var nameExcludeChars = regexp.MustCompile("[^a-z0-9-]")
+	var underscoreExcluded = regexp.MustCompile("^[.]|[_]|[.]$")
+	var nameExcludeChars = regexp.MustCompile("[^a-z0-9-.]")
 
 	newName := strings.ToLower(currName)
 	if len(newName) > NameMaxLength {

--- a/pkg/controller/plan/vm_name_handler_test.go
+++ b/pkg/controller/plan/vm_name_handler_test.go
@@ -11,7 +11,7 @@ func TestVmNameHandler(t *testing.T) {
 
 	//Test all cases in name adjustments
 	originalVmName := "----------------Vm!@#$%^&*()_+-Name/.is,';[]-CorREct-<>123----------------------"
-	newVmName := "vm--name-is-correct-123"
+	newVmName := "vm--name.is-correct-123"
 	g.Expect(changeVmName(originalVmName)).To(gomega.Equal(newVmName))
 
 	//Test the case that the VM name is empty after all removals


### PR DESCRIPTION
Issue:
Right now we are not allowing to keep the VM names which have the dots in the name but we replace the dots with dashes.

Fix:
Use the IsDNS1123Subdomain validation instead of IsDNS1123Label and ignore the dots in the replacemnet of the new name.

Ref:
https://issues.redhat.com/browse/MTV-1744