### PR TITLE
MTV-1610: Avoid uncommon potential inventory crash.

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -685,10 +685,14 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 					for _, ipa := range ipas.GuestStackInfo {
 						routes := ipa.IpRouteConfig.IpRoute
 						for _, route := range routes {
+							var dnsList []string
+							if ipa.DnsConfig != nil {
+								dnsList = ipa.DnsConfig.IpAddress
+							}
 							if len(route.Gateway.IpAddress) > 0 {
 								guestIpStackList = append(guestIpStackList, model.GuestIpStack{
 									Gateway: route.Gateway.IpAddress,
-									DNS:     ipa.DnsConfig.IpAddress,
+									DNS:     dnsList,
 								})
 							}
 						}


### PR DESCRIPTION
Assuming I have matched up the right code correctly, MTV-1610 shows an inventory crash pointing here: https://github.com/kubev2v/forklift/blob/v2.7.2/pkg/controller/provider/container/vsphere/model.go#L660

This pull request just adds a nil check on the DnsConfig field that appears to cause the problem. I have not been able to configure an IP stack without DNS in vSphere, but this is low risk for a speculative fix. It is pretty much copied from the previous fGuestNet case, and I don't see this DnsConfig used anywhere.