### PR TITLE
MTV-1682 | Mutate ESXi secret before testing connection

### DIFF
--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator.go
@@ -159,7 +159,7 @@ func (mutator *SecretMutator) patchSecret() *admissionv1.AdmissionResponse {
 func (mutator *SecretMutator) mutateHostSecret() *admissionv1.AdmissionResponse {
 	if _, ok := mutator.secret.GetLabels()["createdForResource"]; ok { // checking this just because there's no point in mutating an invalid secret
 		var secretChanged bool
-		if _, ok := mutator.secret.Data["user"]; !ok {
+		if user, ok := mutator.secret.Data["user"]; !ok || string(user) == "" {
 			provider := &api.Provider{}
 			providerName := string(mutator.secret.Data["provider"])
 			providerNamespace := mutator.secret.Namespace


### PR DESCRIPTION
Issue:
When testing ESXi Host connection, we don't take into account the mutation of the secret via the mutation hook.

Fix:
a. use the ESXi provider user and password when testing connection in the admission hook, like the secret will be once it's mutated by the mutation hook.
b. when checking for nil user field, also check for empty string to allow for tooling that sand "" instead of nil.

Images:
Before:
![MTV-1682-before](https://github.com/user-attachments/assets/f9f8b7bd-eb53-48c1-b8f4-fed722c18242)

After:
https://github.com/user-attachments/assets/4aa589af-075e-4ec9-a0db-7b3d2375339a

Ref:
https://issues.redhat.com/browse/MTV-1682
