### PR TITLE
MTV-1865 | Remove the q35 machine type

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -407,8 +407,6 @@ func (r *Builder) mapInput(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 }
 
 func (r *Builder) mapResources(vm *model.Workload, object *cnv.VirtualMachineSpec, usesInstanceType bool) {
-	// KubeVirt supports Q35 or PC-Q35 machine types only.
-	object.Template.Spec.Domain.Machine = &cnv.Machine{Type: Q35}
 	if usesInstanceType {
 		return
 	}

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -94,13 +94,6 @@ const (
 	SecureBootOptional = "optional"
 )
 
-// Machine types
-const (
-	PC    = "pc"
-	Q35   = "q35"
-	PcQ35 = "pc-q35"
-)
-
 // Firmware types
 const (
 	BIOS = "bios"
@@ -204,7 +197,6 @@ const (
 	CpuSockets           = "hw_cpu_sockets"
 	CpuThreads           = "hw_cpu_threads"
 	FirmwareType         = "hw_firmware_type"
-	MachineType          = "hw_machine_type"
 	CdromBus             = "hw_cdrom_bus"
 	PointerModel         = "hw_pointer_model"
 	VideoModel           = "hw_video_model"
@@ -247,7 +239,6 @@ var DefaultProperties = map[string]string{
 	CpuPolicy:       CpuPolicyShared,
 	CpuThreadPolicy: CpuThreadPolicyPrefer,
 	FirmwareType:    BIOS,
-	MachineType:     PC,
 	CdromBus:        IdeBus,
 	PointerModel:    UsbTablet,
 	VideoModel:      VideoVirtio,

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -228,7 +228,6 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	}
 	r.mapDisks(vm, persistentVolumeClaims, object)
 	r.mapFirmware(vm, vmRef, object)
-	r.setMachine(object)
 	r.mapInput(object)
 	if !usesInstanceType {
 		r.mapCPU(vm, object)
@@ -323,10 +322,6 @@ func (r *Builder) mapMemory(vm *model.VM, object *cnv.VirtualMachineSpec) error 
 	}
 	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: reservation}
 	return nil
-}
-
-func (r *Builder) setMachine(object *cnv.VirtualMachineSpec) {
-	object.Template.Spec.Domain.Machine = &cnv.Machine{Type: "q35"}
 }
 
 func (r *Builder) mapCPU(vm *model.VM, object *cnv.VirtualMachineSpec) {

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -268,7 +268,6 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	}
 	r.mapDisks(vm, persistentVolumeClaims, object)
 	r.mapFirmware(vm, &vm.Cluster, object)
-	r.setMachine(object)
 	if !usesInstanceType {
 		r.mapCPU(vm, object)
 		r.mapMemory(vm, object)
@@ -368,10 +367,6 @@ func (r *Builder) mapMemory(vm *model.Workload, object *cnv.VirtualMachineSpec) 
 		},
 	}
 	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: reservation}
-}
-
-func (r *Builder) setMachine(object *cnv.VirtualMachineSpec) {
-	object.Template.Spec.Domain.Machine = &cnv.Machine{Type: "q35"}
 }
 
 func (r *Builder) mapCPU(vm *model.Workload, object *cnv.VirtualMachineSpec) {

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -543,7 +543,6 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	}
 	r.mapDisks(vm, vmRef, persistentVolumeClaims, object)
 	r.mapFirmware(vm, object)
-	r.setMachine(object)
 	if !usesInstanceType {
 		r.mapCPU(vm, object)
 		r.mapMemory(vm, object)
@@ -638,10 +637,6 @@ func (r *Builder) mapClock(host *model.Host, object *cnv.VirtualMachineSpec) {
 		tz := cnv.ClockOffsetTimezone(host.Timezone)
 		object.Template.Spec.Domain.Clock.ClockOffset.Timezone = &tz
 	}
-}
-
-func (r *Builder) setMachine(object *cnv.VirtualMachineSpec) {
-	object.Template.Spec.Domain.Machine = &cnv.Machine{Type: "q35"}
 }
 
 func (r *Builder) mapMemory(vm *model.VM, object *cnv.VirtualMachineSpec) {


### PR DESCRIPTION
Issue:
VMs imported from vSphere always have the q35 machine type set. but the machine type is "floating", and thus the VM abi can change between reboots (i.e. update from rhel 8 to rhel9 or 10 on the host side).

Fix:
Remove the q35 machine type.

Ref: https://issues.redhat.com/browse/MTV-1865