### PR TITLE
MTV-1866 | Remove the requests.memory from the builder

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -440,11 +440,7 @@ func (r *Builder) mapResources(vm *model.Workload, object *cnv.VirtualMachineSpe
 
 	// TODO Support HugePages
 	memory := resource.NewQuantity(int64(vm.Flavor.RAM)*1024*1024, resource.BinarySI)
-	resourceRequests := map[core.ResourceName]resource.Quantity{}
-	resourceRequests[core.ResourceMemory] = *memory
 	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: memory}
-
-	object.Template.Spec.Domain.Resources.Requests = resourceRequests
 }
 
 func (r *Builder) getCpuCount(vm *model.Workload, imageCpuProperty string) (count uint32) {

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -316,11 +316,6 @@ func (r *Builder) mapMemory(vm *model.VM, object *cnv.VirtualMachineSpec) error 
 		return err
 	}
 	reservation := resource.NewQuantity(memoryBytes, resource.BinarySI)
-	object.Template.Spec.Domain.Resources = cnv.ResourceRequirements{
-		Requests: map[core.ResourceName]resource.Quantity{
-			core.ResourceMemory: *reservation,
-		},
-	}
 	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: reservation}
 	return nil
 }

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -362,11 +362,6 @@ func (r *Builder) mapClock(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 
 func (r *Builder) mapMemory(vm *model.Workload, object *cnv.VirtualMachineSpec) {
 	reservation := resource.NewQuantity(vm.Memory, resource.BinarySI)
-	object.Template.Spec.Domain.Resources = cnv.ResourceRequirements{
-		Requests: map[core.ResourceName]resource.Quantity{
-			core.ResourceMemory: *reservation,
-		},
-	}
 	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: reservation}
 }
 

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -647,11 +647,6 @@ func (r *Builder) setMachine(object *cnv.VirtualMachineSpec) {
 func (r *Builder) mapMemory(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	memoryBytes := int64(vm.MemoryMB) * 1024 * 1024
 	reservation := resource.NewQuantity(memoryBytes, resource.BinarySI)
-	object.Template.Spec.Domain.Resources = cnv.ResourceRequirements{
-		Requests: map[core.ResourceName]resource.Quantity{
-			core.ResourceMemory: *reservation,
-		},
-	}
 	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: reservation}
 }
 


### PR DESCRIPTION
Issue:
MTV is importing VMs with the requests.memory field and the memory.guest field set. This is problematic as it prevents memor-overcommit and is causing un-necessary memory pressure on VMs in the worst case leading to OOM sitiations.

Fix:
Remove the requests.memory from the builders

Ref: https://issues.redhat.com/browse/MTV-1866