### PR TITLE
MTV-1864 | Add luks to virt-v2v-inspector

### DIFF
--- a/virt-v2v/cmd/entrypoint.go
+++ b/virt-v2v/cmd/entrypoint.go
@@ -79,6 +79,10 @@ func main() {
 
 func runVirtV2VInspection(disks []string) error {
 	args := []string{"-v", "-x", "-if", "raw", "-i", "disk", "-O", global.INSPECTION}
+	args, err := addCommonArgs(args)
+	if err != nil {
+		return err
+	}
 	args = append(args, disks...)
 	fmt.Println("Running the virt-v2v-inspector with args: ", args)
 	v2vCmd := exec.Command("virt-v2v-inspector", args...)


### PR DESCRIPTION
Issue:
When migrating VM with luks from vmware the migration fails on the
virt-v2v-inspector step.

Fix:
Add common vmware args to the inspector. This contains the luks key args,
root on which we want to do the conversion etc.

Ref: https://issues.redhat.com/browse/MTV-1864
