### PR TITLE
MTV-1864 | Add luks support to the warm migration

### DIFF
--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
@@ -109,16 +109,6 @@ func (admitter *PlanAdmitter) validateLUKS() error {
 		return err
 	}
 
-	coldLocal, vErr := admitter.plan.VSphereColdLocal()
-	if vErr != nil {
-		log.Error(vErr, "Could not analyze plan, failing")
-		return vErr
-	}
-	if !coldLocal {
-		err := liberr.New("migration of encrypted disks is not supported for warm migrations or migrations to remote providers")
-		log.Error(err, "Warm migration does not support LUKS")
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
Issue:
When creating the warm migration with luks encrypted disks the migration does not even allow us to create the plan. This is because of the validation hook. But the virt-v2v-in-place supports the `--key` parameter and we are already passing it to it.
![image](https://github.com/user-attachments/assets/257b4537-a736-466d-a016-5c47077a8f30)

Fix:
Remove the warm check in the plan validation.

Ref: https://issues.redhat.com/browse/MTV-1864