### PR TITLE
MTV-1858 | Remove vm preference temporarily 

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1311,20 +1311,17 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus) (object *cnv.VirtualMachine
 	}
 
 	var ok bool
-	object, err = r.vmPreference(vm)
-	if err != nil {
-		r.Log.Info("Building VirtualMachine without a VirtualMachinePreference.",
+	r.Log.Info("Building VirtualMachine without a VirtualMachinePreference.",
+		"vm",
+		vm.String(),
+		"err",
+		err)
+	object, ok = r.vmTemplate(vm)
+	if !ok {
+		r.Log.Info("Building VirtualMachine without template.",
 			"vm",
-			vm.String(),
-			"err",
-			err)
-		object, ok = r.vmTemplate(vm)
-		if !ok {
-			r.Log.Info("Building VirtualMachine without template.",
-				"vm",
-				vm.String())
-			object = r.emptyVm(vm)
-		}
+			vm.String())
+		object = r.emptyVm(vm)
 	}
 
 	err = r.setInstanceType(vm, object)


### PR DESCRIPTION
Issue:
With older version of the Kubevirt migrating specific windows version the preference always sets BIOS and if we set the UEFI the creation fails. 

Quick fix:
Remove the preference usage.

ref: [MTV-1858](https://issues.redhat.com/browse/MTV-1858) [CNV-49381](https://issues.redhat.com/browse/CNV-49381)