### PR TITLE
Add latest win-virtio to upstream virt-v2v build

### DIFF
--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -10,7 +10,7 @@ RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o image-converter ./cmd/i
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-wrapper ./virt-v2v/cmd/entrypoint.go
 
 # Main container
-FROM quay.io/centos/centos:stream9-minimal
+FROM quay.io/centos/centos:stream9
 RUN rm /etc/pki/tls/fips_local.cnf && \
     echo -e '[fips_sect]\ntls1-prf-ems-check = 0\nactivate = 1' > /etc/pki/tls/fips_local.cnf && \
     sed -i '/^\\[ crypto_policy \\]/a Options=RHNoEnforceEMSinFIPS' /etc/pki/tls/openssl.cnf
@@ -19,14 +19,16 @@ ENV LIBGUESTFS_BACKEND=direct LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 
 RUN mkdir /disks && \
     source /etc/os-release && \
-    microdnf install -y \
+    dnf install -y \
         virt-v2v \
         virtio-win && \
-    microdnf clean all
+    dnf clean all
 
-RUN ( [ "$(rpm -q glibc)" == "glibc-2.34-66.el9.x86_64" ] && microdnf -y downgrade glibc-2.34-65.el9.x86_64 || true ) && \
-microdnf -y install libguestfs libguestfs-appliance libguestfs-xfs libguestfs-winsupport qemu-img supermin && \
+RUN ( [ "$(rpm -q glibc)" == "glibc-2.34-66.el9.x86_64" ] && dnf -y downgrade glibc-2.34-65.el9.x86_64 || true ) && \
+dnf -y install libguestfs libguestfs-appliance libguestfs-xfs libguestfs-winsupport qemu-img supermin && \
         depmod $(ls /lib/modules/ |tail -n1)
+
+RUN dnf install -y https://kojihub.stream.centos.org/kojifiles/packages/virtio-win/1.9.40/1.el9/noarch/virtio-win-1.9.40-1.el9.noarch.rpm
 
 # Create tarball for the appliance.
 RUN mkdir -p /usr/lib64/guestfs/appliance && \


### PR DESCRIPTION
Issue:
The latest virtio-win drivers in the AppStream is `virtio-win-1.9.15-4.el9.noarch` which is missing the latest windows drivers.
There are some legal problems with the latest drivers getting pushed to the AppStream but they are available in the koji.

Fix:
Add the `virtio-win-1.9.40-1.el9.noarch` to the **upstream** build.
