### PR TITLE
Backport MTV-1929: Clean up unused active source connections.

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -270,7 +270,6 @@ func (r *Reconciler) setPopulatorDataSourceLabels(plan *api.Plan) {
 			r.Log.Error(err, "Couldn't construct plan context when trying to set populator labels.")
 		} else {
 			runner := Migration{Context: ctx}
-			defer runner.logout()
 			runner.SetPopulatorDataSourceLabels()
 			planCopy := plan.DeepCopy()
 			if plan.Annotations == nil {
@@ -302,7 +301,6 @@ func (r *Reconciler) archive(plan *api.Plan) {
 		r.Log.Error(err, "Couldn't construct plan context while archiving plan.")
 	} else {
 		runner := Migration{Context: ctx}
-		defer runner.logout()
 		runner.Archive()
 	}
 	// Regardless of whether or not we can clean up, mark the plan archived.
@@ -388,7 +386,6 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	//
 	// Cancel.
 	runner := Migration{Context: ctx}
-	defer runner.logout()
 	err = runner.Cancel()
 	if err != nil {
 		return
@@ -428,7 +425,6 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	// Run the migration.
 	snapshot.BeginStagingConditions()
 	runner = Migration{Context: ctx}
-	defer runner.logout()
 	reQ, err = runner.Run()
 	if err != nil {
 		return

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -278,12 +278,6 @@ func (r *Migration) init() (err error) {
 	return
 }
 
-func (r *Migration) logout() {
-	if r.provider != nil {
-		r.provider.Close()
-	}
-}
-
 // Begin the migration.
 func (r *Migration) begin() (err error) {
 	snapshot := r.Plan.Status.Migration.ActiveSnapshot()
@@ -379,6 +373,11 @@ func (r *Migration) begin() (err error) {
 // Archive the plan.
 // Best effort to remove any retained migration resources.
 func (r *Migration) Archive() {
+	defer func() {
+		if r.provider != nil {
+			r.provider.Close()
+		}
+	}()
 	if err := r.init(); err != nil {
 		r.Log.Error(err, "Archive initialization failed.")
 		return
@@ -410,6 +409,11 @@ func (r *Migration) Archive() {
 }
 
 func (r *Migration) SetPopulatorDataSourceLabels() {
+	defer func() {
+		if r.provider != nil {
+			r.provider.Close()
+		}
+	}()
 	err := r.init()
 	if err != nil {
 		r.Log.Error(err, "Setting Populator Data Source labels failed.")
@@ -437,6 +441,11 @@ func (r *Migration) SetPopulatorDataSourceLabels() {
 // Cancel the migration.
 // Delete resources associated with VMs that have been marked canceled.
 func (r *Migration) Cancel() error {
+	defer func() {
+		if r.provider != nil {
+			r.provider.Close()
+		}
+	}()
 	if err := r.init(); err != nil {
 		return liberr.Wrap(err)
 	}


### PR DESCRIPTION
Backport of #1312 into release-2.7.