### PR TITLE
MTV-1442 | Allow to skip shared disks

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -161,6 +161,10 @@ spec:
                 - network
                 - storage
                 type: object
+              migrateSharedDisks:
+                default: true
+                description: Determines if the plan should migrate shared disks.
+                type: boolean
               preserveClusterCpuModel:
                 description: Preserve the CPU model and flags the VM runs with in
                   its oVirt cluster.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -54,6 +54,9 @@ type PlanSpec struct {
 	// Defaults to 'virtio'.
 	// +optional
 	DiskBus cnv.DiskBus `json:"diskBus,omitempty"`
+	// Determines if the plan should migrate shared disks.
+	// +kubebuilder:default:=true
+	MigrateSharedDisks bool `json:"migrateSharedDisks,omitempty"`
 }
 
 // Find a planned VM.
@@ -103,7 +106,7 @@ type Plan struct {
 // just use virt-v2v directly to convert the vm while copying data over. In other
 // cases, we use CDI to transfer disks to the destination cluster and then use
 // virt-v2v-in-place to convert these disks after cutover.
-func (p *Plan) VSphereColdLocal() (bool, error) {
+func (p *Plan) ShouldUseV2vForTransfer() (bool, error) {
 	source := p.Referenced.Provider.Source
 	if source == nil {
 		return false, liberr.New("Cannot analyze plan, source provider is missing.")
@@ -115,7 +118,9 @@ func (p *Plan) VSphereColdLocal() (bool, error) {
 
 	switch source.Type() {
 	case VSphere:
-		return !p.Spec.Warm && destination.IsHost(), nil
+		// The virt-v2v transferes all disks attached to the VM. If we want to skip the shared disks so we don't transfer
+		// them multiple times we need to manage the transfer using KubeVirt CDI DataVolumes and v2v-in-place.
+		return !p.Spec.Warm && destination.IsHost() && p.Spec.MigrateSharedDisks, nil
 	case Ova:
 		return true, nil
 	default:

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -33,6 +33,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
 	cnv "kubevirt.io/api/core/v1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -80,6 +81,10 @@ const (
 const (
 	// CDI import backing file annotation on PVC
 	AnnImportBackingFile = "cdi.kubevirt.io/storage.import.backingFile"
+)
+
+const (
+	Shareable = "shareable"
 )
 
 // Map of vmware guest ids to osinfo ids.
@@ -490,12 +495,73 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 					dv.ObjectMeta.Annotations = make(map[string]string)
 				}
 				dv.ObjectMeta.Annotations[planbase.AnnDiskSource] = r.baseVolume(disk.File)
+				if disk.Shared {
+					dv.ObjectMeta.Labels[Shareable] = "true"
+				}
 				dvs = append(dvs, *dv)
 			}
 		}
 	}
 
 	return
+}
+
+// Return all shareable PVCs
+func (r *Builder) ShareablePVCs() (pvcs []*core.PersistentVolumeClaim, err error) {
+	pvcsList := &core.PersistentVolumeClaimList{}
+	err = r.Destination.Client.List(
+		context.TODO(),
+		pvcsList,
+		&client.ListOptions{
+			LabelSelector: k8slabels.SelectorFromSet(map[string]string{
+				Shareable: "true",
+			}),
+		},
+	)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	pvcs = make([]*core.PersistentVolumeClaim, len(pvcsList.Items))
+	for i, pvc := range pvcsList.Items {
+		// loopvar
+		copyPvc := pvc
+		pvcs[i] = &copyPvc
+	}
+
+	return
+}
+
+// Return PersistentVolumeClaims associated with a VM.
+func (r *Builder) getSharedPVCs(vm *model.VM) (pvcs []*core.PersistentVolumeClaim, err error) {
+	allPvcs, err := r.ShareablePVCs()
+	if err != nil {
+		return pvcs, err
+	}
+	for _, disk := range vm.Disks {
+		if !disk.Shared {
+			continue
+		}
+		pvc := r.getDisksPvc(disk, allPvcs)
+		if pvc != nil {
+			pvcs = append(pvcs, pvc)
+			r.Log.Info("Found shared PVC disk", "disk", disk.File)
+		} else {
+			// No PVC found skipping disk
+			r.Log.Info("No PVC found to the shared disk, the disk will not be created", "disk", disk.File)
+		}
+	}
+	return pvcs, nil
+}
+
+// Return PersistentVolumeClaims associated with a VM.
+func (r *Builder) getDisksPvc(disk vsphere.Disk, pvcs []*core.PersistentVolumeClaim) *core.PersistentVolumeClaim {
+	for _, pvc := range pvcs {
+		if pvc.Annotations[planbase.AnnDiskSource] == r.baseVolume(disk.File) {
+			return pvc
+		}
+	}
+	return nil
 }
 
 // Create the destination Kubevirt VM.
@@ -529,7 +595,27 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 		return
 	}
 	if !r.Context.Plan.Spec.MigrateSharedDisks {
-		r.removeSharedDisks(vm)
+		sharedPVCs, err := r.getSharedPVCs(vm)
+		if err != nil {
+			return err
+		}
+		var temp []vsphere.Disk
+		for _, disk := range vm.Disks {
+			if !disk.Shared {
+				temp = append(temp, disk)
+				continue
+			}
+			pvc := r.getDisksPvc(disk, sharedPVCs)
+			if pvc != nil {
+				temp = append(temp, disk)
+				persistentVolumeClaims = append(persistentVolumeClaims, pvc)
+				r.Log.Info("Found shared PVC disk", "disk", disk.File)
+			} else {
+				// No PVC found skipping disk
+				r.Log.Info("No PVC found to the shared disk, the disk will not be created", "disk", disk.File)
+			}
+		}
+		vm.Disks = temp
 	}
 
 	var conflicts []string
@@ -747,6 +833,9 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 					Bus: bus,
 				},
 			},
+		}
+		if disk.Shared {
+			kubevirtDisk.Cache = cnv.CacheNone
 		}
 		// For multiboot VMs, if the selected boot device is the current disk,
 		// set it as the first in the boot order.

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -331,7 +331,7 @@ func (r *Client) getTaskById(vmRef ref.Ref, taskId string, hosts util.HostsFunc)
 }
 
 func (r *Client) getClient(vm *model.VM, hosts util.HostsFunc) (client *vim25.Client, err error) {
-	if coldLocal, vErr := r.Plan.VSphereColdLocal(); vErr == nil && coldLocal {
+	if coldLocal, vErr := r.Plan.ShouldUseV2vForTransfer(); vErr == nil && coldLocal {
 		// when virt-v2v runs the migration, forklift-controller should interact only
 		// with the component that serves the SDK endpoint of the provider
 		client = r.client.Client

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1708,7 +1708,7 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	nonRoot := true
 	allowPrivilageEscalation := false
 	// virt-v2v image
-	coldLocal, vErr := r.Context.Plan.VSphereColdLocal()
+	coldLocal, vErr := r.Context.Plan.ShouldUseV2vForTransfer()
 	if vErr != nil {
 		err = vErr
 		return

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1900,6 +1900,15 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, configMap *core.Confi
 
 	for i, v := range vmVolumes {
 		pvc := pvcsByName[v.PersistentVolumeClaim.ClaimName]
+		if pvc == nil {
+			r.Log.V(1).Info(
+				"Failed to find the PVC to the Volume for the pod volume mount",
+				"volume",
+				v.Name,
+				"pvc",
+				v.PersistentVolumeClaim.ClaimName)
+			continue
+		}
 		vol := core.Volume{
 			Name: pvc.Name,
 			VolumeSource: core.VolumeSource{
@@ -2081,6 +2090,15 @@ func (r *KubeVirt) libvirtDomain(vmCr *VirtualMachine, pvcs []*core.PersistentVo
 		diskSource := libvirtxml.DomainDiskSource{}
 
 		pvc := pvcsByName[vol.PersistentVolumeClaim.ClaimName]
+		if pvc == nil {
+			r.Log.V(1).Info(
+				"Failed to find the PVC to the Volume for the libvirt domain",
+				"volume",
+				vol.Name,
+				"pvc",
+				vol.PersistentVolumeClaim.ClaimName)
+			continue
+		}
 		if pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == core.PersistentVolumeBlock {
 			diskSource.Block = &libvirtxml.DomainDiskSourceBlock{
 				Dev: fmt.Sprintf("/dev/block%v", i),

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1827,7 +1827,7 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 			break
 		}
 
-		coldLocal, err := r.Context.Plan.VSphereColdLocal()
+		coldLocal, err := r.Context.Plan.ShouldUseV2vForTransfer()
 		switch {
 		case err != nil:
 			return liberr.Wrap(err)
@@ -2022,7 +2022,7 @@ type Predicate struct {
 
 // Evaluate predicate flags.
 func (r *Predicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
-	coldLocal, vErr := r.context.Plan.VSphereColdLocal()
+	coldLocal, vErr := r.context.Plan.ShouldUseV2vForTransfer()
 	if vErr != nil {
 		err = vErr
 		return

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -197,7 +197,7 @@ func (r *Scheduler) buildPending() (err error) {
 }
 
 func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {
-	coldLocal, _ := r.Plan.VSphereColdLocal()
+	coldLocal, _ := r.Plan.ShouldUseV2vForTransfer()
 	if coldLocal {
 		switch vmStatus.Phase {
 		case CreateVM, PostHook, Completed:


### PR DESCRIPTION
Issue: When migrating a VM with shared disks the virt-v2v transfers all disks that are attached to the VM, that includes the shared disks. But if we will transfer 2 VMs with the same shared disk the disk will be migrated twice. This takes a lot of additional resources.

Fix: There are multiple solutions, which vary in complexity. I have chosen the simplest and fastest solution by adding a new Plan parameter migrateSharedDisks this determines if the shared disks should be migrated. By default, it's set to True as that's the default virt-v2v behaviour. If the toggle is turned off the plan will filter out the shared disks and use KubeVirt CDI for disk transfer and virt-v2v-in-place for the guest conversion.

Usage: The user will create 2 plans, one with only one VM and with the `migrateSharedDisks` enabled to transfer the shared disks, and another plan with the toggle disabled which will migrate the additional VMs. If the plans are in correct order (first transfer shared disk) the shared disks will get automatically attached to the new VMs.

Ref: http://issues.redhat.com/browse/MTV-1442