### PR TITLE
chore(containers): build: use a cache mount for building

### DIFF
--- a/build/forklift-api/Containerfile
+++ b/build/forklift-api/Containerfile
@@ -3,7 +3,8 @@ WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
 ENV GOEXPERIMENT strictfipsruntime
-RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o forklift-api github.com/konveyor/forklift-controller/cmd/forklift-api
+ENV GOCACHE /go-build/cache
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o forklift-api github.com/konveyor/forklift-controller/cmd/forklift-api
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155
 # Required to be able to get files from within the pod

--- a/build/forklift-controller/Containerfile
+++ b/build/forklift-controller/Containerfile
@@ -3,7 +3,8 @@ WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
 ENV GOEXPERIMENT strictfipsruntime
-RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o manager github.com/konveyor/forklift-controller/cmd/forklift-controller
+ENV GOCACHE /go-build/cache
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o manager github.com/konveyor/forklift-controller/cmd/forklift-controller
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155
 # RUN microdnf -y update && microdnf -y clean all

--- a/build/openstack-populator/Containerfile
+++ b/build/openstack-populator/Containerfile
@@ -3,7 +3,8 @@ WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
 ENV GOEXPERIMENT strictfipsruntime
-RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o openstack-populator github.com/konveyor/forklift-controller/cmd/openstack-populator
+ENV GOCACHE /go-build/cache
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o openstack-populator github.com/konveyor/forklift-controller/cmd/openstack-populator
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155
 # Required to be able to get files from within the pod

--- a/build/ova-provider-server/Containerfile
+++ b/build/ova-provider-server/Containerfile
@@ -3,8 +3,8 @@ WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
 ENV GOEXPERIMENT strictfipsruntime
-
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o ova-provider-server github.com/konveyor/forklift-controller/cmd/ova-provider-server
+ENV GOCACHE /go-build/cache
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o ova-provider-server github.com/konveyor/forklift-controller/cmd/ova-provider-server
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155
 # Required to be able to get files from within the pod

--- a/build/ovirt-populator/Containerfile
+++ b/build/ovirt-populator/Containerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
 ENV GOEXPERIMENT strictfipsruntime
-
-RUN GOOS=linux GOARCH=amd64 go build -o ovirt-populator github.com/konveyor/forklift-controller/cmd/ovirt-populator
+ENV GOCACHE /go-build/cache
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -o ovirt-populator github.com/konveyor/forklift-controller/cmd/ovirt-populator
 
 FROM registry.access.redhat.com/ubi8/ubi:8.10-1088
 COPY --from=builder /app/ovirt-populator /usr/local/bin/ovirt-populator

--- a/build/populator-controller/Containerfile
+++ b/build/populator-controller/Containerfile
@@ -3,8 +3,8 @@ WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
 ENV GOEXPERIMENT strictfipsruntime
-
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o controller github.com/konveyor/forklift-controller/cmd/populator-controller
+ENV GOCACHE /go-build/cache
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o controller github.com/konveyor/forklift-controller/cmd/populator-controller
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155
 # Required to be able to get files from within the pod

--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -21,10 +21,11 @@ WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
 ENV GOEXPERIMENT strictfipsruntime
+ENV GOCACHE /go-build/cache
 
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-monitor github.com/konveyor/forklift-controller/cmd/virt-v2v-monitor
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o image-converter github.com/konveyor/forklift-controller/cmd/image-converter
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-wrapper github.com/konveyor/forklift-controller/cmd/virt-v2v
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-monitor github.com/konveyor/forklift-controller/cmd/virt-v2v-monitor
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o image-converter github.com/konveyor/forklift-controller/cmd/image-converter
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-wrapper github.com/konveyor/forklift-controller/cmd/virt-v2v
 
 FROM registry.access.redhat.com/ubi9:9.5-1731517889
 


### PR DESCRIPTION
When building with bazel, incremental builds (e.g. after changing just a single source file) were pretty quick. After switching away from bazel, running e.g. `make build-controller-image` would do a full rebuild of the entire source code even if only a single file was touched. To reduce the amount of time that builds take, introduce a cache mount in the
build container. This cache will persist the intermediate build artifacts between container builds so that when a single source file is changed, it will only rebuild that one file and re-use the other object files from previous builds. Set the `$GOCACHE` environment variable to point to this cache mount while building.