### PR TITLE
MTV-1635 | Allow to specify the diskBus

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -60,6 +60,12 @@ spec:
               description:
                 description: Description
                 type: string
+              diskBus:
+                description: |-
+                  Specify the disk bus which will be applied to all VMs disks in plan.
+                  Possible options 'scsi', 'sata' and 'virtio'.
+                  Defaults to 'virtio'.
+                type: string
               map:
                 description: Resource mapping.
                 properties:

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -24,6 +24,7 @@ import (
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cnv "kubevirt.io/api/core/v1"
 )
 
 // PlanSpec defines the desired state of Plan.
@@ -48,6 +49,11 @@ type PlanSpec struct {
 	PreserveClusterCPUModel bool `json:"preserveClusterCpuModel,omitempty"`
 	// Preserve static IPs of VMs in vSphere
 	PreserveStaticIPs bool `json:"preserveStaticIPs,omitempty"`
+	// Specify the disk bus which will be applied to all VMs disks in plan.
+	// Possible options 'scsi', 'sata' and 'virtio'.
+	// Defaults to 'virtio'.
+	// +optional
+	DiskBus cnv.DiskBus `json:"diskBus,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -715,11 +715,16 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 				},
 			},
 		}
+		bus := cnv.DiskBusVirtio
+		if r.Plan.Spec.DiskBus != "" {
+			bus = r.Plan.Spec.DiskBus
+		}
+
 		kubevirtDisk := cnv.Disk{
 			Name: volumeName,
 			DiskDevice: cnv.DiskDevice{
 				Disk: &cnv.DiskTarget{
-					Bus: Virtio,
+					Bus: bus,
 				},
 			},
 		}

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	v1 "k8s.io/api/storage/v1"
+	cnv "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"encoding/json"
@@ -112,6 +113,15 @@ func (admitter *PlanAdmitter) validateLUKS() error {
 	return nil
 }
 
+func (admitter *PlanAdmitter) IsValidDiskBus() bool {
+	switch admitter.plan.Spec.DiskBus {
+	case cnv.DiskBusSCSI, cnv.DiskBusSATA, cnv.DiskBusVirtio:
+		return true
+	default:
+		return false
+	}
+}
+
 func (admitter *PlanAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	log.Info("Plan admitter was called")
 	raw := ar.Request.Object.Raw
@@ -162,6 +172,9 @@ func (admitter *PlanAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv
 	if err != nil {
 		return util.ToAdmissionResponseError(err)
 	}
-
+	if admitter.plan.Spec.DiskBus != "" && !admitter.IsValidDiskBus() {
+		err = liberr.New(fmt.Sprintf("migration to diskBus '%s' is not supported", admitter.plan.Spec.DiskBus))
+		return util.ToAdmissionResponseError(err)
+	}
 	return util.ToAdmissionResponseAllow()
 }


### PR DESCRIPTION
Allow users to specify the plan.spec.diskBus which will set it on all disks during the creation.
Possible options 'scsi', 'sata' and 'virtio'.

Ref: https://issues.redhat.com/browse/MTV-1635