### PR TITLE
chore(bazel): chore-running-bazel-generate

### DIFF
--- a/pkg/apis/forklift/v1beta1/BUILD.bazel
+++ b/pkg/apis/forklift/v1beta1/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/runtime",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor/kubevirt.io/api/core/v1:core",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/scheme",
     ],
 )

--- a/pkg/controller/plan/adapter/vsphere/BUILD.bazel
+++ b/pkg/controller/plan/adapter/vsphere/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//vendor/github.com/vmware/govmomi/vim25/types",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/api/resource",
+        "//vendor/k8s.io/apimachinery/pkg/labels",
         "//vendor/k8s.io/utils/ptr",
         "//vendor/kubevirt.io/api/core/v1:core",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1",

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//vendor/k8s.io/api/storage/v1:storage",
         "//vendor/k8s.io/apimachinery/pkg/api/errors",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/kubevirt.io/api/core/v1:core",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client",
     ],
 )


### PR DESCRIPTION
chore: update bazel deps

Issue:
bazel deps uout of date, release-2.7 does not compile using bazel

Fix:
update bazel deps for release-2.7

running
```bash
make bazel-generate
```