### PR TITLE
MTV-2049 | Don't auto add TPM device if BIOS firmware detected

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -854,11 +854,6 @@ func (r *Builder) mapTpm(vm *model.VM, object *cnv.VirtualMachineSpec) {
 		persistData := true
 		object.Template.Spec.Domain.Devices.TPM = &cnv.TPMDevice{Persistent: &persistData}
 	}
-	if vm.Firmware == BIOS {
-		// Disable the vTPM on non UEFI
-		persistData := false
-		object.Template.Spec.Domain.Devices.TPM = &cnv.TPMDevice{Persistent: &persistData}
-	}
 }
 
 // Build tasks.


### PR DESCRIPTION
ref:
https://issues.redhat.com/browse/MTV-2049
https://issues.redhat.com/browse/CNV-49381

Issue:
After CNV-49381 was fixed in CNV v4.17.1 we don't need the workaround to set the vTPM in MTV

Fix:
Remove the vTPM setup in MTV workaround