### PR TITLE
chore(containers): use proper syntax for ENV in Containerfiles

### DIFF
--- a/build/forklift-api/Containerfile
+++ b/build/forklift-api/Containerfile
@@ -1,9 +1,9 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9-1739267472 AS builder
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
-ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
-ENV GOEXPERIMENT strictfipsruntime
-ENV GOCACHE /go-build/cache
+ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o forklift-api github.com/konveyor/forklift-controller/cmd/forklift-api
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155

--- a/build/forklift-controller/Containerfile
+++ b/build/forklift-controller/Containerfile
@@ -1,9 +1,9 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9-1739267472 AS builder
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
-ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
-ENV GOEXPERIMENT strictfipsruntime
-ENV GOCACHE /go-build/cache
+ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o manager github.com/konveyor/forklift-controller/cmd/forklift-controller
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155

--- a/build/openstack-populator/Containerfile
+++ b/build/openstack-populator/Containerfile
@@ -1,9 +1,9 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9-1739267472 AS builder
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
-ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
-ENV GOEXPERIMENT strictfipsruntime
-ENV GOCACHE /go-build/cache
+ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o openstack-populator github.com/konveyor/forklift-controller/cmd/openstack-populator
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155

--- a/build/ova-provider-server/Containerfile
+++ b/build/ova-provider-server/Containerfile
@@ -1,9 +1,9 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9-1739267472 AS builder
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
-ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
-ENV GOEXPERIMENT strictfipsruntime
-ENV GOCACHE /go-build/cache
+ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o ova-provider-server github.com/konveyor/forklift-controller/cmd/ova-provider-server
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155

--- a/build/ovirt-populator/Containerfile
+++ b/build/ovirt-populator/Containerfile
@@ -2,9 +2,9 @@ FROM registry.access.redhat.com/ubi8/go-toolset:1.21.11-8.1724662611 AS builder
 ENV GOPATH=$APP_ROOT
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
-ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
-ENV GOEXPERIMENT strictfipsruntime
-ENV GOCACHE /go-build/cache
+ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -o ovirt-populator github.com/konveyor/forklift-controller/cmd/ovirt-populator
 
 FROM registry.access.redhat.com/ubi8/ubi:8.10-1088

--- a/build/populator-controller/Containerfile
+++ b/build/populator-controller/Containerfile
@@ -1,9 +1,9 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9-1739267472 AS builder
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
-ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
-ENV GOEXPERIMENT strictfipsruntime
-ENV GOCACHE /go-build/cache
+ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o controller github.com/konveyor/forklift-controller/cmd/populator-controller
 
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1736404155

--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9:9.5-1731517889 AS appliance
 
-ENV LIBGUESTFS_BACKEND direct
+ENV LIBGUESTFS_BACKEND=direct
 
 RUN subscription-manager refresh && \
     dnf install -y --setopt=install_weak_deps=False \
@@ -19,9 +19,9 @@ RUN mkdir -p /usr/local/lib/guestfs/appliance && \
 FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9-1739267472 AS builder
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
-ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
-ENV GOEXPERIMENT strictfipsruntime
-ENV GOCACHE /go-build/cache
+ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOCACHE=/go-build/cache
 
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-monitor github.com/konveyor/forklift-controller/cmd/virt-v2v-monitor
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o image-converter github.com/konveyor/forklift-controller/cmd/image-converter


### PR DESCRIPTION
The syntax "ENV VAR VALUE" is supported but is deprecated, and docker complains about it. The proper syntax is "ENV VAR=VALUE". Switch to that syntax in all Containerfiles.
