### PR TITLE
MTV-2025 | NICs mapping  must match  the source VM mapping

### DIFF
--- a/pkg/virt-v2v/customize/scripts/rhel/run/network_config_util.sh
+++ b/pkg/virt-v2v/customize/scripts/rhel/run/network_config_util.sh
@@ -7,6 +7,9 @@ NETWORK_CONNECTIONS_DIR="${NETWORK_CONNECTIONS_DIR:-/etc/NetworkManager/system-c
 NETWORK_INTERFACES_DIR="${NETWORK_INTERFACES_DIR:-/etc/network/interfaces}"
 IFQUERY_CMD="${IFQUERY_CMD:-ifquery}"
 SYSTEMD_NETWORK_DIR="${SYSTEMD_NETWORK_DIR:-/run/systemd/network}"
+# UDEV_RULES_FILE_TEMP comes earlier lexicographically, hence it take precedence over UDEV_RULES_FILE
+# and will prevent collisions by creating temporary rules first. 
+UDEV_RULES_FILE_TEMP="${UDEV_RULES_FILE_TEMP:-/etc/udev/rules.d/70-persistent-net-temp.rules}"
 UDEV_RULES_FILE="${UDEV_RULES_FILE:-/etc/udev/rules.d/70-persistent-net.rules}"
 NETPLAN_DIR="${NETPLAN_DIR:-/}"
 
@@ -109,7 +112,7 @@ udev_from_ifcfg() {
             continue
         fi
 
-        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"$(remove_quotes "$DEVICE")\""
+        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"temp_$(remove_quotes "$DEVICE")\""
     done
 }
 
@@ -147,7 +150,7 @@ udev_from_nm() {
             continue
         fi
 
-        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"$(remove_quotes "$DEVICE")\""
+        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"temp_$(remove_quotes "$DEVICE")\""
     done
 }
 
@@ -223,7 +226,7 @@ udev_from_netplan() {
         fi
 
         # Create the udev rule based on the extracted MAC address and interface name
-        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"$(remove_quotes "$interface_name")\""
+        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"temp_$(remove_quotes "$interface_name")\""
     done
 }
 
@@ -274,7 +277,22 @@ udev_from_ifquery() {
         fi
 
         # Create the udev rule based on the extracted MAC address and interface name
-        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"$(remove_quotes "$interface_name")\""
+        echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"$(remove_quotes "$S_HW")\",NAME=\"temp_$(remove_quotes "$interface_name")\""
+    done
+}
+
+
+# Create final udev rules based on the temporary udev rules
+udev_final_from_temp_rules() {
+    # Read the temporary udev rules file line by line
+    cat "$UDEV_RULES_FILE_TEMP" | while read line;
+    do
+        # Extract the temporary name and final name
+        TEMP_NAME=$(echo "$line" | grep -o 'NAME="temp_[^"]*"' | cut -d'"' -f2)
+        FINAL_NAME=$(echo "$TEMP_NAME" | sed 's/^temp_//')
+
+        # Generate final udev rule by replacing the temporary name with the final name in the original line
+        echo "${line/temp_$FINAL_NAME/$FINAL_NAME}"
     done
 }
 
@@ -299,14 +317,18 @@ check_dupe_hws() {
 
 # Create udev rules check for duplicates and write them to udev file
 main() {
-    {
+   {
         udev_from_ifcfg
         udev_from_nm
         udev_from_netplan
         udev_from_ifquery
+    } | check_dupe_hws > "$UDEV_RULES_FILE_TEMP" 2>/dev/null
+
+    {
+        udev_final_from_temp_rules
     } | check_dupe_hws > "$UDEV_RULES_FILE" 2>/dev/null
-    echo "New udev rule:"
+
+    echo "New udev rules:"
     cat $UDEV_RULES_FILE
 }
-
 main

--- a/pkg/virt-v2v/customize/scripts/rhel/run/test-network_config_util.sh
+++ b/pkg/virt-v2v/customize/scripts/rhel/run/test-network_config_util.sh
@@ -17,6 +17,7 @@ test_dir() {
     export NETWORK_SCRIPTS_DIR="$TEST_DIR/etc/sysconfig/network-scripts"
     export NETWORK_CONNECTIONS_DIR="$TEST_DIR/etc/NetworkManager/system-connections"
     export UDEV_RULES_FILE="$TEST_DIR/etc/udev/rules.d/70-persistent-net.rules"
+    export UDEV_RULES_FILE_TEMP="$TEST_DIR/etc/udev/rules.d/70-persistent-net-temp.rules"
     export SYSTEMD_NETWORK_DIR="$TEST_DIR/run/systemd/network"
     export NETPLAN_DIR="$TEST_DIR/"
 
@@ -36,6 +37,7 @@ test_dir() {
     cp -a $TEST_SRC_DIR/root/* $TEST_DIR
 
     # Clean up from previous runs
+    rm -f "$UDEV_RULES_FILE_TEMP"
     rm -f "$UDEV_RULES_FILE"
     mkdir -p $(dirname "$UDEV_RULES_FILE")
 


### PR DESCRIPTION
Issue:
When migrating VMs with multiple NICs when mapping the order must match that of the source VM

Fix:
Create a temp udev.rule file with temporarly NICs names with precedence over the "org"  udev rule file - that will overcome the BOOT collisions. After udev applies the temp names  and omitting the collisions issue it'll apply the desired names.

Ref: https://issues.redhat.com/browse/MTV-2025