### PR TITLE
MTV-2025 | Prevent Multiple NICs wrong mapping during migration

### DIFF
--- a/pkg/virt-v2v/customize/scripts/rhel/run/test-network_config_util.sh
+++ b/pkg/virt-v2v/customize/scripts/rhel/run/test-network_config_util.sh
@@ -17,6 +17,7 @@ test_dir() {
     export NETWORK_SCRIPTS_DIR="$TEST_DIR/etc/sysconfig/network-scripts"
     export NETWORK_CONNECTIONS_DIR="$TEST_DIR/etc/NetworkManager/system-connections"
     export UDEV_RULES_FILE="$TEST_DIR/etc/udev/rules.d/70-persistent-net.rules"
+    export UDEV_RULES_FILE_TEMP="$TEST_DIR/etc/udev/rules.d/70-persistent-net-temp.rules"
     export SYSTEMD_NETWORK_DIR="$TEST_DIR/run/systemd/network"
     export NETPLAN_DIR="$TEST_DIR/"
 
@@ -36,6 +37,7 @@ test_dir() {
     cp -a $TEST_SRC_DIR/root/* $TEST_DIR
 
     # Clean up from previous runs
+    rm -f "$UDEV_RULES_FILE_TEMP"
     rm -f "$UDEV_RULES_FILE"
     mkdir -p $(dirname "$UDEV_RULES_FILE")
 


### PR DESCRIPTION
Issue:
When migrating VMs with multiple NICs when mapping the order must match that of the source VM

Fix:
Create a temp udev.rule file with temporarly NICs names with precedence over the "org"  udev rule file - that will overcome the BOOT collisions. After udev applies the temp names  and omitting the collisions issue it'll apply the desired names.

Ref: https://issues.redhat.com/browse/MTV-2025