### PR TITLE
MTV-2025 | Prevent NICs wrong mapping during migration

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -134,6 +134,8 @@ type Validator interface {
 	DirectStorage(vmRef ref.Ref) (bool, error)
 	// Validate that a VM's networks have been mapped.
 	NetworksMapped(vmRef ref.Ref) (bool, error)
+	// Validate the network mapping order.
+	NetworkMappingOrder(vmRef ref.Ref) (bool, error)
 	// Validate that a VM's Host isn't in maintenance mode.
 	MaintenanceMode(vmRef ref.Ref) (bool, error)
 	// Validate whether warm migration is supported from this provider type.

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -197,3 +197,8 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
 func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) NetworkMappingOrder(vmRef ref.Ref) (bool, error) {
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -120,3 +120,8 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
 func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) NetworkMappingOrder(vmRef ref.Ref) (bool, error) {
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -111,3 +111,8 @@ func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
 	// Validate that the vm has the change tracking enabled
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) NetworkMappingOrder(vmRef ref.Ref) (bool, error) {
+	return true, nil
+}

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -177,3 +177,8 @@ func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
 	// Validate that the vm has the change tracking enabled
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) NetworkMappingOrder(vmRef ref.Ref) (bool, error) {
+	return true, nil
+}

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -717,6 +717,7 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if devArray, cast := p.Val.(types.ArrayOfVirtualDevice); cast {
 					devList := []model.Device{}
 					nicList := []model.NIC{}
+					nicsIndex := 0
 					for _, dev := range devArray.VirtualDevice {
 						var nic *types.VirtualEthernetCard
 						switch device := dev.(type) {
@@ -763,12 +764,14 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 							nicList = append(
 								nicList,
 								model.NIC{
-									MAC: nic.MacAddress,
+									MAC:   nic.MacAddress,
+									Order: strconv.Itoa(nicsIndex),
 									Network: model.Ref{
 										Kind: model.NetKind,
 										ID:   network,
 									},
 								})
+							nicsIndex++
 						}
 					}
 					v.model.Devices = devList

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -305,6 +305,7 @@ type Device struct {
 type NIC struct {
 	Network Ref    `json:"network"`
 	MAC     string `json:"mac"`
+	Order   string `json:"order"`
 }
 
 // Guest network.


### PR DESCRIPTION
Issue:
When migrating VMs with multiple NICs when mapping the order must match that of the source VM

Fix:
Create a temp udev.rule file with temporarly NICs names with precedence over the "org"  udev rule file - that will overcome the BOOT collisions. After udev applies the temp names  and omitting the collisions issue it'll apply the desired names.

Ref: https://issues.redhat.com/browse/MTV-2025