### PR TITLE
MTV-383 | Allow customization of target vm name

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -552,6 +552,12 @@ spec:
                       description: Started timestamp.
                       format: date-time
                       type: string
+                    targetName:
+                      description: |-
+                        TargetName specifies a custom name for the VM in the target cluster.
+                        If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
+                        If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                      type: string
                     type:
                       description: Type used to qualify the name.
                       type: string

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -505,6 +505,12 @@ spec:
                     rootDisk:
                       description: Choose the primary disk the VM boots from
                       type: string
+                    targetName:
+                      description: |-
+                        TargetName specifies a custom name for the VM in the target cluster.
+                        If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
+                        If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                      type: string
                     type:
                       description: Type used to qualify the name.
                       type: string
@@ -1159,6 +1165,12 @@ spec:
                         started:
                           description: Started timestamp.
                           format: date-time
+                          type: string
+                        targetName:
+                          description: |-
+                            TargetName specifies a custom name for the VM in the target cluster.
+                            If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
+                            If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
                           type: string
                         type:
                           description: Type used to qualify the name.

--- a/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -79,6 +79,11 @@ type VM struct {
 	//   "{{if eq .NetworkType "Pod"}}pod{{else}}multus-{{.NetworkIndex}}{{end}}"
 	// +optional
 	NetworkNameTemplate string `json:"networkNameTemplate,omitempty"`
+	// TargetName specifies a custom name for the VM in the target cluster.
+	// If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
+	// If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+	// +optional
+	TargetName string `json:"targetName,omitempty"`
 }
 
 // Find a Hook for the specified step.

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -778,6 +778,13 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		if vm.TargetName != "" {
 			vm.NewName = vm.TargetName
 
+			// Check if the new VM name meets DNS1123 protocol requirements
+			if errs := k8svalidation.IsDNS1123Subdomain(vm.NewName); len(errs) > 0 {
+				err = fmt.Errorf("VM name '%s' does not meet DNS1123 protocol requirements", vm.NewName)
+				r.Log.Error(err, "Failed to update the VM name to targetName.")
+				return
+			}
+
 			// Verify target VM name uniqueness in the destination namespace.
 			// Return error if name exists since we do not want to mutate explicit name assignments.
 			nameExist, errName := r.kubevirt.checkIfVmNameExistsInNamespace(vm.NewName, r.Plan.Spec.TargetNamespace)

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -773,11 +773,31 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			err = nil
 			break
 		}
-		if errs := k8svalidation.IsDNS1123Subdomain(vm.Name); len(errs) > 0 {
-			vm.NewName, err = r.kubevirt.changeVmNameDNS1123(vm.Name, r.Plan.Spec.TargetNamespace)
-			if err != nil {
-				r.Log.Error(err, "Failed to update the VM name to meet DNS1123 protocol requirements.")
+
+		// Check if user provided explicit a target virtual machine name
+		if vm.TargetName != "" {
+			vm.NewName = vm.TargetName
+
+			// Verify target VM name uniqueness in the destination namespace.
+			// Return error if name exists since we do not want to mutate explicit name assignments.
+			nameExist, errName := r.kubevirt.checkIfVmNameExistsInNamespace(vm.NewName, r.Plan.Spec.TargetNamespace)
+			if errName != nil {
+				err = liberr.Wrap(errName)
 				return
+			}
+			if nameExist {
+				err = fmt.Errorf("VM name '%s' already exists in the target namespace '%s'", vm.NewName, r.Plan.Spec.TargetNamespace)
+				r.Log.Error(err, "Failed to update the VM name to targetName.")
+				return
+			}
+		} else {
+			// Check if the VM name meets DNS1123 protocol requirements
+			if errs := k8svalidation.IsDNS1123Subdomain(vm.Name); len(errs) > 0 {
+				vm.NewName, err = r.kubevirt.changeVmNameDNS1123(vm.Name, r.Plan.Spec.TargetNamespace)
+				if err != nil {
+					r.Log.Error(err, "Failed to update the VM name to meet DNS1123 protocol requirements.")
+					return
+				}
 			}
 		}
 		vm.Phase = r.next(vm.Phase)


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-383

Issue:
As a migration owner, when creating a migration plan that has VMs with non-conformant names, I would like the ability to change the name of the target VM on the fly before it is migrated.

Currently:
A vm is getting the target name automatically to be unique within the namesapce and to be valid k8s subdomain.

After:
Users can override the automatic mechanism by providing a TargetName

  - If the target name is not valid k8s subdomain, plan validation will fail
  - If the target name is not unique, plan validation will fail
  
 Example:
 ``` bash
kubectl sql "\
       select \
          name as planName, spec.vms[1].name as origName, spec.vms[1].targetName as targetName, \
          status.migration.vms[1].name as migratedVMName \
       from openshift-mtv/plans \
       where targetName is not null"
KIND: Plan	COUNT: 1
planName	origName	targetName  	migratedVMName	
test2   	yzamir_2	my-best-name	my-best-name  	

kubectl sql "select * from openshift-mtv/vms where name = 'my-best-name'"
KIND: VirtualMachine	COUNT: 1
NAMESPACE    	NAME        	CREATION_TIME(RFC3339)       	
openshift-mtv	my-best-name	2025-02-24T11:57:23Z   
```

Plan YAML:
```yaml
spec:
    ...
    vms:
    - id: vm-16117
      name: yzamir_2
      targetName: my-best-name
    ...
```

Screenshots:
YAML:
![targetNameYAML](https://github.com/user-attachments/assets/5c0bc773-e57e-40f6-a1ed-b2563a24c837)

VM:
![targetNameVM](https://github.com/user-attachments/assets/cbe75866-a117-4e35-bf98-218cd608c5d4)

