### PR TITLE
MTV-2093 | Sort the disks by bus

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	v1beta1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
+	container "github.com/konveyor/forklift-controller/pkg/controller/provider/container/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
@@ -130,6 +131,89 @@ var _ = Describe("vSphere builder", func() {
 					Gateway: "172.29.3.1",
 				}},
 		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,16"),
+	)
+
+	DescribeTable("should", func(disks []vsphere.Disk, output []vsphere.Disk) {
+		Expect(builder.sortedDisks(disks)).Should(Equal(output))
+	},
+		Entry("sort all disks by buses",
+			[]vsphere.Disk{
+				{Key: 1, Bus: container.IDE},
+				{Key: 1, Bus: container.SATA},
+				{Key: 1, Bus: container.SCSI},
+				{Key: 2, Bus: container.SCSI},
+			},
+			[]vsphere.Disk{
+				{Key: 1, Bus: container.SCSI},
+				{Key: 2, Bus: container.SCSI},
+				{Key: 1, Bus: container.SATA},
+				{Key: 1, Bus: container.IDE},
+			},
+		),
+		Entry("sort IDE and SATA disks by buses",
+			[]vsphere.Disk{
+				{Key: 1, Bus: container.IDE},
+				{Key: 1, Bus: container.SATA},
+			},
+			[]vsphere.Disk{
+				{Key: 1, Bus: container.SATA},
+				{Key: 1, Bus: container.IDE},
+			},
+		),
+		Entry("sort multiple SATA disks by buses",
+			[]vsphere.Disk{
+				{Key: 3, Bus: container.SATA},
+				{Key: 1, Bus: container.SATA},
+				{Key: 2, Bus: container.SATA},
+			},
+			[]vsphere.Disk{
+				{Key: 1, Bus: container.SATA},
+				{Key: 2, Bus: container.SATA},
+				{Key: 3, Bus: container.SATA},
+			},
+		),
+		Entry("sort multiple SATA and multiple SCSI disks by buses",
+			[]vsphere.Disk{
+				{Key: 3, Bus: container.SATA},
+				{Key: 3, Bus: container.SCSI},
+				{Key: 2, Bus: container.SCSI},
+				{Key: 1, Bus: container.SATA},
+				{Key: 2, Bus: container.SATA},
+				{Key: 1, Bus: container.SCSI},
+			},
+			[]vsphere.Disk{
+				{Key: 1, Bus: container.SCSI},
+				{Key: 2, Bus: container.SCSI},
+				{Key: 3, Bus: container.SCSI},
+				{Key: 1, Bus: container.SATA},
+				{Key: 2, Bus: container.SATA},
+				{Key: 3, Bus: container.SATA},
+			},
+		),
+		Entry("sort multiple all disks by buses",
+			[]vsphere.Disk{
+				{Key: 2, Bus: container.IDE},
+				{Key: 3, Bus: container.SATA},
+				{Key: 3, Bus: container.SCSI},
+				{Key: 2, Bus: container.SCSI},
+				{Key: 3, Bus: container.IDE},
+				{Key: 1, Bus: container.SATA},
+				{Key: 2, Bus: container.SATA},
+				{Key: 1, Bus: container.SCSI},
+				{Key: 1, Bus: container.IDE},
+			},
+			[]vsphere.Disk{
+				{Key: 1, Bus: container.SCSI},
+				{Key: 2, Bus: container.SCSI},
+				{Key: 3, Bus: container.SCSI},
+				{Key: 1, Bus: container.SATA},
+				{Key: 2, Bus: container.SATA},
+				{Key: 3, Bus: container.SATA},
+				{Key: 1, Bus: container.IDE},
+				{Key: 2, Bus: container.IDE},
+				{Key: 3, Bus: container.IDE},
+			},
+		),
 	)
 })
 

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -264,6 +264,7 @@ type VM struct {
 	Devices               []Device       `sql:""`
 	NICs                  []NIC          `sql:""`
 	Disks                 []Disk         `sql:""`
+	Controllers           []Controller   `sql:""`
 	Networks              []Ref          `sql:""`
 	Concerns              []Concern      `sql:""`
 	GuestNetworks         []GuestNetwork `sql:""`
@@ -276,6 +277,13 @@ func (m *VM) Validated() bool {
 	return m.RevisionValidated == m.Revision
 }
 
+// Virtual Controller.
+type Controller struct {
+	Key   int32   `json:"key"`
+	Bus   string  `json:"bus"`
+	Disks []int32 `sql:""`
+}
+
 // Virtual Disk.
 type Disk struct {
 	Key       int32  `json:"key"`
@@ -284,6 +292,7 @@ type Disk struct {
 	Capacity  int64  `json:"capacity"`
 	Shared    bool   `json:"shared"`
 	RDM       bool   `json:"rdm"`
+	Bus       string `json:"bus"`
 	Mode      string `json:"mode,omitempty"`
 }
 


### PR DESCRIPTION
Issue: When running a migration of a VM which has various bus controllers the PVs are not populated by correct disk. This causes that some larger disks are in small PVs.
This issue happens due to the libvirt domain-VMware API missmatch. The virt-v2v is outputing the disks in order as they are in the libvirt domain but Forklift is using the order from API and sorting the disks by key. The libvirt is sorted in order of devices SCSI, SATA and IDE wheras sorting by key from VMware API results in order IDE, SATA and SCSI.

Fix: Gather information about the disk busses and sort the disks by SCSI, SATA and IDE. And within each of these categories we sort by the key from lower to higer.

Ref: https://issues.redhat.com/browse/MTV-2093