### PR TITLE
controller: Skip TLS when missing certs

### DIFF
--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -307,6 +307,11 @@ func (c *RestClient) buildTransport() (err error) {
 		transport.TLSClientConfig = &tls.Config{
 			RootCAs: pool,
 		}
+	} else if Settings.Development {
+		// Disable TLS for development when certs are missing
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
 	}
 
 	c.Transport = transport

--- a/pkg/controller/validation/policy/client.go
+++ b/pkg/controller/validation/policy/client.go
@@ -199,7 +199,7 @@ func (c *Client) buildTransport() (err error) {
 		transport.TLSClientConfig = &tls.Config{
 			RootCAs: pool,
 		}
-	} else {
+	} else if Settings.Development {
 		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}

--- a/pkg/settings/policy.go
+++ b/pkg/settings/policy.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"errors"
 	"os"
 )
 
@@ -38,7 +39,7 @@ func (r *PolicyAgent) Load() (err error) {
 	// TLS
 	if s, found := os.LookupEnv(PolicyAgentCA); found {
 		r.TLS.CA = s
-	} else {
+	} else if _, err := os.Stat(ServiceCAFile); !errors.Is(err, os.ErrNotExist) {
 		r.TLS.CA = ServiceCAFile
 	}
 	r.Limit.Worker, err = getPositiveEnvLimit(PolicyAgentWorkerLimit, 10)

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -11,7 +11,10 @@ import (
 // Global
 var Settings = ControllerSettings{}
 
-const OpenShift = "OPENSHIFT"
+const (
+	OpenShift   = "OPENSHIFT"
+	Development = "DEVELOPMENT"
+)
 
 // Settings
 type ControllerSettings struct {
@@ -31,7 +34,8 @@ type ControllerSettings struct {
 	Profiler
 	// Feature gates.
 	Features
-	OpenShift bool
+	OpenShift   bool
+	Development bool
 }
 
 // Load settings.
@@ -69,7 +73,7 @@ func (r *ControllerSettings) Load() error {
 		return err
 	}
 	r.OpenShift = getEnvBool(OpenShift, false)
-
+	r.Development = getEnvBool(Development, false)
 	return nil
 }
 


### PR DESCRIPTION
Issue: When running controller locally for development the certificates are usually missing and the main controller can fail to send requests to some existing inventory.

Fix: Skip TLS check when the certs are missing.