### PR TITLE
MTV-2018 | Preserve static gateway from different subnet

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/netip"
 	liburl "net/url"
 	"path"
 	"regexp"
@@ -273,18 +272,10 @@ func (r *Builder) mapMacStaticIps(vm *model.VM) (ipMap string, err error) {
 					// not the right IPv4 / IPv6 correlation
 					continue
 				}
-				network, err := netip.ParsePrefix(fmt.Sprintf("%s/%d", guestNetwork.IP, guestNetwork.PrefixLength))
-				if err != nil {
-					return "", err
+				if ipStack.Device != guestNetwork.Device {
+					continue
 				}
-				gw, err := netip.ParseAddr(ipStack.Gateway)
-				if err != nil {
-					return "", err
-				}
-				if network.Contains(gw) {
-					// checks if the gateway in the right network subnet. we set gateway only once as it is suppose to be system wide.
-					gateway = ipStack.Gateway
-				}
+				gateway = ipStack.Gateway
 			}
 			dnsString := strings.Join(guestNetwork.DNS, ",")
 			configurationString := fmt.Sprintf("%s:ip:%s,%s,%d,%s", guestNetwork.MAC, guestNetwork.IP, gateway, guestNetwork.PrefixLength, dnsString)

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -130,6 +130,21 @@ var _ = Describe("vSphere builder", func() {
 					Gateway: "172.29.3.1",
 				}},
 		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,16"),
+		Entry("gateway from different subnet", &model.VM{
+			GuestID: "windows9Guest",
+			GuestNetworks: []vsphere.GuestNetwork{
+				{
+					MAC:          "00:50:56:83:25:47",
+					IP:           "172.29.3.193",
+					Origin:       ManualOrigin,
+					PrefixLength: 24,
+					DNS:          []string{"8.8.8.8"},
+				}},
+			GuestIpStacks: []vsphere.GuestIpStack{
+				{
+					Gateway: "172.29.4.1",
+				}},
+		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.4.1,24,8.8.8.8"),
 	)
 })
 

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -656,7 +656,7 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 			case fGuestNet:
 				if nics, cast := p.Val.(types.ArrayOfGuestNicInfo); cast {
 					guestNetworksList := []model.GuestNetwork{}
-					for _, info := range nics.GuestNicInfo {
+					for index, info := range nics.GuestNicInfo {
 						if info.IpConfig == nil {
 							continue
 						}
@@ -671,6 +671,7 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 								Origin:       ip.Origin,
 								PrefixLength: ip.PrefixLength,
 								DNS:          dnsList,
+								Device:       strconv.Itoa(index),
 							})
 						}
 					}
@@ -691,6 +692,7 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 							}
 							if len(route.Gateway.IpAddress) > 0 {
 								guestIpStackList = append(guestIpStackList, model.GuestIpStack{
+									Device:  route.Gateway.Device,
 									Gateway: route.Gateway.IpAddress,
 									DNS:     dnsList,
 								})

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -300,6 +300,7 @@ type NIC struct {
 
 // Guest network.
 type GuestNetwork struct {
+	Device       string   `json:"device"`
 	MAC          string   `json:"mac"`
 	IP           string   `json:"ip"`
 	Origin       string   `json:"origin"`
@@ -309,6 +310,7 @@ type GuestNetwork struct {
 
 // Guest ipStack
 type GuestIpStack struct {
+	Device  string   `json:"device"`
 	Gateway string   `json:"gateway"`
 	DNS     []string `json:"dns"`
 }


### PR DESCRIPTION
Issue: When running the migration with preserve static IPs, Forklift does not preserve gateway of a NIC from different subnet.

Fix: Right now we are checking if the gateway is from the subnet as correlation between the nic and networks. We need to start using different correlation. The VMware API is exposing the `device` which is the index of the NICs returned from the API in order.

Ref: https://issues.redhat.com/browse/MTV-2018