### PR TITLE
MTV-1966 | Allow to skip shared disks

### DIFF
--- a/docs/enhancements/shared-disks.md
+++ b/docs/enhancements/shared-disks.md
@@ -1,0 +1,99 @@
+---
+title: shared-disks
+authors:
+  - "@mnecas"
+reviewers:
+  - "@yaacov"
+  - "@mansam"
+approvers:
+  - "@yaacov"
+  - "@mansam"
+creation-date: 2025-02-27
+last-updated: 2025-02-27
+status: implementable
+---
+
+# Migrate Shared Disks
+
+## Release Signoff Checklist
+
+- [x] Enhancement is `implementable`
+- [x] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] User-facing documentation is created
+
+## Summary
+
+In the current release of Forklift it is possible to import shared disks using cold migration.
+This is possible because the virt-v2v is transferring all disks attached to the VM, but because
+the shared disks are attached to multiple VMs the shared disks get migrated multiple times and users right now,
+need to delete the extra volumes and reattach the disks.
+
+### Goals
+
+* Forklift will support skipping the shared disks during the disk transfer so they won't be migrated multiple times.
+
+### Non-Goals
+
+* Forklift will not allow creating a large plan which would support first transferring shared disk and then all others.
+This would require breaking lot of standard flows in Forklift.
+
+## Proposal
+
+This enhancement document proposes an additional parameter to the plan called `migrateSharedDisks`.
+This parameter will allow the users to choose if the plan should migrate shared disks or not.
+When the `migrateSharedDisks` will be enabled the Forklift will use the "normal" cold migration flow using virt-v2v and labeling
+the shared PVC. 
+When the `migrateSharedDisks` will be disabled the Forklift will use the KubeVirt CDI for disk transfer, and it will skip
+the shared disks. After the disk transfer it will try to locate the already shared PVCs and attach them to the VMs.
+The Forklift will try to automatically find migrated shared PVCs in the namespace and attach them to the VMs.
+
+### User flow
+The user will do following steps:
+- Turn off all VMs with the attached shared disk on the VMware side.
+- Create a plan with a single VM and the `migrateSharedDisks` enabled in the Forklift.
+- Start the migration of the first plan and wait for it to finish.
+- Create a secondary plan with all other VMs attached and the `migrateSharedDisks` disabled to the same target namespace as first plan.
+- Start the migration of the second plan and wait for it to finish.
+- Check if all shared disks are attached to all VMs.
+
+### Security, Risks, Mitigations and Limitation
+
+One of the limitation on the VMware side is that the shared disks do not support Change Block Tracking,
+which is requirement for the warm migration. So the shared disks can be migrated only with the cold migration.
+
+Another limitation is that the VMs with a shared disk can not be migrated to the separate namespaces as PVCs are
+namespace bound and the VMs from another namespaces are not able to access them.
+
+One of the risks is that all VMs with the shared disk must be turned off during the whole migration process.
+Otherwise, there could be a risk of disk corruption or Forklift could not acquire lock on the disks and the migration,
+would fail in middle of the process.
+
+All these risks/limitation can be solved by adding corresponding validation and either blocking the migration if it's 
+critical risk or warning the user about the potential.
+
+Risk that can not be mitigated by validation is guest conversion of shared disks. With the current implementation of 
+the feature we don't provide the shared disk during guest conversion, so virt-v2v is not aware of that disk. 
+This can lead into issues as the guest conversion will not update the config files such as fstab.
+This could be possibly mitigated in followup PR by mounting the shared disk during the guest conversion.
+But the virt-v2v-in-place directly writes to the disks and if there would be multiple changes at the same time could 
+cause disk corruption. 
+This means that we can not support an Operating System on the shared disk, luckily this is not common scenario as most
+shared disks are used for storing data.
+
+## Design Details
+
+### Test Plan
+
+The existing tests will need to get expanded to have shared disks with multistage process.
+First step to migrate the VMs with the disks and second wihtout.
+
+### Upgrade / Downgrade Strategy
+
+The plans without the `migrateSharedDisks` automatically get the default true.
+
+### Open Questions
+
+## Implementation History
+
+* 02/27/2025 - Enhancement submitted.

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -161,6 +161,10 @@ spec:
                 - network
                 - storage
                 type: object
+              migrateSharedDisks:
+                default: true
+                description: Determines if the plan should migrate shared disks.
+                type: boolean
               networkNameTemplate:
                 description: |-
                   NetworkNameTemplate is a template for generating network interface names in the target virtual machine.

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -10,6 +10,7 @@ import (
 	core "k8s.io/api/core/v1"
 	cnv "kubevirt.io/api/core/v1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Annotations
@@ -142,6 +143,8 @@ type Validator interface {
 	PodNetwork(vmRef ref.Ref) (bool, error)
 	// Validate that we have information about static IPs for every virtual NIC
 	StaticIPs(vmRef ref.Ref) (bool, error)
+	// Validate the shared disk, returns msg and category as the errors depends on the provider implementations
+	SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, msg string, category string, err error)
 	// Validate that the vm has the change tracking enabled
 	ChangeTrackingEnabled(vmRef ref.Ref) (bool, error)
 }

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -65,6 +65,12 @@ func (r *Validator) WarmMigration() bool {
 	return false
 }
 
+// NOOP
+func (r *Validator) SharedDisks(vmRef ref.Ref, client k8sclient.Client) (ok bool, s string, s2 string, err error) {
+	ok = true
+	return
+}
+
 // Load.
 func (r *Validator) Load() (err error) {
 	r.inventory, err = web.NewClient(r.plan.Referenced.Provider.Source)

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/openstack"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Validator
@@ -67,6 +68,12 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 
 // Validate that a VM's Host isn't in maintenance mode.
 func (r *Validator) MaintenanceMode(vmRef ref.Ref) (ok bool, err error) {
+	ok = true
+	return
+}
+
+// NOOP
+func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, s string, s2 string, err error) {
 	ok = true
 	return
 }

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/ova"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // OVA validator.
@@ -23,6 +24,12 @@ func (r *Validator) Load() (err error) {
 // Validate whether warm migration is supported from this provider type.
 func (r *Validator) WarmMigration() (ok bool) {
 	ok = false
+	return
+}
+
+// NOOP
+func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, s string, s2 string, err error) {
+	ok = true
 	return
 }
 

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -10,6 +10,7 @@ import (
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/ovirt"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	"github.com/konveyor/forklift-controller/pkg/settings"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // oVirt validator.
@@ -21,6 +22,12 @@ type Validator struct {
 // Load.
 func (r *Validator) Load() (err error) {
 	r.inventory, err = web.NewClient(r.plan.Referenced.Provider.Source)
+	return
+}
+
+// NOOP
+func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, s string, s2 string, err error) {
+	ok = true
 	return
 }
 

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -331,7 +331,7 @@ func (r *Client) getTaskById(vmRef ref.Ref, taskId string, hosts util.HostsFunc)
 }
 
 func (r *Client) getClient(vm *model.VM, hosts util.HostsFunc) (client *vim25.Client, err error) {
-	if coldLocal, vErr := r.Plan.VSphereColdLocal(); vErr == nil && coldLocal {
+	if useV2vForTransfer, vErr := r.Plan.ShouldUseV2vForTransfer(); vErr == nil && useV2vForTransfer {
 		// when virt-v2v runs the migration, forklift-controller should interact only
 		// with the component that serves the SDK endpoint of the provider
 		client = r.client.Client

--- a/pkg/controller/plan/adapter/vsphere/utils.go
+++ b/pkg/controller/plan/adapter/vsphere/utils.go
@@ -1,0 +1,96 @@
+package vsphere
+
+import (
+	"context"
+
+	planbase "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
+	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	core "k8s.io/api/core/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Return PersistentVolumeClaims associated with a VM.
+func getDisksPvc(disk vsphere.Disk, pvcs []*core.PersistentVolumeClaim, warm bool) *core.PersistentVolumeClaim {
+	for _, pvc := range pvcs {
+		if pvc.Annotations[planbase.AnnDiskSource] == baseVolume(disk.File, warm) {
+			return pvc
+		}
+	}
+	return nil
+}
+
+func baseVolume(fileName string, warm bool) string {
+	if warm {
+		// for warm migrations, we return the very first volume of the disk
+		// as the base volume and CBT will be used to transfer later changes
+		return trimBackingFileName(fileName)
+	} else {
+		// for cold migrations, we return the latest volume as the base,
+		// e.g., my-vm/disk-name-000015.vmdk, since we should transfer
+		// only its state
+		// note that this setting is insignificant when we use virt-v2v on
+		// el9 since virt-v2v doesn't receive the volume to transfer - we
+		// only need this to be consistent for correlating disks with PVCs
+		return fileName
+	}
+}
+
+// Trims the snapshot suffix from a disk backing file name if there is one.
+//
+//	Example:
+//	Input: 	[datastore13] my-vm/disk-name-000015.vmdk
+//	Output: [datastore13] my-vm/disk-name.vmdk
+func trimBackingFileName(fileName string) string {
+	return backingFilePattern.ReplaceAllString(fileName, ".vmdk")
+}
+
+// Return all shareable PVCs
+func listShareablePVCs(c client.Client) (pvcs []*core.PersistentVolumeClaim, err error) {
+	pvcsList := &core.PersistentVolumeClaimList{}
+	err = c.List(
+		context.TODO(),
+		pvcsList,
+		&client.ListOptions{
+			LabelSelector: k8slabels.SelectorFromSet(map[string]string{
+				Shareable: "true",
+			}),
+		},
+	)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	pvcs = make([]*core.PersistentVolumeClaim, len(pvcsList.Items))
+	for i, pvc := range pvcsList.Items {
+		// loopvar
+		copyPvc := pvc
+		pvcs[i] = &copyPvc
+	}
+
+	return
+}
+
+// Return PersistentVolumeClaims and disks associated with a VM.
+func findSharedPVCs(c client.Client, vm *model.VM) (pvcs []*core.PersistentVolumeClaim, missingDiskPVCs []vsphere.Disk, err error) {
+	allPvcs, err := listShareablePVCs(c)
+	if err != nil {
+		return
+	}
+
+	for _, disk := range vm.Disks {
+		if !disk.Shared {
+			continue
+		}
+		// Warm migration disable as the shared disks can't be migrated with warm migration
+		pvc := getDisksPvc(disk, allPvcs, false)
+		if pvc != nil {
+			pvcs = append(pvcs, pvc)
+		} else {
+			missingDiskPVCs = append(missingDiskPVCs, disk)
+		}
+	}
+	return pvcs, missingDiskPVCs, err
+}

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -1,11 +1,18 @@
 package vsphere
 
 import (
+	"fmt"
+
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
+	"github.com/konveyor/forklift-controller/pkg/controller/provider/web/base"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
+	"github.com/konveyor/forklift-controller/pkg/controller/validation"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	"github.com/vmware/govmomi/vim25/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // vSphere validator.
@@ -126,6 +133,94 @@ func (r *Validator) MaintenanceMode(vmRef ref.Ref) (ok bool, err error) {
 // NO-OP
 func (r *Validator) DirectStorage(vmRef ref.Ref) (bool, error) {
 	return true, nil
+}
+
+// This is inefficient, the best implementation should be done inside the inventory instead of many requests.
+// The validations can take a few seconds due to the vddk validation so this should be acceptable.
+// If there is problem at scale, we need to move this to the inventory, most likley under separate endpoint
+// or expanding the vm list endpoint by supporting disk information in filter.
+func (r *Validator) findVmsWithSharedDisk(disk vsphere.Disk) ([]model.VM, error) {
+	var allVms []model.VM
+	err := r.inventory.List(&allVms, base.Param{
+		Key:   base.DetailParam,
+		Value: "all",
+	})
+	if err != nil {
+		return nil, liberr.Wrap(err, "disk", disk)
+	}
+	var resp []model.VM
+	for _, vm := range allVms {
+		if vm.HasDisk(disk) {
+			resp = append(resp, vm)
+		}
+	}
+	return resp, nil
+}
+
+func (r *Validator) findSharedDisksVms(disks []vsphere.Disk) ([]model.VM, error) {
+	for _, disk := range disks {
+		if disk.Shared {
+			return r.findVmsWithSharedDisk(disk)
+		}
+	}
+	return nil, nil
+}
+
+func (r *Validator) findRunningVms(vms []model.VM) []string {
+	var resp []string
+	for _, vm := range vms {
+		if vm.PowerState != string(types.VirtualMachinePowerStatePoweredOff) {
+			resp = append(resp, vm.Name)
+		}
+	}
+	return resp
+}
+
+func (r *Validator) sharedDisksRunningVms(vm *model.VM) (runningVms []string, err error) {
+	sharedDisksVms, err := r.findSharedDisksVms(vm.Disks)
+	if err != nil {
+		return nil, liberr.Wrap(err, "vm", vm)
+	}
+	return r.findRunningVms(sharedDisksVms), nil
+}
+
+func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, msg string, category string, err error) {
+	vm := &model.VM{}
+	err = r.inventory.Find(vm, vmRef)
+	if err != nil {
+		return false, msg, "", liberr.Wrap(err, "vm", vmRef)
+	}
+	// Warm migration
+	if vm.HasSharedDisk() && r.plan.Spec.Warm {
+		return false, "The shared disks cannot be used with warm migration", "", nil
+	}
+
+	// Running VMs
+	runningVms, err := r.sharedDisksRunningVms(vm)
+	if err != nil {
+		return false, "", "", liberr.Wrap(err, "vm", vm)
+	}
+	if len(runningVms) > 0 {
+		msg = fmt.Sprintf("Virtual Machines '%s' are running with attached shared disk, please power them off", runningVms)
+		return false, msg, validation.Critical, nil
+	}
+
+	// Check existing PVCs
+	if !r.plan.Spec.MigrateSharedDisks {
+		_, missingDiskPVCs, err := findSharedPVCs(client, vm)
+		if err != nil {
+			return false, "", "", liberr.Wrap(err, "vm", vm)
+		}
+		if missingDiskPVCs != nil {
+			var missingDiskNames []string
+			for _, disk := range missingDiskPVCs {
+				missingDiskNames = append(missingDiskNames, disk.File)
+			}
+			msg = fmt.Sprintf("Missing shared disks PVC '%s' in namespace '%s', the VMs can be migrated but the disk will not be attached", missingDiskNames, r.plan.Spec.TargetNamespace)
+			return false, msg, validation.Warn, nil
+		}
+	}
+	return true, "", "", nil
 }
 
 // Validate that we have information about static IPs for every virtual NIC

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1827,11 +1827,11 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 			break
 		}
 
-		coldLocal, err := r.Context.Plan.VSphereColdLocal()
+		useV2vForTransfer, err := r.Context.Plan.ShouldUseV2vForTransfer()
 		switch {
 		case err != nil:
 			return liberr.Wrap(err)
-		case coldLocal:
+		case useV2vForTransfer:
 			if err := r.updateConversionProgressV2vMonitor(pod, step); err != nil {
 				// Just log it. Missing progress is not fatal.
 				log.Error(err, "Failed to update conversion progress")
@@ -2022,7 +2022,7 @@ type Predicate struct {
 
 // Evaluate predicate flags.
 func (r *Predicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
-	coldLocal, vErr := r.context.Plan.VSphereColdLocal()
+	useV2vForTransfer, vErr := r.context.Plan.ShouldUseV2vForTransfer()
 	if vErr != nil {
 		err = vErr
 		return
@@ -2036,9 +2036,9 @@ func (r *Predicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
 	case RequiresConversion:
 		allowed = r.context.Source.Provider.RequiresConversion()
 	case CDIDiskCopy:
-		allowed = !coldLocal
+		allowed = !useV2vForTransfer
 	case VirtV2vDiskCopy:
-		allowed = coldLocal
+		allowed = useV2vForTransfer
 	case OpenstackImageMigration:
 		allowed = r.context.Plan.IsSourceProviderOpenstack()
 	case VSphere:

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -197,8 +197,8 @@ func (r *Scheduler) buildPending() (err error) {
 }
 
 func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {
-	coldLocal, _ := r.Plan.VSphereColdLocal()
-	if coldLocal {
+	useV2vForTransfer, _ := r.Plan.ShouldUseV2vForTransfer()
+	if useV2vForTransfer {
 		switch vmStatus.Phase {
 		case CreateVM, PostHook, Completed:
 			// In these phases we already have the disk transferred and are left only to create the VM

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -287,3 +287,41 @@ func (r *VM) Content(detail int) interface{} {
 
 	return r
 }
+
+func (r *VM) HasDisk(disk model.Disk) bool {
+	for _, d := range r.Disks {
+		if d.File == disk.File {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *VM) HasSharedDisk() bool {
+	for _, d := range r.Disks {
+		if d.Shared {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *VM) RemoveSharedDisks() {
+	var disks []model.Disk
+	for _, disk := range r.Disks {
+		if !disk.Shared {
+			disks = append(disks, disk)
+		}
+	}
+	r.Disks = disks
+}
+
+func (r *VM) RemoveDisk(removeDisk model.Disk) {
+	var disks []model.Disk
+	for _, disk := range r.Disks {
+		if disk.File != removeDisk.File {
+			disks = append(disks, disk)
+		}
+	}
+	r.Disks = disks
+}

--- a/pkg/lib/condition/condition.go
+++ b/pkg/lib/condition/condition.go
@@ -37,6 +37,8 @@ const (
 	VMMissingGuestIPs = "VMMissingGuestIPs"
 	// Missing Changed Block
 	VMMissingChangedBlockTracking = "VMMissingChangedBlockTracking"
+	// User needs to power off the VMs wihch has the attached diks
+	SharedDisks = "SharedDisks"
 )
 
 // Condition
@@ -321,7 +323,9 @@ func (r *Conditions) HasBlockerCondition() bool {
 
 // The collection contains blocker conditions that keep the plan reconciling.
 func (r *Conditions) HasReQCondition() bool {
-	return r.HasCondition(ValidatingVDDK) || r.HasCondition(VMMissingChangedBlockTracking)
+	return r.HasCondition(ValidatingVDDK) ||
+		r.HasCondition(VMMissingChangedBlockTracking) ||
+		r.HasCondition(SharedDisks)
 }
 
 // The collection contains the `Ready` condition.


### PR DESCRIPTION
Issue:
In the current release of Forklift, it is possible to import shared disks using cold migration. This is possible because the virt-v2v is transferring all disks attached to the VM, but because the shared disks are attached to multiple VMs the shared disks get migrated multiple times and users right now, need to delete the extra volumes and reattach the disks.

Fix:
Add a new parameter `migrateSharedDisks` to the plan which will determine if the shared disks should be migrated. This parameter will allow the users to choose if the plan should migrate shared disks or not. When the `migrateSharedDisks` will be enabled the Forklift will use the "normal" cold migration flow using virt-v2v and labelling the shared PVC.
When the `migrateSharedDisks` is disabled the Forklift will use the KubeVirt CDI for disk transfer, and it will skip the shared disks. After the disk transfer, it will try to locate the already shared PVCs and attach them to the VMs. The Forklift will try to automatically find migrated shared PVCs in the namespace and attach them to the VMs.

User flow:
- Turn off all VMs with the attached shared disk on the VMware side.
- Create a plan with a single VM and the `migrateSharedDisks` enabled in the Forklift.
- Start the migration of the first plan and wait for it to finish.
- Create a secondary plan with all other VMs attached and the `migrateSharedDisks` disabled to the same target namespace as the first plan.
- Start the migration of the second plan and wait for it to finish.
- Check if all shared disks are attached to all VMs.

Known issues:
- The shared disks are not passed to the guest conversion so virt-v2v is not aware of them and does not update the config files, for example fstab. This will be fixed in follow-up PR.
- The shared disks can not be migrated when attached to a running VM  (mitigated by validations).
- The shared disks do not support warm migration (mitigated by validations).
- The shared disks can not be migrated to multiple target namespaces (mitigated by validations).

Ref:
- Original issue: https://issues.redhat.com/browse/MTV-1966
- This is a continuation of: https://github.com/kubev2v/forklift/pull/1318