### PR TITLE
MTV-2092 | MTV-2105 | spec.running and spec.runStrategy mutually exclusive and spec.running is deprecated on target VM

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1346,9 +1346,16 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus) (object *cnv.VirtualMachine
 		object.ObjectMeta.Annotations = annotations
 	}
 
-	// Power on the destination VM if the source VM was originally powered on.
-	running := vm.RestorePowerState == plan.VMPowerStateOn
-	object.Spec.Running = &running
+	// Set the default run strategy to Halted
+	runStrategy := cnv.RunStrategyHalted
+
+	// If the source VM is powered on, set the destination VM to always run
+	if vm.RestorePowerState == plan.VMPowerStateOn {
+		runStrategy = cnv.RunStrategyAlways
+	}
+
+	// Assign the determined run strategy to the object
+	object.Spec.RunStrategy = &runStrategy
 
 	err = r.Builder.VirtualMachine(vm.Ref, &object.Spec, pvcs, vm.InstanceType != "")
 	if err != nil {


### PR DESCRIPTION
Issue:
1. The field spec.running is deprecated
2. Fix spec.running and spec.runStrategy mutually exclusive scenario during migration