### PR TITLE
Fix panic in cases where vmExport.Status.Links.External is nil.

### DIFF
--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -57,8 +57,13 @@ func (r *Builder) ConfigMap(vmRef ref.Ref, secret *core.Secret, object *core.Con
 		return liberr.Wrap(err)
 	}
 
-	object.Data = map[string]string{
-		"ca.pem": vmExport.Status.Links.External.Cert,
+	links := vmExport.Status.Links
+	if links.External != nil {
+		object.Data = map[string]string{
+			"ca.pem": links.External.Cert,
+		}
+	} else {
+		return liberr.Wrap(fmt.Errorf("failed to get external link from VM-exports"))
 	}
 
 	return nil


### PR DESCRIPTION
Prevent forklift-controller panic by adding nil check for vmExport external link and logging an error when missing. Fixes #495.