### PR TITLE
Preserve PVC mount index between PVC creation and PVC mounting as a volume

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -19,6 +19,9 @@ const (
 	// VMware or disk ID in oVirt.
 	AnnDiskSource = "forklift.konveyor.io/disk-source"
 
+	// Used on DataVolume, contains disk mount order.
+	AnnDiskIndex = "forklift.konveyor.io/disk-index"
+
 	// Set on a PVC to indicate it requires format conversion
 	AnnRequiresConversion = "forklift.konveyor.io/requires-conversion"
 

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -488,6 +488,12 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 				if disk.Shared {
 					dv.ObjectMeta.Labels[Shareable] = "true"
 				}
+
+				// Preserve the disk index as an annotation on the created DataVolume
+				// Note: this annotation will be used to match the PVC to the VM disks by
+				//       matching the disk and PVC index.
+				dv.ObjectMeta.Annotations[planbase.AnnDiskIndex] = fmt.Sprintf("%d", diskIndex)
+
 				// if exists, get the PVC generate name from the PlanSpec, generate the name
 				// and update the GenerateName field in the DataVolume object.
 				pvcNameTemplate := r.getPVCNameTemplate(vm)


### PR DESCRIPTION
Issue:
When we create the PVC for VM disks we don't give them order.
Then when getting them from k8s we assume they are ordered by mount order, this is not garentead to be true.

Fix:
Add the mounting order as an annotation on the PVC.
Use this annotation to sort the PVC before matching them to the VM volumes.