### PR TITLE
Add KubeVirt disk Shareable for shared disk

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -846,6 +846,7 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 			},
 		}
 		if disk.Shared {
+			kubevirtDisk.Shareable = ptr.To(true)
 			kubevirtDisk.Cache = cnv.CacheNone
 		}
 		// For multiboot VMs, if the selected boot device is the current disk,


### PR DESCRIPTION
Issue:
When running migration with a shared disks the VMs won't boot 