### PR TITLE
MTV-1436 | Add ignored network type

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
@@ -60,10 +60,16 @@ spec:
                           description: The namespace (multus only).
                           type: string
                         type:
-                          description: The network type.
+                          description: |-
+                            Type of network to use for the destination.
+                            Valid values:
+                            - pod: Use the Kubernetes pod network
+                            - multus: Use a Multus additional network
+                            - ignored: Network is excluded from mapping
                           enum:
                           - pod
                           - multus
+                          - ignored
                           type: string
                       required:
                       - type

--- a/pkg/apis/forklift/v1beta1/mapping.go
+++ b/pkg/apis/forklift/v1beta1/mapping.go
@@ -28,8 +28,12 @@ import (
 
 // Mapped network destination.
 type DestinationNetwork struct {
-	// The network type.
-	// +kubebuilder:validation:Enum=pod;multus
+	// Type of network to use for the destination.
+	// Valid values:
+	// - pod: Use the Kubernetes pod network
+	// - multus: Use a Multus additional network
+	// - ignored: Network is excluded from mapping
+	// +kubebuilder:validation:Enum=pod;multus;ignored
 	Type string `json:"type"`
 	// The namespace (multus only).
 	Namespace string `json:"namespace,omitempty"`

--- a/pkg/controller/map/network/validation.go
+++ b/pkg/controller/map/network/validation.go
@@ -41,8 +41,9 @@ const (
 
 // Network types.
 const (
-	Pod    = "pod"
-	Multus = "multus"
+	Pod     = "pod"
+	Multus  = "multus"
+	Ignored = "ignored"
 )
 
 // Validate the mp resource.
@@ -151,7 +152,7 @@ func (r *Reconciler) validateDestination(mp *api.NetworkMap) (err error) {
 next:
 	for _, entry := range list {
 		switch entry.Destination.Type {
-		case Pod:
+		case Ignored, Pod:
 			continue next
 		case Multus:
 			if entry.Destination.Namespace == "" {

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -230,8 +230,9 @@ const (
 
 // Network types
 const (
-	Pod    = "pod"
-	Multus = "multus"
+	Pod     = "pod"
+	Multus  = "multus"
+	Ignored = "ignored"
 )
 
 // Default properties
@@ -597,6 +598,34 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 	for vmNetworkName, vmAddresses := range vm.Addresses {
 		if nics, ok := vmAddresses.([]interface{}); ok {
 			for _, nic := range nics {
+				// Look for the network map for the source network
+				var vmNetworkID string
+				for _, vmNetwork := range vm.Networks {
+					if vmNetwork.Name == vmNetworkName {
+						vmNetworkID = vmNetwork.ID
+						break
+					}
+				}
+				var networkPair *api.NetworkPair
+				networkMaps := r.Context.Map.Network.Spec.Map
+				found := false
+				for i := range networkMaps {
+					networkPair = &networkMaps[i]
+					if networkPair.Source.ID == vmNetworkID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					err = liberr.New("no network map for vm network", "network", vmNetworkID)
+					return
+				}
+
+				// Skip network mappings with destination type 'Ignored'
+				if networkPair.Destination.Type == Ignored {
+					continue
+				}
+
 				networkName := fmt.Sprintf("net-%v", numNetworks)
 				kNetwork := cnv.Network{
 					Name: networkName,
@@ -633,27 +662,6 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 					}
 				}
 
-				var vmNetworkID string
-				for _, vmNetwork := range vm.Networks {
-					if vmNetwork.Name == vmNetworkName {
-						vmNetworkID = vmNetwork.ID
-						break
-					}
-				}
-				var networkPair *api.NetworkPair
-				networkMaps := r.Context.Map.Network.Spec.Map
-				found := false
-				for i := range networkMaps {
-					networkPair = &networkMaps[i]
-					if networkPair.Source.ID == vmNetworkID {
-						found = true
-						break
-					}
-				}
-				if !found {
-					err = liberr.New("no network map for vm network", "network", vmNetworkID)
-					return
-				}
 				switch networkPair.Destination.Type {
 				case Pod:
 					kNetwork.Pod = &cnv.PodNetwork{}

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -45,8 +45,9 @@ const (
 
 // Network types
 const (
-	Pod    = "pod"
-	Multus = "multus"
+	Pod     = "pod"
+	Multus  = "multus"
+	Ignored = "ignored"
 )
 
 // Template labels
@@ -252,6 +253,12 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 	netMapIn := r.Context.Map.Network.Spec.Map
 	for i := range netMapIn {
 		mapped := &netMapIn[i]
+
+		// Skip network mappings with destination type 'Ignored'
+		if mapped.Destination.Type == Ignored {
+			continue
+		}
+
 		ref := mapped.Source
 		network := &model.Network{}
 		fErr := r.Source.Inventory.Find(network, ref)

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -55,8 +55,9 @@ const (
 
 // Network types
 const (
-	Pod    = "pod"
-	Multus = "multus"
+	Pod     = "pod"
+	Multus  = "multus"
+	Ignored = "ignored"
 )
 
 // Template labels
@@ -291,6 +292,12 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 	netMapIn := r.Context.Map.Network.Spec.Map
 	for i := range netMapIn {
 		mapped := &netMapIn[i]
+
+		// Skip network mappings with destination type 'Ignored'
+		if mapped.Destination.Type == Ignored {
+			continue
+		}
+
 		ref := mapped.Source
 		network := &model.Network{}
 		fErr := r.Source.Inventory.Find(network, ref)

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -58,8 +58,9 @@ const (
 
 // Network types
 const (
-	Pod    = "pod"
-	Multus = "multus"
+	Pod     = "pod"
+	Multus  = "multus"
+	Ignored = "ignored"
 )
 
 // Template labels
@@ -622,6 +623,12 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 	netMapIn := r.Context.Map.Network.Spec.Map
 	for i := range netMapIn {
 		mapped := &netMapIn[i]
+
+		// Skip network mappings with destination type 'Ignored'
+		if mapped.Destination.Type == Ignored {
+			continue
+		}
+
 		ref := mapped.Source
 		network := &model.Network{}
 		fErr := r.Source.Inventory.Find(network, ref)


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-1436

Issue:
Add an option or dropdown while creating migration plan for network mapping to not migrate/ convert that network in destination VM.

Fix:
Add a new destination network type "ignored"

Example:
``` yaml
apiVersion: forklift.konveyor.io/v1beta1
kind: NetworkMap
metadata:
  name: test2-gfz5b
  namespace: openshift-mtv
spec:
  map:
    - destination:
        type: ignored   <----------------------------------------------------- New type "ignored"
      source:
        id: dvportgroup-17762
        name: VM Network
        type: vsphere
  provider:
    destination:
      apiVersion: forklift.konveyor.io/v1beta1
      kind: Provider
      name: host
      namespace: openshift-mtv
      uid: ee28d0c2-5db3-4d78-9914-a322c442a6f7
    source:
      apiVersion: forklift.konveyor.io/v1beta1
      kind: Provider
      name: test2
      namespace: openshift-mtv
      uid: edd58482-5a34-458e-8fdc-4ead59038fdd
```
Screenshot:
![output](https://github.com/user-attachments/assets/35cbb51d-6c46-4179-afb1-772382e5eb04)
