### PR TITLE
Backport 2.8 | MTV-1609 | VM source templates should not be selected in the VM table

### DIFF
--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -56,6 +56,9 @@ func (h VMHandler) List(ctx *gin.Context) {
 			ctx.Status(http.StatusInternalServerError)
 		}
 	}()
+
+	// We need model.MaxDetail for retrieving IsTemplate field from the database
+	h.Detail = model.MaxDetail
 	db := h.Collector.DB()
 	list := []model.VM{}
 	err = db.List(&list, h.ListOptions(ctx))
@@ -69,6 +72,13 @@ func (h VMHandler) List(ctx *gin.Context) {
 	}
 	pb := PathBuilder{DB: db}
 	for _, m := range list {
+		if m.IsTemplate {
+			log.Info(
+				"Skipping template VM",
+				"vmID", m.ID,
+				"isTemplate", m.IsTemplate)
+			continue
+		}
 		r := &VM{}
 		r.With(&m)
 		r.Link(h.Provider)


### PR DESCRIPTION
Backport of: https://github.com/kubev2v/forklift/pull/1404 to 2.8