### PR TITLE
Remove tautological checks

### DIFF
--- a/pkg/controller/provider/web/openstack/workload.go
+++ b/pkg/controller/provider/web/openstack/workload.go
@@ -146,9 +146,6 @@ func (r *XVM) Expand(db libmodel.DB) (err error) {
 				subnet := &Subnet{}
 				subnet.With(&subnetModel)
 				subnets = append(subnets, *subnet)
-				if err != nil {
-					return
-				}
 			}
 		}
 	}


### PR DESCRIPTION
err was checked for nil twice. Remove the redundant check.
