### PR TITLE
MTV-2187 | Allow to start migration of shared disk with warning validation

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -58,6 +58,7 @@ const (
 	HostNotReady                  = "HostNotReady"
 	DuplicateVM                   = "DuplicateVM"
 	SharedDisks                   = "SharedDisks"
+	SharedWarnDisks               = "SharedWarnDisks"
 	NameNotValid                  = "TargetNameNotValid"
 	HookNotValid                  = "HookNotValid"
 	HookNotReady                  = "HookNotReady"
@@ -552,6 +553,13 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Message:  "VMs with shared disk can not be migrated.", // This should be set by the provider validator
 		Items:    []string{},
 	}
+	sharedWarnDisks := libcnd.Condition{
+		Type:     SharedWarnDisks,
+		Status:   True,
+		Category: Warn,
+		Message:  "VMs with shared disk can not be migrated.", // This should be set by the provider validator
+		Items:    []string{},
+	}
 
 	setOf := map[string]bool{}
 	//
@@ -664,11 +672,13 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		if !ok {
 			if msg != "" {
 				sharedDisks.Message = msg
+				sharedWarnDisks.Message = msg
 			}
-			if category != "" {
-				sharedDisks.Category = category
+			if category == validation.Warn {
+				sharedWarnDisks.Items = append(sharedWarnDisks.Items, ref.String())
+			} else {
+				sharedDisks.Items = append(sharedDisks.Items, ref.String())
 			}
-			sharedDisks.Items = append(sharedDisks.Items, ref.String())
 		}
 		// Destination.
 		provider = plan.Referenced.Provider.Destination
@@ -760,6 +770,9 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 	}
 	if len(sharedDisks.Items) > 0 {
 		plan.Status.SetCondition(sharedDisks)
+	}
+	if len(sharedWarnDisks.Items) > 0 {
+		plan.Status.SetCondition(sharedWarnDisks)
 	}
 	if len(missingCbtForWarm.Items) > 0 {
 		plan.Status.SetCondition(missingCbtForWarm)


### PR DESCRIPTION
Issue: The shared disk has a warning validation which should not block the migration, but due to bug in the code the migration is blocked even with just warning.

Fix: Becuase we are checking in the migration execution if the validation has a SharedDisk type but we do not check what kind of category it is we block the migration even with the warning. Easy solution is to add new validation type with does not match the blocking.

Ref: https://issues.redhat.com/browse/MTV-2187