### PR TITLE
MTV-2199 | Set boot disk to always have Virtio bus

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -502,7 +502,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 					planVM := r.getPlanVM(vm)
 					rootDiskIndex := 0
 					if planVM != nil {
-						rootDiskIndex = utils.GetDeviceNumber(planVM.RootDisk)
+						rootDiskIndex = utils.GetBootDiskNumber(planVM.RootDisk)
 					}
 
 					// Create template data
@@ -806,7 +806,7 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 	var bootDisk int
 	for _, vmConf := range r.Plan.Spec.VMs {
 		if vmConf.ID == vmRef.ID {
-			bootDisk = utils.GetDeviceNumber(vmConf.RootDisk)
+			bootDisk = utils.GetBootDiskNumber(vmConf.RootDisk)
 			break
 		}
 	}
@@ -867,14 +867,15 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 			kubevirtDisk.Shareable = ptr.To(true)
 			kubevirtDisk.Cache = cnv.CacheNone
 		}
-		// For multiboot VMs, if the selected boot device is the current disk,
-		// set it as the first in the boot order.
-		if bootDisk == i+1 {
-			kubevirtDisk.BootOrder = ptr.To(uint(1))
-		}
 		kVolumes = append(kVolumes, volume)
 		kDisks = append(kDisks, kubevirtDisk)
 	}
+	// For multiboot VMs, if the selected boot device is the current disk,
+	// set it as the first in the boot order.
+	kDisks[bootDisk].BootOrder = ptr.To(uint(1))
+	// The boot disk needs to have a virtio bus
+	kDisks[bootDisk].Disk.Bus = cnv.DiskBusVirtio
+
 	object.Template.Spec.Volumes = kVolumes
 	object.Template.Spec.Domain.Devices.Disks = kDisks
 	return nil

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -40,6 +40,15 @@ func CalculateSpaceWithOverhead(requestedSpace int64, volumeMode *core.Persisten
 	return spaceWithOverhead
 }
 
+func GetBootDiskNumber(deviceString string) int {
+	deviceNumber := GetDeviceNumber(deviceString)
+	if deviceNumber == 0 {
+		return 0
+	} else {
+		return deviceNumber - 1
+	}
+}
+
 func GetDeviceNumber(deviceString string) int {
 	if !(strings.HasPrefix(deviceString, diskPrefix) && len(deviceString) > len(diskPrefix)) {
 		// In case we encounter an issue detecting the root disk order,


### PR DESCRIPTION
Issue:
The Kubevirt VM can not boot from hotpluggable disk with scsi bus. We need to keep the virtio bus for boot disk.
https://issues.redhat.com/browse/VIRTCE-24

Fix: Use virtio for boot disk.

Ref: https://issues.redhat.com/browse/MTV-2199