### PR TITLE
MTV-1966 | Add extra shared disk validations

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -564,7 +564,7 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 		return
 	}
 	if !r.Context.Plan.Spec.MigrateSharedDisks {
-		sharedPVCs, missingDiskPVCs, err := findSharedPVCs(r.Destination.Client, vm)
+		sharedPVCs, missingDiskPVCs, err := findSharedPVCs(r.Destination.Client, vm, r.Plan.Spec.TargetNamespace)
 		if err != nil {
 			return liberr.Wrap(err)
 		}


### PR DESCRIPTION
Issue:
Right now when the user will migrate two VMs with the shared disk and the migrateSharedDisks enabled we do not give warning to the user that the disk will be duplicated. Neither if the PVC is already located in the namepsace.

Fix:
Add extra validation for the VMs to show if there would be some disk duplication.

Ref: https://issues.redhat.com/browse/MTV-1966