### PR TITLE
MTV-1796 | Cancel VM only once

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -456,7 +456,7 @@ func (r *Migration) Cancel() error {
 	}
 
 	for _, vm := range r.Plan.Status.Migration.VMs {
-		if vm.HasCondition(Canceled) {
+		if vm.HasCondition(Canceled) && !vm.MarkedCompleted() {
 			dontFailOnError := func(err error) bool {
 				if err != nil {
 					r.Log.Error(liberr.Wrap(err),


### PR DESCRIPTION
Issue: Right now when the user canceles one VM inside the migration the cancel method gets called many times as the other VMs from the plan are still running and the plan is being executed. We should skip the execution of those VMs.

Fix: Check if the VM was marked as completed before executing the cancel method.

Ref: https://issues.redhat.com/browse/MTV-1796