### PR TITLE
MTV-2218 | Fix the vddk config default

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -669,7 +669,7 @@ func (r *KubeVirt) vddkConfigMap(labels map[string]string) (*core.ConfigMap, err
 			data["vddk-config-file"] = vddkConfig
 		} else {
 			data["vddk-config-file"] =
-				"VixDiskLib.nfcAio.Session.BufSizeIn64K=16\n" +
+				"VixDiskLib.nfcAio.Session.BufSizeIn64KB=16\n" +
 					"VixDiskLib.nfcAio.Session.BufCount=4"
 		}
 	}


### PR DESCRIPTION
Issue: The default vddk config is populated by
`VixDiskLib.nfcAio.Session.BufSizeIn64K`
expected value is
`VixDiskLib.nfcAio.Session.BufSizeIn64KB`

Fix: Add the missing `B` to the end of the config.

Ref: https://issues.redhat.com/browse/MTV-2218