### PR TITLE
Backport 2.8 | MTV-2218 | Fix the vddk config default

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -669,7 +669,7 @@ func (r *KubeVirt) vddkConfigMap(labels map[string]string) (*core.ConfigMap, err
 			data["vddk-config-file"] = vddkConfig
 		} else {
 			data["vddk-config-file"] =
-				"VixDiskLib.nfcAio.Session.BufSizeIn64K=16\n" +
+				"VixDiskLib.nfcAio.Session.BufSizeIn64KB=16\n" +
 					"VixDiskLib.nfcAio.Session.BufCount=4"
 		}
 	}


### PR DESCRIPTION
Backport of https://github.com/kubev2v/forklift/pull/1425 to release-2.8