### PR TITLE
MTV-2171 | New name in ova flow of virt-v2v pod

### DIFF
--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -136,7 +136,12 @@ func virtV2vBuildCommand() (args []string, err error) {
 		}
 		args = append(args, vsphereArgs...)
 	case global.OVA:
-		args = append(args, "-i", "ova", os.Getenv("V2V_diskPath"))
+		ovaArgs, err := virtV2vOVAArgs()
+		if err != nil {
+			return nil, err
+		}
+
+		args = append(args, ovaArgs...)
 	}
 
 	return args, nil
@@ -181,6 +186,18 @@ func virtV2vVsphereArgs() (args []string, err error) {
 	}
 
 	args = append(args, "--", os.Getenv("V2V_vmName"))
+	return args, nil
+}
+
+func virtV2vOVAArgs() (args []string, err error) {
+	args = append(args, "-i", "ova", os.Getenv("V2V_diskPath"))
+
+	// When converting VM with name that do not meet DNS1123 RFC requirements,
+	// it should be changed to supported one to ensure the conversion does not fail.
+	if utils.CheckEnvVariablesSet("V2V_NewName") {
+		args = append(args, "-on", os.Getenv("V2V_NewName"))
+	}
+
 	return args, nil
 }
 


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2171

Issue:
MTV can use '-on' option to change guest name automatically when migrate guests from vsphere provider, but MTV can't use '-on' option to change the guest name when migrate guests from ova provider, so MTV should add the same function of changing guest name to ova provider as vsphere provider 

Fix:
add the "-on" flag to the OVA flow in the virt-v2v pod

Screenshot:
Before fix:
![ova-without-new-name-arg](https://github.com/user-attachments/assets/be701e92-0f41-4c83-9f08-c6c9bb92de92)

After fix:
![ova-with-new-name-arg](https://github.com/user-attachments/assets/25925280-88f1-4c9b-bc2a-8ba1825a2ca0)
