### PR TITLE
MTV-2199 | Deprecate plan.spec.DiskBus parameter

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -61,10 +61,7 @@ spec:
                 description: Description
                 type: string
               diskBus:
-                description: |-
-                  Specify the disk bus which will be applied to all VMs disks in plan.
-                  Possible options 'scsi', 'sata' and 'virtio'.
-                  Defaults to 'virtio'.
+                description: 'Deprecated: this field will be deprecated in 2.8.'
                 type: string
               map:
                 description: Resource mapping.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -49,10 +49,7 @@ type PlanSpec struct {
 	PreserveClusterCPUModel bool `json:"preserveClusterCpuModel,omitempty"`
 	// Preserve static IPs of VMs in vSphere
 	PreserveStaticIPs bool `json:"preserveStaticIPs,omitempty"`
-	// Specify the disk bus which will be applied to all VMs disks in plan.
-	// Possible options 'scsi', 'sata' and 'virtio'.
-	// Defaults to 'virtio'.
-	// +optional
+	// Deprecated: this field will be deprecated in 2.8.
 	DiskBus cnv.DiskBus `json:"diskBus,omitempty"`
 	// PVCNameTemplate is a template for generating PVC names for VM disks.
 	// It follows Go template syntax and has access to the following variables:

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -857,16 +857,11 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 				},
 			},
 		}
-		bus := cnv.DiskBusVirtio
-		if r.Plan.Spec.DiskBus != "" {
-			bus = r.Plan.Spec.DiskBus
-		}
-
 		kubevirtDisk := cnv.Disk{
 			Name: volumeName,
 			DiskDevice: cnv.DiskDevice{
 				Disk: &cnv.DiskTarget{
-					Bus: bus,
+					Bus: cnv.DiskBusVirtio,
 				},
 			},
 		}
@@ -880,8 +875,6 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 	// For multiboot VMs, if the selected boot device is the current disk,
 	// set it as the first in the boot order.
 	kDisks[bootDisk].BootOrder = ptr.To(uint(1))
-	// The boot disk needs to have a virtio bus
-	kDisks[bootDisk].Disk.Bus = cnv.DiskBusVirtio
 
 	object.Template.Spec.Volumes = kVolumes
 	object.Template.Spec.Domain.Devices.Disks = kDisks

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
@@ -113,15 +113,6 @@ func (admitter *PlanAdmitter) validateLUKS() error {
 	return nil
 }
 
-func (admitter *PlanAdmitter) IsValidDiskBus() bool {
-	switch admitter.plan.Spec.DiskBus {
-	case cnv.DiskBusSCSI, cnv.DiskBusSATA, cnv.DiskBusVirtio:
-		return true
-	default:
-		return false
-	}
-}
-
 func (admitter *PlanAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	log.Info("Plan admitter was called")
 	raw := ar.Request.Object.Raw
@@ -209,9 +200,6 @@ func (admitter *PlanAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv
 	if err != nil {
 		return util.ToAdmissionResponseError(err)
 	}
-	if admitter.plan.Spec.DiskBus != "" && !admitter.IsValidDiskBus() {
-		err = liberr.New(fmt.Sprintf("migration to diskBus '%s' is not supported", admitter.plan.Spec.DiskBus))
-		return util.ToAdmissionResponseError(err)
-	}
+
 	return util.ToAdmissionResponseAllow()
 }


### PR DESCRIPTION
Issue: The virt-v2v converts the guests to work only with the virtio-blk, which includes updating the Linux configurations to match the new device names (vda, vdx...) and for Windows where it edits the boot section to work with the virtio-blk drivers. The aim of the DiskBus parameter was to allow the users to specify the Bus because KubeVirt only allows hotplug disks with the SCSI bus. This issue was moved to the KubeVirt and will be resolved on their end.

Fix: Deprecate the parameter from 2.8

Ref: 
- https://issues.redhat.com/browse/MTV-2199
- https://github.com/kubev2v/forklift/pull/1333