### PR TITLE
Fix shared disks validations

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/utils.go
+++ b/pkg/controller/plan/adapter/vsphere/utils.go
@@ -2,6 +2,8 @@ package vsphere
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	planbase "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
@@ -45,6 +47,12 @@ func baseVolume(fileName string, warm bool) string {
 //	Output: [datastore13] my-vm/disk-name.vmdk
 func trimBackingFileName(fileName string) string {
 	return backingFilePattern.ReplaceAllString(fileName, ".vmdk")
+}
+
+// stringifyWithQuotes formats the slice with comas between the items and quotes around each item
+// Example [disk1, disk2, disk3] -> 'disk1', 'disk2', 'disk3'
+func stringifyWithQuotes(s []string) string {
+	return fmt.Sprintf("'%s'", strings.Join(s, "', '"))
 }
 
 // Return all shareable PVCs

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -561,21 +561,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Message:  "Duplicate targetName.",
 		Items:    []string{},
 	}
-	sharedDisks := libcnd.Condition{
-		Type:     SharedDisks,
-		Status:   True,
-		Category: Critical,
-		Message:  "VMs with shared disk can not be migrated.", // This should be set by the provider validator
-		Items:    []string{},
-	}
-	sharedWarnDisks := libcnd.Condition{
-		Type:     SharedWarnDisks,
-		Status:   True,
-		Category: Warn,
-		Message:  "VMs with shared disk can not be migrated.", // This should be set by the provider validator
-		Items:    []string{},
-	}
-
+	var sharedDisksConditions []libcnd.Condition
 	setOf := map[string]bool{}
 	setOfTargetName := map[string]bool{}
 	//
@@ -704,15 +690,23 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 			return err
 		}
 		if !ok {
+			sharedDisks := libcnd.Condition{
+				Type:     SharedWarnDisks,
+				Status:   True,
+				Category: category,
+				Message:  "VMs with shared disk can not be migrated.", // This should be set by the provider validator
+				Items:    []string{ref.String()},
+			}
 			if msg != "" {
 				sharedDisks.Message = msg
-				sharedWarnDisks.Message = msg
 			}
 			if category == validation.Warn {
-				sharedWarnDisks.Items = append(sharedWarnDisks.Items, ref.String())
+				sharedDisks.Type = SharedWarnDisks
 			} else {
-				sharedDisks.Items = append(sharedDisks.Items, ref.String())
+				sharedDisks.Type = SharedDisks
 			}
+			sharedDisks.Type = fmt.Sprintf("%s-%s", sharedDisks.Type, ref.ID)
+			sharedDisksConditions = append(sharedDisksConditions, sharedDisks)
 		}
 		// Destination.
 		provider = plan.Referenced.Provider.Destination
@@ -808,11 +802,8 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 	if len(missingStaticIPs.Items) > 0 {
 		plan.Status.SetCondition(missingStaticIPs)
 	}
-	if len(sharedDisks.Items) > 0 {
-		plan.Status.SetCondition(sharedDisks)
-	}
-	if len(sharedWarnDisks.Items) > 0 {
-		plan.Status.SetCondition(sharedWarnDisks)
+	if len(sharedDisksConditions) > 0 {
+		plan.Status.SetCondition(sharedDisksConditions...)
 	}
 	if len(missingCbtForWarm.Items) > 0 {
 		plan.Status.SetCondition(missingCbtForWarm)

--- a/pkg/lib/condition/condition.go
+++ b/pkg/lib/condition/condition.go
@@ -324,8 +324,7 @@ func (r *Conditions) HasBlockerCondition() bool {
 // The collection contains blocker conditions that keep the plan reconciling.
 func (r *Conditions) HasReQCondition() bool {
 	return r.HasCondition(ValidatingVDDK) ||
-		r.HasCondition(VMMissingChangedBlockTracking) ||
-		r.HasCondition(SharedDisks)
+		r.HasCondition(VMMissingChangedBlockTracking)
 }
 
 // The collection contains the `Ready` condition.


### PR DESCRIPTION
Issue: The condition is adding by specific type. If we want to have different condition msg to different VMs within the same plan we need to change the type so the condition is not overriden by next condition. This way all VMs in the items list had message of the last VM.

Fix: Add VM specific condition types.

Ref:
- https://issues.redhat.com/browse/MTV-2206
- https://issues.redhat.com/browse/MTV-2207
- https://issues.redhat.com/browse/MTV-2209