### PR TITLE
MTV-1368 Preserve disk serial numbers from VMware.

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -869,6 +869,14 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 			kubevirtDisk.Shareable = ptr.To(true)
 			kubevirtDisk.Cache = cnv.CacheNone
 		}
+		// Disk serial numbers are only presented to the source guest if
+		// the disk is connected with SCSI and disk.EnableUUID is set to
+		// TRUE, so only save the serial number for those disks. If the
+		// destination VM is configured with VirtIO or SATA, the resulting
+		// serial number will be truncated to 20 characters.
+		if vm.DiskEnableUuid && cnv.DiskBus(disk.Bus) == cnv.DiskBusSCSI {
+			kubevirtDisk.Serial = disk.Serial
+		}
 		kVolumes = append(kVolumes, volume)
 		kDisks = append(kDisks, kubevirtDisk)
 	}

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -659,7 +659,16 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 								}
 								v.model.ChangeTrackingEnabled = boolVal
 							}
+						case "disk.EnableUUID":
+							if s, cast := opt.Value.(string); cast {
+								boolVal, err := strconv.ParseBool(s)
+								if err != nil {
+									return
+								}
+								v.model.DiskEnableUuid = boolVal
+							}
 						}
+
 					}
 				}
 			case fGuestNet:

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -892,6 +892,7 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 					Shared:   backing.Sharing != "sharingNone",
 					Mode:     backing.DiskMode,
 					Bus:      controller.Bus,
+					Serial:   backing.Uuid,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -910,6 +911,7 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 					Mode:     backing.DiskMode,
 					RDM:      true,
 					Bus:      controller.Bus,
+					Serial:   backing.Uuid,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -270,6 +270,7 @@ type VM struct {
 	GuestNetworks         []GuestNetwork `sql:""`
 	GuestIpStacks         []GuestIpStack `sql:""`
 	SecureBoot            bool           `sql:""`
+	DiskEnableUuid        bool           `sql:""`
 }
 
 // Determine if current revision has been validated.

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -295,6 +295,7 @@ type Disk struct {
 	RDM       bool   `json:"rdm"`
 	Bus       string `json:"bus"`
 	Mode      string `json:"mode,omitempty"`
+	Serial    string `json:"serial,omitempty"`
 }
 
 // Virtual Device.

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -246,6 +246,7 @@ type VM struct {
 	GuestNetworks         []model.GuestNetwork `json:"guestNetworks"`
 	GuestIpStacks         []model.GuestIpStack `json:"guestIpStacks"`
 	SecureBoot            bool                 `json:"secureBoot"`
+	DiskEnableUuid        bool                 `json:"diskEnableUuid"`
 }
 
 // Build the resource using the model.
@@ -277,6 +278,7 @@ func (r *VM) With(m *model.VM) {
 	r.GuestNetworks = m.GuestNetworks
 	r.GuestIpStacks = m.GuestIpStacks
 	r.SecureBoot = m.SecureBoot
+	r.DiskEnableUuid = m.DiskEnableUuid
 }
 
 // Build self link (URI).

--- a/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers.rego
@@ -1,0 +1,16 @@
+package io.konveyor.forklift.vmware
+
+disk_uuid_enabled {
+    some i
+    input.diskEnableUuid == true
+    input.disks[i].bus == "scsi"
+}
+
+concerns[flag] {
+    disk_uuid_enabled
+    flag := {
+        "category": "Information",
+	"label": "Disk serial numbers may be truncated",
+	"assessment": "This VM is configured with at least one SCSI disk and the disk.EnableUUID parameter is set to TRUE. This may indicate a need for consistent SCSI disk serial numbers, but be advised that these serial numbers will be truncated after migration."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers_test.rego
@@ -1,0 +1,30 @@
+package io.konveyor.forklift.vmware
+
+test_with_uuid_enabled_scsi {
+    mock_vm := {
+        "name": "test",
+	"diskEnableUuid": true,
+	"disks": [{ "bus": "scsi" }]
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_with_uuid_enabled_sata {
+    mock_vm := {
+        "name": "test",
+	"diskEnableUuid": true,
+	"disks": [{ "bus": "sata" }]
+    }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_uuid_disabled {
+    mock_vm := {
+        "name": "test",
+	"diskEnableUuid": false
+    }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}


### PR DESCRIPTION
Address [MTV-1368](https://issues.redhat.com/browse/MTV-1368) as much as possible for VMware VMs, by copying disk serial numbers into the KubeVirt YAML. Only do this when the source VM is configured with a SCSI disk and has the **disk.EnableUUID** configuration parameter set, because that appears to be the only case where serial numbers are actually presented through to the guest.

Also raise an informational validation message on the VM during plan creation so it is clear that the serial number is not going to be completely preserved. It will be truncated to 20 characters for VirtIO disks and there is no longer an option for SCSI, so there is not currently a way for MTV to automatically preserve them completely.