### PR TITLE
MTV-2236 | Use unshare seccomp profile

### DIFF
--- a/operator/roles/forkliftcontroller/templates/controller/controller-scc.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/controller-scc.yml.j2
@@ -13,3 +13,4 @@ seLinuxContext:
 allowPrivilegedContainer: false
 seccompProfiles:
   - runtime/default
+  - localhost/profiles/unshare.json

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1921,6 +1921,7 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 			return
 		}
 	}
+	unshare := "profiles/unshare.json"
 	// pod
 	pod = &core.Pod{
 		ObjectMeta: meta.ObjectMeta{
@@ -1935,7 +1936,8 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 				RunAsUser:    &user,
 				RunAsNonRoot: &nonRoot,
 				SeccompProfile: &core.SeccompProfile{
-					Type: core.SeccompProfileTypeRuntimeDefault,
+					Type:             core.SeccompProfileTypeLocalhost,
+					LocalhostProfile: &unshare,
 				},
 			},
 			Affinity: &core.Affinity{


### PR DESCRIPTION
Issue: Right now the migration using the quay.io/kubev2v/forklift-virt-v2v:latest fails due to the passt missing permissions. The root cause of this issue is in the passt using the `unshare(2)` syscall. The passt was added to the virt-v2v libguestfs which introduced this issue. The CRI-O is missing the `unshare(2)` from the seccomp settings. We need to specify to use the seccomp which allows the `unshare(2)` syscall and add it to the MTVs SecurityContextConstraints.

Fix: Add the unshare seccomp profile to the guest conversion pod.

Ref: https://issues.redhat.com/browse/MTV-2236