### PR TITLE
Add Fedora guest conversion build for BTRFS support

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -50,6 +50,9 @@ jobs:
           - name: virt-v2v
             file: build/virt-v2v/Containerfile-upstream
             repo: forklift-virt-v2v
+          - name: virt-v2v
+            file: build/virt-v2v/Containerfile-upstream-fedora
+            repo: forklift-virt-v2v-fedora
     runs-on: ubuntu-latest
     steps:
       - name: Checkout forklift

--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -1,0 +1,61 @@
+# Build virt-v2v binary
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9-1739801907 AS builder
+WORKDIR /app
+COPY --chown=1001:0 ./ ./
+ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT strictfipsruntime
+
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-monitor ./cmd/virt-v2v-monitor/virt-v2v-monitor.go
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o image-converter ./cmd/image-converter/image-converter.go
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-wrapper ./cmd/virt-v2v/entrypoint.go
+
+# Main container
+FROM quay.io/fedora/fedora:41
+RUN rm /etc/pki/tls/fips_local.cnf && \
+    echo -e '[fips_sect]\ntls1-prf-ems-check = 0\nactivate = 1' > /etc/pki/tls/fips_local.cnf && \
+    sed -i '/^\\[ crypto_policy \\]/a Options=RHNoEnforceEMSinFIPS' /etc/pki/tls/openssl.cnf
+
+ENV LIBGUESTFS_BACKEND=direct LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+
+RUN mkdir /disks && \
+    source /etc/os-release && \
+    dnf install -y \
+        virt-v2v && \
+    dnf clean all
+
+RUN dnf install -y https://kojihub.stream.centos.org/kojifiles/packages/virtio-win/1.9.40/1.el9/noarch/virtio-win-1.9.40-1.el9.noarch.rpm
+
+
+#Missing libguestfs-winsupport in the Fedora packages
+RUN dnf -y install btrfs libguestfs libguestfs-appliance libguestfs-xfs qemu-img supermin && \
+        depmod $(ls /lib/modules/ |tail -n1)
+
+# Create tarball for the appliance.
+RUN mkdir -p /usr/lib64/guestfs/appliance && \
+        cd /usr/lib64/guestfs/appliance && \
+        libguestfs-make-fixed-appliance . && \
+        qemu-img convert -c -O qcow2 root root.qcow2 && \
+        mv -vf root.qcow2 root && \
+        tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance
+
+COPY --from=builder /app/virt-v2v-monitor /usr/local/bin/virt-v2v-monitor
+
+COPY --from=builder /app/image-converter /usr/local/bin/image-converter
+
+COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
+
+ENTRYPOINT ["/usr/bin/virt-v2v-wrapper"]
+
+LABEL \
+        com.redhat.component="forklift-virt-v2v-container" \
+        name="forklift/forklift-virt-v2v-rhel9" \
+        license="Apache License 2.0" \
+        io.k8s.display-name="Forklift" \
+        io.k8s.description="Forklift - Virt-V2V" \
+        io.openshift.tags="migration,mtv,forklift" \
+        summary="Forklift - Virt-V2V" \
+        description="Forklift - Virt-V2V" \
+        io.k8s.description="Forklift - Virt-V2V" \
+        vendor="Red Hat, Inc." \
+        maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"
+


### PR DESCRIPTION
Issue: The migration of SUSE fails due to the BTRFS. The virt-v2v fails to mount the BTRFS

Fix use Fedora base image which has support of BTRFS.