### PR TITLE
Add virt-v2v container build notes

### DIFF
--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -23,6 +23,7 @@ RUN mkdir /disks && \
         virt-v2v && \
     dnf clean all
 
+# TODO: This should be replaced with `dnf install -y virtio-win` from centos-stream10
 RUN dnf install -y https://kojihub.stream.centos.org/kojifiles/packages/virtio-win/1.9.40/1.el9/noarch/virtio-win-1.9.40-1.el9.noarch.rpm
 
 RUN ( [ "$(rpm -q glibc)" == "glibc-2.34-66.el9.x86_64" ] && dnf -y downgrade glibc-2.34-65.el9.x86_64 || true ) && \

--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -26,7 +26,7 @@ RUN mkdir /disks && \
 RUN dnf install -y https://kojihub.stream.centos.org/kojifiles/packages/virtio-win/1.9.40/1.el9/noarch/virtio-win-1.9.40-1.el9.noarch.rpm
 
 
-#Missing libguestfs-winsupport in the Fedora packages
+# Missing `libguestfs-winsupport` in the Fedora packages, this is not needed for Fedora as the v2v uses ntfs-3g
 RUN dnf -y install btrfs libguestfs libguestfs-appliance libguestfs-xfs qemu-img supermin && \
         depmod $(ls /lib/modules/ |tail -n1)
 


### PR DESCRIPTION
Add notes to the virt-v2v Containerfiles that we need to remove the static path of the virtio-win drivers from centos-stream10 and use the available packages. Ref https://issues.redhat.com/browse/RHEL-62961

Add a note about why we don't need to use the `libguestfs-winsupport` in Fedora builds.