### PR TITLE
MTV-2257 | Ensure pvc generate name ends with -

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -516,6 +516,10 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 
 					generatedName, err := r.executeTemplate(pvcNameTemplate, &templateData)
 					if err == nil && generatedName != "" {
+						// Ensure generatedName ends with "-"
+						if !strings.HasSuffix(generatedName, "-") {
+							generatedName = generatedName + "-"
+						}
 						dv.ObjectMeta.GenerateName = generatedName
 					} else {
 						// Failed to generate PVC name using template


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2257

Issue:
When use pvcNameTemplate: {{.VmName}}-disk-{{.DiskIndex}} during migration,
after the migration the random numbers are added to the end of PVC names
E.g. mtv-function-win2022-test-disk-0pv72h -- {{.DiskIndex}}+random numbers

Fix:
Ensure the PVC template ends with "-" char

Screenshots:
Before:
![pvc-suffix-before](https://github.com/user-attachments/assets/51231d8e-6cfa-4e23-ba66-ecf06d54d107)

After:
![pvc-suffix-after](https://github.com/user-attachments/assets/c416783b-322b-4a89-94e8-a2b9ae9ec8b2)
