### PR TITLE
MTV-2244 | Check length of generated volume name when using plan string templates

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -845,6 +845,15 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 				// fallback to default name and reset error
 				volumeName = fmt.Sprintf("vol-%v", i)
 			}
+
+			// check if the generated name is longer then 63 characters
+			if len(volumeName) > 63 {
+				// if the generated name is longer then 63 characters, trancate it
+				newVolumeName := volumeName[:63]
+				r.Log.Info("Generated volume name is longer than 63 characters, sanitizing it", "volumeName", volumeName, "newVolumeName", newVolumeName)
+
+				volumeName = newVolumeName
+			}
 		}
 
 		volume := cnv.Volume{


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2244

Issue:
When using template to generate the volume name, we may generate a name that is longer the 63 chars

Fix:
Truncate names longer then 63 chars

Notes:
Truncating the name may create none unique volume names, other heuristics for ensuring valid volume names, like fall back to default name, may have their own issues. 

Screenshots:
Before:
![long-pvc-name-before](https://github.com/user-attachments/assets/bb9103fa-0a1f-4928-9bc8-7ac8356100d9)

After:
![long-pvc-name-after](https://github.com/user-attachments/assets/d19893f1-0dc5-478c-a50e-d23970b880a4)

Plan with long templates:
![long-pvc-name-plan-yaml](https://github.com/user-attachments/assets/4ca58aef-b2da-4c5d-9d58-1f1d063c4165)
