### PR TITLE
Fix virt-v2v-in-place path for upstream builds

### DIFF
--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -100,7 +100,7 @@ func runVirtV2vInPlace() error {
 		return err
 	}
 	args = append(args, "/mnt/v2v/input.xml")
-	v2vCmd := exec.Command("/usr/libexec/virt-v2v-in-place", args...)
+	v2vCmd := exec.Command("virt-v2v-in-place", args...)
 	v2vCmd.Stdout = os.Stdout
 	v2vCmd.Stderr = os.Stderr
 	return v2vCmd.Run()


### PR DESCRIPTION
Issue:
The upstream virt-v2v-in-place warm migraiton path fails. Error:
```
Failed to execute virt-v2v command: fork/exec /usr/libexec/virt-v2v-in-place: no such file or directory
```

Fix:
Lets not specify full path of the virt-v2v-in-place.