### PR TITLE
vSphere: ignore canceled VMs when scheduling

### DIFF
--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -22,6 +22,7 @@ const (
 	CreateVM                 = "CreateVM"
 	PostHook                 = "PostHook"
 	Completed                = "Completed"
+	Canceled                 = "Canceled"
 )
 
 // Steps.
@@ -184,6 +185,9 @@ func (r *Scheduler) buildPending() (err error) {
 		err = r.Source.Inventory.Find(vm, vmStatus.Ref)
 		if err != nil {
 			return
+		}
+		if vmStatus.HasCondition(Canceled) {
+			continue
 		}
 		if !vmStatus.MarkedStarted() && !vmStatus.MarkedCompleted() {
 			pending := &pendingVM{


### PR DESCRIPTION
Now that the migration runner attempts to schedule as many VMs as it can in a single reconcilation,
it has exposed a bug in the scheduler where canceled VMs are rescheduled endlessly in certain pathological cases, preventing the reconciliation from terminating.

(for instance, if a VM is canceled before it has been marked started, it will always appear ready to schedule although there is nothing for the plan controller to do with it.)

The endless rescheduling causes the controller to infinite loop and be unable to reconcile resources, necessitating that the offending Migration resource be deleted and the controller pod be restarted.

Checking for the `Canceled` condition on the VM is adequate to prevent the problem. (Requesting cancelation of the VM via the Migration resource will cause the VM to be marked with the Canceled condition in memory as the Plan is reconciled, which will cause it to be ignored by the scheduler, and on the following reconcile it will be cleaned up as intended.)