### PR TITLE
[Backport release-2.7] vSphere: ignore canceled VMs when scheduling 

### DIFF
--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -22,6 +22,7 @@ const (
 	CreateVM                 = "CreateVM"
 	PostHook                 = "PostHook"
 	Completed                = "Completed"
+	Canceled                 = "Canceled"
 )
 
 // Steps.
@@ -184,6 +185,9 @@ func (r *Scheduler) buildPending() (err error) {
 		err = r.Source.Inventory.Find(vm, vmStatus.Ref)
 		if err != nil {
 			return
+		}
+		if vmStatus.HasCondition(Canceled) {
+			continue
 		}
 		if !vmStatus.MarkedStarted() && !vmStatus.MarkedCompleted() {
 			pending := &pendingVM{


### PR DESCRIPTION
Backport of https://github.com/kubev2v/forklift/pull/1465