### PR TITLE
MTV 2285 - Preserve Static IPs fails to match manually configured MAC address on VMware VMs

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -2,6 +2,8 @@ package vsphere
 
 import (
 	"fmt"
+	"strings"
+
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	planbase "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
@@ -310,8 +312,9 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 
 	for _, nic := range vm.NICs {
 		found := false
+		nicMAC := strings.ToLower(nic.MAC)
 		for _, guestNetwork := range vm.GuestNetworks {
-			if nic.MAC == guestNetwork.MAC {
+			if nicMAC == strings.ToLower(guestNetwork.MAC) {
 				found = true
 				break
 			}


### PR DESCRIPTION
In VMware it is possible to manually configure the MAC address on a virtual network adatper. This results in a MAC address that can contain upper and/or lower case characters.
This results in the IP address of the VM not being preserved during migration

Fix:
Ensures that the Mac Address comparison is case-insensitive