### PR TITLE
MTV-2249 | Validate template for k8s spec

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1183,12 +1183,9 @@ func (r *Builder) getPVCNameTemplate(vm *model.VM) string {
 func (r *Builder) getPlenVMNewName(vm *model.VM) string {
 	// Get plan VM
 	planVM := r.getPlanVMStatus(vm)
-	if planVM == nil {
-		return ""
-	}
 
-	// if vm.PVCNameTNewNameemplate is set, use it
-	if planVM.NewName != "" {
+	// if plan VM status has a new name, use it
+	if planVM != nil && planVM.NewName != "" {
 		return planVM.NewName
 	}
 

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1376,7 +1376,7 @@ func (r *Reconciler) IsValidPVCNameTemplate(pvcNameTemplate string) error {
 	}
 
 	// Validate that template output is a valid k8s label
-	errs := k8svalidation.IsValidLabelValue(result)
+	errs := k8svalidation.IsDNS1123Label(result)
 	if len(errs) > 0 {
 		return liberr.New("Template output is not a valid k8s label", "errors", errs)
 	}
@@ -1400,7 +1400,7 @@ func (r *Reconciler) IsValidVolumeNameTemplate(volumeNameTemplate string) error 
 	}
 
 	// Validate that template output is a valid k8s label
-	errs := k8svalidation.IsValidLabelValue(result)
+	errs := k8svalidation.IsDNS1123Label(result)
 	if len(errs) > 0 {
 		return liberr.New("Template output is not a valid k8s label", "errors", errs)
 	}
@@ -1426,7 +1426,7 @@ func (r *Reconciler) IsValidNetworkNameTemplate(networkNameTemplate string) erro
 	}
 
 	// Validate that template output is a valid k8s label
-	errs := k8svalidation.IsValidLabelValue(result)
+	errs := k8svalidation.IsDNS1123Label(result)
 	if len(errs) > 0 {
 		return liberr.New("Template output is not a valid k8s label", "errors", errs)
 	}

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -152,6 +152,11 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			ginkgo.Entry("template with invalid k8s label chars", "disk@{{.DiskIndex}}", false),
 			ginkgo.Entry("template with undefined variable", "{{.UndefinedVar}}", false),
 			ginkgo.Entry("template resulting in empty string", "{{if false}}disk{{end}}", false),
+			ginkgo.Entry("template with special characters", "disk!{{.DiskIndex}}", false),
+			ginkgo.Entry("template with spaces", "disk {{.DiskIndex}}", false),
+			ginkgo.Entry("template with invalid start character", "_{{.VmName}}", false),
+			ginkgo.Entry("template exceeding length limit", "very-very-very-very-very-very-very-very-very-very-long-prefix-{{.VmName}}", false),
+			ginkgo.Entry("template with slash character", "{{.VmName}}/{{.DiskIndex}}", false),
 		)
 	})
 
@@ -179,6 +184,11 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			ginkgo.Entry("template with invalid k8s label chars", "disk@{{.DiskIndex}}", false),
 			ginkgo.Entry("template with undefined variable", "{{.UndefinedVar}}", false),
 			ginkgo.Entry("template resulting in empty string", "{{if false}}disk{{end}}", false),
+			ginkgo.Entry("template starting with non-alphanumeric", "-{{.VmName}}", false),
+			ginkgo.Entry("template ending with non-alphanumeric", "{{.VmName}}-", false),
+			ginkgo.Entry("template with too long result", "very-long-prefix-that-will-definitely-exceed-kubernetes-label-length-limit-for-sure-{{.VmName}}", false),
+			ginkgo.Entry("template with invalid character in the middle", "disk-{{.VmName}}/{{.DiskIndex}}", false),
+			ginkgo.Entry("template with uppercase characters (invalid K8s name)", "DISK-{{.VmName}}", false),
 		)
 	})
 })


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2249

Issue:
Currently we validate the pvc, network and volume template using label validation, but we need to use DNS1123Label validation 

FIx:
Replace the label validations with DNS1123Label validations

Tasks:
  - [x] Add tests for non valid cases
  - [x] Use sanitized VM name, so all input argument will be k8s valid names
  - [x] Use `IsDNS1123Label` instead of `IsValidLabelValue` for PVC, volume and network templates
 
Screenshot:
After:
![pvc-name-invalid](https://github.com/user-attachments/assets/fdb983d4-8432-4fa5-9af6-c10d33f4af62)
