### PR TITLE
MTV-2293 | Missing templates are not an error

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1651,9 +1651,7 @@ func (r *KubeVirt) vmTemplate(vm *plan.VMStatus) (virtualMachine *cnv.VirtualMac
 	}
 	tmpl, err := r.findTemplate(vm)
 	if err != nil {
-		r.Log.Error(err, "could not find template for destination VM.",
-			"vm",
-			vm.String())
+		r.Log.Info("Can't find matching template, not setting a template", "vm", vm.String())
 		return
 	}
 


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2293

Issue:
Error about "could not find template for destination VM" in forklift-controller pod log

Fix:
Embrace the absence of templates, it's ok