### PR TITLE
Revert "MTV 2285 - Preserve Static IPs fails to match manually configured MAC address on VMware VMs"

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -2,8 +2,6 @@ package vsphere
 
 import (
 	"fmt"
-	"strings"
-
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	planbase "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
@@ -312,9 +310,8 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 
 	for _, nic := range vm.NICs {
 		found := false
-		nicMAC := strings.ToLower(nic.MAC)
 		for _, guestNetwork := range vm.GuestNetworks {
-			if nicMAC == strings.ToLower(guestNetwork.MAC) {
+			if nic.MAC == guestNetwork.MAC {
 				found = true
 				break
 			}


### PR DESCRIPTION
Reverts kubev2v/forklift#1468
we should store the mac in lowercase in the DB