### PR TITLE
MTV-2285 | Mac Address comparison case-insensitive

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -684,7 +684,7 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 								dnsList = info.DnsConfig.IpAddress
 							}
 							guestNetworksList = append(guestNetworksList, model.GuestNetwork{
-								MAC:          info.MacAddress,
+								MAC:          strings.ToLower(info.MacAddress),
 								IP:           ip.IpAddress,
 								Origin:       ip.Origin,
 								PrefixLength: ip.PrefixLength,
@@ -772,7 +772,7 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 							nicList = append(
 								nicList,
 								model.NIC{
-									MAC: nic.MacAddress,
+									MAC: strings.ToLower(nic.MacAddress),
 									Network: model.Ref{
 										Kind: model.NetKind,
 										ID:   network,


### PR DESCRIPTION
    Issue:
    In VMware it is possible to manaully configure the MAC address on a virtual network adatper.
    This results in a MAC address that can contain upper and/or lower case characters.

    It appears the validator matches strings without ignoring case.
    This results in the IP address of the VM not being preserved during migration:

    Fix:
    Ensures that the Mac Address comparison is case-insensitive

    Ref: https://issues.redhat.com/browse/MTV-2285