### PR TITLE
MTV-2303 | Sort disks for pvc template indexing same way as the vm builder

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -448,7 +448,11 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 		return
 	}
 
-	for diskIndex, disk := range vm.Disks {
+	// Sort disks by bus, so we can match the disk index to the boot order.
+	// Important: need to match order in mapDisks method
+	disks := r.sortedDisksAsVmware(vm.Disks)
+
+	for diskIndex, disk := range disks {
 		mapped, found := dsMap[disk.Datastore.ID]
 		if !found {
 			continue


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2303

Sort disks for pvc template indexing same way as the vm builder

Issue:
We don't sort the disks in the data-volume method same as in map-disks method

Fix:
Sort disks using same helper sort method used by the mapDisks method