### PR TITLE
MTV-1652 | Need to sync the VM snapshot status with source provider

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -565,6 +565,8 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 					if ref != nil {
 						v.model.Snapshot = v.Ref(*ref)
 					}
+				} else { //Also sync the snapshot status upon deletion
+					v.model.Snapshot = model.Ref{}
 				}
 			case fChangeTracking:
 				if b, cast := p.Val.(bool); cast {


### PR DESCRIPTION
Issue:
VM snapshot status in the source provider  isn't being synced upon snapshot deletion.

Fix:
Snapshot casting in the model fails when a nil snapshot object is being updated after deletion. In that case we need to set the snaphot object in the model to nil  which will be reflected in the provider status

Ref: https://issues.redhat.com/browse/MTV-1652