### PR TITLE
MTV-2308 | VM name should not contain multiple dots

### DIFF
--- a/pkg/controller/plan/vm_name_handler.go
+++ b/pkg/controller/plan/vm_name_handler.go
@@ -33,23 +33,39 @@ func (r *KubeVirt) changeVmNameDNS1123(vmName string, vmNamespace string) (gener
 
 // changes VM name to match DNS1123 RFC convention.
 func changeVmName(currName string) string {
-	var underscoreExcluded = regexp.MustCompile("^[.]|[_]|[.]$")
-	var nameExcludeChars = regexp.MustCompile("[^a-z0-9-.]")
-
 	newName := strings.ToLower(currName)
+	newName = strings.Trim(newName, ".-")
+
+	parts := strings.Split(newName, ".")
+	var validParts []string
+
+	for _, part := range parts {
+		part = strings.ReplaceAll(part, "_", "-")
+
+		notAllowedChars := regexp.MustCompile("[^a-z0-9-]")
+		part = notAllowedChars.ReplaceAllString(part, "")
+
+		part = strings.Trim(part, "-.")
+
+		// Add part only if not empty
+		if part != "" {
+			validParts = append(validParts, part)
+		}
+	}
+
+	// Join valid parts with dots
+	newName = strings.Join(validParts, ".")
+
+	// Ensure length does not exceed max
 	if len(newName) > NameMaxLength {
 		newName = newName[0:NameMaxLength]
 	}
-	if underscoreExcluded.MatchString(newName) {
-		newName = underscoreExcluded.ReplaceAllString(newName, "-")
-	}
-	if nameExcludeChars.MatchString(newName) {
-		newName = nameExcludeChars.ReplaceAllString(newName, "")
-	}
-	newName = strings.Trim(newName, "-")
-	if len(newName) == 0 {
+
+	// Handle case where name is empty after all processing
+	if newName == "" {
 		newName = "vm-" + generateRandVmNameSuffix()
 	}
+
 	return newName
 }
 

--- a/pkg/controller/plan/vm_name_handler_test.go
+++ b/pkg/controller/plan/vm_name_handler_test.go
@@ -4,18 +4,41 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func TestVmNameHandler(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
+	// Helper function to check if VM name is a valid DNS1123 subdomain
+	validateVmName := func(name string) bool {
+		return len(validation.IsDNS1123Subdomain(name)) == 0
+	}
+
 	//Test all cases in name adjustments
 	originalVmName := "----------------Vm!@#$%^&*()_+-Name/.is,';[]-CorREct-<>123----------------------"
 	newVmName := "vm--name.is-correct-123"
-	g.Expect(changeVmName(originalVmName)).To(gomega.Equal(newVmName))
+	changedName := changeVmName(originalVmName)
+	g.Expect(changedName).To(gomega.Equal(newVmName))
+	g.Expect(validateVmName(changedName)).To(gomega.BeTrue(), "Changed name should match DNS1123 subdomain format")
 
 	//Test the case that the VM name is empty after all removals
 	emptyVM := ".__."
 	newVmNameFromId := "vm-"
-	g.Expect(changeVmName(emptyVM)).To(gomega.ContainSubstring(newVmNameFromId))
+	changedEmptyName := changeVmName(emptyVM)
+	g.Expect(changedEmptyName).To(gomega.ContainSubstring(newVmNameFromId))
+	g.Expect(validateVmName(changedEmptyName)).To(gomega.BeTrue(), "Changed name from empty should match DNS1123 subdomain format")
+
+	//Test handling of multiple consecutive dots
+	multiDotVM := "mtv.func.-.rhel.-...8.8"
+	expectedMultiDotResult := "mtv.func.rhel.8.8"
+	changedMultiDotName := changeVmName(multiDotVM)
+	g.Expect(changedMultiDotName).To(gomega.Equal(expectedMultiDotResult))
+	g.Expect(validateVmName(changedMultiDotName)).To(gomega.BeTrue(), "Changed name with multiple dots should match DNS1123 subdomain format")
+
+	multiDotVM2 := ".....mtv.func..-...............rhel.-...8.8"
+	expectedMultiDotResult2 := "mtv.func.rhel.8.8"
+	changedMultiDotName2 := changeVmName(multiDotVM2)
+	g.Expect(changedMultiDotName2).To(gomega.Equal(expectedMultiDotResult2))
+	g.Expect(validateVmName(changedMultiDotName2)).To(gomega.BeTrue(), "Changed name with multiple leading dots should match DNS1123 subdomain format")
 }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2308

Issue:
When we auto correct the VM name to conform to DNS1123 domain name, we do not trim multiple dots

Fix:
Trim multiple dots

  - [x] Replace multiple dots with one dot
  - [x] Trim dots at the start or end of a name
  - [x] Add test case for multiple dots with "-"
  - [x] Add test case for multiple leading dots 

Screenshots:
Before
![dots-before](https://github.com/user-attachments/assets/f7a0d746-c860-440a-8784-a2b1ac36c725)

After
![screenshot-console-openshift-console apps yzamir-mtv apps cnv2 engineering redhat com-2025 03 27-17_22_33](https://github.com/user-attachments/assets/dc852cc1-ea11-4fa6-90e3-fb514cd90c21)

