### PR TITLE
Collect additional storage information

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -84,6 +84,7 @@ const (
 	fCpuCores       = "summary.hardware.numCpuCores"
 	fThumbprint     = "summary.config.sslThumbprint"
 	fMgtServerIp    = "summary.managementServerIp"
+	fScsiLun        = "config.storageDevice.scsiLun"
 	// Network
 	fTag     = "tag"
 	fSummary = "summary"
@@ -100,6 +101,7 @@ const (
 	fCapacity    = "summary.capacity"
 	fFreeSpace   = "summary.freeSpace"
 	fDsMaintMode = "summary.maintenanceMode"
+	fVmfsExtent  = "info"
 	// VM
 	fUUID                = "config.uuid"
 	fFirmware            = "config.firmware"
@@ -698,6 +700,7 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 				fPortGroup,
 				fPNIC,
 				fVNIC,
+				fScsiLun,
 			},
 		},
 		{ // Network
@@ -744,6 +747,7 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 				fCapacity,
 				fFreeSpace,
 				fDsMaintMode,
+				fVmfsExtent,
 				fHost,
 			},
 		},

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -371,6 +371,17 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 							return network.VNICs[i].MTU > network.VNICs[j].MTU
 						})
 				}
+			case fScsiLun:
+				if array, cast := p.Val.(types.ArrayOfScsiLun); cast {
+					v.model.HostScsiDisks = nil
+					for _, iScsiLun := range array.ScsiLun {
+						hostScsiDisk := model.HostScsiDisk{}
+						scsiLun := iScsiLun.GetScsiLun()
+						hostScsiDisk.CanonicalName = scsiLun.CanonicalName
+						hostScsiDisk.Vendor = strings.TrimSpace(scsiLun.Vendor)
+						v.model.HostScsiDisks = append(v.model.HostScsiDisks, hostScsiDisk)
+					}
+				}
 			}
 		}
 	}
@@ -512,6 +523,14 @@ func (v *DatastoreAdapter) Apply(u types.ObjectUpdate) {
 			case fDsMaintMode:
 				if s, cast := p.Val.(string); cast {
 					v.model.MaintenanceMode = s
+				}
+			case fVmfsExtent:
+				if s, cast := p.Val.(types.VmfsDatastoreInfo); cast {
+					backingDevList := []string{}
+					for _, val := range s.Vmfs.Extent {
+						backingDevList = append(backingDevList, val.DiskName)
+					}
+					v.model.BackingDevicesNames = backingDevList
 				}
 			}
 		}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -126,19 +126,31 @@ type Cluster struct {
 
 type Host struct {
 	Base
-	Cluster            string      `sql:"d0,index(cluster)"`
-	Status             string      `sql:""`
-	InMaintenanceMode  bool        `sql:""`
-	ManagementServerIp string      `sql:""`
-	Thumbprint         string      `sql:""`
-	Timezone           string      `sql:""`
-	CpuSockets         int16       `sql:""`
-	CpuCores           int16       `sql:""`
-	ProductName        string      `sql:""`
-	ProductVersion     string      `sql:""`
-	Network            HostNetwork `sql:""`
-	Networks           []Ref       `sql:""`
-	Datastores         []Ref       `sql:""`
+	Cluster            string         `sql:"d0,index(cluster)"`
+	Status             string         `sql:""`
+	InMaintenanceMode  bool           `sql:""`
+	ManagementServerIp string         `sql:""`
+	Thumbprint         string         `sql:""`
+	Timezone           string         `sql:""`
+	CpuSockets         int16          `sql:""`
+	CpuCores           int16          `sql:""`
+	ProductName        string         `sql:""`
+	ProductVersion     string         `sql:""`
+	Network            HostNetwork    `sql:""`
+	Networks           []Ref          `sql:""`
+	Datastores         []Ref          `sql:""`
+	HostScsiDisks      []HostScsiDisk `sql:""`
+}
+
+type HostScsiDisk struct {
+	// Canonical name of the SCSI logical unit.
+	//
+	// Disk partition or extent identifiers refer to this name when
+	// referring to a disk. Use this property to correlate a partition
+	// or extent to a specific SCSI disk.
+	CanonicalName string `json:"canonicalName"`
+	// The vendor of the SCSI device.
+	Vendor string `json:"vendor"`
 }
 
 type HostNetwork struct {
@@ -227,10 +239,11 @@ type DVSHost struct {
 
 type Datastore struct {
 	Base
-	Type            string `sql:""`
-	Capacity        int64  `sql:""`
-	Free            int64  `sql:""`
-	MaintenanceMode string `sql:""`
+	Type                string   `sql:""`
+	Capacity            int64    `sql:""`
+	Free                int64    `sql:""`
+	MaintenanceMode     string   `sql:""`
+	BackingDevicesNames []string `sql:""`
 }
 
 type VM struct {

--- a/pkg/controller/provider/web/vsphere/datastore.go
+++ b/pkg/controller/provider/web/vsphere/datastore.go
@@ -174,10 +174,11 @@ func (h *DatastoreHandler) filter(ctx *gin.Context, list *[]model.Datastore) (er
 // REST Resource.
 type Datastore struct {
 	Resource
-	Type            string `json:"type"`
-	Capacity        int64  `json:"capacity"`
-	Free            int64  `json:"free"`
-	MaintenanceMode string `json:"maintenance"`
+	Type                string   `json:"type"`
+	Capacity            int64    `json:"capacity"`
+	Free                int64    `json:"free"`
+	MaintenanceMode     string   `json:"maintenance"`
+	BackingDevicesNames []string `json:"backingDevicesNames"`
 }
 
 // Build the resource using the model.
@@ -187,6 +188,7 @@ func (r *Datastore) With(m *model.Datastore) {
 	r.Capacity = m.Capacity
 	r.Free = m.Free
 	r.MaintenanceMode = m.MaintenanceMode
+	r.BackingDevicesNames = m.BackingDevicesNames
 }
 
 // Build self link (URI).

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -203,21 +203,22 @@ func (h *HostHandler) buildAdapters(host *Host) (err error) {
 // REST Resource.
 type Host struct {
 	Resource
-	Cluster            string            `json:"cluster"`
-	Status             string            `json:"status"`
-	InMaintenanceMode  bool              `json:"inMaintenance"`
-	ManagementServerIp string            `json:"managementServerIp"`
-	Thumbprint         string            `json:"thumbprint"`
-	Timezone           string            `json:"timezone"`
-	CpuSockets         int16             `json:"cpuSockets"`
-	CpuCores           int16             `json:"cpuCores"`
-	ProductName        string            `json:"productName"`
-	ProductVersion     string            `json:"productVersion"`
-	Network            model.HostNetwork `json:"networking"`
-	Networks           []model.Ref       `json:"networks"`
-	Datastores         []model.Ref       `json:"datastores"`
-	VMs                []model.Ref       `json:"vms"`
-	NetworkAdapters    []NetworkAdapter  `json:"networkAdapters"`
+	Cluster            string               `json:"cluster"`
+	Status             string               `json:"status"`
+	InMaintenanceMode  bool                 `json:"inMaintenance"`
+	ManagementServerIp string               `json:"managementServerIp"`
+	Thumbprint         string               `json:"thumbprint"`
+	Timezone           string               `json:"timezone"`
+	CpuSockets         int16                `json:"cpuSockets"`
+	CpuCores           int16                `json:"cpuCores"`
+	ProductName        string               `json:"productName"`
+	ProductVersion     string               `json:"productVersion"`
+	Network            model.HostNetwork    `json:"networking"`
+	Networks           []model.Ref          `json:"networks"`
+	Datastores         []model.Ref          `json:"datastores"`
+	VMs                []model.Ref          `json:"vms"`
+	NetworkAdapters    []NetworkAdapter     `json:"networkAdapters"`
+	HostScsiDisks      []model.HostScsiDisk `json:"hostScsiDisks"`
 }
 
 // Build the resource using the model.
@@ -237,6 +238,7 @@ func (r *Host) With(m *model.Host) {
 	r.Networks = m.Networks
 	r.Datastores = m.Datastores
 	r.NetworkAdapters = []NetworkAdapter{}
+	r.HostScsiDisks = append(r.HostScsiDisks, m.HostScsiDisks...)
 }
 
 // Build self link (URI).


### PR DESCRIPTION
This PR add a collector for getting a `config.storageDevice.scsiLun` of host and `info.extent` of datastore, so we can pair datastore with host info, where for example vendor is stored. So we can inform the vendor of datastore.