### PR TITLE
MTV-2200 | Add shared disks to guest conversion

### DIFF
--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -30,6 +30,9 @@ RUN ( [ "$(rpm -q glibc)" == "glibc-2.34-66.el9.x86_64" ] && dnf -y downgrade gl
 dnf -y install libguestfs libguestfs-appliance libguestfs-xfs libguestfs-winsupport qemu-img supermin && \
         depmod $(ls /lib/modules/ |tail -n1)
 
+# The virt-v2v-in-place in centos is not in the bin directory and is not accessible via PATH
+ENV PATH="$PATH:/usr/libexec"
+
 # Create tarball for the appliance.
 RUN mkdir -p /usr/lib64/guestfs/appliance && \
         cd /usr/lib64/guestfs/appliance && \

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -98,6 +98,8 @@ type Builder interface {
 	GetPopulatorTaskName(pvc *core.PersistentVolumeClaim) (taskName string, err error)
 	// Get the virtual machine preference name
 	PreferenceName(vmRef ref.Ref, configMap *core.ConfigMap) (name string, err error)
+	// Get the virtual machine preference name
+	GetSharedPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, err error)
 }
 
 // Client API.

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -235,6 +235,11 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*planapi.Task, err error) {
 	return
 }
 
+// NOOP
+func (r *Builder) GetSharedPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, err error) {
+	return
+}
+
 func (r *Builder) PreferenceName(vmRef ref.Ref, configMap *core.ConfigMap) (name string, err error) {
 	// The VM is built from configuration, we don't need the preference
 	err = liberr.New("preferences are not used by this provider")

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -760,6 +760,10 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 	return nil, nil
 }
 
+// NOOP
+func (r *Builder) GetSharedPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, err error) {
+	return
+}
 func (r *Builder) PreferenceName(vmRef ref.Ref, configMap *core.ConfigMap) (name string, err error) {
 	vm := &model.Workload{}
 	if err = r.Source.Inventory.Find(vm, vmRef); err != nil {

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -440,6 +440,10 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*plan.Task, err error) {
 	return
 }
 
+// NOOP
+func (r *Builder) GetSharedPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, err error) {
+	return
+}
 func (r *Builder) PreferenceName(vmRef ref.Ref, configMap *core.ConfigMap) (name string, err error) {
 	// We currently set the operating systems for VMs from OVA to UNKNOWN so we cannot get the corresponding preference
 	err = liberr.New("preferences are not used by this provider")

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -545,6 +545,10 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*plan.Task, err error) {
 	return
 }
 
+// NOOP
+func (r *Builder) GetSharedPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, err error) {
+	return
+}
 func (r *Builder) PreferenceName(vmRef ref.Ref, configMap *core.ConfigMap) (name string, err error) {
 	vm := &model.Workload{}
 	if err = r.Source.Inventory.Find(vm, vmRef); err != nil {

--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -308,7 +308,6 @@ func (c *RestClient) buildTransport() (err error) {
 			RootCAs: pool,
 		}
 	}
-
 	c.Transport = transport
 
 	return

--- a/pkg/virt-v2v/global/variables.go
+++ b/pkg/virt-v2v/global/variables.go
@@ -9,6 +9,8 @@ const (
 	INSPECTION               = "/var/tmp/v2v/inspection.xml"
 	FS             MountPath = "/mnt/disks/disk[0-9]*"
 	BLOCK          MountPath = "/dev/block[0-9]*"
+	FS_SHARED      MountPath = "/mnt/disks/disk-shared[0-9]*"
+	BLOCK_SHARED   MountPath = "/dev/block-shared[0-9]*"
 	VDDK_LIB                 = "/opt/vmware-vix-disklib-distrib"
 	LUKSDIR                  = "/etc/luks"
 	VDDK_CONF_FILE           = "/mnt/vddk-conf/vddk-config-file"

--- a/pkg/virt-v2v/utils/command.go
+++ b/pkg/virt-v2v/utils/command.go
@@ -120,6 +120,21 @@ func getDiskLink(kind global.MountPath, disk string) (string, error) {
 	), nil
 }
 
+func GetSharedDisks() ([]string, error) {
+	fsDisks, err := filepath.Glob(string(global.FS_SHARED))
+	if err != nil {
+		return nil, fmt.Errorf("error getting disks %v", err)
+	}
+	blockDisks, err := filepath.Glob(string(global.BLOCK_SHARED))
+	if err != nil {
+		return nil, fmt.Errorf("error getting disks %v", err)
+	}
+	var resp []string
+	resp = append(resp, fsDisks...)
+	resp = append(resp, blockDisks...)
+	return resp, nil
+}
+
 func GetLinkedDisks() ([]string, error) {
 	disks, err := filepath.Glob(
 		filepath.Join(

--- a/pkg/virt-v2v/utils/xml-reader.go
+++ b/pkg/virt-v2v/utils/xml-reader.go
@@ -3,7 +3,10 @@ package utils
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"os"
+
+	libvirtxml "libvirt.org/libvirt-go-xml"
 )
 
 type InspectionOS struct {
@@ -30,4 +33,59 @@ func GetInspectionV2vFromFile(xmlFilePath string) (*InspectionV2V, error) {
 		return nil, fmt.Errorf("Error unmarshalling XML: %v\n", err)
 	}
 	return &xmlConf, nil
+}
+
+func ReadDomainFromFile(domainPath string) (*libvirtxml.Domain, error) {
+	domcfg := &libvirtxml.Domain{}
+	xmlFile, err := os.Open(domainPath)
+	if err != nil {
+		return nil, err
+	}
+	defer xmlFile.Close()
+	xmlData, err := io.ReadAll(xmlFile)
+	if err != nil {
+		return nil, err
+	}
+	err = domcfg.Unmarshal(string(xmlData))
+	if err != nil {
+		return nil, err
+	}
+	return domcfg, nil
+}
+
+func WriteDomainToFile(domain *libvirtxml.Domain, domainPath string) error {
+	marshal, err := domain.Marshal()
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(domainPath)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write([]byte(marshal))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func AddDiskToDomain(domain *libvirtxml.Domain, path string, i int) {
+	// This is similar to the libvirtDomain in the kubevirt.go
+	// TODO: We should stop using the hd device and use the vmwares device and bus from the libvirt domain
+	domain.Devices.Disks = append(domain.Devices.Disks, libvirtxml.DomainDisk{
+		Device: "disk",
+		Driver: &libvirtxml.DomainDiskDriver{
+			Name: "qemu",
+			Type: "raw",
+		},
+		Target: &libvirtxml.DomainDiskTarget{
+			Dev: "sd" + string(rune('a'+i)),
+			Bus: "scsi",
+		},
+		Source: &libvirtxml.DomainDiskSource{
+			File: &libvirtxml.DomainDiskSourceFile{
+				File: path,
+			},
+		},
+	})
 }


### PR DESCRIPTION
Issue: When migrating the shared disks the VM without the shared disk is missing the conversion step. This causes multiple problem such as outdated fstab, which causes a system to panic.

Fix: We need to attach the already migrated shared disk to the guest conversion pod. But as the disk will be converted multiple times and can be converted multiple times at once we need protect it from multiple writes at once. This is done by adding a overlay to the image.

Ref: https://issues.redhat.com/browse/MTV-2200