### PR TITLE
MTV-2338 | Add Shared to the pvc template information

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -536,11 +536,13 @@ spec:
                           - .PlanName: name of the migration plan
                           - .DiskIndex: initial volume index of the disk
                           - .RootDiskIndex: index of the root disk
+                          - .Shared: true if the volume is shared by multiple VMs, false otherwise
                         Note:
                           This template overrides the plan level template.
                         Examples:
                           "{{.VmName}}-disk-{{.DiskIndex}}"
                           "{{if eq .DiskIndex .RootDiskIndex}}root{{else}}data{{end}}-{{.DiskIndex}}"
+                          "{{if .Shared}}shared-{{end}}{{.VmName}}-{{.DiskIndex}}"
                       type: string
                     restorePowerState:
                       description: Source VM power state before migration.

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -288,11 +288,13 @@ spec:
                     - .PlanName: name of the migration plan
                     - .DiskIndex: initial volume index of the disk
                     - .RootDiskIndex: index of the root disk
+                    - .Shared: true if the volume is shared by multiple VMs, false otherwise
                   Note:
                     This template can be overridden at the individual VM level.
                   Examples:
                     "{{.VmName}}-disk-{{.DiskIndex}}"
                     "{{if eq .DiskIndex .RootDiskIndex}}root{{else}}data{{end}}-{{.DiskIndex}}"
+                    "{{if .Shared}}shared-{{end}}{{.VmName}}-{{.DiskIndex}}"
                 type: string
               targetNamespace:
                 description: Target namespace.
@@ -493,11 +495,13 @@ spec:
                           - .PlanName: name of the migration plan
                           - .DiskIndex: initial volume index of the disk
                           - .RootDiskIndex: index of the root disk
+                          - .Shared: true if the volume is shared by multiple VMs, false otherwise
                         Note:
                           This template overrides the plan level template.
                         Examples:
                           "{{.VmName}}-disk-{{.DiskIndex}}"
                           "{{if eq .DiskIndex .RootDiskIndex}}root{{else}}data{{end}}-{{.DiskIndex}}"
+                          "{{if .Shared}}shared-{{end}}{{.VmName}}-{{.DiskIndex}}"
                       type: string
                     rootDisk:
                       description: Choose the primary disk the VM boots from
@@ -1147,11 +1151,13 @@ spec:
                               - .PlanName: name of the migration plan
                               - .DiskIndex: initial volume index of the disk
                               - .RootDiskIndex: index of the root disk
+                              - .Shared: true if the volume is shared by multiple VMs, false otherwise
                             Note:
                               This template overrides the plan level template.
                             Examples:
                               "{{.VmName}}-disk-{{.DiskIndex}}"
                               "{{if eq .DiskIndex .RootDiskIndex}}root{{else}}data{{end}}-{{.DiskIndex}}"
+                              "{{if .Shared}}shared-{{end}}{{.VmName}}-{{.DiskIndex}}"
                           type: string
                         restorePowerState:
                           description: Source VM power state before migration.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -57,11 +57,13 @@ type PlanSpec struct {
 	//   - .PlanName: name of the migration plan
 	//   - .DiskIndex: initial volume index of the disk
 	//   - .RootDiskIndex: index of the root disk
+	//   - .Shared: true if the volume is shared by multiple VMs, false otherwise
 	// Note:
 	//   This template can be overridden at the individual VM level.
 	// Examples:
 	//   "{{.VmName}}-disk-{{.DiskIndex}}"
 	//   "{{if eq .DiskIndex .RootDiskIndex}}root{{else}}data{{end}}-{{.DiskIndex}}"
+	//   "{{if .Shared}}shared-{{end}}{{.VmName}}-{{.DiskIndex}}"
 	// +optional
 	PVCNameTemplate string `json:"pvcNameTemplate,omitempty"`
 	// VolumeNameTemplate is a template for generating volume interface names in the target virtual machine.
@@ -196,6 +198,7 @@ type PVCNameTemplateData struct {
 	PlanName      string `json:"planName"`
 	DiskIndex     int    `json:"diskIndex"`
 	RootDiskIndex int    `json:"rootDiskIndex"`
+	Shared        bool   `json:"shared,omitempty"`
 }
 
 // VolumeNameTemplateData contains fields used in naming templates.

--- a/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -45,11 +45,13 @@ type VM struct {
 	//   - .PlanName: name of the migration plan
 	//   - .DiskIndex: initial volume index of the disk
 	//   - .RootDiskIndex: index of the root disk
+	//   - .Shared: true if the volume is shared by multiple VMs, false otherwise
 	// Note:
 	//   This template overrides the plan level template.
 	// Examples:
 	//   "{{.VmName}}-disk-{{.DiskIndex}}"
 	//   "{{if eq .DiskIndex .RootDiskIndex}}root{{else}}data{{end}}-{{.DiskIndex}}"
+	//   "{{if .Shared}}shared-{{end}}{{.VmName}}-{{.DiskIndex}}"
 	// +optional
 	PVCNameTemplate string `json:"pvcNameTemplate,omitempty"`
 	// VolumeNameTemplate is a template for generating volume interface names in the target virtual machine.

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -535,6 +535,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 				PlanName:      r.Plan.Name,
 				DiskIndex:     diskIndex,
 				RootDiskIndex: rootDiskIndex,
+				Shared:        disk.Shared,
 			}
 
 			generatedName, err := r.executeTemplate(pvcNameTemplate, &templateData)

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1368,6 +1368,7 @@ func (r *Reconciler) IsValidPVCNameTemplate(pvcNameTemplate string) error {
 		PlanName:      "test-plan",
 		DiskIndex:     0,
 		RootDiskIndex: 0,
+		Shared:        false,
 	}
 
 	result, err := r.IsValidTemplate(pvcNameTemplate, testData)


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2338

Issue:
As a migration owner,
I want customize the PVC names so I can identify shared disks using the PVC name,
so that when I create VMs with shared disks, I can identify the shared PVCs.

Fix:
Add Shared to the pvc template information

example:
```yaml
pvcNameTemplate: '{{if .Shared}}shared-{{end}}{{.VmName}}-{{.DiskIndex}}'
```

Screenshots:
Plan yaml:
![pvc-template-shared](https://github.com/user-attachments/assets/da741271-842a-445d-bd6b-5618a66b989e)

Plan running:
![pvc-template-shared-run](https://github.com/user-attachments/assets/7c8bf9f9-1483-4900-9f57-18d76df3f8dd)
