### PR TITLE
MTV-2309 | Update validate vm name .rego files to include dotes as valid chars

### DIFF
--- a/validation/policies/io/konveyor/forklift/openstack/name.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/name.rego
@@ -15,8 +15,8 @@ valid_vm_string {
 default valid_vm_name = false
 
 valid_vm_name {
-	regex.match("^[a-z0-9][a-z0-9-]*[a-z0-9]$", input.name)
-	count(input.name) < 64
+	regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
+	count(input.name) < 254
 }
 
 concerns[flag] {
@@ -26,6 +26,6 @@ concerns[flag] {
 	flag := {
 		"category": "Warning",
 		"label": "Invalid VM Name",
-		"assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention.",
+		"assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention.",
 	}
 }

--- a/validation/policies/io/konveyor/forklift/ova/name.rego
+++ b/validation/policies/io/konveyor/forklift/ova/name.rego
@@ -13,8 +13,8 @@ valid_vm = true {
 }
 
 valid_vm_name = true {
-    regex.match("^[a-z0-9][a-z0-9-]*[a-z0-9]$", input.name)
-    count(input.name) < 64
+    regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
+    count(input.name) < 254
 }
 
 concerns[flag] {
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name.rego
@@ -13,8 +13,8 @@ valid_vm_string = true {
 }
 
 valid_vm_name = true {
-    regex.match("^[a-z0-9][a-z0-9-]*[a-z0-9]$", input.name)
-    count(input.name) < 64
+    regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
+    count(input.name) < 254
 }
 
 concerns[flag] {
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }

--- a/validation/policies/io/konveyor/forklift/vmware/name.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/name.rego
@@ -13,8 +13,8 @@ valid_vm = true {
 }
 
 valid_vm_name = true {
-    regex.match("^[a-z0-9][a-z0-9-]*[a-z0-9]$", input.name)
-    count(input.name) < 64
+    regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
+    count(input.name) < 254
 }
 
 concerns[flag] {
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2309

Issue:
In MTV 2.8.0, the VM name is allowed with dot, but in the "Virtual Machine" page, for VM: "mtv.func.win2022", it's still report: Invalid VM Name, need to update this page 

"Warning concerns 
  Invalid VM Name"

Fix:
Update the validation to include dots as valid chars, to match 
 - [x] contain no more than 253 characters
 - [x] contain only lowercase alphanumeric characters, '-' or '.'
 - [x] start with an alphanumeric character
 - [x] end with an alphanumeric character

For example:
`my.vm` will now be a valid name

Screenshots:
Before:
![invalid-name-before](https://github.com/user-attachments/assets/451f3e24-188f-456d-beb3-6e129e4e5417)

After:
![invalid-name-after](https://github.com/user-attachments/assets/58a6b99b-59f2-4c1a-8401-f4b73a46de90)
