### PR TITLE
Fix CI sort test

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -149,7 +149,7 @@ var _ = Describe("vSphere builder", func() {
 	)
 
 	DescribeTable("should", func(disks []vsphere.Disk, output []vsphere.Disk) {
-		Expect(builder.sortedDisks(disks)).Should(Equal(output))
+		Expect(builder.sortedDisksAsLibvirt(disks)).Should(Equal(output))
 	},
 		Entry("sort all disks by buses",
 			[]vsphere.Disk{


### PR DESCRIPTION
Issue: The CI build test stoped working due to renaming one of the menthods.

Fix: Use correct name