### PR TITLE
MTV-2345 | Add optional vddk image global settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,6 @@ Note: The order of targets is important as the bundle needs to be created after 
 | UI_PLUGIN_IMAGE            | quay.io/kubev2v/forklift-console-plugin:latest | The forklift OKD/OpenShift UI plugin image.                            |
 | VALIDATION_IMAGE           | quay.io/kubev2v/forklift-validation:latest     | The forklift validation image.                                         |
 | VIRT_V2V_IMAGE             | quay.io/kubev2v/forklift-virt-v2v:latest       | The forklift virt v2v image for cold migration.                        |
+| VDDK_IMAGE                 |                                                | The default Virtual Disk Development Kit (VDDK) image, default empty.  |
 | POPULATOR_CONTROLLER_IMAGE | quay.io/kubev2v/populator-controller:latest    | The forklift volume-populator controller image.                        |
 | OVIRT_POPULATOR_IMAGE      | quay.io/kubev2v/ovirt-populator:latest         | The oVirt populator image.                                             |

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -121,6 +121,8 @@ virt_v2v_container_limits_memory: "8Gi"
 virt_v2v_container_requests_cpu: "1000m"
 virt_v2v_container_requests_memory: "1Gi"
 
+vddk_image: "{{ lookup( 'env', 'VDDK_IMAGE')"
+
 hooks_container_limits_cpu: "1000m"
 hooks_container_limits_memory: "1Gi"
 hooks_container_requests_cpu: "100m"

--- a/operator/roles/forkliftcontroller/templates/controller/configmap-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/configmap-controller.yml.j2
@@ -17,3 +17,6 @@ data:
 {% if controller_max_vm_inflight is number %}
   MAX_VM_INFLIGHT: "{{ controller_max_vm_inflight }}"
 {% endif %}
+{% if vddk_image is string and vddk_image|length > 0 %}
+  VDDK_IMAGE: "{{ vddk_image }}"
+{% endif %}

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -93,6 +93,10 @@ spec:
         - name: MAX_VM_INFLIGHT
           value: "{{ controller_max_vm_inflight }}"
 {% endif %}
+{% if vddk_image is string and vddk_image|length > 0 %}
+        - name: VDDK_IMAGE
+          value: "{{ vddk_image }}"
+{% endif %}
 {% if controller_cdi_export_token_ttl is number %}
         - name: CDI_EXPORT_TOKEN_TTL
           value: "{{ controller_cdi_export_token_ttl }}"

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -488,6 +488,8 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 				Blank: &cdi.DataVolumeBlankImage{},
 			}
 		} else {
+			vddkImage := settings.GetVDDKImage(r.Source.Provider.Spec.Settings)
+
 			// Let CDI do the copying
 			dvSource = cdi.DataVolumeSource{
 				VDDK: &cdi.DataVolumeSourceVDDK{
@@ -496,7 +498,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 					URL:          url,
 					SecretRef:    secret.Name,
 					Thumbprint:   thumbprint,
-					InitImageURL: r.Source.Provider.Spec.Settings[api.VDDK],
+					InitImageURL: vddkImage,
 				},
 			}
 		}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -23,6 +23,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
 	libref "github.com/konveyor/forklift-controller/pkg/lib/ref"
+	"github.com/konveyor/forklift-controller/pkg/settings"
 	template "github.com/openshift/api/template/v1"
 	"github.com/openshift/library-go/pkg/template/generator"
 	"github.com/openshift/library-go/pkg/template/templateprocessing"
@@ -1861,7 +1862,9 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	}
 	// VDDK image
 	var initContainers []core.Container
-	if vddkImage, found := r.Source.Provider.Spec.Settings[api.VDDK]; found {
+
+	vddkImage := settings.GetVDDKImage(r.Source.Provider.Spec.Settings)
+	if vddkImage != "" {
 		initContainers = append(initContainers, core.Container{
 			Name:            "vddk-side-car",
 			Image:           vddkImage,

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/provider-admitter.go
@@ -6,6 +6,7 @@ import (
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/forklift-api/webhooks/util"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
+	"github.com/konveyor/forklift-controller/pkg/settings"
 	admissionv1 "k8s.io/api/admission/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -16,7 +17,8 @@ type ProviderAdmitter struct {
 }
 
 func (admitter *ProviderAdmitter) validateVddkImage() error {
-	if image, found := admitter.provider.Spec.Settings[api.VDDK]; found {
+	image := settings.GetVDDKImage(admitter.provider.Spec.Settings)
+	if image != "" {
 		if image == "" {
 			err := liberr.New("The specified VDDK init image name is empty")
 			log.Error(err, "The specified VDDK init image cannot be empty, failing",

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -16,6 +16,7 @@ const (
 	HookRetry                      = "HOOK_RETRY"
 	ImporterRetry                  = "IMPORTER_RETRY"
 	VirtV2vImage                   = "VIRT_V2V_IMAGE"
+	vddkImage                      = "VDDK_IMAGE"
 	PrecopyInterval                = "PRECOPY_INTERVAL"
 	VirtV2vDontRequestKVM          = "VIRT_V2V_DONT_REQUEST_KVM"
 	SnapshotRemovalTimeout         = "SNAPSHOT_REMOVAL_TIMEOUT"
@@ -100,6 +101,8 @@ type Migration struct {
 	OvaContainerLimitsMemory       string
 	OvaContainerRequestsCpu        string
 	OvaContainerRequestsMemory     string
+	// VDDK image for guest conversion
+	VddkImage string
 }
 
 // Load settings.
@@ -142,6 +145,11 @@ func (r *Migration) Load() (err error) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtV2vImage))
 	}
 	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
+
+	// VDDK image for guest conversion
+	if vddkImage, ok := os.LookupEnv(vddkImage); ok {
+		r.VddkImage = vddkImage
+	}
 
 	// Set timeout to 12 hours instead of the default 2
 	if r.CDIExportTokenTTL, err = getPositiveEnvLimit(CDIExportTokenTTL, 720); err != nil {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 )
 
@@ -116,4 +117,14 @@ func getEnvBool(name string, def bool) bool {
 	}
 
 	return boolean
+}
+
+// GetVDDKImage gets the VDDK image from provider spec settings with fall back to global settings.
+func GetVDDKImage(providerSpecSettings map[string]string) string {
+	vddkImage := providerSpecSettings[api.VDDK]
+	if vddkImage == "" && Settings.Migration.VddkImage != "" {
+		vddkImage = Settings.Migration.VddkImage
+	}
+
+	return vddkImage
 }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2345

Add optional vddk image global settings

Issue:
As a migration administrator I would like to create the VDDK container image automatically and set it as a global settings for all vmWare providers

What happen now:
As a migration administrator I set the vddk image for each new vmware provider

What happen with the fix:
As a migration administrator I create a vddk image using my automation, and set it to be the default image
When creating new vmware provider I can skip setting the vddk image, and migration will fall back into the image I set in the global settings.

Fix:
  - [x] Add an environment variable `VDDK_IMAGE` that can be used to init the global default VDDK container image
  - [x] Add a controller settings field  `vddk_image` to set the environment variable dynamically
  - [x] Use providers vddk image, if missing use gloable default vddk image, if missing default to no vddk image
  - [x] Update vddk image validations 
  
 Why this is safe:
 when the configuration is empty, fall back to using providers vddk image or empty
 
 Screenshot:
 ![global-vddk-image](https://github.com/user-attachments/assets/92ef6441-9a9f-43a7-9c72-2e23db5ed806)
