### PR TITLE
Restrict VM name to 64 chars

### DIFF
--- a/validation/policies/io/konveyor/forklift/openstack/name.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/name.rego
@@ -16,7 +16,7 @@ default valid_vm_name = false
 
 valid_vm_name {
 	regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
-	count(input.name) < 254
+	count(input.name) < 64
 }
 
 concerns[flag] {
@@ -26,6 +26,6 @@ concerns[flag] {
 	flag := {
 		"category": "Warning",
 		"label": "Invalid VM Name",
-		"assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention.",
+		"assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention.",
 	}
 }

--- a/validation/policies/io/konveyor/forklift/ova/name.rego
+++ b/validation/policies/io/konveyor/forklift/ova/name.rego
@@ -14,7 +14,7 @@ valid_vm = true {
 
 valid_vm_name = true {
     regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
-    count(input.name) < 254
+    count(input.name) < 64
 }
 
 concerns[flag] {
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name.rego
@@ -14,7 +14,7 @@ valid_vm_string = true {
 
 valid_vm_name = true {
     regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
-    count(input.name) < 254
+    count(input.name) < 64
 }
 
 concerns[flag] {
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }

--- a/validation/policies/io/konveyor/forklift/vmware/name.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/name.rego
@@ -14,7 +14,7 @@ valid_vm = true {
 
 valid_vm_name = true {
     regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
-    count(input.name) < 254
+    count(input.name) < 64
 }
 
 concerns[flag] {
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-), up to a maximum of 63 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }


### PR DESCRIPTION
Restrict VM name to 64 chars

Issue:
We may use the VM name as source for entities that may require shorted length then K8s subdomain length

Fix:
Restrict the VM name to 63 chars, similar to K8s labels