### PR TITLE
Fix bad regexp in vm name k8s subdomain regexp

### DIFF
--- a/validation/policies/io/konveyor/forklift/openstack/name.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/name.rego
@@ -15,7 +15,7 @@ valid_vm_string {
 default valid_vm_name = false
 
 valid_vm_name {
-	regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
+	regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
 	count(input.name) < 64
 }
 

--- a/validation/policies/io/konveyor/forklift/ova/name.rego
+++ b/validation/policies/io/konveyor/forklift/ova/name.rego
@@ -13,7 +13,7 @@ valid_vm = true {
 }
 
 valid_vm_name = true {
-    regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
+    regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
     count(input.name) < 64
 }
 

--- a/validation/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name.rego
@@ -13,7 +13,7 @@ valid_vm_string = true {
 }
 
 valid_vm_name = true {
-    regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
+    regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
     count(input.name) < 64
 }
 

--- a/validation/policies/io/konveyor/forklift/vmware/name.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/name.rego
@@ -13,7 +13,7 @@ valid_vm = true {
 }
 
 valid_vm_name = true {
-    regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", input.name)
+    regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
     count(input.name) < 64
 }
 


### PR DESCRIPTION
Fix bad regexp in VM name k8s subdomain regexp

Issue:
While fixing the VM name rego validation ( https://github.com/kubev2v/forklift/pull/1505 ) i allowed the "_" char in the vm name

Fix:
Don't allow the "_" char in VM names