### PR TITLE
MTV-2346 | Fix fstab with device name config warm migration

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2265,8 +2265,8 @@ func (r *KubeVirt) libvirtDomain(vmCr *VirtualMachine, pvcs []*core.PersistentVo
 			},
 			Source: &diskSource,
 			Target: &libvirtxml.DomainDiskTarget{
-				Dev: "hd" + string(rune('a'+i)),
-				Bus: "virtio",
+				Dev: "sd" + string(rune('a'+i)),
+				Bus: "scsi",
 			},
 		}
 		libvirtDisks = append(libvirtDisks, libvirtDisk)
@@ -2291,7 +2291,7 @@ func (r *KubeVirt) libvirtDomain(vmCr *VirtualMachine, pvcs []*core.PersistentVo
 			},
 			BootDevices: []libvirtxml.DomainBootDevice{
 				{
-					Dev: "hd",
+					Dev: "sd",
 				},
 			},
 		},


### PR DESCRIPTION
Issue: After warm migration of VM which has mounted disk in fstab by the device name (/dev/sdb) the warm migraiton does not change the fstab config and ends up in the rescue mode.

Fix: The virt-v2v ignores the fstab disks if the disk in the libvirt domain has a virtio bus, we need to switch to the sata or scsi. This way we will force the virt-v2v to change the fstab devices to the virtio paths (vda, vdb...)

Ref: https://issues.redhat.com/browse/MTV-2346