### PR TITLE
MTV-2349 | Add PVCNameTemplateUseGenerateName field to plan

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -294,6 +294,17 @@ spec:
                     "{{.VmName}}-disk-{{.DiskIndex}}"
                     "{{if eq .DiskIndex .RootDiskIndex}}root{{else}}data{{end}}-{{.DiskIndex}}"
                 type: string
+              pvcNameTemplateUseGenerateName:
+                default: true
+                description: |-
+                  PVCNameTemplateUseGenerateName indicates if the PVC name template should use generateName instead of name.
+                  Setting this to false will use the name field of the PVCNameTemplate.
+                  This is useful when using a template that generates a name without a suffix.
+                  For example, if the template is "{{.VmName}}-disk-{{.DiskIndex}}", setting this to false will result in
+                  the PVC name being "{{.VmName}}-disk-{{.DiskIndex}}", which may not be unique.
+                  but will be more predictable.
+                  **DANGER** When set to false, the generated PVC name may not be unique and may cause conflicts.
+                type: boolean
               targetNamespace:
                 description: Target namespace.
                 type: string

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -64,6 +64,16 @@ type PlanSpec struct {
 	//   "{{if eq .DiskIndex .RootDiskIndex}}root{{else}}data{{end}}-{{.DiskIndex}}"
 	// +optional
 	PVCNameTemplate string `json:"pvcNameTemplate,omitempty"`
+	// PVCNameTemplateUseGenerateName indicates if the PVC name template should use generateName instead of name.
+	// Setting this to false will use the name field of the PVCNameTemplate.
+	// This is useful when using a template that generates a name without a suffix.
+	// For example, if the template is "{{.VmName}}-disk-{{.DiskIndex}}", setting this to false will result in
+	// the PVC name being "{{.VmName}}-disk-{{.DiskIndex}}", which may not be unique.
+	// but will be more predictable.
+	// **DANGER** When set to false, the generated PVC name may not be unique and may cause conflicts.
+	// +optional
+	// +kubebuilder:default:=true
+	PVCNameTemplateUseGenerateName bool `json:"pvcNameTemplateUseGenerateName,omitempty"`
 	// VolumeNameTemplate is a template for generating volume interface names in the target virtual machine.
 	// It follows Go template syntax and has access to the following variables:
 	//   - .PVCName: name of the PVC mounted to the VM using this volume


### PR DESCRIPTION
Refs: 
https://issues.redhat.com/browse/MTV-2349

Issue:
PVC name is generated with a HASH suffix to prevent name collisions, some automation requires to set the name verbatim without adding a suffix

Fix:
When users use automation that sets the PVC name, we allow them to take responsibility of the name collision issues, and set the PVC name verbatim.

  - [x] Add a `PVCNameTemplateUseGenerateName` plan field, default to true

Screenshot:
Before:
![pvc-generate-before](https://github.com/user-attachments/assets/c35053a1-07af-462f-ad1e-e243348740e6)

After:
![pvc-generate-after](https://github.com/user-attachments/assets/b077bef4-bde2-44b5-beb9-1609e995fc50)

![pvc-generate-after-1](https://github.com/user-attachments/assets/6dfe34fc-ed55-468e-a278-582298a1f274)
