### PR TITLE
MTV-2054, MTV-2027, MTV-1962 |  Delete plan garbage collection

### DIFF
--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -126,7 +126,9 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		return
 	}
 	defer func() {
-		r.Log.V(2).Info("Conditions.", "all", migration.Status.Conditions)
+		if migration != nil {
+			r.Log.V(2).Info("Conditions.", "all", migration.Status.Conditions)
+		}
 	}()
 
 	// Set owner ref for migration CR if it was created using CLI

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1245,11 +1245,13 @@ func createVddkCheckJob(plan *api.Plan) *batchv1.Job {
 		psc.RunAsNonRoot = ptr.To(true)
 		psc.RunAsUser = ptr.To(qemuUser)
 	}
+
 	return &batchv1.Job{
 		ObjectMeta: meta.ObjectMeta{
-			GenerateName: fmt.Sprintf("vddk-validator-%s", plan.Name),
-			Namespace:    plan.Spec.TargetNamespace,
-			Labels:       getVddkImageValidationJobLabels(plan),
+			GenerateName:    fmt.Sprintf("vddk-validator-%s", plan.Name),
+			Namespace:       plan.Spec.TargetNamespace,
+			OwnerReferences: createOwnerReferences(plan.ObjectMeta, plan.TypeMeta, false),
+			Labels:          getVddkImageValidationJobLabels(plan),
 			Annotations: map[string]string{
 				"provider": plan.Referenced.Provider.Source.Name,
 				"vddk":     vddkImage,


### PR DESCRIPTION
Issue:
All the bugs describe certain cenarios where additional manual steps are required to fully delete a plan.
A plan must be archived before deletion to ensure its associated resources are properly cleaned up in the correct order.

Solution
The current plan is now set as an OwnerReference for all of its dependent resources.
This enables Kubernetes automatic garbage collection, ensuring that when the plan is deleted,
all associated resources are also cleaned up without requiring extra steps.

Signed-off-by: ehazan <ehazan@redhat.com>