### PR TITLE
MTV-2356 | Safe vm name for templates

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -556,6 +556,17 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 			}
 
 			generatedName, err := r.executeTemplate(pvcNameTemplate, &templateData)
+
+			// Validate that template output is a valid k8s label
+			errs := k8svalidation.IsDNS1123Label(generatedName)
+			if len(errs) > 0 {
+				// Raise an error if the generated name is not valid
+				err = errors.New("generated PVC name is not valid")
+
+				// Failed to generate PVC name using template
+				r.Log.Info("Failed to generate PVC name using template", "template", pvcNameTemplate, "error", err)
+			}
+
 			if err == nil && generatedName != "" {
 				// Ensure generatedName ends with "-"
 				if !strings.HasSuffix(generatedName, "-") {

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
 	cnv "kubevirt.io/api/core/v1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -548,7 +549,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 
 			// Create template data
 			templateData := api.PVCNameTemplateData{
-				VmName:        r.getPlenVMNewName(vm),
+				VmName:        r.getPlenVMSafeName(vm),
 				PlanName:      r.Plan.Name,
 				DiskIndex:     diskIndex,
 				RootDiskIndex: rootDiskIndex,
@@ -1240,17 +1241,38 @@ func (r *Builder) getPVCNameTemplate(vm *model.VM) string {
 	return ""
 }
 
-// getPlenVMNewName returns the VM new name if exist, or just the name
-func (r *Builder) getPlenVMNewName(vm *model.VM) string {
+// getPlenVMSafeName returns a safe name for the VM
+// that can be used in the template output
+// The name is sanitized to be a valid k8s label
+func (r *Builder) getPlenVMSafeName(vm *model.VM) string {
+	// Default to vm name
+	newName := vm.Name
+
 	// Get plan VM
 	planVM := r.getPlanVMStatus(vm)
 
 	// if plan VM status has a new name, use it
 	if planVM != nil && planVM.NewName != "" {
-		return planVM.NewName
+		newName = planVM.NewName
 	}
 
-	return vm.Name
+	// New name is a valid subdomain name,
+	// but we need to check if it is a valid k8s label
+
+	// Check if new vm name is valid k8s label
+	if len(newName) > 63 {
+		// if the new name is longer then 63 characters, trancate it
+		newName = newName[:63]
+	}
+
+	// Validate that template output is a valid k8s label
+	errs := k8svalidation.IsDNS1123Label(newName)
+	if len(errs) > 0 {
+		// if the new name replace "." with "-"
+		newName = strings.ReplaceAll(newName, ".", "-")
+	}
+
+	return newName
 }
 
 // getVolumeNameTemplate returns the volume name template


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2356

Safe vm name for templates

Issue:
VM name may include dots, we need to sanitize the vm name before using it in the template.

Fix:
Check length and remove "." from vm name, before using it in the teamples.

Screenshots:
After plan spec:
![vm-vith-dots-volume-name-template](https://github.com/user-attachments/assets/e451302f-792a-4216-b884-e79983aaa34a)

After plan run:
![vm-vith-dots-volume-name-template-1](https://github.com/user-attachments/assets/ce49383e-ef82-4680-9a21-bb545637b770)
