### PR TITLE
 MTV-2019 | Warn if CBT not enabled for individual volumes

### DIFF
--- a/pkg/controller/provider/container/vsphere/cbt_disks_test.go
+++ b/pkg/controller/provider/container/vsphere/cbt_disks_test.go
@@ -1,0 +1,112 @@
+package vsphere
+
+import (
+	modelVsphere "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("isCBTEnabledForDisks", func() {
+	var disks []modelVsphere.Disk
+	var ctkMap map[string]bool
+
+	BeforeEach(func() {
+		disks = []modelVsphere.Disk{}
+		ctkMap = map[string]bool{}
+	})
+
+	Context("All disks with CBT enabled across types", func() {
+		BeforeEach(func() {
+			disks = []modelVsphere.Disk{
+				{ControllerKey: 16000, UnitNumber: 0, Bus: "scsi"}, // scsi0:0
+				{ControllerKey: 17000, UnitNumber: 1, Bus: "sata"}, // sata0:1
+				{ControllerKey: 18000, UnitNumber: 2, Bus: "nvme"}, // nvme0:2
+				{ControllerKey: 19000, UnitNumber: 0, Bus: "ide"},  // ide0:0
+			}
+			ctkMap = map[string]bool{
+				"scsi0:0": true,
+				"sata0:1": true,
+				"nvme0:2": true,
+				"ide0:0":  true,
+			}
+		})
+
+		It("should enable CBT for all disks", func() {
+			isCBTEnabledForDisks(ctkMap, disks)
+			for _, d := range disks {
+				Expect(d.ChangeTrackingEnabled).To(BeTrue())
+			}
+		})
+	})
+
+	Context("Mixed CBT state and missing entries", func() {
+		BeforeEach(func() {
+			disks = []modelVsphere.Disk{
+				{ControllerKey: 16000, UnitNumber: 0, Bus: "scsi"}, // scsi0:0 → true
+				{ControllerKey: 17000, UnitNumber: 1, Bus: "sata"}, // sata0:1 → false
+				{ControllerKey: 18001, UnitNumber: 0, Bus: "nvme"}, // nvme1:0 → true
+				{ControllerKey: 19000, UnitNumber: 1, Bus: "ide"},  // ide0:1 → not in map
+			}
+			ctkMap = map[string]bool{
+				"scsi0:0": true,
+				"sata0:1": false,
+				"nvme1:0": true,
+				// ide0:1 missing
+			}
+		})
+
+		It("should correctly reflect CBT state per device key", func() {
+			isCBTEnabledForDisks(ctkMap, disks)
+			Expect(disks[0].ChangeTrackingEnabled).To(BeTrue())  // scsi0:0
+			Expect(disks[1].ChangeTrackingEnabled).To(BeFalse()) // sata0:1
+			Expect(disks[2].ChangeTrackingEnabled).To(BeTrue())  // nvme1:0
+			Expect(disks[3].ChangeTrackingEnabled).To(BeFalse()) // ide0:1 default false
+		})
+	})
+
+	Context("No entries in the CBT map", func() {
+		BeforeEach(func() {
+			disks = []modelVsphere.Disk{
+				{ControllerKey: 16000, UnitNumber: 1, Bus: "scsi"},
+				{ControllerKey: 17000, UnitNumber: 2, Bus: "sata"},
+			}
+		})
+
+		It("should default all CBT flags to false", func() {
+			isCBTEnabledForDisks(ctkMap, disks)
+			for _, d := range disks {
+				Expect(d.ChangeTrackingEnabled).To(BeFalse())
+			}
+		})
+	})
+
+	Context("CBT enabled for some and missing others", func() {
+		BeforeEach(func() {
+			disks = []modelVsphere.Disk{
+				{ControllerKey: 16000, UnitNumber: 0, Bus: "scsi"}, // scsi0:0
+				{ControllerKey: 17000, UnitNumber: 1, Bus: "sata"}, // sata0:1
+				{ControllerKey: 18000, UnitNumber: 2, Bus: "nvme"}, // nvme0:2 (missing)
+			}
+			ctkMap = map[string]bool{
+				"scsi0:0": true,
+				"sata0:1": false,
+			}
+		})
+
+		It("should match enabled state and default missing to false", func() {
+			isCBTEnabledForDisks(ctkMap, disks)
+			Expect(disks[0].ChangeTrackingEnabled).To(BeTrue())  // scsi0:0
+			Expect(disks[1].ChangeTrackingEnabled).To(BeFalse()) // sata0:1
+			Expect(disks[2].ChangeTrackingEnabled).To(BeFalse()) // nvme0:2
+		})
+	})
+
+	Context("Empty disks slice", func() {
+		It("should not panic or modify anything", func() {
+			Expect(func() {
+				isCBTEnabledForDisks(ctkMap, disks)
+			}).ToNot(Panic())
+			Expect(disks).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -532,6 +532,9 @@ func (v *VmAdapter) Model() model.Model {
 
 // Apply the update to the model.
 func (v *VmAdapter) Apply(u types.ObjectUpdate) {
+	// ctkPerDisk map - CBT enabled disks, we need this here to update the model.Disks
+	// which on initial state is ready only after the ctkPerDisk update
+	ctkPerDisk := map[string]bool{}
 	v.Base.Apply(&v.model.Base, u)
 	for _, p := range u.ChangeSet {
 		switch p.Op {
@@ -648,12 +651,12 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if options, cast := p.Val.(types.ArrayOfOptionValue); cast {
 					for _, val := range options.OptionValue {
 						opt := val.GetOptionValue()
-						switch opt.Key {
-						case "numa.nodeAffinity":
+
+						if opt.Key == "numa.nodeAffinity" {
 							if s, cast := opt.Value.(string); cast {
 								v.model.NumaNodeAffinity = strings.Split(s, ",")
 							}
-						case "ctkEnabled":
+						} else if opt.Key == "ctkEnabled" {
 							if s, cast := opt.Value.(string); cast {
 								boolVal, err := strconv.ParseBool(s)
 								if err != nil {
@@ -661,7 +664,7 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 								}
 								v.model.ChangeTrackingEnabled = boolVal
 							}
-						case "disk.EnableUUID":
+						} else if opt.Key == "disk.EnableUUID" {
 							if s, cast := opt.Value.(string); cast {
 								boolVal, err := strconv.ParseBool(s)
 								if err != nil {
@@ -669,8 +672,23 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 								}
 								v.model.DiskEnableUuid = boolVal
 							}
-						}
+						} else if hasDiskPrefix(opt.Key) && strings.HasSuffix(opt.Key, ".ctkEnabled") {
 
+							if s, cast := opt.Value.(string); cast {
+								boolVal, err := strconv.ParseBool(s)
+								if err != nil {
+									return
+								}
+								if boolVal {
+									ctkPerDisk[strings.Split(opt.Key, ".")[0]] = true
+								}
+							}
+						}
+					}
+
+					//In case of ExtraConfig update, on initial state model.Disks is not ready yet
+					if len(v.model.Disks) > 0 {
+						isCBTEnabledForDisks(ctkPerDisk, v.model.Disks)
 					}
 				}
 			case fGuestNet:
@@ -786,8 +804,38 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 					v.model.NICs = nicList
 					v.updateControllers(&devArray)
 					v.updateDisks(&devArray)
+
+					if len(ctkPerDisk) > 0 {
+						isCBTEnabledForDisks(ctkPerDisk, v.model.Disks)
+					}
 				}
 			}
+		}
+	}
+}
+
+func hasDiskPrefix(key string) bool {
+	return strings.HasPrefix(key, SCSI) ||
+		strings.HasPrefix(key, SATA) ||
+		strings.HasPrefix(key, IDE) ||
+		strings.HasPrefix(key, NVME)
+}
+
+func isCBTEnabledForDisks(ctkPerDisk map[string]bool, disks []model.Disk) {
+	for i := range disks {
+		disk := &disks[i]
+
+		// In vSphere, ControllerKey values are typically large integers that encode the controller bus number.
+		// To extract the actual controller index (e.g., scsi0, scsi1), we round down to the nearest 100 to get the base,
+		// then subtract it from the ControllerKey. For example, 16001 → controllerIndex 1 (16001 - 16000).
+		baseKey := (disk.ControllerKey / 100) * 100
+		controllerIndex := disk.ControllerKey - baseKey
+		deviceKey := fmt.Sprintf("%s%d:%d", disk.Bus, controllerIndex, disk.UnitNumber)
+
+		if ctkPerDisk[deviceKey] {
+			disk.ChangeTrackingEnabled = true
+		} else {
+			disk.ChangeTrackingEnabled = false
 		}
 	}
 }
@@ -872,11 +920,13 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 			switch backing := disk.Backing.(type) {
 			case *types.VirtualDiskFlatVer1BackingInfo:
 				md := model.Disk{
-					Key:      disk.Key,
-					File:     backing.FileName,
-					Capacity: disk.CapacityInBytes,
-					Mode:     backing.DiskMode,
-					Bus:      controller.Bus,
+					Key:           disk.Key,
+					UnitNumber:    *disk.UnitNumber,
+					ControllerKey: disk.ControllerKey,
+					File:          backing.FileName,
+					Capacity:      disk.CapacityInBytes,
+					Mode:          backing.DiskMode,
+					Bus:           controller.Bus,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -888,13 +938,15 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskFlatVer2BackingInfo:
 				md := model.Disk{
-					Key:      disk.Key,
-					File:     backing.FileName,
-					Capacity: disk.CapacityInBytes,
-					Shared:   backing.Sharing != "sharingNone" && backing.Sharing != "",
-					Mode:     backing.DiskMode,
-					Bus:      controller.Bus,
-					Serial:   backing.Uuid,
+					Key:           disk.Key,
+					UnitNumber:    *disk.UnitNumber,
+					ControllerKey: disk.ControllerKey,
+					File:          backing.FileName,
+					Capacity:      disk.CapacityInBytes,
+					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
+					Mode:          backing.DiskMode,
+					Bus:           controller.Bus,
+					Serial:        backing.Uuid,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -906,14 +958,16 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
 				md := model.Disk{
-					Key:      disk.Key,
-					File:     backing.FileName,
-					Capacity: disk.CapacityInBytes,
-					Shared:   backing.Sharing != "sharingNone" && backing.Sharing != "",
-					Mode:     backing.DiskMode,
-					RDM:      true,
-					Bus:      controller.Bus,
-					Serial:   backing.Uuid,
+					Key:           disk.Key,
+					UnitNumber:    *disk.UnitNumber,
+					ControllerKey: disk.ControllerKey,
+					File:          backing.FileName,
+					Capacity:      disk.CapacityInBytes,
+					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
+					Mode:          backing.DiskMode,
+					RDM:           true,
+					Bus:           controller.Bus,
+					Serial:        backing.Uuid,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -925,12 +979,14 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskRawDiskVer2BackingInfo:
 				md := model.Disk{
-					Key:      disk.Key,
-					File:     backing.DescriptorFileName,
-					Capacity: disk.CapacityInBytes,
-					Shared:   backing.Sharing != "sharingNone" && backing.Sharing != "",
-					RDM:      true,
-					Bus:      controller.Bus,
+					Key:           disk.Key,
+					UnitNumber:    *disk.UnitNumber,
+					ControllerKey: disk.ControllerKey,
+					File:          backing.DescriptorFileName,
+					Capacity:      disk.CapacityInBytes,
+					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
+					RDM:           true,
+					Bus:           controller.Bus,
 				}
 				disks = append(disks, md)
 			}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -287,15 +287,18 @@ type Controller struct {
 
 // Virtual Disk.
 type Disk struct {
-	Key       int32  `json:"key"`
-	File      string `json:"file"`
-	Datastore Ref    `json:"datastore"`
-	Capacity  int64  `json:"capacity"`
-	Shared    bool   `json:"shared"`
-	RDM       bool   `json:"rdm"`
-	Bus       string `json:"bus"`
-	Mode      string `json:"mode,omitempty"`
-	Serial    string `json:"serial,omitempty"`
+	Key                   int32  `json:"key"`
+	UnitNumber            int32  `json:"unitNumber"`
+	ControllerKey         int32  `json:"controllerKey"`
+	File                  string `json:"file"`
+	Datastore             Ref    `json:"datastore"`
+	Capacity              int64  `json:"capacity"`
+	Shared                bool   `json:"shared"`
+	RDM                   bool   `json:"rdm"`
+	Bus                   string `json:"bus"`
+	Mode                  string `json:"mode,omitempty"`
+	Serial                string `json:"serial,omitempty"`
+	ChangeTrackingEnabled bool   `json:"changeTrackingEnabled"`
 }
 
 // Virtual Device.

--- a/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disk.rego
@@ -1,0 +1,25 @@
+package io.konveyor.forklift.vmware
+import future.keywords.in
+
+change_tracking_disabled_per_disk(disk) {
+    disk.changeTrackingEnabled == false
+}
+
+concerns[flag] {
+    some disk in input.disks
+    change_tracking_disabled_per_disk(disk)
+
+    path_parts := split(disk.file, "/")
+    filename := trim(path_parts[count(path_parts) - 1], "] ")
+
+    baseKey := (disk.controllerKey / 100) * 100
+    controllerIndex := disk.controllerKey - baseKey
+
+    deviceKey := sprintf("%s%d:%d", [disk.bus, controllerIndex, disk.unitNumber])
+
+    flag := {
+        "category": "Warning",
+        "label": sprintf("Disk - %s does not have CBT enabled", [deviceKey]),
+        "assessment": "Changed Block Tracking (CBT) has not been enabled for this device. This feature is a prerequisite for VM warm migration."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disks_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disks_test.rego
@@ -1,0 +1,166 @@
+package io.konveyor.forklift.vmware
+
+test_with_cbt_enabled_disk {
+     mock_vm := {
+        "name": "test",
+        "disks": [
+            {
+                "key": 2000,
+                "file": "[datastore1] vm-folder/vm.vmdk",
+                "datastore": {
+                    "id": "datastore-101",
+                    "kind": "Datastore"
+                },
+                "changeTrackingEnabled": true,
+                "controllerKey": 1000,
+                "bus": "scsi",
+                "unitNumber": 0,
+            }
+        ]
+    }
+
+    results := concerns with input as mock_vm
+    count(results) == 0
+    
+}
+
+test_with_cbt_disabled_disk {
+     mock_vm := {
+        "name": "test",
+        "disks": [
+            {
+                "key": 2000,
+                "file": "[datastore1] vm-folder/vm.vmdk",
+                "datastore": {
+                    "id": "datastore-101",
+                    "kind": "Datastore"
+                },
+                "changeTrackingEnabled": false,
+                "controllerKey": 1000,
+                "bus": "scsi",
+                "unitNumber": 0
+            }
+        ]
+    }
+
+    results := concerns with input as mock_vm
+    count(results) == 1
+
+}
+
+test_with_all_disks_cbt_enabled {
+    mock_vm := {
+        "name": "test-multi-all-enabled",
+        "disks": [
+            {
+                "key": 2000,
+                "file": "[datastore1] vm-folder/vm1.vmdk",
+                "datastore": {
+                    "id": "datastore-101",
+                    "kind": "Datastore"
+                },
+                "changeTrackingEnabled": true,
+                "controllerKey": 1000,
+                "bus": "scsi",
+                "unitNumber": 0
+            },
+            {
+                "key": 2001,
+                "file": "[datastore1] vm-folder/vm2.vmdk",
+                "datastore": {
+                    "id": "datastore-101",
+                    "kind": "Datastore"
+                },
+                "changeTrackingEnabled": true,
+                "controllerKey": 1000,
+                "bus": "scsi",
+                "unitNumber": 1
+            }
+        ]
+    }
+
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_all_disks_cbt_disabled {
+    mock_vm := {
+        "name": "test-multi-all-disabled",
+        "disks": [
+            {
+                "key": 2000,
+                "file": "[datastore1] vm-folder/vm1.vmdk",
+                "datastore": {
+                    "id": "datastore-101",
+                    "kind": "Datastore"
+                },
+                "changeTrackingEnabled": false,
+                "controllerKey": 1000,
+                "bus": "scsi",
+                "unitNumber": 0
+            },
+            {
+                "key": 2001,
+                "file": "[datastore1] vm-folder/vm2.vmdk",
+                "datastore": {
+                    "id": "datastore-101",
+                    "kind": "Datastore"
+                },
+                "changeTrackingEnabled": false,
+                "controllerKey": 1000,
+                "bus": "scsi",
+                "unitNumber": 1
+            }
+        ]
+    }
+
+    results := concerns with input as mock_vm
+    count(results) == 2
+}
+
+test_with_mixed_cbt_disks {
+    mock_vm := {
+        "name": "test-multi-mixed",
+        "disks": [
+            {
+                "key": 2000,
+                "file": "[datastore1] vm-folder/vm1.vmdk",
+                "datastore": {
+                    "id": "datastore-101",
+                    "kind": "Datastore"
+                },
+                "changeTrackingEnabled": false,
+                "controllerKey": 1000,
+                "bus": "scsi",
+                "unitNumber": 0
+            },
+            {
+                "key": 2001,
+                "file": "[datastore1] vm-folder/vm2.vmdk",
+                "datastore": {
+                    "id": "datastore-101",
+                    "kind": "Datastore"
+                },
+                "changeTrackingEnabled": true,
+                "controllerKey": 1000,
+                "bus": "scsi",
+                "unitNumber": 1
+            },
+            {
+                "key": 2002,
+                "file": "[datastore1] vm-folder/vm3.vmdk",
+                "datastore": {
+                    "id": "datastore-101",
+                    "kind": "Datastore"
+                },
+                "changeTrackingEnabled": false,
+                "controllerKey": 1000,
+                "bus": "scsi",
+                "unitNumber": 2
+            }
+        ]
+    }
+
+    results := concerns with input as mock_vm
+    count(results) == 2
+}


### PR DESCRIPTION
Issue:
For the warm migration to work, the CBT for individual disks needs to be enabled as well.
In case it's off  the whole disk snapshot will be copied after the cut-over resulting in a prolonged VM downtime.

Fix:
A warning about each disk which its CBT is disabled will be displayed while creating a provider. 

Ref:  https://issues.redhat.com/browse/MTV-2019