### PR TITLE
MTV-1589 | Add option to delete virt-v2v pod

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -57,6 +57,13 @@ spec:
               archived:
                 description: Whether this plan should be archived.
                 type: boolean
+              deleteGuestConversionPod:
+                description: |-
+                  DeleteGuestConversionPod determines if the guest conversion pod should be deleted after successful migration.
+                  Note:
+                    - If this option is enabled and migration succeeds then the pod will get deleted. However the VM could still not boot and the virt-v2v logs, with additional information, will be deleted alongside guest conversion pod.
+                    - If migration fails the conversion pod will remain present even if this option is enabled.
+                type: boolean
               description:
                 description: Description
                 type: string

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -106,6 +106,12 @@ type PlanSpec struct {
 	// Determines if the plan should migrate shared disks.
 	// +kubebuilder:default:=true
 	MigrateSharedDisks bool `json:"migrateSharedDisks,omitempty"`
+	// DeleteGuestConversionPod determines if the guest conversion pod should be deleted after successful migration.
+	// Note:
+	//   - If this option is enabled and migration succeeds then the pod will get deleted. However the VM could still not boot and the virt-v2v logs, with additional information, will be deleted alongside guest conversion pod.
+	//   - If migration fails the conversion pod will remain present even if this option is enabled.
+	// +optional
+	DeleteGuestConversionPod bool `json:"deleteGuestConversionPod,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1395,6 +1395,20 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			err = nil
 			return
 		}
+		// Delete pod if user specified that they want to remove it after successful migration.
+		if r.Plan.Spec.DeleteGuestConversionPod {
+			r.Log.Info("Removing guest conversion pod for finished VM.", "vm", vm.String())
+			err = r.kubevirt.DeleteGuestConversionPod(vm)
+			if err != nil {
+				r.Log.Error(
+					err,
+					"Could not remove guest conversion pod for finished VM.",
+					"vm",
+					vm.String(),
+				)
+				err = nil
+			}
+		}
 		vm.SetCondition(
 			libcnd.Condition{
 				Type:     Succeeded,


### PR DESCRIPTION
Issue: When migration completes and user decides to delete VM, resources such as PVC and PV are kept in terminating state because guest conversion pod exists. The pod finished, however it is still referencing the PVC used by VM and thus blocking it's deletion. This happens because of kubernetes `pvc-protection` finalizer.

Fix: Add option for users to define if they want to delete the virt-v2v pod after migration succeeds. We do it this way because even when migration succeeds there is no guarantee that the VM will boot. Removing the guest conversion pod every time would make it impossible to troubleshoot this problem using virt-v2v logs.

Ref: https://issues.redhat.com/browse/MTV-1589