### PR TITLE
MTV-2157 | Enable nested virt on VMs from VMware

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -815,6 +815,19 @@ func (r *Builder) mapCPU(vm *model.VM, object *cnv.VirtualMachineSpec) {
 		Sockets: uint32(vm.CpuCount / vm.CoresPerSocket),
 		Cores:   uint32(vm.CoresPerSocket),
 	}
+	if vm.NestedHVEnabled {
+		//FIXME: Replace in future with single feature flag for nested virt https://issues.redhat.com/browse/CNV-60150
+		var features []cnv.CPUFeature
+		features = append(features, cnv.CPUFeature{
+			Name:   "vmx",
+			Policy: "optional",
+		})
+		features = append(features, cnv.CPUFeature{
+			Name:   "svm",
+			Policy: "optional",
+		})
+		object.Template.Spec.Domain.CPU.Features = features
+	}
 }
 
 func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -114,6 +114,7 @@ const (
 	fMemorySize          = "config.hardware.memoryMB"
 	fDevices             = "config.hardware.device"
 	fExtraConfig         = "config.extraConfig"
+	fNestedHVEnabled     = "config.nestedHVEnabled"
 	fChangeTracking      = "config.changeTrackingEnabled"
 	fGuestName           = "summary.config.guestFullName"
 	fGuestID             = "summary.guest.guestId"
@@ -772,6 +773,7 @@ func (r *Collector) vmPathSet() []string {
 		fDevices,
 		fGuestNet,
 		fExtraConfig,
+		fNestedHVEnabled,
 		fGuestName,
 		fGuestID,
 		fBalloonedMemory,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -673,6 +673,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 
 					}
 				}
+			case fNestedHVEnabled:
+				if b, cast := p.Val.(bool); cast {
+					v.model.NestedHVEnabled = b
+				}
 			case fGuestNet:
 				if nics, cast := p.Val.(types.ArrayOfGuestNicInfo); cast {
 					guestNetworksList := []model.GuestNetwork{}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -271,6 +271,7 @@ type VM struct {
 	GuestIpStacks         []GuestIpStack `sql:""`
 	SecureBoot            bool           `sql:""`
 	DiskEnableUuid        bool           `sql:""`
+	NestedHVEnabled       bool           `sql:""`
 }
 
 // Determine if current revision has been validated.

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -247,6 +247,7 @@ type VM struct {
 	GuestIpStacks         []model.GuestIpStack `json:"guestIpStacks"`
 	SecureBoot            bool                 `json:"secureBoot"`
 	DiskEnableUuid        bool                 `json:"diskEnableUuid"`
+	NestedHVEnabled       bool                 `json:"nestedHVEnabled"`
 }
 
 // Build the resource using the model.
@@ -279,6 +280,7 @@ func (r *VM) With(m *model.VM) {
 	r.GuestIpStacks = m.GuestIpStacks
 	r.SecureBoot = m.SecureBoot
 	r.DiskEnableUuid = m.DiskEnableUuid
+	r.NestedHVEnabled = m.NestedHVEnabled
 }
 
 // Build self link (URI).


### PR DESCRIPTION
Issue:
When a VM from VMware has a Hardware virtualization enabled we are not propagating this to the VM.

Fix:
If VM is using the Hardware virtualization use the CPU host-model and set the CPU feature flags for the nested virt as option, this way the VM can run on both architectures depending on the host.

Ref:
- https://issues.redhat.com/browse/MTV-2157
- https://access.redhat.com/solutions/6692341
- https://issues.redhat.com/browse/CNV-60150