### PR TITLE
MTV-2408: Add network field to guestipstacks

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -287,6 +287,9 @@ func (r *Builder) mapMacStaticIps(vm *model.VM) (ipMap string, err error) {
 				if ipStack.Device != guestNetwork.Device {
 					continue
 				}
+				if ipStack.Network != "0.0.0.0" {
+					continue
+				}
 				gateway = ipStack.Gateway
 			}
 			dnsString := strings.Join(guestNetwork.DNS, ",")

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -712,9 +712,11 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 							}
 							if len(route.Gateway.IpAddress) > 0 {
 								guestIpStackList = append(guestIpStackList, model.GuestIpStack{
-									Device:  route.Gateway.Device,
-									Gateway: route.Gateway.IpAddress,
-									DNS:     dnsList,
+									Device:       route.Gateway.Device,
+									Gateway:      route.Gateway.IpAddress,
+									Network:      route.Network,
+									PrefixLength: route.PrefixLength,
+									DNS:          dnsList,
 								})
 							}
 						}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -322,7 +322,9 @@ type GuestNetwork struct {
 
 // Guest ipStack
 type GuestIpStack struct {
-	Device  string   `json:"device"`
-	Gateway string   `json:"gateway"`
-	DNS     []string `json:"dns"`
+	Device       string   `json:"device"`
+	Gateway      string   `json:"gateway"`
+	Network      string   `json:"network"`
+	PrefixLength int32    `json:"prefix"`
+	DNS          []string `json:"dns"`
 }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2408

Issue:
We use the GuestIpStacks gateway without checking the network

Fix:
  - [x] Get the GuestIpStacks network
  - [x] Check network actually "0.0.0.0" before using the gateway

Get the `guestIpStacks` of the first VM with some dns:
```bash
oc mtv inventory vms test1 -q "where any(guestNetworks[*].dns is not null)" -o json | jq .[0].guestIpStacks
[
  {
    "device": "0",
    "dns": [
      "10.47.242.10",
      "10.38.5.26"
    ],
    "gateway": "10.46.29.254",
    "network": "0.0.0.0",
    "prefix": 0
  }
]

``` 

A VM with one device, but many gateways, only one has "0.0.0.0"
```bash
oc mtv inventory vms test1 -q "where any(guestIpStacks[*].network != '0.0.0.0')" -o json | jq .[0].guestIpStacks
[
  {
    "device": "0",
    "dns": [
      "10.47.242.10",
      "10.38.5.26"
    ],
    "gateway": "10.46.29.254",
    "network": "0.0.0.0",
    "prefix": 0
  },
  {
    "device": "0",
    "dns": [
      "10.47.242.10",
      "10.38.5.26"
    ],
    "gateway": "10.46.29.254",
    "network": "10.2.32.37",
    "prefix": 32
  },
  {
    "device": "0",
    "dns": [
      "10.47.242.10",
      "10.38.5.26"
    ],
    "gateway": "10.46.29.254",
    "network": "10.2.32.38",
    "prefix": 32
  },
  {
    "device": "0",
    "dns": [
      "10.47.242.10",
      "10.38.5.26"
    ],
    "gateway": "10.46.29.254",
    "network": "10.11.160.238",
    "prefix": 32
  },
  {
    "device": "0",
    "dns": [
      "10.47.242.10",
      "10.38.5.26"
    ],
    "gateway": "10.46.29.254",
    "network": "10.38.5.26",
    "prefix": 32
  },
  {
    "device": "0",
    "dns": [
      "10.47.242.10",
      "10.38.5.26"
    ],
    "gateway": "10.46.29.254",
    "network": "10.47.242.10",
    "prefix": 32
  }
]
```
