### PR TITLE
Add advancedOption parameter to /hosts/{id} API

### DIFF
--- a/pkg/controller/provider/container/openstack/collector.go
+++ b/pkg/controller/provider/container/openstack/collector.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"context"
+	"fmt"
 	liburl "net/url"
 	libpath "path"
 	"time"
@@ -116,6 +117,11 @@ func (r *Collector) Test() (_ int, err error) {
 // NO-OP
 func (r *Collector) Version() (_, _, _, _ string, err error) {
 	return
+}
+
+// Follow link
+func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error {
+	return fmt.Errorf("not implemented")
 }
 
 // Start the collector.

--- a/pkg/controller/provider/container/ova/collector.go
+++ b/pkg/controller/provider/container/ova/collector.go
@@ -2,6 +2,7 @@ package ova
 
 import (
 	"context"
+	"fmt"
 	liburl "net/url"
 	libpath "path"
 	"time"
@@ -120,6 +121,11 @@ func (r *Collector) Test() (_ int, err error) {
 // NO-OP
 func (r *Collector) Version() (_, _, _, _ string, err error) {
 	return
+}
+
+// Follow link
+func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error {
+	return fmt.Errorf("not implemented")
 }
 
 // Start the collector.

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -128,6 +128,11 @@ func (r *Collector) HasParity() bool {
 	return r.parity
 }
 
+// Follow link
+func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error {
+	return fmt.Errorf("not implemented")
+}
+
 // Test connect/logout.
 func (r *Collector) Test() (status int, err error) {
 	_, status, err = r.client.system()

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -382,6 +382,8 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 						v.model.HostScsiDisks = append(v.model.HostScsiDisks, hostScsiDisk)
 					}
 				}
+			case fAdvancedOption:
+				v.model.AdvancedOptions = v.Ref(p.Val)
 			}
 		}
 	}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -140,6 +140,7 @@ type Host struct {
 	Networks           []Ref          `sql:""`
 	Datastores         []Ref          `sql:""`
 	HostScsiDisks      []HostScsiDisk `sql:""`
+	AdvancedOptions    Ref            `sql:""`
 }
 
 type HostScsiDisk struct {

--- a/pkg/lib/cmd/inventory/main.go
+++ b/pkg/lib/cmd/inventory/main.go
@@ -181,6 +181,10 @@ func (r *Collector) Name() string {
 	return "tester"
 }
 
+func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error {
+	return nil
+}
+
 func (r *Collector) Owner() meta.Object {
 	return &meta.ObjectMeta{
 		UID: "TEST",

--- a/pkg/lib/inventory/container/container.go
+++ b/pkg/lib/inventory/container/container.go
@@ -146,6 +146,8 @@ type Collector interface {
 	// Return the status code of the connection
 	// 0 = Ignore
 	Test() (int, error)
+	// Follow the link
+	Follow(moRef interface{}, p []string, dst interface{}) error
 	// Reset
 	Reset()
 	// Get the system version - currently, ovirt-only

--- a/pkg/lib/inventory/container/ocp/collector.go
+++ b/pkg/lib/inventory/container/ocp/collector.go
@@ -2,6 +2,7 @@ package ocp
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"time"
 
@@ -110,6 +111,11 @@ func (r *Collector) Reset() {
 // Collector has achieved parity.
 func (r *Collector) HasParity() bool {
 	return r.parity
+}
+
+// Follow link
+func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error {
+	return fmt.Errorf("not implemented")
 }
 
 // Update the versionThreshold


### PR DESCRIPTION
This PR add a collection of `advanedOption` field from `HostSystem` object. This option is only a reference so we store a reference in a database. User can fetch value of `advancedOption` setting from the `/hosts/{id}` endpoint by calling:
```
/providers/vsphere/1/hosts/{id}?advancedOption={optionName}
```

Issue: https://issues.redhat.com/browse/ECOPROJECT-2736