### PR TITLE
Bump virt-v2v base containers versions

### DIFF
--- a/.konflux/virt-v2v/redhat.repo
+++ b/.konflux/virt-v2v/redhat.repo
@@ -9,758 +9,16 @@
 # a "yum repolist" to refresh available repos
 #
 
-[rhel-9-for-$basearch-baseos-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+[lvms-4.17-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quarkus-textonly-1-for-middleware-rpms]
-name = Red Hat build of Quarkus Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.16-rpms]
-name = Red Hat Container Development Kit 3.16 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-$basearch-source-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-$basearch-source-rpms]
-name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-source-rpms]
-name = Red Hat Container Development Kit 3.3 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-$basearch-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rhui-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-rpms]
-name = Red Hat Container Development Kit 3.5 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-aus-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jdv-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Data Virtualization Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-$basearch-source-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -773,3172 +31,22 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-nfv-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-aus-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Quay 3 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-$basearch-debug-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhbop-textonly-1-for-middleware-rpms]
-name = Red Hat Build of OptaPlanner Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-rpms]
-name = Red Hat Container Development Kit 3.6 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rhui-debug-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-8-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-$basearch-rpms]
-name = Kernel Module Management 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhose-textonly-1-for-middleware-rpms]
-name = Red Hat Middleware Container Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Insights Proxy for RHEL9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Certification for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/source/SRPMS
+[codeready-builder-for-rhel-9-$basearch-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/os
 enabled = 1
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-$basearch-source-rpms]
-name = Single Sign-On 7.6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-$basearch-rpms]
-name = JBoss Web Server 6 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[wfk-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Web Framework Kit Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-source-rpms]
-name = Red Hat Container Development Kit 3.5 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-aus-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMS)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jon-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Operations Network Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Debug RPMS)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhsi-textonly-1-for-middleware-rpms]
-name = Red Hat Service Interconnect Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-textonly-1-for-middleware-rhui-rpms]
-name = Single Sign-On Text-Only Advisories from RHUI
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.8-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-$basearch-rpms]
-name = Single Sign-On 7.6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Discovery 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-rpms]
-name = Red Hat Container Development Kit 3.4 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rhui-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-debug-rpms]
-name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.12-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-$basearch-rpms]
-name = JBoss Web Server 5 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-debug-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss AMQ Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Quay 3 (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-debug-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-coreservices-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Core Services Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-$basearch-rpms]
-name = Red Hat Insights Proxy for RHEL9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.15-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-$basearch-rpms]
-name = Kernel Module Management 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-debug-rpms]
-name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Certification for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-$basearch-source-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-2.3-rpms]
-name = Red Hat Container Development Kit 2.3 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
-name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-6-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-$basearch-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Insights Proxy for RHEL9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-$basearch-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-aus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhosds-textonly-3-for-middleware-rpms]
-name = Red Hat OpenShift Dev Spaces 3 Container Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-source-rpms]
-name = Red Hat Container Development Kit 3.4 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Web Server Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.4-debug-rpms]
-name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[network-observability-1-for-rhel-9-$basearch-rpms]
-name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-$basearch-source-rpms]
-name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-aus-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -3951,1982 +59,8 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-snr-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-$basearch-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Application Interconnect for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-$basearch-source-rpms]
-name = Kernel Module Management 2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-$basearch-debug-rpms]
-name = Fast Datapath for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.5-debug-rpms]
-name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[quay-3-for-rhel-9-$basearch-rpms]
-name = Red Hat Quay 3 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.13-for-rhel-9-$basearch-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-source-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-edpm-1.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-aus-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMS)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-source-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.15-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhdh-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-stf-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Source RPMS)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-dev-preview-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-$basearch-textonly-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.9-rpms]
-name = Red Hat Container Development Kit 3.9 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-$basearch-debug-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.10-rpms]
-name = Red Hat Container Development Kit 3.10 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-2.3-source-rpms]
-name = Red Hat Container Development Kit 2.3 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Service Interconnect for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.1-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[pipelines-1.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.17-rpms]
-name = Red Hat Container Development Kit 3.17 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openliberty-textonly-1-for-middleware-rpms]
-name = Open Liberty Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.14-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-mdr-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.19-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
-[service-interconnect-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Data Grid Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-textonly-1-for-middleware-rpms]
-name = Single Sign-On Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.5-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-$basearch-debug-rpms]
-name = Kernel Module Management 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.12-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rhui-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-e4s-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-aus-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMS)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.12-rpms]
-name = Red Hat Container Development Kit 3.12 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-capsule-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1.4-for-rhel-9-$basearch-rpms]
-name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-aus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.5-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-rt-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Application Interconnect for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.17-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (RPMS)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.15-rpms]
-name = Red Hat Container Development Kit 3.15 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.6-source-rpms]
-name = Red Hat Container Development Kit 3.6 /(Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -5939,2808 +73,8 @@ gpgcheck = 1
 gpgkey = file://
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-e4s-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Source RPMS)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.13-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-datagrid-8.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-1-for-rhel-9-$basearch-source-rpms]
-name = Kernel Module Management 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.15-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-maintenance-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-cinderlib-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.8-rpms]
-name = Red Hat Container Development Kit 3.8 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-aus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-$basearch-textonly-debug-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-deployment-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.14-rpms]
-name = Red Hat Container Development Kit 3.14 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[insights-proxy-1-tech-preview-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-rhui-debug-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-tools-18-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-odf-4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-textonly-1-for-middleware-rpms]
-name = OpenJDK Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-developer-1.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-cuda-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.10-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openjdk-11-els-for-rhel-9-$basearch-source-rpms]
-name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-cuda-for-rhel-9-$basearch-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-8-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-6-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fsw-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Fuse Service Works Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-$basearch-debug-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.17-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rhui-source-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.16-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[kmm-2-for-rhel-9-$basearch-debug-rpms]
-name = Kernel Module Management 2 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.13-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-7-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-$basearch-rpms]
-name = Fast Datapath for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.11-rpms]
-name = Red Hat Container Development Kit 3.11 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.15-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.13-rpms]
-name = Red Hat Container Development Kit 3.13 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.13-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-e4s-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Debug RPMS)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[application-interconnect-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Application Interconnect for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-$basearch-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-eus-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (RPMS)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.11-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-$basearch-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhpm-1-for-rhel-9-$basearch-textonly-source-rpms]
-name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[soa-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss SOA Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-far-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-e4s-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.0-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-utils-6.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.18-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-$basearch-source-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nmo-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-clients-3-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.15-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rhui-source-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-eus-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-7.4-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-e4s-debug-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-eus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.13-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-8-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.4-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-eus-source-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Source RPMS)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rhui-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[fast-datapath-for-rhel-9-$basearch-source-rpms]
-name = Fast Datapath for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-beta-deployment-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rh-sso-7.6-for-rhel-9-$basearch-debug-rpms]
-name = Single Sign-On 7.6 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jws-5-for-rhel-9-$basearch-debug-rpms]
-name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.17-for-rhel-9-$basearch-rpms]
-name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[nbde-tang-server-1-for-rhel-9-$basearch-textonly-rpms]
-name = nbde tang server 1 (for RHEL 9 $basearch) (Text-Only Advisories)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/nbde-tang-server-textonly/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17.1-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.2-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[amq-interconnect-textonly-1-for-middleware-rpms]
-name = Red Hat AMQ Interconnect Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[osso-1-for-rhel-9-$basearch-rpms]
-name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-for-rhel-9-textonly-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm-textonly/2/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-source-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.12-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.3-rpms]
-name = Red Hat Container Development Kit 3.3 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ocp-tools-4.16-for-rhel-9-$basearch-source-rpms]
-name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-$basearch-debug-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-appstream-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.16-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.13-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.12-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[service-interconnect-1-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Service Interconnect for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Certification for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cert-manager-1.14-for-rhel-9-$basearch-source-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-supplementary-eus-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ansible-automation-platform-2.3-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.18-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-e4s-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (RPMS)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[codeready-builder-for-rhel-9-$basearch-eus-rhui-rpms]
-name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jpp-textonly-1-for-middleware-rpms]
-name = Red Hat JBoss Portal Text-Only Advisories
-baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file://
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-$basearch-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[cnv-4.16-for-rhel-9-$basearch-rpms]
-name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-solutions-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/os
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 1
-
-[rhelai-1.1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[ossm-3-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-6-client-2-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Debug RPMS)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-podified-1-beta-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhceph-5-tools-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-nfv-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-atomic-7-cdk-3.7-rpms]
-name = Red Hat Container Development Kit 3.7 /(RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[jb-eap-8.0-for-rhel-9-$basearch-rhui-rpms]
-name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
-baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.5-gaudi-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.16-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-$basearch-debug-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-e4s-rhui-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhocp-ironic-4.19-for-rhel-9-$basearch-source-rpms]
-name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rodoo-1-for-rhel-9-$basearch-rpms]
-name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.4-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-resilientstorage-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[dirsrv-12.3-for-rhel-9-$basearch-rpms]
-name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhv-4-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[gitops-1.15-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[lvms-4.19-for-rhel-9-$basearch-rpms]
-name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[discovery-1-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Discovery 1 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-eus-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhelai-1.3-gaudi-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-baseos-aus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhoso-18-beta-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[openstack-17-deployment-tools-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhel-9-for-$basearch-highavailability-eus-source-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Source RPMs)
-baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[satellite-client-6-for-rhel-9-$basearch-e4s-source-rpms]
-name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Source RPMs)
-baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhacm-2.14-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/debug
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-
-[rhwa-nhc-1-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -8753,92 +87,344 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhocp-4.18-for-rhel-9-$basearch-debug-rpms]
-name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/debug
+[openjdk-11-els-for-rhel-9-$basearch-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[discovery-1-for-rhel-9-$basearch-rpms]
-name = Red Hat Discovery 1 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/os
+[rhel-9-for-$basearch-appstream-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/os
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[cert-manager-1.14-for-rhel-9-$basearch-debug-rpms]
-name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/debug
+[rhel-9-for-$basearch-sap-netweaver-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhceph-7-tools-for-rhel-9-$basearch-rpms]
-name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/os
+[rhel-9-for-$basearch-baseos-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[rhel-9-for-$basearch-baseos-aus-debug-rpms]
-name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
-baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/debug
+[dirsrv-12.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/debug
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
 
-[satellite-maintenance-6.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/source/SRPMS
+[rh-sso-textonly-1-for-middleware-rpms]
+name = Single Sign-On Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/source/SRPMS
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.17-rpms]
+name = Red Hat Container Development Kit 3.17 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.11-rpms]
+name = Red Hat Container Development Kit 3.11 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0
@@ -8851,8 +437,8464 @@ gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1
 sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslclientkey = /etc/pki/entitlement/7556729287177415940-key.pem
-sslclientcert = /etc/pki/entitlement/7556729287177415940.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-source-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[wfk-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Framework Kit Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.12-rpms]
+name = Red Hat Container Development Kit 3.12 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosds-textonly-3-for-middleware-rpms]
+name = Red Hat OpenShift Dev Spaces 3 Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss AMQ Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-debug-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-source-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (RPMS)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 6 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-rpms]
+name = Red Hat Container Development Kit 2.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.14-rpms]
+name = Red Hat Container Development Kit 3.14 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[rhel-9-for-$basearch-baseos-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.8-rpms]
+name = Red Hat Container Development Kit 3.8 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Grid Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-debug-rpms]
+name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rhui-rpms]
+name = Single Sign-On Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.13-rpms]
+name = Red Hat Container Development Kit 3.13 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-source-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-rpms]
+name = Red Hat Container Development Kit 3.4 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-rpms]
+name = Red Hat Container Development Kit 3.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMS)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[nbde-tang-server-1-for-rhel-9-$basearch-textonly-rpms]
+name = nbde tang server 1 (for RHEL 9 $basearch) (Text-Only Advisories)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/nbde-tang-server-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-debug-rpms]
+name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jpp-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Portal Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Source RPMS)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-for-rhel-9-textonly-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm-textonly/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-source-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jdv-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Virtualization Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-rpms]
+name = Red Hat Container Development Kit 3.6 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-textonly-1-for-middleware-rpms]
+name = OpenJDK Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-source-rpms]
+name = Red Hat Container Development Kit 3.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-textonly-1-for-middleware-rpms]
+name = Red Hat AMQ Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Server Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-debug-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jon-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Operations Network Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.16-rpms]
+name = Red Hat Container Development Kit 3.16 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-source-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.15-rpms]
+name = Red Hat Container Development Kit 3.15 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-debug-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-debug-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.10-rpms]
+name = Red Hat Container Development Kit 3.10 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openliberty-textonly-1-for-middleware-rpms]
+name = Open Liberty Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-source-rpms]
+name = Red Hat Container Development Kit 3.5 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhsi-textonly-1-for-middleware-rpms]
+name = Red Hat Service Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMS)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-debug-rpms]
+name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-rpms]
+name = Fast Datapath for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhose-textonly-1-for-middleware-rpms]
+name = Red Hat Middleware Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Source RPMS)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-source-rpms]
+name = Red Hat Container Development Kit 3.4 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-source-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fsw-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Fuse Service Works Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-source-rpms]
+name = Red Hat Container Development Kit 2.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-debug-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-source-rpms]
+name = Red Hat Container Development Kit 3.6 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (RPMS)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-debug-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Source RPMS)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-textonly-1-for-middleware-rpms]
+name = Red Hat build of Quarkus Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[soa-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss SOA Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhbop-textonly-1-for-middleware-rpms]
+name = Red Hat Build of OptaPlanner Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.9-rpms]
+name = Red Hat Container Development Kit 3.9 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.7-rpms]
+name = Red Hat Container Development Kit 3.7 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-debug-rpms]
+name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 5 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (RPMS)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-rpms]
+name = Red Hat Container Development Kit 3.5 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/707769419036098099-key.pem
+sslclientcert = /etc/pki/entitlement/707769419036098099.pem
 sslverifystatus = 1
 metadata_expire = 86400
 enabled_metadata = 0

--- a/.konflux/virt-v2v/rpms.lock.yaml
+++ b/.konflux/virt-v2v/rpms.lock.yaml
@@ -718,13 +718,13 @@ arches:
     name: perl-NDBM_File
     evr: 1.15-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.92-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 401501
-    checksum: sha256:eb0402981b2fce935550fef841f4c6eb24928456370e8b7b689ca073db3d2708
+    size: 428188
+    checksum: sha256:d8ed17b9700c4acee11a339c9e0814862ad5b20e072c1414021dcb050c7da90b
     name: perl-Net-SSLeay
-    evr: 1.92-2.el9
-    sourcerpm: perl-Net-SSLeay-1.92-2.el9.src.rpm
+    evr: 1.94-1.el9
+    sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 100044
@@ -970,13 +970,13 @@ arches:
     name: python-srpm-macros
     evr: 3.9-54.el9
     sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.2-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.5-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 87640
-    checksum: sha256:c419389a2939e341c3ab55be65b7315d6b060af9bbe2bd4ef621cb46deb61b46
+    size: 87632
+    checksum: sha256:93dd7a77ab7c2bbc0b1ef7ec9714ea83018fbf0ce019bd65c2650c4abfbaad34
     name: python3-audit
-    evr: 3.1.2-2.el9
-    sourcerpm: audit-3.1.2-2.el9.src.rpm
+    evr: 3.1.5-1.el9
+    sourcerpm: audit-3.1.5-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 41452
@@ -991,13 +991,13 @@ arches:
     name: python3-libselinux
     evr: 3.6-1.el9
     sourcerpm: libselinux-3.6-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-libsemanage-3.6-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-libsemanage-3.6-2.1.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 83333
-    checksum: sha256:b54590c634a9fbd67a4af6fabadb4946ab340ecb667d0b63a33cc4b690d653af
+    size: 82828
+    checksum: sha256:b7f5d62cbb163b3c13f0db87e326dc3937d206b9c22732dc75de3b7fae32248e
     name: python3-libsemanage
-    evr: 3.6-1.el9
-    sourcerpm: libsemanage-3.6-1.el9.src.rpm
+    evr: 3.6-2.1.el9_5
+    sourcerpm: libsemanage-3.6-2.1.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-policycoreutils-3.6-2.1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2216589
@@ -1131,13 +1131,6 @@ arches:
     name: yajl
     evr: 2.1.0-22.el9
     sourcerpm: yajl-2.1.0-22.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/a/attr-2.5.1-3.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 66700
-    checksum: sha256:49f7baeb53e07a4b9b5739e36932f17f014abb765b3fa6c0c0f8af6a8ebf4d9b
-    name: attr
-    evr: 2.5.1-3.el9
-    sourcerpm: attr-2.5.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-54.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 4816328
@@ -1166,20 +1159,20 @@ arches:
     name: cpio
     evr: 2.13-16.el9
     sourcerpm: cpio-2.13-16.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-2.6.0-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-2.7.2-3.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 326442
-    checksum: sha256:a8285c046092fb1a864a51f860a04021679696abdd289edec5dae1819bd2b598
+    size: 341855
+    checksum: sha256:a5cb6c046de71a54313b2d420db6e72bfae0761f591a051a7d676e3e063fe160
     name: cryptsetup
-    evr: 2.6.0-3.el9
-    sourcerpm: cryptsetup-2.6.0-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.6.0-3.el9.x86_64.rpm
+    evr: 2.7.2-3.el9_5
+    sourcerpm: cryptsetup-2.7.2-3.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.7.2-3.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 488371
-    checksum: sha256:179bf940d5834cc65e7f6748ecfe24df15a7d00fe41d33e2b6193f95df2cf4ce
+    size: 534806
+    checksum: sha256:db7fc8be731f94a9a28f29522ee1c8000dbcdddb78be470825fea8af5338818e
     name: cryptsetup-libs
-    evr: 2.6.0-3.el9
-    sourcerpm: cryptsetup-2.6.0-3.el9.src.rpm
+    evr: 2.7.2-3.el9_5
+    sourcerpm: cryptsetup-2.7.2-3.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-gssapi-2.1.27-21.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 28739
@@ -1278,13 +1271,13 @@ arches:
     name: e2fsprogs-libs
     evr: 1.46.5-5.el9
     sourcerpm: e2fsprogs-1.46.5-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.190-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.191-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 39619
-    checksum: sha256:8318e4801d9a4e5cb9c0b647b8b3c1d969627d8f8ced0d5220bdddf668583e63
+    size: 39913
+    checksum: sha256:9c26ab1eea196541d9cde34a96acbf8647746ccd0447ad353dec5ec4225826a5
     name: elfutils-debuginfod-client
-    evr: 0.190-2.el9
-    sourcerpm: elfutils-0.190-2.el9.src.rpm
+    evr: 0.191-4.el9
+    sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/file-5.39-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 53222
@@ -1334,13 +1327,13 @@ arches:
     name: glib-networking
     evr: 2.68.3-3.el9
     sourcerpm: glib-networking-2.68.3-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-100.el9_4.4.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-125.el9_5.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1790492
-    checksum: sha256:ba58fe9cbc0344698e4785b7591739cfb5f354c6ab19f95ae012375aa1a932e8
+    size: 1796886
+    checksum: sha256:e4625f4ab64dfb0b89a93390ea3bb699479d78bbcc36d4d76942416d68c4dc75
     name: glibc-gconv-extra
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
+    evr: 2.34-125.el9_5.1
+    sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1133828
@@ -1460,13 +1453,6 @@ arches:
     name: kernel-modules-core
     evr: 5.14.0-503.38.1.el9_5
     sourcerpm: kernel-5.14.0-503.38.1.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/keyutils-1.6.3-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 79682
-    checksum: sha256:756fb606dfbf6c6f92fcd3316ba902b5e09232102cb6371d9bccd983b8d4bbdf
-    name: keyutils
-    evr: 1.6.3-1.el9
-    sourcerpm: keyutils-1.6.3-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 132888
@@ -1978,27 +1964,6 @@ arches:
     name: rpcbind
     evr: 1.2.6-7.el9
     sourcerpm: rpcbind-1.2.6-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/rpm-plugin-selinux-4.16.1.3-29.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 18300
-    checksum: sha256:1992d66204a8bb340e0796543f2879bf04aad5a0ba4ade0a3b7f5a7e397f8319
-    name: rpm-plugin-selinux
-    evr: 4.16.1.3-29.el9
-    sourcerpm: rpm-4.16.1.3-29.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-38.1.45-3.el9_5.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 52484
-    checksum: sha256:217d992f42cab6cae7b0236daeefe78d067f882481f20316198e0736f1325ab2
-    name: selinux-policy
-    evr: 38.1.45-3.el9_5
-    sourcerpm: selinux-policy-38.1.45-3.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-targeted-38.1.45-3.el9_5.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 7225392
-    checksum: sha256:575305a4fc873ef9b1fcaf6005a6f04be6d3ff4a5887d6db8ed97cef23c501c5
-    name: selinux-policy-targeted
-    evr: 38.1.45-3.el9_5
-    sourcerpm: selinux-policy-38.1.45-3.el9_5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/snappy-1.1.8-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 38032
@@ -2041,20 +2006,20 @@ arches:
     name: syslinux-nonlinux
     evr: 6.04-0.20.el9
     sourcerpm: syslinux-6.04-0.20.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-container-252-32.el9_4.7.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-container-252-46.el9_5.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 607026
-    checksum: sha256:7c78f86b62afb3126ca58efdbfec31cabdae548cd52d562dcf37d927885ddefb
+    size: 611094
+    checksum: sha256:47532478e89141a07bbd3773124d8f3157ce8d78f9da8bfcbb372b2c8aae0967
     name: systemd-container
-    evr: 252-32.el9_4.7
-    sourcerpm: systemd-252-32.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-32.el9_4.7.x86_64.rpm
+    evr: 252-46.el9_5.2
+    sourcerpm: systemd-252-46.el9_5.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-46.el9_5.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2018876
-    checksum: sha256:f0b1a973c8ab5508044fe7c1e358d454116cb7931cca1d33af0d83a44f082715
+    size: 2106078
+    checksum: sha256:17aa97edfa2f51d1fb9e6952bfd9904c635d02ab1908f66985aacdae1df8d8ae
     name: systemd-udev
-    evr: 252-32.el9_4.7
-    sourcerpm: systemd-252-32.el9_4.7.src.rpm
+    evr: 252-46.el9_5.2
+    sourcerpm: systemd-252-46.el9_5.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tpm2-tools-5.2-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 828074
@@ -2118,12 +2083,6 @@ arches:
     checksum: sha256:ce11dc78d92b207947633e00a792a3c8c3b7b4f23c2b7912eaba587dc7893f4c
     name: abattis-cantarell-fonts
     evr: 0.301-4.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.src.rpm
-    repoid: rhel-9-for-x86_64-appstream-source-rpms
-    size: 8251850
-    checksum: sha256:1fd3a712280b0bdb5144a5e9ee6600327bfba34fce9853c2ebadd47b221d46ed
-    name: adobe-source-code-pro-fonts
-    evr: 2.030.1.050-12.el9.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/a/augeas-1.13.0-6.el9_4.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 2582325
@@ -2472,12 +2431,12 @@ arches:
     checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.92-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
-    size: 584828
-    checksum: sha256:86bc5a1bc9f0ac7dd52eef4213a83b82169eee926f73924ca855aa58e7124d30
+    size: 693539
+    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
     name: perl-Net-SSLeay
-    evr: 1.92-2.el9
+    evr: 1.94-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 141038
@@ -2694,18 +2653,18 @@ arches:
     checksum: sha256:79e361ea2094e08f19c5a441a6e839b5424d1c4848d40cd3b3a5bcf1fb4b41f5
     name: yajl
     evr: 2.1.0-22.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/attr-2.5.1-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 482234
-    checksum: sha256:5171534e7de11df197f3c5e08658544983198288e04624c739b5c3d9db07b59c
-    name: attr
-    evr: 2.5.1-3.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/audit-3.1.2-2.el9.src.rpm
+    size: 8251850
+    checksum: sha256:1fd3a712280b0bdb5144a5e9ee6600327bfba34fce9853c2ebadd47b221d46ed
+    name: adobe-source-code-pro-fonts
+    evr: 2.030.1.050-12.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/audit-3.1.5-1.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 1244786
-    checksum: sha256:51c8217179ab65007a0c7b97075158feaba4f421a1efa72a289ae57c81eead17
+    size: 1252866
+    checksum: sha256:05d66fdb25dbad2e629c90f0c90cc64d446f2fe1811d73d270190922621cbf3e
     name: audit
-    evr: 3.1.2-2.el9
+    evr: 3.1.5-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/binutils-2.35.2-54.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 22368671
@@ -2730,12 +2689,12 @@ arches:
     checksum: sha256:0448d6f73fb814a7b6771981dd7bdb22540a0fa9e7e724dd5446308e4a957c55
     name: cpio
     evr: 2.13-16.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cryptsetup-2.6.0-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cryptsetup-2.7.2-3.el9_5.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 19933853
-    checksum: sha256:0bab4a49266de2ec7714a6a59fb62ce1967d12916eba1542b6617958d6ef9bd1
+    size: 11659362
+    checksum: sha256:5a72dbb2b730ff70acd0b566490583e5f08333ca05619840e7c982982141c5d0
     name: cryptsetup
-    evr: 2.6.0-3.el9
+    evr: 2.7.2-3.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-21.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 4030574
@@ -2796,12 +2755,12 @@ arches:
     checksum: sha256:a8fc8e505e79f9a3f2cead3e4705f08469195659f4761889e6011ecac6c75610
     name: efi-rpm-macros
     evr: 6-2.el9_0
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/elfutils-0.190-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/elfutils-0.191-4.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 9251309
-    checksum: sha256:37ca914c6d3748859317727fd88f57c6c3fa15963b510dc63a7921fc7f08f509
+    size: 9335734
+    checksum: sha256:d3d8ebb8716c88a4d1f8ad5757040fc30ff3d2b04034e726f95aecb6711c205d
     name: elfutils
-    evr: 0.190-2.el9
+    evr: 0.191-4.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/file-5.39-16.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1003666
@@ -2844,12 +2803,12 @@ arches:
     checksum: sha256:08f2d7a3c389bd63fb7ff6f8ac4a5a1fbb088451ca40f4fbe8ed70d2e820e897
     name: glib-networking
     evr: 2.68.3-3.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.34-100.el9_4.4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.34-125.el9_5.1.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 18626628
-    checksum: sha256:609d4863fbcbcc09c71823c7b05065d719529c7500836bda2bc760b3f16d09f7
+    size: 18727742
+    checksum: sha256:a80b272db684a3386983a445e07d1b36c3e6fc723eb93ecf89cae7d08970fd83
     name: glibc
-    evr: 2.34-100.el9_4.4
+    evr: 2.34-125.el9_5.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gnutls-3.8.3-4.el9_4.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 8583403
@@ -2940,12 +2899,6 @@ arches:
     checksum: sha256:be6ea9c0b712430f1124877b5045d80a028064375e761770199f6ef4f5b33baf
     name: kernel
     evr: 5.14.0-503.38.1.el9_5
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/keyutils-1.6.3-1.el9.src.rpm
-    repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 150790
-    checksum: sha256:6afa567438acd0d3a6a66bc6a3c68ec2f4ae5ed9c7230c3f0478d2281a092688
-    name: keyutils
-    evr: 1.6.3-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 582431
@@ -3054,12 +3007,12 @@ arches:
     checksum: sha256:cc4ad1925bfe7cbdf29ec71bf7fd743017f05a92ae1fa94d9b0814fe3cf557a6
     name: libselinux
     evr: 3.6-1.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libsemanage-3.6-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libsemanage-3.6-2.1.el9_5.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 216930
-    checksum: sha256:166c3fa12c547c6ff90575323b1aa9cf3c40d0eceb238a0fe79d76b575b6c606
+    size: 217965
+    checksum: sha256:e59edae9373828841f89176c798609b5c5867eeaecba2672c0c1e3b7406d9c80
     name: libsemanage
-    evr: 3.6-1.el9
+    evr: 3.6-2.1.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libssh-0.10.4-13.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 670226
@@ -3258,18 +3211,6 @@ arches:
     checksum: sha256:6fd5417237b1e77a458ca88109d97a7456af0ce407768562b3a779ce8bd0bde3
     name: rpcbind
     evr: 1.2.6-7.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/rpm-4.16.1.3-29.el9.src.rpm
-    repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 4473911
-    checksum: sha256:a2a8a583bf75ca728f6ebe64eeeb8df2a49eb77dd7766ccadaf8bd4e74be45a6
-    name: rpm
-    evr: 4.16.1.3-29.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/selinux-policy-38.1.45-3.el9_5.src.rpm
-    repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 1159633
-    checksum: sha256:746f69f084a907fe8d3c6f5076b6677e209081e91a5c406f224750d268fd7807
-    name: selinux-policy
-    evr: 38.1.45-3.el9_5
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/setools-4.4.4-1.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 416171
@@ -3294,12 +3235,12 @@ arches:
     checksum: sha256:c0ebe8295039fb2d68d97b0bc5117fabedf5385009c95e6aa8f0e55efd30127b
     name: syslinux
     evr: 6.04-0.20.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/systemd-252-32.el9_4.7.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/systemd-252-46.el9_5.2.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 13157861
-    checksum: sha256:06d6012342057d8f66d2c0f56e8bb1150fbf856a0f4f6d41516a9f683e062302
+    size: 37292288
+    checksum: sha256:df2db42f3f1c3ec2fc71d8cb01dae5167fe21bbd669a88ae809aba0470690651
     name: systemd
-    evr: 252-32.el9_4.7
+    evr: 252-46.el9_5.2
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tpm2-tools-5.2-4.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1227059

--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9:9.4-1214.1729773476 AS appliance
+FROM registry.redhat.io/ubi9:9.5-1739449058 AS appliance
 
 ENV LIBGUESTFS_BACKEND direct
 
@@ -26,7 +26,7 @@ RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-monitor github
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o image-converter github.com/konveyor/forklift-controller/cmd/image-converter
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-wrapper github.com/konveyor/forklift-controller/cmd/virt-v2v
 
-FROM registry.redhat.io/ubi9:9.4-1214.1729773476
+FROM registry.redhat.io/ubi9:9.5-1739449058
 RUN mkdir /disks && \
     source /etc/os-release && \
     dnf update -y && \


### PR DESCRIPTION
Bumps ubi9 versions from 9.4 to 9.5 in Containerfile for downstream builds.