### PR TITLE
MTV-2315 | Skip guest conversion

### DIFF
--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -1594,6 +1594,26 @@ spec:
               diskBus:
                 description: 'Deprecated: this field will be deprecated in 2.8.'
                 type: string
+              installLegacyDrivers:
+                description: |-
+                  InstallLegacyDrivers determines whether to install legacy windows drivers in the VM.
+                  The following Vm's are lack of SHA-2 support and need legacy drivers:
+                  Windows XP (all)
+                  Windows Server 2003
+                  Windows Vista (all)
+                  Windows Server 2008
+                  Windows 7 (pre-SP1)
+                  Windows Server 2008 R2
+                  Behavior:
+                  - If set to nil (unset), the system will automatically detect whether the VM requires legacy drivers
+                    based on its guest OS type (using IsLegacyWindows).
+                  - If set to true, legacy drivers will be installed unconditionally by setting the VIRTIO_WIN environment variable.
+                  - If set to false, legacy drivers will be skipped, and the system will fall back to using the standard (SHA-2 signed) drivers.
+
+
+                  When enabled, legacy drivers are exposed to the virt-v2v conversion process via the VIRTIO_WIN environment variable,
+                  which points to the legacy ISO at /usr/local/virtio-win.iso.
+                type: boolean
               map:
                 description: Resource mapping.
                 properties:
@@ -1837,6 +1857,10 @@ spec:
                   the PVC name being "{{.VmName}}-disk-{{.DiskIndex}}", which may not be unique.
                   but will be more predictable.
                   **DANGER** When set to false, the generated PVC name may not be unique and may cause conflicts.
+                type: boolean
+              skipGuestConversion:
+                default: false
+                description: Determines if the plan should skip the guest conversion.
                 type: boolean
               targetNamespace:
                 description: Target namespace.
@@ -3336,7 +3360,7 @@ spec:
               storageVendorProduct:
                 description: |-
                   StorageVendorProduct is the storage vendor the target disk and PVC are connected to
-                  Supported values [ontap, primera3par]
+                  Supported values [vantara, ontap, primera3par]
                 type: string
               vmdkPath:
                 description: |-

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -334,6 +334,10 @@ spec:
                   but will be more predictable.
                   **DANGER** When set to false, the generated PVC name may not be unique and may cause conflicts.
                 type: boolean
+              skipGuestConversion:
+                default: false
+                description: Determines if the plan should skip the guest conversion.
+                type: boolean
               targetNamespace:
                 description: Target namespace.
                 type: string

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -129,6 +129,9 @@ type PlanSpec struct {
 	// When enabled, legacy drivers are exposed to the virt-v2v conversion process via the VIRTIO_WIN environment variable,
 	// which points to the legacy ISO at /usr/local/virtio-win.iso.
 	InstallLegacyDrivers *bool `json:"installLegacyDrivers,omitempty"`
+	// Determines if the plan should skip the guest conversion.
+	// +kubebuilder:default:=false
+	SkipGuestConversion bool `json:"skipGuestConversion,omitempty"`
 }
 
 // Find a planned VM.
@@ -192,7 +195,7 @@ func (p *Plan) ShouldUseV2vForTransfer() (bool, error) {
 	case VSphere:
 		// The virt-v2v transferes all disks attached to the VM. If we want to skip the shared disks so we don't transfer
 		// them multiple times we need to manage the transfer using KubeVirt CDI DataVolumes and v2v-in-place.
-		return !p.Spec.Warm && destination.IsHost() && p.Spec.MigrateSharedDisks, nil
+		return !p.Spec.Warm && destination.IsHost() && p.Spec.MigrateSharedDisks && !p.Spec.SkipGuestConversion, nil
 	case Ova:
 		return true, nil
 	default:

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1459,6 +1459,11 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus, sortVolumesByLibvirt bool) 
 	// Set the 'app' label for identification of the virtual machine instance(s)
 	object.Spec.Template.ObjectMeta.Labels["app"] = vm.Name
 
+	err = r.setVmLabels(object)
+	if err != nil {
+		return
+	}
+
 	//Add the original name and ID info to the VM annotations
 	if len(originalName) > 0 {
 		annotations := make(map[string]string)
@@ -1520,6 +1525,18 @@ func (r *KubeVirt) setInstanceType(vm *plan.VMStatus, object *cnv.VirtualMachine
 		return
 	}
 	object.Spec.Instancetype = &cnv.InstancetypeMatcher{Name: vm.InstanceType, Kind: kind}
+	return
+}
+
+func (r *KubeVirt) setVmLabels(object *cnv.VirtualMachine) (err error) {
+	labels := object.ObjectMeta.Labels
+	if labels == nil {
+		object.ObjectMeta.Labels = map[string]string{}
+	}
+	if r.Plan.Provider.Source.RequiresConversion() {
+		labels["guestConverted"] = strconv.FormatBool(!r.Plan.Spec.SkipGuestConversion)
+	}
+	object.ObjectMeta.Labels = labels
 	return
 }
 

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -301,7 +301,7 @@ func (r *BasePredicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
 	case HasPostHook:
 		_, allowed = r.vm.FindHook(api.PhasePostHook)
 	case RequiresConversion:
-		allowed = r.context.Source.Provider.RequiresConversion()
+		allowed = r.context.Source.Provider.RequiresConversion() && !r.context.Plan.Spec.SkipGuestConversion
 	case CDIDiskCopy:
 		allowed = !useV2vForTransfer
 	case VirtV2vDiskCopy:


### PR DESCRIPTION
Issue: If there is a guest operating system which is not working with the virt-v2v the whole migration fails. This PR adds a way to work around this issue by skipping the guest conversion parts using the plan.spec.skipGuestConversion parameter. This parameter can true or false, defaults to false.

Fix: Skip the guest conversion, this causes a problem that we are right now using the Virtio buses on everything but if we do not install the drivers on the guest, the VM won't boot. I have defaulted to switch to the sata for disk and e1000e for networking.

Ref: [MTV-2315](https://issues.redhat.com/browse/MTV-2315)