### PR TITLE
xcopy-populator: Improved logging in vmkfstools-wrapper.sh

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/Makefile
@@ -38,11 +38,11 @@ build: generate fmt vet ## Build manager binary.
 test-copy-using-cli: build
 	bin/vsphere-xcopy-volume-populator \
 		--source-vmdk="[eco-iscsi-ds2] vm-1/vm-1.vmdk" \
-		--target-pvc=test-cli \
+		--owner-uid=test-cli \
+		--owner-name=test-cli \
 		--target-namespace=default \
 		--storage-vendor=ontap \
 		--secret-name=populator-secret \
-		--owner-uid=test-cli \
 		--kubeconfig=$$KUBECONFIG
 
 test-copy-using-cli-3par: build

--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
@@ -103,6 +103,7 @@ func (p *RemoteEsxcliPopulator) Populate(sourceVMDKFile string, volumeHandle str
 
 	retries := 5
 	for i := 1; i < retries; i++ {
+		klog.Infof("retry %d/%d to find the device %s", i, retries, esxNaa)
 		_, err = p.VSphereClient.RunEsxCommand(context.Background(), host, []string{"storage", "core", "device", "list", "-d", esxNaa})
 		if err == nil {
 			klog.Infof("found device %s", esxNaa)
@@ -110,12 +111,12 @@ func (p *RemoteEsxcliPopulator) Populate(sourceVMDKFile string, volumeHandle str
 		} else {
 			_, err = p.VSphereClient.RunEsxCommand(context.Background(), host, []string{"storage", "core", "adapter", "rescan", "-t", "add", "-a", "1"})
 			if err != nil {
-				klog.Errorf("failed to rescan for adapters, atepmt %d/%d due to: %s", i, retries, err)
-				i, err := rand.Int(rand.Reader, big.NewInt(10))
+				klog.Errorf("failed to rescan for adapters, attempt %d/%d due to: %s", i, retries, err)
+				r, err := rand.Int(rand.Reader, big.NewInt(10))
 				if err != nil {
 					return fmt.Errorf("failed to randomize a sleep interval: %w", err)
 				}
-				time.Sleep(time.Duration(i.Int64()) * time.Second)
+				time.Sleep(time.Duration(r.Int64()) * time.Second)
 			}
 		}
 	}
@@ -138,7 +139,7 @@ func (p *RemoteEsxcliPopulator) Populate(sourceVMDKFile string, volumeHandle str
 	}
 
 	response := ""
-	klog.Info("respose from esxcli ", r)
+	klog.Info("response from esxcli ", r)
 	for _, l := range r {
 		response += l.Value("message")
 	}

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/create-vib.sh
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/create-vib.sh
@@ -7,7 +7,7 @@ pushd "$SCRIPT_DIR"
 
 CUSTOM_VIB_TEMP_DIR=/tmp/vib-temp-rgo
 CUSTOM_VIB_NAME=vmkfstools-wrapper
-CUSTOM_VIB_VERSION="0.0.49"
+CUSTOM_VIB_VERSION="0.0.52"
 CUSTOM_VIB_VENDOR="REDHAT"
 CUSTOM_VIB_VENDOR_URL="https://redhat.com"
 CUSTOM_VIB_SUMMARY="Custom VIB to wrap vmkfstools as esxcli plugin"

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vib-install-playbook.yaml
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vib-install-playbook.yaml
@@ -24,6 +24,13 @@
         src="{{ src_location }}{{ src_vib }}"
         dest="{{ dest_location }}{{src_vib}}"
 
+    - name: Wait for hostd status to be 'hostd is running' and exit code 0
+      command: /etc/init.d/hostd status
+      register: hostd_status_result
+      until: hostd_status_result.stdout is search('hostd is running') and hostd_status_result.rc == 0
+      retries: 5
+      delay: 10
+
     - name: Search for existing VIB installation
       shell: esxcli software vib list | grep vmkfstools-wrapper 
       register: vibs
@@ -41,6 +48,13 @@
     - name: restart /etc/init.d/hosts restart
       shell: /etc/init.d/hostd restart
 
+    - name: Wait for hostd status to be 'hostd is running' and exit code 0
+      command: /etc/init.d/hostd status
+      register: hostd_status_result
+      until: hostd_status_result.stdout is search('hostd is running') and hostd_status_result.rc == 0
+      retries: 5
+      delay: 10
+
     - name: Confirm VIB is installed
       shell: esxcli software vib list | grep vmkfstools-wrapper
       register: vibs
@@ -48,5 +62,4 @@
       ignore_errors: yes
 
     - debug: var=vibs.stdout
-
 


### PR DESCRIPTION
The log on the ESXi under /var/log/vmkfstools-wrapper.log will now like
this:

2025-04-24T16:06:58+0000 [2109325] INFO: cleaning the resulting rdm file /vmfs/volumes/{REDACTED}
2025-04-24T16:06:58+0000 [2109325] INFO: check the file /vmfs/volumes/{REDACTED}
2025-04-24T16:06:58+0000 [2109325] INFO: find: /vmfs/volumes/{REDACTED} No such file or directory

ECOPROJECT-2836

Signed-off-by: Roy Golan <rgolan@redhat.com>
