### PR TITLE
MTV-2421 | Skip deletion for non vddk jobs

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1165,6 +1165,9 @@ func (r *Reconciler) cancelOtherActiveVddkCheckJobs(plan *api.Plan) (err error) 
 	}
 
 	for _, job := range jobs.Items {
+		if _, found := job.Labels["vddk"]; !found {
+			continue
+		}
 		if job.Status.Active > 0 && job.Labels["vddk"] != jobLabels["vddk"] {
 			r.Log.Info("Another validation job is active for this plan. Stopping...", "job", job)
 			// make sure to delete the pod associated with this job so that it doesn't


### PR DESCRIPTION
Issue: All hook jobs gets deleted beofre they finish and recreated. In the logs I noticed lot of logs deleting the hook jobs with log:
```
Another validation job is active for this plan. Stopping...
```

Fix: This issue is caused by vddk job deletor, we check all jobs related to the migration plan and compare the vddk image hashes. If they are not equal we delete the old job. Beucase the hook jobs are missing the vddk label there is a difference as we compare the empty string to the vddk hash. So the deletor deletes the hook job.

Ref: https://issues.redhat.com/browse/MTV-2421