### PR TITLE
xcopy-populaotr: allow the populator SA fetch PVs

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/Makefile
@@ -38,7 +38,7 @@ build: generate fmt vet ## Build manager binary.
 test-copy-using-cli: build
 	bin/vsphere-xcopy-volume-populator \
 		--source-vmdk="[eco-iscsi-ds2] vm-1/vm-1.vmdk" \
-		--target-pvc=test-cli \
+		--owner-name=test-cli \
 		--target-namespace=default \
 		--storage-vendor=ontap \
 		--secret-name=populator-secret \

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -157,5 +157,7 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterroles
+  - clusterrolebindings
   verbs:
   - create


### PR DESCRIPTION
The populator needs to use the PV spec.CSI.volumeHandle because some
storage vendors need that to identify the LUN and fetch its details. The
PVC name or volumeName is not acceptable.
The volumeHadle is by the CSI spec the identifier in the storage system
so it is expected every provider can use that to uniquely identify
that LUN

Signed-off-by: Roy Golan <rgolan@redhat.com>
