### PR TITLE
Move externally-facing constants to API package

### DIFF
--- a/pkg/apis/forklift/v1beta1/doc.go
+++ b/pkg/apis/forklift/v1beta1/doc.go
@@ -22,5 +22,81 @@ limitations under the License.
 // +groupName=forklift.konveyor.io
 package v1beta1
 
+import libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
+
 // GlanceSource represents an image of which the source is Glance, to be used in storage mapping
 const GlanceSource = "glance"
+
+// Conditions
+const (
+	ConditionExecuting = "Executing"
+	ConditionRunning   = "Running"
+	ConditionPending   = "Pending"
+	ConditionCanceled  = "Canceled"
+	ConditionSucceeded = "Succeeded"
+	ConditionFailed    = "Failed"
+	ConditionBlocked   = "Blocked"
+	ConditionDeleted   = "Deleted"
+)
+
+// Condition categories
+const (
+	CategoryRequired = libcnd.Required
+	CategoryAdvisory = libcnd.Advisory
+	CategoryCritical = libcnd.Critical
+	CategoryError    = libcnd.Error
+	CategoryWarn     = libcnd.Warn
+)
+
+// VM Phases:
+//
+// Common phases.
+const (
+	PhaseStarted   = "Started"
+	PhasePreHook   = "PreHook"
+	PhasePostHook  = "PostHook"
+	PhaseCompleted = "Completed"
+)
+
+// Warm and cold phases.
+const (
+	PhaseAddCheckpoint                     = "AddCheckpoint"
+	PhaseAddFinalCheckpoint                = "AddFinalCheckpoint"
+	PhaseAllocateDisks                     = "AllocateDisks"
+	PhaseConvertGuest                      = "ConvertGuest"
+	PhaseConvertOpenstackSnapshot          = "ConvertOpenstackSnapshot"
+	PhaseCopyDisks                         = "CopyDisks"
+	PhaseCopyDisksVirtV2V                  = "CopyDisksVirtV2V"
+	PhaseCopyingPaused                     = "CopyingPaused"
+	PhaseCreateDataVolumes                 = "CreateDataVolumes"
+	PhaseCreateFinalSnapshot               = "CreateFinalSnapshot"
+	PhaseCreateGuestConversionPod          = "CreateGuestConversionPod"
+	PhaseCreateInitialSnapshot             = "CreateInitialSnapshot"
+	PhaseCreateSnapshot                    = "CreateSnapshot"
+	PhaseCreateVM                          = "CreateVM"
+	PhaseFinalize                          = "Finalize"
+	PhasePowerOffSource                    = "PowerOffSource"
+	PhaseRemoveFinalSnapshot               = "RemoveFinalSnapshot"
+	PhaseRemovePenultimateSnapshot         = "RemovePenultimateSnapshot"
+	PhaseRemovePreviousSnapshot            = "RemovePreviousSnapshot"
+	PhaseStoreInitialSnapshotDeltas        = "StoreInitialSnapshotDeltas"
+	PhaseStorePowerState                   = "StorePowerState"
+	PhaseStoreSnapshotDeltas               = "StoreSnapshotDeltas"
+	PhaseWaitForDataVolumesStatus          = "WaitForDataVolumesStatus"
+	PhaseWaitForFinalDataVolumesStatus     = "WaitForFinalDataVolumesStatus"
+	PhaseWaitForFinalSnapshot              = "WaitForFinalSnapshot"
+	PhaseWaitForFinalSnapshotRemoval       = "WaitForFinalSnapshotRemoval"
+	PhaseWaitForInitialSnapshot            = "WaitForInitialSnapshot"
+	PhaseWaitForPenultimateSnapshotRemoval = "WaitForPenultimateSnapshotRemoval"
+	PhaseWaitForPowerOff                   = "WaitForPowerOff"
+	PhaseWaitForPreviousSnapshotRemoval    = "WaitForPreviousSnapshotRemoval"
+	PhaseWaitForSnapshot                   = "WaitForSnapshot"
+)
+
+// Step/task phases.
+const (
+	StepStarted   = "Started"
+	StepPending   = "Pending"
+	StepRunning   = "Running"
+	StepCompleted = "Completed"
+)

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -229,7 +229,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		plan.Status.SetCondition(libcnd.Condition{
 			Type:     libcnd.Ready,
 			Status:   True,
-			Category: Required,
+			Category: api.CategoryRequired,
 			Message:  "The migration plan is ready.",
 		})
 	}
@@ -308,7 +308,7 @@ func (r *Reconciler) archive(plan *api.Plan) {
 		libcnd.Condition{
 			Type:     Archived,
 			Status:   True,
-			Category: Advisory,
+			Category: api.CategoryAdvisory,
 			Reason:   UserRequested,
 			Message:  "The migration plan has been archived.",
 		})
@@ -378,7 +378,7 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 					libcnd.Condition{
 						Type:     Canceled,
 						Status:   True,
-						Category: Advisory,
+						Category: api.CategoryAdvisory,
 						Reason:   Modified,
 						Message:  "The migration has been canceled.",
 						Durable:  true,
@@ -500,7 +500,7 @@ func (r *Reconciler) matchSnapshot(ctx *plancontext.Context) (matched bool) {
 				libcnd.Condition{
 					Type:     Canceled,
 					Status:   True,
-					Category: Advisory,
+					Category: api.CategoryAdvisory,
 					Reason:   Modified,
 					Message:  "The migration has been canceled.",
 					Durable:  true,
@@ -548,7 +548,7 @@ func (r *Reconciler) activeMigration(plan *api.Plan) (migration *api.Migration, 
 	deleted := libcnd.Condition{
 		Type:     Canceled,
 		Status:   True,
-		Category: Advisory,
+		Category: api.CategoryAdvisory,
 		Reason:   Deleted,
 		Message:  "The migration has been deleted.",
 		Durable:  true,

--- a/pkg/controller/plan/migrator/base/doc.go
+++ b/pkg/controller/plan/migrator/base/doc.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	libitr "github.com/konveyor/forklift-controller/pkg/lib/itinerary"
 )
@@ -14,45 +15,6 @@ var (
 	VirtV2vDiskCopy         libitr.Flag = 0x10
 	OpenstackImageMigration libitr.Flag = 0x20
 	VSphere                 libitr.Flag = 0x40
-)
-
-// Phases.
-const (
-	Started                           = "Started"
-	PreHook                           = "PreHook"
-	StorePowerState                   = "StorePowerState"
-	PowerOffSource                    = "PowerOffSource"
-	WaitForPowerOff                   = "WaitForPowerOff"
-	CreateDataVolumes                 = "CreateDataVolumes"
-	WaitForDataVolumesStatus          = "WaitForDataVolumesStatus"
-	WaitForFinalDataVolumesStatus     = "WaitForFinalDataVolumesStatus"
-	CreateVM                          = "CreateVM"
-	CopyDisks                         = "CopyDisks"
-	AllocateDisks                     = "AllocateDisks"
-	CopyingPaused                     = "CopyingPaused"
-	AddCheckpoint                     = "AddCheckpoint"
-	AddFinalCheckpoint                = "AddFinalCheckpoint"
-	CreateSnapshot                    = "CreateSnapshot"
-	CreateInitialSnapshot             = "CreateInitialSnapshot"
-	CreateFinalSnapshot               = "CreateFinalSnapshot"
-	Finalize                          = "Finalize"
-	CreateGuestConversionPod          = "CreateGuestConversionPod"
-	ConvertGuest                      = "ConvertGuest"
-	CopyDisksVirtV2V                  = "CopyDisksVirtV2V"
-	PostHook                          = "PostHook"
-	Completed                         = "Completed"
-	WaitForSnapshot                   = "WaitForSnapshot"
-	WaitForInitialSnapshot            = "WaitForInitialSnapshot"
-	WaitForFinalSnapshot              = "WaitForFinalSnapshot"
-	ConvertOpenstackSnapshot          = "ConvertOpenstackSnapshot"
-	StoreSnapshotDeltas               = "StoreSnapshotDeltas"
-	StoreInitialSnapshotDeltas        = "StoreInitialSnapshotDeltas"
-	RemovePreviousSnapshot            = "RemovePreviousSnapshot"
-	RemovePenultimateSnapshot         = "RemovePenultimateSnapshot"
-	RemoveFinalSnapshot               = "RemoveFinalSnapshot"
-	WaitForFinalSnapshotRemoval       = "WaitForFinalSnapshotRemoval"
-	WaitForPreviousSnapshotRemoval    = "WaitForPreviousSnapshotRemoval"
-	WaitForPenultimateSnapshotRemoval = "WaitForPenultimateSnapshotRemoval"
 )
 
 // Steps.
@@ -71,60 +33,60 @@ var (
 	ColdItinerary = libitr.Itinerary{
 		Name: "",
 		Pipeline: libitr.Pipeline{
-			{Name: Started},
-			{Name: PreHook, All: HasPreHook},
-			{Name: StorePowerState},
-			{Name: PowerOffSource},
-			{Name: WaitForPowerOff},
-			{Name: CreateDataVolumes},
-			{Name: CopyDisks, All: CDIDiskCopy},
-			{Name: AllocateDisks, All: VirtV2vDiskCopy},
-			{Name: CreateGuestConversionPod, All: RequiresConversion},
-			{Name: ConvertGuest, All: RequiresConversion},
-			{Name: CopyDisksVirtV2V, All: RequiresConversion},
-			{Name: ConvertOpenstackSnapshot, All: OpenstackImageMigration},
-			{Name: CreateVM},
-			{Name: PostHook, All: HasPostHook},
-			{Name: Completed},
+			{Name: api.PhaseStarted},
+			{Name: api.PhasePreHook, All: HasPreHook},
+			{Name: api.PhaseStorePowerState},
+			{Name: api.PhasePowerOffSource},
+			{Name: api.PhaseWaitForPowerOff},
+			{Name: api.PhaseCreateDataVolumes},
+			{Name: api.PhaseCopyDisks, All: CDIDiskCopy},
+			{Name: api.PhaseAllocateDisks, All: VirtV2vDiskCopy},
+			{Name: api.PhaseCreateGuestConversionPod, All: RequiresConversion},
+			{Name: api.PhaseConvertGuest, All: RequiresConversion},
+			{Name: api.PhaseCopyDisksVirtV2V, All: RequiresConversion},
+			{Name: api.PhaseConvertOpenstackSnapshot, All: OpenstackImageMigration},
+			{Name: api.PhaseCreateVM},
+			{Name: api.PhasePostHook, All: HasPostHook},
+			{Name: api.PhaseCompleted},
 		},
 	}
 	WarmItinerary = libitr.Itinerary{
 		Name: "Warm",
 		Pipeline: libitr.Pipeline{
-			{Name: Started},
-			{Name: PreHook, All: HasPreHook},
-			{Name: CreateInitialSnapshot},
-			{Name: WaitForInitialSnapshot},
-			{Name: StoreInitialSnapshotDeltas, All: VSphere},
-			{Name: CreateDataVolumes},
+			{Name: api.PhaseStarted},
+			{Name: api.PhasePreHook, All: HasPreHook},
+			{Name: api.PhaseCreateInitialSnapshot},
+			{Name: api.PhaseWaitForInitialSnapshot},
+			{Name: api.PhaseStoreInitialSnapshotDeltas, All: VSphere},
+			{Name: api.PhaseCreateDataVolumes},
 			// Precopy loop start
-			{Name: WaitForDataVolumesStatus},
-			{Name: CopyDisks},
-			{Name: CopyingPaused},
-			{Name: RemovePreviousSnapshot, All: VSphere},
-			{Name: WaitForPreviousSnapshotRemoval, All: VSphere},
-			{Name: CreateSnapshot},
-			{Name: WaitForSnapshot},
-			{Name: StoreSnapshotDeltas, All: VSphere},
-			{Name: AddCheckpoint},
+			{Name: api.PhaseWaitForDataVolumesStatus},
+			{Name: api.PhaseCopyDisks},
+			{Name: api.PhaseCopyingPaused},
+			{Name: api.PhaseRemovePreviousSnapshot, All: VSphere},
+			{Name: api.PhaseWaitForPreviousSnapshotRemoval, All: VSphere},
+			{Name: api.PhaseCreateSnapshot},
+			{Name: api.PhaseWaitForSnapshot},
+			{Name: api.PhaseStoreSnapshotDeltas, All: VSphere},
+			{Name: api.PhaseAddCheckpoint},
 			// Precopy loop end
-			{Name: StorePowerState},
-			{Name: PowerOffSource},
-			{Name: WaitForPowerOff},
-			{Name: RemovePenultimateSnapshot, All: VSphere},
-			{Name: WaitForPenultimateSnapshotRemoval, All: VSphere},
-			{Name: CreateFinalSnapshot},
-			{Name: WaitForFinalSnapshot},
-			{Name: AddFinalCheckpoint},
-			{Name: WaitForFinalDataVolumesStatus},
-			{Name: Finalize},
-			{Name: RemoveFinalSnapshot, All: VSphere},
-			{Name: WaitForFinalSnapshotRemoval, All: VSphere},
-			{Name: CreateGuestConversionPod, All: RequiresConversion},
-			{Name: ConvertGuest, All: RequiresConversion},
-			{Name: CreateVM},
-			{Name: PostHook, All: HasPostHook},
-			{Name: Completed},
+			{Name: api.PhaseStorePowerState},
+			{Name: api.PhasePowerOffSource},
+			{Name: api.PhaseWaitForPowerOff},
+			{Name: api.PhaseRemovePenultimateSnapshot, All: VSphere},
+			{Name: api.PhaseWaitForPenultimateSnapshotRemoval, All: VSphere},
+			{Name: api.PhaseCreateFinalSnapshot},
+			{Name: api.PhaseWaitForFinalSnapshot},
+			{Name: api.PhaseAddFinalCheckpoint},
+			{Name: api.PhaseWaitForFinalDataVolumesStatus},
+			{Name: api.PhaseFinalize},
+			{Name: api.PhaseRemoveFinalSnapshot, All: VSphere},
+			{Name: api.PhaseWaitForFinalSnapshotRemoval, All: VSphere},
+			{Name: api.PhaseCreateGuestConversionPod, All: RequiresConversion},
+			{Name: api.PhaseConvertGuest, All: RequiresConversion},
+			{Name: api.PhaseCreateVM},
+			{Name: api.PhasePostHook, All: HasPostHook},
+			{Name: api.PhaseCompleted},
 		},
 	}
 )

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -69,9 +69,6 @@ const (
 	Canceled                      = "Canceled"
 	Deleted                       = "Deleted"
 	Paused                        = "Paused"
-	Pending                       = "Pending"
-	Running                       = "Running"
-	Blocked                       = "Blocked"
 	Archived                      = "Archived"
 	unsupportedVersion            = "UnsupportedVersion"
 	VDDKInvalid                   = "VDDKInvalid"
@@ -81,17 +78,9 @@ const (
 	NetMapOrder                   = "NetworkMapUnordered"
 )
 
-// Categories
-const (
-	Required = libcnd.Required
-	Advisory = libcnd.Advisory
-	Critical = libcnd.Critical
-	Error    = libcnd.Error
-	Warn     = libcnd.Warn
-)
-
 // Reasons
 const (
+	Started                     = "Started"
 	NotSet                      = "NotSet"
 	NotFound                    = "NotFound"
 	NotUnique                   = "NotUnique"
@@ -196,7 +185,7 @@ func (r *Reconciler) validatePVCNameTemplate(plan *api.Plan) error {
 		invalidPVCNameTemplate := libcnd.Condition{
 			Type:     NotValid,
 			Status:   True,
-			Category: Critical,
+			Category: api.CategoryCritical,
 			Message:  "PVC name template is invalid.",
 			Items:    []string{},
 		}
@@ -212,7 +201,7 @@ func (r *Reconciler) validateVolumeNameTemplate(plan *api.Plan) error {
 		invalidPVCNameTemplate := libcnd.Condition{
 			Type:     NotValid,
 			Status:   True,
-			Category: Critical,
+			Category: api.CategoryCritical,
 			Message:  "Volume name template is invalid.",
 			Items:    []string{},
 		}
@@ -228,7 +217,7 @@ func (r *Reconciler) validateNetworkNameTemplate(plan *api.Plan) error {
 		invalidPVCNameTemplate := libcnd.Condition{
 			Type:     NotValid,
 			Status:   True,
-			Category: Critical,
+			Category: api.CategoryCritical,
 			Message:  "Network name template is invalid.",
 			Items:    []string{},
 		}
@@ -255,7 +244,7 @@ func (r *Reconciler) validateOpenShiftVersion(plan *api.Plan) error {
 			Type:     unsupportedVersion,
 			Status:   True,
 			Reason:   NotSupported,
-			Category: Critical,
+			Category: api.CategoryCritical,
 			Message:  "Source version is not supported.",
 			Items:    []string{},
 		}
@@ -310,7 +299,7 @@ func (r *Reconciler) validateWarmMigration(plan *api.Plan) (err error) {
 		plan.Status.SetCondition(libcnd.Condition{
 			Type:     WarmMigrationNotReady,
 			Status:   True,
-			Category: Critical,
+			Category: api.CategoryCritical,
 			Reason:   NotSupported,
 			Message:  "Warm migration from the source provider is not supported.",
 		})
@@ -323,7 +312,7 @@ func (r *Reconciler) validateTargetNamespace(plan *api.Plan) (err error) {
 	newCnd := libcnd.Condition{
 		Type:     NamespaceNotValid,
 		Status:   True,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Target namespace is not valid.",
 	}
 	if plan.Spec.TargetNamespace == "" {
@@ -344,7 +333,7 @@ func (r *Reconciler) validateNetworkMap(plan *api.Plan) (err error) {
 	newCnd := libcnd.Condition{
 		Type:     NetRefNotValid,
 		Status:   True,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Map.Network is not valid.",
 	}
 	if !libref.RefSet(&ref) {
@@ -372,7 +361,7 @@ func (r *Reconciler) validateNetworkMap(plan *api.Plan) (err error) {
 		plan.Status.SetCondition(libcnd.Condition{
 			Type:     NetMapNotReady,
 			Status:   True,
-			Category: Critical,
+			Category: api.CategoryCritical,
 			Message:  "Map.Network does not have Ready condition.",
 		})
 	}
@@ -388,7 +377,7 @@ func (r *Reconciler) validateStorageMap(plan *api.Plan) (err error) {
 	newCnd := libcnd.Condition{
 		Type:     DsRefNotValid,
 		Status:   True,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Map.Storage is not valid.",
 	}
 	if !libref.RefSet(&ref) {
@@ -416,7 +405,7 @@ func (r *Reconciler) validateStorageMap(plan *api.Plan) (err error) {
 		plan.Status.SetCondition(libcnd.Condition{
 			Type:     DsMapNotReady,
 			Status:   True,
-			Category: Critical,
+			Category: api.CategoryCritical,
 			Message:  "Map.Storage does not have Ready condition.",
 		})
 	}
@@ -435,7 +424,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     VMNotFound,
 		Status:   True,
 		Reason:   NotFound,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VM not found.",
 		Items:    []string{},
 	}
@@ -443,7 +432,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     DuplicateVM,
 		Status:   True,
 		Reason:   NotUnique,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Duplicate (source) VM.",
 		Items:    []string{},
 	}
@@ -451,7 +440,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     DuplicateVM,
 		Status:   True,
 		Reason:   Ambiguous,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VM reference is ambiguous.",
 		Items:    []string{},
 	}
@@ -459,7 +448,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     NameNotValid,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Warn,
+		Category: api.CategoryWarn,
 		Message:  "Target VM name does not comply with DNS1123 RFC, will be automatically changed.",
 		Items:    []string{},
 	}
@@ -467,7 +456,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     VMAlreadyExists,
 		Status:   True,
 		Reason:   NotUnique,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Target VM already exists.",
 		Items:    []string{},
 	}
@@ -475,7 +464,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     VMNetworksNotMapped,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VM has unmapped networks.",
 		Items:    []string{},
 	}
@@ -483,7 +472,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     VMStorageNotMapped,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VM has unmapped storage.",
 		Items:    []string{},
 	}
@@ -491,7 +480,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     VMStorageNotSupported,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VM has unsupported storage. Migration of Direct LUN/FC from oVirt is supported as from version 4.5.2.1",
 		Items:    []string{},
 	}
@@ -499,7 +488,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     HostNotReady,
 		Status:   True,
 		Reason:   InMaintenanceMode,
-		Category: Warn,
+		Category: api.CategoryWarn,
 		Message:  "VM host is in maintenance mode.",
 		Items:    []string{},
 	}
@@ -507,7 +496,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     VMMultiplePodNetworkMappings,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VM has more than one interface mapped to the pod network.",
 		Items:    []string{},
 	}
@@ -515,7 +504,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     VMMissingGuestIPs,
 		Status:   True,
 		Reason:   MissingGuestInfo,
-		Category: Warn,
+		Category: api.CategoryWarn,
 		Message:  "Guest information on vNICs is missing, cannot preserve static IPs. If this machine has static IP, make sure VMware tools are installed and the VM is running.",
 		Items:    []string{},
 	}
@@ -523,35 +512,35 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     VMMissingChangedBlockTracking,
 		Status:   True,
 		Reason:   MissingChangedBlockTracking,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Changed Block Tracking (CBT) has not been enabled on some VM. This feature is a prerequisite for VM warm migration.",
 		Items:    []string{},
 	}
 	pvcNameInvalid := libcnd.Condition{
 		Type:     NotValid,
 		Status:   True,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VM PVC name template is invalid.",
 		Items:    []string{},
 	}
 	volumeNameInvalid := libcnd.Condition{
 		Type:     NotValid,
 		Status:   True,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VM volume name template is invalid.",
 		Items:    []string{},
 	}
 	networkNameInvalid := libcnd.Condition{
 		Type:     NotValid,
 		Status:   True,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VM network name template is invalid.",
 		Items:    []string{},
 	}
 	targetNameInvalid := libcnd.Condition{
 		Type:     NotValid,
 		Status:   True,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "TargetName is invalid.",
 		Items:    []string{},
 	}
@@ -559,7 +548,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     DuplicateVM,
 		Status:   True,
 		Reason:   NotUnique,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Duplicate targetName.",
 		Items:    []string{},
 	}
@@ -569,7 +558,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     NetMapOrder,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Warn,
+		Category: api.CategoryWarn,
 		Message:  "VM network mapping is unordered, this can cause the interface names to be different after migration.",
 		Items:    []string{},
 	}
@@ -577,7 +566,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     NetMapOrder,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Warn,
+		Category: api.CategoryWarn,
 		Message:  "VM nics number per plan's network number are unequal, names might not be preserved.",
 		Items:    []string{},
 	}
@@ -594,7 +583,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 				Type:     VMRefNotValid,
 				Status:   True,
 				Reason:   NotSet,
-				Category: Critical,
+				Category: api.CategoryCritical,
 				Message:  "Either `ID` or `Name` required.",
 			})
 			continue
@@ -876,14 +865,14 @@ func (r *Reconciler) validateTransferNetwork(plan *api.Plan) (err error) {
 	notFound := libcnd.Condition{
 		Type:     TransferNetNotValid,
 		Status:   True,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Reason:   NotFound,
 		Message:  "Transfer network is not valid.",
 	}
 	notValid := libcnd.Condition{
 		Type:     TransferNetNotValid,
 		Status:   True,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Reason:   NotValid,
 		Message:  "Transfer network default route annotation is not a valid IP address.",
 	}
@@ -920,7 +909,7 @@ func (r *Reconciler) validateHooks(plan *api.Plan) (err error) {
 		Type:     HookNotValid,
 		Status:   True,
 		Reason:   NotSet,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Hook specified by: `namespace` and `name`.",
 		Items:    []string{},
 	}
@@ -928,7 +917,7 @@ func (r *Reconciler) validateHooks(plan *api.Plan) (err error) {
 		Type:     HookNotValid,
 		Status:   True,
 		Reason:   NotFound,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Hook not found.",
 		Items:    []string{},
 	}
@@ -936,7 +925,7 @@ func (r *Reconciler) validateHooks(plan *api.Plan) (err error) {
 		Type:     HookNotReady,
 		Status:   True,
 		Reason:   NotFound,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Hook does not have `Ready` condition.",
 		Items:    []string{},
 	}
@@ -944,14 +933,14 @@ func (r *Reconciler) validateHooks(plan *api.Plan) (err error) {
 		Type:     HookStepNotValid,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "Hook step not valid.",
 		Items:    []string{},
 	}
 	for _, vm := range plan.Spec.VMs {
 		for _, ref := range vm.Hooks {
 			// Step not valid.
-			if _, found := map[string]int{PreHook: 1, PostHook: 1}[ref.Step]; !found {
+			if _, found := map[string]int{api.PhasePreHook: 1, api.PhasePostHook: 1}[ref.Step]; !found {
 				description := fmt.Sprintf(
 					"VM: %s step: %s",
 					vm.String(),
@@ -1058,14 +1047,14 @@ func (r *Reconciler) validateVddkImageJob(job *batchv1.Job, plan *api.Plan) (err
 		Type:     VDDKInvalid,
 		Status:   True,
 		Reason:   NotSet,
-		Category: Critical,
+		Category: api.CategoryCritical,
 		Message:  "VDDK init image is invalid",
 	}
 	vddkValidationInProgress := libcnd.Condition{
 		Type:     ValidatingVDDK,
 		Status:   True,
 		Reason:   Started,
-		Category: Advisory,
+		Category: api.CategoryAdvisory,
 		Message:  "Validating VDDK init image",
 	}
 
@@ -1102,7 +1091,7 @@ func (r *Reconciler) validateVddkImageJob(job *batchv1.Job, plan *api.Plan) (err
 					Type:     VDDKInitImageUnavailable,
 					Status:   True,
 					Reason:   waiting.Reason,
-					Category: Critical,
+					Category: api.CategoryCritical,
 					Message:  "Unable to Pull VDDK init image. Check that the image URL is correct.",
 				})
 			} else {
@@ -1110,7 +1099,7 @@ func (r *Reconciler) validateVddkImageJob(job *batchv1.Job, plan *api.Plan) (err
 					Type:     VDDKInitImageNotReady,
 					Status:   True,
 					Reason:   waiting.Reason,
-					Category: Advisory,
+					Category: api.CategoryAdvisory,
 					Message:  waiting.Message,
 				})
 			}


### PR DESCRIPTION
Goals:
- Reduce duplication by defining constants in a single place that can be imported elsewhere without import cycles.
- Expose constants that make up part of Forklift's API envelope (plan statuses, conditions) in the `api` package.

This could possibly be taken further, but this is a starting point for consideration. Importing from the `api` package and the new names do make the constants slightly harder to read while skimming code, but it avoids error-prone redefinition in multiple packages, and it prevents some confusing situations that currently exist where a vague constant like `Running` is defined in one package for a particular use and imported elsewhere for a conceptually unrelated purpose.