### PR TITLE
Add populator_vsphere_xcopy_volume_image_fqin to the operator

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -110,6 +110,7 @@ populator_ovirt_image_fqin: "{{ lookup( 'env', 'OVIRT_POPULATOR_IMAGE') or looku
 populator_controller_deployment_name: "{{ app_name }}-volume-populator-controller"
 populator_controller_container_name: "{{ app_name }}-populator-controller"
 populator_openstack_image_fqin: "{{ lookup( 'env', 'OPENSTACK_POPULATOR_IMAGE') or lookup( 'env', 'RELATED_IMAGE_OPENSTACK_POPULATOR') }}"
+populator_vsphere_xcopy_volume_image_fqin: "{{ lookup( 'env', 'VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VSPHERE_XCOPY_VOLUME_POPULATOR') }}"
 
 must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_MUST_GATHER') }}"
 

--- a/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
@@ -28,6 +28,10 @@ spec:
             value: {{ populator_ovirt_image_fqin }}
           - name: OPENSTACK_POPULATOR_IMAGE
             value: {{ populator_openstack_image_fqin }}
+{% if feature_copy_offload|bool %}
+          - name: VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE
+            value: {{ populator_vsphere_xcopy_volume_image_fqin }}
+{% endif %}
           ports:
             - containerPort: 8080
               name: http-endpoint


### PR DESCRIPTION
Issues:
1. The xcopy volume populator is missing on the populator-controller
2. When user wants to customize the volume populator

Fix:
Add new argument to the operator `populator_vsphere_xcopy_volume_image_fqin` and pass it to the populator controller as `VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE` env.