### PR TITLE
MTV-2446 | OCP to OCP migration fail due to MAC address preserve

### DIFF
--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -482,7 +482,7 @@ func (r *Builder) mapNetworks(sourceVm *cnv.VirtualMachine, targetVmSpec *cnv.Vi
 		kInterface = interfacesMap[network.Name]
 		kInterface.Name = network.Name
 		kInterface.MacAddress = ""
-		
+
 		switch {
 		case network.Multus != nil:
 			name, namespace := ocpclient.GetNetworkNameAndNamespace(network.Multus.NetworkName, &ref.Ref{Name: sourceVm.Name, Namespace: sourceVm.Namespace})


### PR DESCRIPTION
Cold Migrating from ocp to ocp in different namespace failed due to collisions mac address

failure:
admission webhook "mutatevirtualmachines.kubemacpool.io" denied the request: Failed to create virtual machine allocation error: Failed to allocate mac to the vm object: failed to allocate requested mac address 

Before:
![image](https://github.com/user-attachments/assets/ff6c145f-420f-4c36-bca0-60ad6d291459)
![image](https://github.com/user-attachments/assets/420f3d72-31c4-4137-9193-2b0aeade803b)

After
![image](https://github.com/user-attachments/assets/3e74df86-2e83-4e05-bf06-d31efff7e9ee)
![image](https://github.com/user-attachments/assets/632646df-6b1c-4afb-afbe-b1eb157e7644)
