### PR TITLE
Add windows drivers for older versions in konflux

### DIFF
--- a/.konflux/virt-v2v/appliance/redhat.repo
+++ b/.konflux/virt-v2v/appliance/redhat.repo
@@ -1,0 +1,9194 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-debug-rpms]
+name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhbop-textonly-1-for-middleware-rpms]
+name = Red Hat Build of OptaPlanner Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.11-rpms]
+name = Red Hat Container Development Kit 3.11 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.10-rpms]
+name = Red Hat Container Development Kit 3.10 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-debug-rpms]
+name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.7-rpms]
+name = Red Hat Container Development Kit 3.7 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhsi-textonly-1-for-middleware-rpms]
+name = Red Hat Service Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-rpms]
+name = Red Hat Container Development Kit 2.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-debug-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-textonly-1-for-middleware-rpms]
+name = OpenJDK Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhose-textonly-1-for-middleware-rpms]
+name = Red Hat Middleware Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 5 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.15-rpms]
+name = Red Hat Container Development Kit 3.15 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-debug-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[wfk-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Framework Kit Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fsw-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Fuse Service Works Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.9-rpms]
+name = Red Hat Container Development Kit 3.9 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[rhel-9-for-$basearch-baseos-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-debug-rpms]
+name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-source-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosds-textonly-3-for-middleware-rpms]
+name = Red Hat OpenShift Dev Spaces 3 Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.8-rpms]
+name = Red Hat Container Development Kit 3.8 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-source-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss AMQ Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[codeready-builder-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-textonly-1-for-middleware-rpms]
+name = Red Hat build of Quarkus Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Server Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-source-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rpms]
+name = Single Sign-On Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[nbde-tang-server-1-for-rhel-9-$basearch-textonly-rpms]
+name = nbde tang server 1 (for RHEL 9 $basearch) (Text-Only Advisories)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/nbde-tang-server-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-source-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-debug-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-debug-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-source-rpms]
+name = Red Hat Container Development Kit 3.5 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-debug-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jpp-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Portal Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jon-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Operations Network Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openliberty-textonly-1-for-middleware-rpms]
+name = Open Liberty Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-rpms]
+name = Red Hat Container Development Kit 3.6 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.13-rpms]
+name = Red Hat Container Development Kit 3.13 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.17-rpms]
+name = Red Hat Container Development Kit 3.17 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-rpms]
+name = Red Hat Container Development Kit 3.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-source-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-rpms]
+name = Red Hat Container Development Kit 3.4 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-debug-rpms]
+name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-for-rhel-9-textonly-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm-textonly/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-source-rpms]
+name = Red Hat Container Development Kit 3.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-textonly-1-for-middleware-rpms]
+name = Red Hat AMQ Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-rpms]
+name = Fast Datapath for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jdv-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Virtualization Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-debug-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-source-rpms]
+name = Red Hat Container Development Kit 2.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 6 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rhui-rpms]
+name = Single Sign-On Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-source-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-source-rpms]
+name = Red Hat Container Development Kit 3.6 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.16-rpms]
+name = Red Hat Container Development Kit 3.16 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-debug-rpms]
+name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[soa-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss SOA Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-source-rpms]
+name = Red Hat Container Development Kit 3.4 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.12-rpms]
+name = Red Hat Container Development Kit 3.12 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Grid Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-rpms]
+name = Red Hat Container Development Kit 3.5 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.14-rpms]
+name = Red Hat Container Development Kit 3.14 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/7354635794023833100-key.pem
+sslclientcert = /etc/pki/entitlement/7354635794023833100.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0

--- a/.konflux/virt-v2v/appliance/rpms.in.yaml
+++ b/.konflux/virt-v2v/appliance/rpms.in.yaml
@@ -1,0 +1,13 @@
+packages:
+  - qemu-img
+  - libguestfs-devel
+  - libguestfs-winsupport
+  - libguestfs-xfs
+contentOrigin:
+  repofiles:
+    - ./redhat.repo
+context:
+  containerfile:
+    file: ../../../build/virt-v2v/Containerfile-downstream
+    stageName: appliance
+arches: [x86_64]

--- a/.konflux/virt-v2v/appliance/rpms.lock.yaml
+++ b/.konflux/virt-v2v/appliance/rpms.lock.yaml
@@ -1,0 +1,2063 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/augeas-libs-1.14.1-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 438164
+    checksum: sha256:0d15455953c386b5b7bc7b3368e9f2af5dd9b220ecf7b5526fe90b812703698c
+    name: augeas-libs
+    evr: 1.14.1-2.el9
+    sourcerpm: augeas-1.14.1-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/capstone-4.0.2-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 788501
+    checksum: sha256:494e45c1214b9210a44418228ee580d1838f211597e473a7f2d4b17331a27055
+    name: capstone
+    evr: 4.0.2-10.el9
+    sourcerpm: capstone-4.0.2-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 365931
+    checksum: sha256:3d12bc7e21276434108c97561f75d1854283afb73d4fface3b836acee09f8d98
+    name: checkpolicy
+    evr: 3.6-1.el9
+    sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/clevis-21-208.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 62508
+    checksum: sha256:beb835c39f8085d61aec31f655cc1a42ce76a070509f705cd034e5028ce55857
+    name: clevis
+    evr: 21-208.el9
+    sourcerpm: clevis-21-208.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/clevis-luks-21-208.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 40033
+    checksum: sha256:48e5a71a245ef9b0c0045dc48a3d02b6832625b73f961a8208848c1dd9e93ec1
+    name: clevis-luks
+    evr: 21-208.el9
+    sourcerpm: clevis-21-208.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/d/dnsmasq-2.85-16.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 339509
+    checksum: sha256:994cfdb204a4f815c58535034d409f0f5e8735e5faac9f832187d4f8a3efc839
+    name: dnsmasq
+    evr: 2.85-16.el9_4
+    sourcerpm: dnsmasq-2.85-16.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/e/edk2-ovmf-20241117-2.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 6398963
+    checksum: sha256:6fd9a777974da9b838842ab53d2bec9971e926c777bc6c7f5db81011790b78d7
+    name: edk2-ovmf
+    evr: 20241117-2.el9
+    sourcerpm: edk2-20241117-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/gdisk-1.0.7-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 253973
+    checksum: sha256:eb8973df11266ce57f1db004883df3f14690c17646992c2d977f81cd6ba560f7
+    name: gdisk
+    evr: 1.0.7-5.el9
+    sourcerpm: gdisk-1.0.7-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/geolite2-city-20191217-6.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 23756501
+    checksum: sha256:5cc6df7774a9bcc7db6e48f610b779db2f1848ee7af81a75fb53725f9ee58117
+    name: geolite2-city
+    evr: 20191217-6.el9
+    sourcerpm: geolite2-20191217-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/geolite2-country-20191217-6.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1687130
+    checksum: sha256:d075919b3ea033169ae1b24ba9d5819c912f378385da4e52d4fb724d04a29de6
+    name: geolite2-country
+    evr: 20191217-6.el9
+    sourcerpm: geolite2-20191217-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/gnutls-dane-3.8.3-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 21005
+    checksum: sha256:313eebc173895910227e2fe1fe5a6ec388df9f88b276546a2e6a8f1fe149fbba
+    name: gnutls-dane
+    evr: 3.8.3-6.el9
+    sourcerpm: gnutls-3.8.3-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/gnutls-utils-3.8.3-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 299745
+    checksum: sha256:f023263ed30906562c5c6799da8bd39dc728d4ea665ee9766df52ace8a9e2af6
+    name: gnutls-utils
+    evr: 3.8.3-6.el9
+    sourcerpm: gnutls-3.8.3-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/h/hexedit-1.6-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 46084
+    checksum: sha256:41183708d72ca26e340f9549ca0747f2e7ed50b738110efd6243811d739ee11d
+    name: hexedit
+    evr: 1.6-1.el9
+    sourcerpm: hexedit-1.6-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/h/hivex-libs-1.3.24-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 44960
+    checksum: sha256:1a3170accb28ab7435c97df38036350077b56601710aa1010eb231431b38d5ee
+    name: hivex-libs
+    evr: 1.3.24-1.el9
+    sourcerpm: hivex-1.3.24-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/i/ipxe-roms-qemu-20200823-9.git4bd064de.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 696047
+    checksum: sha256:9309fd2b2c1ade294cda0baa5c2de03b8ad478c923ee65ef4e02b2b55fa8ee89
+    name: ipxe-roms-qemu
+    evr: 20200823-9.git4bd064de.el9_0
+    sourcerpm: ipxe-20200823-9.git4bd064de.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/j/jose-14-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 73995
+    checksum: sha256:e99a5d567d44735a16b936ddef74d090b626f5b63cc6759361e9a000943b1f94
+    name: jose
+    evr: 14-1.el9
+    sourcerpm: jose-14-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libfdt-1.6.0-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 36905
+    checksum: sha256:4964932c9994906fdec1208f102178622d60754d06f886e372f02fb4d6da5374
+    name: libfdt
+    evr: 1.6.0-7.el9
+    sourcerpm: dtc-1.6.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libguestfs-1.54.0-8.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1205626
+    checksum: sha256:8d49f080cba0466483f010673f5aeff5ce53ddc467ce6d74df2a7682b1430b6e
+    name: libguestfs
+    evr: 1:1.54.0-8.el9_6
+    sourcerpm: libguestfs-1.54.0-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libguestfs-appliance-1.54.0-8.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2281158
+    checksum: sha256:c4f5e20a1a57c23d93c1ae0bcfd612b750f79ccc5b737578e6c55e12dfbfa118
+    name: libguestfs-appliance
+    evr: 1:1.54.0-8.el9_6
+    sourcerpm: libguestfs-1.54.0-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libguestfs-winsupport-9.3-1.el9_3.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2517670
+    checksum: sha256:80c2c919631a7b4640f45537c968d46312895a317d24e73ec2ea8073358a1a57
+    name: libguestfs-winsupport
+    evr: 9.3-1.el9_3
+    sourcerpm: libguestfs-winsupport-9.3-1.el9_3.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libguestfs-xfs-1.54.0-8.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 10287
+    checksum: sha256:f27288cafdad3f09a252d15b56fa12979c79039844c600cf686dddf5884a0171
+    name: libguestfs-xfs
+    evr: 1:1.54.0-8.el9_6
+    sourcerpm: libguestfs-1.54.0-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libjose-14-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 67231
+    checksum: sha256:a78d32b8e7f9782e4d3d8740a31d3b2ad10a1b75f506368d8625592f20919fbe
+    name: libjose
+    evr: 14-1.el9
+    sourcerpm: jose-14-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libluksmeta-9-12.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 28058
+    checksum: sha256:088cacedbce4a2476cf6e527da0dfbc48ffb0a75eebb5566f9dc7df4833e5a62
+    name: libluksmeta
+    evr: 9-12.el9
+    sourcerpm: luksmeta-9-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 36179
+    checksum: sha256:70a1e33b55a32d85ea4508e9ebeefb3e0ce2f57619ee84c97c63af5dc1456342
+    name: libmaxminddb
+    evr: 1.5.2-4.el9
+    sourcerpm: libmaxminddb-1.5.2-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libnbd-1.20.3-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 178646
+    checksum: sha256:c8622abd5520130af5ca67270d8676970ac466ade75032c791bf0a26ce7595b9
+    name: libnbd
+    evr: 1.20.3-1.el9
+    sourcerpm: libnbd-1.20.3-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libpmem-1.12.1-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 117415
+    checksum: sha256:a397978ab7744ed3c3795fc471d047b8fba6a5b8af82d7f5e9bc034e2906b0f8
+    name: libpmem
+    evr: 1.12.1-1.el9
+    sourcerpm: nvml-1.12.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 71992
+    checksum: sha256:9bd269ec50504f997683e963481f870bb937c3cfdb54a057e9acca67bf2b7631
+    name: libslirp
+    evr: 4.4.0-8.el9
+    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libtpms-0.9.1-4.20211126git1ff6fe1f43.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 189788
+    checksum: sha256:b7ab88898f81a136522f83039b82944f6e2dc9c73d6a5ba20320ccaf329d02e3
+    name: libtpms
+    evr: 0.9.1-4.20211126git1ff6fe1f43.el9_5
+    sourcerpm: libtpms-0.9.1-4.20211126git1ff6fe1f43.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/liburing-2.5-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 42739
+    checksum: sha256:cc7894188e8c9cc06335a47150f05ad80cbbf91cbf7c877e5e75683bddf61b53
+    name: liburing
+    evr: 2.5-1.el9
+    sourcerpm: liburing-2.5-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-client-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 462647
+    checksum: sha256:88563426548029aa8150fecc9b123382659ad6f9b1beca955bd8724a5b9378ad
+    name: libvirt-client
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-common-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 145324
+    checksum: sha256:a46c61b8e4f09043271c0d7b57ca5e28973c8b495813ed14a19a599d91de0499
+    name: libvirt-daemon-common
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-config-network-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 33208
+    checksum: sha256:b01657fa8ff15b050c755d5f477b6d94f2523138244b32155249869bc2bfea6e
+    name: libvirt-daemon-config-network
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-network-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 281845
+    checksum: sha256:bde9d96f05d7250bf7b00e88766008f4392577a805dd105a7cfef1d765c7b310
+    name: libvirt-daemon-driver-network
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-qemu-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1020529
+    checksum: sha256:f5224624f1e564efc6bf46ae55cb541fb3e3c93e26cfa20d8e437b77e10a29d9
+    name: libvirt-daemon-driver-qemu
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-secret-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 225069
+    checksum: sha256:b8648c33932c6d81fcdbbcaed46cf2ce4cc65def5ca90dfd529dedacd51cef83
+    name: libvirt-daemon-driver-secret
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-storage-core-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 282348
+    checksum: sha256:c008db2c31f3bf6fbdac082a8b0f6774921eb8a8f12dca0c0d3ece4e60a98fe1
+    name: libvirt-daemon-driver-storage-core
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-log-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 73180
+    checksum: sha256:6d167df9310248a17b58b5ec9f729836eb0dd5f386ac951d140d89cecd2e6ffc
+    name: libvirt-daemon-log
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-libs-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 5334776
+    checksum: sha256:ae4b238d060353147d22e1ff475b14784428fdb3f98e64db9462afa161358f8d
+    name: libvirt-libs
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/luksmeta-9-12.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 23634
+    checksum: sha256:3be1ff9059f65c2455f1701c388feebbed719b9b40e6cb23aed734f40c746e23
+    name: luksmeta
+    evr: 9-12.el9
+    sourcerpm: luksmeta-9-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 5401
+    checksum: sha256:55a6690cee8af0140d0f9c4b7103f9c1dc80e564eb0e2fc17ac9c4ad8c3596e8
+    name: nbdkit
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-basic-filters-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 346721
+    checksum: sha256:c3ab79a3600df5022488846403644b22cae7de5e82f57fdc3096c14c372a6c26
+    name: nbdkit-basic-filters
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-basic-plugins-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 223807
+    checksum: sha256:f4afac06ce640c817ebdf5a3d184e58606d7e2da71dc4663960df3f8804b4f31
+    name: nbdkit-basic-plugins
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-curl-plugin-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 41180
+    checksum: sha256:a0f8bded2945fde117082253f5dd624187982a7846bff5970e598dc03098995c
+    name: nbdkit-curl-plugin
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-selinux-1.38.5-3.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 24504
+    checksum: sha256:182205a1ad124a6cb46674627c0bab16b49eeb95953cf26af194ff993307e56e
+    name: nbdkit-selinux
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-server-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 132670
+    checksum: sha256:28be5705cdf4a79118279a15ce58296ad4c0d49996cfe40e351393d33d2c822e
+    name: nbdkit-server
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-ssh-plugin-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 30025
+    checksum: sha256:6b43d9934d1b39d4a1a0f4cf8cad62f5df894ab1513391a47bfb0c69b8032191
+    name: nbdkit-ssh-plugin
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-0^20250217.ga1e48a0-9.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 264431
+    checksum: sha256:d46d62bcf865df245f3538ab121e3235ee06beab7f4f463b3518896612d631e9
+    name: passt
+    evr: 0^20250217.ga1e48a0-9.el9_6
+    sourcerpm: passt-0^20250217.ga1e48a0-9.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-selinux-0^20250217.ga1e48a0-9.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 29183
+    checksum: sha256:13a6d7eac2d0b0ac5ef9139aef1bf5d5c4b128e1c30e9c512665bb8c20cb8f6f
+    name: passt-selinux
+    evr: 0^20250217.ga1e48a0-9.el9_6
+    sourcerpm: passt-0^20250217.ga1e48a0-9.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/pixman-0.40.0-6.el9_3.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 277483
+    checksum: sha256:40581f27200096a57adc25a51d3d373a81f55d3abc0529cbe057c2c458318145
+    name: pixman
+    evr: 0.40.0-6.el9_3
+    sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-2.1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 82931
+    checksum: sha256:fcbe07b75cd10b0a2752d558a8b7750cb13b59473439701d8c568195f05c3805
+    name: policycoreutils-python-utils
+    evr: 3.6-2.1.el9
+    sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.5-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 88009
+    checksum: sha256:023ddd2c1dda3422bc1b067e562b39621eaefdf778efd0dae07fc144ba188fb5
+    name: python3-audit
+    evr: 3.1.5-4.el9
+    sourcerpm: audit-3.1.5-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 41452
+    checksum: sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069
+    name: python3-distro
+    evr: 1.5.0-7.el9
+    sourcerpm: python-distro-1.5.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 196472
+    checksum: sha256:7af821a0ee7c7b56df79de25fe35cc2d0fd6f45df5c3bcec2c5e72d7378ba265
+    name: python3-libselinux
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 82730
+    checksum: sha256:8a17df19f0ff5dbb98fe608999cb2370983d8565658df01d0993b3028cbf28d6
+    name: python3-libsemanage
+    evr: 3.6-5.el9_6
+    sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-policycoreutils-3.6-2.1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2216589
+    checksum: sha256:7dbe7be855cc83e372add890e9e0c5256ef57132d9731b5db204c425bf21b194
+    name: python3-policycoreutils
+    evr: 3.6-2.1.el9
+    sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-img-9.1.0-15.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2607045
+    checksum: sha256:f89317b5054f394d177af6117f0addb5f7ff594d8f0a72b8d02a0c76b6eb3436
+    name: qemu-img
+    evr: 17:9.1.0-15.el9_6.4
+    sourcerpm: qemu-kvm-9.1.0-15.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-common-9.1.0-15.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 705846
+    checksum: sha256:39888681ae1da072a281e9da72771672f2205acc7ec83d724b6a42ec5e4fe7a8
+    name: qemu-kvm-common
+    evr: 17:9.1.0-15.el9_6.4
+    sourcerpm: qemu-kvm-9.1.0-15.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-core-9.1.0-15.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 5130107
+    checksum: sha256:467261cb89ae35da29aa71a50e9955f309f49f432a176209c01f54b751a5679c
+    name: qemu-kvm-core
+    evr: 17:9.1.0-15.el9_6.4
+    sourcerpm: qemu-kvm-9.1.0-15.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/scrub-2.6.1-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 48350
+    checksum: sha256:70f0f86547ea20873df09b3ff91e6dc107d071ac1971556c1aa35bb03a500beb
+    name: scrub
+    evr: 2.6.1-4.el9
+    sourcerpm: scrub-2.6.1-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/seabios-bin-1.16.3-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 104354
+    checksum: sha256:f2758eb2e733d130750ad3153d7775e8cc71be8bdf8f0f5e4ee7e40257df6236
+    name: seabios-bin
+    evr: 1.16.3-4.el9
+    sourcerpm: seabios-1.16.3-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/seavgabios-bin-1.16.3-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 37280
+    checksum: sha256:09622222e1b5ff84d2f0df23d29cc21ed3de37003a9a8fee3492f588027f7fd4
+    name: seavgabios-bin
+    evr: 1.16.3-4.el9
+    sourcerpm: seabios-1.16.3-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/supermin-5.3.5-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 785075
+    checksum: sha256:ca97403842c6cbab5850bc4791071cfd48362df7ba75606afa7668b69c40ab2b
+    name: supermin
+    evr: 5.3.5-1.el9
+    sourcerpm: supermin-5.3.5-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/swtpm-0.8.0-2.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 46802
+    checksum: sha256:21b44b871a345a9dbaac62fd041cf8d697d1fe3826d994e431ad88ffce9da633
+    name: swtpm
+    evr: 0.8.0-2.el9_4
+    sourcerpm: swtpm-0.8.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/swtpm-libs-0.8.0-2.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 53192
+    checksum: sha256:ba793c7d979bd31548e8b202665b144af6976b8b2dc5f0f53811058ef81c2f89
+    name: swtpm-libs
+    evr: 0.8.0-2.el9_4
+    sourcerpm: swtpm-0.8.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/swtpm-tools-0.8.0-2.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 127941
+    checksum: sha256:743b4553c6f5208e804995a1e2513f0ea2e79e51cf698929a83bc49d406f4a34
+    name: swtpm-tools
+    evr: 0.8.0-2.el9_4
+    sourcerpm: swtpm-0.8.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/u/unbound-libs-1.16.2-18.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 563049
+    checksum: sha256:b0b9e483f6c8da82d93d1ae35145bb061a5b49746d5f0b2c5356e8bd4330c7a4
+    name: unbound-libs
+    evr: 1.16.2-18.el9_6
+    sourcerpm: unbound-1.16.2-18.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-63.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 4818636
+    checksum: sha256:4eb918b63dee7daf32117df2e3fcb02ad4ba3d96cb25677cf55315deceb7e22a
+    name: binutils
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 753176
+    checksum: sha256:339d9bb2dc0e41c4756f1a4f82e82f6654818b72de74f1f0377c76277617352b
+    name: binutils-gold
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/bzip2-1.0.8-10.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 61101
+    checksum: sha256:1e9012bb13c1df2750a6c2a4aafaa8996ea3a75478aa3c8a0961c29f9a81a202
+    name: bzip2
+    evr: 1.0.8-10.el9_5
+    sourcerpm: bzip2-1.0.8-10.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cpio-2.13-16.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 286157
+    checksum: sha256:d9b53fda4b8757fd63b53a415f533ab876c18c28a94fd21d10658de85978f254
+    name: cpio
+    evr: 2.13-16.el9
+    sourcerpm: cpio-2.13-16.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-2.7.2-3.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 341855
+    checksum: sha256:a5cb6c046de71a54313b2d420db6e72bfae0761f591a051a7d676e3e063fe160
+    name: cryptsetup
+    evr: 2.7.2-3.el9_5
+    sourcerpm: cryptsetup-2.7.2-3.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.7.2-3.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 534806
+    checksum: sha256:db7fc8be731f94a9a28f29522ee1c8000dbcdddb78be470825fea8af5338818e
+    name: cryptsetup-libs
+    evr: 2.7.2-3.el9_5
+    sourcerpm: cryptsetup-2.7.2-3.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-gssapi-2.1.27-21.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 28739
+    checksum: sha256:ea04812e70f7185355de2cf44ccd03dba237e3671b670cd3c53debd7665bc667
+    name: cyrus-sasl-gssapi
+    evr: 2.1.27-21.el9
+    sourcerpm: cyrus-sasl-2.1.27-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/daxctl-libs-78-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 45763
+    checksum: sha256:064003981145cb7383ec6850f1e85ac18183d3dacd1bc568f0a47ba3105fdb96
+    name: daxctl-libs
+    evr: 78-2.el9
+    sourcerpm: ndctl-78-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-1.02.202-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 146604
+    checksum: sha256:fef2c0542d2e66f9208e25c34f82e6735b8b3396cd46e5a2ac4c8f54e6c0c1df
+    name: device-mapper
+    evr: 9:1.02.202-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-event-1.02.202-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 37226
+    checksum: sha256:bc5bef65f67afe13cd57a0f0033bb57dac321d4d0f67802a2932b99867b29f60
+    name: device-mapper-event
+    evr: 9:1.02.202-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-event-libs-1.02.202-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 34526
+    checksum: sha256:060edac61323c1c87c547f9431997953ff7ebab84011d3382b01e87780263675
+    name: device-mapper-event-libs
+    evr: 9:1.02.202-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.202-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 185301
+    checksum: sha256:8b48aabdb24179ec8e28b1d5d8da85fc7ded64e30fc4367de3c455b895212626
+    name: device-mapper-libs
+    evr: 9:1.02.202-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-persistent-data-1.1.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1173142
+    checksum: sha256:33b20d692595c100b00c47987ec74f207fb99c8520d0f0f173fd073f0e920fd6
+    name: device-mapper-persistent-data
+    evr: 1.1.0-1.el9
+    sourcerpm: device-mapper-persistent-data-1.1.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dhcp-client-4.4.2-19.b1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 812977
+    checksum: sha256:72823b0e47915484302ade0a5480985e51565968a01e884cb899ebc57d21cc5b
+    name: dhcp-client
+    evr: 12:4.4.2-19.b1.el9
+    sourcerpm: dhcp-4.4.2-19.b1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dhcp-common-4.4.2-19.b1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 133925
+    checksum: sha256:abf06b4ccaafa322bd7d49ca8b239d6852af8f4ba31b8ab3edc1512208767327
+    name: dhcp-common
+    evr: 12:4.4.2-19.b1.el9
+    sourcerpm: dhcp-4.4.2-19.b1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 411559
+    checksum: sha256:2d4c4fdfc10215af3c957c24995b79a26e27e6d76de4ed1f5198d25bf7ef9671
+    name: diffutils
+    evr: 3.7-12.el9
+    sourcerpm: diffutils-3.7-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dosfstools-4.2-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 163749
+    checksum: sha256:7228697855b1acaa00f8b5ab46d2f6ce9b0c4ce06ec5f25b771622498832596b
+    name: dosfstools
+    evr: 4.2-3.el9
+    sourcerpm: dosfstools-4.2-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dracut-057-88.git20250311.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 485922
+    checksum: sha256:25d66f65d31e7f8635dd930d64ccd93f771d881b5ab110748371039a0b7623c9
+    name: dracut
+    evr: 057-88.git20250311.el9_6
+    sourcerpm: dracut-057-88.git20250311.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/e2fsprogs-1.46.5-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1056089
+    checksum: sha256:32967b664c08ff8443661984920cd0167f0175ba34bc4347f8bd98eb788527f1
+    name: e2fsprogs
+    evr: 1.46.5-7.el9
+    sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/e2fsprogs-libs-1.46.5-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 230313
+    checksum: sha256:6eb6679be603a85817d580e1881e3e5d0ca5b5f8224be379b43d1facced8441c
+    name: e2fsprogs-libs
+    evr: 1.46.5-7.el9
+    sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.192-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 47282
+    checksum: sha256:e5b1a7a9e1467bfe00913e9b22ba5665852f8c61900205a32d3043ace9e1c7c2
+    name: elfutils-debuginfod-client
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/file-5.39-16.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 53222
+    checksum: sha256:64f29bc71f9c26e6460abaff21d8e43738077cde4fbd6d1b96825a50ba0abd74
+    name: file
+    evr: 5.39-16.el9
+    sourcerpm: file-5.39-16.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/fuse-2.9.9-17.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 85864
+    checksum: sha256:1bf8e4b14ad76ded455adeb74ccdc9d031127459c03b9c01a409e550bfd75069
+    name: fuse
+    evr: 2.9.9-17.el9
+    sourcerpm: fuse-2.9.9-17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 8750
+    checksum: sha256:548265cbee787fa659bc79c07e15a12007f39eb70e905bf660ec488f0bb8820f
+    name: fuse-common
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/fuse-libs-2.9.9-17.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 101562
+    checksum: sha256:57ea8a9ed7a2d6fef54c540b393649e2fda62381e5a714860ee3cf786f7ef46b
+    name: fuse-libs
+    evr: 2.9.9-17.el9
+    sourcerpm: fuse-2.9.9-17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gettext-0.21-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1193150
+    checksum: sha256:febf6aec8699ca352aba5a7a249ed0cb011b68c5bab17f6178f09b1035974dde
+    name: gettext
+    evr: 0.21-8.el9
+    sourcerpm: gettext-0.21-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 313328
+    checksum: sha256:b319325e941e03e3e7381161889ab39473398194786a52fc1653d025211b6e1a
+    name: gettext-libs
+    evr: 0.21-8.el9
+    sourcerpm: gettext-0.21-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-168.el9_6.14.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1753645
+    checksum: sha256:df6ded7d6c44fb4b23e9d11cf63b8b81f12f1edc08f5a19f20c1c059d3cf8649
+    name: glibc-gconv-extra
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1133828
+    checksum: sha256:4d8ff13569b3b231b3fb847e9e22615c6e08215d1f2c0c78eac2e345b9efd394
+    name: groff-base
+    evr: 1.22.4-10.el9
+    sourcerpm: groff-1.22.4-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gssproxy-0.8.4-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 116911
+    checksum: sha256:b4c296c0d0a4fa11bc5fc1119516405c6075b52fe5945aec3447037aedb7951e
+    name: gssproxy
+    evr: 0.8.4-7.el9
+    sourcerpm: gssproxy-0.8.4-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/inih-49-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 20510
+    checksum: sha256:d5ff4d9d43f6c32797e80e0518bb3656ae46643069bdc0ef9b8749d912cd74ab
+    name: inih
+    evr: 49-6.el9
+    sourcerpm: inih-49-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/ipcalc-1.0.0-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 45060
+    checksum: sha256:185c9b26e524ad1e026cb223f05b6eaf9fd5769ced16ff9897080aa8735ffe64
+    name: ipcalc
+    evr: 1.0.0-5.el9
+    sourcerpm: ipcalc-1.0.0-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iproute-tc-6.11.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 459306
+    checksum: sha256:9e780365ee736bd765b5efac45d9630539a531c925278a0a6450cb568a4f433c
+    name: iproute-tc
+    evr: 6.11.0-1.el9
+    sourcerpm: iproute-6.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 476678
+    checksum: sha256:3e79ca4cc3d35c1f1e0ac6c9f05c5be56b7ab6dd1f8ae719a21ec1b9e3bfa018
+    name: iptables-libs
+    evr: 1.8.10-11.el9_5
+    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 214056
+    checksum: sha256:54e031813637738af285ff4b1c2e4a20b913f2ea643a29940a07ccaf8bd197f5
+    name: iptables-nft
+    evr: 1.8.10-11.el9_5
+    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iputils-20210202-11.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 178195
+    checksum: sha256:2760d3b457614fd29d24f6ceff4cd5354fb099193237ba9914dbeee5e69e67d3
+    name: iputils
+    evr: 20210202-11.el9_6.1
+    sourcerpm: iputils-20210202-11.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/j/jansson-2.14-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 49137
+    checksum: sha256:4e9aec51ee46d7265d6edd1245b5d5ab5e8336dc2a4ca17f2cace2ce8bae3761
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/j/jq-1.6-17.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 194646
+    checksum: sha256:9e996fbd48660f2815b29c88e1fd3b2ac5359eafb811f6208c6c4814ffb11e5b
+    name: jq
+    evr: 1.6-17.el9
+    sourcerpm: jq-1.6-17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kbd-2.4.0-11.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 428483
+    checksum: sha256:3271c89a49edb384441b749a30b662968f99f66a169dd01bac2b3cb39e2263e9
+    name: kbd
+    evr: 2.4.0-11.el9
+    sourcerpm: kbd-2.4.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 579544
+    checksum: sha256:8dcc48e93bffc5e2d819f8c8c468648362c13d554f756c421711386c8fadf950
+    name: kbd-legacy
+    evr: 2.4.0-11.el9
+    sourcerpm: kbd-2.4.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1739470
+    checksum: sha256:f698c807d4805c83b2dc8564427a7c4445d1c41a23d4bdb7988eba489e73932f
+    name: kbd-misc
+    evr: 2.4.0-11.el9
+    sourcerpm: kbd-2.4.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-core-5.14.0-570.23.1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 18707617
+    checksum: sha256:fd1a8051a2d698dba71b8b92bffd0325edb5ac6dc78c2eac3502b69f4d6edfd7
+    name: kernel-core
+    evr: 5.14.0-570.23.1.el9_6
+    sourcerpm: kernel-5.14.0-570.23.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-modules-core-5.14.0-570.23.1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 32489925
+    checksum: sha256:978372dd2b6714d9902d10b41eaa9096166bd560c9747dca31efdd3b650c7667
+    name: kernel-modules-core
+    evr: 5.14.0-570.23.1.el9_6
+    sourcerpm: kernel-5.14.0-570.23.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 132888
+    checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
+    name: kmod
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kpartx-0.8.7-35.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 47844
+    checksum: sha256:baef9e9207915c24e48c81dc3dfa3308b07d4446fa487eec23033e247da38144
+    name: kpartx
+    evr: 0.8.7-35.el9_6.1
+    sourcerpm: device-mapper-multipath-0.8.7-35.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/less-590-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 170758
+    checksum: sha256:a726061c966a134a5e5b42b60e4162ee85a2cef8843b6fd28e08264ceebb54f4
+    name: less
+    evr: 590-5.el9
+    sourcerpm: less-590-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libaio-0.3.111-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 27100
+    checksum: sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c
+    name: libaio
+    evr: 0.3.111-13.el9
+    sourcerpm: libaio-0.3.111-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libbasicobjects-0.1.1-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 29215
+    checksum: sha256:b2e095838b4c40ade395ca6bbafec8be461e5630960d2a8d307e6c456dc4656b
+    name: libbasicobjects
+    evr: 0.1.1-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libcollection-0.7.0-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 48366
+    checksum: sha256:75da9e9faf295a7cdc1e8aede617c5468860ed03750f5543eb1ed00ca1d6c1e3
+    name: libcollection
+    evr: 0.7.0-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libconfig-1.7.2-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 77187
+    checksum: sha256:a703ce30dbfad94d6ee711ebdb134b8c44abdb7b85a56a5326d486c27e423360
+    name: libconfig
+    evr: 1.7.2-9.el9
+    sourcerpm: libconfig-1.7.2-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 109330
+    checksum: sha256:9e41ff5754a5dca1308adf9617828934d56cb60d8d08f128f80e4328f69bc78c
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+    sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libev-4.33-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 55816
+    checksum: sha256:5060a2d021e411d792000ea68f76604bc56e0c7a9d024de2a478814b91b5f9e8
+    name: libev
+    evr: 4.33-6.el9
+    sourcerpm: libev-4.33-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libibverbs-54.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 466434
+    checksum: sha256:fc593dc18f73c296df4fa808341cb2dbee7e5082fb872b79e7984c3b24279d3b
+    name: libibverbs
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libini_config-1.3.1-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 70916
+    checksum: sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35
+    name: libini_config
+    evr: 1.3.1-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libkcapi-1.4.0-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 50196
+    checksum: sha256:7456c9c74bf79b07fc7df6b79700685166aae9220fb1355c3ddbdf1aee22bdce
+    name: libkcapi
+    evr: 1.4.0-2.el9
+    sourcerpm: libkcapi-1.4.0-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libkcapi-hmaccalc-1.4.0-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 28929
+    checksum: sha256:70da32465019008174e087a0cfd020cfd6ddbb421cc72939b14bc094528b5649
+    name: libkcapi-hmaccalc
+    evr: 1.4.0-2.el9
+    sourcerpm: libkcapi-1.4.0-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 62066
+    checksum: sha256:beeb73e78390077c6afd9ed6177bad8bad278dbfaae9d90edf7243cdf6a44a3f
+    name: libnetfilter_conntrack
+    evr: 1.0.9-1.el9
+    sourcerpm: libnetfilter_conntrack-1.0.9-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 32236
+    checksum: sha256:177882bfe48c9c9effc7b1bce6b58b2466988c53e400c07fb1ba2d3a4ebe6f40
+    name: libnfnetlink
+    evr: 1.0.1-23.el9_5
+    sourcerpm: libnfnetlink-1.0.1-23.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnfsidmap-2.5.4-34.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 67310
+    checksum: sha256:e4e9b49a0217e9b50c534cd20eec1c5a7903d1a68f930de65ae17d2a9ca9800a
+    name: libnfsidmap
+    evr: 1:2.5.4-34.el9
+    sourcerpm: nfs-utils-2.5.4-34.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 91380
+    checksum: sha256:e64d7b270be4be36af80ed220852cb760a1069e34667b1ba9eec7a02762a14bf
+    name: libnftnl
+    evr: 1.2.6-4.el9_4
+    sourcerpm: libnftnl-1.2.6-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 376137
+    checksum: sha256:89728a253a5bf1c8e01c40573f1283d40188e003bdbd4ac565f8b0f05bced55c
+    name: libnl3
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnvme-1.11.1-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 114880
+    checksum: sha256:c7e6a9e6d51c3a3e31a075faa68b2518baf554788a2939aa1483f22ce66ecb29
+    name: libnvme
+    evr: 1.11.1-1.el9
+    sourcerpm: libnvme-1.11.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpath_utils-0.2.1-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 32479
+    checksum: sha256:ed4bfb8d96a13bad9b85dde758d6f481fa62abd56595760134e3ea195e63806e
+    name: libpath_utils
+    evr: 0.2.1-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 52912
+    checksum: sha256:c972030a8fbaa2d981f0e5fdfc42d6d5173dd047c94d86ab7732e3e53fc4e97a
+    name: libpipeline
+    evr: 1.5.3-4.el9
+    sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 38387
+    checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpng-1.6.37-12.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 121655
+    checksum: sha256:42e7addb96958b293571949829378c054d6a1a762dccb78d5a777f8c531fc811
+    name: libpng
+    evr: 2:1.6.37-12.el9
+    sourcerpm: libpng-1.6.37-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/librdmacm-54.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 75775
+    checksum: sha256:334a6ff9a86cfed3af1dc2b08b840e74c9cd84b35a8d7bfd15a0db51ca8a0d30
+    name: librdmacm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libref_array-0.1.5-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 30902
+    checksum: sha256:99c5576869a0daf3be0498f55e01a8085e82daa8a71a48c256f03c79ed149353
+    name: libref_array
+    evr: 0.1.5-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 198410
+    checksum: sha256:e5d79885864cd5b2a307065b43ba1af1523ec7ac26eace2717c70ede1b6e4c56
+    name: libselinux-utils
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libss-1.46.5-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 34195
+    checksum: sha256:9e96642e8dfdc4d305bd45a6980a4bf5831600fd10b95ac59522770ad706b611
+    name: libss
+    evr: 1.46.5-7.el9
+    sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-0.10.4-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 224804
+    checksum: sha256:7c51bc940814b49a57b331b68508732b76b16f5c237538c26fc06e6d824da77f
+    name: libssh
+    evr: 0.10.4-13.el9
+    sourcerpm: libssh-0.10.4-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-13.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 11463
+    checksum: sha256:0cc66bee3af1b8939f108dce622a47a58482f182ab3abb851b3252a44315aa23
+    name: libssh-config
+    evr: 0.10.4-13.el9
+    sourcerpm: libssh-0.10.4-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libtirpc-1.3.3-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 98934
+    checksum: sha256:f82cd69dc3aac881d5b574930c7d274687054cb5b03d3a8e3affa7bbcd5950b1
+    name: libtirpc
+    evr: 1.3.3-9.el9
+    sourcerpm: libtirpc-1.3.3-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libusbx-1.0.26-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 80311
+    checksum: sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7
+    name: libusbx
+    evr: 1.0.26-1.el9
+    sourcerpm: libusbx-1.0.26-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libverto-libev-0.3.2-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 15452
+    checksum: sha256:95fa428623ac713c8fa6d5c00355881d4d8cf8029bb74a90a2d4ce16cf603816
+    name: libverto-libev
+    evr: 0.3.2-3.el9
+    sourcerpm: libverto-0.3.2-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-20250513-151.1.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 501395158
+    checksum: sha256:5a85309a17c64cdc5d47d4f1902e59551c7b532129d7f46bc1b3b3c61da99dca
+    name: linux-firmware
+    evr: 20250513-151.1.el9_6
+    sourcerpm: linux-firmware-20250513-151.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-whence-20250513-151.1.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 120585
+    checksum: sha256:48dabe871fd05e810fdb2d8ae416a9a8e4beebd8389f97d980eef749b379b172
+    name: linux-firmware-whence
+    evr: 20250513-151.1.el9_6
+    sourcerpm: linux-firmware-20250513-151.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lsscsi-0.32-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 72326
+    checksum: sha256:7a0b587bfdd7e9ab76560ea93e3f7fbd1c6dc0511bc6d3519f83e6431f22ffe6
+    name: lsscsi
+    evr: 0.32-6.el9
+    sourcerpm: lsscsi-0.32-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lvm2-2.03.28-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1626649
+    checksum: sha256:b8d91da58f0168d9210850fa40b15dd4ba5917c251e444e882688b7f5dd9b80d
+    name: lvm2
+    evr: 9:2.03.28-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lvm2-libs-2.03.28-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1062922
+    checksum: sha256:a7377a8c8988620ce74a38e91336a5459d9d8d941c24d8f476259b455aab2d47
+    name: lvm2-libs
+    evr: 9:2.03.28-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lzo-2.10-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 70686
+    checksum: sha256:2703054410f61e3a0cc8bf082800a75170644141e4f98aea3f483765ae372d3f
+    name: lzo
+    evr: 2.10-7.el9
+    sourcerpm: lzo-2.10-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lzop-1.04-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 60502
+    checksum: sha256:6eb21e6aa9350281c9d5b99962452c9f3848cfb3cfebe3114b53649e472a1047
+    name: lzop
+    evr: 1.04-8.el9
+    sourcerpm: lzop-1.04-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/m/man-db-2.9.3-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1245006
+    checksum: sha256:1eb7770a27102f59012f704e90aa04b130ab4f46fec983a7441ec9e8810f2da4
+    name: man-db
+    evr: 2.9.3-7.el9
+    sourcerpm: man-db-2.9.3-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/m/mdadm-4.3-4.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 456330
+    checksum: sha256:f633c556a06d40aa7dcd4c93f13735c4d6a568813f9e03b50c88c469ed030c54
+    name: mdadm
+    evr: 4.3-4.el9_5
+    sourcerpm: mdadm-4.3-4.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/m/mtools-4.0.26-4.el9_0.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 231610
+    checksum: sha256:b4d856e2edb6fa79ee752355904320ab077945c63d75b61b9bc78ccdd64d106b
+    name: mtools
+    evr: 4.0.26-4.el9_0
+    sourcerpm: mtools-4.0.26-4.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/ndctl-libs-78-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 94842
+    checksum: sha256:9e46d827a61e9c7fe36b5bdb35234bfe703a601309634ba1f109bfb1791f13cf
+    name: ndctl-libs
+    evr: 78-2.el9
+    sourcerpm: ndctl-78-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/nfs-utils-2.5.4-34.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 473840
+    checksum: sha256:8222b8071e297379d6037f8ea68b940e4488a44fc1792fe1664b23387c1b9300
+    name: nfs-utils
+    evr: 1:2.5.4-34.el9
+    sourcerpm: nfs-utils-2.5.4-34.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/numactl-libs-2.0.19-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 33709
+    checksum: sha256:ce2f00b2527e29f6b389e5899750e2b6eb1e5ce484ddfdcd6f01fa311efe7860
+    name: numactl-libs
+    evr: 2.0.19-1.el9
+    sourcerpm: numactl-2.0.19-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/numad-0.5-37.20150602git.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 39286
+    checksum: sha256:39b620572ecad31ecc016cb3266cffd1084f8d0738f574131d474b80a88da2bc
+    name: numad
+    evr: 0.5-37.20150602git.el9
+    sourcerpm: numad-0.5-37.20150602git.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/oniguruma-6.9.6-1.el9.6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 226451
+    checksum: sha256:a532fc644b41ead28ac07fb4217e2ceb9cdd5fdaadc13e9a02b7be3ee703bf85
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+    sourcerpm: oniguruma-6.9.6-1.el9.6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/parted-3.5-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 603349
+    checksum: sha256:8c6d3e1418832074e521955b969ca597df66bbf1c76f4e16032f83046f82cbaa
+    name: parted
+    evr: 3.5-3.el9
+    sourcerpm: parted-3.5-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pigz-2.8-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 99148
+    checksum: sha256:3d468520034285d071ad3ae5cdf8726d88e66a24c41aa6d4bd7919a3e32a0cd3
+    name: pigz
+    evr: 2.8-1.el9
+    sourcerpm: pigz-2.8-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 45675
+    checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 12438
+    checksum: sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-2.1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 251967
+    checksum: sha256:8dcd39960d3103f7a4ad2b9f7a0e15469ebf4da98f6c215cddfffdb830dc12b5
+    name: policycoreutils
+    evr: 3.6-2.1.el9
+    sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/polkit-0.117-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 163384
+    checksum: sha256:66f11e356814400f9b420b6da3cf9e9c344808b2f4d77a341883a9e908a6ca73
+    name: polkit
+    evr: 0.117-13.el9
+    sourcerpm: polkit-0.117-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/polkit-libs-0.117-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 8690164
+    checksum: sha256:62cdf67da1a4b9fef97017775ea7640d5e7896533caf4fc176cd79ed121b9421
+    name: polkit-libs
+    evr: 0.117-13.el9
+    sourcerpm: polkit-0.117-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/polkit-pkla-compat-0.1-21.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 52512
+    checksum: sha256:548978c62b24b7adda4ebcc5db878e22b18f50248bc45aa4a209b86eddd86948
+    name: polkit-pkla-compat
+    evr: 0.1-21.el9
+    sourcerpm: polkit-pkla-compat-0.1-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 361526
+    checksum: sha256:506ad778f63821e8d9647ca8e0a3ff21b8af9c1666060d5200f9b26ee718333c
+    name: procps-ng
+    evr: 3.3.17-14.el9
+    sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 38224
+    checksum: sha256:9669f5bed1c9532ede399cd1ea6f8937ae7d18cfb56d59f2939a4b456390035f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-pyyaml-5.4.1-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 213932
+    checksum: sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e
+    name: python3-pyyaml
+    evr: 5.4.1-6.el9
+    sourcerpm: PyYAML-5.4.1-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 623460
+    checksum: sha256:91946d729d2b03b4abe1c43962f22d110468db0163241cda7b1d549c615d0261
+    name: python3-setools
+    evr: 4.4.4-1.el9
+    sourcerpm: setools-4.4.4-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/q/quota-4.09-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 206761
+    checksum: sha256:ffe9439076c7fcf6785626d7dcbf42b7ab307ab87360a34e2632359e2f4814fe
+    name: quota
+    evr: 1:4.09-4.el9
+    sourcerpm: quota-4.09-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/q/quota-nls-4.09-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 80718
+    checksum: sha256:bf0c353db02e9591162a6d1880f6ce3d99e1621a8ce32feb6bed1b5ab6408b68
+    name: quota-nls
+    evr: 1:4.09-4.el9
+    sourcerpm: quota-4.09-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/rpcbind-1.2.6-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 63366
+    checksum: sha256:da6368abd485c9c8a3643947ce11bece4775232d10bd8ec68e23a0bdf4275330
+    name: rpcbind
+    evr: 1.2.6-7.el9
+    sourcerpm: rpcbind-1.2.6-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/rpm-plugin-selinux-4.16.1.3-37.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 18109
+    checksum: sha256:1e21fe626bb81ccf59e8de8194395017e3a5fa929cbf6c6da82ba1598f6bb27f
+    name: rpm-plugin-selinux
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-38.1.53-5.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 46473
+    checksum: sha256:e397424c237fb3b0b19f7ba7b1d59ec5a54e8c184ae8be1b1d12223f5ec1f3b7
+    name: selinux-policy
+    evr: 38.1.53-5.el9_6
+    sourcerpm: selinux-policy-38.1.53-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-targeted-38.1.53-5.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 7251875
+    checksum: sha256:e5a1a2e4ca35e6639ac12a651c3fcb4aede1b62755d71920c9819c7939430b5b
+    name: selinux-policy-targeted
+    evr: 38.1.53-5.el9_6
+    sourcerpm: selinux-policy-38.1.53-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/snappy-1.1.8-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 38032
+    checksum: sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f
+    name: snappy
+    evr: 1.1.8-8.el9
+    sourcerpm: snappy-1.1.8-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/squashfs-tools-4.4-10.git1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 172047
+    checksum: sha256:a892b543eca94673ae19b1948d37ce515d70ddccd89f30794cae5c8931b74c43
+    name: squashfs-tools
+    evr: 4.4-10.git1.el9
+    sourcerpm: squashfs-tools-4.4-10.git1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-6.04-0.20.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 588436
+    checksum: sha256:9af2b296b7080e7b0551a8fa971e7ee5a3bf709443b43dd5ffd6c9e6d3f8aab0
+    name: syslinux
+    evr: 6.04-0.20.el9
+    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-extlinux-6.04-0.20.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 135023
+    checksum: sha256:7eb3714428f764f644f1995c05a3dbc55077d8fd0b330ba1698e342b1640a63d
+    name: syslinux-extlinux
+    evr: 6.04-0.20.el9
+    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-extlinux-nonlinux-6.04-0.20.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 408744
+    checksum: sha256:a40ce10dd82ee4517f1c528a9ca14f1baa5a2d8b39f298531916688241906460
+    name: syslinux-extlinux-nonlinux
+    evr: 6.04-0.20.el9
+    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-nonlinux-6.04-0.20.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 591736
+    checksum: sha256:e9b444304de40694390b37c36ace8b0d8ba39f376b9215c3c7977dd2c198e6c1
+    name: syslinux-nonlinux
+    evr: 6.04-0.20.el9
+    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-container-252-51.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 611994
+    checksum: sha256:97575533d2be7533aaf1aa7e90e60207509920eb5019935fb08c9dc6b98e2e28
+    name: systemd-container
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-51.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 2122081
+    checksum: sha256:21f9f14a7d5139c7578229dac56566acb8fa08d0e91dd3affe31fcd40f69f29b
+    name: systemd-udev
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tpm2-tools-5.2-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 828074
+    checksum: sha256:2f2698967c9e1741966cc107520857b1ddcbf668ae6c43621cc3d7562d418009
+    name: tpm2-tools
+    evr: 5.2-4.el9
+    sourcerpm: tpm2-tools-5.2-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/u/userspace-rcu-0.12.1-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 116929
+    checksum: sha256:7ad3d7984e1c37cc17819e84e8b0e731836ca5a7a56108b0d8e8378028b581b3
+    name: userspace-rcu
+    evr: 0.12.1-6.el9
+    sourcerpm: userspace-rcu-0.12.1-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/x/xfsprogs-6.4.0-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1138692
+    checksum: sha256:3b672ce3677d8be9f0103de6bd24aa6d9575104f09089898f296d8cb19317192
+    name: xfsprogs
+    evr: 6.4.0-5.el9
+    sourcerpm: xfsprogs-6.4.0-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 235693
+    checksum: sha256:f16d17c26a241400586ddc3d734ce863e3f19d433881ec640a47bedf0dafd07b
+    name: xz
+    evr: 5.2.5-8.el9_0
+    sourcerpm: xz-5.2.5-8.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/z/zstd-1.5.5-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 479423
+    checksum: sha256:b437abeff5d5319c25115f2bc2ba1bb6cc4d957727ce6cbf3072df77bbef2719
+    name: zstd
+    evr: 1.5.5-1.el9
+    sourcerpm: zstd-1.5.5-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/Packages/l/libguestfs-devel-1.54.0-8.el9_6.x86_64.rpm
+    repoid: codeready-builder-for-rhel-9-x86_64-rpms
+    size: 283526
+    checksum: sha256:f7e70c03ce622dfeb1e49b542c39458c9089272ac8c7ea8231ae0f6202854e1d
+    name: libguestfs-devel
+    evr: 1:1.54.0-8.el9_6
+    sourcerpm: libguestfs-1.54.0-8.el9_6.src.rpm
+  source:
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/a/augeas-1.14.1-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2661871
+    checksum: sha256:e7fc9d8dfc200330be70b420cb9ba7df159d24e7b41d5fc029d5588ee32a4b9f
+    name: augeas
+    evr: 1.14.1-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/capstone-4.0.2-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3321474
+    checksum: sha256:4fe5d72b82caaacf77aeab8f8cdb30b2535b4b9979890ce1291eae521e0504d9
+    name: capstone
+    evr: 4.0.2-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/checkpolicy-3.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 94887
+    checksum: sha256:37868cfff2b89ed3fa75621cd498861e37c8a450e4db066395acfee392b12f8a
+    name: checkpolicy
+    evr: 3.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/clevis-21-208.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 106327
+    checksum: sha256:12b188e92ca58fad9ff40d4563bf1016a2bd4e94ad71b1b2dc3de8c14333d235
+    name: clevis
+    evr: 21-208.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/d/dnsmasq-2.85-16.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 592430
+    checksum: sha256:417389fd944ace4e8f721e0e7edb6c768c9da29d349cb148d6c780247349a2a5
+    name: dnsmasq
+    evr: 2.85-16.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/d/dtc-1.6.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 172071
+    checksum: sha256:7324de7a291155bbdd6122ef37c3bb456a30cf7d7b7d040fc5354649e1d7b968
+    name: dtc
+    evr: 1.6.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/e/edk2-20241117-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 48010094
+    checksum: sha256:ef57486fb23ff34584b0f54a690bb0eca4295b1900b050bbcd918e89cb501be9
+    name: edk2
+    evr: 20241117-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/gdisk-1.0.7-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 223602
+    checksum: sha256:5e716707b1d7defbc87ad5c4a86861c95ee79594cad2289dc22846eefe43a075
+    name: gdisk
+    evr: 1.0.7-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/geolite2-20191217-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 34872389
+    checksum: sha256:847196a090190750da4545e3586f7b9aaa3cd5a82a327776054d61bf1847b92c
+    name: geolite2
+    evr: 20191217-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/h/hexedit-1.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45068
+    checksum: sha256:d7817351432bbfa683e73e30419f34efa6d11b63ccb21de12bd7fd9e92ae57ad
+    name: hexedit
+    evr: 1.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/h/hivex-1.3.24-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 762030
+    checksum: sha256:c6e1e1efc59126a20b1faddca5bfcef6a25b5955f86af9a48f6cdadbc2e6e53b
+    name: hivex
+    evr: 1.3.24-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/i/ipxe-20200823-9.git4bd064de.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2668621
+    checksum: sha256:089b448cb0d83c1a9c9a5b09b248fc8a6bc353abc4a3a79962df2780038c242f
+    name: ipxe
+    evr: 20200823-9.git4bd064de.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/j/jose-14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 775746
+    checksum: sha256:de03c2c73f31318fd5044267761c0e5eae0904caa68af853a549be6fe8faee29
+    name: jose
+    evr: 14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libguestfs-1.54.0-8.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19059798
+    checksum: sha256:07473757d21ce386266b4ded4a164b77bf3d653b97d25dadf18cd75576facad2
+    name: libguestfs
+    evr: 1:1.54.0-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libguestfs-winsupport-9.3-1.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1375864
+    checksum: sha256:fb44f1e36edc932054743f33e5b3368e239920367383081ae113e9064ef003ea
+    name: libguestfs-winsupport
+    evr: 9.3-1.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libmaxminddb-1.5.2-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 610097
+    checksum: sha256:34a6423fae0433753d49d69e2d48befdff7333ba8b67e8dd29aaecccba6db2e5
+    name: libmaxminddb
+    evr: 1.5.2-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libnbd-1.20.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1628736
+    checksum: sha256:5b4e6cd210ad3dc4b31cfcab2caabdda39ecfc7bfd9768d4ceea4e8d783a0f09
+    name: libnbd
+    evr: 1.20.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 128699
+    checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
+    name: libslirp
+    evr: 4.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libtpms-0.9.1-4.20211126git1ff6fe1f43.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 823007
+    checksum: sha256:73da7bd03dbb0eb558e1f92d4144ae511d109c7e380d7dfb6db12fec80d939c6
+    name: libtpms
+    evr: 0.9.1-4.20211126git1ff6fe1f43.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/liburing-2.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306309
+    checksum: sha256:748f99b4f3a7b03d1e91877d6a51e7f89c0e66089dbfc0b09a2ab53a85079793
+    name: liburing
+    evr: 2.5-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libvirt-10.10.0-7.3.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10052196
+    checksum: sha256:02378dd26cdb2e647249fecf5087ba4e53c86b72f80528f51567f2ffc67f436b
+    name: libvirt
+    evr: 10.10.0-7.3.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/luksmeta-9-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 282795
+    checksum: sha256:10cb8ed956492edce5a31624f3da0ce393e53bfd46de272cbffaf0318d474046
+    name: luksmeta
+    evr: 9-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/n/nbdkit-1.38.5-3.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2543192
+    checksum: sha256:7b11a3cf5d7630c09ffdb2f3ae901ca13b2374883655be752ebc2338ef2f5171
+    name: nbdkit
+    evr: 1.38.5-3.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/n/nvml-1.12.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2890535
+    checksum: sha256:ddae6b30fd428de4c662f280ebf4fb8123e9d078908ce3f2915e304287cdfc05
+    name: nvml
+    evr: 1.12.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/passt-0^20250217.ga1e48a0-9.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 304123
+    checksum: sha256:db0e875f311e21f07b2f64716e0627af377bdebde49984485dbfe3bd7637f230
+    name: passt
+    evr: 0^20250217.ga1e48a0-9.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/pixman-0.40.0-6.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 647633
+    checksum: sha256:0bd62940984b88bfd5914463d948999e29665450e6850ad5c9c4fbc129f3c3d0
+    name: pixman
+    evr: 0.40.0-6.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python-distro-1.5.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 66472
+    checksum: sha256:cb263958210ce5470439a4123f81f79765eda41f07709d840c13f72875db9c4b
+    name: python-distro
+    evr: 1.5.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/q/qemu-kvm-9.1.0-15.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 132975924
+    checksum: sha256:5f846d5abe4c7cae5e6b503e45c5981faa6eab83773b8e32b33b98dae2ca45a9
+    name: qemu-kvm
+    evr: 17:9.1.0-15.el9_6.4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/scrub-2.6.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 387460
+    checksum: sha256:2280fa49d9d3cb069cc0b159484e3ae9820fc816629f73f663c8aae5994e504b
+    name: scrub
+    evr: 2.6.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/seabios-1.16.3-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 659244
+    checksum: sha256:fd93e2f7297f3261e4a3738d81aab2b13c24e027fa86ed18f122f0138c1ac3e4
+    name: seabios
+    evr: 1.16.3-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/supermin-5.3.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 248488
+    checksum: sha256:5554d9949408a306b61c843573b96227edf77a54407d4fbdda1fb24ea0b309d4
+    name: supermin
+    evr: 5.3.5-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/swtpm-0.8.0-2.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 378833
+    checksum: sha256:96fe693d2a8cb7ee9d7c52766af355d425ed1518d9bfe49ede98ad5013081d47
+    name: swtpm
+    evr: 0.8.0-2.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/u/unbound-1.16.2-18.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 6293213
+    checksum: sha256:f3c9e128e48642f9e65569deea35b09994f477d3626dd086560744e90c21e1f2
+    name: unbound
+    evr: 1.16.2-18.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/audit-3.1.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1262288
+    checksum: sha256:f589dc92fde418c7945245488cc084d565ece3995af808e741c5aa28c87a648a
+    name: audit
+    evr: 3.1.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/binutils-2.35.2-63.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 22426920
+    checksum: sha256:7e8e6c0116f7e862225990df4faaa664fe3b86198538cd350f01b3e5bd16cf41
+    name: binutils
+    evr: 2.35.2-63.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/bzip2-1.0.8-10.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 824335
+    checksum: sha256:ed1556ca58615a5ca90b09f3cad8ddb8fe7b1885a4de49c40a31a39ca592bc25
+    name: bzip2
+    evr: 1.0.8-10.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cpio-2.13-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1395694
+    checksum: sha256:0448d6f73fb814a7b6771981dd7bdb22540a0fa9e7e724dd5446308e4a957c55
+    name: cpio
+    evr: 2.13-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cryptsetup-2.7.2-3.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11659362
+    checksum: sha256:5a72dbb2b730ff70acd0b566490583e5f08333ca05619840e7c982982141c5d0
+    name: cryptsetup
+    evr: 2.7.2-3.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4030574
+    checksum: sha256:e46ec9eefa07147569cecd7e2377c37db8380243672f7ed5c744e47341923048
+    name: cyrus-sasl
+    evr: 2.1.27-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/device-mapper-multipath-0.8.7-35.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 758320
+    checksum: sha256:9185cbc2f78e88e75c5a18ed0a2bfd4433a248fad13ac52f966e2edad12687c5
+    name: device-mapper-multipath
+    evr: 0.8.7-35.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/device-mapper-persistent-data-1.1.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 28940167
+    checksum: sha256:7e3fe6a388c466a9a4a27ecd1104bee2ae57b404d61f13e035b23d861432a110
+    name: device-mapper-persistent-data
+    evr: 1.1.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/dhcp-4.4.2-19.b1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 10011377
+    checksum: sha256:dd030b15b457d35bafb10fbf80031239dcc158ae3456039d80fd620c3e74a9ad
+    name: dhcp
+    evr: 12:4.4.2-19.b1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/diffutils-3.7-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1477522
+    checksum: sha256:7a10e2d961f8d755f8ccf51a1fb7f68687671b82d9486e4b8d648561af1a185e
+    name: diffutils
+    evr: 3.7-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/ding-libs-0.6.1-53.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 926394
+    checksum: sha256:491a9ab14a3d8c679c45c2c4a140c4cc17a8abf5545a04e5d9227e93de9096b3
+    name: ding-libs
+    evr: 0.6.1-53.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/dosfstools-4.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 333826
+    checksum: sha256:7661c7fdd763ca04617d9a5a02f59cf0d9f0a28b251f5e45161ea95b0ff68dd3
+    name: dosfstools
+    evr: 4.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/dracut-057-88.git20250311.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 535294
+    checksum: sha256:2ea363c64a7fc761844d4f27a8ca0af830ee3bf48678b6a589ab029551e12518
+    name: dracut
+    evr: 057-88.git20250311.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 7418303
+    checksum: sha256:c38c97745729d7808cb5e520e73fe30f7aa9abd5d9c684968e329c4fa4067223
+    name: e2fsprogs
+    evr: 1.46.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/elfutils-0.192-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11943728
+    checksum: sha256:b5a00f4c49b8980167b250ed7f9e18b90162087cac06276a4fb4ce578a1e3d5a
+    name: elfutils
+    evr: 0.192-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/file-5.39-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1003666
+    checksum: sha256:e8261cbcd55b85efdcd12ce1a2c6e63a72c64c872d618de4ba24557a1fda63c0
+    name: file
+    evr: 5.39-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/fuse-2.9.9-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1832743
+    checksum: sha256:9a11b340f925ae501331459e5d8d2edb819b947406d26cb565cf46a9f1b27f97
+    name: fuse
+    evr: 2.9.9-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
+    evr: 3.10.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gettext-0.21-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9750918
+    checksum: sha256:1b4dc42c4afa9d998cd13750e0aa73e0d3a16f6792bfc5e17d39aabd9c68426d
+    name: gettext
+    evr: 0.21-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.14.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 19817684
+    checksum: sha256:afd2246bd19e857541d0cd006dcad75fe7f06a72e14727ddd706cdb22a5aaaa3
+    name: glibc
+    evr: 2.34-168.el9_6.14
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gnutls-3.8.3-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8589339
+    checksum: sha256:ab9b4771150e288f915499690934a04871dbe5a585db4407a2b8ba136c4d0749
+    name: gnutls
+    evr: 3.8.3-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4138121
+    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
+    name: groff
+    evr: 1.22.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gssproxy-0.8.4-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 587464
+    checksum: sha256:72af91df90b9faa511245614dedb596b7f77d5e5ec15b98d4743516c8b7e6b82
+    name: gssproxy
+    evr: 0.8.4-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/inih-49-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 26129
+    checksum: sha256:1f04866daa55017c62b94c7f627dbfe57af0aa0cdbdef80bb06a9289a82d24ff
+    name: inih
+    evr: 49-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/ipcalc-1.0.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 62787
+    checksum: sha256:f4af9efdfe497c5f1fa92941adab932fab2b6927965ec90638e737a3821b34d7
+    name: ipcalc
+    evr: 1.0.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/iproute-6.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 937429
+    checksum: sha256:11bfd8c1de1c26b8510340b467a933a800134d2e6e6f58a215d729a0727eee58
+    name: iproute
+    evr: 6.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/iptables-1.8.10-11.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 709624
+    checksum: sha256:5e4edd2e85c004f5fb06f0761d6cf41c530bb9973262315285be0ad11e8e8b51
+    name: iptables
+    evr: 1.8.10-11.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/iputils-20210202-11.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 601258
+    checksum: sha256:9dd32ad99d09763e61fc6fe281ef4aa7f74e64bc25653f74f270a41eb92193c6
+    name: iputils
+    evr: 20210202-11.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/j/jansson-2.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 447607
+    checksum: sha256:f15174491e4b92ca0c70b85b57cc8eac4373c424fc1c78e6bf492f99f28cb77b
+    name: jansson
+    evr: 2.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1503300
+    checksum: sha256:792ddc2a380e924ca859eeb01e83b93789af3dd10aca70697d5dfa32d13575a2
+    name: jq
+    evr: 1.6-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kbd-2.4.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1167414
+    checksum: sha256:8d50e573c7beff06b0167dd7d6bccfe542bc393aaf652bbecb205277af293231
+    name: kbd
+    evr: 2.4.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.23.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 149285421
+    checksum: sha256:61a58444dd7f7f8a8a92f7e7b5edc3f6cb57152cac6c75fec79979abdae7295a
+    name: kernel
+    evr: 5.14.0-570.23.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
+    name: kmod
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 385311
+    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
+    name: less
+    evr: 590-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libaio-0.3.111-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 59434
+    checksum: sha256:bb79dc7d84e0f73faf10a48f6344b75b33c697b6448abbc0e0160e3b2348ed3d
+    name: libaio
+    evr: 0.3.111-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libconfig-1.7.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1043612
+    checksum: sha256:b314b38835f8cb5ce01ac1064e5760d7e4b26a80fdd027b0f03d884322096566
+    name: libconfig
+    evr: 1.7.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 531597
+    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libev-4.33-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 581721
+    checksum: sha256:fc97ef4c51b1ec2382425ff9917988ae3eab2a78a152f6a08a7cbe858e52b36d
+    name: libev
+    evr: 4.33-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libkcapi-1.4.0-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 364003
+    checksum: sha256:c9fee402dec3be5a4a3fb5e4f498054bf0d0ddbe67414cdd4a99ff8c05c2adce
+    name: libkcapi
+    evr: 1.4.0-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 388193
+    checksum: sha256:959db92c90bf83ba3634cc4b7600288f7620c247acc7e6ee072f455458eaad0e
+    name: libnetfilter_conntrack
+    evr: 1.0.9-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnfnetlink-1.0.1-23.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 334502
+    checksum: sha256:c4509f7791e6fcebc1470eaca4dfd6add95c308559e61efa4833a76d2f1acedb
+    name: libnfnetlink
+    evr: 1.0.1-23.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnftnl-1.2.6-4.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 400952
+    checksum: sha256:125de9f4ca8c293ccc5de32f6cc7dde0e4458f75aefc56b09924c15e56fee98a
+    name: libnftnl
+    evr: 1.2.6-4.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5068824
+    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
+    name: libnl3
+    evr: 3.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnvme-1.11.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 751873
+    checksum: sha256:a029281159350bbaaa464f4fd77152f174a8407817bc0f3ed587101abb321dba
+    name: libnvme
+    evr: 1.11.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libpipeline-1.5.3-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1006052
+    checksum: sha256:f1a40821328b6e3fd7264c78c18f8c2045e7a30a05ef9f8b2934d5ca15724ce3
+    name: libpipeline
+    evr: 1.5.3-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libpng-1.6.37-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1527840
+    checksum: sha256:41f1d58a05cafaa0e6e8cf82f5a3a0f00afa47a082f093364da7cc279576d2fc
+    name: libpng
+    evr: 2:1.6.37-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libselinux-3.6-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 271153
+    checksum: sha256:a08a84389665ef614eb6d9b06a53128eab89b650c799c0558f3ae04df97c4b13
+    name: libselinux
+    evr: 3.6-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libsemanage-3.6-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 223978
+    checksum: sha256:33e4ad8374bdaa1dd4b4a46b2b379d025590d80e5d666801aea4f437a9a6ccd9
+    name: libsemanage
+    evr: 3.6-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libssh-0.10.4-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 670226
+    checksum: sha256:27606f3c6b33c346dec927f99a56cece41b09a0780b8c3d33599bb9020a5906f
+    name: libssh
+    evr: 0.10.4-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libtirpc-1.3.3-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 589716
+    checksum: sha256:95d684042f4c5f63ac57923639fd1e7d6d278766b4ee99feb24baa5567fe4b7e
+    name: libtirpc
+    evr: 1.3.3-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libusbx-1.0.26-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 643959
+    checksum: sha256:e9359c9ad4fedd8d880f23c2c6a248fd0e17d657ee4ef5d17d572844dfe5f016
+    name: libusbx
+    evr: 1.0.26-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libverto-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 396005
+    checksum: sha256:a648c6c90c2cfcd6836681bff947499285656e60a5b2243a53b7d6590a8b73ee
+    name: libverto
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/linux-firmware-20250513-151.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 465491510
+    checksum: sha256:d8eced04b42aa71a20da01a6663efaf05c09cfc2feff8ae1e672c4f01bd321ca
+    name: linux-firmware
+    evr: 20250513-151.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lsscsi-0.32-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 208622
+    checksum: sha256:194c000e5b85acb97e926c32a74edff60ea90d9a10162350a966d5e811a5eca5
+    name: lsscsi
+    evr: 0.32-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lvm2-2.03.28-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2992347
+    checksum: sha256:5361a813c7d6ea933fba20b461c5e3af5528b8876724460f8526f82564e0a063
+    name: lvm2
+    evr: 9:2.03.28-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lzo-2.10-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 614312
+    checksum: sha256:df1303a4bad0c6126e65fb9ac2c0881ad5ceab39e8a97a59afe1f757adc0b3c6
+    name: lzo
+    evr: 2.10-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lzop-1.04-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 404704
+    checksum: sha256:bd42a5d06d76aef940669d0b674a8828bfc60152ab2dbff22a3483c70e40b970
+    name: lzop
+    evr: 1.04-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/m/man-db-2.9.3-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1910721
+    checksum: sha256:bc6830986c1500ac2a8cf36dd575e53731b0160be2bc208ab141c52c292ac54b
+    name: man-db
+    evr: 2.9.3-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/m/mdadm-4.3-4.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 641686
+    checksum: sha256:407f4ecbeb3529505d1340cdc07117f7f35ca1f5defc6a530c18e5d82c2b25b0
+    name: mdadm
+    evr: 4.3-4.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/m/mtools-4.0.26-4.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 543062
+    checksum: sha256:a1c07910b80453f4aad247389b24dfb650f41d03b12900ec45e0574988b19ea6
+    name: mtools
+    evr: 4.0.26-4.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/ndctl-78-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 450744
+    checksum: sha256:5260964c5a505a9fe77ff1579eb4cf293879c5735d50757b2e728f2725e28fff
+    name: ndctl
+    evr: 78-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/nfs-utils-2.5.4-34.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799882
+    checksum: sha256:2ed1f701b51c6ab2435fa8ed56fcabc3f99004acad77d2cb1a045edf16f5618a
+    name: nfs-utils
+    evr: 1:2.5.4-34.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/numactl-2.0.19-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 231614
+    checksum: sha256:df493be344a68a29145a960db9b1fff8ff8ed673338b1608f404a648ef38164c
+    name: numactl
+    evr: 2.0.19-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/numad-0.5-37.20150602git.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 39137
+    checksum: sha256:b2c676c8f0fc82cdc420698b4acf8e604b70fd6289891443acd9200040674ec9
+    name: numad
+    evr: 0.5-37.20150602git.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 935874
+    checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/PyYAML-5.4.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 186404
+    checksum: sha256:a26c273bb984ac1c17f22aaac3fcd547c5f54cdc86dda0584f90ac363996f4b0
+    name: PyYAML
+    evr: 5.4.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/parted-3.5-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1923182
+    checksum: sha256:150ec567a9f144f10a8a79ee31ad19fce2edc9ce10c4e897f2e4d58b999d0d38
+    name: parted
+    evr: 3.5-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/pigz-2.8-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 131701
+    checksum: sha256:2eb6030553235feec36ab1406d80066f60ca545bf5a073a43a2a841a70892d2a
+    name: pigz
+    evr: 2.8-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 310904
+    checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
+    name: pkgconf
+    evr: 1.7.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/policycoreutils-3.6-2.1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 7982064
+    checksum: sha256:3ee0c11e4cb602eb81993a8492688246c3d750bc0f592ba895dbce0aa734580a
+    name: policycoreutils
+    evr: 3.6-2.1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/polkit-0.117-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 336356709
+    checksum: sha256:29fafdd944809b56c0c2e9fe65c2f777e18e5d53473c95e14f6365af4287b131
+    name: polkit
+    evr: 0.117-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/polkit-pkla-compat-0.1-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 302278
+    checksum: sha256:8e4af06bc58994064b55ef7cdac31d48f9797f874fa82e011ad75b6233940636
+    name: polkit-pkla-compat
+    evr: 0.1-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/procps-ng-3.3.17-14.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1054334
+    checksum: sha256:acfd5c270ba5724a0f5f2a84cc47ee222d6a03095421fddbf6932375ec7d67f0
+    name: procps-ng
+    evr: 3.3.17-14.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/q/quota-4.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 560123
+    checksum: sha256:dc1ee202e7a726ba6de3f148ba362e8a7ddd774599c4433caec6d5331e18e1a2
+    name: quota
+    evr: 1:4.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/rdma-core-54.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2015866
+    checksum: sha256:d22ac38cce2d526f51eb3f9e1c647974bc979c014ba909272b7c3bd9eaf30b90
+    name: rdma-core
+    evr: 54.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/rpcbind-1.2.6-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 147311
+    checksum: sha256:6fd5417237b1e77a458ca88109d97a7456af0ce407768562b3a779ce8bd0bde3
+    name: rpcbind
+    evr: 1.2.6-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/rpm-4.16.1.3-37.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4490587
+    checksum: sha256:b15a51773d702299bc9d83245544b60c8e733c0404f49e7badc5fa815449d151
+    name: rpm
+    evr: 4.16.1.3-37.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/selinux-policy-38.1.53-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1165990
+    checksum: sha256:d2d67cbefde4402aaf8d4ea0e0820683f183d388c43c3bc7841beefceca1af68
+    name: selinux-policy
+    evr: 38.1.53-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/setools-4.4.4-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 416171
+    checksum: sha256:6e57d0e6a49d784f9ac26173e7dc42ccdb7cf82f174c5c7b0a04e19551058fc6
+    name: setools
+    evr: 4.4.4-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/snappy-1.1.8-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1106755
+    checksum: sha256:e5cfaaae4882a9ad4ed8749430ead0acb7228a44a20e8aa27eb21dcb1795c1fd
+    name: snappy
+    evr: 1.1.8-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/squashfs-tools-4.4-10.git1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 265964
+    checksum: sha256:a8f3e58f77b03b2a161ccbe7f3579cc3b0e444c7b07ddf5d310596f871f78ca8
+    name: squashfs-tools
+    evr: 4.4-10.git1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/syslinux-6.04-0.20.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5311285
+    checksum: sha256:c0ebe8295039fb2d68d97b0bc5117fabedf5385009c95e6aa8f0e55efd30127b
+    name: syslinux
+    evr: 6.04-0.20.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/systemd-252-51.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 43223467
+    checksum: sha256:fd06bfa3f3ee8b7d0f563715a2362c9220bacd78b7ae099690e7439999c5eb05
+    name: systemd
+    evr: 252-51.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tpm2-tools-5.2-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1227059
+    checksum: sha256:c02043f848a7a7e59827d7fe53304b714e4a20b05811898ecf72a0747034ec77
+    name: tpm2-tools
+    evr: 5.2-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/u/userspace-rcu-0.12.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 542890
+    checksum: sha256:bcf02180bfad8ee8ce791c995003e6ab1c419e9781dcecfc61213ca97db8fcf0
+    name: userspace-rcu
+    evr: 0.12.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/x/xfsprogs-6.4.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1392193
+    checksum: sha256:116e6658aa9566330427a682d5068f481a17a429cc3f6873031782c8fae90e32
+    name: xfsprogs
+    evr: 6.4.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/x/xz-5.2.5-8.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1168293
+    checksum: sha256:bce98f3a307e75a8ac28f909e29b41d64b15461fa9ddf0bf4ef3c2f6de946b46
+    name: xz
+    evr: 5.2.5-8.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/z/zstd-1.5.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2378112
+    checksum: sha256:922957570bae59b0a45bd9d96ce804c65c6c3260f50198f40804d95ffb0db65e
+    name: zstd
+    evr: 1.5.5-1.el9
+  module_metadata: []

--- a/.konflux/virt-v2v/runtime/redhat.repo
+++ b/.konflux/virt-v2v/runtime/redhat.repo
@@ -1,0 +1,9194 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+
+[gitops-1.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fsw-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Fuse Service Works Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rpms]
+name = Single Sign-On Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss AMQ Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[nbde-tang-server-1-for-rhel-9-$basearch-textonly-rpms]
+name = nbde tang server 1 (for RHEL 9 $basearch) (Text-Only Advisories)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/nbde-tang-server-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-rpms]
+name = Red Hat Container Development Kit 3.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-source-rpms]
+name = Red Hat Container Development Kit 3.5 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-rpms]
+name = Red Hat Container Development Kit 3.4 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.15-rpms]
+name = Red Hat Container Development Kit 3.15 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.13-rpms]
+name = Red Hat Container Development Kit 3.13 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-source-rpms]
+name = Red Hat Container Development Kit 3.6 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhbop-textonly-1-for-middleware-rpms]
+name = Red Hat Build of OptaPlanner Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-debug-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Certification for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-source-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[soa-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss SOA Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openliberty-textonly-1-for-middleware-rpms]
+name = Open Liberty Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-debug-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-source-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.8-rpms]
+name = Red Hat Container Development Kit 3.8 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-textonly-1-for-middleware-rpms]
+name = Red Hat build of Quarkus Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-for-rhel-9-textonly-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm-textonly/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-textonly-1-for-middleware-rpms]
+name = OpenJDK Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-rpms]
+name = Fast Datapath for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-9-$basearch-source-rpms]
+name = Single Sign-On 7.6 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rh-sso/7.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.12-rpms]
+name = Red Hat Container Development Kit 3.12 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[rhoso-18.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso/18.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-debug-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.15-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Grid Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.16-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.3 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-dev-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform Dev Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-dev-preview/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-rpms]
+name = Red Hat Container Development Kit 3.5 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.16-rpms]
+name = Red Hat Container Development Kit 3.16 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-source-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhsi-textonly-1-for-middleware-rpms]
+name = Red Hat Service Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 6 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-debug-rpms]
+name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-debug-rpms]
+name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rhui-rpms]
+name = Single Sign-On Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[wfk-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Framework Kit Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1-for-rhel-9-$basearch-rpms]
+name = Kernel Module Management 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/kmm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.7-rpms]
+name = Red Hat Container Development Kit 3.7 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosds-textonly-3-for-middleware-rpms]
+name = Red Hat OpenShift Dev Spaces 3 Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-source-rpms]
+name = Red Hat Container Development Kit 2.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.9-rpms]
+name = Red Hat Container Development Kit 3.9 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1.0-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified 1.0 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-podified/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-stf/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-source-rpms]
+name = Red Hat Container Development Kit 3.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.11-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.11 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-debug-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-9-$basearch-source-rpms]
+name = Fast Datapath for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-rpms]
+name = JBoss Web Server 5 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-edpm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Data Foundation for RHEL 9 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhodf/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-debug-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-rpms]
+name = Red Hat Container Development Kit 3.6 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-source-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhose-textonly-1-for-middleware-rpms]
+name = Red Hat Middleware Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.19-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/3.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.16-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.16 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel9/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jdv-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Virtualization Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Discovery 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/discovery/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Server Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-9-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-debug-rpms]
+name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Web Server 5 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-1-tech-preview-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Insights Proxy 1 Tech Preview for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/insights-proxy-tech-preview/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jon-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Operations Network Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-9-$basearch-source-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/network-observability/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhdh-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Developer Hub 1 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhdh/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.17-for-rhel-9-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.17-rpms]
+name = Red Hat Container Development Kit 3.17 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-9-$basearch-debug-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 9 for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/osso/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.17-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.17 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhacm/2.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-source-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.18-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.18 (for RHEL 9 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nmo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-debug-rpms]
+name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-18-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso/18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.17-for-rhel-9-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.17 (RHEL 9) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-utils/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhceph-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.19-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.19 (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/pipelines/1.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-cinderlib-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Cinderlib for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-cinderlib/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-nhc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-9-$basearch-aus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 9 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.19-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.18-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-9-$basearch-rpms]
+name = Red Hat Service Interconnect for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.14-rpms]
+name = Red Hat Container Development Kit 3.14 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-9-$basearch-source-rpms]
+name = JBoss Web Server 6 (RHEL 9) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jws/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-eus-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel9/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-aus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-snr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-far/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.3-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.3) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[insights-proxy-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Insights Proxy for RHEL9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/insights-proxy/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-eus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.10-rpms]
+name = Red Hat Container Development Kit 3.10 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-eus-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Application Interconnect for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhai/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-3-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 3 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ossm/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-9-$basearch-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/amq/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-rt-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-tools-18-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift 18 Tools Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-tools/18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-9-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.10-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.10 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-e4s-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-3.0-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (3.0) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.1) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-9-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 9) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ocp-tools/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.17-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-resilientstorage-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jdg/8.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.12-for-rhel-9-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.12 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-cuda-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch - Cuda (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-9-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhv-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.5-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.5) for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12.0-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Directory Server 12.0 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-gaudi-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch - Gaudi (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-gaudi/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-edpm-1-beta-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Services on OpenShift External Data Plane Management Beta for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-edpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Enterprise Linux AI (1.2) for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/dirsrv/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-9-$basearch-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rodoo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-developer/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-source-rpms]
+name = Red Hat Container Development Kit 3.4 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/rhui/$releasever/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-aus-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel9/$releasever/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.19-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.19 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-nfv-e4s-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Real Time for NFV - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel9/$releasever/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Satellite 6.16 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/satellite/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-rpms]
+name = Red Hat Container Development Kit 2.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.14-for-rhel-9-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp-ironic/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17 Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack-deployment-tools/17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3-for-rhel-9-$basearch-debug-rpms]
+name = Red Hat Quay 3 (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/quay/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-maintenance/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.16-for-rhel-9-$basearch-rpms]
+name = Logical Volume Manager Storage 4.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jpp-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Portal Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-debug-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-12-for-rhel-9-$basearch-eus-debug-rpms]
+name = Red Hat Directory Server 12 for RHEL 9 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/dirsrv/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenStack Platform 17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/openstack/17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhsi/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhwa-mdr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoso-podified-1-beta-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Services on OpenShift Podified Beta for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/rhoso-podified/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.18-for-rhel-9-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.18 for RHEL 9 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.14-for-rhel-9-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.14 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cert-manager/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.17-for-rhel-9-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.17 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/lvms/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-9-$basearch-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/$releasever/$basearch/codeready-builder/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-9-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/gitops/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/ansible-automation-platform/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-netweaver-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP NetWeaver (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhpm-1-for-rhel-9-$basearch-textonly-rpms]
+name = Power monitoring for Red Hat OpenShift (for RHEL 9 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhpm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-9-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 9) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhelai-1.4-cuda-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (1.4) for RHEL 9 $basearch - Cuda (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai-cuda/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-9-$basearch-rhui-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 9 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel9/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-highavailability-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - High Availability (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/rhui/$releasever/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-9-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 9 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel9/$basearch/openstack-deployment-tools/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-sap-solutions-rhui-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - SAP Solutions (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel9/rhui/$releasever/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-debug-rpms]
+name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.11-rpms]
+name = Red Hat Container Development Kit 3.11 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-textonly-1-for-middleware-rpms]
+name = Red Hat AMQ Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-supplementary-eus-debug-rpms]
+name = Red Hat Enterprise Linux 9 for $basearch - Supplementary - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/$releasever/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.17-for-rhel-9-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.17 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/sat-capsule/6.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-9-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/cnv/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/467728618270217482-key.pem
+sslclientcert = /etc/pki/entitlement/467728618270217482.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0

--- a/.konflux/virt-v2v/runtime/rpms.in.yaml
+++ b/.konflux/virt-v2v/runtime/rpms.in.yaml
@@ -1,0 +1,11 @@
+packages:
+  - virt-v2v
+  - virtio-win
+contentOrigin:
+  repofiles:
+    - ./redhat.repo
+context:
+  containerfile:
+    file: ../../../build/virt-v2v/Containerfile-downstream
+    stageName: runtime
+arches: [x86_64]

--- a/.konflux/virt-v2v/runtime/rpms.lock.yaml
+++ b/.konflux/virt-v2v/runtime/rpms.lock.yaml
@@ -1,0 +1,3298 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/abattis-cantarell-fonts-0.301-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 377278
+    checksum: sha256:4b92bfb55c4e356a7960b721ec7f16c191e0081f9cb1bae98b1411078a706e48
+    name: abattis-cantarell-fonts
+    evr: 0.301-4.el9
+    sourcerpm: abattis-cantarell-fonts-0.301-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/augeas-libs-1.14.1-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 438164
+    checksum: sha256:0d15455953c386b5b7bc7b3368e9f2af5dd9b220ecf7b5526fe90b812703698c
+    name: augeas-libs
+    evr: 1.14.1-2.el9
+    sourcerpm: augeas-1.14.1-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/capstone-4.0.2-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 788501
+    checksum: sha256:494e45c1214b9210a44418228ee580d1838f211597e473a7f2d4b17331a27055
+    name: capstone
+    evr: 4.0.2-10.el9
+    sourcerpm: capstone-4.0.2-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 365931
+    checksum: sha256:3d12bc7e21276434108c97561f75d1854283afb73d4fface3b836acee09f8d98
+    name: checkpolicy
+    evr: 3.6-1.el9
+    sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/clevis-21-208.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 62508
+    checksum: sha256:beb835c39f8085d61aec31f655cc1a42ce76a070509f705cd034e5028ce55857
+    name: clevis
+    evr: 21-208.el9
+    sourcerpm: clevis-21-208.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/clevis-luks-21-208.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 40033
+    checksum: sha256:48e5a71a245ef9b0c0045dc48a3d02b6832625b73f961a8208848c1dd9e93ec1
+    name: clevis-luks
+    evr: 21-208.el9
+    sourcerpm: clevis-21-208.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/cmake-rpm-macros-3.26.5-2.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 12250
+    checksum: sha256:1c74969c8a4f21851f5b89f25ac55c689b75bed1318d0435fc3a14a49c39d0e3
+    name: cmake-rpm-macros
+    evr: 3.26.5-2.el9
+    sourcerpm: cmake-3.26.5-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/d/dnsmasq-2.85-16.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 339509
+    checksum: sha256:994cfdb204a4f815c58535034d409f0f5e8735e5faac9f832187d4f8a3efc839
+    name: dnsmasq
+    evr: 2.85-16.el9_4
+    sourcerpm: dnsmasq-2.85-16.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/d/dwz-0.14-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 133177
+    checksum: sha256:9b429a1abaadc0fd63cb0667ef5bc5ec4db4debc340f7f5742a9252dd8301a30
+    name: dwz
+    evr: 0.14-3.el9
+    sourcerpm: dwz-0.14-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/e/edk2-ovmf-20241117-2.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 6398963
+    checksum: sha256:6fd9a777974da9b838842ab53d2bec9971e926c777bc6c7f5db81011790b78d7
+    name: edk2-ovmf
+    evr: 20241117-2.el9
+    sourcerpm: edk2-20241117-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/e/efi-srpm-macros-6-2.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 24452
+    checksum: sha256:1a1fa7561f5cef960b36c6a796d8a6fb4af70511118dacbfd5f707181a6c02fe
+    name: efi-srpm-macros
+    evr: 6-2.el9_0
+    sourcerpm: efi-rpm-macros-6-2.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/f/fonts-srpm-macros-2.0.5-7.el9.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 30140
+    checksum: sha256:f8c6aaa6af574698f6d1a7eb8e7f6ed725e4366dc14553bc816f5aa305675367
+    name: fonts-srpm-macros
+    evr: 1:2.0.5-7.el9.1
+    sourcerpm: fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/gdisk-1.0.7-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 253973
+    checksum: sha256:eb8973df11266ce57f1db004883df3f14690c17646992c2d977f81cd6ba560f7
+    name: gdisk
+    evr: 1.0.7-5.el9
+    sourcerpm: gdisk-1.0.7-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/geolite2-city-20191217-6.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 23756501
+    checksum: sha256:5cc6df7774a9bcc7db6e48f610b779db2f1848ee7af81a75fb53725f9ee58117
+    name: geolite2-city
+    evr: 20191217-6.el9
+    sourcerpm: geolite2-20191217-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/geolite2-country-20191217-6.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1687130
+    checksum: sha256:d075919b3ea033169ae1b24ba9d5819c912f378385da4e52d4fb724d04a29de6
+    name: geolite2-country
+    evr: 20191217-6.el9
+    sourcerpm: geolite2-20191217-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/ghc-srpm-macros-1.5.0-6.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 9252
+    checksum: sha256:80fb1c39b5d8c23352b8928332fa0794e679e054ffa3f04a34c2b18bb7e28c93
+    name: ghc-srpm-macros
+    evr: 1.5.0-6.el9
+    sourcerpm: ghc-srpm-macros-1.5.0-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/gnutls-dane-3.8.3-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 21005
+    checksum: sha256:313eebc173895910227e2fe1fe5a6ec388df9f88b276546a2e6a8f1fe149fbba
+    name: gnutls-dane
+    evr: 3.8.3-6.el9
+    sourcerpm: gnutls-3.8.3-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/gnutls-utils-3.8.3-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 299745
+    checksum: sha256:f023263ed30906562c5c6799da8bd39dc728d4ea665ee9766df52ace8a9e2af6
+    name: gnutls-utils
+    evr: 3.8.3-6.el9
+    sourcerpm: gnutls-3.8.3-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/go-srpm-macros-3.6.0-10.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 28143
+    checksum: sha256:c1cbc05c812994c77b7f7bf80e76039c94d6ba887c9169228833e7e702aa095a
+    name: go-srpm-macros
+    evr: 3.6.0-10.el9_6
+    sourcerpm: go-rpm-macros-3.6.0-10.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/guestfs-tools-1.52.2-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 3978882
+    checksum: sha256:8da582d72b9ae92113801c1eea46dcc7c080f3b6e372373e2cb0afaa3c193b5f
+    name: guestfs-tools
+    evr: 1.52.2-3.el9_6
+    sourcerpm: guestfs-tools-1.52.2-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/h/hexedit-1.6-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 46084
+    checksum: sha256:41183708d72ca26e340f9549ca0747f2e7ed50b738110efd6243811d739ee11d
+    name: hexedit
+    evr: 1.6-1.el9
+    sourcerpm: hexedit-1.6-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/h/hivex-libs-1.3.24-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 44960
+    checksum: sha256:1a3170accb28ab7435c97df38036350077b56601710aa1010eb231431b38d5ee
+    name: hivex-libs
+    evr: 1.3.24-1.el9
+    sourcerpm: hivex-1.3.24-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/i/ipxe-roms-qemu-20200823-9.git4bd064de.el9_0.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 696047
+    checksum: sha256:9309fd2b2c1ade294cda0baa5c2de03b8ad478c923ee65ef4e02b2b55fa8ee89
+    name: ipxe-roms-qemu
+    evr: 20200823-9.git4bd064de.el9_0
+    sourcerpm: ipxe-20200823-9.git4bd064de.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/j/jose-14-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 73995
+    checksum: sha256:e99a5d567d44735a16b936ddef74d090b626f5b63cc6759361e9a000943b1f94
+    name: jose
+    evr: 14-1.el9
+    sourcerpm: jose-14-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-srpm-macros-1.0-13.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 17792
+    checksum: sha256:7e891fa264fb538bf4a26aa94e91ff0c3084bf2613e2061dbb6f4f0c26856777
+    name: kernel-srpm-macros
+    evr: 1.0-13.el9
+    sourcerpm: kernel-srpm-macros-1.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libfdt-1.6.0-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 36905
+    checksum: sha256:4964932c9994906fdec1208f102178622d60754d06f886e372f02fb4d6da5374
+    name: libfdt
+    evr: 1.6.0-7.el9
+    sourcerpm: dtc-1.6.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libguestfs-1.54.0-8.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1205626
+    checksum: sha256:8d49f080cba0466483f010673f5aeff5ce53ddc467ce6d74df2a7682b1430b6e
+    name: libguestfs
+    evr: 1:1.54.0-8.el9_6
+    sourcerpm: libguestfs-1.54.0-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libguestfs-appliance-1.54.0-8.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2281158
+    checksum: sha256:c4f5e20a1a57c23d93c1ae0bcfd612b750f79ccc5b737578e6c55e12dfbfa118
+    name: libguestfs-appliance
+    evr: 1:1.54.0-8.el9_6
+    sourcerpm: libguestfs-1.54.0-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libguestfs-winsupport-9.3-1.el9_3.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2517670
+    checksum: sha256:80c2c919631a7b4640f45537c968d46312895a317d24e73ec2ea8073358a1a57
+    name: libguestfs-winsupport
+    evr: 9.3-1.el9_3
+    sourcerpm: libguestfs-winsupport-9.3-1.el9_3.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libguestfs-xfs-1.54.0-8.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 10287
+    checksum: sha256:f27288cafdad3f09a252d15b56fa12979c79039844c600cf686dddf5884a0171
+    name: libguestfs-xfs
+    evr: 1:1.54.0-8.el9_6
+    sourcerpm: libguestfs-1.54.0-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libjose-14-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 67231
+    checksum: sha256:a78d32b8e7f9782e4d3d8740a31d3b2ad10a1b75f506368d8625592f20919fbe
+    name: libjose
+    evr: 14-1.el9
+    sourcerpm: jose-14-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libluksmeta-9-12.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 28058
+    checksum: sha256:088cacedbce4a2476cf6e527da0dfbc48ffb0a75eebb5566f9dc7df4833e5a62
+    name: libluksmeta
+    evr: 9-12.el9
+    sourcerpm: luksmeta-9-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 36179
+    checksum: sha256:70a1e33b55a32d85ea4508e9ebeefb3e0ce2f57619ee84c97c63af5dc1456342
+    name: libmaxminddb
+    evr: 1.5.2-4.el9
+    sourcerpm: libmaxminddb-1.5.2-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libnbd-1.20.3-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 178646
+    checksum: sha256:c8622abd5520130af5ca67270d8676970ac466ade75032c791bf0a26ce7595b9
+    name: libnbd
+    evr: 1.20.3-1.el9
+    sourcerpm: libnbd-1.20.3-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libosinfo-1.10.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 330658
+    checksum: sha256:df5ba797a439ee766e3c9d646c1adbd5a49f88d1d27da859e4f232b751fcbeca
+    name: libosinfo
+    evr: 1.10.0-1.el9
+    sourcerpm: libosinfo-1.10.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libpmem-1.12.1-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 117415
+    checksum: sha256:a397978ab7744ed3c3795fc471d047b8fba6a5b8af82d7f5e9bc034e2906b0f8
+    name: libpmem
+    evr: 1.12.1-1.el9
+    sourcerpm: nvml-1.12.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libproxy-webkitgtk4-0.4.15-35.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 23007
+    checksum: sha256:c28db0927e8d45e528e29ef90ecfe75153244df035d0ae0ba84a62abbc8e0870
+    name: libproxy-webkitgtk4
+    evr: 0.4.15-35.el9
+    sourcerpm: libproxy-0.4.15-35.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 71992
+    checksum: sha256:9bd269ec50504f997683e963481f870bb937c3cfdb54a057e9acca67bf2b7631
+    name: libslirp
+    evr: 4.4.0-8.el9
+    sourcerpm: libslirp-4.4.0-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libsoup-2.72.0-10.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 413102
+    checksum: sha256:f9b3791cbc944efa8292275d0947daa039b61cb3a8c63f7a455a7faa19834f61
+    name: libsoup
+    evr: 2.72.0-10.el9_6.2
+    sourcerpm: libsoup-2.72.0-10.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libtpms-0.9.1-4.20211126git1ff6fe1f43.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 189788
+    checksum: sha256:b7ab88898f81a136522f83039b82944f6e2dc9c73d6a5ba20320ccaf329d02e3
+    name: libtpms
+    evr: 0.9.1-4.20211126git1ff6fe1f43.el9_5
+    sourcerpm: libtpms-0.9.1-4.20211126git1ff6fe1f43.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/liburing-2.5-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 42739
+    checksum: sha256:cc7894188e8c9cc06335a47150f05ad80cbbf91cbf7c877e5e75683bddf61b53
+    name: liburing
+    evr: 2.5-1.el9
+    sourcerpm: liburing-2.5-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-client-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 462647
+    checksum: sha256:88563426548029aa8150fecc9b123382659ad6f9b1beca955bd8724a5b9378ad
+    name: libvirt-client
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-common-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 145324
+    checksum: sha256:a46c61b8e4f09043271c0d7b57ca5e28973c8b495813ed14a19a599d91de0499
+    name: libvirt-daemon-common
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-config-network-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 33208
+    checksum: sha256:b01657fa8ff15b050c755d5f477b6d94f2523138244b32155249869bc2bfea6e
+    name: libvirt-daemon-config-network
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-network-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 281845
+    checksum: sha256:bde9d96f05d7250bf7b00e88766008f4392577a805dd105a7cfef1d765c7b310
+    name: libvirt-daemon-driver-network
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-qemu-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1020529
+    checksum: sha256:f5224624f1e564efc6bf46ae55cb541fb3e3c93e26cfa20d8e437b77e10a29d9
+    name: libvirt-daemon-driver-qemu
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-secret-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 225069
+    checksum: sha256:b8648c33932c6d81fcdbbcaed46cf2ce4cc65def5ca90dfd529dedacd51cef83
+    name: libvirt-daemon-driver-secret
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-storage-core-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 282348
+    checksum: sha256:c008db2c31f3bf6fbdac082a8b0f6774921eb8a8f12dca0c0d3ece4e60a98fe1
+    name: libvirt-daemon-driver-storage-core
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-log-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 73180
+    checksum: sha256:6d167df9310248a17b58b5ec9f729836eb0dd5f386ac951d140d89cecd2e6ffc
+    name: libvirt-daemon-log
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-libs-10.10.0-7.3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 5334776
+    checksum: sha256:ae4b238d060353147d22e1ff475b14784428fdb3f98e64db9462afa161358f8d
+    name: libvirt-libs
+    evr: 10.10.0-7.3.el9_6
+    sourcerpm: libvirt-10.10.0-7.3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 93189
+    checksum: sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a
+    name: libxcrypt-compat
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 250837
+    checksum: sha256:b22bb9f995e96b2b00711760c57fe4e93b4328815de61c39d53717b6a61f6d8c
+    name: libxslt
+    evr: 1.1.34-13.el9_6
+    sourcerpm: libxslt-1.1.34-13.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/lua-srpm-macros-1-6.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 10476
+    checksum: sha256:64946edfd54f7d4668f7fdcb7be961ceaca8cff7d0bef438bef4e2498ccf3cd6
+    name: lua-srpm-macros
+    evr: 1-6.el9
+    sourcerpm: lua-rpm-macros-1-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/luksmeta-9-12.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 23634
+    checksum: sha256:3be1ff9059f65c2455f1701c388feebbed719b9b40e6cb23aed734f40c746e23
+    name: luksmeta
+    evr: 9-12.el9
+    sourcerpm: luksmeta-9-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/m/mingw-binutils-generic-2.43.1-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 984872
+    checksum: sha256:7e2ebe65154a953defc28db065a62e88f62c80a783ef644a54406c26d2927887
+    name: mingw-binutils-generic
+    evr: 2.43.1-2.el9
+    sourcerpm: mingw-binutils-2.43.1-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/m/mingw-filesystem-base-148-7.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 24519
+    checksum: sha256:86f70a264537b9dc8c3ad2869e78c65e45d3997879a92a60f6a1915cd976a3e5
+    name: mingw-filesystem-base
+    evr: 148-7.el9
+    sourcerpm: mingw-filesystem-148-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/m/mingw32-crt-12.0.0-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 3445973
+    checksum: sha256:7e76fcc66237184a4e01a2d80221dac88235ff3ddc8e3c169a5dc89f47939a8b
+    name: mingw32-crt
+    evr: 12.0.0-4.el9
+    sourcerpm: mingw-crt-12.0.0-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/m/mingw32-filesystem-148-7.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 397178
+    checksum: sha256:2b1287c4e083b228e19ecfc7ab0ec03388f1f2ca8cf01403f5f4467bf77c298d
+    name: mingw32-filesystem
+    evr: 148-7.el9
+    sourcerpm: mingw-filesystem-148-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/m/mingw32-srvany-1.1-3.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 54266
+    checksum: sha256:ad919161ed84764c8683f8c2f700d09a9157d0f54091c0f7b3f92fe870d6bf2b
+    name: mingw32-srvany
+    evr: 1.1-3.el9
+    sourcerpm: mingw-srvany-1.1-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 5401
+    checksum: sha256:55a6690cee8af0140d0f9c4b7103f9c1dc80e564eb0e2fc17ac9c4ad8c3596e8
+    name: nbdkit
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-basic-filters-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 346721
+    checksum: sha256:c3ab79a3600df5022488846403644b22cae7de5e82f57fdc3096c14c372a6c26
+    name: nbdkit-basic-filters
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-basic-plugins-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 223807
+    checksum: sha256:f4afac06ce640c817ebdf5a3d184e58606d7e2da71dc4663960df3f8804b4f31
+    name: nbdkit-basic-plugins
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-curl-plugin-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 41180
+    checksum: sha256:a0f8bded2945fde117082253f5dd624187982a7846bff5970e598dc03098995c
+    name: nbdkit-curl-plugin
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-nbd-plugin-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 35549
+    checksum: sha256:ffa2adbea2b5e9ef9c79b875f126c918d3684573b1148b889686433ab41c78c7
+    name: nbdkit-nbd-plugin
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-python-plugin-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 40788
+    checksum: sha256:18484dd5a1d4b36cc868b7fb1c1c7176fc483ef7ff2b2ab980d2b07543d7b245
+    name: nbdkit-python-plugin
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-selinux-1.38.5-3.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 24504
+    checksum: sha256:182205a1ad124a6cb46674627c0bab16b49eeb95953cf26af194ff993307e56e
+    name: nbdkit-selinux
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-server-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 132670
+    checksum: sha256:28be5705cdf4a79118279a15ce58296ad4c0d49996cfe40e351393d33d2c822e
+    name: nbdkit-server
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-ssh-plugin-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 30025
+    checksum: sha256:6b43d9934d1b39d4a1a0f4cf8cad62f5df894ab1513391a47bfb0c69b8032191
+    name: nbdkit-ssh-plugin
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-vddk-plugin-1.38.5-3.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 50553
+    checksum: sha256:29c53893b324733aed461474611a08441573b8f437a6614121d397a020625194
+    name: nbdkit-vddk-plugin
+    evr: 1.38.5-3.el9_6
+    sourcerpm: nbdkit-1.38.5-3.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 9270
+    checksum: sha256:783710ad3710e594275fb23d280f030a68279927ca82ce38787f4c93971eaa88
+    name: ocaml-srpm-macros
+    evr: 6-6.el9
+    sourcerpm: ocaml-srpm-macros-6-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/o/openblas-srpm-macros-2-11.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 8807
+    checksum: sha256:091911db0712bfe9b03952046191438bdd9b1080558e0c1014611d39aa80571d
+    name: openblas-srpm-macros
+    evr: 2-11.el9
+    sourcerpm: openblas-srpm-macros-2-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/o/osinfo-db-20250124-2.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 572759
+    checksum: sha256:a6c20b6694154a918025a55b2a70496aa3fb115018af69cf3fea52c4453e7cc4
+    name: osinfo-db
+    evr: 20250124-2.el9_6
+    sourcerpm: osinfo-db-20250124-2.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/o/osinfo-db-tools-1.10.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 79633
+    checksum: sha256:b9a0c02d24185b936dfe2582fce7f665357b14080544e6682be53e1ea0d917a1
+    name: osinfo-db-tools
+    evr: 1.10.0-1.el9
+    sourcerpm: osinfo-db-tools-1.10.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-0^20250217.ga1e48a0-9.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 264431
+    checksum: sha256:d46d62bcf865df245f3538ab121e3235ee06beab7f4f463b3518896612d631e9
+    name: passt
+    evr: 0^20250217.ga1e48a0-9.el9_6
+    sourcerpm: passt-0^20250217.ga1e48a0-9.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-selinux-0^20250217.ga1e48a0-9.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 29183
+    checksum: sha256:13a6d7eac2d0b0ac5ef9139aef1bf5d5c4b128e1c30e9c512665bb8c20cb8f6f
+    name: passt-selinux
+    evr: 0^20250217.ga1e48a0-9.el9_6
+    sourcerpm: passt-0^20250217.ga1e48a0-9.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 21821
+    checksum: sha256:52cda881960f48be35a47ba1c54f242efac1ab0d1fd74b0e2bcb48a1723907c8
+    name: perl-AutoLoader
+    evr: 5.74-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-B-1.80-481.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 188182
+    checksum: sha256:1d9743f0a5ba875908984dbe875025aa51bc62fc9d1bec3fbef12f6688c1d771
+    name: perl-B
+    evr: 1.80-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 32039
+    checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
+    name: perl-Carp
+    evr: 1.50-460.el9
+    sourcerpm: perl-Carp-1.50-460.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 22914
+    checksum: sha256:45347749c36c4750c9083d4784700fb85c3a4c277c3bf69873a1c6ae97ee6c4b
+    name: perl-Class-Struct
+    evr: 0.66-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 59910
+    checksum: sha256:6cd912e640cbc8785e33dae9cf07561509491a0ec76a81c01d6b7a77ad08668d
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+    sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 29409
+    checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
+    name: perl-Digest
+    evr: 1.19-4.el9
+    sourcerpm: perl-Digest-1.19-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 40274
+    checksum: sha256:2a6b21a144ae1d060e51ee2b6328c5dd1a646f429da160f386c2eb420b1220b4
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+    sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1802386
+    checksum: sha256:d05248697e48928be004ed4c683b04966aa452ae1e2bd81f650c6de108b46956
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+    sourcerpm: perl-Encode-3.08-462.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Errno-1.30-481.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 15331
+    checksum: sha256:891006d2a5ec8528b1e7fe181a3e1617733b1050250b381f29261b70e83865ed
+    name: perl-Errno
+    evr: 1.30-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 34509
+    checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
+    name: perl-Exporter
+    evr: 5.74-461.el9
+    sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Fcntl-1.13-481.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 22098
+    checksum: sha256:726645728dabb2f1badb1c4a6170c5db29118a536cdfa482c882aaef6ed97fb4
+    name: perl-Fcntl
+    evr: 1.13-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-File-Basename-2.85-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 17916
+    checksum: sha256:746f919f1aebc91a28f00e20eda7b41991db9e50abf2fa22cd7f8168a8f9898a
+    name: perl-File-Basename
+    evr: 2.85-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 38466
+    checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
+    name: perl-File-Path
+    evr: 2.18-4.el9
+    sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 64150
+    checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+    sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-File-stat-1.09-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 17853
+    checksum: sha256:355aba30d043f829e4e7e70466564ba85f65f7a2416aba0ceddfc9e59288aab4
+    name: perl-File-stat
+    evr: 1.09-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-FileHandle-2.03-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 15921
+    checksum: sha256:480ac4c1de2c1e1f94ed8895793b93d96bd50dc95e6e4fa9c39a82a24998f717
+    name: perl-FileHandle
+    evr: 2.03-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 65144
+    checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+    sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 16222
+    checksum: sha256:c9c6209474ec44ca5b070ffb147589359c551757f95b358a8f35d2627c4950cf
+    name: perl-Getopt-Std
+    evr: 1.12-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 58720
+    checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+    sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-IO-1.43-481.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 94663
+    checksum: sha256:dc85c28902667c1bd3c6f19b6a08bdda5e1d25b11e832b269e15fde94e6ab52d
+    name: perl-IO
+    evr: 1.43-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 46457
+    checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+    sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 226003
+    checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+    sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 24124
+    checksum: sha256:422c83bcdd2f84d9751fe4ea289e6bc8bfbc41e6540d6482671317fbc2ff1a17
+    name: perl-IPC-Open3
+    evr: 1.21-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 35058
+    checksum: sha256:3ae8affe13cc15cfaee1c6dd078ada14891dde5dca263927a9b5ed87f241d2c0
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+    sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 14781
+    checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+    sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 23899
+    checksum: sha256:fbd179e177943079b17db7c887b77dcca46b009ae41d85da5c16e1f33d20a1c9
+    name: perl-NDBM_File
+    evr: 1.15-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 428188
+    checksum: sha256:d8ed17b9700c4acee11a339c9e0814862ad5b20e072c1414021dcb050c7da90b
+    name: perl-Net-SSLeay
+    evr: 1.94-1.el9
+    sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 100044
+    checksum: sha256:70b078b5b692c8d8b26600ae4868b50d613289a89c50b702109bce542d2c8888
+    name: perl-POSIX
+    evr: 1.94-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 94564
+    checksum: sha256:0647785b169c4bbdc65adf06d28981ce7fd1c9f93aecaa4e53a4515a21ebbf81
+    name: perl-PathTools
+    evr: 3.78-461.el9
+    sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 22564
+    checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+    sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 93727
+    checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+    sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 234403
+    checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+    sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 44477
+    checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+    sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 77262
+    checksum: sha256:7ce874bde7d9ad15abf70a3b7edbab77548eb2eb8b529c1e48b2426ee7f948f9
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+    sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 12017
+    checksum: sha256:c4f02fdf5b501ab67b4824fc4473ba420f482254ad82e90b546d9b10a5464820
+    name: perl-SelectSaver
+    evr: 1.02-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 59776
+    checksum: sha256:762751146305f9aea53b74a21495a610e7bdde956fa3246565d265b1128b56a8
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+    sourcerpm: perl-Socket-2.031-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 100335
+    checksum: sha256:0097fdb40a1f83e56d5bf91160c07151b7cdd64f829fc0e328cdf3b43c2b4fa6
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+    sourcerpm: perl-Storable-3.21-460.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Symbol-1.08-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 14535
+    checksum: sha256:2364cd3b0a19572b16a1379c228046a405851bcd0676860a6aeb9bcb3869498f
+    name: perl-Symbol
+    evr: 1.08-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 52228
+    checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+    sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 25043
+    checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+    sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 18680
+    checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+    sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 25935
+    checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+    sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 37469
+    checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+    sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 128279
+    checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
+    name: perl-URI
+    evr: 5.09-3.el9
+    sourcerpm: perl-URI-5.09-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-base-2.27-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 16674
+    checksum: sha256:dab1d27f285d579c9783e80817f98a2835e7bf06842d704a7f85cfdb7ab4b0a3
+    name: perl-base
+    evr: 2.27-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 25865
+    checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
+    name: perl-constant
+    evr: 1.33-461.el9
+    sourcerpm: perl-constant-1.33-461.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-if-0.60.800-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 14343
+    checksum: sha256:714022b8937ed9c6d4638b99aef0a8426b782e7948019b50b06d9cd2e32e454a
+    name: perl-if
+    evr: 0.60.800-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 74840
+    checksum: sha256:359a94a09f0082a637c5bc2aa4ddac23dd79e929daa38dfed85d0e1afff31fba
+    name: perl-interpreter
+    evr: 4:5.32.1-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 137289
+    checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
+    name: perl-libnet
+    evr: 3.13-4.el9
+    sourcerpm: perl-libnet-3.13-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-libs-5.32.1-481.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2303445
+    checksum: sha256:d20aebf4d96f4ad0e7dc97b63bbe41baa6f927a34eac9068a22f1d62e71611dc
+    name: perl-libs
+    evr: 4:5.32.1-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-mro-1.23-481.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 30125
+    checksum: sha256:3cf76960b8c866deebf333a9dfd64a7dd9f4689cb82e37d0c0ddab2c031b3651
+    name: perl-mro
+    evr: 1.23-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-overload-1.31-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 46643
+    checksum: sha256:813598b9d9a3ada4975144cf0dd0f25906589a92c7708556dcbf464501d72848
+    name: perl-overload
+    evr: 1.31-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-overloading-0.02-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 13658
+    checksum: sha256:feca093162af099f769448e95170a357f2d2bd66da36299d1a999782d57da51d
+    name: perl-overloading
+    evr: 0.02-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 16286
+    checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
+    name: perl-parent
+    evr: 1:0.238-460.el9
+    sourcerpm: perl-parent-0.238-460.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 121317
+    checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+    sourcerpm: perl-podlators-4.14-460.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-srpm-macros-1-41.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 9639
+    checksum: sha256:fa6a45cf7cb8b6f8a28ce85be31483eacc7b0b4c01d598123ec649867b67c8f4
+    name: perl-srpm-macros
+    evr: 1-41.el9
+    sourcerpm: perl-srpm-macros-1-41.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-subs-1.03-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 11986
+    checksum: sha256:df6327eb3774c2254fc45c630cedf3b32b3bdd7f146bf25ffe0342f9904dac43
+    name: perl-subs
+    evr: 1.03-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/perl-vars-1.05-481.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 13347
+    checksum: sha256:c54caddd2a5adaf84088833a9eb126e772b6db090800c3293b819f432ddd6b6c
+    name: perl-vars
+    evr: 1.05-481.el9
+    sourcerpm: perl-5.32.1-481.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/pixman-0.40.0-6.el9_3.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 277483
+    checksum: sha256:40581f27200096a57adc25a51d3d373a81f55d3abc0529cbe057c2c458318145
+    name: pixman
+    evr: 0.40.0-6.el9_3
+    sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-2.1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 82931
+    checksum: sha256:fcbe07b75cd10b0a2752d558a8b7750cb13b59473439701d8c568195f05c3805
+    name: policycoreutils-python-utils
+    evr: 3.6-2.1.el9
+    sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/pyproject-srpm-macros-1.16.2-1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 14828
+    checksum: sha256:1bec3715412a73295a9cd2cdbc147ebee0fe23b50f4146bddc08a5761ed3928d
+    name: pyproject-srpm-macros
+    evr: 1.16.2-1.el9
+    sourcerpm: pyproject-rpm-macros-1.16.2-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 18705
+    checksum: sha256:cc14196e07f9c6383f5bdf2c1171e7d41256326324c4a03c98d62d81413f3fb3
+    name: python-srpm-macros
+    evr: 3.9-54.el9
+    sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.5-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 88009
+    checksum: sha256:023ddd2c1dda3422bc1b067e562b39621eaefdf778efd0dae07fc144ba188fb5
+    name: python3-audit
+    evr: 3.1.5-4.el9
+    sourcerpm: audit-3.1.5-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-distro-1.5.0-7.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 41452
+    checksum: sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069
+    name: python3-distro
+    evr: 1.5.0-7.el9
+    sourcerpm: python-distro-1.5.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-libselinux-3.6-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 196472
+    checksum: sha256:7af821a0ee7c7b56df79de25fe35cc2d0fd6f45df5c3bcec2c5e72d7378ba265
+    name: python3-libselinux
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-libsemanage-3.6-5.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 82730
+    checksum: sha256:8a17df19f0ff5dbb98fe608999cb2370983d8565658df01d0993b3028cbf28d6
+    name: python3-libsemanage
+    evr: 3.6-5.el9_6
+    sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-policycoreutils-3.6-2.1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2216589
+    checksum: sha256:7dbe7be855cc83e372add890e9e0c5256ef57132d9731b5db204c425bf21b194
+    name: python3-policycoreutils
+    evr: 3.6-2.1.el9
+    sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-img-9.1.0-15.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2607045
+    checksum: sha256:f89317b5054f394d177af6117f0addb5f7ff594d8f0a72b8d02a0c76b6eb3436
+    name: qemu-img
+    evr: 17:9.1.0-15.el9_6.4
+    sourcerpm: qemu-kvm-9.1.0-15.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-common-9.1.0-15.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 705846
+    checksum: sha256:39888681ae1da072a281e9da72771672f2205acc7ec83d724b6a42ec5e4fe7a8
+    name: qemu-kvm-common
+    evr: 17:9.1.0-15.el9_6.4
+    sourcerpm: qemu-kvm-9.1.0-15.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-core-9.1.0-15.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 5130107
+    checksum: sha256:467261cb89ae35da29aa71a50e9955f309f49f432a176209c01f54b751a5679c
+    name: qemu-kvm-core
+    evr: 17:9.1.0-15.el9_6.4
+    sourcerpm: qemu-kvm-9.1.0-15.el9_6.4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 9344
+    checksum: sha256:1dbb5db859d110aa275cbacd07e2576dcbe321ab0803f04d85dc3fa1a203ef10
+    name: qt5-srpm-macros
+    evr: 5.15.9-1.el9
+    sourcerpm: qt5-5.15.9-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/r/redhat-rpm-config-209-1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 77658
+    checksum: sha256:a9e214f1085628ce546a11eebab20e0fc769bf15208bb12b947efa109b1d4dd7
+    name: redhat-rpm-config
+    evr: 209-1.el9
+    sourcerpm: redhat-rpm-config-209-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/r/rust-srpm-macros-17-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 11243
+    checksum: sha256:8e91d6d5122b9effe0e3539ef0d55e57c4b3eff68544e46a413129cb961d5941
+    name: rust-srpm-macros
+    evr: 17-4.el9
+    sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/scrub-2.6.1-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 48350
+    checksum: sha256:70f0f86547ea20873df09b3ff91e6dc107d071ac1971556c1aa35bb03a500beb
+    name: scrub
+    evr: 2.6.1-4.el9
+    sourcerpm: scrub-2.6.1-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/seabios-bin-1.16.3-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 104354
+    checksum: sha256:f2758eb2e733d130750ad3153d7775e8cc71be8bdf8f0f5e4ee7e40257df6236
+    name: seabios-bin
+    evr: 1.16.3-4.el9
+    sourcerpm: seabios-1.16.3-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/seavgabios-bin-1.16.3-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 37280
+    checksum: sha256:09622222e1b5ff84d2f0df23d29cc21ed3de37003a9a8fee3492f588027f7fd4
+    name: seavgabios-bin
+    evr: 1.16.3-4.el9
+    sourcerpm: seabios-1.16.3-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/supermin-5.3.5-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 785075
+    checksum: sha256:ca97403842c6cbab5850bc4791071cfd48362df7ba75606afa7668b69c40ab2b
+    name: supermin
+    evr: 5.3.5-1.el9
+    sourcerpm: supermin-5.3.5-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/swtpm-0.8.0-2.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 46802
+    checksum: sha256:21b44b871a345a9dbaac62fd041cf8d697d1fe3826d994e431ad88ffce9da633
+    name: swtpm
+    evr: 0.8.0-2.el9_4
+    sourcerpm: swtpm-0.8.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/swtpm-libs-0.8.0-2.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 53192
+    checksum: sha256:ba793c7d979bd31548e8b202665b144af6976b8b2dc5f0f53811058ef81c2f89
+    name: swtpm-libs
+    evr: 0.8.0-2.el9_4
+    sourcerpm: swtpm-0.8.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/swtpm-tools-0.8.0-2.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 127941
+    checksum: sha256:743b4553c6f5208e804995a1e2513f0ea2e79e51cf698929a83bc49d406f4a34
+    name: swtpm-tools
+    evr: 0.8.0-2.el9_4
+    sourcerpm: swtpm-0.8.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/u/unbound-libs-1.16.2-18.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 563049
+    checksum: sha256:b0b9e483f6c8da82d93d1ae35145bb061a5b49746d5f0b2c5356e8bd4330c7a4
+    name: unbound-libs
+    evr: 1.16.2-18.el9_6
+    sourcerpm: unbound-1.16.2-18.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/v/virt-v2v-2.7.1-8.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 2383804
+    checksum: sha256:46349708f292bacc37f34d5418e3121a5864ef3cd9e0080e362460a16a9fa4e7
+    name: virt-v2v
+    evr: 1:2.7.1-8.el9_6
+    sourcerpm: virt-v2v-2.7.1-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/v/virtio-win-1.9.46-0.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 270780602
+    checksum: sha256:04edb64e45a4c7fe3692815b771c63a822c5bfb60e89a30eb1631d0ac0e5d89b
+    name: virtio-win
+    evr: 1.9.46-0.el9_6
+    sourcerpm: virtio-win-1.9.46-0.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/w/webkit2gtk3-jsc-2.48.3-1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 8949183
+    checksum: sha256:7512a4e0ba6c52e910a68832eb73b40d1bac83adc25e531d5db9f16a0ff49820
+    name: webkit2gtk3-jsc
+    evr: 2.48.3-1.el9_6
+    sourcerpm: webkit2gtk3-2.48.3-1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 856543
+    checksum: sha256:cfb5e8fddaed92b1b22c957183d0ea626a4468f42a46dae4e68a795cb8c20393
+    name: adobe-source-code-pro-fonts
+    evr: 2.030.1.050-12.el9.1
+    sourcerpm: adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-63.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 4818636
+    checksum: sha256:4eb918b63dee7daf32117df2e3fcb02ad4ba3d96cb25677cf55315deceb7e22a
+    name: binutils
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 753176
+    checksum: sha256:339d9bb2dc0e41c4756f1a4f82e82f6654818b72de74f1f0377c76277617352b
+    name: binutils-gold
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/bzip2-1.0.8-10.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 61101
+    checksum: sha256:1e9012bb13c1df2750a6c2a4aafaa8996ea3a75478aa3c8a0961c29f9a81a202
+    name: bzip2
+    evr: 1.0.8-10.el9_5
+    sourcerpm: bzip2-1.0.8-10.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cpio-2.13-16.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 286157
+    checksum: sha256:d9b53fda4b8757fd63b53a415f533ab876c18c28a94fd21d10658de85978f254
+    name: cpio
+    evr: 2.13-16.el9
+    sourcerpm: cpio-2.13-16.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-2.7.2-3.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 341855
+    checksum: sha256:a5cb6c046de71a54313b2d420db6e72bfae0761f591a051a7d676e3e063fe160
+    name: cryptsetup
+    evr: 2.7.2-3.el9_5
+    sourcerpm: cryptsetup-2.7.2-3.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.7.2-3.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 534806
+    checksum: sha256:db7fc8be731f94a9a28f29522ee1c8000dbcdddb78be470825fea8af5338818e
+    name: cryptsetup-libs
+    evr: 2.7.2-3.el9_5
+    sourcerpm: cryptsetup-2.7.2-3.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-gssapi-2.1.27-21.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 28739
+    checksum: sha256:ea04812e70f7185355de2cf44ccd03dba237e3671b670cd3c53debd7665bc667
+    name: cyrus-sasl-gssapi
+    evr: 2.1.27-21.el9
+    sourcerpm: cyrus-sasl-2.1.27-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/daxctl-libs-78-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 45763
+    checksum: sha256:064003981145cb7383ec6850f1e85ac18183d3dacd1bc568f0a47ba3105fdb96
+    name: daxctl-libs
+    evr: 78-2.el9
+    sourcerpm: ndctl-78-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-1.02.202-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 146604
+    checksum: sha256:fef2c0542d2e66f9208e25c34f82e6735b8b3396cd46e5a2ac4c8f54e6c0c1df
+    name: device-mapper
+    evr: 9:1.02.202-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-event-1.02.202-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 37226
+    checksum: sha256:bc5bef65f67afe13cd57a0f0033bb57dac321d4d0f67802a2932b99867b29f60
+    name: device-mapper-event
+    evr: 9:1.02.202-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-event-libs-1.02.202-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 34526
+    checksum: sha256:060edac61323c1c87c547f9431997953ff7ebab84011d3382b01e87780263675
+    name: device-mapper-event-libs
+    evr: 9:1.02.202-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.202-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 185301
+    checksum: sha256:8b48aabdb24179ec8e28b1d5d8da85fc7ded64e30fc4367de3c455b895212626
+    name: device-mapper-libs
+    evr: 9:1.02.202-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-persistent-data-1.1.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1173142
+    checksum: sha256:33b20d692595c100b00c47987ec74f207fb99c8520d0f0f173fd073f0e920fd6
+    name: device-mapper-persistent-data
+    evr: 1.1.0-1.el9
+    sourcerpm: device-mapper-persistent-data-1.1.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dhcp-client-4.4.2-19.b1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 812977
+    checksum: sha256:72823b0e47915484302ade0a5480985e51565968a01e884cb899ebc57d21cc5b
+    name: dhcp-client
+    evr: 12:4.4.2-19.b1.el9
+    sourcerpm: dhcp-4.4.2-19.b1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dhcp-common-4.4.2-19.b1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 133925
+    checksum: sha256:abf06b4ccaafa322bd7d49ca8b239d6852af8f4ba31b8ab3edc1512208767327
+    name: dhcp-common
+    evr: 12:4.4.2-19.b1.el9
+    sourcerpm: dhcp-4.4.2-19.b1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 411559
+    checksum: sha256:2d4c4fdfc10215af3c957c24995b79a26e27e6d76de4ed1f5198d25bf7ef9671
+    name: diffutils
+    evr: 3.7-12.el9
+    sourcerpm: diffutils-3.7-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dosfstools-4.2-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 163749
+    checksum: sha256:7228697855b1acaa00f8b5ab46d2f6ce9b0c4ce06ec5f25b771622498832596b
+    name: dosfstools
+    evr: 4.2-3.el9
+    sourcerpm: dosfstools-4.2-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dracut-057-88.git20250311.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 485922
+    checksum: sha256:25d66f65d31e7f8635dd930d64ccd93f771d881b5ab110748371039a0b7623c9
+    name: dracut
+    evr: 057-88.git20250311.el9_6
+    sourcerpm: dracut-057-88.git20250311.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/e2fsprogs-1.46.5-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1056089
+    checksum: sha256:32967b664c08ff8443661984920cd0167f0175ba34bc4347f8bd98eb788527f1
+    name: e2fsprogs
+    evr: 1.46.5-7.el9
+    sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/e2fsprogs-libs-1.46.5-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 230313
+    checksum: sha256:6eb6679be603a85817d580e1881e3e5d0ca5b5f8224be379b43d1facced8441c
+    name: e2fsprogs-libs
+    evr: 1.46.5-7.el9
+    sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.192-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 47282
+    checksum: sha256:e5b1a7a9e1467bfe00913e9b22ba5665852f8c61900205a32d3043ace9e1c7c2
+    name: elfutils-debuginfod-client
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/file-5.39-16.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 53222
+    checksum: sha256:64f29bc71f9c26e6460abaff21d8e43738077cde4fbd6d1b96825a50ba0abd74
+    name: file
+    evr: 5.39-16.el9
+    sourcerpm: file-5.39-16.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/fuse-2.9.9-17.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 85864
+    checksum: sha256:1bf8e4b14ad76ded455adeb74ccdc9d031127459c03b9c01a409e550bfd75069
+    name: fuse
+    evr: 2.9.9-17.el9
+    sourcerpm: fuse-2.9.9-17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 8750
+    checksum: sha256:548265cbee787fa659bc79c07e15a12007f39eb70e905bf660ec488f0bb8820f
+    name: fuse-common
+    evr: 3.10.2-9.el9
+    sourcerpm: fuse3-3.10.2-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/fuse-libs-2.9.9-17.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 101562
+    checksum: sha256:57ea8a9ed7a2d6fef54c540b393649e2fda62381e5a714860ee3cf786f7ef46b
+    name: fuse-libs
+    evr: 2.9.9-17.el9
+    sourcerpm: fuse-2.9.9-17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gettext-0.21-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1193150
+    checksum: sha256:febf6aec8699ca352aba5a7a249ed0cb011b68c5bab17f6178f09b1035974dde
+    name: gettext
+    evr: 0.21-8.el9
+    sourcerpm: gettext-0.21-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 313328
+    checksum: sha256:b319325e941e03e3e7381161889ab39473398194786a52fc1653d025211b6e1a
+    name: gettext-libs
+    evr: 0.21-8.el9
+    sourcerpm: gettext-0.21-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glib-networking-2.68.3-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 194155
+    checksum: sha256:ea51df291db08b66ab8ef6fc4b1d6675f3c39879b91794106603747a06b01683
+    name: glib-networking
+    evr: 2.68.3-3.el9
+    sourcerpm: glib-networking-2.68.3-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-168.el9_6.14.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1753645
+    checksum: sha256:df6ded7d6c44fb4b23e9d11cf63b8b81f12f1edc08f5a19f20c1c059d3cf8649
+    name: glibc-gconv-extra
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1133828
+    checksum: sha256:4d8ff13569b3b231b3fb847e9e22615c6e08215d1f2c0c78eac2e345b9efd394
+    name: groff-base
+    evr: 1.22.4-10.el9
+    sourcerpm: groff-1.22.4-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gsettings-desktop-schemas-40.0-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 704384
+    checksum: sha256:befbe1a5dc7b843b993d7db6f08c9f29c504d549ad7b51fda5485380f47ded3c
+    name: gsettings-desktop-schemas
+    evr: 40.0-6.el9
+    sourcerpm: gsettings-desktop-schemas-40.0-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gssproxy-0.8.4-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 116911
+    checksum: sha256:b4c296c0d0a4fa11bc5fc1119516405c6075b52fe5945aec3447037aedb7951e
+    name: gssproxy
+    evr: 0.8.4-7.el9
+    sourcerpm: gssproxy-0.8.4-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/h/hwdata-0.348-9.18.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1724460
+    checksum: sha256:3f50d2d645126aab5407531cdfa813544c85c44d312bc19dcc3378460b9eb03d
+    name: hwdata
+    evr: 0.348-9.18.el9
+    sourcerpm: hwdata-0.348-9.18.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/inih-49-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 20510
+    checksum: sha256:d5ff4d9d43f6c32797e80e0518bb3656ae46643069bdc0ef9b8749d912cd74ab
+    name: inih
+    evr: 49-6.el9
+    sourcerpm: inih-49-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/ipcalc-1.0.0-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 45060
+    checksum: sha256:185c9b26e524ad1e026cb223f05b6eaf9fd5769ced16ff9897080aa8735ffe64
+    name: ipcalc
+    evr: 1.0.0-5.el9
+    sourcerpm: ipcalc-1.0.0-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iproute-tc-6.11.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 459306
+    checksum: sha256:9e780365ee736bd765b5efac45d9630539a531c925278a0a6450cb568a4f433c
+    name: iproute-tc
+    evr: 6.11.0-1.el9
+    sourcerpm: iproute-6.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 476678
+    checksum: sha256:3e79ca4cc3d35c1f1e0ac6c9f05c5be56b7ab6dd1f8ae719a21ec1b9e3bfa018
+    name: iptables-libs
+    evr: 1.8.10-11.el9_5
+    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 214056
+    checksum: sha256:54e031813637738af285ff4b1c2e4a20b913f2ea643a29940a07ccaf8bd197f5
+    name: iptables-nft
+    evr: 1.8.10-11.el9_5
+    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iputils-20210202-11.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 178195
+    checksum: sha256:2760d3b457614fd29d24f6ceff4cd5354fb099193237ba9914dbeee5e69e67d3
+    name: iputils
+    evr: 20210202-11.el9_6.1
+    sourcerpm: iputils-20210202-11.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/j/jansson-2.14-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 49137
+    checksum: sha256:4e9aec51ee46d7265d6edd1245b5d5ab5e8336dc2a4ca17f2cace2ce8bae3761
+    name: jansson
+    evr: 2.14-1.el9
+    sourcerpm: jansson-2.14-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/j/jq-1.6-17.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 194646
+    checksum: sha256:9e996fbd48660f2815b29c88e1fd3b2ac5359eafb811f6208c6c4814ffb11e5b
+    name: jq
+    evr: 1.6-17.el9
+    sourcerpm: jq-1.6-17.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kbd-2.4.0-11.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 428483
+    checksum: sha256:3271c89a49edb384441b749a30b662968f99f66a169dd01bac2b3cb39e2263e9
+    name: kbd
+    evr: 2.4.0-11.el9
+    sourcerpm: kbd-2.4.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kbd-legacy-2.4.0-11.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 579544
+    checksum: sha256:8dcc48e93bffc5e2d819f8c8c468648362c13d554f756c421711386c8fadf950
+    name: kbd-legacy
+    evr: 2.4.0-11.el9
+    sourcerpm: kbd-2.4.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kbd-misc-2.4.0-11.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1739470
+    checksum: sha256:f698c807d4805c83b2dc8564427a7c4445d1c41a23d4bdb7988eba489e73932f
+    name: kbd-misc
+    evr: 2.4.0-11.el9
+    sourcerpm: kbd-2.4.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-core-5.14.0-570.23.1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 18707617
+    checksum: sha256:fd1a8051a2d698dba71b8b92bffd0325edb5ac6dc78c2eac3502b69f4d6edfd7
+    name: kernel-core
+    evr: 5.14.0-570.23.1.el9_6
+    sourcerpm: kernel-5.14.0-570.23.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-modules-core-5.14.0-570.23.1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 32489925
+    checksum: sha256:978372dd2b6714d9902d10b41eaa9096166bd560c9747dca31efdd3b650c7667
+    name: kernel-modules-core
+    evr: 5.14.0-570.23.1.el9_6
+    sourcerpm: kernel-5.14.0-570.23.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 132888
+    checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
+    name: kmod
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kpartx-0.8.7-35.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 47844
+    checksum: sha256:baef9e9207915c24e48c81dc3dfa3308b07d4446fa487eec23033e247da38144
+    name: kpartx
+    evr: 0.8.7-35.el9_6.1
+    sourcerpm: device-mapper-multipath-0.8.7-35.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/less-590-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 170758
+    checksum: sha256:a726061c966a134a5e5b42b60e4162ee85a2cef8843b6fd28e08264ceebb54f4
+    name: less
+    evr: 590-5.el9
+    sourcerpm: less-590-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libaio-0.3.111-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 27100
+    checksum: sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c
+    name: libaio
+    evr: 0.3.111-13.el9
+    sourcerpm: libaio-0.3.111-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libatomic-11.5.0-5.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 28095
+    checksum: sha256:f319f76d1b4f3c82cc2cf8eee5b3c170a1d6f5c1c72d7790141307159572578a
+    name: libatomic
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libbasicobjects-0.1.1-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 29215
+    checksum: sha256:b2e095838b4c40ade395ca6bbafec8be461e5630960d2a8d307e6c456dc4656b
+    name: libbasicobjects
+    evr: 0.1.1-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 323932
+    checksum: sha256:bb3175e435723e98cc1a5063eafa82231092eca3bf6276d24505eaeaaa817113
+    name: libbrotli
+    evr: 1.0.9-7.el9_5
+    sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 60575
+    checksum: sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526
+    name: libcbor
+    evr: 0.7.0-5.el9
+    sourcerpm: libcbor-0.7.0-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libcollection-0.7.0-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 48366
+    checksum: sha256:75da9e9faf295a7cdc1e8aede617c5468860ed03750f5543eb1ed00ca1d6c1e3
+    name: libcollection
+    evr: 0.7.0-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libconfig-1.7.2-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 77187
+    checksum: sha256:a703ce30dbfad94d6ee711ebdb134b8c44abdb7b85a56a5326d486c27e423360
+    name: libconfig
+    evr: 1.7.2-9.el9
+    sourcerpm: libconfig-1.7.2-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 109330
+    checksum: sha256:9e41ff5754a5dca1308adf9617828934d56cb60d8d08f128f80e4328f69bc78c
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+    sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libev-4.33-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 55816
+    checksum: sha256:5060a2d021e411d792000ea68f76604bc56e0c7a9d024de2a478814b91b5f9e8
+    name: libev
+    evr: 4.33-6.el9
+    sourcerpm: libev-4.33-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 102746
+    checksum: sha256:6da940c0528f3e4453db84cb85b402c8f4293a197b1921158df9651edb4845e0
+    name: libfido2
+    evr: 1.13.0-2.el9
+    sourcerpm: libfido2-1.13.0-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libibverbs-54.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 466434
+    checksum: sha256:fc593dc18f73c296df4fa808341cb2dbee7e5082fb872b79e7984c3b24279d3b
+    name: libibverbs
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libicu-67.1-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 10023600
+    checksum: sha256:d6a263811f4752dfaeb28c7e0f37f8300ed2355e66c5ad994f7ae2a4a4ac6fdd
+    name: libicu
+    evr: 67.1-9.el9
+    sourcerpm: icu-67.1-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libini_config-1.3.1-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 70916
+    checksum: sha256:15e9210db22e9c36ecce5354f3453bed6e62e38ff81d20cde20cf09de87f6d35
+    name: libini_config
+    evr: 1.3.1-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libkcapi-1.4.0-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 50196
+    checksum: sha256:7456c9c74bf79b07fc7df6b79700685166aae9220fb1355c3ddbdf1aee22bdce
+    name: libkcapi
+    evr: 1.4.0-2.el9
+    sourcerpm: libkcapi-1.4.0-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libkcapi-hmaccalc-1.4.0-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 28929
+    checksum: sha256:70da32465019008174e087a0cfd020cfd6ddbb421cc72939b14bc094528b5649
+    name: libkcapi-hmaccalc
+    evr: 1.4.0-2.el9
+    sourcerpm: libkcapi-1.4.0-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 62066
+    checksum: sha256:beeb73e78390077c6afd9ed6177bad8bad278dbfaae9d90edf7243cdf6a44a3f
+    name: libnetfilter_conntrack
+    evr: 1.0.9-1.el9
+    sourcerpm: libnetfilter_conntrack-1.0.9-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 32236
+    checksum: sha256:177882bfe48c9c9effc7b1bce6b58b2466988c53e400c07fb1ba2d3a4ebe6f40
+    name: libnfnetlink
+    evr: 1.0.1-23.el9_5
+    sourcerpm: libnfnetlink-1.0.1-23.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnfsidmap-2.5.4-34.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 67310
+    checksum: sha256:e4e9b49a0217e9b50c534cd20eec1c5a7903d1a68f930de65ae17d2a9ca9800a
+    name: libnfsidmap
+    evr: 1:2.5.4-34.el9
+    sourcerpm: nfs-utils-2.5.4-34.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 91380
+    checksum: sha256:e64d7b270be4be36af80ed220852cb760a1069e34667b1ba9eec7a02762a14bf
+    name: libnftnl
+    evr: 1.2.6-4.el9_4
+    sourcerpm: libnftnl-1.2.6-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 376137
+    checksum: sha256:89728a253a5bf1c8e01c40573f1283d40188e003bdbd4ac565f8b0f05bced55c
+    name: libnl3
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnvme-1.11.1-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 114880
+    checksum: sha256:c7e6a9e6d51c3a3e31a075faa68b2518baf554788a2939aa1483f22ce66ecb29
+    name: libnvme
+    evr: 1.11.1-1.el9
+    sourcerpm: libnvme-1.11.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpath_utils-0.2.1-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 32479
+    checksum: sha256:ed4bfb8d96a13bad9b85dde758d6f481fa62abd56595760134e3ea195e63806e
+    name: libpath_utils
+    evr: 0.2.1-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 52912
+    checksum: sha256:c972030a8fbaa2d981f0e5fdfc42d6d5173dd047c94d86ab7732e3e53fc4e97a
+    name: libpipeline
+    evr: 1.5.3-4.el9
+    sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 38387
+    checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpng-1.6.37-12.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 121655
+    checksum: sha256:42e7addb96958b293571949829378c054d6a1a762dccb78d5a777f8c531fc811
+    name: libpng
+    evr: 2:1.6.37-12.el9
+    sourcerpm: libpng-1.6.37-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libproxy-0.4.15-35.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 79470
+    checksum: sha256:370e37b9167e2320a405e4fda7659e2e7c3ed44ded0b44f9eabde8919ea79d5e
+    name: libproxy
+    evr: 0.4.15-35.el9
+    sourcerpm: libproxy-0.4.15-35.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpsl-0.21.1-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 67454
+    checksum: sha256:ad1a62ef07682bb64a476c1a49f5cfc7abc9beb44775e7e511bf737e9a6bf99d
+    name: libpsl
+    evr: 0.21.1-5.el9
+    sourcerpm: libpsl-0.21.1-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/librdmacm-54.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 75775
+    checksum: sha256:334a6ff9a86cfed3af1dc2b08b840e74c9cd84b35a8d7bfd15a0db51ca8a0d30
+    name: librdmacm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libref_array-0.1.5-53.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 30902
+    checksum: sha256:99c5576869a0daf3be0498f55e01a8085e82daa8a71a48c256f03c79ed149353
+    name: libref_array
+    evr: 0.1.5-53.el9
+    sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 198410
+    checksum: sha256:e5d79885864cd5b2a307065b43ba1af1523ec7ac26eace2717c70ede1b6e4c56
+    name: libselinux-utils
+    evr: 3.6-3.el9
+    sourcerpm: libselinux-3.6-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libss-1.46.5-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 34195
+    checksum: sha256:9e96642e8dfdc4d305bd45a6980a4bf5831600fd10b95ac59522770ad706b611
+    name: libss
+    evr: 1.46.5-7.el9
+    sourcerpm: e2fsprogs-1.46.5-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-0.10.4-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 224804
+    checksum: sha256:7c51bc940814b49a57b331b68508732b76b16f5c237538c26fc06e6d824da77f
+    name: libssh
+    evr: 0.10.4-13.el9
+    sourcerpm: libssh-0.10.4-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-13.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 11463
+    checksum: sha256:0cc66bee3af1b8939f108dce622a47a58482f182ab3abb851b3252a44315aa23
+    name: libssh-config
+    evr: 0.10.4-13.el9
+    sourcerpm: libssh-0.10.4-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libtirpc-1.3.3-9.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 98934
+    checksum: sha256:f82cd69dc3aac881d5b574930c7d274687054cb5b03d3a8e3affa7bbcd5950b1
+    name: libtirpc
+    evr: 1.3.3-9.el9
+    sourcerpm: libtirpc-1.3.3-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libusbx-1.0.26-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 80311
+    checksum: sha256:393daea3d5cfd8f2f66121f91d1589c53893f87130fb5b2b3b77c5b571788ec7
+    name: libusbx
+    evr: 1.0.26-1.el9
+    sourcerpm: libusbx-1.0.26-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libverto-libev-0.3.2-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 15452
+    checksum: sha256:95fa428623ac713c8fa6d5c00355881d4d8cf8029bb74a90a2d4ce16cf603816
+    name: libverto-libev
+    evr: 0.3.2-3.el9
+    sourcerpm: libverto-0.3.2-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-20250513-151.1.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 501395158
+    checksum: sha256:5a85309a17c64cdc5d47d4f1902e59551c7b532129d7f46bc1b3b3c61da99dca
+    name: linux-firmware
+    evr: 20250513-151.1.el9_6
+    sourcerpm: linux-firmware-20250513-151.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-whence-20250513-151.1.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 120585
+    checksum: sha256:48dabe871fd05e810fdb2d8ae416a9a8e4beebd8389f97d980eef749b379b172
+    name: linux-firmware-whence
+    evr: 20250513-151.1.el9_6
+    sourcerpm: linux-firmware-20250513-151.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lsscsi-0.32-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 72326
+    checksum: sha256:7a0b587bfdd7e9ab76560ea93e3f7fbd1c6dc0511bc6d3519f83e6431f22ffe6
+    name: lsscsi
+    evr: 0.32-6.el9
+    sourcerpm: lsscsi-0.32-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lvm2-2.03.28-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1626649
+    checksum: sha256:b8d91da58f0168d9210850fa40b15dd4ba5917c251e444e882688b7f5dd9b80d
+    name: lvm2
+    evr: 9:2.03.28-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lvm2-libs-2.03.28-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1062922
+    checksum: sha256:a7377a8c8988620ce74a38e91336a5459d9d8d941c24d8f476259b455aab2d47
+    name: lvm2-libs
+    evr: 9:2.03.28-6.el9
+    sourcerpm: lvm2-2.03.28-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lzo-2.10-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 70686
+    checksum: sha256:2703054410f61e3a0cc8bf082800a75170644141e4f98aea3f483765ae372d3f
+    name: lzo
+    evr: 2.10-7.el9
+    sourcerpm: lzo-2.10-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lzop-1.04-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 60502
+    checksum: sha256:6eb21e6aa9350281c9d5b99962452c9f3848cfb3cfebe3114b53649e472a1047
+    name: lzop
+    evr: 1.04-8.el9
+    sourcerpm: lzop-1.04-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/m/man-db-2.9.3-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1245006
+    checksum: sha256:1eb7770a27102f59012f704e90aa04b130ab4f46fec983a7441ec9e8810f2da4
+    name: man-db
+    evr: 2.9.3-7.el9
+    sourcerpm: man-db-2.9.3-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/m/mdadm-4.3-4.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 456330
+    checksum: sha256:f633c556a06d40aa7dcd4c93f13735c4d6a568813f9e03b50c88c469ed030c54
+    name: mdadm
+    evr: 4.3-4.el9_5
+    sourcerpm: mdadm-4.3-4.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/m/mtools-4.0.26-4.el9_0.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 231610
+    checksum: sha256:b4d856e2edb6fa79ee752355904320ab077945c63d75b61b9bc78ccdd64d106b
+    name: mtools
+    evr: 4.0.26-4.el9_0
+    sourcerpm: mtools-4.0.26-4.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 420158
+    checksum: sha256:1b5e5805334bc78c977d7acf02256021a9216e26348a5383cf86dfb0b0c91101
+    name: ncurses
+    evr: 6.2-10.20210508.el9
+    sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/ndctl-libs-78-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 94842
+    checksum: sha256:9e46d827a61e9c7fe36b5bdb35234bfe703a601309634ba1f109bfb1791f13cf
+    name: ndctl-libs
+    evr: 78-2.el9
+    sourcerpm: ndctl-78-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/nfs-utils-2.5.4-34.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 473840
+    checksum: sha256:8222b8071e297379d6037f8ea68b940e4488a44fc1792fe1664b23387c1b9300
+    name: nfs-utils
+    evr: 1:2.5.4-34.el9
+    sourcerpm: nfs-utils-2.5.4-34.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/numactl-libs-2.0.19-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 33709
+    checksum: sha256:ce2f00b2527e29f6b389e5899750e2b6eb1e5ce484ddfdcd6f01fa311efe7860
+    name: numactl-libs
+    evr: 2.0.19-1.el9
+    sourcerpm: numactl-2.0.19-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/numad-0.5-37.20150602git.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 39286
+    checksum: sha256:39b620572ecad31ecc016cb3266cffd1084f8d0738f574131d474b80a88da2bc
+    name: numad
+    evr: 0.5-37.20150602git.el9
+    sourcerpm: numad-0.5-37.20150602git.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/oniguruma-6.9.6-1.el9.6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 226451
+    checksum: sha256:a532fc644b41ead28ac07fb4217e2ceb9cdd5fdaadc13e9a02b7be3ee703bf85
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+    sourcerpm: oniguruma-6.9.6-1.el9.6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssh-8.7p1-45.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 474534
+    checksum: sha256:d43f19d3e736943bdadbda47db016e9da81ce1900f50ecfe470f7a8bc9bce243
+    name: openssh
+    evr: 8.7p1-45.el9
+    sourcerpm: openssh-8.7p1-45.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 735750
+    checksum: sha256:309d1c9c176bf35b494c8b31a0f3eeceddd0b27be1dfc9defbe9838b9d5a707c
+    name: openssh-clients
+    evr: 8.7p1-45.el9
+    sourcerpm: openssh-8.7p1-45.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/parted-3.5-3.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 603349
+    checksum: sha256:8c6d3e1418832074e521955b969ca597df66bbf1c76f4e16032f83046f82cbaa
+    name: parted
+    evr: 3.5-3.el9
+    sourcerpm: parted-3.5-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pigz-2.8-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 99148
+    checksum: sha256:3d468520034285d071ad3ae5cdf8726d88e66a24c41aa6d4bd7919a3e32a0cd3
+    name: pigz
+    evr: 2.8-1.el9
+    sourcerpm: pigz-2.8-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 45675
+    checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-2.1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 251967
+    checksum: sha256:8dcd39960d3103f7a4ad2b9f7a0e15469ebf4da98f6c215cddfffdb830dc12b5
+    name: policycoreutils
+    evr: 3.6-2.1.el9
+    sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/polkit-0.117-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 163384
+    checksum: sha256:66f11e356814400f9b420b6da3cf9e9c344808b2f4d77a341883a9e908a6ca73
+    name: polkit
+    evr: 0.117-13.el9
+    sourcerpm: polkit-0.117-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/polkit-libs-0.117-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 8690164
+    checksum: sha256:62cdf67da1a4b9fef97017775ea7640d5e7896533caf4fc176cd79ed121b9421
+    name: polkit-libs
+    evr: 0.117-13.el9
+    sourcerpm: polkit-0.117-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/polkit-pkla-compat-0.1-21.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 52512
+    checksum: sha256:548978c62b24b7adda4ebcc5db878e22b18f50248bc45aa4a209b86eddd86948
+    name: polkit-pkla-compat
+    evr: 0.1-21.el9
+    sourcerpm: polkit-pkla-compat-0.1-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 361526
+    checksum: sha256:506ad778f63821e8d9647ca8e0a3ff21b8af9c1666060d5200f9b26ee718333c
+    name: procps-ng
+    evr: 3.3.17-14.el9
+    sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 38224
+    checksum: sha256:9669f5bed1c9532ede399cd1ea6f8937ae7d18cfb56d59f2939a4b456390035f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/publicsuffix-list-dafsa-20210518-3.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 60882
+    checksum: sha256:e6ec3390a736b085f403168c512a6b2b6f8e12a8fd5a4459f1c7dbbff2b67c33
+    name: publicsuffix-list-dafsa
+    evr: 20210518-3.el9
+    sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-pyyaml-5.4.1-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 213932
+    checksum: sha256:55aed527552e915b75c47128300e9295b944270bef5177167b737d39758ebb3e
+    name: python3-pyyaml
+    evr: 5.4.1-6.el9
+    sourcerpm: PyYAML-5.4.1-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-setools-4.4.4-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 623460
+    checksum: sha256:91946d729d2b03b4abe1c43962f22d110468db0163241cda7b1d549c615d0261
+    name: python3-setools
+    evr: 4.4.4-1.el9
+    sourcerpm: setools-4.4.4-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/q/quota-4.09-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 206761
+    checksum: sha256:ffe9439076c7fcf6785626d7dcbf42b7ab307ab87360a34e2632359e2f4814fe
+    name: quota
+    evr: 1:4.09-4.el9
+    sourcerpm: quota-4.09-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/q/quota-nls-4.09-4.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 80718
+    checksum: sha256:bf0c353db02e9591162a6d1880f6ce3d99e1621a8ce32feb6bed1b5ab6408b68
+    name: quota-nls
+    evr: 1:4.09-4.el9
+    sourcerpm: quota-4.09-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/rpcbind-1.2.6-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 63366
+    checksum: sha256:da6368abd485c9c8a3643947ce11bece4775232d10bd8ec68e23a0bdf4275330
+    name: rpcbind
+    evr: 1.2.6-7.el9
+    sourcerpm: rpcbind-1.2.6-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/r/rpm-plugin-selinux-4.16.1.3-37.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 18109
+    checksum: sha256:1e21fe626bb81ccf59e8de8194395017e3a5fa929cbf6c6da82ba1598f6bb27f
+    name: rpm-plugin-selinux
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-38.1.53-5.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 46473
+    checksum: sha256:e397424c237fb3b0b19f7ba7b1d59ec5a54e8c184ae8be1b1d12223f5ec1f3b7
+    name: selinux-policy
+    evr: 38.1.53-5.el9_6
+    sourcerpm: selinux-policy-38.1.53-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-targeted-38.1.53-5.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 7251875
+    checksum: sha256:e5a1a2e4ca35e6639ac12a651c3fcb4aede1b62755d71920c9819c7939430b5b
+    name: selinux-policy-targeted
+    evr: 38.1.53-5.el9_6
+    sourcerpm: selinux-policy-38.1.53-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/snappy-1.1.8-8.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 38032
+    checksum: sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f
+    name: snappy
+    evr: 1.1.8-8.el9
+    sourcerpm: snappy-1.1.8-8.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/squashfs-tools-4.4-10.git1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 172047
+    checksum: sha256:a892b543eca94673ae19b1948d37ce515d70ddccd89f30794cae5c8931b74c43
+    name: squashfs-tools
+    evr: 4.4-10.git1.el9
+    sourcerpm: squashfs-tools-4.4-10.git1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-6.04-0.20.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 588436
+    checksum: sha256:9af2b296b7080e7b0551a8fa971e7ee5a3bf709443b43dd5ffd6c9e6d3f8aab0
+    name: syslinux
+    evr: 6.04-0.20.el9
+    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-extlinux-6.04-0.20.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 135023
+    checksum: sha256:7eb3714428f764f644f1995c05a3dbc55077d8fd0b330ba1698e342b1640a63d
+    name: syslinux-extlinux
+    evr: 6.04-0.20.el9
+    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-extlinux-nonlinux-6.04-0.20.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 408744
+    checksum: sha256:a40ce10dd82ee4517f1c528a9ca14f1baa5a2d8b39f298531916688241906460
+    name: syslinux-extlinux-nonlinux
+    evr: 6.04-0.20.el9
+    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-nonlinux-6.04-0.20.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 591736
+    checksum: sha256:e9b444304de40694390b37c36ace8b0d8ba39f376b9215c3c7977dd2c198e6c1
+    name: syslinux-nonlinux
+    evr: 6.04-0.20.el9
+    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-container-252-51.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 611994
+    checksum: sha256:97575533d2be7533aaf1aa7e90e60207509920eb5019935fb08c9dc6b98e2e28
+    name: systemd-container
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-51.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 2122081
+    checksum: sha256:21f9f14a7d5139c7578229dac56566acb8fa08d0e91dd3affe31fcd40f69f29b
+    name: systemd-udev
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tpm2-tools-5.2-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 828074
+    checksum: sha256:2f2698967c9e1741966cc107520857b1ddcbf668ae6c43621cc3d7562d418009
+    name: tpm2-tools
+    evr: 5.2-4.el9
+    sourcerpm: tpm2-tools-5.2-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/u/unzip-6.0-58.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 190785
+    checksum: sha256:009698f3b4432b9df219fd2f894234aad1cee8c4e4e61384b4e293ef8e28e9c2
+    name: unzip
+    evr: 6.0-58.el9_5
+    sourcerpm: unzip-6.0-58.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/u/userspace-rcu-0.12.1-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 116929
+    checksum: sha256:7ad3d7984e1c37cc17819e84e8b0e731836ca5a7a56108b0d8e8378028b581b3
+    name: userspace-rcu
+    evr: 0.12.1-6.el9
+    sourcerpm: userspace-rcu-0.12.1-6.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/x/xfsprogs-6.4.0-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1138692
+    checksum: sha256:3b672ce3677d8be9f0103de6bd24aa6d9575104f09089898f296d8cb19317192
+    name: xfsprogs
+    evr: 6.4.0-5.el9
+    sourcerpm: xfsprogs-6.4.0-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 235693
+    checksum: sha256:f16d17c26a241400586ddc3d734ce863e3f19d433881ec640a47bedf0dafd07b
+    name: xz
+    evr: 5.2.5-8.el9_0
+    sourcerpm: xz-5.2.5-8.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/z/zip-3.0-35.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 276200
+    checksum: sha256:ef28011ba191f53260cebb1e42b0148ae65d9029940146699e802f501dba009c
+    name: zip
+    evr: 3.0-35.el9
+    sourcerpm: zip-3.0-35.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/z/zstd-1.5.5-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 479423
+    checksum: sha256:b437abeff5d5319c25115f2bc2ba1bb6cc4d957727ce6cbf3072df77bbef2719
+    name: zstd
+    evr: 1.5.5-1.el9
+    sourcerpm: zstd-1.5.5-1.el9.src.rpm
+  source:
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/a/abattis-cantarell-fonts-0.301-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 582900
+    checksum: sha256:ce11dc78d92b207947633e00a792a3c8c3b7b4f23c2b7912eaba587dc7893f4c
+    name: abattis-cantarell-fonts
+    evr: 0.301-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/a/augeas-1.14.1-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2661871
+    checksum: sha256:e7fc9d8dfc200330be70b420cb9ba7df159d24e7b41d5fc029d5588ee32a4b9f
+    name: augeas
+    evr: 1.14.1-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/capstone-4.0.2-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3321474
+    checksum: sha256:4fe5d72b82caaacf77aeab8f8cdb30b2535b4b9979890ce1291eae521e0504d9
+    name: capstone
+    evr: 4.0.2-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/checkpolicy-3.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 94887
+    checksum: sha256:37868cfff2b89ed3fa75621cd498861e37c8a450e4db066395acfee392b12f8a
+    name: checkpolicy
+    evr: 3.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/clevis-21-208.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 106327
+    checksum: sha256:12b188e92ca58fad9ff40d4563bf1016a2bd4e94ad71b1b2dc3de8c14333d235
+    name: clevis
+    evr: 21-208.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/c/cmake-3.26.5-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10671338
+    checksum: sha256:2f86bb96562eaf679969c2716738fbdfcc8a3966ecc3bb6317596fe2e214ea2b
+    name: cmake
+    evr: 3.26.5-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/d/dnsmasq-2.85-16.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 592430
+    checksum: sha256:417389fd944ace4e8f721e0e7edb6c768c9da29d349cb148d6c780247349a2a5
+    name: dnsmasq
+    evr: 2.85-16.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/d/dtc-1.6.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 172071
+    checksum: sha256:7324de7a291155bbdd6122ef37c3bb456a30cf7d7b7d040fc5354649e1d7b968
+    name: dtc
+    evr: 1.6.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/d/dwz-0.14-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 159459
+    checksum: sha256:7565e0aed6cfb90c2c4be4ae2b33536fc4cf9b1b05a6a07da940ec564475580f
+    name: dwz
+    evr: 0.14-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/e/edk2-20241117-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 48010094
+    checksum: sha256:ef57486fb23ff34584b0f54a690bb0eca4295b1900b050bbcd918e89cb501be9
+    name: edk2
+    evr: 20241117-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/gdisk-1.0.7-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 223602
+    checksum: sha256:5e716707b1d7defbc87ad5c4a86861c95ee79594cad2289dc22846eefe43a075
+    name: gdisk
+    evr: 1.0.7-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/geolite2-20191217-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 34872389
+    checksum: sha256:847196a090190750da4545e3586f7b9aaa3cd5a82a327776054d61bf1847b92c
+    name: geolite2
+    evr: 20191217-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/ghc-srpm-macros-1.5.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10180
+    checksum: sha256:2d980af2311afd353583b200783cb39a5da7e89b6dbb9e67aa7d77a2c53e0cab
+    name: ghc-srpm-macros
+    evr: 1.5.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/go-rpm-macros-3.6.0-10.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 134995
+    checksum: sha256:6c475fcaeb2eef79bb8d37bdc2d1e8ad07ec44be137fce4c677fd0ea11add375
+    name: go-rpm-macros
+    evr: 3.6.0-10.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/g/guestfs-tools-1.52.2-3.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 16087047
+    checksum: sha256:6e435b25665452bde950d8d0d72acac10b9052005147e5e8c99a704db2d43dba
+    name: guestfs-tools
+    evr: 1.52.2-3.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/h/hexedit-1.6-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 45068
+    checksum: sha256:d7817351432bbfa683e73e30419f34efa6d11b63ccb21de12bd7fd9e92ae57ad
+    name: hexedit
+    evr: 1.6-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/h/hivex-1.3.24-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 762030
+    checksum: sha256:c6e1e1efc59126a20b1faddca5bfcef6a25b5955f86af9a48f6cdadbc2e6e53b
+    name: hivex
+    evr: 1.3.24-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/i/ipxe-20200823-9.git4bd064de.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2668621
+    checksum: sha256:089b448cb0d83c1a9c9a5b09b248fc8a6bc353abc4a3a79962df2780038c242f
+    name: ipxe
+    evr: 20200823-9.git4bd064de.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/j/jose-14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 775746
+    checksum: sha256:de03c2c73f31318fd5044267761c0e5eae0904caa68af853a549be6fe8faee29
+    name: jose
+    evr: 14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/k/kernel-srpm-macros-1.0-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28536
+    checksum: sha256:6607ae4cf2e0ee6971a740ef64937853e4e636179822de40e709e8e3e0c7853b
+    name: kernel-srpm-macros
+    evr: 1.0-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libguestfs-1.54.0-8.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 19059798
+    checksum: sha256:07473757d21ce386266b4ded4a164b77bf3d653b97d25dadf18cd75576facad2
+    name: libguestfs
+    evr: 1:1.54.0-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libguestfs-winsupport-9.3-1.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1375864
+    checksum: sha256:fb44f1e36edc932054743f33e5b3368e239920367383081ae113e9064ef003ea
+    name: libguestfs-winsupport
+    evr: 9.3-1.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libmaxminddb-1.5.2-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 610097
+    checksum: sha256:34a6423fae0433753d49d69e2d48befdff7333ba8b67e8dd29aaecccba6db2e5
+    name: libmaxminddb
+    evr: 1.5.2-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libnbd-1.20.3-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1628736
+    checksum: sha256:5b4e6cd210ad3dc4b31cfcab2caabdda39ecfc7bfd9768d4ceea4e8d783a0f09
+    name: libnbd
+    evr: 1.20.3-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libosinfo-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306786
+    checksum: sha256:2efb475aa7815e6f24efaa0ca26276785935ec611d9a13ff3ded1dcda59b5fae
+    name: libosinfo
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libslirp-4.4.0-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 128699
+    checksum: sha256:5e740382ebf1511fc7c4fa0c1db0bc72fad624329ff9e359cea75cccbed503e4
+    name: libslirp
+    evr: 4.4.0-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libsoup-2.72.0-10.el9_6.2.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1515442
+    checksum: sha256:206c644b09742022e04e437ce07a2602b46400b05a7ef1f86c04c843a74822b0
+    name: libsoup
+    evr: 2.72.0-10.el9_6.2
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libtpms-0.9.1-4.20211126git1ff6fe1f43.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 823007
+    checksum: sha256:73da7bd03dbb0eb558e1f92d4144ae511d109c7e380d7dfb6db12fec80d939c6
+    name: libtpms
+    evr: 0.9.1-4.20211126git1ff6fe1f43.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/liburing-2.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 306309
+    checksum: sha256:748f99b4f3a7b03d1e91877d6a51e7f89c0e66089dbfc0b09a2ab53a85079793
+    name: liburing
+    evr: 2.5-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libvirt-10.10.0-7.3.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10052196
+    checksum: sha256:02378dd26cdb2e647249fecf5087ba4e53c86b72f80528f51567f2ffc67f436b
+    name: libvirt
+    evr: 10.10.0-7.3.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/libxslt-1.1.34-13.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 3555712
+    checksum: sha256:c56b2595a736692ae40af40759c7ce7a29fd8871f69c15359f6772e6570d1d72
+    name: libxslt
+    evr: 1.1.34-13.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/lua-rpm-macros-1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12116
+    checksum: sha256:19fdee3aa469d583a7f48dce71513da47c5046018bc35bfbe57c818b7aae21d0
+    name: lua-rpm-macros
+    evr: 1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/l/luksmeta-9-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 282795
+    checksum: sha256:10cb8ed956492edce5a31624f3da0ce393e53bfd46de272cbffaf0318d474046
+    name: luksmeta
+    evr: 9-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/m/mingw-binutils-2.43.1-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 28227077
+    checksum: sha256:4e9496e6dc783277c67045574ae4a2ba5772b2ba3e77701f660c3e4aec4cd1da
+    name: mingw-binutils
+    evr: 2.43.1-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/m/mingw-crt-12.0.0-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10348994
+    checksum: sha256:e3ca759c2fea0fa3a493b3316402ac2abae0fe5dbec5b1228f43760f69f47c4e
+    name: mingw-crt
+    evr: 12.0.0-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/m/mingw-filesystem-148-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 49976
+    checksum: sha256:08ae83f9a7f58607ee529bfe8b28f09b14ad9620a6655b6f88cc178130bd3525
+    name: mingw-filesystem
+    evr: 148-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/m/mingw-srvany-1.1-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 34488
+    checksum: sha256:8b37477cc6c04afb63ce2cf8df3318ddea41edf01b0b970fcfe7b65de7d61936
+    name: mingw-srvany
+    evr: 1.1-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/n/nbdkit-1.38.5-3.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2543192
+    checksum: sha256:7b11a3cf5d7630c09ffdb2f3ae901ca13b2374883655be752ebc2338ef2f5171
+    name: nbdkit
+    evr: 1.38.5-3.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/n/nvml-1.12.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 2890535
+    checksum: sha256:ddae6b30fd428de4c662f280ebf4fb8123e9d078908ce3f2915e304287cdfc05
+    name: nvml
+    evr: 1.12.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/o/ocaml-srpm-macros-6-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10233
+    checksum: sha256:198f33946c3b1c1e104109073449ac03fd59035e6c3f646ad847626aa646e336
+    name: ocaml-srpm-macros
+    evr: 6-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/o/openblas-srpm-macros-2-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 9345
+    checksum: sha256:fe7a59edc21a63ddabfc48585a536d7c97dbcf27d46fa1e8b723df87a3c76bb3
+    name: openblas-srpm-macros
+    evr: 2-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/o/osinfo-db-20250124-2.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 176763
+    checksum: sha256:8dee9b4e27b489e6808635f6fb9edaaea6900e4e09e3b4cfb6ef20e7f98e6937
+    name: osinfo-db
+    evr: 20250124-2.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/o/osinfo-db-tools-1.10.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 71184
+    checksum: sha256:2bd22032e8b549b1009783e61381ae8700f26556934ef93200cf441f717902fc
+    name: osinfo-db-tools
+    evr: 1.10.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/passt-0^20250217.ga1e48a0-9.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 304123
+    checksum: sha256:db0e875f311e21f07b2f64716e0627af377bdebde49984485dbfe3bd7637f230
+    name: passt
+    evr: 0^20250217.ga1e48a0-9.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-5.32.1-481.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 12784744
+    checksum: sha256:f1bf16242337d7910e8a00b94f047a5ae9fc648040321043857318d7ff7132be
+    name: perl
+    evr: 4:5.32.1-481.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Carp-1.50-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 37030
+    checksum: sha256:67ec8f31b0276573adc231a83abb15d42f31f56c2520f377da39e6dc9904ccf9
+    name: perl-Carp
+    evr: 1.50-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Data-Dumper-2.174-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 131573
+    checksum: sha256:554ef703b9510fdfc7fb7439f20e5b5be6bc05f720ad81fc4cf3973111532d7e
+    name: perl-Data-Dumper
+    evr: 2.174-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-1.19-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22653
+    checksum: sha256:cfac6eec4d3564b4a9a46df943e5e3b11434673dccfe095e2f631978636d61d1
+    name: perl-Digest
+    evr: 1.19-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Digest-MD5-2.58-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 60213
+    checksum: sha256:759005f7d3a3ee7a97da1af8f4c4e30a6d8592f1bc5ca95e6e065c6793f8ea17
+    name: perl-Digest-MD5
+    evr: 2.58-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Encode-3.08-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 1915541
+    checksum: sha256:f5a4058ed88a2763aad3a39a13d7cbe68d0d76f8d7a98b634cb7de63f747e407
+    name: perl-Encode
+    evr: 4:3.08-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Exporter-5.74-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32709
+    checksum: sha256:67cf67c052ac12e234811589fe0a446a8ad79d4ab09da1187b422397d5f41440
+    name: perl-Exporter
+    evr: 5.74-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Path-2.18-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43503
+    checksum: sha256:2523a27381e16676442f21d6c90a0ebabeb65eb37d0ef4a2dacc02155bad183b
+    name: perl-File-Path
+    evr: 2.18-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-File-Temp-0.231.100-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 89500
+    checksum: sha256:540bfbab1936e66314c0eac3a0880cd4a6ad55242055d7492a398868653d2d89
+    name: perl-File-Temp
+    evr: 1:0.231.100-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Getopt-Long-2.52-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 55697
+    checksum: sha256:c5260e60a5d3e4a6ba1ac7aad158322bfc7af0e9e85c10a4426860620cefda28
+    name: perl-Getopt-Long
+    evr: 1:2.52-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-HTTP-Tiny-0.076-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 93389
+    checksum: sha256:fe6eea19db536fbb948f3bbaf2d334bce7c39638342b8c6b79df7b3cc0a3a103
+    name: perl-HTTP-Tiny
+    evr: 0.076-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-IP-0.41-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 58169
+    checksum: sha256:820b50e8bbd44baeb36fb2c4996d88909043fb26333c16a0f4f5335d1bc1d04a
+    name: perl-IO-Socket-IP
+    evr: 0.41-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 295384
+    checksum: sha256:f70d650d6e7f244491287e88d0f95637461c3fbd4e6a6124d285520eb0606924
+    name: perl-IO-Socket-SSL
+    evr: 2.073-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-MIME-Base64-3.16-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 43653
+    checksum: sha256:b48266a93fef844c4b3ee3ff3d61df0cc497558b12e2b7be9e8a87fd3bd3a88b
+    name: perl-MIME-Base64
+    evr: 3.16-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Mozilla-CA-20200520-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 151174
+    checksum: sha256:488e0f8b1f3d167a5eb3c0156045adea8d1dbe668b24c83b988fa42250690b0d
+    name: perl-Mozilla-CA
+    evr: 20200520-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Net-SSLeay-1.94-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 693539
+    checksum: sha256:f31ac8a6104047329d21a8594231b8966eada47009adc44737771dad0e4286df
+    name: perl-Net-SSLeay
+    evr: 1.94-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-PathTools-3.78-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 141038
+    checksum: sha256:3457f843826ffa381deea36e926b9c89e78b024bb0d7877d3eaf0ce9af414d1d
+    name: perl-PathTools
+    evr: 3.78-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Escapes-1.07-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 22192
+    checksum: sha256:278a6249918084e23053e4847fd00c417de61ecf551ae11c6eaca2068b136ded
+    name: perl-Pod-Escapes
+    evr: 1:1.07-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225409
+    checksum: sha256:5ee087f47aa3f1f317069a5c5914f78caea706b0c5690baf6245c5fc9579d71a
+    name: perl-Pod-Perldoc
+    evr: 3.28.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Simple-3.42-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 318605
+    checksum: sha256:0519c7d5391807d300f0490e57ef0402a6831f6820045f6faec44c60b47e110c
+    name: perl-Pod-Simple
+    evr: 1:3.42-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Pod-Usage-2.01-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 91508
+    checksum: sha256:82e3309aa8a5b9967dd1bdae4c0e3855e91722244bec647cc95499709aec7bc9
+    name: perl-Pod-Usage
+    evr: 4:2.01-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 187594
+    checksum: sha256:2b9117c65c6939ee02a54d235897441f826ec331eec1db4b674f37e06fc6638a
+    name: perl-Scalar-List-Utils
+    evr: 4:1.56-462.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Socket-2.031-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 57721
+    checksum: sha256:cbd4a46e548d84325929c4fc205c20239359f1562729281247265d780fd375ad
+    name: perl-Socket
+    evr: 4:2.031-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Storable-3.21-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 225886
+    checksum: sha256:ec9eda9094c07d88067eda454000dfd55465b9dcc3f675599df828044317aa63
+    name: perl-Storable
+    evr: 1:3.21-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-ANSIColor-5.01-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 69123
+    checksum: sha256:40014939aeafb292b2baea665a8a3b1ee227dac7ecaac540c5fb537a6f8c3824
+    name: perl-Term-ANSIColor
+    evr: 5.01-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Term-Cap-1.17-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23367
+    checksum: sha256:52658f861201f1947d07040968098fa9d31433c46bb8b38cd33ca2cd1fdb3b67
+    name: perl-Term-Cap
+    evr: 1.17-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-ParseWords-3.30-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 18773
+    checksum: sha256:68425a0a7b9566b14abb56211c43f55146ac20c70a6dc69f983729505c94379c
+    name: perl-Text-ParseWords
+    evr: 3.30-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 30727
+    checksum: sha256:e3728f77c64a1dc3edae34554fdcb1f6c940b54f665c8529b730f4afff6f1543
+    name: perl-Text-Tabs+Wrap
+    evr: 2013.0523-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-Time-Local-1.300-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 54755
+    checksum: sha256:f9d3745fb10235d5097536f81976f8234921de7a5c4b5cd599aa2b790f4ad18b
+    name: perl-Time-Local
+    evr: 2:1.300-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-URI-5.09-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 123780
+    checksum: sha256:20fa38e20285da9712b42fdb9a5dffbc72644c4d608db827e2a10e9d8055dce2
+    name: perl-URI
+    evr: 5.09-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-constant-1.33-461.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32045
+    checksum: sha256:c68aeb1a1dbcf82f3be9b0b23a8fcbaaa9083d46328a76b6646af5412eaeedca
+    name: perl-constant
+    evr: 1.33-461.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-libnet-3.13-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 110461
+    checksum: sha256:e473459e582b0cf07d4ecb9c7045547ad3543b24b5796f06ff8b42184d4a0fad
+    name: perl-libnet
+    evr: 3.13-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-parent-0.238-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 23463
+    checksum: sha256:cb61d28f218c1b1f51be254fa0282270b54fb051e4a164e7937411d7023d8c66
+    name: perl-parent
+    evr: 1:0.238-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-podlators-4.14-460.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 150048
+    checksum: sha256:71e7c3e0eb8d62e314cf45b89d5be318ddb507399a96018079dd5fffe2b18de9
+    name: perl-podlators
+    evr: 1:4.14-460.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/perl-srpm-macros-1-41.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 10651
+    checksum: sha256:05990bf148e58515223b0936ee7b621e5d39bb875e2481a4d84522bd4b57d4e3
+    name: perl-srpm-macros
+    evr: 1-41.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/pixman-0.40.0-6.el9_3.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 647633
+    checksum: sha256:0bd62940984b88bfd5914463d948999e29665450e6850ad5c9c4fbc129f3c3d0
+    name: pixman
+    evr: 0.40.0-6.el9_3
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/pyproject-rpm-macros-1.16.2-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 289973
+    checksum: sha256:cb7775937762f5ab13165854b5fab8d1e1ea8003451ccb02faaf60b4590c1949
+    name: pyproject-rpm-macros
+    evr: 1.16.2-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python-distro-1.5.0-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 66472
+    checksum: sha256:cb263958210ce5470439a4123f81f79765eda41f07709d840c13f72875db9c4b
+    name: python-distro
+    evr: 1.5.0-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python-rpm-macros-3.9-54.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 32761
+    checksum: sha256:b48fc9a942da394ad4cefd19dd2ebf4c5839d0267a41c797fb04dc6173b5f296
+    name: python-rpm-macros
+    evr: 3.9-54.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/q/qemu-kvm-9.1.0-15.el9_6.4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 132975924
+    checksum: sha256:5f846d5abe4c7cae5e6b503e45c5981faa6eab83773b8e32b33b98dae2ca45a9
+    name: qemu-kvm
+    evr: 17:9.1.0-15.el9_6.4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/q/qt5-5.15.9-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 13771
+    checksum: sha256:149c54e64307cb3da96287a068f09c4ea5d3968bf2ba088383069f294695cc6d
+    name: qt5
+    evr: 5.15.9-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/r/redhat-rpm-config-209-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 96708
+    checksum: sha256:a6f4aa2f37f5c6205cca36ea99c640c6509587aa29732a3e145d7c3af304868f
+    name: redhat-rpm-config
+    evr: 209-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/r/rust-srpm-macros-17-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 35132
+    checksum: sha256:dfb94bc23f8c1be02f7d94e4b6d6dc05e98c7d4a162f5ef64f407bf6af738d42
+    name: rust-srpm-macros
+    evr: 17-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/scrub-2.6.1-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 387460
+    checksum: sha256:2280fa49d9d3cb069cc0b159484e3ae9820fc816629f73f663c8aae5994e504b
+    name: scrub
+    evr: 2.6.1-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/seabios-1.16.3-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 659244
+    checksum: sha256:fd93e2f7297f3261e4a3738d81aab2b13c24e027fa86ed18f122f0138c1ac3e4
+    name: seabios
+    evr: 1.16.3-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/supermin-5.3.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 248488
+    checksum: sha256:5554d9949408a306b61c843573b96227edf77a54407d4fbdda1fb24ea0b309d4
+    name: supermin
+    evr: 5.3.5-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/s/swtpm-0.8.0-2.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 378833
+    checksum: sha256:96fe693d2a8cb7ee9d7c52766af355d425ed1518d9bfe49ede98ad5013081d47
+    name: swtpm
+    evr: 0.8.0-2.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/u/unbound-1.16.2-18.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 6293213
+    checksum: sha256:f3c9e128e48642f9e65569deea35b09994f477d3626dd086560744e90c21e1f2
+    name: unbound
+    evr: 1.16.2-18.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/v/virt-v2v-2.7.1-8.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 7352457
+    checksum: sha256:80f0292c864e3c600dd2d01748b8d57312d1174d97bb39e1415671c9d1c1adfd
+    name: virt-v2v
+    evr: 1:2.7.1-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/v/virtio-win-1.9.46-0.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 253160759
+    checksum: sha256:412d2b74fcc2055a70ac4d91f47ca24727d118bb819ba63f7189672121328f11
+    name: virtio-win
+    evr: 1.9.46-0.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/w/webkit2gtk3-2.48.3-1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-appstream-source-rpms
+    size: 44228159
+    checksum: sha256:d655cde1970056d39c393edc6dc0d08069803b2a34c36cdd73a327e3e5353526
+    name: webkit2gtk3
+    evr: 2.48.3-1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8251850
+    checksum: sha256:1fd3a712280b0bdb5144a5e9ee6600327bfba34fce9853c2ebadd47b221d46ed
+    name: adobe-source-code-pro-fonts
+    evr: 2.030.1.050-12.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/a/audit-3.1.5-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1262288
+    checksum: sha256:f589dc92fde418c7945245488cc084d565ece3995af808e741c5aa28c87a648a
+    name: audit
+    evr: 3.1.5-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/binutils-2.35.2-63.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 22426920
+    checksum: sha256:7e8e6c0116f7e862225990df4faaa664fe3b86198538cd350f01b3e5bd16cf41
+    name: binutils
+    evr: 2.35.2-63.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/brotli-1.0.9-7.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 498766
+    checksum: sha256:0c54d337221bca2bfeafaa7ce372aed7a2fcdb1f800be609ed8579bc1187bcd4
+    name: brotli
+    evr: 1.0.9-7.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/b/bzip2-1.0.8-10.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 824335
+    checksum: sha256:ed1556ca58615a5ca90b09f3cad8ddb8fe7b1885a4de49c40a31a39ca592bc25
+    name: bzip2
+    evr: 1.0.8-10.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cpio-2.13-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1395694
+    checksum: sha256:0448d6f73fb814a7b6771981dd7bdb22540a0fa9e7e724dd5446308e4a957c55
+    name: cpio
+    evr: 2.13-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cryptsetup-2.7.2-3.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11659362
+    checksum: sha256:5a72dbb2b730ff70acd0b566490583e5f08333ca05619840e7c982982141c5d0
+    name: cryptsetup
+    evr: 2.7.2-3.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/c/cyrus-sasl-2.1.27-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4030574
+    checksum: sha256:e46ec9eefa07147569cecd7e2377c37db8380243672f7ed5c744e47341923048
+    name: cyrus-sasl
+    evr: 2.1.27-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/device-mapper-multipath-0.8.7-35.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 758320
+    checksum: sha256:9185cbc2f78e88e75c5a18ed0a2bfd4433a248fad13ac52f966e2edad12687c5
+    name: device-mapper-multipath
+    evr: 0.8.7-35.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/device-mapper-persistent-data-1.1.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 28940167
+    checksum: sha256:7e3fe6a388c466a9a4a27ecd1104bee2ae57b404d61f13e035b23d861432a110
+    name: device-mapper-persistent-data
+    evr: 1.1.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/dhcp-4.4.2-19.b1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 10011377
+    checksum: sha256:dd030b15b457d35bafb10fbf80031239dcc158ae3456039d80fd620c3e74a9ad
+    name: dhcp
+    evr: 12:4.4.2-19.b1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/diffutils-3.7-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1477522
+    checksum: sha256:7a10e2d961f8d755f8ccf51a1fb7f68687671b82d9486e4b8d648561af1a185e
+    name: diffutils
+    evr: 3.7-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/ding-libs-0.6.1-53.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 926394
+    checksum: sha256:491a9ab14a3d8c679c45c2c4a140c4cc17a8abf5545a04e5d9227e93de9096b3
+    name: ding-libs
+    evr: 0.6.1-53.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/dosfstools-4.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 333826
+    checksum: sha256:7661c7fdd763ca04617d9a5a02f59cf0d9f0a28b251f5e45161ea95b0ff68dd3
+    name: dosfstools
+    evr: 4.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/d/dracut-057-88.git20250311.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 535294
+    checksum: sha256:2ea363c64a7fc761844d4f27a8ca0af830ee3bf48678b6a589ab029551e12518
+    name: dracut
+    evr: 057-88.git20250311.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 7418303
+    checksum: sha256:c38c97745729d7808cb5e520e73fe30f7aa9abd5d9c684968e329c4fa4067223
+    name: e2fsprogs
+    evr: 1.46.5-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/efi-rpm-macros-6-2.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 26255
+    checksum: sha256:a8fc8e505e79f9a3f2cead3e4705f08469195659f4761889e6011ecac6c75610
+    name: efi-rpm-macros
+    evr: 6-2.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/elfutils-0.192-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 11943728
+    checksum: sha256:b5a00f4c49b8980167b250ed7f9e18b90162087cac06276a4fb4ce578a1e3d5a
+    name: elfutils
+    evr: 0.192-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/file-5.39-16.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1003666
+    checksum: sha256:e8261cbcd55b85efdcd12ce1a2c6e63a72c64c872d618de4ba24557a1fda63c0
+    name: file
+    evr: 5.39-16.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 50762
+    checksum: sha256:6da7d722d419e6e9ce5abb4f6adcb82613d0629261011ec42134cfe092078e83
+    name: fonts-rpm-macros
+    evr: 1:2.0.5-7.el9.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/fuse-2.9.9-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1832743
+    checksum: sha256:9a11b340f925ae501331459e5d8d2edb819b947406d26cb565cf46a9f1b27f97
+    name: fuse
+    evr: 2.9.9-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/f/fuse3-3.10.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799367
+    checksum: sha256:ddfcd07bcdcc07bdabe0f05b2c5c3bb1d6582af9c6b127632dd74f8ca78d56c9
+    name: fuse3
+    evr: 3.10.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gcc-11.5.0-5.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 81877102
+    checksum: sha256:ed35dd39cd89aec444199a916667169638150fd12199dbb3c3d2638e43121565
+    name: gcc
+    evr: 11.5.0-5.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gettext-0.21-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9750918
+    checksum: sha256:1b4dc42c4afa9d998cd13750e0aa73e0d3a16f6792bfc5e17d39aabd9c68426d
+    name: gettext
+    evr: 0.21-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/glib-networking-2.68.3-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 256221
+    checksum: sha256:08f2d7a3c389bd63fb7ff6f8ac4a5a1fbb088451ca40f4fbe8ed70d2e820e897
+    name: glib-networking
+    evr: 2.68.3-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/glibc-2.34-168.el9_6.14.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 19817684
+    checksum: sha256:afd2246bd19e857541d0cd006dcad75fe7f06a72e14727ddd706cdb22a5aaaa3
+    name: glibc
+    evr: 2.34-168.el9_6.14
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gnutls-3.8.3-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 8589339
+    checksum: sha256:ab9b4771150e288f915499690934a04871dbe5a585db4407a2b8ba136c4d0749
+    name: gnutls
+    evr: 3.8.3-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/groff-1.22.4-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4138121
+    checksum: sha256:16d1628338ede3c55a795782f05848112d47816ba073978af6fcd90ecce08f5c
+    name: groff
+    evr: 1.22.4-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gsettings-desktop-schemas-40.0-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 715307
+    checksum: sha256:8ea2b5a68577e8db8cbf83440a145e686cd5219c511307340249bec56369f98b
+    name: gsettings-desktop-schemas
+    evr: 40.0-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gssproxy-0.8.4-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 587464
+    checksum: sha256:72af91df90b9faa511245614dedb596b7f77d5e5ec15b98d4743516c8b7e6b82
+    name: gssproxy
+    evr: 0.8.4-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/h/hwdata-0.348-9.18.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2508307
+    checksum: sha256:af6cdae99470d14fa48057ac70a01cc8ab8567577eb74fc8c8be32ac080ad0ba
+    name: hwdata
+    evr: 0.348-9.18.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/icu-67.1-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 23182150
+    checksum: sha256:e02b9fac958c410f2c476bb2d3daf55c314700a320b96c1454b8cd63a37b5bfb
+    name: icu
+    evr: 67.1-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/inih-49-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 26129
+    checksum: sha256:1f04866daa55017c62b94c7f627dbfe57af0aa0cdbdef80bb06a9289a82d24ff
+    name: inih
+    evr: 49-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/ipcalc-1.0.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 62787
+    checksum: sha256:f4af9efdfe497c5f1fa92941adab932fab2b6927965ec90638e737a3821b34d7
+    name: ipcalc
+    evr: 1.0.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/iproute-6.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 937429
+    checksum: sha256:11bfd8c1de1c26b8510340b467a933a800134d2e6e6f58a215d729a0727eee58
+    name: iproute
+    evr: 6.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/iptables-1.8.10-11.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 709624
+    checksum: sha256:5e4edd2e85c004f5fb06f0761d6cf41c530bb9973262315285be0ad11e8e8b51
+    name: iptables
+    evr: 1.8.10-11.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/i/iputils-20210202-11.el9_6.1.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 601258
+    checksum: sha256:9dd32ad99d09763e61fc6fe281ef4aa7f74e64bc25653f74f270a41eb92193c6
+    name: iputils
+    evr: 20210202-11.el9_6.1
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/j/jansson-2.14-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 447607
+    checksum: sha256:f15174491e4b92ca0c70b85b57cc8eac4373c424fc1c78e6bf492f99f28cb77b
+    name: jansson
+    evr: 2.14-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/j/jq-1.6-17.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1503300
+    checksum: sha256:792ddc2a380e924ca859eeb01e83b93789af3dd10aca70697d5dfa32d13575a2
+    name: jq
+    evr: 1.6-17.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kbd-2.4.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1167414
+    checksum: sha256:8d50e573c7beff06b0167dd7d6bccfe542bc393aaf652bbecb205277af293231
+    name: kbd
+    evr: 2.4.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-570.23.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 149285421
+    checksum: sha256:61a58444dd7f7f8a8a92f7e7b5edc3f6cb57152cac6c75fec79979abdae7295a
+    name: kernel
+    evr: 5.14.0-570.23.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kmod-28-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 582431
+    checksum: sha256:28b89be6334167a3a6b3d73c82c11301e1ca065c853b18509eca456c4ee06508
+    name: kmod
+    evr: 28-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/less-590-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 385311
+    checksum: sha256:345830f76771e7e7a6b2a7af0b0374d2c39d970de4578379070aed36fd59d4bb
+    name: less
+    evr: 590-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libaio-0.3.111-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 59434
+    checksum: sha256:bb79dc7d84e0f73faf10a48f6344b75b33c697b6448abbc0e0160e3b2348ed3d
+    name: libaio
+    evr: 0.3.111-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libcbor-0.7.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 276760
+    checksum: sha256:0fe4d1387cdb9c79ee26a6677df578b4d30facf4afa06cfa674fb686c3fa754a
+    name: libcbor
+    evr: 0.7.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libconfig-1.7.2-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1043612
+    checksum: sha256:b314b38835f8cb5ce01ac1064e5760d7e4b26a80fdd027b0f03d884322096566
+    name: libconfig
+    evr: 1.7.2-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libedit-3.1-38.20210216cvs.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 531597
+    checksum: sha256:067e19c3ad8c9254119e7918ef7d2af3c3d33d364d34016f4b65fb71eb1676b3
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libev-4.33-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 581721
+    checksum: sha256:fc97ef4c51b1ec2382425ff9917988ae3eab2a78a152f6a08a7cbe858e52b36d
+    name: libev
+    evr: 4.33-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libfido2-1.13.0-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 865138
+    checksum: sha256:c3f125f8b3242600cc1013183930e990b4b791c0d6c6544bf371a28c7abfebe1
+    name: libfido2
+    evr: 1.13.0-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libkcapi-1.4.0-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 364003
+    checksum: sha256:c9fee402dec3be5a4a3fb5e4f498054bf0d0ddbe67414cdd4a99ff8c05c2adce
+    name: libkcapi
+    evr: 1.4.0-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 388193
+    checksum: sha256:959db92c90bf83ba3634cc4b7600288f7620c247acc7e6ee072f455458eaad0e
+    name: libnetfilter_conntrack
+    evr: 1.0.9-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnfnetlink-1.0.1-23.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 334502
+    checksum: sha256:c4509f7791e6fcebc1470eaca4dfd6add95c308559e61efa4833a76d2f1acedb
+    name: libnfnetlink
+    evr: 1.0.1-23.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnftnl-1.2.6-4.el9_4.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 400952
+    checksum: sha256:125de9f4ca8c293ccc5de32f6cc7dde0e4458f75aefc56b09924c15e56fee98a
+    name: libnftnl
+    evr: 1.2.6-4.el9_4
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnl3-3.11.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5068824
+    checksum: sha256:13f6ea90f26fbc96e3754584a576c03ca41221fc939164f5a7b6341a6372fd7a
+    name: libnl3
+    evr: 3.11.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libnvme-1.11.1-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 751873
+    checksum: sha256:a029281159350bbaaa464f4fd77152f174a8407817bc0f3ed587101abb321dba
+    name: libnvme
+    evr: 1.11.1-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libpipeline-1.5.3-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1006052
+    checksum: sha256:f1a40821328b6e3fd7264c78c18f8c2045e7a30a05ef9f8b2934d5ca15724ce3
+    name: libpipeline
+    evr: 1.5.3-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libpng-1.6.37-12.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1527840
+    checksum: sha256:41f1d58a05cafaa0e6e8cf82f5a3a0f00afa47a082f093364da7cc279576d2fc
+    name: libpng
+    evr: 2:1.6.37-12.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libproxy-0.4.15-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 123932
+    checksum: sha256:7b2cdc89e0020245af06c0b12f3e077c457cf3947d60c53b9303a0fe36d84002
+    name: libproxy
+    evr: 0.4.15-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libpsl-0.21.1-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 9160109
+    checksum: sha256:0325329a882e68a2f817bac959abe49abc67d3dac9381a5a02c006916a86f17c
+    name: libpsl
+    evr: 0.21.1-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libselinux-3.6-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 271153
+    checksum: sha256:a08a84389665ef614eb6d9b06a53128eab89b650c799c0558f3ae04df97c4b13
+    name: libselinux
+    evr: 3.6-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libsemanage-3.6-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 223978
+    checksum: sha256:33e4ad8374bdaa1dd4b4a46b2b379d025590d80e5d666801aea4f437a9a6ccd9
+    name: libsemanage
+    evr: 3.6-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libssh-0.10.4-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 670226
+    checksum: sha256:27606f3c6b33c346dec927f99a56cece41b09a0780b8c3d33599bb9020a5906f
+    name: libssh
+    evr: 0.10.4-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libtirpc-1.3.3-9.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 589716
+    checksum: sha256:95d684042f4c5f63ac57923639fd1e7d6d278766b4ee99feb24baa5567fe4b7e
+    name: libtirpc
+    evr: 1.3.3-9.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libusbx-1.0.26-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 643959
+    checksum: sha256:e9359c9ad4fedd8d880f23c2c6a248fd0e17d657ee4ef5d17d572844dfe5f016
+    name: libusbx
+    evr: 1.0.26-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libverto-0.3.2-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 396005
+    checksum: sha256:a648c6c90c2cfcd6836681bff947499285656e60a5b2243a53b7d6590a8b73ee
+    name: libverto
+    evr: 0.3.2-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libxcrypt-4.4.18-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 543970
+    checksum: sha256:d18f72eb41ecd0370e2e47f1dc5774be54e9ff3b4dd333578017666c7c488f40
+    name: libxcrypt
+    evr: 4.4.18-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/linux-firmware-20250513-151.1.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 465491510
+    checksum: sha256:d8eced04b42aa71a20da01a6663efaf05c09cfc2feff8ae1e672c4f01bd321ca
+    name: linux-firmware
+    evr: 20250513-151.1.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lsscsi-0.32-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 208622
+    checksum: sha256:194c000e5b85acb97e926c32a74edff60ea90d9a10162350a966d5e811a5eca5
+    name: lsscsi
+    evr: 0.32-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lvm2-2.03.28-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2992347
+    checksum: sha256:5361a813c7d6ea933fba20b461c5e3af5528b8876724460f8526f82564e0a063
+    name: lvm2
+    evr: 9:2.03.28-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lzo-2.10-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 614312
+    checksum: sha256:df1303a4bad0c6126e65fb9ac2c0881ad5ceab39e8a97a59afe1f757adc0b3c6
+    name: lzo
+    evr: 2.10-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/lzop-1.04-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 404704
+    checksum: sha256:bd42a5d06d76aef940669d0b674a8828bfc60152ab2dbff22a3483c70e40b970
+    name: lzop
+    evr: 1.04-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/m/man-db-2.9.3-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1910721
+    checksum: sha256:bc6830986c1500ac2a8cf36dd575e53731b0160be2bc208ab141c52c292ac54b
+    name: man-db
+    evr: 2.9.3-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/m/mdadm-4.3-4.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 641686
+    checksum: sha256:407f4ecbeb3529505d1340cdc07117f7f35ca1f5defc6a530c18e5d82c2b25b0
+    name: mdadm
+    evr: 4.3-4.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/m/mtools-4.0.26-4.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 543062
+    checksum: sha256:a1c07910b80453f4aad247389b24dfb650f41d03b12900ec45e0574988b19ea6
+    name: mtools
+    evr: 4.0.26-4.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/ncurses-6.2-10.20210508.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3587693
+    checksum: sha256:0aa2d8068439cb17c73b678a8c9290e3e9aef0011b7aaa9fa5b24739297b22e4
+    name: ncurses
+    evr: 6.2-10.20210508.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/ndctl-78-2.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 450744
+    checksum: sha256:5260964c5a505a9fe77ff1579eb4cf293879c5735d50757b2e728f2725e28fff
+    name: ndctl
+    evr: 78-2.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/nfs-utils-2.5.4-34.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 799882
+    checksum: sha256:2ed1f701b51c6ab2435fa8ed56fcabc3f99004acad77d2cb1a045edf16f5618a
+    name: nfs-utils
+    evr: 1:2.5.4-34.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/numactl-2.0.19-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 231614
+    checksum: sha256:df493be344a68a29145a960db9b1fff8ff8ed673338b1608f404a648ef38164c
+    name: numactl
+    evr: 2.0.19-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/n/numad-0.5-37.20150602git.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 39137
+    checksum: sha256:b2c676c8f0fc82cdc420698b4acf8e604b70fd6289891443acd9200040674ec9
+    name: numad
+    evr: 0.5-37.20150602git.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 935874
+    checksum: sha256:9c864465c92115ad613c822f457af3f1f9d6e545321746cceb8b4c0f461a2fc4
+    name: oniguruma
+    evr: 6.9.6-1.el9.6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/o/openssh-8.7p1-45.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2415807
+    checksum: sha256:2cc10ea59a3685a9752db18962e69e87257a862bc283b7dd233d7ffdf2fa0281
+    name: openssh
+    evr: 8.7p1-45.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/PyYAML-5.4.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 186404
+    checksum: sha256:a26c273bb984ac1c17f22aaac3fcd547c5f54cdc86dda0584f90ac363996f4b0
+    name: PyYAML
+    evr: 5.4.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/parted-3.5-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1923182
+    checksum: sha256:150ec567a9f144f10a8a79ee31ad19fce2edc9ce10c4e897f2e4d58b999d0d38
+    name: parted
+    evr: 3.5-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/pigz-2.8-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 131701
+    checksum: sha256:2eb6030553235feec36ab1406d80066f60ca545bf5a073a43a2a841a70892d2a
+    name: pigz
+    evr: 2.8-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 310904
+    checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
+    name: pkgconf
+    evr: 1.7.3-10.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/policycoreutils-3.6-2.1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 7982064
+    checksum: sha256:3ee0c11e4cb602eb81993a8492688246c3d750bc0f592ba895dbce0aa734580a
+    name: policycoreutils
+    evr: 3.6-2.1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/polkit-0.117-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 336356709
+    checksum: sha256:29fafdd944809b56c0c2e9fe65c2f777e18e5d53473c95e14f6365af4287b131
+    name: polkit
+    evr: 0.117-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/polkit-pkla-compat-0.1-21.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 302278
+    checksum: sha256:8e4af06bc58994064b55ef7cdac31d48f9797f874fa82e011ad75b6233940636
+    name: polkit-pkla-compat
+    evr: 0.1-21.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/procps-ng-3.3.17-14.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1054334
+    checksum: sha256:acfd5c270ba5724a0f5f2a84cc47ee222d6a03095421fddbf6932375ec7d67f0
+    name: procps-ng
+    evr: 3.3.17-14.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/protobuf-c-1.3.3-13.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 513224
+    checksum: sha256:d4d82978c58a2f9ca8e24b953fd9ac74efee41572ec9649c4f2f183cda98b33f
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/publicsuffix-list-20210518-3.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 93646
+    checksum: sha256:3e2e87867d4d3967d0cd00d1a80812438e5b20eda61b620fe8b62084e528490b
+    name: publicsuffix-list
+    evr: 20210518-3.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/q/quota-4.09-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 560123
+    checksum: sha256:dc1ee202e7a726ba6de3f148ba362e8a7ddd774599c4433caec6d5331e18e1a2
+    name: quota
+    evr: 1:4.09-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/rdma-core-54.0-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2015866
+    checksum: sha256:d22ac38cce2d526f51eb3f9e1c647974bc979c014ba909272b7c3bd9eaf30b90
+    name: rdma-core
+    evr: 54.0-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/rpcbind-1.2.6-7.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 147311
+    checksum: sha256:6fd5417237b1e77a458ca88109d97a7456af0ce407768562b3a779ce8bd0bde3
+    name: rpcbind
+    evr: 1.2.6-7.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/r/rpm-4.16.1.3-37.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 4490587
+    checksum: sha256:b15a51773d702299bc9d83245544b60c8e733c0404f49e7badc5fa815449d151
+    name: rpm
+    evr: 4.16.1.3-37.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/selinux-policy-38.1.53-5.el9_6.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1165990
+    checksum: sha256:d2d67cbefde4402aaf8d4ea0e0820683f183d388c43c3bc7841beefceca1af68
+    name: selinux-policy
+    evr: 38.1.53-5.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/setools-4.4.4-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 416171
+    checksum: sha256:6e57d0e6a49d784f9ac26173e7dc42ccdb7cf82f174c5c7b0a04e19551058fc6
+    name: setools
+    evr: 4.4.4-1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/snappy-1.1.8-8.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1106755
+    checksum: sha256:e5cfaaae4882a9ad4ed8749430ead0acb7228a44a20e8aa27eb21dcb1795c1fd
+    name: snappy
+    evr: 1.1.8-8.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/squashfs-tools-4.4-10.git1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 265964
+    checksum: sha256:a8f3e58f77b03b2a161ccbe7f3579cc3b0e444c7b07ddf5d310596f871f78ca8
+    name: squashfs-tools
+    evr: 4.4-10.git1.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/syslinux-6.04-0.20.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 5311285
+    checksum: sha256:c0ebe8295039fb2d68d97b0bc5117fabedf5385009c95e6aa8f0e55efd30127b
+    name: syslinux
+    evr: 6.04-0.20.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/s/systemd-252-51.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 43223467
+    checksum: sha256:fd06bfa3f3ee8b7d0f563715a2362c9220bacd78b7ae099690e7439999c5eb05
+    name: systemd
+    evr: 252-51.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tpm2-tools-5.2-4.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1227059
+    checksum: sha256:c02043f848a7a7e59827d7fe53304b714e4a20b05811898ecf72a0747034ec77
+    name: tpm2-tools
+    evr: 5.2-4.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/u/unzip-6.0-58.el9_5.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1436757
+    checksum: sha256:49de0234c5e8f588c94b435c35225bcccd4cc94bb19cac94110d9aa0c5060f69
+    name: unzip
+    evr: 6.0-58.el9_5
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/u/userspace-rcu-0.12.1-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 542890
+    checksum: sha256:bcf02180bfad8ee8ce791c995003e6ab1c419e9781dcecfc61213ca97db8fcf0
+    name: userspace-rcu
+    evr: 0.12.1-6.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/x/xfsprogs-6.4.0-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1392193
+    checksum: sha256:116e6658aa9566330427a682d5068f481a17a429cc3f6873031782c8fae90e32
+    name: xfsprogs
+    evr: 6.4.0-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/x/xz-5.2.5-8.el9_0.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1168293
+    checksum: sha256:bce98f3a307e75a8ac28f909e29b41d64b15461fa9ddf0bf4ef3c2f6de946b46
+    name: xz
+    evr: 5.2.5-8.el9_0
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/z/zip-3.0-35.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 1137410
+    checksum: sha256:416b6957a4365204cfb2ba9e5b9b9f21075b615114c6afe46c83166de258bb5d
+    name: zip
+    evr: 3.0-35.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/z/zstd-1.5.5-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2378112
+    checksum: sha256:922957570bae59b0a45bd9d96ce804c65c6c3260f50198f40804d95ffb0db65e
+    name: zstd
+    evr: 1.5.5-1.el9
+  module_metadata: []

--- a/.konflux/virt-v2v/win2008iso/redhat.repo
+++ b/.konflux/virt-v2v/win2008iso/redhat.repo
@@ -1,0 +1,20961 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+
+[rhel-7-server-v2vwin-1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/v2vwin/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virt V2V Tool for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhoar-textonly-1-for-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhoar/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Application Runtimes Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhscon-2-main-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscon-main/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Console Main for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack/10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Extended Life Cycle Support for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.2-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - E4S) from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/fast-datapath/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhui-rhscl-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhscl/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-puppet-upgrade-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6-puppet-upgrade/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta - Puppet Upgrade (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Extended Update Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.1-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.1 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-optional-6.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sat-capsule-optional/6.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.0 - Optional (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rt-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rt/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time Beta (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/dotnet/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-devtools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/12/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 Developer Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmtc-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmtc/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Migration Toolkit for Containers for RHEL 7 $basearch (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-osd-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-osd/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 4 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.8-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.8/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.8 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rhui-e4s-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-source-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/devtools/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-supplementary-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/supplementary/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-1.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/1.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 1.0 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-3-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jws/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 3 (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.13-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.13.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.13.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.4 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Optional (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-6-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jws/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 6 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-rhn-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhn-tools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server - Extended Update Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions - Optional (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7.6/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.2-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.2 (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-director/9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-$basearch-server-7-mrg-messaging-2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mrg-m/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 2 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - TUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.3 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.19-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.19.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.19.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/satellite/6.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.0 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.3 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-splunk-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server-splunk/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Splunk (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-extras-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/extras/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-coreservices-1-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbcs/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Core Services (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - TUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rh-common/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.0-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/3scale-amp/2.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.0 Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.13-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.13 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.0-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/atomic/7/$basearch/cdk/3.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.0 Beta /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.3-eus-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/7Server/$basearch/jbeap/7.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.3 EUS (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-supplementary-debuginfo]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/supplementary/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Supplementary (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-mon/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-6-puppet-upgrade-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/satellite/6-puppet-upgrade/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Beta - Puppet Upgrade (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-thirdparty-oracle-java-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/oracle-java/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Oracle Java (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-2.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/2.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 2.0 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-discovery-0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/discovery/0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Discovery 0 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.3-tech-preview-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.3 Tech Preview (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.7 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-rhn-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/rhn-tools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server - Extended Update Support (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-quay-3-text-only-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/quay-textonly/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Quay Enterprise v3 Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-6-client-2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-client-2/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Client 2 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack/7.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Extended Life Cycle Support for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.9 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.2-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.2 (for RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/supplementary/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-big-data-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server-bigdata/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Big Data (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/7.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-e4s-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.0-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/7.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.0 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.5 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-htb-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) HTB (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhamp-1.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhamp/1.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 1.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-e4s-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Web Server Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-discovery-0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/discovery/0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Discovery 0 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-3-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jws/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 3 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-deployment-tools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-deployment-tools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Director Deployment Tools Beta for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.3-puppet4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.3-puppet4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.17-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.17 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-e4s-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Update Services for SAP Solutions (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-client-6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-client/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - Update Services for SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-16-stf-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-stf/16/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 16 Service Telemetry Framework for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/14/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-puppet4-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.3-puppet4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - Update Services SAP Solutions) from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-director/7.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.2 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rt-htb-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/rt/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time HTB (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.5 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-deployment-tools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-deployment-tools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Director Deployment Tools Beta for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-optional-6.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sat-capsule-optional/6.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.0 - Optional (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - TUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-puppet4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.3-puppet4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.1-eus-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/7Server/$basearch/jbeap/7.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 EUS (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-power-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-power/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 for IBM Power (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-rhn-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/rhn-tools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server - AUS (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/dotnet/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - AUS - Optional (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.14-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.14/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.14 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-devtools/10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - AUS - Optional (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.9 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-devtools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Developer Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-thirdparty-oracle-java-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/oracle-java/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Oracle Java (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.3-puppet4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.3-puppet4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.3 - Puppet 4 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/dotnet/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.2 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-optools-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-optools/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Operational Extended Life Cycle Support Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-htb-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server HTB (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-power-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-power/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 for IBM Power (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.2 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-osd-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-osd/1.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.1 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-client-6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-client/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhosds-textonly-3-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
+sslverify = 1
+name = Red Hat OpenShift Dev Spaces 3 Container Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-tools/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Tools (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-2.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 2.4 /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.4 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.5-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.5 Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-textonly-1-for-middleware-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On Text-Only Advisories from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.4 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.9-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-6.3-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/6.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 6.3 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-for-power-le-ossm-1.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/power-le/7/7Server/$basearch/ossm/1.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 7 IBM Power LE (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-satellite-tools-6.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/sat-tools/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server from RHUI) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-eus-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage from RHUI (for RHEL 7 Server) - Extended Update Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-devtools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Developer Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rh-common/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-mobile-services-1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mobile-services/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Mobile Services v1 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-director/9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 director for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.9 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rh-common/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.8 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.2-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.2 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-web-admin-server-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-webadmin/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Web Admin Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-htb-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/fast-datapath/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sjis-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sjis/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for S-JIS (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv/4.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4.1 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-power-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-power/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 for IBM Power (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.16-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.16/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.16 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - TUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - TUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.3-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.3 (for RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-optional-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta from RHUI(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.6 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-nfv-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/nfv/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time for NFV (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.9 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-2-textonly-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 2 Text-Only Advisories for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.6 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhose-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
+sslverify = 1
+name = Red Hat Middleware Container Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-client-6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-client/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rhui-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) Beta (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - AUS - Optional (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-htb-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) HTB (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.1-tech-preview-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.1 Tech Preview (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-els-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack-director/7.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Extended Life Cycle Support director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.10 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-htb-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) HTB (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-puppet4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.3-puppet4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Source RPMs for Red Hat Enterprise Linux 7 RHEL 7 Server EUS
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-2.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/2.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 2.1 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.2-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.2 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-textonly-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ceph-textonly/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage 2 Text-Only Advisories for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhn-tools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-devtools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-devtools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Developer Tools Beta for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.3-tech-preview-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.3 Tech Preview (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.7 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.7-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-mgmt-agent-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv-mgmt-agent/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Management Agents for RHEL 7 Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.2 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-big-data-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server-bigdata/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Big Data (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-3-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jws/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 3 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.5 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-rhui-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) Beta (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rt-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rt/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time Beta (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.3 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-e4s-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv/4.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4.1 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-els-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-mon/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-optional-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions - Optional (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-6.4-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/6.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 6.4 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.7 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.1 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openjdk-11-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openjdk/11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sat-capsule/6.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.0 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.11-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.11 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.4 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.4 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.7-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.11-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.11 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-devtools/10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-thirdparty-oracle-java-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/oracle-java/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Oracle Java Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-6-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 6 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.9 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-installer/1.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.10 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-tools/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 4 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.6-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.6 Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-1.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/1.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.1 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.11-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.11 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.1-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.1-manager-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.1 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-cts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-cts/5.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Certification Test Suite (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-tools-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-tools/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Tools Extended Life Cycle Support for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.11-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.11 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhn-tools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) - Extended Update Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.22-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.22.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.22.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/cert/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certification (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-calamari-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-calamari/1.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/14/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-extras-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.6 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-calamari-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-calamari/1.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-ews-2-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbews/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Web Server 2 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[a-mq-clients-1-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/a-mq/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss A-MQ Clients 1 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-tools-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-tools/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Tools Extended Life Cycle Support for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhev-mgmt-agent-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhev-mgmt-agent/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Management Agents for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-supplementary-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Supplementary (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.6-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.6 RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-6.4-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/6.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 6.4 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.9 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-coreservices-1-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbcs/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Core Services (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.3 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.2 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.4-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.4 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.1-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.1 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-nfv-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/nfv/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time for NFV (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.9-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.9 Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.19-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.19.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.19.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-coreservices-1-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbcs/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Core Services (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss AMQ Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sjis-for-rhel-7-server-aus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sjis/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for S-JIS (RHEL 7 Server) - AUS (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[a-mq-clients-1-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/a-mq/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss A-MQ Clients 1 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.2 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-rhn-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhn-tools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server - Extended Update Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhds-10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/directoryserver/10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Directory Server 10 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-$basearch-server-7-mrg-messaging-2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mrg-m/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 2 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.8-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.8 RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-insights-3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/insights/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Insights 3 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-textonly-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-textonly/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage 4 Text-Only Advisories for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-e4s-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmt-1.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmt/1.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Migration Toolkit 1.2 for RHEL 7 $basearch (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ose/3.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Enterprise 3.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.1-for-rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/jbeap/7.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 Beta (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-devtools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/12/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 Developer Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-5-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jws/5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 5 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-devtools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/14/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 Developer Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhoar-nodejs-8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhoar-nodejs/8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Application Runtimes Node.js v8 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.4 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.8 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-manager-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager-tools/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4 Tools (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.3 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-mon/1.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-for-rhel-7-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/cf-me/server/7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-nagios-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-nagios/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Nagios (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.1 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhscon-2-agent-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscon-agent/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Console Agent for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.1 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/14/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-for-power-le-ossm-1.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/power-le/7/7Server/$basearch/ossm/1.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 7 IBM Power LE (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-samba-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rh-gluster-samba/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Samba (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-satellite-tools-6-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/sat-tools/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server from RHUI) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhscon-2-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscon-installer/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Console Installer for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sjis-for-rhel-7-server-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sjis/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for S-JIS (RHEL 7 Server) - Extended Update Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/6.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-big-data-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server-bigdata/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Big Data (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-tools/1.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-osd-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhceph-osd/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 3 Extended Life Cycle Support for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server - TUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/5.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-2.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/2.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 2.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rt-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rt/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support - Optional (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.4-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.4 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhscon-2-agent-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscon-agent/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Console Agent for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-3-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/rhui/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Update Infrastructure 3 Beta for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.12-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.12/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.12 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sat-capsule/6.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.0 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.8 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-hub-4-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/automation-hub/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Hub 4 Beta for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rhui-e4s-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Update Services for SAP Solutions (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.4-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.4 (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-eus-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage from RHUI (for RHEL 7 Server) - Extended Update Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.2-tech-preview-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.2 Tech Preview (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-cts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-cts/5.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Certification Test Suite (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.2-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/7.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.2 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-puppet-upgrade-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6-puppet-upgrade/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta - Puppet Upgrade (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-nfs-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server-nfs/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 NFS (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[wfk-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Web Framework Kit Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-6-puppet-upgrade-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/satellite/6-puppet-upgrade/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Beta - Puppet Upgrade (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fdio-early-access-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/fdio-ea/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Early Access (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-tus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 for $basearch - High Availability - Telecommunications Update Service (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-cts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-cts/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta Certification Test Suite for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-tools/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-octavia-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-octavia/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Octavia Extended Life Cycle Support for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.6-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.6 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/devtools/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Beta Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-rhcmsys-9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/certificate-system/9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certificate System 9 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-services-catalog-1-tech-preview-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/automation-services-catalog-tech-preview/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Services Catalog 1 Tech Preview for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.3-puppet4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.3-puppet4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - TUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-2.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/2.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 2.1 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-osd-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-osd/1.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.4 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.2-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - E4S) from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sjis-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sjis/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for S-JIS (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.6 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.3-puppet4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.3-puppet4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.3 - Puppet 4 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.2 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rhui-e4s-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Update Services for SAP Solutions (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - Update Services SAP Solutions) from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[fsw-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Fuse Service Works Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.5-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.5 Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.6-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.6 Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/7.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Tools 7.0 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-satellite-client-6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sat-client/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - ELS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/6.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.3-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.3 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.4-tech-preview-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.4 Tech Preview (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-tools/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-rhui-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) Beta (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/devtools/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Beta RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.1 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/devtools/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.4 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.10 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-client-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhs-client/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Native Client for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/12/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack/10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Extended Life Cycle Support for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhamp-1.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhamp/1.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 1.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.10-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.10/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.10 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - TUS - Optional (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rhui-e4s-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Update Services for SAP Solutions (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-eus-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Extended Update Support (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-installer/1.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-ews-2-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbews/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Web Server 2 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rhui-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) Beta (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.1-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-6.4-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/6.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 6.4 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.2 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.5-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.5 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.2 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.5-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.5 RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.4 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.2-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.2 (for RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhn-tools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-1.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/1.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.1 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.3 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.13-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.13 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-maintenance-6.11-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-maintenance/6.11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Maintenance 6.11 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-3-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/rhui/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Update Infrastructure 3 Beta for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-satellite-6-client-2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sat-client-2/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Client 2 (for RHEL 7 Server - ELS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-e4s-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Update Services for SAP Solutions (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.3-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.3 (for RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.2 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.2-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.2 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-devtools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/14/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 Developer Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-mon-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhceph-mon/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 3 Extended Life Cycle Support for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-2.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 2.4 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sjis-for-rhel-7-server-aus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sjis/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for S-JIS (RHEL 7 Server) - AUS (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmtv-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmtv/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Migration Toolkit for Virtualization for RHEL 7 $basearch (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.2-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.2 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.9 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-insights-3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/insights/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Insights 3 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-satellite-tools-6.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/sat-tools/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server from RHUI) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.15-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.15/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.15 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-optools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-optools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Operational Tools Beta for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.4-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.4 (for RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4-build-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhvh-build/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 7 Build Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-2.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/2.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 2.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-octavia-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-octavia/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Octavia for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/14/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-insights-3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/insights/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Insights 3 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-clients-3-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Clients 3 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.12-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.12/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.12 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-deployment-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/12/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 12 Director Deployment Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.8 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-els-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-calamari-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-calamari/1.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.1-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.1 (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.2 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-hub-4.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/automation-hub/4.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Hub 4.2 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - TUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-1.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/1.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 1.0 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.4-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.4 (for RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-eus-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Extended Update Support (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-lb-for-rhel-7-server-htb-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/loadbalancer/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Load Balancer (for RHEL 7 Server) HTB (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-beta-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/devtools/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Beta Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2 Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.2-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/7.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.2 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rt-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rt/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.0 /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-web-admin-server-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-webadmin/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Web Admin Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.6 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmt-1.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmt/1.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Migration Toolkit 1.2 for RHEL 7 $basearch (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.0 /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7.6/$basearch/supplementary/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-clients-3-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Clients 3 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.1 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-hts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/hts/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Hardware Certification Test Suite (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.3-puppet4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.3-puppet4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-nfv-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/nfv/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time for NFV (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.1-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.5 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.22-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.22.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.22.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhevh-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhevh/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Hypervisor 7 - Extended Life Cycle Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.7-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[quarkus-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
+sslverify = 1
+name = Red Hat build of Quarkus Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-els-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 for $basearch - High Availability - Extended Life Cycle Support (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-calamari-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-calamari/1.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhoar-nodejs-8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhoar-nodejs/8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Application Runtimes Node.js v8 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-rh-common-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/rh-common/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-3-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jws/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 3 (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-optional-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions - Optional (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.10 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.5 /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-tools/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Tools (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.10 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-tools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv-tools/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Tools Beta (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-tools/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-clients-2.9-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq/2.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Clients 2.9 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/14/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-textonly-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-textonly/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage 3 Text-Only Advisories for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-maintenance-6.11-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-maintenance/6.11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Maintenance 6.11 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Extended Update Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-6-client-2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-client-2/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Client 2 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.1 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhscl/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Beta Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-2.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.1 /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Enterprise 3.1 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-utils-6.11-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-utils/6.11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Utils 6.11 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-1.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/1.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.4-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.4 (for RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.2-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - E4S) from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-extras-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.5 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.5 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.3-puppet4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.3-puppet4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.3 - Puppet 4 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.24-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.24/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.24 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.2 /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.0-manager-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.0 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhui-rhscl-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-interconnect-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Interconnect Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.7 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-for-system-z-ossm-1.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/system-z/7/7Server/$basearch/ossm/1.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 7 IBM Z (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-optional-6.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/satellite-optional/6.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.0 - Optional (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-splunk-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server-splunk/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Splunk (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-rhn-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/rhn-tools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server - Extended Update Support (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-eus-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability from RHUI (for RHEL 7 Server) - Extended Update Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Enterprise 3.1 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.5 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/dotnet/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.2 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4-build-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhvh-build/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 7 Build (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-mon/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-optional-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support - Optional from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rhui-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) Beta (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/supplementary/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhsi-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
+sslverify = 1
+name = Red Hat Service Interconnect Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6-client-2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-client-2/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Client 2 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-htb-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional HTB (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-cts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-cts/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta Certification Test Suite for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.11-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.11 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-inst/6.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Platform Installer (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openjdk-11-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openjdk/11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-htb-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) HTB (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/fast-datapath/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2 Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[a-mq-clients-1-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/a-mq/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss A-MQ Clients 1 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-satellite-tools-6.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/sat-tools/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server from RHUI) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-mon/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 4 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-beta-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/devtools/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Beta Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.15-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.15/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.15 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Optional (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-htb-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/fast-datapath/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath Beta (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.13-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.13 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-mgmt-agent-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhv-mgmt-agent/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Management Agents for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.1 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.1-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.1 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.9 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-director/7.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack/10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Extended Life Cycle Support for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-tools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv-tools/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Tools Beta (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.1 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.2-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/7.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.2 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - TUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-mon/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.0-manager-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.0 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.3-mgmt-agent-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-mgmt-agent/4.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4.3 Management Agents EUS for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-eus-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability from RHUI (for RHEL 7 Server) - Extended Update Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-extras-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-adv-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-adv/5.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Advanced (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhev-mgmt-agent-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhev-mgmt-agent/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Management Agents for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - TUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-nfs-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server-nfs/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 NFS (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openjdk-11-els-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/openjdk/11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 7 Server (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.5 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.6 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.6 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.1 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.9 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sjis-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sjis/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for S-JIS (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ose/3.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Enterprise 3.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack/7.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Extended Life Cycle Support for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.9 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-osd-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-osd/1.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack-devtools/10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools Extended Life Cycle Support for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4-build-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhvh-build/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 7 Build (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-6-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 6 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/cert/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certification Beta (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-interconnect-1-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq-interconnect/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss AMQ Interconnect 1 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv/4.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4.0 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-director/9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-supplementary-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/supplementary/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Supplementary (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhds-10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/directoryserver/10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Directory Server 10 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - TUS - Optional (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - Update Services SAP Solutions) from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.2 /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-installer/1.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.3-mgmt-agent-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-mgmt-agent/4.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4.3 Management Agents EUS for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4.2-build-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhvh-build/4.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 4.2 Build EUS (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.5 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.3-manager-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.3 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-rh-common-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/rh-common/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-inst/6.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Platform Installer (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.3 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-client-6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-client/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - TUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.5-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.5 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-osd-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-osd/1.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-tower-3.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible-tower/3.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Ansible Tower 3.4 Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-tools/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.2 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Optional (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-mgmt-agent-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhv-mgmt-agent/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Management Agents for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.11-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.11 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-deployment-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 11 Director Deployment Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions - Optional (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Optional (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-6.3-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/6.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 6.3 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-client-6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-client/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Optional (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhscon-2-main-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscon-main/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Console Main for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.8 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-tools/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Tools (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-splunk-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server-splunk/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Splunk (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhscl/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 RHEL 7 Server EUS
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/12/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-coreservices-1-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbcs/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Core Services (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sjis-for-rhel-7-server-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sjis/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for S-JIS (RHEL 7 Server) - Extended Update Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.12-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.12/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.12 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-optional-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions - Optional (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/dotnet/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhoar-nodejs-10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhoar-nodejs/10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Application Runtimes Node.js v10 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rhui-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) Beta (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-director/8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 director for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-for-system-z-ossm-1.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/system-z/7/7Server/$basearch/ossm/1.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 7 IBM Z (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-for-system-z-ossm-1.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/system-z/7/7Server/$basearch/ossm/1.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 7 IBM Z (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7.6/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/cert/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certification Beta (for RHEL 7 Server)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/devtools/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.10 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openjdk-11-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openjdk/11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.1-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.1 (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/14/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-for-rhel-7-server-files]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server/3.1/files
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Server (FILES)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.5 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.20-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.20.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.20.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-splunk-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server-splunk/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Splunk (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.8-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.8/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.8 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.1-eus-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/7Server/$basearch/jbeap/7.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 EUS (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Extended Update Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.14-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.14/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.14 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-optional-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-deployment-tools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-deployment-tools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Director Deployment Tools Beta for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.3-puppet4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.3-puppet4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.3 - Puppet 4 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-rhn-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/rhn-tools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server - Extended Update Support (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.9-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.9/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.9 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.10 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-client-6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-client/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - TUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.14-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.14 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.8 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.3 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-octavia-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-octavia/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Octavia Extended Life Cycle Support for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openjdk-11-els-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/openjdk/11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 7 Server (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.4 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.5 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.10 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv/4.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4.0 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.3 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.10 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-utils-6.11-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-utils/6.11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Utils 6.11 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.17-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.17.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.17.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.8 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.11-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.11 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv/4.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4.0 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4-build-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhvh-build/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 7 Build Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-automation-platform-1.2-textonly-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible-automation-platform-textonly/1.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Automation Platform 1.2 Text-Only Advisories for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-debug-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/devtools/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.4-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.4 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[soa-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss SOA Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-extras-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/extras/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/jbeap/7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7 (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.1 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-htb-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional HTB (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-satellite-tools-6.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/sat-tools/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server from RHUI) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.3 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.4 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-devtools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/14/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 Developer Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/12/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.3-manager-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.3 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/jbeap/7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7 (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rh-common/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-16-stf-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-stf/16/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 16 Service Telemetry Framework for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-mobile-services-1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mobile-services/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Mobile Services v1 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-optional-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-osd-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-osd/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 4 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-maintenance-6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-maintenance/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Maintenance 6 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-web-admin-agent-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-webadmin-agent/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Web Admin Agent (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.5 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhcmsys-9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/certificate-system/9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certificate System 9 RPMs (for RHEL 7 Server)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-osd-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-osd/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 4 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-mobile-services-1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mobile-services/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Mobile Services v1 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.0-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.0 (for RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.0-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/7.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.0 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/5.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-hub-4.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/automation-hub/4.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Hub 4.2 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.2-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.2 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.3 /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.3-puppet4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.3-puppet4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-devtools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Developer Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.3-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.3 (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-capsule-6-puppet-upgrade-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-capsule/6-puppet-upgrade/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6 Beta - Puppet Upgrade (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.3-puppet4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.3-puppet4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[openliberty-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Open Liberty Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Enterprise 3.2 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.4 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.3-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.3 (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.6 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.10 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-els-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (for RHEL 7 Server) - Extended Life Cycle Support (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.4 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sjis-for-rhel-7-server-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sjis/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for S-JIS (RHEL 7 Server) - Extended Update Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/fast-datapath/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-services-catalog-1-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/automation-services-catalog/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Services Catalog 1 Beta for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-els-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 for $basearch - High Availability - Extended Life Cycle Support (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.3-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.3 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-3-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/rhui/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Update Infrastructure 3 Beta for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.13-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.13.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.13.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-optional-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support - Optional from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.1-for-rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/jdg/7.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.1 Beta (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-8.1-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/8.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 8.1 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-osd-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhceph-osd/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 3 Extended Life Cycle Support for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-samba-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rh-gluster-samba/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Samba (for RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) - Extended Update Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.3-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.3 (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-optional-6.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sat-capsule-optional/6.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.0 - Optional (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.8 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-hub-4.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/automation-hub/4.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Hub 4.2 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-maintenance-6.11-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-maintenance/6.11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Maintenance 6.11 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-web-admin-server-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-webadmin/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Web Admin Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-thirdparty-oracle-java-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/oracle-java/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Oracle Java Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.16-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.16/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.16 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4 Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-5-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jws/5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 5 (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhcmsys-9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/certificate-system/9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certificate System 9 Source RPMs (for RHEL 7 Server)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-devtools/10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.3 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-rh-common-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rh-common/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.1-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/7.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.1 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhoar-nodejs-10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhoar-nodejs/10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Application Runtimes Node.js v10 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscl/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[interconnect-2-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/interconnect/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Interconnect 2 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) - Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-els-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (for RHEL 7 Server) - Extended Life Cycle Support (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.3-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.3 (for RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.3-puppet4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.3-puppet4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.5 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-2.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/2.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 2.0 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.0-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/3scale-amp/2.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.0 Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - TUS (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - TUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.14-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.14/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.14 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.4 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhevh-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhevh/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Hypervisor 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-satellite-tools-6-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/sat-tools/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server from RHUI) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.3 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Server (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.4-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.4 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.5 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-5-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jws/5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 5 (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.10 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-cts-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-cts/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta Certification Test Suite for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-devtools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-devtools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Developer Tools Beta for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-6-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/satellite/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Beta (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.7 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Extended Update Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-satellite-tools-6.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/sat-tools/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server from RHUI) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.3 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.4 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 for $basearch - High Availability - Extended Life Cycle Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.1-for-rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/jdg/7.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.1 Beta (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.6 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-thirdparty-oracle-java-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/oracle-java/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Oracle Java (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-octavia-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-octavia/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Octavia for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-osd-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-osd/1.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/dotnet/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.1-for-rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/jbeap/7.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 Beta (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmt-1.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmt/1.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Migration Toolkit 1.2 for RHEL 7 $basearch (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-els-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 for $basearch - High Availability - Extended Life Cycle Support (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-devtools-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-devtools/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Developer Tools Extended Life Cycle Support for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.1-for-rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/jbeap/7.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 Beta (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-interconnect-1-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq-interconnect/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss AMQ Interconnect 1 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-puppet4-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.3-puppet4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - Update Services SAP Solutions) from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-web-admin-agent-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-webadmin-agent/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Web Admin Agent (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.6-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.6 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-optional-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support - Optional from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-tools/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-deployment-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 11 Director Deployment Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-tools/1.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.4 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/dotnet/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - AUS (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.2 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.1-tech-preview-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.1 Tech Preview (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.5-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.5/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.5 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.2-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.2 (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-supplementary-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/supplementary/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Supplementary (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-rhui-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.4-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.4 (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.0-manager-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.0 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-osd-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-osd/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.6 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/supplementary/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.1 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/7.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.9 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.2-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.2 (for RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Extended Update Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.0-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.0 (for RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.7 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-capsule-6-puppet-upgrade-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-capsule/6-puppet-upgrade/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6 Beta - Puppet Upgrade (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.3-eus-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/7Server/$basearch/jbeap/7.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.3 EUS (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-mgmt-agent-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv-mgmt-agent/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Management Agents for RHEL 7 Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-coreservices-1-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbcs/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Core Services (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.1-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/7.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.1 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.5 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-calamari-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-calamari/1.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-samba-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rh-gluster-samba/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Samba (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Server (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/14/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Extended Update Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-supplementary-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/supplementary/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (for RHEL 7 Server) - Extended Life Cycle Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support - Optional (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.4 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-5-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jws/5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 5 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-interconnect-1-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq-interconnect/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss AMQ Interconnect 1 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.5 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.3 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhevh-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhevh/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Hypervisor 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jon-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Operations Network Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.6 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-8.1-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/8.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 8.1 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhn-tools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-capsule-6-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-capsule/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6 Beta (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.6 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-hub-4-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/automation-hub/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Hub 4 Beta for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.4-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.4 Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-rhcmsys-9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/certificate-system/9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certificate System 9 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.1-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 (for RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/satellite/6.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.0 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhscon-2-agent-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscon-agent/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Console Agent for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-capsule-6-puppet-upgrade-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-capsule/6-puppet-upgrade/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6 Beta - Puppet Upgrade (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/7.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Tools 7.0 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-optools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-optools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Operational Tools Beta for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-installer/1.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.9-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.9/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.9 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-web-admin-agent-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-webadmin-agent/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Web Admin Agent (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.1 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-eus-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage from RHUI (for RHEL 7 Server) - Extended Update Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/7.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-deployment-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/12/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 12 Director Deployment Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-client-6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-client/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.8 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-v2vwin-1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/v2vwin/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virt V2V Tool for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.1-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/7.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.1 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-nfs-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server-nfs/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 NFS (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.3-puppet4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.3-puppet4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.3 - Puppet 4 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-puppet4-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.3-puppet4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - Update Services SAP Solutions) from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.11-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.11 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-rhn-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhn-tools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server - Extended Update Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.12-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.12/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.12 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.3-puppet4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.3-puppet4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.3 - Puppet 4 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-optional-6.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/satellite-optional/6.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.0 - Optional (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.6 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.4-tech-preview-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.4 Tech Preview (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhds-10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/directoryserver/10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Directory Server 10 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-tools-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhceph-tools/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 3 Extended Life Cycle Support for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-devtools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 Developer Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rt-htb-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/rt/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time HTB (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-web-admin-agent-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-webadmin-agent/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Web Admin Agent (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.8 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - TUS (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.1-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - E4S) from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - TUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.6 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-6-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jws/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 6 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.3-mgmt-agent-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-mgmt-agent/4.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4.3 Management Agents EUS for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-mgmt-agent-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv-mgmt-agent/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Management Agents for RHEL 7 Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.2-mgmt-agent-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhv-mgmt-agent/4.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4.2 Management Agents for RHEL 7 EUS (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-tools/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.17-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.17.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.17.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-mgmt-agent-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhv-mgmt-agent/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Management Agents for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.6 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.3-puppet4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.3-puppet4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.1-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 (for RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.4-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.4 RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.3-puppet4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.3-puppet4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 for $basearch - High Availability - Extended Life Cycle Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-client-6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-client/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - Update Services for SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-els-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rh-common/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-satellite-6-client-2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sat-client-2/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Client 2 (for RHEL 7 Server - ELS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.10 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-osd-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-osd/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4 Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - TUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.3 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.8 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.3 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-tools-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhceph-tools/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 3 Extended Life Cycle Support for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.0 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack-devtools/10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools Extended Life Cycle Support for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-maintenance-6-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-maintenance/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Maintenance 6 Beta (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-director/7.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.6 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.5-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.5/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.5 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.6 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.7 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-htb-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional HTB (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-clients-3-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Clients 3 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.1 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhscl/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Debug RPMs for Red Hat Enterprise Linux 7 RHEL 7 Server EUS
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-osd-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhceph-osd/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 3 Extended Life Cycle Support for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-mon/1.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/satellite/6.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.0 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2 RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-beta-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/devtools/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Beta RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 for $basearch - High Availability - Extended Life Cycle Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.8 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-deployment-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 10 Director Deployment Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.12-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.12 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.1-debug-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - E4S) from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.8 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rhui/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Update Infrastructure 3 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.1 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Extended Life Cycle Support for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.4-tech-preview-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.4 Tech Preview (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-supplementary-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhscon-2-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscon-installer/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Console Installer for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-web-admin-agent-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-webadmin-agent/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Web Admin Agent (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/jbeap/7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7 (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 2 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.2 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.6-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.6/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.6 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhscl/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Beta RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-for-power-le-ossm-1.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/power-le/7/7Server/$basearch/ossm/1.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 7 IBM Power LE (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhev-mgmt-agent-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhev-mgmt-agent/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Management Agents for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-2.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/2.0.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 2.0.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.3-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.3 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-adv-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-adv/5.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Advanced (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-htb-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/fast-datapath/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath Beta (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.4-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.4 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-2.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/2.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 2.1 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.11-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.11 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.1 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.3 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.3 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.1 /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.5 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-optional-6.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/satellite-optional/6.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.0 - Optional (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-installer/1.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.1-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - E4S) from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-deployment-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 13 Director Deployment Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.4-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.4 (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-deployment-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 11 Director Deployment Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.17-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.17.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.17.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-rhui-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) Beta (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.5 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fdio-early-access-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/fdio-ea/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Early Access (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-cts-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-cts/5.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Certification Test Suite (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmtv-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmtv/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Migration Toolkit for Virtualization for RHEL 7 $basearch (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.24-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.24/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.24 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.6-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.6 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.3-manager-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.3 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-power-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv-power/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 for IBM Power Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-tools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv-tools/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 Tools Beta (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-8.1-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/8.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 8.1 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rt-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rt/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-htb-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server HTB (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/dotnet/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.5 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.3-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/7.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.3 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-nagios-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-nagios/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Nagios ( Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-5-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jws/5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 5 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.9 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/7.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.22-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.22.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.22.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) - Extended Update Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.2-mgmt-agent-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhv-mgmt-agent/4.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4.2 Management Agents for RHEL 7 EUS (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-1.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/1.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.1 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.2 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.16-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.16 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.11-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.11 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-maintenance-6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-maintenance/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Maintenance 6 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-tools/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 4 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - TUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.20-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.20.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.20.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-e4s-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-2.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/2.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 2.1 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-web-admin-agent-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-webadmin-agent/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Web Admin Agent (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.3-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/7.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.3 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-crw-text-only-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/crw-textonly/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Code Ready Workspaces Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-deployment-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 10 Director Deployment Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-mon/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 4 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-mon/1.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-lb-for-rhel-7-server-htb-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/loadbalancer/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Load Balancer (for RHEL 7 Server) HTB (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-eus-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Extended Update Support (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-power-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv-power/4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 for IBM Power Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.0-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/atomic/7/$basearch/cdk/3.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.0 Beta /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.9-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.9/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.9 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmtv-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmtv/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Migration Toolkit for Virtualization for RHEL 7 $basearch (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.3-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.3 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-e4s-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.10 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.5-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.5/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.5 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-cts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-cts/6.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Certification Test Suite (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rt-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rt/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time Beta (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.8 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-deployment-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/12/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 12 Director Deployment Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Extended Life Cycle Support for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-supplementary-debuginfo]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/supplementary/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Supplementary (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.6 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-services-catalog-1-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/automation-services-catalog/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Services Catalog 1 Beta for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-samba-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rh-gluster-samba/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Samba (for RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-mrg-messaging-3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/mrg-m/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 3 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.4 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.11-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.11 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-capsule-6-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-capsule/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6 Beta (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.2-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.2 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-2.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/2.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 2.1 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-rhn-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/rhn-tools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server - AUS (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/12/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-tus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 for $basearch - High Availability - Telecommunications Update Service (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/cert/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certification (for RHEL 7 Server)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-manager-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager-tools/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4 Tools (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-discovery-0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/discovery/0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Discovery 0 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-for-rhel-7-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/cf-me/server/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-satellite-tools-6.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/sat-tools/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server from RHUI) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-devtools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-devtools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Developer Tools Beta for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.8 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhoar-nodejs-8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhoar-nodejs/8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Application Runtimes Node.js v8 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.7 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-big-data-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server-bigdata/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Big Data (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-supplementary-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/supplementary/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Extended Update Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.24-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.24/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.24 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-e4s-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.16-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.16/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.16 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.11-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.11 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rh-common/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-6-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 6 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 2 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-rhn-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/rhn-tools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server - AUS (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-eus-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Extended Update Support (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.1 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.8 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-devtools-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-devtools/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Developer Tools Extended Life Cycle Support for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.10-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.10/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.10 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-clients-2-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Clients 2 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-tools/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 4 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.4-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.4 Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.1-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 (for RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-clients-2-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Clients 2 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/12/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-clients-2.9-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq/2.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Clients 2.9 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-devtools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 Developer Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-2.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/2.0.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 2.0.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.0-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/3scale-amp/2.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.0 Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-mrg-messaging-3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/mrg-m/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 3 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-2.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/2.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 2.0 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.4 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-manager-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager-tools/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4 Tools (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - TUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-maintenance-6-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-maintenance/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Maintenance 6 Beta (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.8 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sjis-for-rhel-7-server-aus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sjis/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for S-JIS (RHEL 7 Server) - AUS (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-for-rhel-7-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/cf-me/server/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.3 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-mrg-messaging-3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/mrg-m/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 3 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-tower-3.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible-tower/3.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Ansible Tower 3.5 Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-tools-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-tools/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Tools Extended Life Cycle Support for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.8-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.8/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.8 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-htb-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server HTB (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - TUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-16-stf-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-stf/16/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 16 Service Telemetry Framework for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support - Optional (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/dotnet/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-samba-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rh-gluster-samba/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Samba (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-samba-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rh-gluster-samba/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Samba (for RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.6-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.6/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.6 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-3-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jws/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 3 (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-nfs-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server-nfs/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 NFS (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-5-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jws/5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 5 (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.6 /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-rhcmsys-9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/certificate-system/9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certificate System 9 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-mon/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.1-tech-preview-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.1 Tech Preview (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-cts-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-cts/6.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Certification Test Suite (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-coreservices-1-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbcs/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Core Services (RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4-build-files]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhvh-build/4/files
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 7 Build (Files)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[interconnect-2-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/interconnect/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Interconnect 2 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-octavia-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-octavia/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Octavia for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.2-tech-preview-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.2 Tech Preview (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/12/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.4 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhbop-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Build of OptaPlanner Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.1-manager-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.1 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.20-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.20.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.20.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-maintenance-6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-maintenance/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Maintenance 6 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4.3-build-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhvh-build/4.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 4.3 Build EUS (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.11-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.11 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.10 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/dotnet/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.6 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.1-for-rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/jdg/7.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.1 Beta (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscl/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-clients-2-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Clients 2 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4-build-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhvh-build/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 7 Build Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.3-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.3 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-client-6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-client/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - Update Services for SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-devtools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/12/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 Developer Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-devtools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-devtools/11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 Developer Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4-build-beta-files]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhvh-build/4/files
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 7 Build Beta (Files)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fdio-early-access-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/fdio-ea/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Early Access (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.1-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.1 (RHEL 7 Server) (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sap-hana/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (for RHEL 7 Server) - Extended Life Cycle Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-services-catalog-1-tech-preview-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/automation-services-catalog-tech-preview/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Services Catalog 1 Tech Preview for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) - Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.19-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.19.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.19.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server - TUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.5-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.5 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-client-6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-client/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-satellite-client-6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sat-client/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - ELS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-client-6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-client/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - TUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - AUS (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.1-eus-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/7Server/$basearch/jbeap/7.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.1 EUS (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-devtools-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-devtools/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Developer Tools Extended Life Cycle Support for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-els-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-1.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/1.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.0 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-thirdparty-oracle-java-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/oracle-java/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Oracle Java (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.6 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-maintenance-6-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-maintenance/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Maintenance 6 Beta (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.0-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/7.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.0 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.6 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-mon/1.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/7.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-osd-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-osd/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.10 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6-client-2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-client-2/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Client 2 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[interconnect-2-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/interconnect/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Interconnect 2 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rhui-e4s-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4.3-build-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhvh-build/4.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 4.3 Build EUS (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Beta Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.5 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/6.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhscon-2-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscon-installer/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Console Installer for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.5 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rhui/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Update Infrastructure 3 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - AUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-director/8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-supplementary-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Supplementary (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhev-mgmt-agent-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhev-mgmt-agent/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Management Agents for RHEL 7 - Extended Life Cycle Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rhui-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) Beta (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-tools/1.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-deployment-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 13 Director Deployment Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-6-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/satellite/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Beta (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.3 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-optools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-optools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Operational Tools Beta for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-extras-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/extras/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.8 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-calamari-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-calamari/1.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rhui/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Update Infrastructure 3 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.3-eus-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/7Server/$basearch/jbeap/7.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.3 EUS (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[openjdk-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
+sslverify = 1
+name = OpenJDK Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Extended Update Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jbeap-7.0-for-rhel-7-server-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/jbeap/7.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.0 (for RHEL 7 Server) (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-tools-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhceph-tools/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 3 Extended Life Cycle Support for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.7 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-mon/1.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-mon-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhceph-mon/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 3 Extended Life Cycle Support for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-rhui-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-deployment-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 13 Director Deployment Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-coreservices-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Core Services Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhev-mgmt-agent-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhev-mgmt-agent/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Management Agents for RHEL 7 - Extended Life Cycle Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-osd-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-osd/3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-1.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/1.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 1.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.3 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-nfs-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server-nfs/3.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 NFS (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-rhui-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-tus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 for $basearch - High Availability - Telecommunications Update Service (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-tower-3.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible-tower/3.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Ansible Tower 3.6 Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.8-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.8 Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rhui-e4s-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Update Services for SAP Solutions (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.2-manager-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.2 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.7-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.7 Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/12/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-hts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/hts/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Hardware Certification Test Suite (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-satellite-tools-6-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/sat-tools/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server from RHUI) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-6.3-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/6.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 6.3 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.7-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.7 RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-supplementary-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/supplementary/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary from RHUI (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - AUS (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-tower-3.8-textonly-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible-tower/3.8/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Ansible Tower 3.8 Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-client-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhs-client/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Native Client for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openjdk-11-els-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/openjdk/11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 7 Server (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.6-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.6 (for RHEL 7 Server - TUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.6 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.15-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.15/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.15 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Extended Life Cycle Support for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmtc-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmtc/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Migration Toolkit for Containers for RHEL 7 $basearch (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-optools/9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4-build-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhvh-build/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 7 Build (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.2 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-ews-2-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbews/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Web Server 2 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-adv-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-adv/5.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Advanced (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.7 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Life Cycle Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/dotnet/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) - Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.5 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.12-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.12/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.12 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/devtools/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools Beta Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-htb-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) HTB (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.13-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.13/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.13 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.9 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-e4s-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jdv-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Virtualization Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-deployment-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/14/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 14 Director Deployment Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-2.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/2.0.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 2.0.0 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhcmsys-9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/certificate-system/9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certificate System 9 Debug RPMs (for RHEL 7 Server)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/12/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.8 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-rh-common-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rh-common/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-2.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/2.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 2.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sat-capsule/6.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.0 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.5-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.5/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-eus-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP HANA (for RHEL 7 Server) Extended Update Support (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-satellite-client-6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sat-client/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server - ELS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.6-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.6/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.6 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhoar-nodejs-10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhoar-nodejs/10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Application Runtimes Node.js v10 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-optools-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-optools/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Operational Extended Life Cycle Support Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sap/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Extended Update Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-6-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jws/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 6 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.2-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/rh-sso/7.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.2 (RHEL 7 Server) (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.1 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhevh-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhevh/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Hypervisor 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions - Optional (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-services-catalog-1-tech-preview-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/automation-services-catalog-tech-preview/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Services Catalog 1 Tech Preview for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rt-htb-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/rt/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time HTB (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-12-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/12/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 12 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.10-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.10/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.10 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-els-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (for RHEL 7 Server) - Extended Life Cycle Support (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack/7.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Extended Life Cycle Support for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-power-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv-power/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4 for IBM Power Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-nfs-for-rhel-7-server-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server-nfs/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 NFS (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-sso-7.3-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-sso/7.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Single Sign-On 7.3 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Enterprise 3.2 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-$basearch-server-7-mrg-messaging-2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mrg-m/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 2 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jbeap/7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack/11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-els-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack-devtools/10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools Extended Life Cycle Support for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-puppet-upgrade-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6-puppet-upgrade/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta - Puppet Upgrade (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.6 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhn-tools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-osd-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-osd/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-rh-common-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/rh-common/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-v2vwin-1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/v2vwin/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virt V2V Tool for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.6 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Enterprise 3.1 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-splunk-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server-splunk/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Splunk (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jpp-textonly-1-for-middleware-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Portal Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file://
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.4 /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-tower-3.7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible-tower/3.7/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Ansible Tower 3.7 Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-mon/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-director/8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jws-3-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/jws/3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Web Server 3 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-els-satellite-6-client-2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sat-client-2/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Client 2 (for RHEL 7 Server - ELS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-els-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack-director/7.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Extended Life Cycle Support director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-optools/14/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.6-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.6 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhosj-1.13-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhosj/1.13.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Jaeger 1.13.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.2-tech-preview-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.2 Tech Preview (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6-client-2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-client-2/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Client 2 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.7-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.7 Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.9 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server - TUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ossm-2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ossm/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Service Mesh 2 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4.2-build-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhvh-build/4.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 4.2 Build EUS (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - TUS - Optional (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - AUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-3-mon-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhceph-mon/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 3 Extended Life Cycle Support for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-tower-3.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible-tower/3.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Ansible Tower 3.3 Text-Only Advisories
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.10 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/devtools/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-client-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhs-client/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Native Client for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-big-data-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server-bigdata/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Big Data (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.2 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.7/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - TUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/5.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.9 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-e4s-rhui-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-satellite-tools-6.8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/sat-tools/6.8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.8 (for RHEL 7 Server - TUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.9 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Server (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-devtools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/devtools/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-2.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/2.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 2.1 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmtc-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmtc/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Migration Toolkit for Containers for RHEL 7 $basearch (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[amq-clients-2.9-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/amq/2.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat AMQ Clients 2.9 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sap/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhui-rhscl-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhscl/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Debug RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-octavia-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-octavia/13/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Octavia Extended Life Cycle Support for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-els-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/8.10/$basearch/openstack-director/7.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Extended Life Cycle Supportdirector for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-2.3-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 2.3 /(Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.1-manager-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.1 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-splunk-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-server-splunk/3.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Splunk (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-mon/1.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ose/3.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Enterprise 3.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.11-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.11 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-deployment-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/14/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 14 Director Deployment Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-rh-common-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rh-common/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common from RHUI (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-2.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 2.3 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.5-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.5/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.5 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.4 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-supplementary-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhmap-4.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhmap/4.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Mobile Application Platform v4.4 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhv/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4 Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.8-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.8/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.8 Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - Update Services SAP Solutions) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.10/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.10 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-client-6-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-client/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Client 6 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhamp-1.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhamp/1.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 1.0 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-eap-7.4-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jbeap/7.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = JBoss Enterprise Application Platform 7.4 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-deployment-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/14/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 14 Director Deployment Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Enterprise 3.2 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-3.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/3.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 3.5 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-big-data-for-rhel-7-server-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/8.10/$basearch/rhgs-server-bigdata/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Big Data (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-tus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/tus/rhel/server/7/8.10/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - TUS (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-lb-for-rhel-7-server-htb-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/loadbalancer/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Load Balancer (for RHEL 7 Server) HTB (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.2-manager-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.2 (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-for-rhel-7-server-eus-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/sap/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHEL for SAP (for RHEL 7 Server) Extended Update Support (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.3-puppet4-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.3-puppet4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - EUS) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.7/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.7 (for RHEL 7 Server - EUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-tools-6.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-tools/6.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.5 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-capsule-6-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-capsule/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6 Beta (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.4 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/10/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-2.4-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 2.4 /(Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.9 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-utils-6.11-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-utils/6.11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Utils 6.11 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-eus-satellite-tools-6.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/sat-tools/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server - EUS) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/7.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-14-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/14/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 14 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.2-manager-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv-manager/4.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager v4.2 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-eus-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability from RHUI (for RHEL 7 Server) - Extended Update Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhacm-1.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhacm/1.0/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Advanced Cluster Management for Kubernetes 1.0 Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-services-catalog-1-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/automation-services-catalog/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Services Catalog 1 Beta for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-tools/7.0/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Tools 7.0 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.2-mgmt-agent-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhv-mgmt-agent/4.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization 4.2 Management Agents for RHEL 7 EUS (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-6.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/satellite/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6.1 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-1.3-tech-preview-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/1.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 1.3 Tech Preview (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/resilientstorage/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/resilientstorage/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-htb-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage (for RHEL 7 Server) HTB (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhv-4.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhv/4.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Manager 4.1 (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.11-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.11/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.11 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-13-optools-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/openstack-optools/13/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 13 Operational Extended Life Cycle Support Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-osd-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-osd/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-3scale-amp-2.3-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/3scale-amp/2.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat 3scale API Management Platform 2.3 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack/8/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-4-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhceph-mon/4/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 4 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4.3-build-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rhvh-build/4.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 4.3 Build EUS (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-rs-for-rhel-7-server-els-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/rhui/server/7/7Server/$basearch/resilientstorage/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Resilient Storage for $basearch (for RHEL 7 Server) - Extended Life Cycle Support (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-6-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/satellite/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Beta (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhevh-els-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhevh/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Hypervisor 7 - Extended Life Cycle Support (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-puppet4-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.3-puppet4/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 Server - Update Services SAP Solutions) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhscon-2-main-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhscon-main/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Storage Console Main for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-automation-hub-4-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/automation-hub/4/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Automation Hub 4 Beta for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-2.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/2.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 2.2 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.3-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/sat-tools/6.3/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.3 (for RHEL 7 Server - Update Services SAP Solutions) from RHUI (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-rhui-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/sap-hana/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (RHEL 7 Server) Beta (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-deployment-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-deployment-tools/10/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 10 Director Deployment Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/rhui/server/7/$basearch/dotnet/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhevh-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhevh/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Hypervisor 7 - Extended Life Cycle Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-7-satellite-6-puppet-upgrade-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/satellite/6-puppet-upgrade/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Beta - Puppet Upgrade (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-cts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-cts/6.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Certification Test Suite (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-sap-hana-for-rhel-7-server-els-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/sap-hana/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for SAP HANA (for RHEL 7 Server) - Extended Life Cycle Support (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cnv-4.12-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/cnv/4.12/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Native Virtualization 4.12 (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-installer/1.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Update Services for SAP Solutions (Source RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7.6/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[jb-datagrid-7.3-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/jdg/7.3/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat JBoss Data Grid 7.3 (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-e4s-satellite-tools-6.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/server/7/8.10/$basearch/sat-tools/6.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.9 (for RHEL 7 Server - Update Services SAP Solutions) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ansible/2.9/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.9 Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ose-4.11-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/ose/4.11/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenShift Container Platform 4.11 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-capsule-6.5-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-capsule/6.5/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Capsule 6.5 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-7-cdk-3.15-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Container Development Kit 3.15 /(RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhui-eus-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/rhui/server/7/8.10/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extended Update Support - Optional (Debug RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-11-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/openstack-tools/11/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 11 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-aus-satellite-6-client-2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/aus/rhel/server/7/8.10/$basearch/sat-client-2/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite 6 Client 2 (for RHEL 7 Server - AUS) (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhev-mgmt-agent-els-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/els/rhel/server/7/7Server/$basearch/rhev-mgmt-agent/3/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Virtualization Management Agents for RHEL 7 - Extended Life Cycle Support (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-ansible-2.9-rhui-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/$basearch/ansible/2.9/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ansible Engine 2.9 Source RPMs for Red Hat Enterprise Linux 7 Server from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhvh-4.2-build-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/8.10/$basearch/rhvh-build/4.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Virtualization Host 4.2 Build EUS (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-osd-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/ceph-osd/1.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Ceph Storage OSD 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhn-tools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-nagios-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/rhgs-nagios/3.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Gluster Storage 3 Nagios (Source RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-e4s-rhui-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/e4s/rhel/rhui/server/7/8.10/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Update Services for SAP Solutions (RPMs) from RHUI
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement/8197658759172031251.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/8.10/$basearch/openstack-inst/6.0/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Platform Installer (RPMs)
+sslclientkey = /etc/pki/entitlement/8197658759172031251-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1

--- a/.konflux/virt-v2v/win2008iso/rpms.in.yaml
+++ b/.konflux/virt-v2v/win2008iso/rpms.in.yaml
@@ -1,0 +1,10 @@
+packages:
+  - virtio-win-1.9.4-2.el7.2
+contentOrigin:
+  repofiles:
+    - ./redhat.repo
+context:
+  containerfile:
+    file: ../../../build/virt-v2v/Containerfile-downstream
+    stageName: win2008iso
+arches: [x86_64]

--- a/.konflux/virt-v2v/win2008iso/rpms.lock.yaml
+++ b/.konflux/virt-v2v/win2008iso/rpms.lock.yaml
@@ -1,0 +1,21 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: https://cdn.redhat.com/content/dist/rhel/server/7/7.6/x86_64/supplementary/os/Packages/v/virtio-win-1.9.4-2.el7.2.noarch.rpm
+    repoid: rhel-7-server-supplementary-rpms
+    size: 56787344
+    checksum: sha1:1427a49a69d9e047edc751dcb03d55b889ec24d8
+    name: virtio-win
+    evr: 1.9.4-2.el7.2
+    sourcerpm: virtio-win-1.9.4-2.el7.2.src.rpm
+  source:
+  - url: https://cdn.redhat.com/content/dist/rhel/server/7/7.6/x86_64/supplementary/source/SRPMS/Packages/v/virtio-win-1.9.4-2.el7.2.src.rpm
+    repoid: rhel-7-server-supplementary-source-rpms
+    size: 124992704
+    checksum: sha256:6c70a0502a6d15b14058d28e6e329916d39d41801b8a430ac17a9f96b398cc43
+    name: virtio-win
+    evr: 1.9.4-2.el7.2
+  module_metadata: []

--- a/.tekton/virt-v2v-dev-preview-pull-request.yaml
+++ b/.tekton/virt-v2v-dev-preview-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
   - name: build-source-image
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "rpm", "path": ".konflux/virt-v2v"}]'
+    value: '[{"type": "rpm", "path": ".konflux/virt-v2v/appliance"}, {"type": "rpm", "path": ".konflux/virt-v2v/runtime"}, {"type": "rpm", "path": ".konflux/virt-v2v/win2008iso"}]'
   - name: build-args-file
     value: build/release.conf
   - name: build-args

--- a/.tekton/virt-v2v-dev-preview-push.yaml
+++ b/.tekton/virt-v2v-dev-preview-push.yaml
@@ -36,7 +36,7 @@ spec:
   - name: build-source-image
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "rpm", "path": ".konflux/virt-v2v"}]'
+    value: '[{"type": "rpm", "path": ".konflux/virt-v2v/appliance"}, {"type": "rpm", "path": ".konflux/virt-v2v/runtime"}, {"type": "rpm", "path": ".konflux/virt-v2v/win2008iso"}]'
   - name: build-args-file
     value: build/release.conf
   - name: build-args

--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -1,3 +1,8 @@
+FROM registry.redhat.io/ubi9:9.6-1747219013 AS win2008iso
+
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+RUN yum install -y --setopt=install_weak_deps=False virtio-win-1.9.4-2.el7.2
+
 FROM registry.redhat.io/ubi9:9.6-1747219013 AS appliance
 
 ENV LIBGUESTFS_BACKEND=direct
@@ -26,7 +31,7 @@ RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-monitor github
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o image-converter github.com/kubev2v/forklift/cmd/image-converter
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-wrapper github.com/kubev2v/forklift/cmd/virt-v2v
 
-FROM registry.redhat.io/ubi9:9.6-1747219013
+FROM registry.redhat.io/ubi9:9.6-1747219013 AS runtime
 RUN mkdir /disks && \
     source /etc/os-release && \
     dnf update -y && \
@@ -45,6 +50,8 @@ COPY --from=builder /app/virt-v2v-monitor /usr/local/bin/virt-v2v-monitor
 COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
+
+COPY --from=win2008iso /usr/share/virtio-win/virtio-win.iso /usr/share/virtio-win/virtio-win-2008.iso
 
 ENTRYPOINT ["/usr/bin/virt-v2v-wrapper"]
 


### PR DESCRIPTION
Issue: Windows 2008 is EOL so we need to use older drivers for support.

Fix: Include older drivers from rhel-7 in the virt-v2v image to be used later.

Ref: https://issues.redhat.com/browse/MTV-1700