### PR TITLE
MTV-2075 | Dont override vm original name

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -71,8 +71,6 @@ const (
 	AnnKubevirtValidations = "vm.kubevirt.io/validations"
 	// PVC annotation containing the name of the importer pod.
 	AnnImporterPodName = "cdi.kubevirt.io/storage.import.importPodName"
-	//  Original VM name on source (value=vmOriginalName)
-	AnnOriginalName = "original-name"
 	// Openshift display name annotation (value=vmName)
 	AnnDisplayName = "openshift.io/display-name"
 	//  Original VM name on source (value=vmOriginalID)
@@ -1465,7 +1463,6 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus, sortVolumesByLibvirt bool) 
 	//Add the original name and ID info to the VM annotations
 	if len(vm.NewName) > 0 {
 		annotations := make(map[string]string)
-		annotations[AnnOriginalName] = vm.Name
 		annotations[AnnDisplayName] = vm.Name
 		annotations[AnnOriginalID] = vm.ID
 		object.ObjectMeta.Annotations = annotations


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-2075 - use correct vm name in migration status
https://issues.redhat.com/browse/MTV-2076 - add display name

Issue:
When changing the vm name to comply with DNS1123 we unintentionally remove the original name from the migration.

Fix:
Don't change the original name in the migration CR

Screenshots:
Before and After:
![migration-vm-name](https://github.com/user-attachments/assets/64f6bf38-e3c6-4eed-80fc-386d2e18d095)

Before:
![migration-vm-name-before](https://github.com/user-attachments/assets/0bdd9744-b0aa-4038-ab49-e6329ff48528)

After:
![migration-vm-name-after](https://github.com/user-attachments/assets/8bc8e643-3688-4ac2-94b5-3cfcddb42262)

VM annotations:
![vm-name-after](https://github.com/user-attachments/assets/0f896192-d7a5-402c-b796-9b8b12820c91)


