### PR TITLE
MTV-2314 | Warn about potentially unsupported OVAs.

### DIFF
--- a/cmd/ova-provider-server/ova-provider-server.go
+++ b/cmd/ova-provider-server/ova-provider-server.go
@@ -124,6 +124,7 @@ type Envelope struct {
 type VM struct {
 	Name                  string
 	OvaPath               string
+	OvaSource             string
 	OsType                string
 	RevisionValidated     int64
 	PolicyVersion         int

--- a/cmd/ova-provider-server/ova-provider-server.go
+++ b/cmd/ova-provider-server/ova-provider-server.go
@@ -435,8 +435,8 @@ const (
 	Unknown    = "Unknown"
 	VMware     = "VMware"
 	VirtualBox = "VirtualBox"
-	RHV        = "RHV"
 	Xen        = "Xen"
+	Ovirt      = "oVirt"
 )
 
 // Check the OVF XML for any markers that might cause import problems later on.
@@ -447,6 +447,7 @@ func guessOvaSource(envelope Envelope) string {
 		"http://schemas.citrix.com/ovf/envelope/1": Xen,
 		"http://www.citrix.com/xenclient/ovf/1":    Xen,
 		"http://www.virtualbox.org/ovf/machine":    VirtualBox,
+		"http://www.ovirt.org/ovf":                 Ovirt,
 	}
 
 	foundVMware := false

--- a/pkg/controller/plan/adapter/ova/builder.go
+++ b/pkg/controller/plan/adapter/ova/builder.go
@@ -494,6 +494,9 @@ func getDiskSourcePath(filePath string) string {
 }
 
 func getResourceCapacity(capacity int64, units string) (int64, error) {
+	if strings.ToLower(units) == "megabytes" {
+		return capacity * (1 << 20), nil
+	}
 	items := strings.Split(units, "*")
 	for i := range items {
 		item := strings.TrimSpace(items[i])

--- a/pkg/controller/provider/container/ova/model.go
+++ b/pkg/controller/provider/container/ova/model.go
@@ -210,6 +210,9 @@ func (r *VMAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 			} else if vm.OvaPath != m.OvaPath {
 				vm.ApplyTo(m)
 				err = tx.Update(m)
+			} else if vm.OvaSource != m.OvaSource {
+				vm.ApplyTo(m)
+				err = tx.Update(m)
 			}
 			return
 		}

--- a/pkg/controller/provider/container/ova/resource.go
+++ b/pkg/controller/provider/container/ova/resource.go
@@ -14,6 +14,7 @@ type Base struct {
 type VM struct {
 	Name                  string   `json:"Name"`
 	OvaPath               string   `json:"OvaPath"`
+	OvaSource             string   `json:"OvaSource"`
 	RevisionValidated     int64    `json:"RevisionValidated"`
 	PolicyVersion         int      `json:"PolicyVersion"`
 	UUID                  string   `json:"UUID"`
@@ -68,6 +69,7 @@ func (r *VM) ApplyTo(m *model.VM) {
 	m.Name = r.Name
 	m.ID = r.UUID
 	m.OvaPath = r.OvaPath
+	m.OvaSource = r.OvaSource
 	m.RevisionValidated = r.RevisionValidated
 	m.PolicyVersion = r.PolicyVersion
 	m.UUID = r.UUID

--- a/pkg/controller/provider/model/ova/model.go
+++ b/pkg/controller/provider/model/ova/model.go
@@ -69,6 +69,7 @@ type Network struct {
 type VM struct {
 	Base
 	OvaPath               string    `sql:""`
+	OvaSource             string    `sql:""`
 	RevisionValidated     int64     `sql:"d0,index(revisionValidated)"`
 	PolicyVersion         int       `sql:"d0,index(policyVersion)"`
 	UUID                  string    `sql:""`

--- a/pkg/controller/provider/web/ova/vm.go
+++ b/pkg/controller/provider/web/ova/vm.go
@@ -204,6 +204,7 @@ func (r *VM1) Content(detail int) interface{} {
 type VM struct {
 	VM1
 	OvaPath               string          `json:"ovaPath"`
+	OvaSource             string          `json:"ovaSource"`
 	RevisionValidated     int64           `json:"revisionValidated"`
 	PolicyVersion         int             `json:"policyVersion"`
 	UUID                  string          `json:"uuid"`
@@ -253,6 +254,7 @@ func (r *VM) With(m *model.VM) {
 	r.NumaNodeAffinity = m.NumaNodeAffinity
 	r.NICs = m.NICs
 	r.OvaPath = m.OvaPath
+	r.OvaSource = m.OvaSource
 	r.Disks = m.Disks
 	r.Networks = m.Networks
 }

--- a/validation/policies/io/konveyor/forklift/ova/export_source.rego
+++ b/validation/policies/io/konveyor/forklift/ova/export_source.rego
@@ -1,0 +1,14 @@
+package io.konveyor.forklift.ova
+
+unsupported_export_source {
+    input.ovaSource != "VMware"
+}
+
+concerns[flag] {
+    unsupported_export_source
+    flag := {
+        "category": "Warning",
+        "label": "Unsupported OVA source",
+        "assessment": "This OVA may not have been exported from a VMware source, and may have issues during import."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/ova/export_source_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/export_source_test.rego
@@ -1,0 +1,13 @@
+package io.konveyor.forklift.ova
+
+test_with_unsupported_source {
+    mock_vm := { "name": "test", "ovaSource": "Unknown" }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_with_supported_source {
+    mock_vm := { "name": "test", "ovaSource": "VMware" }
+    results = concerns with input as mock_vm
+    count(results) == 0
+}


### PR DESCRIPTION
Issue:
Errors in OVA import due to differences in expected OVF formatting, in this case "MegaBytes" as a unit instead of "bytes * 2^20".

Fix:
Address this one unit instance by allowing "MegaBytes" as a resource unit, and add a warning for OVFs that look like they might have been exported from anything other than VMware. 

Ref: https://issues.redhat.com/browse/MTV-2314