### PR TITLE
MTV-2025 | MTV-1673 | NICs mapping is unordered

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -702,89 +702,75 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 
 	numNetworks := 0
 	netMapIn := r.Context.Map.Network.Spec.Map
-	for i := range netMapIn {
-		mapped := &netMapIn[i]
 
-		// Skip network mappings with destination type 'Ignored'
-		if mapped.Destination.Type == Ignored {
+	for _, nic := range vm.NICs {
+		mapped := r.findNetworkMapping(nic, netMapIn)
+
+		// Skip if no valid mapping found or the destination type is Ignored
+		if mapped == nil || mapped.Destination.Type == Ignored {
 			continue
 		}
 
-		ref := mapped.Source
-		network := &model.Network{}
-		fErr := r.Source.Inventory.Find(network, ref)
-		if fErr != nil {
-			err = fErr
-			return
-		}
+		networkName := fmt.Sprintf("net-%v", numNetworks)
 
-		needed := []vsphere.NIC{}
-		for _, nic := range vm.NICs {
-			switch network.Variant {
-			case vsphere.NetDvPortGroup, vsphere.OpaqueNetwork:
-				if nic.Network.ID == network.Key {
-					needed = append(needed, nic)
-				}
-			default:
-				if nic.Network.ID == network.ID {
-					needed = append(needed, nic)
-				}
+		// If a name template is defined, try to use it
+		networkNameTemplate := r.getNetworkNameTemplate(vm)
+		if networkNameTemplate != "" {
+			templateData := api.NetworkNameTemplateData{
+				NetworkName:      mapped.Destination.Name,
+				NetworkNamespace: mapped.Destination.Namespace,
+				NetworkType:      mapped.Destination.Type,
+				NetworkIndex:     numNetworks,
+			}
+			if generated, err := r.executeTemplate(networkNameTemplate, &templateData); err == nil && generated != "" {
+				networkName = generated
+			} else {
+				r.Log.Info("Failed to generate network name using template, using default", "template", networkNameTemplate, "error", err)
 			}
 		}
-		if len(needed) == 0 {
-			continue
+
+		numNetworks++
+		kNetwork := cnv.Network{Name: networkName}
+		kInterface := cnv.Interface{
+			Name:       networkName,
+			Model:      Virtio,
+			MacAddress: nic.MAC,
 		}
-		for _, nic := range needed {
-			networkName := fmt.Sprintf("net-%v", numNetworks)
 
-			// If the network name template is set, use it to generate the network name.
-			networkNameTemplate := r.getNetworkNameTemplate(vm)
-			if networkNameTemplate != "" {
-				// Create template data
-				templateData := api.NetworkNameTemplateData{
-					NetworkName:      mapped.Destination.Name,
-					NetworkNamespace: mapped.Destination.Namespace,
-					NetworkType:      mapped.Destination.Type,
-					NetworkIndex:     numNetworks,
-				}
-
-				networkName, err = r.executeTemplate(networkNameTemplate, &templateData)
-				if err != nil {
-					// Failed to generate network name using template
-					r.Log.Info("Failed to generate network name using template, using default name", "template", networkNameTemplate, "error", err)
-
-					// Fallback to default name and reset error
-					networkName = fmt.Sprintf("net-%v", numNetworks)
-					err = nil
-				}
+		switch mapped.Destination.Type {
+		case Pod:
+			kNetwork.Pod = &cnv.PodNetwork{}
+			kInterface.Masquerade = &cnv.InterfaceMasquerade{}
+		case Multus:
+			kNetwork.Multus = &cnv.MultusNetwork{
+				NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
 			}
-
-			numNetworks++
-			kNetwork := cnv.Network{
-				Name: networkName,
-			}
-			kInterface := cnv.Interface{
-				Name:       networkName,
-				Model:      Virtio,
-				MacAddress: nic.MAC,
-			}
-			switch mapped.Destination.Type {
-			case Pod:
-				kNetwork.Pod = &cnv.PodNetwork{}
-				kInterface.Masquerade = &cnv.InterfaceMasquerade{}
-			case Multus:
-				kNetwork.Multus = &cnv.MultusNetwork{
-					NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
-				}
-				kInterface.Bridge = &cnv.InterfaceBridge{}
-			}
-			kNetworks = append(kNetworks, kNetwork)
-			kInterfaces = append(kInterfaces, kInterface)
+			kInterface.Bridge = &cnv.InterfaceBridge{}
 		}
+
+		kNetworks = append(kNetworks, kNetwork)
+		kInterfaces = append(kInterfaces, kInterface)
 	}
+
 	object.Template.Spec.Networks = kNetworks
 	object.Template.Spec.Domain.Devices.Interfaces = kInterfaces
 	return
+}
+
+func (r *Builder) findNetworkMapping(nic vsphere.NIC, netMap []api.NetworkPair) *api.NetworkPair {
+	for i := range netMap {
+		candidate := &netMap[i]
+		network := &model.Network{}
+		if err := r.Source.Inventory.Find(network, candidate.Source); err != nil {
+			continue
+		}
+
+		if (network.Variant == vsphere.NetDvPortGroup || network.Variant == vsphere.OpaqueNetwork) &&
+			nic.Network.ID == network.Key || nic.Network.ID == network.ID {
+			return candidate
+		}
+	}
+	return nil
 }
 
 func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -2,6 +2,7 @@ package vsphere
 
 import (
 	"fmt"
+
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	planbase "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
@@ -296,7 +297,8 @@ func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, m
 	return true, "", "", nil
 }
 
-// Validate that we have information about static IPs for every virtual NIC
+// Validate that we have information about static IPs for every guest network.
+// Virtual nics are not required to have a static IP.
 func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 	if !r.plan.Spec.PreserveStaticIPs {
 		return true, nil
@@ -308,9 +310,9 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 		return
 	}
 
-	for _, nic := range vm.NICs {
+	for _, guestNetwork := range vm.GuestNetworks {
 		found := false
-		for _, guestNetwork := range vm.GuestNetworks {
+		for _, nic := range vm.NICs {
 			if nic.MAC == guestNetwork.MAC {
 				found = true
 				break

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -100,12 +100,12 @@ var _ = Describe("vsphere validation tests", func() {
 			},
 
 			// Directly declare entries here
-			Entry("when the vm doesn't have static ips, and the plan set with static ip", "test", true, true),
+			Entry("when the vm doesn't have static ips, and the plan set with static ip", "test", true, false),
 			Entry("when the vm doesn't have static ips, and the plan set without static ip", "test", false, false),
 			Entry("when the vm have static ips, and the plan set with static ip", "full_guest_network", true, false),
 			Entry("when the vm have static ips, and the plan set without static ip", "test", false, false),
 			Entry("when the vm doesn't have static ips, and the plan set without static ip, vm is non-windows", "not_windows_guest", false, false),
-			Entry("when the vm doesn't have static ips, and the plan set with static ip, vm is non-windows", "not_windows_guest", true, true),
+			Entry("when the vm doesn't have static ips, and the plan set with static ip, vm is non-windows", "not_windows_guest", true, false),
 			Entry("when the vm doesn't exist", "missing_from_invetory", true, true),
 		)
 	})

--- a/pkg/controller/provider/container/vsphere/sort_nics_by_guest_network_test.go
+++ b/pkg/controller/provider/container/vsphere/sort_nics_by_guest_network_test.go
@@ -1,0 +1,72 @@
+package vsphere
+
+import (
+	modelVsphere "github.com/konveyor/forklift-controller/pkg/controller/provider/model/vsphere"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SortNICsByGuestNetworkOrder", func() {
+	var vm *modelVsphere.VM
+
+	BeforeEach(func() {
+		vm = &modelVsphere.VM{
+			NICs:          []modelVsphere.NIC{},
+			GuestNetworks: []modelVsphere.GuestNetwork{},
+		}
+	})
+
+	Context("NICs match GuestNetworks order", func() {
+		BeforeEach(func() {
+			vm.NICs = []modelVsphere.NIC{
+				{MAC: "00:11:22:33:44:55", Index: 0},
+				{MAC: "66:77:88:99:AA:BB", Index: 1},
+				{MAC: "CC:DD:EE:FF:00:11", Index: 2},
+			}
+			vm.GuestNetworks = []modelVsphere.GuestNetwork{
+				{MAC: "66:77:88:99:AA:BB", Device: "0"},
+				{MAC: "00:11:22:33:44:55", Device: "1"},
+				{MAC: "CC:DD:EE:FF:00:11", Device: "2"},
+			}
+		})
+
+		It("should reorder NICs to match GuestNetworks", func() {
+			SortNICsByGuestNetworkOrder(vm)
+			Expect(vm.NICs[0].MAC).To(Equal("66:77:88:99:AA:BB"))
+			Expect(vm.NICs[1].MAC).To(Equal("00:11:22:33:44:55"))
+			Expect(vm.NICs[2].MAC).To(Equal("CC:DD:EE:FF:00:11"))
+		})
+	})
+
+	Context("Some NICs do not match GuestNetworks", func() {
+		BeforeEach(func() {
+			vm.NICs = []modelVsphere.NIC{
+				{MAC: "00:11:22:33:44:55", Index: 0},
+				{MAC: "66:77:88:99:AA:BB", Index: 1},
+				{MAC: "CC:DD:EE:FF:00:11", Index: 2},
+			}
+			vm.GuestNetworks = []modelVsphere.GuestNetwork{
+				{MAC: "66:77:88:99:AA:BB", Device: "0"},
+				{MAC: "00:11:22:33:44:55", Device: "1"},
+				// Missing "CC:DD:EE:FF:00:11"
+			}
+		})
+
+		It("should reorder matching NICs and leave unmatched NICs at the end", func() {
+			SortNICsByGuestNetworkOrder(vm)
+			Expect(vm.NICs[0].MAC).To(Equal("66:77:88:99:AA:BB"))
+			Expect(vm.NICs[1].MAC).To(Equal("00:11:22:33:44:55"))
+			Expect(vm.NICs[2].MAC).To(Equal("CC:DD:EE:FF:00:11")) // Unmatched NIC remains
+		})
+	})
+
+	Context("Empty NICs and GuestNetworks", func() {
+		It("should not panic or modify anything", func() {
+			Expect(func() {
+				SortNICsByGuestNetworkOrder(vm)
+			}).ToNot(Panic())
+			Expect(vm.NICs).To(BeEmpty())
+			Expect(vm.GuestNetworks).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -325,6 +325,7 @@ type Device struct {
 type NIC struct {
 	Network Ref    `json:"network"`
 	MAC     string `json:"mac"`
+	Index   int    `json:"order"`
 }
 
 // Guest network.


### PR DESCRIPTION
MTV-2025 | MTV-1673 | NICs mapping is unordered
MTV-2489 | Update warning message for VM static ip setting Issue:
1. When migrating VMs with multiple NICs the mapping order must match source VM order
2. Display warning when one or more interfaces lack static IP configuration

Fix:
1. Iterate over vm.NICs directly, preserving the original order of network interfaces from the source VM during migration. Previously, networks were generated based on the order of network mappings (netMapIn), which could result in a different NIC order in the target VM.
2. Get warning message when no interface in VM with static ip

Ref: https://issues.redhat.com/browse/MTV-2025
https://issues.redhat.com/browse/MTV-1673
https://issues.redhat.com/browse/MTV-2489