### PR TITLE
MTV-2364 | Inconsistent hostname

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -273,6 +273,13 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		})
 	}
 
+	if vm.HostName != "" {
+		env = append(env, core.EnvVar{
+			Name:  "V2V_HOSTNAME",
+			Value: vm.HostName,
+		})
+	}
+
 	libvirtURL, fingerprint, err := r.getSourceDetails(vm, sourceSecret)
 	if err != nil {
 		return

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -133,6 +133,7 @@ const (
 	fIsTemplate          = "config.template"
 	fGuestNet            = "guest.net"
 	fGuestIpStack        = "guest.ipStack"
+	fHostName            = "guest.hostName"
 )
 
 // Selections
@@ -817,6 +818,7 @@ func (r *Collector) vmPathSet() []string {
 		fSnapshot,
 		fChangeTracking,
 		fGuestIpStack,
+		fHostName,
 	}
 
 	apiVer := strings.Split(r.client.ServiceContent.About.ApiVersion, ".")

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -638,6 +638,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if s, cast := p.Val.(string); cast {
 					v.model.GuestName = s
 				}
+			case fHostName:
+				if s, cast := p.Val.(string); cast {
+					v.model.HostName = s
+				}
 			case fTpmPresent:
 				if b, cast := p.Val.(bool); cast {
 					v.model.TpmEnabled = b

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -266,6 +266,7 @@ type VM struct {
 	CoresPerSocket        int32          `sql:""`
 	MemoryMB              int32          `sql:""`
 	GuestName             string         `sql:""`
+	HostName              string         `sql:""`
 	GuestID               string         `sql:""`
 	BalloonedMemory       int32          `sql:""`
 	IpAddress             string         `sql:""`

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -235,6 +235,7 @@ type VM struct {
 	CoresPerSocket        int32                `json:"coresPerSocket"`
 	MemoryMB              int32                `json:"memoryMB"`
 	GuestName             string               `json:"guestName"`
+	HostName              string               `json:"hostName"`
 	GuestID               string               `json:"guestId"`
 	BalloonedMemory       int32                `json:"balloonedMemory"`
 	IpAddress             string               `json:"ipAddress"`
@@ -267,6 +268,7 @@ func (r *VM) With(m *model.VM) {
 	r.CoresPerSocket = m.CoresPerSocket
 	r.MemoryMB = m.MemoryMB
 	r.GuestName = m.GuestName
+	r.HostName = m.HostName
 	r.GuestID = m.GuestID
 	r.BalloonedMemory = m.BalloonedMemory
 	r.IpAddress = m.IpAddress

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -25,6 +25,7 @@ const (
 	EnvSecretKeyName              = "V2V_secretKey"
 	EnvLocalMigrationName         = "LOCAL_MIGRATION"
 	EnvVirtIoWinLegacyDriversName = "VIRTIO_WIN"
+	EnvHostName                   = "V2V_HOSTNAME"
 )
 
 const (
@@ -79,6 +80,8 @@ type AppConfig struct {
 	SecretKey string
 	// V2V_virtIoWinDrivers
 	VirtIoWinLegacyDrivers string
+	// hostname
+	HostName string
 
 	// Paths
 	VddkConfFile         string
@@ -111,6 +114,7 @@ func (s *AppConfig) Load() (err error) {
 	flag.StringVar(&s.InspectionOutputFile, "inspection-output-file", InspectionOutputFile, "Path where the virt-v2v-inspector will output the metadata")
 	flag.StringVar(&s.LibvirtDomainFile, "libvirt-domain-file", V2vInPlaceLibvirtDomain, "Path to the libvirt domain used in the in-place conversion")
 	flag.StringVar(&s.VirtIoWinLegacyDrivers, "virtio-win-legacy-drivers", os.Getenv(EnvVirtIoWinLegacyDriversName), "Path to the virtio-win legacy drivers ISO")
+	flag.StringVar(&s.HostName, "hostname", os.Getenv(EnvHostName), "Hostname of the vm")
 	flag.Parse()
 
 	return s.validate()

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -149,7 +149,9 @@ func (c *Conversion) addVirtV2vArgs(cmd utils.CommandBuilder) (err error) {
 func (c *Conversion) addVirtV2vVsphereArgs(cmd utils.CommandBuilder) (err error) {
 	cmd.AddArg("-i", "libvirt").
 		AddArg("-ic", c.LibvirtUrl).
-		AddArg("-ip", c.SecretKey)
+		AddArg("-ip", c.SecretKey).
+		AddArg("--hostname", c.HostName)
+
 	err = c.addCommonArgs(cmd)
 	if err != nil {
 		return err

--- a/validation/policies/io/konveyor/forklift/vmware/hostname.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/hostname.rego
@@ -1,0 +1,31 @@
+package io.konveyor.forklift.vmware
+
+import future.keywords.in
+
+is_empty_hostname {
+    input.hostName == ""
+}
+
+
+is_localhost_hostname {
+    input.hostName == "localhost.localdomain"
+}
+
+concerns[flag] {
+    is_empty_hostname
+    flag := {
+        "category": "Warning",
+        "label": "Empty Host Name",
+        "assessment": "The 'hostname' field is missing or empty. The hostname might be renamed during migration."
+    }
+}
+
+
+concerns[flag] {
+    is_localhost_hostname
+    flag := {
+        "category": "Warning",
+        "label": "Default Host Name",
+        "assessment": "The 'hostname' is set to 'localhost.localdomain', which is a default value. The hostname might be renamed during migration."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/vmware/hostname_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/hostname_test.rego
@@ -1,0 +1,19 @@
+package io.konveyor.forklift.vmware
+
+import data.io.konveyor.forklift.vmware.concerns
+
+# Test for empty hostname
+test_empty_hostName {
+     mock_vm := {
+        "name": "test",
+        "hostName": ""
+    }
+    results =  concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_localhost_hostname {
+    mock_vm := { "hostName": "localhost.localdomain" }
+    results = concerns with input as mock_vm
+    count(results) == 1
+}


### PR DESCRIPTION
Issue:
Inconsistency in the hostname between the source and destination VMs Due to lack of host name in the incventory.

Fix:
 Fetching the hostname for each VM and apply that to the destination VM.

 Ref: https://issues.redhat.com/browse/MTV-2364