### PR TITLE
MTV-2271 | Enable prefetch for vsphere xcopy d/s

### DIFF
--- a/.tekton/vsphere-xcopy-volume-populator-dev-preview-pull-request.yaml
+++ b/.tekton/vsphere-xcopy-volume-populator-dev-preview-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: .
   - name: build-source-image
     value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "cmd/vsphere-xcopy-volume-populator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/vsphere-xcopy-volume-populator-dev-preview-push.yaml
+++ b/.tekton/vsphere-xcopy-volume-populator-dev-preview-push.yaml
@@ -33,6 +33,8 @@ spec:
     value: .
   - name: build-source-image
     value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "cmd/vsphere-xcopy-volume-populator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/build/vsphere-xcopy-volume-populator/Containerfile-downstream
+++ b/build/vsphere-xcopy-volume-populator/Containerfile-downstream
@@ -1,30 +1,25 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.22.9-1739801907 AS builder
-USER root
-WORKDIR /usr/src/app
+FROM registry.redhat.io/ubi9/go-toolset:1.22-1744194661 AS builder
+COPY --chown=1001:0 . /src
+WORKDIR /src/cmd/vsphere-xcopy-volume-populator
 
-# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading
-# them in subsequent builds if they change
-COPY go.mod go.sum ./
-RUN go mod download && go mod verify
+ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
 
-COPY . .
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/.cache/go-build \
-    go build -o bin/vsphere-xcopy-volume-populator
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o bin/vsphere-xcopy-volume-populator
 
 RUN make vmkfstools-wrapper
 
-FROM registry.redhat.io/ubi9-minimal:9.5-1745855087
+FROM registry.redhat.io/ubi9-minimal:9.5-1742914212
 
-COPY --from=builder /usr/src/app/bin/vsphere-xcopy-volume-populator \
-    /bin/vsphere-xcopy-volume-populator
+COPY --from=builder /src/cmd/vsphere-xcopy-volume-populator/bin/vsphere-xcopy-volume-populator \
+/bin/vsphere-xcopy-volume-populator
 
-COPY --from=builder /usr/src/app/vmkfstools-wrapper/vmkfstools-wrapper.vib \
-    /bin/vmkfstools-wrapper.vib
-COPY --from=builder /usr/src/app/vmkfstools-wrapper/vib-install-playbook.yaml \
-    /bin/vib-install-playbook.yaml
-COPY --from=builder /usr/src/app/vmkfstools-wrapper/esxi_hosts.yaml \
-    /bin/esxi_hosts.yaml
+COPY --from=builder /src/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vmkfstools-wrapper.vib \
+/bin/vmkfstools-wrapper.vib
+COPY --from=builder /src/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vib-install-playbook.yaml \
+/bin/vib-install-playbook.yaml
+COPY --from=builder /src/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/esxi_hosts.yaml \
+/bin/esxi_hosts.yaml
 
 ENTRYPOINT ["/bin/vsphere-xcopy-volume-populator"]
 
@@ -39,7 +34,3 @@ LABEL \
         description="Migration Toolkit for Virtualization - vSphere XCOPY Volume Populator" \
         vendor="Red Hat, Inc." \
         maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>"
-
-
-
-


### PR DESCRIPTION
Enable prefetch for vsphere-xcopy-volume-populator downstream image. 
Modify downstream containerfile.

Ref: https://issues.redhat.com/browse/MTV-2271