### PR TITLE
xcopy-populator: Add python to Containerfile

### DIFF
--- a/build/vsphere-xcopy-volume-populator/Containerfile
+++ b/build/vsphere-xcopy-volume-populator/Containerfile
@@ -12,6 +12,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/.cache/go-build \
     go build -o bin/vsphere-xcopy-volume-populator
 
+RUN dnf install -y \
+    # install python for vmkfstools-wrapper tests \
+    python
 RUN make vmkfstools-wrapper
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal


### PR DESCRIPTION
This is needed to run the vmkfstools-wrapper test

Signed-off-by: Roy Golan <rgolan@redhat.com>
