### PR TITLE
QoL for generating .kustomized_manifests

### DIFF
--- a/.github/workflows/validate-kustomized-manifests.yaml
+++ b/.github/workflows/validate-kustomized-manifests.yaml
@@ -25,6 +25,6 @@ jobs:
             echo "File .kustomized_manifests corresponds to the operator/ directory."
             exit 0
           else
-            echo "File .kustomized_manifests does not correspond to the latest changes in operator/ directory. Run 'kustomize build config/manifests > .kustomized_manifests' inside 'operator/' directory."
+            echo "File .kustomized_manifests does not correspond to the latest changes in operator/ directory. Run 'make kustomized-manifests'.
             exit 1
           fi;

--- a/Makefile
+++ b/Makefile
@@ -505,3 +505,7 @@ dev-controller: generate fmt vet build-controller
 	API_HOST="forklift-inventory-openshift-mtv.apps.ocp-edge-cluster-0.qe.lab.redhat.com" \
 	./bin/forklift-controller
 	#dlv --listen=:5432 --headless=true --api-version=2 exec ./bin/forklift-controller \
+
+.PHONY: kustomized-manifests
+kustomized-manifests: kubectl
+	kubectl kustomize operator/config/manifests > operator/.kustomized_manifests


### PR DESCRIPTION
Adds a make target for QoL, to regenerate .kustomized_manifests file in
operator/ directory.

Change info in kustomized_manifests validation job about how to resolve .kustomized_manifests conflict.