### PR TITLE
Automatically handle Pipeline step transitions when moving to the next phase

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -363,14 +363,24 @@ func (r *Migration) NextPhase(vm *plan.VMStatus) {
 		return
 	}
 	vm.Phase = r.migrator.Next(vm)
-	nextStep, found := vm.FindStep(r.migrator.Step(vm))
-	if !found {
-		vm.AddError(fmt.Sprintf("Next step '%s' not found", r.migrator.Step(vm)))
-		return
-	}
-	if currentStep.Name != nextStep.Name {
+	switch vm.Phase {
+	case api.PhaseCompleted:
+		// `Completed` is a terminal phase that does not belong
+		// to a pipeline step. If it is the next VM phase, then
+		// mark the current pipeline step complete without
+		// looking for a following step.
 		currentStep.MarkCompleted()
 		currentStep.Phase = api.StepCompleted
+	default:
+		nextStep, found := vm.FindStep(r.migrator.Step(vm))
+		if !found {
+			vm.AddError(fmt.Sprintf("Next step '%s' not found", r.migrator.Step(vm)))
+			return
+		}
+		if currentStep.Name != nextStep.Name {
+			currentStep.MarkCompleted()
+			currentStep.Phase = api.StepCompleted
+		}
 	}
 	return
 }


### PR DESCRIPTION
This PR adds a method to the migration runner called `NextPhase()` that will move the VM to the next phase and automatically complete the current pipeline step if the next phase belongs to a different one. It's no longer necessary for the last phase in a step to manually complete it which will allow phases to be reordered and moved between steps more easily.

(Extracted from https://github.com/kubev2v/forklift/pull/1648)