### PR TITLE
MTV-2522 |  network config script isn't win-2008 compatible

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
@@ -1,0 +1,55 @@
+#This script configures static IP settings on legacy Windows network interfaces
+#based on input that maps MAC addresses to IP configuration details.
+#Input string will be added to the script while creating the virt-v2v pod
+#Input string format: MAC:ip:IP,Gateway,Prefix,DNS1,DNS2
+
+# Input string
+$inputString = "{{.InputString}}"
+
+
+function Convert-PrefixToMask($prefix) {
+    $bin = ("1" * $prefix).PadRight(32, "0")
+    $bytes = ($bin.ToCharArray() -join "") -split "(.{8})" | Where-Object { $_ }
+    return ($bytes | ForEach-Object { [Convert]::ToInt32($_, 2) }) -join "."
+}
+
+# Split entries by '_'
+$entries = $inputString -split '_'
+
+# Extract parts
+foreach ($entry in $entries) {
+    if ($entry -match '^([0-9A-Fa-f:\-]+):ip:([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)$'){
+        $mac = $matches[1].ToUpper().Replace(":", "-")
+        $ip = $matches[2]
+        $gw = $matches[3]
+        $prefix = [int]$matches[4]
+        $dns1 = $matches[5]
+        $dns2 = $matches[6]
+        $mask = Convert-PrefixToMask $prefix
+
+        Write-Host "Searching for MAC: $mac`n"
+
+        $adapter = Get-WmiObject Win32_NetworkAdapter | Where-Object {
+        $_.MACAddress -and ($_.MACAddress.ToUpper().Replace(":", "-") -eq $mac) -and $_.NetConnectionID
+        }
+
+        if (-not $adapter) {
+            Write-Warning "Adapter with MAC $mac not found!`n"
+            exit 1
+        }
+
+        $iface = $adapter.NetConnectionID
+        Write-Host "Using interface: $iface`n"
+
+        Start-Process -FilePath "netsh" -ArgumentList "interface ipv4 set address name=`"$iface`" static $ip $mask $gw" -Wait -Verb RunAs
+        Start-Process -FilePath "netsh" -ArgumentList "interface ipv4 set dnsservers name=`"$iface`" static $dns1" -Wait -Verb RunAs
+         if ($dns2 -and $dns2 -ne "") {
+            Start-Process -FilePath "netsh" -ArgumentList "interface ipv4 add dnsservers name=`"$iface`" $dns2 index=2" -Wait -Verb RunAs
+        }
+
+        Write-Host "IP configuration applied`n"
+    } else {
+        Write-Warning "Input string format is invalid`n"
+    }
+}
+

--- a/pkg/virt-v2v/customize/scripts/windows/9999-restore_config-legacy.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-restore_config-legacy.ps1
@@ -1,0 +1,45 @@
+# Migration - Reconfigure disks
+# A legacy version of the script that does not use Get-Disk
+
+Write-Host "`nRe-enabling all offline drives`n"
+
+# Find VirtIO disks and their disk numbers
+$virtioDisks = Get-WmiObject -Class Win32_DiskDrive | Where-Object {
+    $_.Model -like '*VirtIO*' -or $_.Caption -like '*VirtIO*'
+}
+
+if ($virtioDisks) {
+    foreach ($disk in $virtioDisks) {
+        Write-Host "Processing disk $($disk.Index): $($disk.Model)`n"
+
+        # Prepare diskpart script content
+        $diskpartScriptContent = @"
+select disk $($disk.Index)
+online disk
+attributes disk clear readonly
+exit
+"@
+
+        # Write to temporary file
+        $tempScriptPath = Join-Path $env:TEMP "diskpart_script_$($disk.Index).txt"
+        $diskpartScriptContent | Out-File $tempScriptPath -Encoding ASCII
+
+        try {
+            $diskpartOutput = & diskpart /s $tempScriptPath 2>&1
+            $outputString = $diskpartOutput -join "`n"
+
+            if ($outputString -match "error" -and $outputString -notmatch "already online") {
+                Write-Warning "  - DiskPart reported error. Output:`n$outputString`n"
+            } else {
+                Write-Host "  - Successfully processed disk $($disk.Index).`n"
+            }
+        } catch {
+            Write-Error "  - Error running diskpart: $($_.Exception.Message)`n"
+        } finally {
+            # Clean up temporary file
+            Remove-Item $tempScriptPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+} else {
+    Write-Warning "No VirtIO disks found.`n"
+}


### PR DESCRIPTION
Issue:
As of MTV 2.8.4, support for older drivers enables migration of Windows 2008 R2 guests. However, we encountered a new virt-v2v issue (RHEL-91611) where the `Get-NetAdapter` cmdlet is unavailable on Windows 2008 R2, causing static IP configuration to fail in firstboot scripts. Same as for re-enabling offline drivers script.

Fix:
Adding a  legacy-compatible scripts without relying on modern cmdlets. It ensures static IP preservation and disks re-enablement during migration of Windows 2008 R2 VMs

Ref: https://issues.redhat.com/browse/MTV-2522