### PR TITLE
MTV-2539 | MTV-2536 | MTV-2500 | Various CA certificate issues

### DIFF
--- a/pkg/controller/host/validation.go
+++ b/pkg/controller/host/validation.go
@@ -237,7 +237,7 @@ func (r *Reconciler) validateSecret(host *api.Host) (err error) {
 				"password",
 			}
 
-			err := r.VerifyTLSConnection(host.Spec.IpAddress, secret)
+			_, err := r.VerifyTLSConnection(host.Spec.IpAddress, secret)
 			if err != nil {
 				cnd.Message = err.Error()
 				cnd.Reason = DataErr

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -10,9 +10,9 @@ import (
 
 	planapi "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+	"github.com/konveyor/forklift-controller/pkg/controller/base"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 	"github.com/konveyor/forklift-controller/pkg/controller/plan/util"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/ovirt"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
@@ -388,7 +388,7 @@ func (r *Client) connect() (err error) {
 		Username(r.user()).
 		Password(r.password()).
 		CACert(r.cacert()).
-		Insecure(ovirt.GetInsecureSkipVerifyFlag(r.Source.Secret)).
+		Insecure(base.GetInsecureSkipVerifyFlag(r.Source.Secret)).
 		Build()
 	if err != nil {
 		err = liberr.Wrap(err)

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -18,6 +18,7 @@ import (
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/plan"
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
+	basecontroller "github.com/konveyor/forklift-controller/pkg/controller/base"
 	planbase "github.com/konveyor/forklift-controller/pkg/controller/plan/adapter/base"
 	plancontext "github.com/konveyor/forklift-controller/pkg/controller/plan/context"
 	utils "github.com/konveyor/forklift-controller/pkg/controller/plan/util"
@@ -378,7 +379,7 @@ func (r *Builder) getSourceDetails(vm *model.VM, sourceSecret *core.Secret) (lib
 	}
 
 	sslVerify := ""
-	if container.GetInsecureSkipVerifyFlag(sourceSecret) {
+	if basecontroller.GetInsecureSkipVerifyFlag(sourceSecret) {
 		sslVerify = "no_verify=1"
 	}
 

--- a/pkg/controller/plan/adapter/vsphere/host.go
+++ b/pkg/controller/plan/adapter/vsphere/host.go
@@ -3,9 +3,9 @@ package vsphere
 import (
 	"context"
 	liburl "net/url"
-	"strconv"
 	"time"
 
+	"github.com/konveyor/forklift-controller/pkg/controller/base"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/vsphere"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	"github.com/vmware/govmomi"
@@ -73,7 +73,7 @@ func (r *EsxHost) connect(ctx context.Context) (err error) {
 	url.User = liburl.UserPassword(
 		r.user(),
 		r.password())
-	soapClient := soap.NewClient(url, r.getInsecureSkipVerifyFlag())
+	soapClient := soap.NewClient(url, base.GetInsecureSkipVerifyFlag(r.Secret))
 	soapClient.SetThumbprint(url.Host, r.thumbprint())
 	vimClient, err := vim25.NewClient(ctx, soapClient)
 	if err != nil {
@@ -127,20 +127,4 @@ func (r *EsxHost) thumbprint() string {
 	}
 
 	return ""
-}
-
-// GetInsecureSkipVerifyFlag gets the insecureSkipVerify boolean flag
-// value from the provider connection secret.
-func (r *EsxHost) getInsecureSkipVerifyFlag() bool {
-	insecure, found := r.Secret.Data["insecureSkipVerify"]
-	if !found {
-		return true
-	}
-
-	insecureSkipVerify, err := strconv.ParseBool(string(insecure))
-	if err != nil {
-		return true
-	}
-
-	return insecureSkipVerify
 }

--- a/pkg/controller/provider/container/ovirt/client.go
+++ b/pkg/controller/provider/container/ovirt/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/konveyor/forklift-controller/pkg/controller/base"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libweb "github.com/konveyor/forklift-controller/pkg/lib/inventory/web"
 	"github.com/konveyor/forklift-controller/pkg/lib/logging"
@@ -61,7 +62,7 @@ func (r *Client) connect() (status int, err error) {
 		return
 	}
 
-	if GetInsecureSkipVerifyFlag(r.secret) {
+	if base.GetInsecureSkipVerifyFlag(r.secret) {
 		TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	} else {
 		cacert := r.secret.Data["cacert"]
@@ -201,20 +202,4 @@ func (r *Client) system() (system *System, status int, err error) {
 	}
 
 	return
-}
-
-// GetInsecureSkipVerifyFlag gets the insecureSkipVerify boolean flag
-// value from the ovirt connection secret.
-func GetInsecureSkipVerifyFlag(secret *core.Secret) bool {
-	insecure, found := secret.Data["insecureSkipVerify"]
-	if !found {
-		return false
-	}
-
-	insecureSkipVerify, err := strconv.ParseBool(string(insecure))
-	if err != nil {
-		return false
-	}
-
-	return insecureSkipVerify
 }

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -8,12 +8,12 @@ import (
 	"regexp"
 
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/konveyor/forklift-controller/pkg/controller/base"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/container"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/ovirt"
-	"github.com/konveyor/forklift-controller/pkg/controller/provider/container/vsphere"
 	libcnd "github.com/konveyor/forklift-controller/pkg/lib/condition"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	libref "github.com/konveyor/forklift-controller/pkg/lib/ref"
+	"github.com/konveyor/forklift-controller/pkg/lib/util"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -173,6 +173,35 @@ func (r *Reconciler) validateURL(provider *api.Provider) error {
 	return nil
 }
 
+func (r *Reconciler) validateConnectionStatus(provider *api.Provider, secret *core.Secret) {
+	if base.GetInsecureSkipVerifyFlag(secret) {
+		provider.Status.SetCondition(libcnd.Condition{
+			Type:     ConnectionInsecure,
+			Status:   True,
+			Reason:   SkipTLSVerification,
+			Category: Warn,
+			Message:  "TLS is susceptible to machine-in-the-middle attacks when certificate verification is skipped.",
+		})
+	} else {
+		crt, err := r.VerifyTLSConnection(provider.Spec.URL, secret)
+		if err != nil {
+			provider.Status.SetCondition(libcnd.Condition{
+				Type:     ConnectionTestFailed,
+				Status:   True,
+				Reason:   Tested,
+				Category: Critical,
+				Message:  err.Error(),
+			})
+			return
+		}
+
+		// Only set fingerprint for vSphere providers
+		if provider.Type() == api.VSphere {
+			provider.Status.Fingerprint = util.Fingerprint(crt)
+		}
+	}
+}
+
 // Validate secret (ref).
 //  1. The references is complete.
 //  2. The secret exists.
@@ -217,39 +246,22 @@ func (r *Reconciler) validateSecret(provider *api.Provider) (secret *core.Secret
 	switch provider.Type() {
 	case api.OpenShift:
 		keyList = []string{"token"}
+
+		r.validateConnectionStatus(provider, secret)
 	case api.VSphere:
 		keyList = []string{
 			"user",
 			"password",
 		}
 
-		if vsphere.GetInsecureSkipVerifyFlag(secret) {
-			provider.Status.SetCondition(libcnd.Condition{
-				Type:     ConnectionInsecure,
-				Status:   True,
-				Reason:   SkipTLSVerification,
-				Category: Warn,
-				Message:  "TLS is susceptible to machine-in-the-middle attacks when certificate verification is skipped.",
-			})
-		}
-
-		err := r.VerifyTLSConnection(provider.Spec.URL, secret)
-		if err != nil {
-			provider.Status.SetCondition(libcnd.Condition{
-				Type:     ConnectionTestFailed,
-				Status:   True,
-				Reason:   Tested,
-				Category: Critical,
-				Message:  err.Error(),
-			})
-		}
+		r.validateConnectionStatus(provider, secret)
 	case api.OVirt:
 		keyList = []string{
 			"user",
 			"password",
 		}
 
-		if ovirt.GetInsecureSkipVerifyFlag(secret) {
+		if base.GetInsecureSkipVerifyFlag(secret) {
 			provider.Status.SetCondition(libcnd.Condition{
 				Type:     ConnectionInsecure,
 				Status:   True,


### PR DESCRIPTION
   
    Issue:
    1. Missing vddk-thumbprint during TLS verification.
    2. Connection Failed with VMware Provider with Fetching CA
    3. OCP provider created without CA or skip CA remains stuck even after manual fix
    
    Fix:
    1. Assigning provider Fingerprint upon successfull TLS verification.
    2. Added TLS verification for OCP provider.
    
    Ref: https://issues.redhat.com/browse/MTV-2539
         https://issues.redhat.com/browse/MTV-2536
         https://issues.redhat.com/browse/MTV-2500