### PR TITLE
MTV-2501 | Dangling plan

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -210,6 +210,13 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	// Validations.
 	err = r.validate(plan)
 	if err != nil {
+		if r.isDanglingArchivedPlan(plan) {
+			r.Log.Info("Dangling Plan - Aborting reconcile of plan without source provider.")
+			r.archive(plan)
+			if err = r.updatePlanStatus(plan); err != nil {
+				r.Log.Error(err, "failed to update plan status")
+			}
+		}
 		return
 	}
 
@@ -237,17 +244,8 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	// End staging conditions.
 	plan.Status.EndStagingConditions()
 
-	// Record events.
-	r.Record(plan, plan.Status.Conditions)
-
-	// Apply changes.
-	plan.Status.ObservedGeneration = plan.Generation
-	// At this point, the plan contains data that is not persisted by design, like the Referenced data
-	// and the staged flags in the status, and more data that has been loaded in the validate function,
-	// like the name of the VMs in the spec section, therefore we don't want the plan to be overridden
-	// by data from the server (even the spec section is overridden) and so we pass a copy of the plan
-	err = r.Status().Update(context.TODO(), plan.DeepCopy())
-	if err != nil {
+	if err = r.updatePlanStatus(plan); err != nil {
+		r.Log.Error(err, "failed to update plan status")
 		return
 	}
 
@@ -261,6 +259,28 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 
 	// Done.
 	return
+}
+
+func (r *Reconciler) isDanglingArchivedPlan(plan *api.Plan) bool {
+	return plan.Spec.Archived && plan.Referenced.Provider.Source == nil
+}
+
+func (r *Reconciler) updatePlanStatus(plan *api.Plan) error {
+	// Record events.
+	r.Record(plan, plan.Status.Conditions)
+
+	// Apply changes.
+	plan.Status.ObservedGeneration = plan.Generation
+
+	// At this point, the plan contains data that is not persisted by design, like the Referenced data
+	// and the staged flags in the status, and more data that has been loaded in the validate function,
+	// like the name of the VMs in the spec section, therefore we don't want the plan to be overridden
+	// by data from the server (even the spec section is overridden) and so we pass a copy of the plan
+	if err := r.Status().Update(context.TODO(), plan.DeepCopy()); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *Reconciler) setPopulatorDataSourceLabels(plan *api.Plan) {

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
@@ -129,9 +129,15 @@ func (admitter *PlanAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv
 			Name:      admitter.plan.Spec.Provider.Source.Name,
 		},
 		&admitter.sourceProvider)
+
 	if err != nil {
-		log.Error(err, "Failed to get source provider, can't determine permissions")
-		return util.ToAdmissionResponseError(err)
+		if admitter.plan.Spec.Archived {
+			log.Info("Plan is archived, skipping validation")
+			return util.ToAdmissionResponseAllow()
+		} else {
+			log.Error(err, "Failed to get source provider, can't determine permissions")
+			return util.ToAdmissionResponseError(err)
+		}
 	}
 
 	providerGR, err := api.GetGroupResource(&api.Provider{})


### PR DESCRIPTION
 Issue:
    Deleting a provider with existing related plan causes error when archiving, leading to leftovers if plan is force deleted
    
  Fix:
    Allowing archiving dangling plan in the provider hook.
    

 Ref: https://issues.redhat.com/browse/MTV-2501