### PR TITLE
Update lint go version

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -25,7 +25,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.54
+          version: v1.59.1
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 


### PR DESCRIPTION
Issue:
I get this error on my PR :
r.Source undefined (type *Client has no field or method Source) (typecheck)

which probably due to old Go version in lint.

Fix:
Updating GO version to 1.23