### PR TITLE
MTV-2524 | Round VMware disk capacity up to next megabyte.

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1087,7 +1087,7 @@ func (r *Builder) Tasks(vmRef ref.Ref) (list []*plan.Task, err error) {
 		vm.RemoveSharedDisks()
 	}
 	for _, disk := range vm.Disks {
-		mB := disk.Capacity / 0x100000
+		mB := utils.RoundUp(disk.Capacity, 0x100000) / 0x100000
 		list = append(
 			list,
 			&plan.Task{

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -21,7 +21,7 @@ const (
 	diskPrefix = "/dev/sd"
 )
 
-func roundUp(requestedSpace, multiple int64) int64 {
+func RoundUp(requestedSpace, multiple int64) int64 {
 	if multiple == 0 {
 		return requestedSpace
 	}
@@ -30,7 +30,7 @@ func roundUp(requestedSpace, multiple int64) int64 {
 }
 
 func CalculateSpaceWithOverhead(requestedSpace int64, volumeMode *core.PersistentVolumeMode) int64 {
-	alignedSize := roundUp(requestedSpace, DefaultAlignBlockSize)
+	alignedSize := RoundUp(requestedSpace, DefaultAlignBlockSize)
 	var spaceWithOverhead int64
 	if *volumeMode == core.PersistentVolumeFilesystem {
 		spaceWithOverhead = int64(math.Ceil(float64(alignedSize) / (1 - float64(settings.Settings.FileSystemOverhead)/100)))


### PR DESCRIPTION
Issue:
A VMware disk image was set to a number of bytes that did not align to 1MiB, and the imported VM would not start.

Fix:
I have not yet been able to set a disk to such a size in VMware, but a speculative fix is to change the conversion from bytes to MiB in the vSphere builder, which just divides by 0x100000 without rounding up first. With non-aligned size values, this division results in a smaller number, for example: 19000005632 / 0x100000 = 18999148544, vs. rounding up to 19000197120.

Reference:
https://issues.redhat.com/browse/MTV-2524