### PR TITLE
MTV-2524 | Round VMware disk capacity up to next megabyte, part 2.

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -567,12 +567,13 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 				},
 			}
 		}
+		alignedCapacity := utils.RoundUp(disk.Capacity, utils.DefaultAlignBlockSize)
 		dvSpec := cdi.DataVolumeSpec{
 			Source: &dvSource,
 			Storage: &cdi.StorageSpec{
 				Resources: core.ResourceRequirements{
 					Requests: core.ResourceList{
-						core.ResourceStorage: *resource.NewQuantity(disk.Capacity, resource.BinarySI),
+						core.ResourceStorage: *resource.NewQuantity(alignedCapacity, resource.BinarySI),
 					},
 				},
 				StorageClassName: &storageClass,


### PR DESCRIPTION
Issue: need one more change for previously merged pull request #1886.

Fix: also align disk size in DataVolume creation request. I still haven't managed to reproduce the original bug, but this probably won't hurt anything.

Ref: https://github.com/kubev2v/forklift/pull/1886