### PR TITLE
VIB ensure install

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/Makefile
@@ -10,6 +10,8 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+include vmkfstools-wrapper/version.mk
+
 .PHONY: all
 all: build
 
@@ -31,23 +33,23 @@ generate:
 	go generate ./...
 
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
-	go build -o bin/vsphere-xcopy-volume-populator
+build: generate fmt vet
+	go build -ldflags="-X github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/populator.VibVersion=$(VIB_VERSION)" -o bin/vsphere-xcopy-volume-populator
 
 # prerequisits: ensure a PVC exists.
 test-copy-using-cli: build
 	bin/vsphere-xcopy-volume-populator \
-		--source-vmdk="[eco-iscsi-ds2] vm-1/vm-1.vmdk" \
+		--source-vmdk="[eco-iscsi-ds3] vm-6/vm-6.vmdk" \
 		--owner-name=test-cli \
 		--target-namespace=default \
-		--storage-vendor=ontap \
+		--storage-vendor-product=ontap \
 		--secret-name=populator-secret \
 		--owner-uid=test-cli \
 		--kubeconfig=$$KUBECONFIG
 
 test-copy-using-cli-3par: build
 	bin/vsphere-xcopy-volume-populator \
-		--source-vmdk="[eco-iscsi-ds1] boris01/boris01.vmdk" \
+		--source-vmdk="[eco-iscsi-ds1] vm-6/vm-6.vmdk" \
 	    --owner-name=test1\
 		--target-namespace=default \
 		--storage-vendor-product=primera3par \

--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/populate.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/populate.go
@@ -40,14 +40,14 @@ type LUN struct {
 
 // VMDisk is the target VMDisk in vmware
 type VMDisk struct {
-	VMName     string
-	Datacenter string
-	VmdkFile   string
-	VmnameDir  string
+	VMName    string
+	Datastore string
+	VmdkFile  string
+	VmnameDir string
 }
 
 func (d *VMDisk) Path() string {
-	return fmt.Sprintf("/vmfs/volumes/%s/%s/%s", d.Datacenter, d.VmnameDir, d.VmdkFile)
+	return fmt.Sprintf("/vmfs/volumes/%s/%s/%s", d.Datastore, d.VmnameDir, d.VmdkFile)
 }
 
 func ParseVmdkPath(vmdkPath string) (VMDisk, error) {
@@ -66,5 +66,5 @@ func ParseVmdkPath(vmdkPath string) (VMDisk, error) {
 	vmdk := pathParts[1]
 	vmdkParts := strings.SplitN(vmdk, ".", 2)
 	vmname_sub := vmdkParts[0]
-	return VMDisk{VMName: vmname_sub, Datacenter: datastore, VmdkFile: vmdk, VmnameDir: vmname_dir}, nil
+	return VMDisk{VMName: vmname_sub, Datastore: datastore, VmdkFile: vmdk, VmnameDir: vmname_dir}, nil
 }

--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
@@ -77,6 +77,10 @@ func (p *RemoteEsxcliPopulator) Populate(sourceVMDKFile string, volumeHandle str
 	}
 	klog.Infof("Got ESXI host: %s", host)
 
+	err = ensureVib(p.VSphereClient, host, vmDisk.Datastore, VibVersion)
+	if err != nil {
+		return fmt.Errorf("failed to ensure VIB is installed: %w", err)
+	}
 	// for iSCSI add the host to the group using IQN. Is there something else for FC?
 	r, err := p.VSphereClient.RunEsxCommand(context.Background(), host, []string{"storage", "core", "adapter", "list"})
 	if err != nil {

--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
@@ -1,0 +1,92 @@
+package populator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/vmware"
+	"github.com/vmware/govmomi/object"
+	"k8s.io/klog/v2"
+)
+
+const (
+	vibName     = "vmkfstools-wrapper"
+	vibLocation = "/bin/vmkfstools-wrapper.vib"
+)
+
+// VibVersion is set by ldflags
+var VibVersion = "x.x.x"
+
+// ensure vib will fetch the vib version and in case needed will install it
+// on the target ESX
+func ensureVib(client vmware.Client, esx *object.HostSystem, datastore string, desiredVibVersion string) error {
+	klog.Infof("ensuring vib version on ESXi %s: %s", esx.Name(), VibVersion)
+
+	version, err := getViBVersion(client, esx)
+	if err != nil {
+		return fmt.Errorf("failed to get the VIB version from ESXi %s: %w", esx.Name(), err)
+	}
+
+	klog.Infof("current vib version on ESXi %s: %s", esx.Name(), version)
+	if version == desiredVibVersion {
+		return nil
+	}
+
+	vibPath, err := uploadVib(client, esx, datastore)
+	if err != nil {
+		return fmt.Errorf("failed to upload the VIB to ESXi %s: %w", esx.Name(), err)
+	}
+	klog.Infof("uploaded vib to ESXi %s", esx.Name())
+
+	err = installVib(client, esx, vibPath)
+	if err != nil {
+		return fmt.Errorf("failed to install the VIB on ESXi %s: %w", esx.Name(), err)
+	}
+	klog.Infof("installed vib on ESXi %s version %s", esx.Name(), VibVersion)
+	return nil
+}
+
+func getViBVersion(client vmware.Client, esxi *object.HostSystem) (string, error) {
+	r, err := client.RunEsxCommand(context.Background(), esxi, []string{"software", "vib", "get", "-n", vibName})
+	if err != nil {
+		vFault, conversonErr := vmware.ErrToFault(err)
+		if conversonErr != nil {
+			return "", err
+		}
+		if vFault != nil {
+			for _, m := range vFault.ErrMsgs {
+				if strings.Contains(m, "[NoMatchError]") {
+					// vib is not installed. return empty object
+					return "", nil
+				}
+			}
+		}
+		return "", err
+	}
+
+	klog.Infof("reply from get vib %v", r)
+	return r[0].Value("Version"), err
+}
+
+func uploadVib(client vmware.Client, esx *object.HostSystem, datastore string) (string, error) {
+	ds, err := client.GetDatastore(context.Background(), datastore)
+	if err != nil {
+		return "", fmt.Errorf("failed to upload file: %w", err)
+	}
+
+	if err = ds.UploadFile(context.Background(), vibLocation, vibName+".vib", nil); err != nil {
+		return "", fmt.Errorf("failed to upload %s: %w", vibLocation, err)
+	}
+	return fmt.Sprintf("/vmfs/volumes/%s/%s", datastore, vibName+".vib"), nil
+}
+
+func installVib(client vmware.Client, esx *object.HostSystem, vibPath string) error {
+	r, err := client.RunEsxCommand(context.Background(), esx, []string{"software", "vib", "install", "-f", "1", "-v", vibPath})
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("reply from get vib %v", r)
+	return nil
+}

--- a/cmd/vsphere-xcopy-volume-populator/internal/vmware/mocks/vmware_mock_client.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/vmware/mocks/vmware_mock_client.go
@@ -42,6 +42,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// GetDatastore mocks base method.
+func (m *MockClient) GetDatastore(ctx context.Context, datastore string) (*object.Datastore, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDatastore", ctx, datastore)
+	ret0, _ := ret[0].(*object.Datastore)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDatastore indicates an expected call of GetDatastore.
+func (mr *MockClientMockRecorder) GetDatastore(ctx, datastore any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatastore", reflect.TypeOf((*MockClient)(nil).GetDatastore), ctx, datastore)
+}
+
 // GetEsxByVm mocks base method.
 func (m *MockClient) GetEsxByVm(ctx context.Context, vmName string) (*object.HostSystem, error) {
 	m.ctrl.T.Helper()

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/Makefile
@@ -1,10 +1,12 @@
 SHELL := /bin/bash
 
+include version.mk
+
 test:
 	python vmkfstools_wrapper_test.py
 
 build: test
-	./create-vib.sh
+	VIB_VERSION=${VIB_VERSION} ./create-vib.sh 
 
 install: build
 	ANSIBLE_HOST_KEY_CHECKING=false \

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/create-vib.sh
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/create-vib.sh
@@ -7,7 +7,7 @@ pushd "$SCRIPT_DIR"
 
 CUSTOM_VIB_TEMP_DIR=/tmp/vib-temp-rgo
 CUSTOM_VIB_NAME=vmkfstools-wrapper
-CUSTOM_VIB_VERSION="0.1.0"
+CUSTOM_VIB_VERSION="${VIB_VERSION}"
 CUSTOM_VIB_VENDOR="REDHAT"
 CUSTOM_VIB_VENDOR_URL="https://redhat.com"
 CUSTOM_VIB_SUMMARY="Custom VIB to wrap vmkfstools as esxcli plugin"

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/create-vib.sh
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/create-vib.sh
@@ -7,7 +7,7 @@ pushd "$SCRIPT_DIR"
 
 CUSTOM_VIB_TEMP_DIR=/tmp/vib-temp-rgo
 CUSTOM_VIB_NAME=vmkfstools-wrapper
-CUSTOM_VIB_VERSION="0.0.86"
+CUSTOM_VIB_VERSION="0.1.0"
 CUSTOM_VIB_VENDOR="REDHAT"
 CUSTOM_VIB_VENDOR_URL="https://redhat.com"
 CUSTOM_VIB_SUMMARY="Custom VIB to wrap vmkfstools as esxcli plugin"
@@ -27,7 +27,7 @@ mkdir -p ${CUSTOM_VIB_TEMP_DIR}
 mkdir -p ${VIB_PAYLOAD_DIR}
 
 # Create ESXi folder structure for file(s) placement
-CUSTOM_VIB_BIN_DIR=${VIB_PAYLOAD_DIR}/bin
+CUSTOM_VIB_BIN_DIR=${VIB_PAYLOAD_DIR}/opt/redhat
 ESXCLI_PLUGINS_DIR=${VIB_PAYLOAD_DIR}/usr/lib/vmware/esxcli/ext/
 mkdir -p ${CUSTOM_VIB_BIN_DIR}
 mkdir -p ${ESXCLI_PLUGINS_DIR}
@@ -41,7 +41,7 @@ cp -v vmkfstools_wrapper.py ${CUSTOM_VIB_BIN_DIR}/vmkfstools-wrapper
 chmod +x ${CUSTOM_VIB_BIN_DIR}/vmkfstools-wrapper
 
 # Create tgz with payload
-tar czvf ${CUSTOM_VIB_TEMP_DIR}/payload1 -C ${VIB_PAYLOAD_DIR} bin usr
+tar czvf ${CUSTOM_VIB_TEMP_DIR}/payload1 -C ${VIB_PAYLOAD_DIR} opt usr
 
 # Calculate payload size/hash
 PAYLOAD_FILES=$(tar tf ${CUSTOM_VIB_TEMP_DIR}/payload1 | grep -v -E '/$' | sed -e 's/^/    <file>/' -e 's/$/<\/file>/')

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/esxcli-vmkfstools.xml
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/esxcli-vmkfstools.xml
@@ -28,7 +28,7 @@
          <format-parameters>
             <formatter>simple</formatter>
          </format-parameters>
-         <execute>/bin/vmkfstools-wrapper --clone -s $val{source-vmdk} -t $val{target-lun} </execute>
+         <execute>/opt/redhat/vmkfstools-wrapper --clone -s $val{source-vmdk} -t $val{target-lun} </execute>
       </command>
       <command path="vmkfstools.taskGet">
          <description>Get a clone task status</description>
@@ -46,7 +46,7 @@
          <format-parameters>
             <formatter>simple</formatter>
          </format-parameters>
-         <execute>/bin/vmkfstools-wrapper --task-get -i $val{id}</execute>
+         <execute>/opt/redhat/vmkfstools-wrapper --task-get -i $val{id}</execute>
       </command>
       <command path="vmkfstools.taskClean">
          <description>Clean task artifacts</description>
@@ -64,7 +64,7 @@
          <format-parameters>
             <formatter>simple</formatter>
          </format-parameters>
-         <execute>/bin/vmkfstools-wrapper --task-clean -i $val{id}</execute>
+         <execute>/opt/redhat/vmkfstools-wrapper --task-clean -i $val{id}</execute>
       </command>
 
    </commands>

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/version.mk
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/version.mk
@@ -1,0 +1,1 @@
+VIB_VERSION := 0.1.0

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vib-install-playbook.yaml
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vib-install-playbook.yaml
@@ -38,9 +38,6 @@
     - name: Install Red Hat's vmkfstools-wrapper
       shell: esxcli software vib install -v {{ dest_location }}{{ src_vib }} -f
 
-    - name: restart /etc/init.d/hosts restart
-      shell: /etc/init.d/hostd restart
-
     - name: Confirm VIB is installed
       shell: esxcli software vib list | grep vmkfstools-wrapper
       register: vibs
@@ -50,5 +47,4 @@
       delay: 10
 
     - debug: var=vibs.stdout
-
 

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -3694,6 +3694,8 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterroles
+  - clusterrolebindings
   verbs:
   - create
 - apiGroups:

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -157,6 +157,8 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterroles
+  - clusterrolebindings
   verbs:
   - create
 - apiGroups:

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1720,5 +1720,46 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 	if err != nil && !k8serr.IsAlreadyExists(err) {
 		return err
 	}
+
+	clusterRole := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "populator-pv-reader",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"persistentvolumes"},
+				Verbs:     []string{"get"},
+			},
+		},
+	}
+
+	err = r.Destination.Client.Create(context.TODO(), &clusterRole, &client.CreateOptions{})
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		return err
+	}
+	crBinding := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "populator-pv-reader-binding",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "populator",
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "populator-pv-reader",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	err = r.Destination.Client.Create(context.TODO(), &crBinding, &client.CreateOptions{})
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION

https://issues.redhat.com/browse/ECOPROJECT-3066

Motivation
The VIB is a critical piece of the flow, and it will probably go under
changes as we go. We do have an ansible script to install it, but that
actions is manual. Instead we can try to always look for the vib on the
ESX in context, and check the version, and remediate if necessary. That
way we are always updated and aligned to the populator version.

Modification
With the former fix making the wrapper VIB not needing a restart of
hostd, the installation process becomes quicker and safer.
The populator will fetch the VIB version and compare to the desired
version. If not there it will upload the vib, from the container
filesystem, to the same datastore the VM is on, and then install it,
all through remote ESX commands through the API.

Result
The populator pod automatically checks and installs the VIB on each
attempt to run clone the disk. We pay few seconds in the worst case,
just once per ESX.

