### PR TITLE
Fix downstream v2v image to contain the virt-v2v-in-place

### DIFF
--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -34,6 +34,7 @@ RUN mkdir /disks && \
     virt-v2v \
     virtio-win
 
+ENV PATH="$PATH:/usr/libexec"
 ENV LIBGUESTFS_BACKEND=direct
 
 RUN mkdir -p /usr/lib64/guestfs/appliance


### PR DESCRIPTION
Isuse:
The warm migraiton fails with
```
Building command:virt-v2v-in-place[-v -x -i libvirtxml --root first /mnt/v2v/input.xml]Failed to execute virt-v2v command exec: "virt-v2v-in-place": executable file not found in $PATH
```

Fix:
Add `ENV PATH="$PATH:/usr/libexec"`