### PR TITLE
fix os assessment description

### DIFF
--- a/validation/policies/io/konveyor/forklift/vmware/vm_os.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/vm_os.rego
@@ -12,9 +12,6 @@ concerns[flag] {
     flag := {
         "category":   "Warning",
         "label":      "Unsupported operating system detected",
-        "assessment": sprintf(
-            "The guest operating system (%s) is not currently supported by the Migration Toolkit for Virtualization",
-            [ input.guestId ]
-          )
+        "assessment": "The guest operating system is not currently supported by the Migration Toolkit for Virtualization"
     }
 }


### PR DESCRIPTION
Each concern is part of a VM, so, like any other Rego rule, it makes sense not to return the formatted` input.guestId`.