### PR TITLE
Enable nudging of refs in images.conf

### DIFF
--- a/.tekton/forklift-api-dev-preview-push.yaml
+++ b/.tekton/forklift-api-dev-preview-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*, build/forklift-operator-bundle/images.conf"
     build.appstudio.openshift.io/repo: https://github.com/kubev2v/forklift?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
Enable nudging of image references in operator-bundle's images.conf file.