### PR TITLE
Move quay img refs from images.conf

### DIFF
--- a/.tekton/forklift-api-dev-preview-push.yaml
+++ b/.tekton/forklift-api-dev-preview-push.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*, build/forklift-operator-bundle/images.conf"
     build.appstudio.openshift.io/repo: https://github.com/kubev2v/forklift?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/build/forklift-operator-bundle/Containerfile-downstream
+++ b/build/forklift-operator-bundle/Containerfile-downstream
@@ -11,6 +11,19 @@ ARG DEFAULT_CHANNEL
 ARG REGISTRY
 ARG OCP_VERSIONS
 
+ARG API_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-api-dev-preview@sha256:2e86855ae3bf055b10f62df6269a93fc095a6c499edeb56b02e36c46a92b9083"
+ARG CONTROLLER_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-controller-dev-preview@sha256:785d88a649e2e10e298f8bb78fb365533e2d5296d0e766c7b840e7b3a0ca0c98"
+ARG MUST_GATHER_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-must-gather-dev-preview@sha256:b4ca6968f86b8ed23f360b325036fa813e3c21483b5487a81c5583fd3327d99b"
+ARG OPENSTACK_POPULATOR_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/openstack-populator-dev-preview@sha256:09661fdb1805515dc3ab7743bd156a592ab4a84ac4c88d646599617c6db371ea"
+ARG OPERATOR_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-operator-dev-preview@sha256:8601a266a795635ebfc379d94cc67c5e14a520576491e8f2cce2c5a6116ad504"
+ARG OVA_PROVIDER_SERVER_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/ova-provider-server-dev-preview@sha256:27abd135cc0cec6bac353b03773fbf5d0c4d844a5a4b40421f6fefb51888c568"
+ARG OVIRT_POPULATOR_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/ovirt-populator-dev-preview@sha256:6d2e7e253ea9de541001a552b97eeb4de8e745fc927ebe866607d33dadc4b253"
+ARG POPULATOR_CONTROLLER_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/populator-controller-dev-preview@sha256:031d3bd4925c38a27bea7d94257669d2004f09330834fee7feb1489f0839782e"
+ARG UI_PLUGIN_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-console-plugin-dev-preview@sha256:3afdcfc48d6189ad1a4562767fd5ce70ac92929d3e06537d0d76c6e29e7155a4"
+ARG VALIDATION_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/validation-dev-preview@sha256:8b332c831decb8698db7aeee51fd45d2609a294a94fd8d6df26d06b8461ccadc"
+ARG VIRT_V2V_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/virt-v2v-dev-preview@sha256:bc96fb8453931bcc2b932f3b1c7108dc4c40e592698e0fa341e6903426158f30"
+ARG VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/vsphere-xcopy-volume-populator-dev-preview@sha256:9a7289458f347098ea159fb27c19b6dc7c2ea9ad50466b649da39d3744c87b4e"
+
 USER root
 
 COPY --from=envsubst /usr/bin/envsubst /usr/bin/envsubst

--- a/build/forklift-operator-bundle/images.conf
+++ b/build/forklift-operator-bundle/images.conf
@@ -27,19 +27,4 @@ export UI_PLUGIN_IMAGE="registry.redhat.io/mtv-candidate/mtv-console-plugin-rhel
 export OVA_PROVIDER_SERVER_IMAGE="registry.redhat.io/mtv-candidate/mtv-ova-provider-server-rhel9@sha256:27abd135cc0cec6bac353b03773fbf5d0c4d844a5a4b40421f6fefb51888c568"
 export VALIDATION_IMAGE="registry.redhat.io/mtv-candidate/mtv-validation-rhel9@sha256:320304c7b9ebbbebf6aac3c916ad3ae2fbf8ca8c2039a3bbbfa64894ae5ae0e3"
 
-else
-
-export API_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-api-dev-preview@sha256:52e1c7160d3a5f07d2aaaa67cc6e8dc6b864bbf20d1a94c5f44059e74f4b3372"
-export CONTROLLER_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-controller-dev-preview@sha256:785d88a649e2e10e298f8bb78fb365533e2d5296d0e766c7b840e7b3a0ca0c98"
-export MUST_GATHER_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-must-gather-dev-preview@sha256:b4ca6968f86b8ed23f360b325036fa813e3c21483b5487a81c5583fd3327d99b"
-export OPENSTACK_POPULATOR_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/openstack-populator-dev-preview@sha256:09661fdb1805515dc3ab7743bd156a592ab4a84ac4c88d646599617c6db371ea"
-export OPERATOR_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-operator-dev-preview@sha256:8601a266a795635ebfc379d94cc67c5e14a520576491e8f2cce2c5a6116ad504"
-export OVA_PROVIDER_SERVER_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/ova-provider-server-dev-preview@sha256:27abd135cc0cec6bac353b03773fbf5d0c4d844a5a4b40421f6fefb51888c568"
-export OVIRT_POPULATOR_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/ovirt-populator-dev-preview@sha256:6d2e7e253ea9de541001a552b97eeb4de8e745fc927ebe866607d33dadc4b253"
-export POPULATOR_CONTROLLER_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/populator-controller-dev-preview@sha256:031d3bd4925c38a27bea7d94257669d2004f09330834fee7feb1489f0839782e"
-export UI_PLUGIN_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-console-plugin-dev-preview@sha256:3afdcfc48d6189ad1a4562767fd5ce70ac92929d3e06537d0d76c6e29e7155a4"
-export VALIDATION_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/validation-dev-preview@sha256:8b332c831decb8698db7aeee51fd45d2609a294a94fd8d6df26d06b8461ccadc"
-export VIRT_V2V_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/virt-v2v-dev-preview@sha256:bc96fb8453931bcc2b932f3b1c7108dc4c40e592698e0fa341e6903426158f30"
-export VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE="quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/vsphere-xcopy-volume-populator-dev-preview@sha256:9a7289458f347098ea159fb27c19b6dc7c2ea9ad50466b649da39d3744c87b4e"
-
 fi


### PR DESCRIPTION
As Konflux does not differentiate between registries and tries to also update downstream references we need to move those away and disable nudging of images.conf