### PR TITLE
MTV-2471 | Windows-Preserve multiple ip’s per nic

### DIFF
--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -26,6 +26,7 @@ const (
 	EnvLocalMigrationName         = "LOCAL_MIGRATION"
 	EnvVirtIoWinLegacyDriversName = "VIRTIO_WIN"
 	EnvHostName                   = "V2V_HOSTNAME"
+	EnvMultipleIpsPerNicName      = "V2V_multipleIPsPerNic"
 )
 
 const (
@@ -83,6 +84,8 @@ type AppConfig struct {
 	// hostname
 	HostName string
 
+	// V2V_multipleIPsPerNic
+	MultipleIpsPerNicName string
 	// Paths
 	VddkConfFile         string
 	InspectionOutputFile string
@@ -115,6 +118,7 @@ func (s *AppConfig) Load() (err error) {
 	flag.StringVar(&s.LibvirtDomainFile, "libvirt-domain-file", V2vInPlaceLibvirtDomain, "Path to the libvirt domain used in the in-place conversion")
 	flag.StringVar(&s.VirtIoWinLegacyDrivers, "virtio-win-legacy-drivers", os.Getenv(EnvVirtIoWinLegacyDriversName), "Path to the virtio-win legacy drivers ISO")
 	flag.StringVar(&s.HostName, "hostname", os.Getenv(EnvHostName), "Hostname of the vm")
+	flag.StringVar(&s.MultipleIpsPerNicName, "multiple-ips-per-nic", os.Getenv(EnvMultipleIpsPerNicName), "Multiple IPs per NIC")
 	flag.Parse()
 
 	return s.validate()

--- a/pkg/virt-v2v/customize/scripts/windows/9999-preserve_complementry_ips_per_nic.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-preserve_complementry_ips_per_nic.ps1.tmpl
@@ -1,0 +1,42 @@
+# Wait for the netkvm (virtio-net) driver to become active.
+$startdate = Get-Date
+$adapters = @()
+While (-Not $adapters -and $startdate.AddMinutes(5) -gt (Get-Date)) {
+    Start-Sleep -Seconds 5
+    $adapters = Get-NetAdapter -Physical | Where DriverFileName -eq "netkvm.sys"
+    Write-Host "Waiting for netkvm.sys adapters..."
+}
+
+# Define MACs and IPs for each adapter
+$networkConfigs = @(
+{{- range $i, $cfg := . }}
+    @{
+        MAC = '{{ lower $cfg.MAC }}'
+        IPs = @{{ formatIPs $cfg.IPs }}
+        PrefixLength = {{ (index $cfg.IPs 0).PrefixLength }}
+        DNS = @{{ formatDNS $cfg }}
+    }{{ if ne (add $i 1) (len $) }},{{ end }}
+{{- end }}
+)
+
+
+
+
+# Apply settings
+foreach ($config in $networkConfigs) {
+    $adapter = Get-NetAdapter -Physical | Where-Object { $_.MacAddress -eq $config.MAC }
+
+    if ($adapter) {
+        $ifindex = $adapter.ifIndex
+        $name = $adapter.Name
+        Write-Host "Configuring adapter '$name' ($($config.MAC))"
+
+        foreach ($ip in $config.IPs) {
+            Write-Host "Setting IP $ip on '$name'"
+            New-NetIPAddress -InterfaceIndex $ifindex -IPAddress $ip -PrefixLength $config.PrefixLength
+            Set-DnsClientServerAddress -InterfaceIndex $ifindex -ServerAddresses $config.DNS
+        }
+    } else {
+        Write-Warning "Adapter with MAC $($config.MAC) not found"
+    }
+}


### PR DESCRIPTION
Issue:
Nics with multiple Ip's are not preserved.
Only the primary ip is preserved  from virt-v2v but the rest are droped due to re-assigning of default-gatway .

Fix:
Preserve the complementry IP's seperatly to avoid re-assigning of default-gatway .

Ref:
https://issues.redhat.com/browse/MTV-2471