### PR TITLE
MTV-2628 | TLS error when changing migration network

### DIFF
--- a/pkg/controller/base/controller.go
+++ b/pkg/controller/base/controller.go
@@ -127,7 +127,7 @@ func GetInsecureSkipVerifyFlag(secret *core.Secret) bool {
 	return insecureSkipVerify
 }
 
-func (r *Reconciler) VerifyTLSConnection(rawURL string, secret *core.Secret) (*x509.Certificate, error) {
+func VerifyTLSConnection(rawURL string, secret *core.Secret) (*x509.Certificate, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL: %w", err)
@@ -136,7 +136,6 @@ func (r *Reconciler) VerifyTLSConnection(rawURL string, secret *core.Secret) (*x
 	// Attempt to get certificate
 	cert, err := util.GetTlsCertificate(parsedURL, secret)
 	if err != nil {
-		r.Log.Error(err, "failed to get TLS certificate", "url", parsedURL)
 		return nil, fmt.Errorf("failed to get TLS certificate: %w", err)
 	}
 	if cert == nil {
@@ -158,7 +157,6 @@ func (r *Reconciler) VerifyTLSConnection(rawURL string, secret *core.Secret) (*x
 	// Dial TLS
 	conn, err := tls.Dial("tcp", host, tlsConfig)
 	if err != nil {
-		r.Log.Error(err, "failed to create a secure connection to server")
 		return nil, fmt.Errorf("failed to create a secure TLS connection: %w", err)
 	}
 	defer conn.Close()

--- a/pkg/controller/host/validation.go
+++ b/pkg/controller/host/validation.go
@@ -237,12 +237,13 @@ func (r *Reconciler) validateSecret(host *api.Host) (err error) {
 				"user",
 				"password",
 			}
-			if base.GetInsecureSkipVerifyFlag(secret) {
-				_, err := r.VerifyTLSConnection(host.Spec.IpAddress, secret)
+			if !base.GetInsecureSkipVerifyFlag(secret) {
+				_, err = base.VerifyTLSConnection(host.Spec.IpAddress, secret)
 				if err != nil {
 					cnd.Message = err.Error()
 					cnd.Reason = DataErr
 					host.Status.SetCondition(cnd)
+					return
 				}
 			}
 		}

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -184,7 +184,7 @@ func (r *Reconciler) validateConnectionStatus(provider *api.Provider, secret *co
 			Message:  "TLS is susceptible to machine-in-the-middle attacks when certificate verification is skipped.",
 		})
 	} else {
-		_, err := r.VerifyTLSConnection(provider.Spec.URL, secret)
+		_, err := base.VerifyTLSConnection(provider.Spec.URL, secret)
 		if err != nil {
 			provider.Status.SetCondition(libcnd.Condition{
 				Type:     ConnectionTestFailed,

--- a/pkg/lib/util/util.go
+++ b/pkg/lib/util/util.go
@@ -19,12 +19,22 @@ func GetTlsCertificate(url *liburl.URL, secret *core.Secret) (crt *x509.Certific
 	if err != nil {
 		return
 	}
+	host := ""
+	if url.Host == "" {
+		//There are cases where the URL is provided without a host, e.g. "https://path/to/resource"
+		url.Host = url.Path
+	}
+	host = url.Host
 
-	host := url.Host
+	if host == "" {
+		err = liberr.New("URL host or path is empty")
+		return
+	}
 	if url.Port() == "" {
 		host += ":443"
 	}
-
+	// disable verification since we don't trust it yet
+	cfg.InsecureSkipVerify = true
 	conn, err := tls.Dial("tcp", host, cfg)
 	if err == nil && len(conn.ConnectionState().PeerCertificates) > 0 {
 		crt = conn.ConnectionState().PeerCertificates[0]


### PR DESCRIPTION
Issue:
When Creating esxi provider
Changing migration network from host view under provider, Fails with: "failed to verify certificate: x509: certificate signed by unknown authority"

Fix:
Add un-trusted CA to cert pools in the missing parts we haven't caught so far.

Ref:
https://issues.redhat.com/browse/MTV-2628