### PR TITLE
xcopy-populator: Use the make 'build' target to build the container

### DIFF
--- a/build/vsphere-xcopy-volume-populator/Containerfile
+++ b/build/vsphere-xcopy-volume-populator/Containerfile
@@ -13,7 +13,7 @@ RUN go mod download && go mod verify
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/.cache/go-build \
-    go build -o bin/vsphere-xcopy-volume-populator
+    make build
 
 RUN dnf install -y \
     # install python for vmkfstools-wrapper tests \

--- a/build/vsphere-xcopy-volume-populator/Containerfile-downstream
+++ b/build/vsphere-xcopy-volume-populator/Containerfile-downstream
@@ -5,7 +5,7 @@ WORKDIR /src/cmd/vsphere-xcopy-volume-populator
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
 ENV GOEXPERIMENT=strictfipsruntime
 
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o bin/vsphere-xcopy-volume-populator
+RUN GOOS=linux GOARCH=amd64 make build
 
 # We need python for running a test during build process
 # This is not used for actually running the populator in production

--- a/cmd/vsphere-xcopy-volume-populator/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/Makefile
@@ -10,6 +10,8 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+PATH := $(shell go env GOPATH)/bin:$(PATH)
+
 include vmkfstools-wrapper/version.mk
 
 .PHONY: all
@@ -32,8 +34,15 @@ generate:
 	go generate ./...
 
 .PHONY: build
-build: generate fmt vet
-	go build -ldflags="-X github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/populator.VibVersion=$(VIB_VERSION)" -o bin/vsphere-xcopy-volume-populator
+build: fmt vet
+	PATH=$(PATH) \
+	go build \
+	-ldflags="w -s -X github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/populator.VibVersion=$(VIB_VERSION)" \
+	-o bin/vsphere-xcopy-volume-populator
+
+MOCKGEN := $(shell which mockgen 2>/dev/null)
+install-mockgen:
+	[ -z "$(MOCKGEN)" ] && go install go.uber.org/mock/mockgen@latest || true
 
 # pre-requisits: ensure a PVC exists.
 test-copy-using-cli: build

--- a/cmd/vsphere-xcopy-volume-populator/go.mod
+++ b/cmd/vsphere-xcopy-volume-populator/go.mod
@@ -1,12 +1,14 @@
 module github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator
 
-go 1.22.0
+go 1.23
+
+toolchain go1.23.10
 
 require (
 	github.com/netapp/trident v0.0.0-20240628081112-cb68cb389d9d
 	github.com/stretchr/testify v1.10.0
 	github.com/vmware/govmomi v0.48.0
-	go.uber.org/mock v0.5.0
+	go.uber.org/mock v0.5.2
 	k8s.io/apimachinery v0.31.3
 	k8s.io/client-go v0.28.10
 	k8s.io/klog/v2 v2.130.1

--- a/cmd/vsphere-xcopy-volume-populator/go.sum
+++ b/cmd/vsphere-xcopy-volume-populator/go.sum
@@ -246,8 +246,8 @@ go.opentelemetry.io/otel/sdk v1.28.0 h1:b9d7hIry8yZsgtbmM0DKyPWMMUMlK9NEKuIG4aBq
 go.opentelemetry.io/otel/sdk v1.28.0/go.mod h1:oYj7ClPUA7Iw3m+r7GeEjz0qckQRJK2B8zjcZEfu7Pg=
 go.opentelemetry.io/otel/trace v1.29.0 h1:J/8ZNK4XgR7a21DZUAsbF8pZ5Jcw1VhACmnYt39JTi4=
 go.opentelemetry.io/otel/trace v1.29.0/go.mod h1:eHl3w0sp3paPkYstJOmAimxhiFXPg+MMTlEh3nsQgWQ=
-go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
-go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
+go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
+go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/storage.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/storage.go
@@ -1,6 +1,6 @@
 package populator
 
-//go:generate mockgen -destination=mocks/storage_mock_client.go -package=storage_mocks . StorageApi
+//go:generate go mockgen -destination=mocks/storage_mock_client.go -package=storage_mocks . StorageApi
 type StorageApi interface {
 	StorageMapper
 	StorageResolver

--- a/cmd/vsphere-xcopy-volume-populator/vendor/modules.txt
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/modules.txt
@@ -345,8 +345,8 @@ go.opentelemetry.io/otel/metric/embedded
 ## explicit; go 1.21
 go.opentelemetry.io/otel/trace
 go.opentelemetry.io/otel/trace/embedded
-# go.uber.org/mock v0.5.0
-## explicit; go 1.22
+# go.uber.org/mock v0.5.2
+## explicit; go 1.23
 go.uber.org/mock/gomock
 # go.uber.org/multierr v1.11.0
 ## explicit; go 1.19


### PR DESCRIPTION
The build target contains the needed build tags to make sure the VIB
version is injected into the binary

Signed-off-by: Roy Golan <rgolan@redhat.com>
