### PR TITLE
MTV-2669 | An incorrect IP address keeps the VMware provider stuck in a non-ready state

### DIFF
--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -259,6 +259,14 @@ func (r *Reconciler) validateSecret(provider *api.Provider) (secret *core.Secret
 		var crt *x509.Certificate
 		crt, err = util.GetTlsCertificate(providerUrl, secret)
 		if err != nil {
+			provider.Status.Phase = ConnectionFailed
+			provider.Status.SetCondition(libcnd.Condition{
+				Type:     ConnectionTestFailed,
+				Status:   True,
+				Reason:   Tested,
+				Category: Critical,
+				Message:  err.Error(),
+			})
 			return
 		}
 		provider.Status.Fingerprint = util.Fingerprint(crt)

--- a/pkg/lib/util/util.go
+++ b/pkg/lib/util/util.go
@@ -6,13 +6,33 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	liburl "net/url"
 	"strconv"
+	"time"
 
 	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	liberr "github.com/konveyor/forklift-controller/pkg/lib/error"
 	core "k8s.io/api/core/v1"
 )
+
+func dialTLSWithTimeout(host string, cfg *tls.Config, timeout time.Duration) (*tls.Conn, error) {
+	conn, err := net.DialTimeout("tcp", host, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConn := tls.Client(conn, cfg)
+
+	// Set handshake timeout
+	err = tlsConn.Handshake()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return tlsConn, nil
+}
 
 func GetTlsCertificate(url *liburl.URL, secret *core.Secret) (crt *x509.Certificate, err error) {
 	cfg, err := tlsConfig(secret)
@@ -35,7 +55,7 @@ func GetTlsCertificate(url *liburl.URL, secret *core.Secret) (crt *x509.Certific
 	}
 	// disable verification since we don't trust it yet
 	cfg.InsecureSkipVerify = true
-	conn, err := tls.Dial("tcp", host, cfg)
+	conn, err := dialTLSWithTimeout(host, cfg, 5*time.Second)
 	if err == nil && len(conn.ConnectionState().PeerCertificates) > 0 {
 		crt = conn.ConnectionState().PeerCertificates[0]
 	} else {


### PR DESCRIPTION
Issue:
Creating a VMware provider with wrong ip for example https://10.10.10.10/sdk ending with creating the provider with "undefined" state and the forkflift-controller gets stuck.

Fix:
1. Add a timeout to the tls-certificate method.
2. Change provider condition upon timeout
3. Update provider status after validation failure Ref: https://issues.redhat.com/browse/MTV-2669

Ref: https://issues.redhat.com/browse/MTV-2669
