### PR TITLE
Collect vendor and model of the host

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -92,6 +92,8 @@ const (
 	fHostBusAdapter = "config.storageDevice.hostBusAdapter"
 	fScsiTopology   = "config.storageDevice.scsiTopology.adapter"
 	fAdvancedOption = "configManager.advancedOption"
+	fmodel          = "hardware.systemInfo.model"
+	fvendor         = "hardware.systemInfo.vendor"
 	// Network
 	fTag     = "tag"
 	fSummary = "summary"
@@ -740,6 +742,8 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 				fAdvancedOption,
 				fHostBusAdapter,
 				fScsiTopology,
+				fmodel,
+				fvendor,
 			},
 		},
 		{ // Network

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -428,6 +428,14 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 						v.model.HostScsiTopology = append(v.model.HostScsiTopology, hostScsiTopology)
 					}
 				}
+			case fmodel:
+				if b, cast := p.Val.(string); cast {
+					v.model.Model = b
+				}
+			case fvendor:
+				if b, cast := p.Val.(string); cast {
+					v.model.Vendor = b
+				}
 			}
 		}
 	}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -148,6 +148,8 @@ type Host struct {
 	CpuCores           int16              `sql:""`
 	ProductName        string             `sql:""`
 	ProductVersion     string             `sql:""`
+	Model              string             `sql:""`
+	Vendor             string             `sql:""`
 	Network            HostNetwork        `sql:""`
 	Networks           []Ref              `sql:""`
 	Datastores         []Ref              `sql:""`


### PR DESCRIPTION
Adding the Collection of each host’s hardware vendor (hardware.systemInfo.vendor) and model (hardware.systemInfo.model) in the vSphere collector, and add corresponding Vendor and Model fields to the Host struct.

Signed-off-by: Aviel Segev <asegev@redhat.com>
