### PR TITLE
xcopy-populator: Add PVC accessMode=RWX by default

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -583,6 +583,10 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 		// otherwise, let the storage profile decide the default values.
 		if mapped.Destination.AccessMode != "" {
 			dvSpec.Storage.AccessModes = []core.PersistentVolumeAccessMode{mapped.Destination.AccessMode}
+		} else {
+			// we expect the storage class for migration to support RWX for live migration to work.
+			// In case the override is needed, set it in the StorageMap mapping
+			dvSpec.Storage.AccessModes = []core.PersistentVolumeAccessMode{core.ReadWriteMany}
 		}
 		if mapped.Destination.VolumeMode != "" {
 			dvSpec.Storage.VolumeMode = &mapped.Destination.VolumeMode


### PR DESCRIPTION
AccessMode is required for PVC, and when a
StorageMap.Map[].Destination.AccessMode doesn't specify
what accessMode to set, the migration fails on creating the PVC.

https://issues.redhat.com/browse/ECOPROJECT-3111

Signed-off-by: Roy Golan <rgolan@redhat.com>
