### PR TITLE
xcopy-popualtor: For ontap, resolve luns using PV's internalName

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/Makefile
@@ -39,7 +39,7 @@ build: generate fmt vet
 # prerequisits: ensure a PVC exists.
 test-copy-using-cli: build
 	bin/vsphere-xcopy-volume-populator \
-		--source-vmdk="[eco-iscsi-ds3] vm-6/vm-6.vmdk" \
+		--source-vmdk="[eco-iscsi-ds2] vm-2/vm-2.vmdk" \
 		--owner-name=test-cli \
 		--target-namespace=default \
 		--storage-vendor-product=ontap \

--- a/cmd/vsphere-xcopy-volume-populator/internal/ontap/ontap.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/ontap/ontap.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/populator"
 	drivers "github.com/netapp/trident/storage_drivers"
@@ -77,9 +76,8 @@ func NewNetappClonner(hostname, username, password string) (NetappClonner, error
 }
 
 func (c *NetappClonner) ResolveVolumeHandleToLUN(volumeHandle string) (populator.LUN, error) {
-	// for trident we need convert the dashes to underscores so pvc-123-456 becomes pvc_123_456
-	volumeHandle = strings.ReplaceAll(volumeHandle, "-", "_")
-	l, err := c.api.LunGetByName(context.Background(), fmt.Sprintf("/vol/trident_%s/lun0", volumeHandle))
+	// trident sets internalName attribute on a volume, and that is the real volume name in the system
+	l, err := c.api.LunGetByName(context.Background(), fmt.Sprintf("/vol/%s/lun0", volumeHandle))
 	if err != nil {
 		return populator.LUN{}, err
 	}


### PR DESCRIPTION
Motivation
Using the PVs volumeHandle may not be enough for some ontap
installation. The name of the LUN in ontap is set by the CSI driver, and
the default prefix, "trident_pvc_" that is controlled by the trident
configuration can be different. That breaks the resolve logic.

Modification
When using ontap, trident CSI is setting the real name of the lun using
the volume attribute 'internalName'. Using that looks is more reliable
than the heuristic with the volumeHandle

Result
ontap provider will work with whatever trident configuration
`TridentBackend.config.ontap_config.storage_prefix` is set to.

https://issues.redhat.com/browse/ECOPROJECT-2880

Signed-off-by: Roy Golan <rgolan@redhat.com>
