### PR TITLE
MTV-2664 | Network configuration scripts doesn't work well for win2008 sp2

### DIFF
--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -21,6 +21,7 @@ const (
 	WindowsDynamicRegex     = `^([0-9]+_win_firstboot(([\w\-]*).ps1))$`
 	LinuxDynamicRegex       = `^([0-9]+_linux_(run|firstboot)(([\w\-]*).sh))$`
 	ShellSuffix             = ".sh"
+	UploadCmd               = "--upload"
 )
 
 //go:embed scripts
@@ -287,6 +288,7 @@ func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) {
 	uploadRemoveDuplicatesPath := ""
 	uploadPreserveMultipleIpPath := ""
 	if c.appConfig.VirtIoWinLegacyDrivers != "" {
+		initPath = filepath.Join(windowsScriptsPath, "9999-run-mtv-ps-scripts-legacy.bat")
 		restoreScriptPath = filepath.Join(windowsScriptsPath, "9999-restore_config-legacy.ps1")
 
 		if c.appConfig.StaticIPs != "" {
@@ -329,7 +331,7 @@ func (c *Customize) addWinDynamicScripts(cmdBuilder utils.CommandBuilder, dir st
 	for _, script := range dynamicScripts {
 		fmt.Printf("Adding windows dynamic scripts '%s'\n", script)
 		upload := c.formatUpload(script, filepath.Join(WinFirstbootScriptsPath, filepath.Base(script)))
-		cmdBuilder.AddArg("--upload", upload)
+		cmdBuilder.AddArg(UploadCmd, upload)
 	}
 	return nil
 }
@@ -403,7 +405,7 @@ func (c *Customize) handleStaticIPConfiguration(cmdBuilder utils.CommandBuilder)
 		if err := c.fileSystem.WriteFile(macToIPFilePath, []byte(macToIPFileContent), 0755); err != nil {
 			return fmt.Errorf("failed to write MAC to IP mapping file: %w", err)
 		}
-		cmdBuilder.AddArg("--upload", fmt.Sprintf("%s:/tmp/macToIP", macToIPFilePath))
+		cmdBuilder.AddArg(UploadCmd, fmt.Sprintf("%s:/tmp/macToIP", macToIPFilePath))
 	}
 
 	return nil

--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
@@ -9,17 +9,27 @@ $inputString = "{{.InputString}}"
 
 function Convert-PrefixToMask($prefix) {
     $bin = ("1" * $prefix).PadRight(32, "0")
-    $bytes = ($bin.ToCharArray() -join "") -split "(.{8})" | Where-Object { $_ }
-    return ($bytes | ForEach-Object { [Convert]::ToInt32($_, 2) }) -join "."
+    $mask = ""
+    for ($i = 0; $i -lt 32; $i += 8) {
+        $chunk = $bin.Substring($i, 8)
+        $num = [Convert]::ToInt32($chunk, 2)
+        if ($mask -ne "") {
+            $mask = $mask + "."
+        }
+        $mask = $mask + $num
+    }
+    return $mask
 }
 
 # Split entries by '_'
-$entries = $inputString -split '_'
+$entries = $inputString.Split("_")
 
 # Extract parts
 foreach ($entry in $entries) {
-    if ($entry -match '^([0-9A-Fa-f:\-]+):ip:([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)$'){
-        $mac = $matches[1].ToUpper().Replace(":", "-")
+    if ($entry -match "^([0-9A-Fa-f:\-]+):ip:([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)$") {
+        $mac = $matches[1]
+        $mac = $mac.ToUpper()
+        $mac = $mac.Replace(":", "-")
         $ip = $matches[2]
         $gw = $matches[3]
         $prefix = [int]$matches[4]
@@ -29,11 +39,20 @@ foreach ($entry in $entries) {
 
         Write-Host "Searching for MAC: $mac`n"
 
-        $adapter = Get-WmiObject Win32_NetworkAdapter | Where-Object {
-        $_.MACAddress -and ($_.MACAddress.ToUpper().Replace(":", "-") -eq $mac) -and $_.NetConnectionID
+        $adapters = Get-WmiObject Win32_NetworkAdapter
+        $adapter = $null
+
+        foreach ($a in $adapters) {
+            if ($a.MACAddress -and $a.NetConnectionID) {
+                $aMac = $a.MACAddress.ToUpper().Replace(":", "-")
+                if ($aMac -eq $mac) {
+                    $adapter = $a
+                    break
+                }
+            }
         }
 
-        if (-not $adapter) {
+        if ($adapter -eq $null) {
             Write-Warning "Adapter with MAC $mac not found!`n"
             exit 1
         }
@@ -41,14 +60,24 @@ foreach ($entry in $entries) {
         $iface = $adapter.NetConnectionID
         Write-Host "Using interface: $iface`n"
 
-        Start-Process -FilePath "netsh" -ArgumentList "interface ipv4 set address name=`"$iface`" static $ip $mask $gw" -Wait -Verb RunAs
-        Start-Process -FilePath "netsh" -ArgumentList "interface ipv4 set dnsservers name=`"$iface`" static $dns1" -Wait -Verb RunAs
-         if ($dns2 -and $dns2 -ne "") {
-            Start-Process -FilePath "netsh" -ArgumentList "interface ipv4 add dnsservers name=`"$iface`" $dns2 index=2" -Wait -Verb RunAs
-        }
+       $cmd = "netsh interface ip set address name=`"$iface`" static $ip $mask $gw"
+       # Use WScript.Shell COM object to run netsh commands:
+       # - The '0' parameter hides the command window (runs silently)
+       # - The '$true' parameter ensures the script waits for the command to finish before continuing
+       $wshell = New-Object -ComObject WScript.Shell
+       $wshell.Run($cmd, 0, $true)
 
+       $cmd = "netsh interface ip set dns name=`"$iface`" static $dns1"
+       $wshell.Run($cmd, 0, $true)
+        
+        if ($dns2 -ne "") {
+            $cmd = "netsh interface ip add dns name=`"$iface`" $dns2 index=2"
+            $wshell.Run($cmd, 0, $true)
+        } 
+        
         Write-Host "IP configuration applied`n"
-    } else {
+    }
+    else {
         Write-Warning "Input string format is invalid`n"
     }
 }

--- a/pkg/virt-v2v/customize/scripts/windows/9999-run-mtv-ps-scripts-legacy.bat
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-run-mtv-ps-scripts-legacy.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem Set PowerShell 1.0 execution policy to Unrestricted (requires admin)
+rem This is required to allow execution of unsigned PowerShell scripts during first boot.
+rem By default, PowerShell may block .ps1 scripts (ExecutionPolicy = Restricted),
+rem and setting it to Unrestricted ensures the scripts can run without being blocked.
+reg add "HKLM\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell" /v ExecutionPolicy /t REG_SZ /d Unrestricted /f
+
+set firstboot=C:\Program Files\Guestfs\Firstboot
+set scripts=%firstboot%\scripts
+set scripts_done=%firstboot%\scripts-done
+
+echo Running MTV first boot scripts
+
+for %%f in ("%scripts%\*.ps1") do (
+  echo running "%%~f"
+  powershell.exe -Command "& '%%~f'"
+  set elvl=!errorlevel!
+  echo .... exit code !elvl!
+  move "%%~f" "%scripts_done%"
+)
+
+rem Optionally reset policy to Restricted (requires admin)
+rem This locks script execution back down after boot scripts are complete
+reg add "HKLM\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell" /v ExecutionPolicy /t REG_SZ /d Restricted /f


### PR DESCRIPTION
Issue:
Warm migrate win 2008 sp2 VM: mtv-func-win2008 (PowerShell: 1.0) with static ips from vCenter7 to ocp cluster with preserve static ip: on, after migration the static ip settings no longer existed. Check the network script: 9999-network-config.ps1 execution log, hit error: "Missing expression after unary operator '-'." The script work well on win 2008r2 (PowerShell: 2.0), need modification for PowerShell: 1.0

Fix:
1.Make the network-config script powershell-1.0 compatible.
 2.Add a new script 9999-run-mtv-ps-scripts-legacy.bat that supports powershell-1.0 running policy.

Ref: https://issues.redhat.com/browse/MTV-2664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new batch script for running PowerShell scripts during the first boot on Windows systems with legacy drivers.
* **Improvements**
  * Enhanced the handling of network configuration scripts for Windows, improving reliability and compatibility.
  * Updated internal logic for script execution and configuration, leading to more robust processing of PowerShell scripts during system customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->