### PR TITLE
Add missing VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE to manager

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3694,6 +3694,8 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterroles
+  - clusterrolebindings
   verbs:
   - create
 - apiGroups:
@@ -4074,6 +4076,8 @@ spec:
           value: ${VSPHERE_OS_MAP}
         - name: VIRT_CUSTOMIZE_MAP
           value: ${VIRT_CUSTOMIZE_MAP}
+        - name: VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE
+          value: ${VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE}
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: Always
         livenessProbe:
@@ -4546,7 +4550,7 @@ spec:
   - name: Migration Toolkit for Virtualization Documentation
     url: https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization
   - name: Forklift Operator
-    url: http://github.com/kubev2v/forklift
+    url: https://github.com/kubev2v/forklift
   maintainers:
   - email: openshift-operators@redhat.com
     name: Red Hat

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -4076,6 +4076,8 @@ spec:
           value: ${VSPHERE_OS_MAP}
         - name: VIRT_CUSTOMIZE_MAP
           value: ${VIRT_CUSTOMIZE_MAP}
+        - name: VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE
+          value: ${VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE}
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: Always
         livenessProbe:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3694,6 +3694,8 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterroles
+  - clusterrolebindings
   verbs:
   - create
 - apiGroups:
@@ -4074,6 +4076,8 @@ spec:
           value: ${VSPHERE_OS_MAP}
         - name: VIRT_CUSTOMIZE_MAP
           value: ${VIRT_CUSTOMIZE_MAP}
+        - name: VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE
+          value: ${VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE}
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: Always
         livenessProbe:
@@ -4550,7 +4554,7 @@ spec:
   - name: Forklift Documentation
     url: https://konveyor.github.io/forklift
   - name: Forklift Operator
-    url: http://github.com/kubev2v/forklift
+    url: https://github.com/kubev2v/forklift
   maintainers:
   - email: forklift-dev@googlegroups.com
     name: Forklift by Konveyor Community

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -78,6 +78,8 @@ spec:
           value: ${VSPHERE_OS_MAP}
         - name: VIRT_CUSTOMIZE_MAP
           value: ${VIRT_CUSTOMIZE_MAP}
+        - name: VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE
+          value: ${VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Issue:
The forklift-volume-populator-controller is created with empty VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE.

Fix:
Add missing VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE to manager and run `make generate-manifests kustomized-manifests`