### PR TITLE
MTV-2403 | Add regexp string manipulation template helper

### DIFF
--- a/pkg/templateutil/README.md
+++ b/pkg/templateutil/README.md
@@ -51,6 +51,7 @@ The following string functions are available for use in your templates:
 | `initials` | Extracts first letter of each word | `{{ initials "John Doe" }}` → `JD` |
 | `hasPrefix` | Checks if string starts with prefix | `{{ hasPrefix "go" "golang" }}` → `true` |
 | `hasSuffix` | Checks if string ends with suffix | `{{ hasSuffix "ing" "coding" }}` → `true` |
+| `mustRegexReplaceAll` | Replaces matches using regex with submatch expansion | `{{ mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W" }}` → `-W-xxW-` |
 
 ### Math Functions
 

--- a/pkg/templateutil/templateutil.go
+++ b/pkg/templateutil/templateutil.go
@@ -34,6 +34,7 @@ func AddStringFuncs(funcMap template.FuncMap) template.FuncMap {
 	funcMap["initials"] = sprigFuncs["initials"]
 	funcMap["hasPrefix"] = sprigFuncs["hasPrefix"]
 	funcMap["hasSuffix"] = sprigFuncs["hasSuffix"]
+	funcMap["mustRegexReplaceAll"] = sprigFuncs["mustRegexReplaceAll"]
 
 	return funcMap
 }

--- a/pkg/templateutil/templateutil_test.go
+++ b/pkg/templateutil/templateutil_test.go
@@ -17,7 +17,7 @@ func TestAddStringFuncs(t *testing.T) {
 		"lower", "upper", "contains", "replace", "trim",
 		"trimAll", "trimSuffix", "trimPrefix", "title",
 		"untitle", "repeat", "substr", "nospace", "trunc",
-		"initials", "hasPrefix", "hasSuffix",
+		"initials", "hasPrefix", "hasSuffix", "mustRegexReplaceAll",
 	}
 
 	for _, funcName := range expectedFuncs {
@@ -124,6 +124,27 @@ func TestExecuteTemplate(t *testing.T) {
 			data:         map[string]interface{}{"Name": "World"},
 			expected:     "",
 			expectError:  true,
+		},
+		{
+			name:         "Using mustRegexReplaceAll function",
+			templateText: `{{mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W"}}`,
+			data:         nil,
+			expected:     "-W-xxW-",
+			expectError:  false,
+		},
+		{
+			name:         "Complex regex replacement",
+			templateText: `{{mustRegexReplaceAll "([a-z]+)([0-9]+)" .Input "$2-$1"}}`,
+			data:         map[string]interface{}{"Input": "test123word456"},
+			expected:     "123-test456-word",
+			expectError:  false,
+		},
+		{
+			name:         "Drive letter extraction with formatting",
+			templateText: `disk-{{ mustRegexReplaceAll "([A-Za-z]+):.*" .Input "$1" | lower }}`,
+			data:         map[string]interface{}{"Input": "C:\\"},
+			expected:     "disk-c",
+			expectError:  false,
 		},
 	}
 


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-2403

Issue
Users can't do complex string manipulation action

Fix:
Add `mustRegexReplaceAll` method from `sprig` lib to allow more fine tuned string manipulations 

Part of a fix for MTV-2403 -
Add an option to use more fine tuned string manipulations 

Example:
```
templateText: `disk-{{ mustRegexReplaceAll "([A-Za-z]+):.*" .Input "$1" | lower }}`,
data:         map[string]interface{}{"Input": "C:\\"},
expected:     "disk-c",
```