### PR TITLE
MTV-2403 | Collect guest disk info

### DIFF
--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -1824,8 +1824,10 @@ spec:
                     - .VmName: name of the VM
                     - .PlanName: name of the migration plan
                     - .DiskIndex: initial volume index of the disk
+                    - .WinDriveLetter: Windows drive letter (lower case, if applicable, e.g. "c", require guest agent)
                     - .RootDiskIndex: index of the root disk
                     - .Shared: true if the volume is shared by multiple VMs, false otherwise
+                    - .FileName: name of the file in the source provider (vmWare only, require guest agent)
                   Note:
                     This template can be overridden at the individual VM level.
                   Examples:

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -309,8 +309,10 @@ spec:
                     - .VmName: name of the VM
                     - .PlanName: name of the migration plan
                     - .DiskIndex: initial volume index of the disk
+                    - .WinDriveLetter: Windows drive letter (lower case, if applicable, e.g. "c", require guest agent)
                     - .RootDiskIndex: index of the root disk
                     - .Shared: true if the volume is shared by multiple VMs, false otherwise
+                    - .FileName: name of the file in the source provider (vmWare only, require guest agent)
                   Note:
                     This template can be overridden at the individual VM level.
                   Examples:

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -56,8 +56,10 @@ type PlanSpec struct {
 	//   - .VmName: name of the VM
 	//   - .PlanName: name of the migration plan
 	//   - .DiskIndex: initial volume index of the disk
+	//   - .WinDriveLetter: Windows drive letter (lower case, if applicable, e.g. "c", require guest agent)
 	//   - .RootDiskIndex: index of the root disk
 	//   - .Shared: true if the volume is shared by multiple VMs, false otherwise
+	//   - .FileName: name of the file in the source provider (vmWare only, require guest agent)
 	// Note:
 	//   This template can be overridden at the individual VM level.
 	// Examples:
@@ -230,12 +232,13 @@ func (r *Plan) IsSourceProviderVSphere() bool { return r.Provider.Source.Type() 
 
 // PVCNameTemplateData contains fields used in naming templates.
 type PVCNameTemplateData struct {
-	VmName        string `json:"vmName"`
-	PlanName      string `json:"planName"`
-	DiskIndex     int    `json:"diskIndex"`
-	RootDiskIndex int    `json:"rootDiskIndex"`
-	Shared        bool   `json:"shared,omitempty"`
-	FileName      string `json:"fileName,omitempty"`
+	VmName         string `json:"vmName"`
+	PlanName       string `json:"planName"`
+	DiskIndex      int    `json:"diskIndex"`
+	WinDriveLetter string `json:"winDriveLetter,omitempty"`
+	RootDiskIndex  int    `json:"rootDiskIndex"`
+	Shared         bool   `json:"shared,omitempty"`
+	FileName       string `json:"fileName,omitempty"`
 }
 
 // VolumeNameTemplateData contains fields used in naming templates.

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -640,12 +640,13 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 
 			// Create template data
 			templateData := api.PVCNameTemplateData{
-				VmName:        r.getPlenVMSafeName(vm),
-				PlanName:      r.Plan.Name,
-				DiskIndex:     diskIndex,
-				RootDiskIndex: rootDiskIndex,
-				Shared:        disk.Shared,
-				FileName:      disk.File,
+				VmName:         r.getPlenVMSafeName(vm),
+				PlanName:       r.Plan.Name,
+				DiskIndex:      diskIndex,
+				RootDiskIndex:  rootDiskIndex,
+				Shared:         disk.Shared,
+				FileName:       disk.File,
+				WinDriveLetter: disk.WinDriveLetter,
 			}
 
 			generatedName, err := r.executeTemplate(pvcNameTemplate, &templateData)

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1375,12 +1375,13 @@ func (r *Reconciler) IsValidPVCNameTemplate(pvcNameTemplate string) error {
 
 	// Test template with sample data
 	testData := api.PVCNameTemplateData{
-		VmName:        "test-vm",
-		PlanName:      "test-plan",
-		DiskIndex:     0,
-		RootDiskIndex: 0,
-		Shared:        false,
-		FileName:      "[test07_ds1] test_sp/test-000001.vmdk",
+		VmName:         "test-vm",
+		PlanName:       "test-plan",
+		DiskIndex:      0,
+		RootDiskIndex:  0,
+		Shared:         false,
+		FileName:       "[test07_ds1] test_sp/test-000001.vmdk",
+		WinDriveLetter: "c",
 	}
 
 	result, err := r.IsValidTemplate(pvcNameTemplate, testData)

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -138,6 +138,7 @@ const (
 	fSnapshot                 = "snapshot"
 	fIsTemplate               = "config.template"
 	fGuestNet                 = "guest.net"
+	fGuestDisk                = "guest.disk"
 	fGuestIpStack             = "guest.ipStack"
 	fHostName                 = "guest.hostName"
 )
@@ -814,6 +815,7 @@ func (r *Collector) vmPathSet() []string {
 		fMemorySize,
 		fDevices,
 		fGuestNet,
+		fGuestDisk,
 		fExtraConfig,
 		fNestedHVEnabled,
 		fGuestName,

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -320,6 +320,7 @@ type VM struct {
 	Networks                 []Ref          `sql:""`
 	Concerns                 []Concern      `sql:""`
 	GuestNetworks            []GuestNetwork `sql:""`
+	GuestDisks               []GuestDisk    `sql:""`
 	GuestIpStacks            []GuestIpStack `sql:""`
 	SecureBoot               bool           `sql:""`
 	DiskEnableUuid           bool           `sql:""`
@@ -351,6 +352,7 @@ type Disk struct {
 	Bus                   string `json:"bus"`
 	Mode                  string `json:"mode,omitempty"`
 	Serial                string `json:"serial,omitempty"`
+	WinDriveLetter        string `json:"winDriveLetter,omitempty"`
 	ChangeTrackingEnabled bool   `json:"changeTrackingEnabled"`
 }
 
@@ -383,4 +385,29 @@ type GuestIpStack struct {
 	Network      string   `json:"network"`
 	PrefixLength int32    `json:"prefix"`
 	DNS          []string `json:"dns"`
+}
+
+// Guest disk.
+type GuestDisk struct {
+	// The key of the VirtualDevice.
+	//
+	// `VirtualDevice.key`
+	Key int32 `xml:"key" json:"key"`
+
+	// Name of the virtual disk in the guest operating system.
+	//
+	// For example: C:\\ ( in linux it can by a path like /home ).
+	DiskPath string `xml:"diskPath,omitempty" json:"diskPath,omitempty"`
+	// Total capacity of the disk, in bytes.
+	//
+	// This is part of the virtual machine configuration.
+	Capacity int64 `xml:"capacity,omitempty" json:"capacity,omitempty"`
+	// Free space on the disk, in bytes.
+	//
+	// This is retrieved by VMware Tools.
+	FreeSpace int64 `xml:"freeSpace,omitempty" json:"freeSpace,omitempty"`
+	// Filesystem type, if known.
+	//
+	// For example NTFS or ext3.
+	FilesystemType string `xml:"filesystemType,omitempty" json:"filesystemType,omitempty"`
 }

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -246,6 +246,7 @@ type VM struct {
 	Devices                  []model.Device       `json:"devices"`
 	NICs                     []model.NIC          `json:"nics"`
 	GuestNetworks            []model.GuestNetwork `json:"guestNetworks"`
+	GuestDisks               []model.GuestDisk    `json:"guestDisks"`
 	GuestIpStacks            []model.GuestIpStack `json:"guestIpStacks"`
 	SecureBoot               bool                 `json:"secureBoot"`
 	DiskEnableUuid           bool                 `json:"diskEnableUuid"`
@@ -281,6 +282,7 @@ func (r *VM) With(m *model.VM) {
 	r.NumaNodeAffinity = m.NumaNodeAffinity
 	r.NICs = m.NICs
 	r.GuestNetworks = m.GuestNetworks
+	r.GuestDisks = m.GuestDisks
 	r.GuestIpStacks = m.GuestIpStacks
 	r.SecureBoot = m.SecureBoot
 	r.DiskEnableUuid = m.DiskEnableUuid


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-2403

Issue
Users can't use the vmware disk path when creating a PVC name template

Fix:
Add disk path to the vmware pvcnametemplate
Field name is: `{{ .WinDriveLetter }}`

```bash
19:00 $ oc mtv inventory vms vsphere -q "select name, guestName, disks[*].winDriveLetter as drive, guestDisks[*].diskPath as mount where guestName ~= 'Linux 8'"
name                                 guestName                            drive       mount
mtv-rhel8-sanity-ceph-rbd            Red Hat Enterprise Linux 8 (64-bit)  []          []
mtv-rhel8-sanity-nfs                 Red Hat Enterprise Linux 8 (64-bit)  []          []
mtv-rhel8-warm-2disks2nics-nfs-4-19  Red Hat Enterprise Linux 8 (64-bit)  []          [/boot]
mtv-rhel8-sanity                     Red Hat Enterprise Linux 8 (64-bit)  []          []
mtv-rhel8-sanity-nfs-4-16            Red Hat Enterprise Linux 8 (64-bit)  []          []
mtv-rhel8-warm-2disks2nics-nfs       Red Hat Enterprise Linux 8 (64-bit)  []          []
mtv-rhel8-warm-2disks2nics-nfs-4-18  Red Hat Enterprise Linux 8 (64-bit)  []          [/boot]
mtv-rhel8-warm-2disks2nics-nfs-4-17  Red Hat Enterprise Linux 8 (64-bit)  []          []
mtv-rhel8-sanity-nfs-4-19            Red Hat Enterprise Linux 8 (64-bit)  []          [/boot]
mtv-rhel8-sanity-nfs-4-18            Red Hat Enterprise Linux 8 (64-bit)  []          []
mtv-rhel8-warm-2disks2nics-ceph-rbd  Red Hat Enterprise Linux 8 (64-bit)  []          []
mtv-rhel8-warm-2disks2nics-nfs-4-16  Red Hat Enterprise Linux 8 (64-bit)  []          [/boot]
mtv-rhel8-warm-2disks2nics           Red Hat Enterprise Linux 8 (64-bit)  []          []
mtv-rhel8-sanity-nfs-4-17            Red Hat Enterprise Linux 8 (64-bit)  []          []
✔ ~/Projects/kubev2v/forklift [collect-disk-guest-info|✔] 


19:00 $ oc mtv inventory vms vsphere -q "select name, guestName, disks[*].winDriveLetter as drive, guestDisks[*].diskPath as mount where guestName ~= 'Windows'"
name                          guestName                               drive       mount
mtv-win2019-79-ceph-rbd-4-17  Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-function-win2022          Microsoft Windows Server 2019 (64-bit)  []          []
mtv-function-win2022-test     Microsoft Windows Server 2019 (64-bit)  []          []
mtv-func-win2022              Microsoft Windows Server 2019 (64-bit)  []          []
mtv-win2019-79-nfs-4-16       Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-win2019-79                Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-win2019-79-ceph-rbd       Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-win2019-79-ceph-rbd-4-19  Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-win2019-79-nfs            Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-win2019-79-nfs-4-17       Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-win2019-79-nfs-4-18       Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-win2019-79-ceph-rbd-4-18  Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-win2019-79-ceph-rbd-4-16  Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]
mtv-func-win2019              Microsoft Windows Server 2012 (64-bit)  []          []
mtv-win2019-79-nfs-4-19       Microsoft Windows Server 2012 (64-bit)  [c]         [C:\]

```

Part of a fix for MTV-2403 -
Add an option to use disk path in cases the file name is not a good source of information for windows disk letter