### PR TITLE
chore | More verbose template validation errors

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -198,6 +198,8 @@ func (r *Reconciler) validatePVCNameTemplate(plan *api.Plan) error {
 		}
 
 		plan.Status.SetCondition(invalidPVCNameTemplate)
+
+		r.Log.Info("PVC name template is invalid", "error", err.Error(), "plan", plan.Name, "namespace", plan.Namespace)
 	}
 
 	return nil
@@ -214,6 +216,8 @@ func (r *Reconciler) validateVolumeNameTemplate(plan *api.Plan) error {
 		}
 
 		plan.Status.SetCondition(invalidPVCNameTemplate)
+
+		r.Log.Info("Volume name template is invalid", "error", err.Error(), "plan", plan.Name, "namespace", plan.Namespace)
 	}
 
 	return nil
@@ -230,6 +234,8 @@ func (r *Reconciler) validateNetworkNameTemplate(plan *api.Plan) error {
 		}
 
 		plan.Status.SetCondition(invalidPVCNameTemplate)
+
+		r.Log.Info("Network name template is invalid", "error", err.Error(), "plan", plan.Name, "namespace", plan.Namespace)
 	}
 
 	return nil
@@ -1385,7 +1391,8 @@ func (r *Reconciler) IsValidPVCNameTemplate(pvcNameTemplate string) error {
 	// Validate that template output is a valid k8s label
 	errs := k8svalidation.IsDNS1123Label(result)
 	if len(errs) > 0 {
-		return liberr.New("Template output is not a valid k8s label", "errors", errs)
+		errMsg := fmt.Sprintf("Template output is not a valid k8s label [%s]", result)
+		return liberr.New(errMsg, errs)
 	}
 
 	return nil
@@ -1409,7 +1416,8 @@ func (r *Reconciler) IsValidVolumeNameTemplate(volumeNameTemplate string) error 
 	// Validate that template output is a valid k8s label
 	errs := k8svalidation.IsDNS1123Label(result)
 	if len(errs) > 0 {
-		return liberr.New("Template output is not a valid k8s label", "errors", errs)
+		errMsg := fmt.Sprintf("Template output is not a valid k8s label [%s]", result)
+		return liberr.New(errMsg, errs)
 	}
 
 	return nil
@@ -1435,7 +1443,8 @@ func (r *Reconciler) IsValidNetworkNameTemplate(networkNameTemplate string) erro
 	// Validate that template output is a valid k8s label
 	errs := k8svalidation.IsDNS1123Label(result)
 	if len(errs) > 0 {
-		return liberr.New("Template output is not a valid k8s label", "errors", errs)
+		errMsg := fmt.Sprintf("Template output is not a valid k8s label [%s]", result)
+		return liberr.New(errMsg, errs)
 	}
 
 	return nil

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -114,7 +114,11 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 		var reconciler *Reconciler
 
 		ginkgo.BeforeEach(func() {
-			reconciler = &Reconciler{}
+			reconciler = &Reconciler{
+				Reconciler: base.Reconciler{
+					Log: planValidationLog,
+				},
+			}
 		})
 
 		source := createProvider(sourceName, sourceNamespace, "", v1beta1.OpenShift, &core.ObjectReference{Name: sourceSecretName, Namespace: sourceNamespace})
@@ -141,7 +145,6 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 				if shouldBeValid {
 					gomega.Expect(hasInvalidCondition).To(gomega.BeFalse())
 				} else {
-
 					gomega.Expect(hasInvalidCondition).To(gomega.BeTrue())
 				}
 			},
@@ -164,7 +167,11 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 		var reconciler *Reconciler
 
 		ginkgo.BeforeEach(func() {
-			reconciler = &Reconciler{}
+			reconciler = &Reconciler{
+				Reconciler: base.Reconciler{
+					Log: planValidationLog,
+				},
+			}
 		})
 
 		ginkgo.DescribeTable("should validate PVC name template correctly",


### PR DESCRIPTION
Issue:
Template validation errors are not very helpful

Fix:
Add more information about template validation errors

Examples:
``` bash
14:50 $ oc mtv plan create bad-template-1 -S vmw --vms mtv-func-win2022 --pvc-name-template "pvc-{{ .FileName }}"
No target provider specified, using default OpenShift provider: host
NetworkMap 'bad-template-1-hc77x' created in namespace 'openshift-mtv'
StorageMap 'bad-template-1-f5dzv' created in namespace 'openshift-mtv'
No target namespace specified, using plan namespace: openshift-mtv
Plan 'bad-template-1' created in namespace 'openshift-mtv'

14:51 $ oc mtv plan create bad-template-2 -S vmw --vms mtv-func-win2022 --pvc-name-template "pvc-{{ .fileName }}"
No target provider specified, using default OpenShift provider: host
NetworkMap 'bad-template-2-4gq4x' created in namespace 'openshift-mtv'
StorageMap 'bad-template-2-6nzpp' created in namespace 'openshift-mtv'
No target namespace specified, using plan namespace: openshift-mtv
Plan 'bad-template-2' created in namespace 'openshift-mtv'
```

``` bash
15:09 $ oc logs forklift-controller-7c85686cf8-ldfbk | grep "template is invalid"
Defaulted container "main" out of: main, inventory
{"level":"info","ts":"2025-06-10 12:09:11.164","logger":"plan|9q8v8","msg":"Condition deleted.","plan":{"name":"bad-template-1","namespace":"openshift-mtv"},"condition":{"type":"NotValid","status":"True","category":"Critical","message":"PVC name template is invalid: Template output is not a valid k8s label [pvc-[test07_ds1] test_sp/test-000001.vmdk]","lastTransitionTime":"2025-06-10T11:51:13Z"}}
{"level":"debug","ts":"2025-06-10 12:09:11.165","logger":"events","msg":"PVC name template is invalid: Template output is not a valid k8s label [pvc-[test07_ds1] test_sp/test-000001.vmdk]","type":"Warning","object":{"kind":"Plan","namespace":"openshift-mtv","name":"bad-template-1","uid":"fc60121c-5e59-4d58-acd8-3a93f27547d8","apiVersion":"forklift.konveyor.io/v1beta1","resourceVersion":"2257841"},"reason":"NotValid"}
{"level":"info","ts":"2025-06-10 12:09:11.173","logger":"plan|sb6sk","msg":"Condition deleted.","plan":{"name":"bad-template-2","namespace":"openshift-mtv"},"condition":{"type":"NotValid","status":"True","category":"Critical","message":"PVC name template is invalid: Template execution failed caused by: 'Template execution failed' caused by: 'template: template:1:7: executing \"template\" at <.fileName>: can't evaluate field fileName in type v1beta1.PVCNameTemplateData'","lastTransitionTime":"2025-06-10T11:51:29Z"}}
```