### PR TITLE
inventory: Don't return error when a single provider fails

### DIFF
--- a/pkg/controller/provider/web/ocp/provider.go
+++ b/pkg/controller/provider/web/ocp/provider.go
@@ -107,8 +107,8 @@ func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, 
 			r.With(m)
 			aErr := h.AddCount(&r)
 			if aErr != nil {
-				err = aErr
-				return
+				log.Error(aErr, "Failed to get count for provider", "provider", p.Name, "url", ctx.Request.URL)
+				continue
 			}
 			r.Link()
 			content = append(content, r.Content(h.Detail))


### PR DESCRIPTION
When getting an error for single provider, we were returning an error response status, which caused the UI to display an "inventory cannot be reached" error rather than showing the information for the providers that succeeded. Change this to log the error but still return partial data to provide a better user experience.

Fixes https://issues.redhat.com/browse/MTV-2701
