### PR TITLE
MTV-2715 | OCP provider failed to create

### DIFF
--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -242,7 +242,6 @@ func (r *Reconciler) validateSecret(provider *api.Provider) (secret *core.Secret
 	case api.OpenShift:
 		keyList = []string{"token"}
 
-		r.validateConnectionStatus(provider, secret)
 	case api.VSphere:
 		keyList = []string{
 			"user",


### PR DESCRIPTION
Issue:
Connection failed when create OCP Provider with "Fetch certificate from URL"

Fix:
The validate connection status was added by mistake to ocp provider as part of a conclustive tls issues fixes.

Ref: https://issues.redhat.com/browse/MTV-2715