### PR TITLE
ECOPROJECT-3074 | Adding a unique ID for Rego validation files

### DIFF
--- a/pkg/controller/provider/model/base/model.go
+++ b/pkg/controller/provider/model/base/model.go
@@ -45,6 +45,7 @@ func (r InvalidKindError) Error() string {
 
 // VM concerns.
 type Concern struct {
+	Id         string `json:"id"`
 	Label      string `json:"label"`
 	Category   string `json:"category"`
 	Assessment string `json:"assessment"`

--- a/validation/README.adoc
+++ b/validation/README.adoc
@@ -30,6 +30,7 @@ has_drs_enabled {
 concerns[flag] {
     has_drs_enabled
     flag := {
+        "id": "vmware.drs.enabled",
         "category": "Information",
         "label": "VM running in a DRS-enabled cluster",
         "assessment": "Distributed resource scheduling is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment."
@@ -122,6 +123,7 @@ data:
     concerns[flag] {
       has_multiple_disks
         flag := {
+          "id": "custom.multiple_disk.detected",
           "category": "Information",
           "label": "Multiple disks detected",
           "assessment": "Example user-supplied extra validation rule - multiple disks have been detected on this VM."
@@ -220,36 +222,43 @@ The JSON body output from the validation service is a _result_ hash whose value 
    "result": {
        "concerns": [
            {
+               "id": "vmware.drs.enabled",
                "assessment": "Distributed resource scheduling is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
                "category": "Information",
                "label": "VM running in a DRS-enabled cluster"
            },
            {
+               "id": "vmware.cpu_memory.hotplug.enabled",
                "assessment": "Hot pluggable CPU or memory is not currently supported by OpenShift Virtualization. Review CPU or memory configuration after migration.",
                "category": "Warning",
                "label": "CPU/Memory hotplug detected"
            },
            {
+               "id": "vmware.multiple_disk",
                "assessment": "Multiple disks have been detected on this VM.",
                "category": "Information",
                "label": "Multiple disks detected"
            },
            {
+               "id": "vmware.numa_affinity.detected",
                "assessment": "NUMA node affinity is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
                "category": "Warning",
                "label": "NUMA node affinity detected"
            },
            {
+               "id":"vmware.snapshot.detected",
                "assessment": "Online snapshots are not currently supported by OpenShift Virtualization.",
                "category": "Information",
                "label": "VM snapshot detected"
            },
            {
+               "id": "vmware.cpu_affinity.detected",
                "assessment": "CPU affinity is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
                "category": "Warning",
                "label": "CPU affinity detected"
            },
            {
+               "id": "vmware.changed_block_tracking.disabled",
                "assessment": "Changed Block Tracking (CBT) has not been enabled on this VM. This feature is a prerequisite for VM warm migration.",
                "category": "Warning",
                "label": "Changed Block Tracking (CBT) not enabled"

--- a/validation/policies/io/konveyor/forklift/openstack/bios_boot_menu.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/bios_boot_menu.rego
@@ -9,6 +9,7 @@ has_boot_menu_enabled if input.image.properties.hw_boot_menu == "true"
 concerns[flag] {
 	has_boot_menu_enabled
 	flag := {
+		"id": "openstack.bios.boot_menu.enabled",
 		"category": "Warning",
 		"label": "VM has BIOS boot menu enabled",
 		"assessment": "The VM has a BIOS boot menu enabled. This is not currently supported by OpenShift Virtualization. The VM can be migrated but the BIOS boot menu will not be enabled in the target environment.",

--- a/validation/policies/io/konveyor/forklift/openstack/cpu_shares.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/cpu_shares.rego
@@ -10,6 +10,7 @@ has_cpushares_enabled if "quota:cpu_shares" in object.keys(input.flavor.extraSpe
 concerns[flag] {
 	has_cpushares_enabled
 	flag := {
+		"id": "openstack.cpu.shares.defined",
 		"category": "Warning",
 		"label": "VM has CPU Shares Defined",
 		"assessment": "The VM has CPU shares defined. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but the CPU shares configuration will be missing in the target environment.",

--- a/validation/policies/io/konveyor/forklift/openstack/disk_interface_type.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_interface_type.rego
@@ -11,6 +11,7 @@ invalid_disk_interface if {
 concerns[flag] {
 	invalid_disk_interface
 	flag := {
+	    "id": "openstack.disk.unsupported_interface",
 		"category": "Warning",
 		"label": "Unsupported disk interface type detected",
 		"assessment": "The disk interface type is not supported by OpenShift Virtualization (only sata, scsi and virtio interface types are currently supported). The migrated VM will be given a virtio disk interface type.",

--- a/validation/policies/io/konveyor/forklift/openstack/disk_status.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_status.rego
@@ -8,6 +8,7 @@ valid_disk_status[i] {
 concerns[flag] {
 	count(valid_disk_status) != count(input.volumes)
 	flag := {
+		"id": "openstack.disk.status.unsupported",
 		"category": "Critical",
 		"label": "VM has one or more disks with an unsupported status",
 		"assessment": "One or more of the VM's disks has an unsupported status condition. The VM disk transfer is likely to fail.",

--- a/validation/policies/io/konveyor/forklift/openstack/floating_ips.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/floating_ips.rego
@@ -10,6 +10,7 @@ floating_ips[i] {
 concerns[flag] {
 	count(floating_ips) != 0
 	flag := {
+		"id": "openstack.network.floating_ips.detected",
 		"category": "Warning",
 		"label": "Floating IPs detected",
 		"assessment": "The VM has floating IPs assigned. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but the Floating IP configuration will be missing in the target environment.",

--- a/validation/policies/io/konveyor/forklift/openstack/host_devices.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/host_devices.rego
@@ -10,6 +10,7 @@ host_devices if "pci_passthrough:alias" in object.keys(input.flavor.extraSpecs)
 concerns[flag] {
 	host_devices
 	flag := {
+		"id": "openstack.host_devices.mapped",
 		"category": "Warning",
 		"label": "VM has mapped host devices",
 		"assessment": "The VM is configured with hardware devices mapped from the host. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have any host device attached to it in the target environment.",

--- a/validation/policies/io/konveyor/forklift/openstack/name.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/name.rego
@@ -24,6 +24,7 @@ concerns[flag] {
 	valid_vm_string
 	not valid_vm_name
 	flag := {
+		"id": "openstack.vm.name.invalid",
 		"category": "Warning",
 		"label": "Invalid VM Name",
 		"assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters.",

--- a/validation/policies/io/konveyor/forklift/openstack/numa_tune.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/numa_tune.rego
@@ -12,6 +12,7 @@ has_numa_enabled if "hw:numa_nodes" in object.keys(input.flavor.extraSpecs)
 concerns[flag] {
 	has_numa_enabled
 	flag := {
+		"id": "openstack.numa_tuning.detected",
 		"category": "Warning",
 		"label": "NUMA tuning detected",
 		"assessment": "NUMA tuning is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this NUMA mapping in the target environment.",

--- a/validation/policies/io/konveyor/forklift/openstack/secure_boot.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/secure_boot.rego
@@ -11,6 +11,7 @@ secure_boot_enabled if input.flavor.extraSpecs["os:secure_boot"] == "required"
 concerns[flag] {
 	secure_boot_enabled
 	flag := {
+		"id": "openstack.secure_boot.detected",
 		"category": "Warning",
 		"label": "UEFI secure boot detected",
 		"assessment": "UEFI secure boot is currently only partially supported by OpenShift Virtualization. Some functionality may be missing after the VM is migrated.",

--- a/validation/policies/io/konveyor/forklift/openstack/shared_disk.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/shared_disk.rego
@@ -10,6 +10,7 @@ shared_disks[i] {
 concerns[flag] {
 	count(shared_disks) > 0
 	flag := {
+	    "id": "openstack.disk.shared.detected",
 		"category": "Warning",
 		"label": "Shared disk detected",
 		"assessment": "The VM has a disk that is shared. Shared disks are not currently supported by OpenShift Virtualization.",

--- a/validation/policies/io/konveyor/forklift/openstack/vif_models.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vif_models.rego
@@ -11,6 +11,7 @@ invalid_vif_model if {
 concerns[flag] {
 	invalid_vif_model
 	flag := {
+	    "id": "openstack.network.vif_model.unsupported",
 		"category": "Warning",
 		"label": "Unsupported VIF model detected",
 		"assessment": "The VIF model is not supported by OpenShift Virtualization (only e1000, e1000e, rtl8139, ne2k_pci, pcnet and virtio VIF models are currently supported). The migrated VM will be given a virtio VIF model.",

--- a/validation/policies/io/konveyor/forklift/openstack/vm_os.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vm_os.rego
@@ -37,6 +37,7 @@ has_unsupported_guest_os if {
 concerns[flag] {
 	has_unsupported_guest_os
 	flag := {
+	    "id": "openstack.os.unsupported",
 		"category": "Warning",
 		"label": "Unsupported operative system detected",
 		"assessment": "The VM is running an operative system that is not currently supported by OpenShift Virtualization.",

--- a/validation/policies/io/konveyor/forklift/openstack/vm_status.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vm_status.rego
@@ -14,6 +14,7 @@ concerns[flag] {
 	valid_status_string
 	not legal_vm_status
 	flag := {
+	    "id": "openstack.vm.status.invalid",
 		"category": "Critical",
 		"label": "VM has a status condition that may prevent successful migration",
 		"assessment": "The VM's status is not 'ACTIVE' or 'SHUTOFF'. Attempting to migrate this VM may fail.",

--- a/validation/policies/io/konveyor/forklift/openstack/watchdog.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/watchdog.rego
@@ -12,6 +12,7 @@ has_watchdog_enabled if input.image.properties.hw_watchdog_action
 concerns[flag] {
 	has_watchdog_enabled
 	flag := {
+	    "id": "openstack.watchdog.detected",
 		"category": "Warning",
 		"label": "Watchdog detected",
 		"assessment": "The VM is configured with a watchdog device, which is not currently supported by OpenShift Virtualization. A watchdog device will not be present in the destination VM.",

--- a/validation/policies/io/konveyor/forklift/ova/cpu_affinity.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_affinity.rego
@@ -7,6 +7,7 @@ has_cpu_affinity {
 concerns[flag] {
     has_cpu_affinity
     flag := {
+        "id": "ova.cpu_affinity.detected",
         "category": "Warning",
         "label": "CPU affinity detected",
         "assessment": "The VM will be migrated without CPU affinity, but administrators can set it after migration."

--- a/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug.rego
@@ -17,6 +17,7 @@ has_hotplug_enabled = true {
 concerns[flag] {
     has_hotplug_enabled
     flag := {
+        "id": "ova.cpu_memory.hotplug.enabled",
         "category": "Warning",
         "label": "CPU/Memory hotplug detected",
         "assessment": "Hot pluggable CPU or memory is not currently supported by Migration Toolkit for Virtualization. You can reconfigure CPU or memory after migration."

--- a/validation/policies/io/konveyor/forklift/ova/export_source.rego
+++ b/validation/policies/io/konveyor/forklift/ova/export_source.rego
@@ -7,6 +7,7 @@ unsupported_export_source {
 concerns[flag] {
     unsupported_export_source
     flag := {
+        "id": "ova.source.unsupported",
         "category": "Warning",
         "label": "Unsupported OVA source",
         "assessment": "This OVA may not have been exported from a VMware source, and may have issues during import."

--- a/validation/policies/io/konveyor/forklift/ova/name.rego
+++ b/validation/policies/io/konveyor/forklift/ova/name.rego
@@ -22,6 +22,7 @@ concerns[flag] {
     valid_vm
     not valid_vm_name
     flag := {
+        "id": "ova.name.invalid",
         "category": "Warning",
         "label": "Invalid VM Name",
         "assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters."

--- a/validation/policies/io/konveyor/forklift/ovirt/ballooned_memory.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ballooned_memory.rego
@@ -9,6 +9,7 @@ has_ballooned_memory = value {
 concerns[flag] {
     has_ballooned_memory
     flag := {
+        "id": "ovirt.memory.ballooning.enabled",
         "category": "Information",
         "label": "VM has memory ballooning enabled",
         "assessment": "The VM has memory ballooning enabled. This is not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/bios_boot_menu.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/bios_boot_menu.rego
@@ -9,6 +9,7 @@ has_boot_menu_enabled = value {
 concerns[flag] {
     has_boot_menu_enabled
     flag := {
+        "id": "ovirt.bios.boot_menu.enabled",
         "category": "Warning",
         "label": "VM has BIOS boot menu enabled",
         "assessment": "The VM has a BIOS boot menu enabled. This is not currently supported by OpenShift Virtualization. The VM can be migrated but the BIOS boot menu will not be enabled in the target environment."

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_custom_model.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_custom_model.rego
@@ -9,6 +9,7 @@ custom_cpu_model = true {
 concerns[flag] {
     custom_cpu_model
     flag := {
+        "id": "ovirt.cpu.custom_model.detected",
         "category": "Warning",
         "label": "Custom CPU Model detected",
         "assessment": "The VM is configured with a custom CPU model. This configuration will apply to the migrated VM and may not be supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_policy.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_policy.rego
@@ -10,6 +10,7 @@ not_supported_cpu_policy = true {
 concerns[flag] {
     not_supported_cpu_policy
     flag := {
+        "id": "ovirt.cpu.pinning_policy.unsupported",
         "category": "Warning",
         "label": "Unsupported CPU pinning policy detected",
         "assessment": "Resize and Pin NUMA and Isolated Threads are not supported by OpenShift Virtualization. Some functionality may be missing after the VM is migrated."

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_shares.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_shares.rego
@@ -9,6 +9,7 @@ has_cpushares_enabled = true {
 concerns[flag] {
     has_cpushares_enabled
     flag := {
+        "id": "ovirt.cpu.shares.defined",
         "category": "Warning",
         "label": "VM has CPU Shares Defined",
         "assessment": "The VM has CPU shares defined. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but the CPU shares configuration will be missing in the target environment."

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_tune.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_tune.rego
@@ -9,6 +9,7 @@ has_cpu_affinity = true {
 concerns[flag] {
     has_cpu_affinity
     flag := {
+        "id": "ovirt.cpu.tuning.detected",
         "category": "Warning",
         "label": "CPU tuning detected",
         "assessment": "CPU tuning other than 1 vCPU - 1 pCPU is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment."

--- a/validation/policies/io/konveyor/forklift/ovirt/custom_properties.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/custom_properties.rego
@@ -9,6 +9,7 @@ vm_has_custom_properties = true {
 concerns[flag] {
     vm_has_custom_properties
     flag := {
+        "id": "ovirt.vm.custom_properties.detected",
         "category": "Warning",
         "label": "VM custom properties detected",
         "assessment": "The VM is configured with custom properties, which are not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_interface_type.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_interface_type.rego
@@ -13,6 +13,7 @@ number_of_disks [i] {
 concerns[flag] {
     count(valid_disk_interfaces) != count(number_of_disks)
     flag := {
+        "id": "ovirt.disk.interface_type.unsupported",
         "category": "Warning",
         "label": "Unsupported disk interface type detected",
         "assessment": "The disk interface type is not supported by OpenShift Virtualization (only sata, virtio_scsi and virtio interface types are currently supported). The migrated VM will be given a virtio disk interface type."

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_status.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_status.rego
@@ -8,6 +8,7 @@ invalid_disk_status [i] {
 concerns[flag] {
     count(invalid_disk_status) > 0
     flag := {
+        "id": "ovirt.disk.illegal_or_locked_status",
         "category": "Critical",
         "label": "VM has an illegal or locked disk status condition",
         "assessment": "One or more of the VM's disks has an illegal or locked status condition. The VM disk transfer is likely to fail."

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type.rego
@@ -13,6 +13,7 @@ valid_disk_storage_type_lun [i] {
 concerns[flag] {
     count(valid_disk_storage_type) + count(valid_disk_storage_type_lun) != count(number_of_disks)
     flag := {
+        "id": "ovirt.disk.storage_type.unsupported",
         "category": "Critical",
         "label": "Unsupported disk storage type detected",
         "assessment": "The VM has a disk with a storage type other than 'image' or 'lun', which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."

--- a/validation/policies/io/konveyor/forklift/ovirt/display_type.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/display_type.rego
@@ -9,6 +9,7 @@ has_spice_display_enabled = true {
 concerns[flag] {
     has_spice_display_enabled
     flag := {
+        "id": "ovirt.display_type.spice.enabled",
         "category": "Information",
         "label": "VM Display Type",
         "assessment": "The VM is using the SPICE protocol for video display. This is not supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/ha.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ha.rego
@@ -9,6 +9,7 @@ has_ha_enabled = value {
 concerns[flag] {
     has_ha_enabled
     flag := {
+        "id": "ovirt.ha.enabled",
         "category": "Warning",
         "label": "VM configured as HA",
         "assessment": "The VM is configured to be highly available. High availability is not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/ha_reservation.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ha_reservation.rego
@@ -9,6 +9,7 @@ has_ha_reservation = value {
 concerns[flag] {
     has_ha_reservation
     flag := {
+        "id": "ovirt.ha.reservation.enabled",
         "category": "Warning",
         "label": "Cluster has HA reservation",
         "assessment": "The cluster running the source VM has a resource reservation to allow highly available VMs to be started. This feature is not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/host_devices.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/host_devices.rego
@@ -9,6 +9,7 @@ has_host_devices = true {
 concerns[flag] {
     has_host_devices
     flag := {
+        "id": "ovirt.host_devices.mapped",
         "category": "Warning",
         "label": "VM has mapped host devices",
         "assessment": "The VM is configured with hardware devices mapped from the host. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have any host device attached to it in the target environment."

--- a/validation/policies/io/konveyor/forklift/ovirt/illegal_images.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/illegal_images.rego
@@ -9,6 +9,7 @@ has_illegal_images = value {
 concerns[flag] {
     has_illegal_images
     flag := {
+        "id": "ovirt.disk.illegal_images.detected",
         "category": "Critical",
         "label": "Illegal disk images detected",
         "assessment": "The VM has one or more snapshots with disks in ILLEGAL state, which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."

--- a/validation/policies/io/konveyor/forklift/ovirt/io_threads.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/io_threads.rego
@@ -9,6 +9,7 @@ has_iothreads_enabled = true {
 concerns[flag] {
     has_iothreads_enabled
     flag := {
+        "id": "ovirt.iothreads.configured",
         "category": "Information",
         "label": "IO Threads configuration detected",
         "assessment": "The VM is configured to use I/O threads. This configuration will not be automatically applied to the migrated VM, and must be manually re-applied if required."

--- a/validation/policies/io/konveyor/forklift/ovirt/ksm.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ksm.rego
@@ -9,6 +9,7 @@ has_ksm_enabled = value {
 concerns[flag] {
     has_ksm_enabled
     flag := {
+        "id": "ovirt.cluster.ksm_enabled",
         "category": "Warning",
         "label": "Cluster has KSM enabled",
         "assessment": "The host running the source VM has kernel samepage merging enabled for more efficient memory utilization. This feature is not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name.rego
@@ -22,6 +22,7 @@ concerns[flag] {
     valid_vm_string
     not valid_vm_name
     flag := {
+        "id": "ovirt.name.invalid",
         "category": "Warning",
         "label": "Invalid VM Name",
         "assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters. "

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_custom_properties.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_custom_properties.rego
@@ -9,6 +9,7 @@ vnic_has_custom_properties = true {
 concerns[flag] {
     vnic_has_custom_properties
     flag := {
+        "id": "ovirt.nic.custom_properties.detected",
         "category": "Warning",
         "label": "vNIC custom properties detected",
         "assessment": "The VM's vNIC Profile is configured with custom properties, which are not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_interface_type.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_interface_type.rego
@@ -13,6 +13,7 @@ number_of_nics [i] {
 concerns[flag] {
     count(valid_nic_interfaces) != count(number_of_nics)
     flag := {
+        "id": "ovirt.nic.interface_type.unsupported",
         "category": "Warning",
         "label": "Unsupported NIC interface type detected",
         "assessment": "The NIC interface type is not supported by OpenShift Virtualization (only e1000, rtl8139 and virtio interface types are currently supported). The migrated VM will be given a virtio NIC interface type."

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_network_filter.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_network_filter.rego
@@ -8,6 +8,7 @@ nics_with_nework_filter_enabled [i] {
 concerns[flag] {
     count(nics_with_nework_filter_enabled) > 0
     flag := {
+        "id": "ovirt.nic.network_filter.detected",
         "category": "Warning",
         "label": "NIC with network filter detected",
         "assessment": "The VM is using a vNIC Profile configured with a network filter. These are not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_pci_passthrough.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_pci_passthrough.rego
@@ -8,6 +8,7 @@ nic_set_to_pci_passthrough [i] {
 concerns[flag] {
     count(nic_set_to_pci_passthrough) > 0
     flag := {
+        "id": "ovirt.nic.pci_passthrough.detected",
         "category": "Warning",
         "label": "NIC with host device passthrough detected",
         "assessment": "The VM is using a vNIC profile configured for host device passthrough, which is not currently supported by OpenShift Virtualization. The VM will be configured with an SRIOV NIC, but the destination network will need to be set up correctly."

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_plugged.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_plugged.rego
@@ -8,6 +8,7 @@ unplugged_nics [i] {
 concerns[flag] {
     count(unplugged_nics) > 0
     flag := {
+        "id": "ovirt.nic.unplugged.detected",
         "category": "Warning",
         "label": "Unplugged NIC detected",
         "assessment": "The VM has a NIC that is unplugged from a network. This is not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_port_mirroring.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_port_mirroring.rego
@@ -8,6 +8,7 @@ nics_with_port_mirroring_enabled [i] {
 concerns[flag] {
     count(nics_with_port_mirroring_enabled) > 0
     flag := {
+        "id": "ovirt.nic.port_mirroring.detected",
         "category": "Warning",
         "label": "NIC with port mirroring detected",
         "assessment": "The VM is using a vNIC Profile configured with port mirroring. This is not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_qos.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_qos.rego
@@ -8,6 +8,7 @@ nics_with_qos_enabled [i] {
 concerns[flag] {
     count(nics_with_qos_enabled) > 0
     flag := {
+        "id": "ovirt.nic.qos.detected",
         "category": "Warning",
         "label": "NIC with QoS settings detected",
         "assessment": "The VM has a vNIC Profile that includes Quality of Service settings. This is not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/numa_tune.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/numa_tune.rego
@@ -9,6 +9,7 @@ has_numa_affinity = true {
 concerns[flag] {
     has_numa_affinity
     flag := {
+        "id": "ovirt.numa.tuning.detected",
         "category": "Warning",
         "label": "NUMA tuning detected",
         "assessment": "NUMA tuning is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this NUMA mapping in the target environment."

--- a/validation/policies/io/konveyor/forklift/ovirt/online_snapshot.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/online_snapshot.rego
@@ -8,6 +8,7 @@ online_snapshots [i] {
 concerns[flag] {
     count(online_snapshots) > 0
     flag := {
+        "id": "ovirt.snapshot.online_memory.detected",
         "category": "Warning",
         "label": "Online (memory) snapshot detected",
         "assessment": "The VM has a snapshot that contains a memory copy. Online snapshots such as this are not curently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/placement_policy.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/placement_policy.rego
@@ -9,6 +9,7 @@ warn_placement_policy = true {
 concerns[flag] {
     warn_placement_policy
     flag := {
+        "id": "ovirt.placement_policy.affinity_set",
         "category": "Warning",
         "label": "Placement policy affinity",
         "assessment": "The VM has a placement policy affinity setting that requires live migration to be enabled in OpenShift Virtualization for compatibility. The target storage classes must also support RWX access mode."

--- a/validation/policies/io/konveyor/forklift/ovirt/scsi_reservation.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/scsi_reservation.rego
@@ -8,6 +8,7 @@ disks_with_scsi_reservation [i] {
 concerns[flag] {
     count(disks_with_scsi_reservation) > 0
     flag := {
+        "id": "ovirt.disk.scsi_reservation.enabled",
         "category": "Warning",
         "label": "Shared disk detected",
         "assessment": "The VM has a disk that is shared. Shared disks are not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/secure_boot.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/secure_boot.rego
@@ -9,6 +9,7 @@ secure_boot_enabled = true {
 concerns[flag] {
     secure_boot_enabled
     flag := {
+        "id": "ovirt.secure_boot.detected",
         "category": "Warning",
         "label": "UEFI secure boot detected",
         "assessment": "UEFI secure boot is currently only partially supported by OpenShift Virtualization. Some functionality may be missing after the VM is migrated."

--- a/validation/policies/io/konveyor/forklift/ovirt/shared_disk.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/shared_disk.rego
@@ -8,6 +8,7 @@ shared_disks [i] {
 concerns[flag] {
     count(shared_disks) > 0
     flag := {
+        "id": "ovirt.disk.shared.detected",
         "category": "Warning",
         "label": "Shared disk detected",
         "assessment": "The VM has a disk that is shared. Shared disks are not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/storage_error_resume_behaviour.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/storage_error_resume_behaviour.rego
@@ -9,6 +9,7 @@ storage_error_resume_behaviour = true {
 concerns[flag] {
     storage_error_resume_behaviour
     flag := {
+        "id": "ovirt.storage.resume_behavior.unsupported",
         "category": "Information",
         "label": "VM storage error resume behavior",
         "assessment": sprintf("The VM has storage error resume behavior set to '%v', which is not currently supported by OpenShift Virtualization", [input.storageErrorResumeBehaviour])

--- a/validation/policies/io/konveyor/forklift/ovirt/tpm.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/tpm.rego
@@ -9,6 +9,7 @@ has_tpm_os = true {
 concerns[flag] {
     has_tpm_os
     flag := {
+        "id": "ovirt.tpm.required_by_os",
         "category": "Warning",
         "label": "TPM detected",
         "assessment": "The VM is detected with an operation system that must have a TPM device. TPM data is not transferred during the migration."

--- a/validation/policies/io/konveyor/forklift/ovirt/usb.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/usb.rego
@@ -9,6 +9,7 @@ has_usb_enabled = value {
 concerns[flag] {
     has_usb_enabled
     flag := {
+        "id": "ovirt.usb.enabled",
         "category": "Warning",
         "label": "USB support enabled",
         "assessment": "The VM has USB support enabled, but USB device attachment is not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/vm_os.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/vm_os.rego
@@ -9,6 +9,7 @@ has_unsupported_os = true {
 concerns[flag] {
     has_unsupported_os
     flag := {
+        "id": "ovirt.os.unsupported",
         "category": "Warning",
         "label": "Unsupported operating system detected",
         "assessment": "The guest operating system is RHEL6 which is not currently supported by OpenShift Virtualization."

--- a/validation/policies/io/konveyor/forklift/ovirt/vm_status.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/vm_status.rego
@@ -15,6 +15,7 @@ concerns[flag] {
     valid_status_string
     not legal_vm_status
     flag := {
+        "id": "ovirt.vm.status_invalid",
         "category": "Critical",
         "label": "VM has a status condition that may prevent successful migration",
         "assessment": "The VM's status is not 'up' or 'down'. Attempting to migrate this VM may fail."

--- a/validation/policies/io/konveyor/forklift/ovirt/watchdog.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/watchdog.rego
@@ -9,6 +9,7 @@ has_watchdog_enabled = true {
 concerns[flag] {
     has_watchdog_enabled
     flag := {
+        "id": "ovirt.watchdog.enabled",
         "category": "Warning",
         "label": "Watchdog detected",
         "assessment": "The VM is configured with a watchdog device, which is not currently supported by OpenShift Virtualization. A watchdog device will not be present in the destination VM."

--- a/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking.rego
@@ -7,6 +7,7 @@ change_tracking_disabled {
 concerns[flag] {
     change_tracking_disabled
     flag := {
+        "id": "vmware.changed_block_tracking.disabled",
         "category": "Warning",
         "label": "Changed Block Tracking (CBT) not enabled",
         "assessment": "For VM warm migration, Changed Block Tracking (CBT) must be enabled in VMware."

--- a/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disk.rego
@@ -18,6 +18,7 @@ concerns[flag] {
     deviceKey := sprintf("%s%d:%d", [disk.bus, controllerIndex, disk.unitNumber])
 
     flag := {
+        "id": "vmware.changed_block_tracking.disk.disabled",
         "category": "Warning",
         "label": sprintf("Disk - %s does not have CBT enabled", [deviceKey]),
         "assessment": "Changed Block Tracking (CBT) has not been enabled for this device. This feature is a prerequisite for VM warm migration."

--- a/validation/policies/io/konveyor/forklift/vmware/cpu_affinity.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/cpu_affinity.rego
@@ -7,6 +7,7 @@ has_cpu_affinity {
 concerns[flag] {
     has_cpu_affinity
     flag := {
+        "id": "vmware.cpu_affinity.detected",
         "category": "Warning",
         "label": "CPU affinity detected",
         "assessment": "The VM will be migrated without CPU affinity, but administrators can set it after migration."

--- a/validation/policies/io/konveyor/forklift/vmware/cpu_memory_hotplug.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/cpu_memory_hotplug.rego
@@ -17,6 +17,7 @@ has_hotplug_enabled = true {
 concerns[flag] {
     has_hotplug_enabled
     flag := {
+        "id": "vmware.cpu_memory.hotplug.enabled",
         "category": "Warning",
         "label": "CPU/Memory hotplug detected",
         "assessment": "Hot pluggable CPU or memory is not currently supported by Migration Toolkit for Virtualization. You can reconfigure CPU or memory after migration."

--- a/validation/policies/io/konveyor/forklift/vmware/datastore.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/datastore.rego
@@ -8,6 +8,7 @@ null_datastore {
 concerns[flag] {
     null_datastore
     flag := {
+        "id": "vmware.datastore.missing",
         "category": "Critical",
         "label": "Disk is not located on a datastore",
         "assessment": "The VM is configured with a disk that is not located on a datastore. The VM cannot be migrated."

--- a/validation/policies/io/konveyor/forklift/vmware/disk_mode.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_mode.rego
@@ -9,6 +9,7 @@ independent_disk {
 concerns[flag] {
     independent_disk
     flag := {
+        "id": "vmware.disk_mode.independent",
         "category": "Critical",
         "label": "Independent disk detected",
         "assessment": "Independent disks cannot be transferred using recent versions of VDDK. The VM cannot be migrated unless disks are changed to 'Dependent' mode in VMware."

--- a/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers.rego
@@ -9,8 +9,9 @@ disk_uuid_enabled {
 concerns[flag] {
     disk_uuid_enabled
     flag := {
+        "id": "vmware.disk_serial.truncated",
         "category": "Information",
-	"label": "Disk serial numbers may be truncated",
-	"assessment": "This VM is configured with at least one SCSI disk and the disk.EnableUUID parameter is set to TRUE. This may indicate a need for consistent SCSI disk serial numbers, but be advised that these serial numbers will be truncated after migration."
+        "label": "Disk serial numbers may be truncated",
+        "assessment": "This VM is configured with at least one SCSI disk and the disk.EnableUUID parameter is set to TRUE. This may indicate a need for consistent SCSI disk serial numbers, but be advised that these serial numbers will be truncated after migration."
     }
 }

--- a/validation/policies/io/konveyor/forklift/vmware/dpm_enabled.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/dpm_enabled.rego
@@ -7,6 +7,7 @@ has_dpm_enabled {
 concerns[flag] {
     has_dpm_enabled
     flag := {
+        "id": "vmware.dpm.enabled",
         "category": "Information",
         "label": "vSphere DPM detected",
         "assessment": "Distributed Power Management is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment. "

--- a/validation/policies/io/konveyor/forklift/vmware/drs_enabled.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/drs_enabled.rego
@@ -7,6 +7,7 @@ has_drs_enabled {
 concerns[flag] {
     has_drs_enabled
     flag := {
+        "id": "vmware.drs.enabled",
         "category": "Information",
         "label": "VM running in a DRS-enabled cluster",
         "assessment": "Distributed resource scheduling is not currently supported by Migration Toolkit for Virtualization. The VM can be migrated but it will not have this feature in the target environment."

--- a/validation/policies/io/konveyor/forklift/vmware/fault_tolerance.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/fault_tolerance.rego
@@ -7,6 +7,7 @@ has_fault_tolerance_enabled {
 concerns[flag] {
     has_fault_tolerance_enabled
     flag := {
+        "id": "vmware.fault_tolerance.enabled",
         "category": "Information",
         "label": "Fault tolerance",
         "assessment": "Fault tolerance is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment."

--- a/validation/policies/io/konveyor/forklift/vmware/host_affinity.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/host_affinity.rego
@@ -8,6 +8,7 @@ has_host_affinity {
 concerns[flag] {
     has_host_affinity
     flag := {
+        "id": "vmware.host_affinity.detected",
         "category": "Warning",
         "label": "VM-Host affinity detected",
         "assessment": "The VM will be migrated without node affinity, but administrators can set it after migration."

--- a/validation/policies/io/konveyor/forklift/vmware/hostname.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/hostname.rego
@@ -14,6 +14,7 @@ is_localhost_hostname {
 concerns[flag] {
     is_empty_hostname
     flag := {
+        "id": "vmware.hostname.empty",
         "category": "Warning",
         "label": "Empty Host Name",
         "assessment": "The 'hostname' field is missing or empty. The hostname might be renamed during migration."
@@ -24,6 +25,7 @@ concerns[flag] {
 concerns[flag] {
     is_localhost_hostname
     flag := {
+        "id": "vmware.hostname.default",
         "category": "Warning",
         "label": "Default Host Name",
         "assessment": "The 'hostname' is set to 'localhost.localdomain', which is a default value. The hostname might be renamed during migration."

--- a/validation/policies/io/konveyor/forklift/vmware/name.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/name.rego
@@ -22,6 +22,7 @@ concerns[flag] {
     valid_vm
     not valid_vm_name
     flag := {
+        "id": "vmware.vm.name.invalid",
         "category": "Warning",
         "label": "Invalid VM Name",
         "assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters."

--- a/validation/policies/io/konveyor/forklift/vmware/numa_affinity.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/numa_affinity.rego
@@ -7,6 +7,7 @@ has_numa_node_affinity {
 concerns[flag] {
     has_numa_node_affinity
     flag := {
+        "id": "vmware.numa_affinity.detected",
         "category": "Warning",
         "label": "NUMA node affinity detected",
         "assessment": "NUMA node affinity is not currently supported by Migration Toolkit for Virtualization. The VM can be migrated but it will not have this feature in the target environment."

--- a/validation/policies/io/konveyor/forklift/vmware/nvme_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/nvme_disk.rego
@@ -8,6 +8,7 @@ has_nvme_bus {
 concerns[flag] {
     has_nvme_bus
     flag := {
+        "id": "vmware.disk.nvme.detected",
         "category": "Critical",
         "label": "Disk NVMe was detcted",
         "assessment": "NVMe disks are not currently supported by MTV. The VM cannot be migrated"

--- a/validation/policies/io/konveyor/forklift/vmware/passthrough_device.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/passthrough_device.rego
@@ -8,6 +8,7 @@ has_passthrough_device {
 concerns[flag] {
     has_passthrough_device
     flag := {
+        "id": "vmware.passthrough_device.detected",
         "category": "Critical",
         "label": "Passthrough device detected",
         "assessment": "SCSI or PCI passthrough devices are not currently supported by Migration Toolkit for Virtualization. The VM cannot be migrated unless the passthrough device is removed."

--- a/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
@@ -8,6 +8,7 @@ has_rdm_disk {
 concerns[flag] {
     has_rdm_disk
     flag := {
+        "id": "vmware.disk.rdm.detected",
         "category": "Critical",
         "label": "Raw Device Mapped disk detected",
         "assessment": "RDM disks are not currently supported by Migration Toolkit for Virtualization. The VM cannot be migrated unless the RDM disks are removed. You can reattach them to the VM after migration."

--- a/validation/policies/io/konveyor/forklift/vmware/snapshot.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/snapshot.rego
@@ -7,6 +7,7 @@ has_snapshot {
 concerns[flag] {
     has_snapshot
     flag := {
+        "id": "vmware.snapshot.detected",
         "category": "Information",
         "label": "VM snapshot detected",
         "assessment": "Online snapshots are not currently supported by OpenShift Virtualization. VM will be migrated with current snapshot."

--- a/validation/policies/io/konveyor/forklift/vmware/sriov_device.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/sriov_device.rego
@@ -8,6 +8,7 @@ has_sriov_device {
 concerns[flag] {
     has_sriov_device
     flag := {
+        "id": "vmware.device.sriov.detected",
         "category": "Warning",
         "label": "SR-IOV passthrough adapter configuration detected",
         "assessment": "SR-IOV passthrough adapter configuration is not currently supported by Migration Toolkit for Virtualization. Administrators can configure this after migration."

--- a/validation/policies/io/konveyor/forklift/vmware/tpm_enabled.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/tpm_enabled.rego
@@ -9,6 +9,7 @@ has_tpm_enabled = true {
 concerns[flag] {
     has_tpm_enabled
     flag := {
+        "id": "vmware.tpm.detected",
         "category": "Warning",
         "label": "TPM detected",
         "assessment": "The VM is configured with a TPM device. TPM data will not be transferred during the migration."

--- a/validation/policies/io/konveyor/forklift/vmware/usb_controller.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/usb_controller.rego
@@ -8,6 +8,7 @@ has_usb_controller {
 concerns[flag] {
     has_usb_controller
     flag := {
+        "id": "vmware.usb_controller.detected",
         "category": "Warning",
         "label": "USB controller detected",
         "assessment": "USB controllers are not currently supported by Migration Toolkit for Virtualization. The VM can be migrated but the devices attached to the USB controller will not be migrated. Administrators can configure this after migration."

--- a/validation/policies/io/konveyor/forklift/vmware/vm_os.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/vm_os.rego
@@ -10,6 +10,7 @@ has_unsupported_os = true {
 concerns[flag] {
     has_unsupported_os
     flag := {
+        "id": "vmware.os.unsupported",
         "category":   "Warning",
         "label":      "Unsupported operating system detected",
         "assessment": "The guest operating system is not currently supported by the Migration Toolkit for Virtualization"


### PR DESCRIPTION
Problem: We need to group identical warning messages (the Assessment field).
Proposal: Assign a unique ID to each message so we can group them reliably.
Currently, grouping by label causes issues because labels may vary.

[ECOPROJECT-3074](https://issues.redhat.com/browse/ECOPROJECT-3074)

/cc @mnecas @machacekondra 

Signed-off-by: Aviel Segev <asegev@redhat.com>
