### PR TITLE
[chore] Match controller-gen version for go v1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ check_container_runtime:
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN)
 $(DEFAULT_CONTROLLER_GEN):
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.0
 
 .PHONY: kubectl
 kubectl: $(KUBECTL)

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -54,7 +54,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: hooks.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -173,7 +173,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: hosts.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -389,7 +389,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: migrations.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1022,7 +1022,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: networkmaps.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1304,7 +1304,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: openstackvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1411,7 +1411,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: ovirtvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1518,7 +1518,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: plans.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -2806,7 +2806,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: providers.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -2988,7 +2988,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: storagemaps.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -3295,7 +3295,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: vspherexcopyvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -54,7 +54,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: hooks.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -173,7 +173,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: hosts.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -389,7 +389,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: migrations.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1022,7 +1022,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: networkmaps.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1304,7 +1304,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: openstackvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1411,7 +1411,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: ovirtvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1518,7 +1518,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: plans.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -2808,7 +2808,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: providers.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -2990,7 +2990,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: storagemaps.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -3297,7 +3297,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: vspherexcopyvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -54,7 +54,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: hooks.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -173,7 +173,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: hosts.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -389,7 +389,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: migrations.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1022,7 +1022,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: networkmaps.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1304,7 +1304,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: openstackvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1411,7 +1411,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: ovirtvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -1518,7 +1518,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: plans.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -2806,7 +2806,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: providers.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -2988,7 +2988,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: storagemaps.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
@@ -3295,7 +3295,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: vspherexcopyvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_hooks.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_hooks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: hooks.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_hosts.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_hosts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: hosts.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: migrations.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: networkmaps.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_openstackvolumepopulators.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_openstackvolumepopulators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: openstackvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_ovirtvolumepopulators.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_ovirtvolumepopulators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: ovirtvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: plans.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: providers.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_storagemaps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: storagemaps.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io

--- a/operator/config/crd/bases/forklift.konveyor.io_vspherexcopyvolumepopulators.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_vspherexcopyvolumepopulators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: vspherexcopyvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io


### PR DESCRIPTION
Issue:
controller-gen version must match the go tools used, we build our images using go 1.23

Fix:
Use controller-gen version 0.17.0