### PR TITLE
chore | Sent an error on inventory client watch fail

### DIFF
--- a/pkg/lib/inventory/web/client.go
+++ b/pkg/lib/inventory/web/client.go
@@ -285,6 +285,12 @@ func (r *Client) Watch(url string, resource interface{}, h EventHandler) (status
 	}
 	status, err = post(reader)
 	if err != nil || status != http.StatusOK {
+		if err != nil {
+			err = liberr.Wrap(err, "status", status, "url", url)
+		} else {
+			err = liberr.New(
+				"inventory client watch return with none StatusOK", "status", status, "url", url)
+		}
 		return
 	}
 	w = &Watch{reader: reader}


### PR DESCRIPTION
Issue:
In inventory web client, we may return misleading error when  status != http.StatusOK
in this case the err value can be `nil` and the error is lost

Fix:
Add an error the case of   status != http.StatusOK

Before:
`{"level":"error","ts":"2025-06-17 11:07:17.634","logger":"storageMap","msg":"","error":"Not Implemented","stacktrace":"github ... `

After:
`{"level":"error","ts":"2025-06-18 07:28:06.685","logger":"storageMap","msg":"","error":"inventory client watch return with none StatusOK","stacktrace":"github.com/kubev2v/forklift/pkg/controller/ ... `