### PR TITLE
MTV-2014 | Force disable TPM if not enabled on source

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1097,13 +1097,11 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 
 func (r *Builder) mapTpm(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	if vm.TpmEnabled {
-		persistData := true
-		object.Template.Spec.Domain.Devices.TPM = &cnv.TPMDevice{Persistent: &persistData}
-	}
-
-	// Disable the vTPM on non UEFI
-	// MTV-2014 - win 2022 fails to boot with vTPM enabled
-	if vm.Firmware == BIOS {
+		// If the VM has vTPM enabled, we need to set Persistent in the VM spec.
+		object.Template.Spec.Domain.Devices.TPM = &cnv.TPMDevice{Persistent: ptr.To(true)}
+	} else {
+		// Force disable the vTPM
+		// MTV-2014 - win 2022 fails to boot with vTPM enabled
 		object.Template.Spec.Domain.Devices.TPM = &cnv.TPMDevice{Enabled: ptr.To(false)}
 	}
 }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2014

Issue:
In #1853 we disabled TPM only on BIOS machines, but we need to disable TPM on any machine that does not enable it on the source.

Fix:
Always disable TPM if the the source machine does not have TPM enabled

