### PR TITLE
Always use insecure skip verify for ESX hosts

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/host.go
+++ b/pkg/controller/plan/adapter/vsphere/host.go
@@ -5,10 +5,8 @@ import (
 	liburl "net/url"
 	"time"
 
-	"github.com/kubev2v/forklift/pkg/controller/base"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
-	"github.com/kubev2v/forklift/pkg/lib/util"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/session"
@@ -74,19 +72,11 @@ func (r *EsxHost) connect(ctx context.Context) (err error) {
 	url.User = liburl.UserPassword(
 		r.user(),
 		r.password())
-	thumbprint := r.thumbprint()
-	skipVerifying := base.GetInsecureSkipVerifyFlag(r.Secret)
 
-	if !skipVerifying {
-		cert, errtls := base.VerifyTLSConnection(r.URL, r.Secret)
-		if errtls != nil {
-			return liberr.Wrap(errtls)
-		}
-		thumbprint = util.Fingerprint(cert)
-	}
+	// Always use insecure skip verify for ESX hosts.
+	soapClient := soap.NewClient(url, true)
+	soapClient.SetThumbprint(url.Host, r.thumbprint())
 
-	soapClient := soap.NewClient(url, skipVerifying)
-	soapClient.SetThumbprint(url.Host, thumbprint)
 	vimClient, err := vim25.NewClient(ctx, soapClient)
 	if err != nil {
 		return liberr.Wrap(err)


### PR DESCRIPTION
Issue:
The line `skipVerifying := base.GetInsecureSkipVerifyFlag(r.Secret)`  tests the host secret for the field `insecureSkipVerify`
We currently don't set this field, and so it is always false.

Fix:
Set the `soap.NewClient` to always use insecure connection.

Future fix:
Document and update UI to set the missing  `insecureSkipVerify` field