### PR TITLE
Fix "Not implemented" error for ensureWatch in ocp providers

### DIFF
--- a/pkg/controller/map/network/handler/ocp/handler.go
+++ b/pkg/controller/map/network/handler/ocp/handler.go
@@ -22,51 +22,45 @@ type Handler struct {
 }
 
 // Ensure watch on networks.
+// OCP inventory doesn't support watches. Instead, a generic event is sent to
+// the channel periodically to trigger reconciliation.
 func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
-	w, err := watch.Ensure(
+	watch.EnsurePeriodicEvents(
 		r.Provider(),
 		&ocp.NetworkAttachmentDefinition{},
-		r)
-	if err != nil {
-		return
-	}
-
+		handler.DefaultEventInterval,
+		r.generateEvents)
 	log.Info(
-		"Inventory watch ensured.",
+		"Periodic Inventory events ensured.",
 		"provider",
 		path.Join(
 			r.Provider().Namespace,
-			r.Provider().Name),
-		"watch",
-		w.ID())
+			r.Provider().Name))
 
 	return
 }
 
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if network, cast := e.Resource.(*ocp.NetworkAttachmentDefinition); cast {
-		r.changed(network)
-	}
+	log.Info("OCP doesn't support web watches, this should not be called",
+		"provider",
+		path.Join(
+			r.Provider().Namespace,
+			r.Provider().Name))
 }
 
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if network, cast := e.Resource.(*ocp.NetworkAttachmentDefinition); cast {
-		r.changed(network)
-	}
+	log.Info("OCP doesn't support web watches, this should not be called",
+		"provider",
+		path.Join(
+			r.Provider().Namespace,
+			r.Provider().Name))
+
 }
 
-// Network changed.
-// Find all of the NetworkMap CRs the reference both the
-// provider and the changed network and enqueue reconcile events.
-func (r *Handler) changed(network *ocp.NetworkAttachmentDefinition) {
-	log.V(3).Info(
-		"Network (NAD) changed.",
-		"name",
-		path.Join(
-			network.Namespace,
-			network.Name))
+// Send a generic event to the channel for all associated CRs.
+func (r *Handler) generateEvents() {
 	list := api.NetworkMapList{}
 	err := r.List(context.TODO(), &list)
 	if err != nil {
@@ -76,23 +70,10 @@ func (r *Handler) changed(network *ocp.NetworkAttachmentDefinition) {
 	}
 	for i := range list.Items {
 		mp := &list.Items[i]
-		ref := mp.Spec.Provider.Destination
-		if !r.MatchProvider(ref) {
-			continue
-		}
-		for _, pair := range mp.Spec.Map {
-			ref := pair.Destination
-			if ref.Namespace == network.Namespace && ref.Name == network.Name {
-				log.V(3).Info(
-					"Queue reconcile event.",
-					"map",
-					path.Join(
-						mp.Namespace,
-						mp.Name))
-				r.Enqueue(event.GenericEvent{
-					Object: mp,
-				})
-			}
+		if r.MatchProvider(mp.Spec.Provider.Source) || r.MatchProvider(mp.Spec.Provider.Destination) {
+			r.Enqueue(event.GenericEvent{
+				Object: mp,
+			})
 		}
 	}
 }

--- a/pkg/controller/map/network/handler/ocp/handler.go
+++ b/pkg/controller/map/network/handler/ocp/handler.go
@@ -1,6 +1,7 @@
 package ocp
 
 import (
+	"context"
 	"path"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -9,7 +10,6 @@ import (
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libweb "github.com/kubev2v/forklift/pkg/lib/inventory/web"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
-	"golang.org/x/net/context"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 

--- a/pkg/controller/map/storage/handler/ocp/handler.go
+++ b/pkg/controller/map/storage/handler/ocp/handler.go
@@ -22,49 +22,44 @@ type Handler struct {
 }
 
 // Ensure watch on storageClass.
+// OCP inventory doesn't support watches. Instead, a generic event is sent to
+// the channel every so often to trigger reconciliation.
 func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
-	w, err := watch.Ensure(
+	watch.EnsurePeriodicEvents(
 		r.Provider(),
 		&ocp.StorageClass{},
-		r)
-	if err != nil {
-		return
-	}
-
+		handler.DefaultEventInterval,
+		r.generateEvents)
 	log.Info(
-		"Inventory watch ensured.",
+		"Periodic Inventory events ensured.",
 		"provider",
 		path.Join(
 			r.Provider().Namespace,
-			r.Provider().Name),
-		"watch",
-		w.ID())
+			r.Provider().Name))
 
 	return
 }
 
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if storageClass, cast := e.Resource.(*ocp.StorageClass); cast {
-		r.changed(storageClass)
-	}
+	log.Info("OCP doesn't support web watches, this should not be called",
+		"provider",
+		path.Join(
+			r.Provider().Namespace,
+			r.Provider().Name))
 }
 
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if storageClass, cast := e.Resource.(*ocp.StorageClass); cast {
-		r.changed(storageClass)
-	}
+	log.Info("OCP doesn't support web watches, this should not be called",
+		"provider",
+		path.Join(
+			r.Provider().Namespace,
+			r.Provider().Name))
 }
 
-// Storage changed.
-// Find all of the StorageMap CRs the reference both the
-// provider and the changed storageClass and enqueue reconcile events.
-func (r *Handler) changed(storageClass *ocp.StorageClass) {
-	log.V(3).Info(
-		"StorageClass changed.",
-		"name",
-		storageClass.Name)
+// Send a generic event to the channel for all associated CRs.
+func (r *Handler) generateEvents() {
 	list := api.StorageMapList{}
 	err := r.List(context.TODO(), &list)
 	if err != nil {
@@ -74,23 +69,10 @@ func (r *Handler) changed(storageClass *ocp.StorageClass) {
 	}
 	for i := range list.Items {
 		mp := &list.Items[i]
-		ref := mp.Spec.Provider.Destination
-		if !r.MatchProvider(ref) {
-			continue
-		}
-		for _, pair := range mp.Spec.Map {
-			ref := pair.Destination
-			if ref.StorageClass == storageClass.Name {
-				log.V(3).Info(
-					"Queue reconcile event.",
-					"map",
-					path.Join(
-						mp.Namespace,
-						mp.Name))
-				r.Enqueue(event.GenericEvent{
-					Object: mp,
-				})
-			}
+		if r.MatchProvider(mp.Spec.Provider.Source) || r.MatchProvider(mp.Spec.Provider.Destination) {
+			r.Enqueue(event.GenericEvent{
+				Object: mp,
+			})
 		}
 	}
 }

--- a/pkg/controller/map/storage/handler/ocp/handler.go
+++ b/pkg/controller/map/storage/handler/ocp/handler.go
@@ -1,6 +1,7 @@
 package ocp
 
 import (
+	"context"
 	"path"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -9,7 +10,6 @@ import (
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libweb "github.com/kubev2v/forklift/pkg/lib/inventory/web"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
-	"golang.org/x/net/context"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 

--- a/pkg/controller/plan/handler/ocp/handler.go
+++ b/pkg/controller/plan/handler/ocp/handler.go
@@ -1,6 +1,7 @@
 package ocp
 
 import (
+	"context"
 	"path"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -9,7 +10,6 @@ import (
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libweb "github.com/kubev2v/forklift/pkg/lib/inventory/web"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
-	"golang.org/x/net/context"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 

--- a/pkg/controller/plan/handler/ocp/handler.go
+++ b/pkg/controller/plan/handler/ocp/handler.go
@@ -21,52 +21,41 @@ type Handler struct {
 	*handler.Handler
 }
 
-// Ensure watch on VMs.
+// Ensure watch on host. OCP inventory doesn't support watches. Instead, a
+// generic event is sent to the channel periodically to trigger reconciliation.
 func (r *Handler) Watch(watch *handler.WatchManager) (err error) {
-	w, err := watch.Ensure(
-		r.Provider(),
-		&ocp.VM{},
-		r)
-	if err != nil {
-		return
-	}
-
+	watch.EnsurePeriodicEvents(r.Provider(), &ocp.VM{}, handler.DefaultEventInterval, r.generateEvents)
 	log.Info(
-		"Inventory watch ensured.",
+		"Periodic Inventory events ensured.",
 		"provider",
 		path.Join(
 			r.Provider().Namespace,
 			r.Provider().Name),
-		"watch",
-		w.ID())
+	)
 
 	return
 }
 
 // Resource created.
 func (r *Handler) Created(e libweb.Event) {
-	if vm, cast := e.Resource.(*ocp.VM); cast {
-		r.changed(vm)
-	}
+	log.Info("OCP doesn't support web watches, this should not be called",
+		"provider",
+		path.Join(
+			r.Provider().Namespace,
+			r.Provider().Name))
 }
 
 // Resource deleted.
 func (r *Handler) Deleted(e libweb.Event) {
-	if vm, cast := e.Resource.(*ocp.VM); cast {
-		r.changed(vm)
-	}
+	log.Info("OCP doesn't support web watches, this should not be called",
+		"provider",
+		path.Join(
+			r.Provider().Namespace,
+			r.Provider().Name))
 }
 
-// VM changed.
-// Find all of the Plan CRs the reference both the provider
-// and in the same target namespace and enqueue reconcile events.
-func (r *Handler) changed(vm *ocp.VM) {
-	log.V(3).Info(
-		"VM changed.",
-		"name",
-		path.Join(
-			vm.Namespace,
-			vm.Name))
+// Send a generic event into the channel for all associated CRs.
+func (r *Handler) generateEvents() {
 	list := api.PlanList{}
 	err := r.List(context.TODO(), &list)
 	if err != nil {
@@ -76,17 +65,7 @@ func (r *Handler) changed(vm *ocp.VM) {
 	}
 	for i := range list.Items {
 		plan := &list.Items[i]
-		ref := plan.Spec.Provider.Destination
-		if !r.MatchProvider(ref) {
-			continue
-		}
-		if plan.Spec.TargetNamespace == vm.Namespace {
-			log.V(3).Info(
-				"Queue reconcile event.",
-				"plan",
-				path.Join(
-					plan.Namespace,
-					plan.Name))
+		if r.MatchProvider(plan.Spec.Provider.Source) || r.MatchProvider(plan.Spec.Provider.Destination) {
 			r.Enqueue(event.GenericEvent{
 				Object: plan,
 			})

--- a/pkg/controller/watch/handler/watch.go
+++ b/pkg/controller/watch/handler/watch.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"path"
 	"sync"
+	"time"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web"
@@ -10,8 +12,18 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	DefaultEventInterval = time.Second * 10
+)
+
+// A stoppable resource.
+type Stoppable interface {
+	// End the watch.
+	End()
+}
+
 // Watch map keyed by resource kind.
-type watchMap map[string]*libweb.Watch
+type watchMap map[string]Stoppable
 
 // Provider map keyed by provider.UID.
 type ProviderMap map[types.UID]watchMap
@@ -23,30 +35,41 @@ type WatchManager struct {
 	providerMap ProviderMap
 }
 
-// Ensure watch has been created.
-// An existing watch that is not `alive` will be replaced.
+func (m *WatchManager) ensureStoppablesUnlocked(
+	provider *api.Provider) *watchMap {
+	if m.providerMap == nil {
+		m.providerMap = make(ProviderMap)
+	}
+	stoppables, found := m.providerMap[provider.UID]
+	if !found {
+		stoppables = make(map[string]Stoppable)
+		m.providerMap[provider.UID] = stoppables
+	}
+
+	return &stoppables
+}
+
+// Ensure a watch has been created.
 func (m *WatchManager) Ensure(
 	provider *api.Provider,
 	resource interface{},
 	handler libweb.EventHandler) (watch *libweb.Watch, err error) {
-	//
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	if m.providerMap == nil {
-		m.providerMap = make(ProviderMap)
-	}
-	watchMap, found := m.providerMap[provider.UID]
-	if !found {
-		watchMap = make(map[string]*libweb.Watch)
-		m.providerMap[provider.UID] = watchMap
-	}
+	stoppables := m.ensureStoppablesUnlocked(provider)
 	kind := libref.ToKind(resource)
-	if w, found := watchMap[kind]; found {
-		if w.Alive() {
-			watch = w
-			return
+	if s, found := (*stoppables)[kind]; found {
+		if w, cast := s.(*libweb.Watch); cast {
+			if w.Alive() {
+				watch = w
+				return
+			}
+		} else {
+			log.Info("Creating a new watch for a resource that already has a periodic update")
+			delete(*stoppables, kind)
 		}
 	}
+
 	client, err := web.NewClient(provider)
 	if err != nil {
 		return
@@ -55,22 +78,85 @@ func (m *WatchManager) Ensure(
 	if err != nil {
 		return
 	}
-	watchMap[kind] = w
+	(*stoppables)[kind] = w
 	watch = w
 
 	return
 }
 
+type PeriodicEventGenerator struct {
+	stopChannel chan struct{}
+}
+
+func (r *PeriodicEventGenerator) End() {
+	close(r.stopChannel)
+}
+
+// Ensure that we've started a periodic event generator for the provider
+// resource.
+func (m *WatchManager) EnsurePeriodicEvents(
+	provider *api.Provider,
+	resource interface{},
+	interval time.Duration,
+	tickFunc func()) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	stoppables := m.ensureStoppablesUnlocked(provider)
+	kind := libref.ToKind(resource)
+	if _, found := (*stoppables)[kind]; found {
+		return
+	}
+	eventGenerator := &PeriodicEventGenerator{stopChannel: make(chan struct{})}
+	log.Info(
+		"Periodic event generator started.",
+		"provider",
+		path.Join(provider.Namespace, provider.Name))
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				tickFunc()
+			case <-eventGenerator.stopChannel:
+				log.Info("Periodic event generator stopped.",
+					"provider",
+					path.Join(provider.Namespace, provider.Name))
+				return
+			}
+		}
+	}()
+
+	(*stoppables)[kind] = eventGenerator
+}
+
 // A provider has been deleted.
-// Delete associated watches.
 func (m *WatchManager) Deleted(provider *api.Provider) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	if watchMap, found := m.providerMap[provider.UID]; found {
-		for _, w := range watchMap {
-			w.End()
+	if stoppables, found := m.providerMap[provider.UID]; found {
+		for _, s := range stoppables {
+			s.End()
+		}
+		delete(m.providerMap, provider.UID)
+		log.Info(
+			"Watch stopped.",
+			"provider",
+			path.Join(
+				provider.Namespace,
+				provider.Name))
+	}
+}
+
+// End all watches.
+func (m *WatchManager) End() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	for _, stoppables := range m.providerMap {
+		for _, s := range stoppables {
+			s.End()
 		}
 	}
-
-	delete(m.providerMap, provider.UID)
+	clear(m.providerMap)
 }


### PR DESCRIPTION
Since OCP providers no longer provide 'watch' functionality via the inventory web interface, we provide a fake watch implementation that simply drips events into the channel and causes the objects to re-reconcile periodically.
