### PR TITLE
ECOPROJECT-2558, MTV-1616 | Streamline the VDDK image creation

### DIFF
--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -3724,6 +3724,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -184,3 +184,9 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+  verbs:
+    - get

--- a/pkg/settings/inventory.go
+++ b/pkg/settings/inventory.go
@@ -70,6 +70,11 @@ func (r *Inventory) Load() error {
 			}
 		}
 	}
+	consoleOrigin, err := getOpenshiftConsoleOrigin()
+	if err != nil {
+		return err
+	}
+	r.CORS.AllowedOrigins = append(r.CORS.AllowedOrigins, consoleOrigin)
 	// WorkingDir
 	if s, found := os.LookupEnv(WorkingDir); found {
 		r.WorkingDir = s


### PR DESCRIPTION
During the UI implementation, we encountered some CORS-related issues and would like to wait until the [PR](https://github.com/kubev2v/forklift-console-plugin/pull/1651) is merged to determine whether it’s a local problem.

I tried using the new upload feature to create a VDDK image with the forklift dev operator, but it seems to have the same CORS issue.

The problem: For POST requests, the web server enforces CORS. Currently, allowedOrigins is initialized as an empty array (and can be configured using the CORS_ALLOWED_ORIGINS environment variable); therefore, the w.allow method, which is responsible for authorizing requests, drops them (for POST) and returns a 403.

While debugging, I noticed that the UI requests originate from the console URL. This PR suggests fixing the problem by adding the console URL to the allowed origins. 

I’m not sure this is the best approach—please feel free to comment or suggest an alternative.

[ECOPROJECT-2558](https://issues.redhat.com/browse/ECOPROJECT-2558)
[MTV-1616](https://issues.redhat.com/browse/MTV-1616)
![Cors Issue](https://github.com/user-attachments/assets/16e78ada-52bd-437e-b4f9-f2302048315a)
