### PR TITLE
PAC rules prevented the build of API image

### DIFF
--- a/.tekton/forklift-api-dev-preview-pull-request.yaml
+++ b/.tekton/forklift-api-dev-preview-pull-request.yaml
@@ -14,6 +14,8 @@ metadata:
       ".konflux/forklift-api/rpms.lock.yaml".pathChanged() ||
       "build/forklift-api/Containerfile-downstream".pathChanged() ||
       "pkg/forklift-api/***".pathChanged() ||
+      "pkg/controller/***".pathChanged() ||
+      "pkg/lib/***".pathChanged() ||
       "cmd/forklift-api/***".pathChanged() )
   creationTimestamp: null
   labels:

--- a/.tekton/forklift-api-dev-preview-push.yaml
+++ b/.tekton/forklift-api-dev-preview-push.yaml
@@ -12,6 +12,8 @@ metadata:
       ".konflux/forklift-api/rpms.lock.yaml".pathChanged() ||
       "build/forklift-api/Containerfile-downstream".pathChanged() ||
       "pkg/forklift-api/***".pathChanged() ||
+      "pkg/controller/***".pathChanged() ||
+      "pkg/lib/***".pathChanged() ||
       "cmd/forklift-api/***".pathChanged() )
   creationTimestamp: null
   labels:

--- a/.tekton/forklift-controller-dev-preview-pull-request.yaml
+++ b/.tekton/forklift-controller-dev-preview-pull-request.yaml
@@ -13,6 +13,8 @@ metadata:
       ".konflux/forklift-controller/rpms.lock.yaml".pathChanged() ||
       "build/forklift-controller/Containerfile-downstream".pathChanged() ||
       "pkg/controller/***".pathChanged() ||
+      "pkg/forklift-api/***".pathChanged() ||
+      "pkg/lib/***".pathChanged() ||
       "cmd/forklift-controller/***".pathChanged() )
   creationTimestamp: null
   labels:

--- a/.tekton/forklift-controller-dev-preview-push.yaml
+++ b/.tekton/forklift-controller-dev-preview-push.yaml
@@ -12,6 +12,8 @@ metadata:
       ".konflux/forklift-controller/rpms.lock.yaml".pathChanged() ||
       "build/forklift-controller/Containerfile-downstream".pathChanged() ||
       "pkg/controller/***".pathChanged() ||
+      "pkg/forklift-api/***".pathChanged() ||
+      "pkg/lib/***".pathChanged() ||
       "cmd/forklift-controller/***".pathChanged() )
   creationTimestamp: null
   labels:


### PR DESCRIPTION
forklift-api should be rebuild even when there are changes to the pkg/controller directory and vice versa.