### PR TITLE
MTV-2403 | Augment hw disk information based on guest agent

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -807,24 +807,22 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				}
 			case fGuestDisk:
 				if disks, cast := p.Val.(types.ArrayOfGuestDiskInfo); cast {
-					for _, info := range disks.GuestDiskInfo {
-						var guestDiskKey int32
-						if len(info.Mappings) == 0 {
-							continue // Skip if no mappings are available
-						}
-
-						// This assumes that the first mapping is the primary one
-						guestDiskKey = info.Mappings[0].Key
-
-						newGuestDisk := model.GuestDisk{
+					v.model.GuestDisks = make([]model.GuestDisk, len(disks.GuestDiskInfo))
+					for i, info := range disks.GuestDiskInfo {
+						v.model.GuestDisks[i] = model.GuestDisk{
 							DiskPath:       info.DiskPath,
 							Capacity:       info.Capacity,
 							FreeSpace:      info.FreeSpace,
 							FilesystemType: info.FilesystemType,
-							Key:            guestDiskKey,
 						}
+					}
 
-						v.updateOrAppendGuestDisk(newGuestDisk)
+					// Update matching disk items with Windows drive letters based on index
+					for i, guestDisk := range v.model.GuestDisks {
+						if i < len(v.model.Disks) {
+							winDriveLetter := v.extractWinDriveLetter(guestDisk.DiskPath)
+							v.model.Disks[i].WinDriveLetter = winDriveLetter
+						}
 					}
 				}
 			case fGuestNet:
@@ -1057,17 +1055,6 @@ func (v *VmAdapter) getDiskController(key int32) *model.Controller {
 	return nil
 }
 
-// getDiskGuestInfo retrieves the guest disk information for a given device key.
-func (v *VmAdapter) getDiskGuestInfo(deviceKey int32) *model.GuestDisk {
-	for _, guestDisk := range v.model.GuestDisks {
-		if guestDisk.Key == deviceKey {
-			return &guestDisk
-		}
-	}
-
-	return nil
-}
-
 // Update virtual disk devices.
 func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 	disks := []model.Disk{}
@@ -1076,32 +1063,17 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 		case *types.VirtualDisk:
 			disk := dev.(*types.VirtualDisk)
 			controller := v.getDiskController(disk.ControllerKey)
-			guestDiskInfo := v.getDiskGuestInfo(disk.Key)
-
-			// Try to extract the Windows drive letter from the guest disk info
-			winDriveLetter := ""
-			if guestDiskInfo != nil {
-				winDriveLetter = guestDiskInfo.DiskPath
-				// Check if this looks like a Windows drive letter (e.g., "C:\\")
-				if len(winDriveLetter) == 3 && winDriveLetter[1] == ':' && winDriveLetter[2] == '\\' {
-					// Extract the drive letter and convert to lowercase
-					winDriveLetter = strings.ToLower(string(winDriveLetter[0]))
-				} else {
-					winDriveLetter = ""
-				}
-			}
 
 			switch backing := disk.Backing.(type) {
 			case *types.VirtualDiskFlatVer1BackingInfo:
 				md := model.Disk{
-					Key:            disk.Key,
-					UnitNumber:     *disk.UnitNumber,
-					ControllerKey:  disk.ControllerKey,
-					File:           backing.FileName,
-					Capacity:       disk.CapacityInBytes,
-					Mode:           backing.DiskMode,
-					Bus:            controller.Bus,
-					WinDriveLetter: winDriveLetter,
+					Key:           disk.Key,
+					UnitNumber:    *disk.UnitNumber,
+					ControllerKey: disk.ControllerKey,
+					File:          backing.FileName,
+					Capacity:      disk.CapacityInBytes,
+					Mode:          backing.DiskMode,
+					Bus:           controller.Bus,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -1113,16 +1085,15 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskFlatVer2BackingInfo:
 				md := model.Disk{
-					Key:            disk.Key,
-					UnitNumber:     *disk.UnitNumber,
-					ControllerKey:  disk.ControllerKey,
-					File:           backing.FileName,
-					Capacity:       disk.CapacityInBytes,
-					Shared:         backing.Sharing != "sharingNone" && backing.Sharing != "",
-					Mode:           backing.DiskMode,
-					Bus:            controller.Bus,
-					Serial:         backing.Uuid,
-					WinDriveLetter: winDriveLetter,
+					Key:           disk.Key,
+					UnitNumber:    *disk.UnitNumber,
+					ControllerKey: disk.ControllerKey,
+					File:          backing.FileName,
+					Capacity:      disk.CapacityInBytes,
+					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
+					Mode:          backing.DiskMode,
+					Bus:           controller.Bus,
+					Serial:        backing.Uuid,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -1134,17 +1105,16 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
 				md := model.Disk{
-					Key:            disk.Key,
-					UnitNumber:     *disk.UnitNumber,
-					ControllerKey:  disk.ControllerKey,
-					File:           backing.FileName,
-					Capacity:       disk.CapacityInBytes,
-					Shared:         backing.Sharing != "sharingNone" && backing.Sharing != "",
-					Mode:           backing.DiskMode,
-					RDM:            true,
-					Bus:            controller.Bus,
-					Serial:         backing.Uuid,
-					WinDriveLetter: winDriveLetter,
+					Key:           disk.Key,
+					UnitNumber:    *disk.UnitNumber,
+					ControllerKey: disk.ControllerKey,
+					File:          backing.FileName,
+					Capacity:      disk.CapacityInBytes,
+					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
+					Mode:          backing.DiskMode,
+					RDM:           true,
+					Bus:           controller.Bus,
+					Serial:        backing.Uuid,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -1156,61 +1126,38 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskRawDiskVer2BackingInfo:
 				md := model.Disk{
-					Key:            disk.Key,
-					UnitNumber:     *disk.UnitNumber,
-					ControllerKey:  disk.ControllerKey,
-					File:           backing.DescriptorFileName,
-					Capacity:       disk.CapacityInBytes,
-					Shared:         backing.Sharing != "sharingNone" && backing.Sharing != "",
-					RDM:            true,
-					Bus:            controller.Bus,
-					WinDriveLetter: winDriveLetter,
+					Key:           disk.Key,
+					UnitNumber:    *disk.UnitNumber,
+					ControllerKey: disk.ControllerKey,
+					File:          backing.DescriptorFileName,
+					Capacity:      disk.CapacityInBytes,
+					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
+					RDM:           true,
+					Bus:           controller.Bus,
 				}
 				disks = append(disks, md)
 			}
 		}
 	}
 
+	// Update Windows drive letters for all disks based on guest disk information
+	for i := range disks {
+		if i < len(v.model.GuestDisks) {
+			winDriveLetter := v.extractWinDriveLetter(v.model.GuestDisks[i].DiskPath)
+			disks[i].WinDriveLetter = winDriveLetter
+		}
+	}
+
 	v.model.Disks = disks
 }
 
-// updateOrAppendGuestDisk updates an existing guest disk with the same key or appends a new one
-func (v *VmAdapter) updateOrAppendGuestDisk(newDisk model.GuestDisk) {
-	fountExistingDisk := false
-
-	// Find existing disk with the same key
-	for i, existingDisk := range v.model.GuestDisks {
-		if existingDisk.Key == newDisk.Key {
-			// Replace existing disk
-			v.model.GuestDisks[i] = newDisk
-
-			fountExistingDisk = true
-			break // Exit the loop when found
-		}
+// extractWinDriveLetter extracts the Windows drive letter from a disk path.
+// For example: "C:\\" returns "c", "/home" returns ""
+func (v *VmAdapter) extractWinDriveLetter(diskPath string) string {
+	// Check if this looks like a Windows drive letter (e.g., "C:\\")
+	if len(diskPath) >= 3 && diskPath[1] == ':' && diskPath[2] == '\\' {
+		// Extract the drive letter and convert to lowercase
+		return strings.ToLower(string(diskPath[0]))
 	}
-
-	// No existing disk found, append new one
-	if !fountExistingDisk {
-		v.model.GuestDisks = append(v.model.GuestDisks, newDisk)
-	}
-
-	// Check for m.model.Disks with the same key
-	for i, disk := range v.model.Disks {
-		if disk.Key == newDisk.Key {
-			// Try to extract the Windows drive letter from the new GuestDisk's DiskPath
-			winDriveLetter := newDisk.DiskPath
-
-			// Check if this looks like a Windows drive letter (e.g., "C:\\")
-			if len(winDriveLetter) == 3 && winDriveLetter[1] == ':' && winDriveLetter[2] == '\\' {
-				// Extract the drive letter and convert to lowercase
-				winDriveLetter = strings.ToLower(string(winDriveLetter[0]))
-			} else {
-				winDriveLetter = ""
-			}
-
-			// Update the Disk's WinDriveLetter using the new GuestDisk's DiskPath
-			v.model.Disks[i].WinDriveLetter = winDriveLetter
-			return
-		}
-	}
+	return ""
 }

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -391,11 +391,6 @@ type GuestIpStack struct {
 
 // Guest disk.
 type GuestDisk struct {
-	// The key of the VirtualDevice.
-	//
-	// `VirtualDevice.key`
-	Key int32 `xml:"key" json:"key"`
-
 	// Name of the virtual disk in the guest operating system.
 	//
 	// For example: C:\\ ( in linux it can by a path like /home ).


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2403

**Issue:**
In https://github.com/kubev2v/forklift/pull/1974 we used the `Mappings` field in the guest disk info to map the guest info to hw disks.
In the wild  `Mappings` can be `null` preventing us from collecting the guest info data.

**Fix:**
Use guest disk info index, to match to hw disks

**Example of guest disk info with null mappings:**

``` bash
$ govc object.collect -json vm/mtv-func-win2022-uefi  guest.disk
[
  {
    "Name": "guest.disk",
    "Op": "assign",
    "Val": {
      "GuestDiskInfo": [
        {
          "DiskPath": "C:\\",
          "Capacity": 16404967424,
          "FreeSpace": 4105310208,
          "FilesystemType": "NTFS",
          "Mappings": null
        },
        {
          "DiskPath": "E:\\",
          "Capacity": 1054863360,
          "FreeSpace": 1037144064,
          "FilesystemType": "NTFS",
          "Mappings": null
        },
        {
          "DiskPath": "F:\\",
          "Capacity": 2128605184,
          "FreeSpace": 2109042688,
          "FilesystemType": "NTFS",
          "Mappings": null
        }
      ]
    }
  }
]
```

**Before fix:**

```bash
$ oc mtv inventory vms v8-us -q "where name ~= 'mtv-func-win2022-uefi'" -o json | jq .[].guestDisks
[]
```

**After fix:**
```bash
$ oc mtv inventory vms v8-us -q "where name ~= 'mtv-func-win2022-uefi'" -o json | jq .[].guestDisks
[
  {
    "capacity": 16404967424,
    "diskPath": "C:\\",
    "filesystemType": "NTFS",
    "freeSpace": 4105310208
  },
  {
    "capacity": 1054863360,
    "diskPath": "E:\\",
    "filesystemType": "NTFS",
    "freeSpace": 1037144064
  },
  {
    "capacity": 2128605184,
    "diskPath": "F:\\",
    "filesystemType": "NTFS",
    "freeSpace": 2109042688
  }
]
```


```bash
$ oc mtv inventory vms v8-us -q "where name ~= 'mtv-func-win2022-uefi'" -o json | jq .[].disks
[
  {
    "bus": "sata",
    "capacity": 17179869184,
    "changeTrackingEnabled": false,
    "controllerKey": 15000,
    "datastore": {
      "id": "datastore-12",
      "kind": "Datastore"
    },
    "file": "[mtv-nfs-us-v8] mtv-func-win2022-uefi/mtv-func-win2022-uefi.vmdk",
    "key": 16001,
    "mode": "persistent",
    "rdm": false,
    "serial": "6000C291-cdb5-e6f1-449d-139299696330",
    "shared": false,
    "unitNumber": 1,
    "winDriveLetter": "c"
  },
  {
    "bus": "sata",
    "capacity": 1073741824,
    "changeTrackingEnabled": true,
    "controllerKey": 15000,
    "datastore": {
      "id": "datastore-12",
      "kind": "Datastore"
    },
    "file": "[mtv-nfs-us-v8] mtv-func-win2022-uefi/mtv-func-win2022-uefi_1.vmdk",
    "key": 16002,
    "mode": "persistent",
    "rdm": false,
    "serial": "6000C29d-323f-596a-57b7-68d154722dde",
    "shared": false,
    "unitNumber": 2,
    "winDriveLetter": "e"
  },
  {
    "bus": "sata",
    "capacity": 2147483648,
    "changeTrackingEnabled": true,
    "controllerKey": 15000,
    "datastore": {
      "id": "datastore-12",
      "kind": "Datastore"
    },
    "file": "[mtv-nfs-us-v8] mtv-func-win2022-uefi/mtv-func-win2022-uefi_2.vmdk",
    "key": 16003,
    "mode": "persistent",
    "rdm": false,
    "serial": "6000C299-5011-98a5-bda7-56865c6ac7a6",
    "shared": false,
    "unitNumber": 3,
    "winDriveLetter": "f"
  }
]
```