### PR TITLE
MTV-2802 | Mutate host secret add skip verify flag

### DIFF
--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator_test.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator_test.go
@@ -1,8 +1,16 @@
 package mutators
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1beta1"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/gomega"
 )
@@ -29,4 +37,146 @@ func TestCertAppending(t *testing.T) {
 	//Test the case when the certificate is changed by one byte to verify that "contains" returns false.
 	newCa = append(newCa, 0x01)
 	g.Expect(contains(providedCa, newCa)).To(BeFalse())
+}
+
+func TestMutateHostSecretInsecureSkipVerify(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Create a provider with insecureSkipVerify setting
+	provider := &api.Provider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-provider",
+			Namespace: "test-namespace",
+		},
+		Spec: api.ProviderSpec{
+			Secret: core.ObjectReference{
+				Name:      "provider-secret",
+				Namespace: "test-namespace",
+			},
+		},
+	}
+
+	// Create provider secret with insecureSkipVerify
+	providerSecret := &core.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "provider-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			"insecureSkipVerify": []byte("true"),
+			"user":               []byte("admin"),
+			"password":           []byte("password"),
+		},
+	}
+
+	// Create host secret without insecureSkipVerify
+	hostSecret := &core.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host-secret",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"createdForResourceType": "hosts",
+				"createdForResource":     "test-host",
+			},
+		},
+		Data: map[string][]byte{
+			"provider": []byte("test-provider"),
+			"user":     []byte("host-user"),
+			"password": []byte("host-password"),
+			// Note: no insecureSkipVerify key
+		},
+	}
+
+	// Create fake client with the objects
+	scheme := runtime.NewScheme()
+	_ = core.AddToScheme(scheme)
+	_ = api.SchemeBuilder.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(provider, providerSecret).
+		Build()
+
+	// Create admission request
+	hostSecretBytes, err := json.Marshal(hostSecret)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	admissionRequest := &admissionv1.AdmissionRequest{
+		Object: runtime.RawExtension{
+			Raw: hostSecretBytes,
+		},
+	}
+
+	admissionReview := &admissionv1.AdmissionReview{
+		Request: admissionRequest,
+	}
+
+	// Create mutator and test
+	mutator := &SecretMutator{
+		Client: fakeClient,
+	}
+
+	response := mutator.Mutate(admissionReview)
+
+	// Verify the response
+	g.Expect(response.Allowed).To(BeTrue())
+	g.Expect(response.Patch).ToNot(BeNil())
+	g.Expect(response.PatchType).ToNot(BeNil())
+	g.Expect(*response.PatchType).To(Equal(admissionv1.PatchTypeJSONPatch))
+}
+
+func TestMutateHostSecretWithInsecureSkipVerify(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Create host secret with insecureSkipVerify already present
+	hostSecret := &core.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host-secret",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"createdForResourceType": "hosts",
+				"createdForResource":     "test-host",
+			},
+		},
+		Data: map[string][]byte{
+			"provider":           []byte("test-provider"),
+			"user":               []byte("host-user"),
+			"password":           []byte("host-password"),
+			"insecureSkipVerify": []byte("false"), // Already present
+		},
+	}
+
+	// Create fake client
+	scheme := runtime.NewScheme()
+	_ = core.AddToScheme(scheme)
+	_ = api.SchemeBuilder.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	// Create admission request
+	hostSecretBytes, err := json.Marshal(hostSecret)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	admissionRequest := &admissionv1.AdmissionRequest{
+		Object: runtime.RawExtension{
+			Raw: hostSecretBytes,
+		},
+	}
+
+	admissionReview := &admissionv1.AdmissionReview{
+		Request: admissionRequest,
+	}
+
+	// Create mutator and test
+	mutator := &SecretMutator{
+		Client: fakeClient,
+	}
+
+	response := mutator.Mutate(admissionReview)
+
+	// Verify the response - should be allowed but no patch since insecureSkipVerify already exists
+	g.Expect(response.Allowed).To(BeTrue())
+	g.Expect(response.Patch).To(BeNil()) // No patch needed
 }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2802

**Issue:**
In https://github.com/kubev2v/forklift/pull/2073 we "hot fixed" the missing host secret field by forcing insecure skip verify to true.

**Fix:**
  - Revert #2073
  - Add a secret mutation hook to set the missing `insecureSkipVerify` field in the host secret based on provider settings.

**Concerns:**
  - skip verify settings may be different for the vCenter and the ESXi.
  - a ca cert that works for vCenter may not work for the ESXi , causing TLS error.

**Notes:**
  - users can set skip verify flag in host secret manually, overriding copy from vCenter secret
  - users can set `cacert` field in host secret to use custom cacert for the ESXi host
 
**How to tests:**
_Scenario I: host secret without skip flag, copy from provider_
a. create a vCenter provider + secret with skip verify set to `true`
b. create a Host + secret without setting skip verify.

Check the new Host secret, a new field with skip verify set to `true` should be set.

_Scenario I: host secret without skip flag, copy from provider_
a. create a vCenter provider + secret with skip verify set to `fasle`
b. create a Host + secret without setting skip verify.

Check the new Host secret, a new field with skip verify set to `false` should be set.

_Scenario III: host secret with skip flag, ignore provider settings_
a. create a vCenter provider + secret with skip verify set to `true`
b. create a Host + secret with setting skip verify set to `false` and `cacert` data field to valid certificate.

Check the new Host secret, a field with skip verify set to `false` should not be changed.


