### PR TITLE
Silence 'overriding recipe' warnings in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-GOOS ?= `go env GOOS`
-GOPATH ?= `go env GOPATH`
+GOOS ?= $(shell go env GOOS)
+GOPATH ?= $(shell go env GOPATH)
 GOBIN ?= $(GOPATH)/bin
 GO111MODULE = auto
 


### PR DESCRIPTION
The makefile was attempting to set make variables GOOS and GOPATH like
this:
  GOOS ?= `go env GOOS`
  GOPATH ?= `go env GOPATH`

This resulted in warnings like this:

  $ make build-controller-image
  Makefile:333: warning: overriding recipe for target '`go'
  Makefile:328: warning: ignoring old recipe for target '`go'
  Makefile:333: warning: overriding recipe for target 'env'
  Makefile:328: warning: ignoring old recipe for target 'env'
  Makefile:338: warning: overriding recipe for target '`go'
  Makefile:333: warning: ignoring old recipe for target '`go'
  Makefile:338: warning: overriding recipe for target 'env'
  Makefile:333: warning: ignoring old recipe for target 'env'
  Makefile:550: warning: overriding recipe for target '`go'
  Makefile:338: warning: ignoring old recipe for target '`go'
  Makefile:550: warning: overriding recipe for target 'env'
  Makefile:338: warning: ignoring old recipe for target 'env'
  /usr/bin/podman build -t quay.io/kubev2v/forklift-controller:devel -f build/forklift-controller/Containerfile .
  [1/2] STEP 1/7: FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 AS builder
  [1/2] STEP 2/7: WORKDIR /app
  --> Using cache 33c5c6c7b748e43828c6ea7f475f6bc50c8eda6cd6e00687b7694b8dc979a356
  ... etc

But the backtick syntax is not supported by make. It only works in shell
scripts. Instead use the normal $(shell ...) syntax.
