### PR TITLE
MTV-2808 | fix the automatic clusterrolebinding creation for the populator SA

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -8,6 +8,7 @@ import (
 	liburl "net/url"
 	"path"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1793,9 +1794,12 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 		r.Destination.Client,
 		deploy, func() error {
 			if deploy.CreationTimestamp.IsZero() {
-				deploy = &crBinding
+				deploy.Subjects = crBinding.Subjects
+				deploy.RoleRef = crBinding.RoleRef
 			} else {
-				deploy.Subjects = append(deploy.Subjects, crBinding.Subjects...)
+				if !slices.Contains(deploy.Subjects, crBinding.Subjects[0]) {
+					deploy.Subjects = append(deploy.Subjects, crBinding.Subjects[0])
+				}
 			}
 			return nil
 		})


### PR DESCRIPTION
The binding was duplicating the subjects. The patch implementation now
don't include those.
Also the creation of the binding was change to not run over other fields
as we saw that sometimes it fails

https://issues.redhat.com/browse/MTV-2808

Signed-off-by: Roy Golan <rgolan@redhat.com>
