### PR TITLE
Improve error reporting for ocp providers

### DIFF
--- a/pkg/controller/provider/container/openstack/collector.go
+++ b/pkg/controller/provider/container/openstack/collector.go
@@ -119,6 +119,11 @@ func (r *Collector) Version() (_, _, _, _ string, err error) {
 	return
 }
 
+// returns runtime errors - not supported by openstack collector
+func (r *Collector) GetRuntimeErrors() map[string]error {
+	return nil
+}
+
 // Follow link
 func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error {
 	return fmt.Errorf("not implemented")

--- a/pkg/controller/provider/container/ova/collector.go
+++ b/pkg/controller/provider/container/ova/collector.go
@@ -123,6 +123,11 @@ func (r *Collector) Version() (_, _, _, _ string, err error) {
 	return
 }
 
+// returns runtime errors - not supported by ova collector
+func (r *Collector) GetRuntimeErrors() map[string]error {
+	return nil
+}
+
 // Follow link
 func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error {
 	return fmt.Errorf("not implemented")

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -152,6 +152,11 @@ func (r *Collector) Version() (major, minor, build, revision string, err error) 
 	return
 }
 
+// returns runtime errors - not supported by ovirt collector
+func (r *Collector) GetRuntimeErrors() map[string]error {
+	return nil
+}
+
 func parseVersion(fullVersion string) (major, minor, build, revision string) {
 	version := strings.Split(fullVersion, ".")
 	major = version[0]

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -363,6 +363,11 @@ func (r *Collector) Version() (_, _, _, _ string, err error) {
 	return
 }
 
+// returns runtime errors - not supported by vsphere collector
+func (r *Collector) GetRuntimeErrors() map[string]error {
+	return nil
+}
+
 // Start the collector.
 func (r *Collector) Start() error {
 	ctx := context.Background()

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -32,6 +32,7 @@ const (
 	ConnectionTestFailed    = "ConnectionTestFailed"
 	InventoryCreated        = "InventoryCreated"
 	LoadInventory           = "LoadInventory"
+	InventoryError          = "InventoryError"
 	ConnectionInsecure      = "ConnectionInsecure"
 )
 
@@ -366,6 +367,24 @@ func (r *Reconciler) inventoryCreated(provider *api.Provider) error {
 		return nil
 	}
 	if r, found := r.container.Get(provider); found {
+		// Check for runtime errors from any collector that supports them
+		if errors := r.GetRuntimeErrors(); len(errors) > 0 {
+			// Set inventory error condition for any runtime errors
+			var errorMessages []string
+			for kind, err := range errors {
+				errorMessages = append(errorMessages, fmt.Sprintf("%s: %s", kind, err.Error()))
+			}
+			provider.Status.SetCondition(
+				libcnd.Condition{
+					Type:     InventoryError,
+					Status:   True,
+					Reason:   "RuntimeError",
+					Category: Error,
+					Message:  fmt.Sprintf("Inventory runtime errors: %v", errorMessages),
+				})
+			return nil
+		}
+
 		if r.HasParity() {
 			provider.Status.SetCondition(
 				libcnd.Condition{
@@ -385,6 +404,8 @@ func (r *Reconciler) inventoryCreated(provider *api.Provider) error {
 					Message:  "Loading the inventory.",
 				})
 		}
+	} else {
+		log.Info("No collector found", "provider", provider)
 	}
 
 	return nil

--- a/pkg/controller/provider/web/ocp/base.go
+++ b/pkg/controller/provider/web/ocp/base.go
@@ -13,6 +13,7 @@ import (
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/lib/ref"
 	core "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -109,6 +110,18 @@ func (r *PathBuilder) forNamespace(id, leaf string) (path string, err error) {
 	return
 }
 
+func (h Handler) setError(kind string, err error) {
+	if ocpcollector, cast := h.Collector.(*ocpcontainer.Collector); cast {
+		ocpcollector.SetError(kind, err)
+	}
+}
+
+func (h Handler) clearError(kind string) {
+	if ocpcollector, cast := h.Collector.(*ocpcontainer.Collector); cast {
+		ocpcollector.ClearError(kind)
+	}
+}
+
 // Construct a kubernetes client for this handler using a user-provided
 // token (extracted from `ctx`) for authentication to the cluster if the handler
 // is for the local 'host' cluster. This guarantees that the objects returned
@@ -179,8 +192,10 @@ func (h Handler) VMs(ctx *gin.Context, provider *api.Provider) (vms []*model.VM,
 	}
 	err = client.List(context.TODO(), &l, options...)
 	if err != nil {
+		h.setError(ref.ToKind(&cnv.VirtualMachine{}), err)
 		return
 	}
+	h.clearError(ref.ToKind(&cnv.VirtualMachine{}))
 
 	for _, obj := range l.Items {
 		m := &model.VM{}
@@ -203,6 +218,7 @@ func (h Handler) Namespaces(ctx *gin.Context, provider *api.Provider) (namespace
 		ns := &core.Namespace{}
 		err = client.Get(context.TODO(), types.NamespacedName{Name: provider.GetNamespace()}, ns)
 		if err != nil {
+			h.setError(ref.ToKind(&core.Namespace{}), err)
 			return
 		}
 		nsitems = []core.Namespace{*ns}
@@ -210,11 +226,13 @@ func (h Handler) Namespaces(ctx *gin.Context, provider *api.Provider) (namespace
 		list := core.NamespaceList{}
 		err = client.List(context.TODO(), &list, h.ListOptions(ctx)...)
 		if err != nil {
+			h.setError(ref.ToKind(&core.Namespace{}), err)
 			return
 		}
 
 		nsitems = list.Items
 	}
+	h.clearError(ref.ToKind(&core.Namespace{}))
 
 	for _, ns := range nsitems {
 		m := model.Namespace{}
@@ -234,8 +252,10 @@ func (h Handler) StorageClasses(ctx *gin.Context) (storageclasses []model.Storag
 	// the query for restricted host providers.
 	err = client.List(context.TODO(), &list, h.ListOptions(ctx)...)
 	if err != nil {
+		h.setError(ref.ToKind(&storage.StorageClass{}), err)
 		return
 	}
+	h.clearError(ref.ToKind(&storage.StorageClass{}))
 
 	for _, sc := range list.Items {
 		m := model.StorageClass{}
@@ -257,8 +277,10 @@ func (h Handler) NetworkAttachmentDefinitions(ctx *gin.Context, provider *api.Pr
 	}
 	err = client.List(context.TODO(), &list, options...)
 	if err != nil {
+		h.setError(ref.ToKind(&net.NetworkAttachmentDefinition{}), err)
 		return
 	}
+	h.clearError(ref.ToKind(&net.NetworkAttachmentDefinition{}))
 	for _, nad := range list.Items {
 		m := model.NetworkAttachmentDefinition{}
 		m.With(&nad)
@@ -280,8 +302,10 @@ func (h Handler) InstanceTypes(ctx *gin.Context, provider *api.Provider) (instan
 	}
 	err = client.List(context.TODO(), &list, options...)
 	if err != nil {
+		h.setError(ref.ToKind(&instancetype.VirtualMachineInstancetype{}), err)
 		return
 	}
+	h.clearError(ref.ToKind(&instancetype.VirtualMachineInstancetype{}))
 
 	for _, itype := range list.Items {
 		m := model.InstanceType{}
@@ -300,6 +324,11 @@ func (h Handler) ClusterInstanceTypes(ctx *gin.Context) (clusterinstances []mode
 	// clusterinstancetypes are listable by any authenticated user, so no need to
 	// pass the 'provider' to ListOptions even for restricted host providers.
 	err = client.List(context.TODO(), &list, h.ListOptions(ctx)...)
+	if err != nil {
+		h.setError(ref.ToKind(&instancetype.VirtualMachineClusterInstancetype{}), err)
+		return
+	}
+	h.clearError(ref.ToKind(&instancetype.VirtualMachineClusterInstancetype{}))
 	for _, cit := range list.Items {
 		m := model.ClusterInstanceType{}
 		m.With(&cit)

--- a/pkg/lib/cmd/inventory/main.go
+++ b/pkg/lib/cmd/inventory/main.go
@@ -176,6 +176,10 @@ func (*Collector) Version() (string, string, string, string, error) {
 	return "", "", "", "", nil
 }
 
+func (*Collector) GetRuntimeErrors() map[string]error {
+	return nil
+}
+
 func (r *Collector) Name() string {
 	return "tester"
 }

--- a/pkg/lib/inventory/container/container.go
+++ b/pkg/lib/inventory/container/container.go
@@ -152,4 +152,6 @@ type Collector interface {
 	Reset()
 	// Get the system version - currently, ovirt-only
 	Version() (string, string, string, string, error)
+	// Get runtime errors - returns map of resource kind to error
+	GetRuntimeErrors() map[string]error
 }

--- a/pkg/lib/inventory/container/ocp/collector.go
+++ b/pkg/lib/inventory/container/ocp/collector.go
@@ -46,6 +46,8 @@ type Collector struct {
 	client client.Client
 	// cancel function.
 	cancel func()
+	//
+	errors map[string]error
 }
 
 // New collector.
@@ -64,6 +66,7 @@ func New(
 		cluster:     cluster,
 		secret:      secret,
 		log:         log,
+		errors:      make(map[string]error),
 	}
 }
 
@@ -222,4 +225,21 @@ func (r *Collector) buildClient() (err error) {
 		})
 
 	return
+}
+
+func (r *Collector) ClearError(kind string) {
+	delete(r.errors, kind)
+}
+
+func (r *Collector) SetError(kind string, err error) {
+	r.errors[kind] = err
+}
+
+// returns a copy of all current errors that were encountered while querying the inventory
+func (r *Collector) GetRuntimeErrors() map[string]error {
+	errors := make(map[string]error)
+	for k, v := range r.errors {
+		errors[k] = v
+	}
+	return errors
 }

--- a/pkg/lib/inventory/container/ocp/collector.go
+++ b/pkg/lib/inventory/container/ocp/collector.go
@@ -3,16 +3,23 @@ package ocp
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path"
 	"time"
 
+	net "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	ocp "github.com/kubev2v/forklift/pkg/lib/client/openshift"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	core "k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	cnv "kubevirt.io/api/core/v1"
+	instancetype "kubevirt.io/api/instancetype/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -96,7 +103,47 @@ func (r *Collector) HasParity() bool {
 
 // Test connection with credentials.
 func (r *Collector) Test() (int, error) {
-	return 0, r.buildClient()
+	if err := r.buildClient(); err != nil {
+		return 0, err
+	}
+
+	// Test permissions for all resource types that the OCP provider needs
+	testResources := []struct {
+		resource string
+		list     client.ObjectList
+	}{
+		{"namespaces", &core.NamespaceList{}},
+		{"storageclasses", &storage.StorageClassList{}},
+		{"network-attachment-definitions", &net.NetworkAttachmentDefinitionList{}},
+		{"virtualmachines", &cnv.VirtualMachineList{}},
+		{"virtualmachineinstancetypes", &instancetype.VirtualMachineInstancetypeList{}},
+		{"virtualmachineclusterinstancetypes", &instancetype.VirtualMachineClusterInstancetypeList{}},
+	}
+
+	ctx := context.TODO()
+	for _, resource := range testResources {
+		listOptions := &client.ListOptions{Limit: 1}
+
+		if err := r.client.List(ctx, resource.list, listOptions); err != nil {
+			r.log.Info(
+				"Permission test failed for resource",
+				"resource", resource.resource,
+				"error", err.Error())
+
+			var statusCode int
+			apiStatus, ok := err.(k8serrors.APIStatus)
+			if ok {
+				statusCode = int(apiStatus.Status().Code)
+			} else {
+				statusCode = http.StatusInternalServerError
+			}
+			return statusCode, liberr.New(fmt.Sprintf(
+				"Failed to get resource %s: %v",
+				resource.resource, err))
+		}
+	}
+
+	return 0, nil
 }
 
 // Start the collector.


### PR DESCRIPTION
When creating a new ocp provider, if it is not configured correctly, it would
often get stuck in 'staging' state and never give the user any indication of
why wasn't working. This patch series attempts to improve the situation and
make the problem more debuggable to a user.

The first patch implements an actual connection test for ocp providers which
didnt' exist before and should allow the user to catch a lot of configuration
errors early.

The second patch may not be necessary since the first patch may be sufficient.
But it keeps a map of errors that were encountered during inventory requests and
provides an interface for the provider reconciler to get that information and
use it to report Conditions on the provider object.

Fixes: https://issues.redhat.com/browse/MTV-2447
