### PR TITLE
MTV-2677 | Missing important warning for Preserve Static IPs

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -310,6 +310,9 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 		return
 	}
 
+	if vm.PowerState != string(types.VirtualMachinePowerStatePoweredOn) {
+		return
+	}
 	for _, guestNetwork := range vm.GuestNetworks {
 		found := false
 		for _, nic := range vm.NICs {

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -29,7 +29,11 @@ func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 				GuestNetworks: []vsphere.GuestNetwork{
 					{MAC: "mac1"},
 				},
-				GuestID: "windows7Guest"},
+				GuestID: "windows7Guest",
+				VM1: model.VM1{
+					PowerState: "poweredOn", // default state
+				},
+			},
 		}
 		if ref.Name == "full_guest_network" {
 			res.VM.GuestNetworks = append(res.VM.GuestNetworks, vsphere.GuestNetwork{MAC: "mac2"})

--- a/validation/policies/io/konveyor/forklift/vmware/power_state.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/power_state.rego
@@ -1,0 +1,15 @@
+package io.konveyor.forklift.vmware
+
+is_vm_powered_off {
+    input.powerState == "poweredOff"
+}
+
+concerns[flag] {
+    is_vm_powered_off
+    flag := {
+        "id": "vmware.vm_powered_off.detected",
+        "category": "Warning",
+        "label": "VM is powered off - Static IP preservation requires the VM to be powered on",
+        "assessment": "Static IP preservation requires the VM to be powered on."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/vmware/power_state_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/power_state_test.rego
@@ -1,0 +1,13 @@
+package io.konveyor.forklift.vmware
+
+test_with_power_state_powered_on {
+    mock_vm := { "name": "test", "powerState": "poweredOn" }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_power_state_powered_off {
+    mock_vm := { "name": "test", "powerState": "poweredOff" }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}


### PR DESCRIPTION
Issue:
Create a cold migration plan to migrate a shutoff VM with "Preserve Static IPs" on, the plan page is without warning message below, which will cause user migrate a shutoff VM, and the VM will not have static ip settings on the target cluster.

Fix:
Add powerstate logic for staticIp validation plus adding opa warning for VM's power state is off.

Ref:
https://issues.redhat.com/browse/MTV-2677