### PR TITLE
MTV-2698 | Disable the RHNoEnforceEMSinFIPS

### DIFF
--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -32,6 +32,11 @@ RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o image-converter github.
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o virt-v2v-wrapper github.com/kubev2v/forklift/cmd/virt-v2v
 
 FROM registry.redhat.io/ubi9:9.6-1747219013 AS runtime
+
+RUN rm /etc/pki/tls/fips_local.cnf && \
+    echo -e '[fips_sect]\ntls1-prf-ems-check = 0\nactivate = 1' > /etc/pki/tls/fips_local.cnf && \
+    sed -i '/^\\[ crypto_policy \\]/a Options=RHNoEnforceEMSinFIPS' /etc/pki/tls/openssl.cnf
+
 RUN mkdir /disks && \
     source /etc/os-release && \
     dnf update -y && \


### PR DESCRIPTION
Backport of: https://github.com/kubev2v/forklift/pull/2133

Issue:
virt-v2v conversion is failing on FIPS enabled clusters with:
```
[0.0] Setting up the source: -i libvirt -ic
vpx://administrator%40vsphere.local@10.6.46.170/data/host/10.6.46.28?no_verify=1
 -it vddk mtv-func-rhel8-multi-nicsvirt-v2v:
 error: exception: libvirt: VIR_ERR_INTERNAL_ERROR: VIR_FROM_ESX:
internal error: curl_easy_perform() returned an error: SSL connect error
 (35) : error:1C8000E9:Provider routines::ems not enabled rm -rf -- '/tmp/v2v.73O7Vz'
```

Fix:
We have remove the EMS disable from the downstream build in the new konflux build files. We still have it in our upstream builds so we did not notice this issue during the development.

Ref:
- https://bugzilla.redhat.com/show_bug.cgi?id=2216256
- #585
- https://issues.redhat.com/browse/MTV-2698