### PR TITLE
MTV-2800 | Fix look up for existing VMs in OCP provider

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"path"
 	"strconv"
 
 	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -739,16 +738,16 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		if pErr != nil {
 			return liberr.Wrap(pErr)
 		}
-		id := path.Join(
-			plan.Spec.TargetNamespace,
-			ref.Name)
+		vmName := ref.Name
 		if vm.TargetName != "" {
 			// if target name is provided, use it to look for existing VMs
-			id = path.Join(
-				plan.Spec.TargetNamespace,
-				vm.TargetName)
+			vmName = vm.TargetName
 		}
-		_, pErr = inventory.VM(&refapi.Ref{Name: id})
+		vmRef := &refapi.Ref{
+			Name:      vmName,
+			Namespace: plan.Spec.TargetNamespace,
+		}
+		_, pErr = inventory.VM(vmRef)
 		if pErr == nil {
 			if _, found := plan.Status.Migration.FindVM(*ref); !found {
 				// This VM is preexisting or is being managed by a


### PR DESCRIPTION
When we validate a vm name for a migration plan, we query whether an existing vm with that name already exists. But we were looking up the vm by concatenating the namespace and vm name:

``` go
Ref { Name: "namespace/vmname"}
```

But if the vmname contains invalid characters (especially a '/' character, which is valid in vsphere), that lookup fails and treats everything before the last '/' character as the namespace. That query predictably fails. For example, if the vsphere vm was named "foo/bar", and the target namespace was "default", the kubernetes query would try to find the vm "default/foo/bar". That resulted in an error response like:

```
invalid namespace "default/foo": [may not contain '/']
```

We should properly specify the resource name and the namespace separately in the `Ref`:

``` go
Ref { Namespace: "default", Name: "foo/bar"}
```

With this fix, we will not get the same error message and the validation will be able to proceed. We will later determine that the vm name is invalid and so we will automatically assign a new targetName for the vm migration.

Fixes: https://issues.redhat.com/browse/MTV-2800
