### PR TITLE
MTV-2849 | Need to keep the default gateway setting after migration

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
@@ -77,14 +77,14 @@ if (-not $groupedRoutes) {
         # Fallback to route.exe if New-NetRoute failed
         if (-not $reAddSucceeded) {
             # Re-add one preserved route using legacy route.exe
-            $command = "route -p ADD $network MASK $netmask $gateway"
+            $command = "route -p ADD $network MASK $netmask $gateway IF $interfaceIndex"
             if ($metricStr -ne "") {
                 $command += " $metricStr"
             }
 
             try {
                 cmd /c $command
-                Write-Host "  Re-added: $dest via $gateway metric $metric" -ForegroundColor Green
+                Write-Host "  Re-added with route.exe: $dest via $gateway metric $metric on IF $interfaceIndex" -ForegroundColor Green
             } catch {
                 Write-Host "    Failed to re-add route: $($_.Exception.Message)" -ForegroundColor Red
             }


### PR DESCRIPTION
Issue:
Regression - default gateway settings are missing after a cold migration with preserve static ip.

The root cause is  the duplication routes being deleted. The remove duplications flow is:
1. Deletes all duplicates . 2.Tries to re-add the route using New-NetRoute.
3. If that fails, it falls back to the "route" command

If re-adding a route fails silently, the gateway route is simply gone, leading to:
1. No default gateway showing. 2.No connectivity despite a configured IP.

Fix:
Add InterfaceIndex to "route" command .
This removes all ambiguity and ensures:
1. The correct interface gets the route.
2. You avoid silent misrouting or ignored routes. 3.The default gateway is reliably assigned, even during early boot or interface flapping.

Ref: https://issues.redhat.com/browse/MTV-2849