### PR TITLE
MTV-2760 | Dual NICs Mapped to Pod Network Show "Ready" Status.

### DIFF
--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -78,8 +78,7 @@ func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
 			return
 		}
 		for _, nic := range vm.NICs {
-			// TODO move from NIC name to NIC ID? ID should be unique
-			if nic.Name == network.Name && mapped.Destination.Type == Pod {
+			if nic.Network == network.Name && mapped.Destination.Type == Pod {
 				podMapped++
 			}
 		}


### PR DESCRIPTION
Issue:
migration OVA plan for a VM that has two network cards (NICs). The issue is, both of these source NICs are incorrectly mapped to the same pod network, yet the plan still shows a "ready" status, even though this misconfiguration isn't reflected in the YAML.

Fix:
Compare nic's network (instead of name) to network's name.

Ref: https://issues.redhat.com/browse/MTV-2760