### PR TITLE
CNV-64582 | Add a feature flag to format vmware system serial

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -8,6 +8,7 @@ feature_validation: true
 feature_volume_populator: true
 feature_copy_offload: false
 feature_ocp_live_migration: false
+feature_vmware_system_serial_number: false
 
 k8s_cluster: false
 feature_auth_required: true

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -132,6 +132,10 @@ spec:
         - name: FEATURE_OCP_LIVE_MIGRATION
           value: "true"
 {% endif %}
+{% if feature_vmware_system_serial_number|bool %}
+        - name: FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER
+          value: "true"
+{% endif %}
 {% if ovirt_osmap_configmap_name is defined %}
         - name: OVIRT_OS_MAP
           value: {{ ovirt_osmap_configmap_name }}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -907,9 +907,20 @@ func (r *Builder) mapCPU(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	}
 }
 
+func (r *Builder) getSystemSerial(vm *model.VM) string {
+	// On deployments where VMware serial number formtting is enabled,
+	if settings.Settings.VmwareSystemSerialNumber {
+		// we use the UUID to generate a VMware serial number.
+		return UUIDToVMwareSerial(vm.UUID)
+	}
+
+	// Default to using .config.uuid as the system serial number
+	return vm.UUID
+}
+
 func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	firmware := &cnv.Firmware{
-		Serial: vm.UUID,
+		Serial: r.getSystemSerial(vm),
 	}
 	switch vm.Firmware {
 	case Efi:

--- a/pkg/controller/plan/adapter/vsphere/uuid_to_vmware_serial.go
+++ b/pkg/controller/plan/adapter/vsphere/uuid_to_vmware_serial.go
@@ -1,0 +1,42 @@
+package vsphere
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// UUIDToVMwareSerial converts a UUID string to VMware serial format
+// Input: "422c6a2a-5ea9-1083-39f3-3b140fffb444"
+// Output: "VMware-42 2c 6a 2a 5e a9 10 83-39 f3 3b 14 0f ff b4 44"
+func UUIDToVMwareSerial(uuid string) string {
+	// Validate UUID format using regex
+	uuidRegex := regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	if !uuidRegex.MatchString(uuid) {
+		// Fallback to original UUID if it doesn't match the expected format
+		return uuid
+	}
+
+	// Remove hyphens from UUID
+	cleanUUID := strings.ReplaceAll(uuid, "-", "")
+
+	// Convert to lowercase for consistency
+	cleanUUID = strings.ToLower(cleanUUID)
+
+	// Insert spaces every 2 characters
+	var spacedUUID strings.Builder
+	for i := 0; i < len(cleanUUID); i += 2 {
+		if i > 0 {
+			spacedUUID.WriteString(" ")
+		}
+		spacedUUID.WriteString(cleanUUID[i : i+2])
+	}
+
+	// Split the spaced string into two parts
+	spacedString := spacedUUID.String()
+	firstPart := spacedString[:23]  // "42 2c 6a 2a 5e a9 10 83"
+	secondPart := spacedString[24:] // "39 f3 3b 14 0f ff b4 44"
+
+	// Combine with VMware prefix and separator
+	return fmt.Sprintf("VMware-%s-%s", firstPart, secondPart)
+}

--- a/pkg/controller/plan/adapter/vsphere/uuid_to_vmware_serial_test.go
+++ b/pkg/controller/plan/adapter/vsphere/uuid_to_vmware_serial_test.go
@@ -1,0 +1,82 @@
+package vsphere
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UUIDToVMwareSerial", func() {
+	DescribeTable("should convert valid UUIDs to VMware serial format",
+		func(input string, expected string) {
+			result := UUIDToVMwareSerial(input)
+			Expect(result).To(Equal(expected))
+		},
+		Entry("standard UUID lowercase",
+			"422c6a2a-5ea9-1083-39f3-3b140fffb444",
+			"VMware-42 2c 6a 2a 5e a9 10 83-39 f3 3b 14 0f ff b4 44"),
+		Entry("standard UUID uppercase",
+			"422C6A2A-5EA9-1083-39F3-3B140FFFB444",
+			"VMware-42 2c 6a 2a 5e a9 10 83-39 f3 3b 14 0f ff b4 44"),
+		Entry("standard UUID mixed case",
+			"422c6A2a-5eA9-1083-39F3-3b140FFFb444",
+			"VMware-42 2c 6a 2a 5e a9 10 83-39 f3 3b 14 0f ff b4 44"),
+		Entry("UUID with all zeros",
+			"00000000-0000-0000-0000-000000000000",
+			"VMware-00 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00"),
+		Entry("UUID with all F's",
+			"ffffffff-ffff-ffff-ffff-ffffffffffff",
+			"VMware-ff ff ff ff ff ff ff ff-ff ff ff ff ff ff ff ff"),
+		Entry("UUID with numbers only",
+			"12345678-1234-1234-1234-123456789012",
+			"VMware-12 34 56 78 12 34 12 34-12 34 12 34 56 78 90 12"),
+		Entry("UUID with letters only",
+			"abcdefab-cdef-abcd-efab-cdefabcdefab",
+			"VMware-ab cd ef ab cd ef ab cd-ef ab cd ef ab cd ef ab"),
+	)
+
+	DescribeTable("should return original string for invalid UUIDs",
+		func(input string, expected string) {
+			result := UUIDToVMwareSerial(input)
+			Expect(result).To(Equal(expected))
+		},
+		Entry("empty string", "", ""),
+		Entry("too short UUID",
+			"422c6a2a-5ea9-1083-39f3",
+			"422c6a2a-5ea9-1083-39f3"),
+		Entry("too long UUID",
+			"422c6a2a-5ea9-1083-39f3-3b140fffb444-extra",
+			"422c6a2a-5ea9-1083-39f3-3b140fffb444-extra"),
+		Entry("UUID without hyphens",
+			"422c6a2a5ea9108339f33b140fffb444",
+			"422c6a2a5ea9108339f33b140fffb444"),
+		Entry("UUID with invalid characters",
+			"422c6a2a-5ea9-1083-39f3-3b140fffb44g",
+			"422c6a2a-5ea9-1083-39f3-3b140fffb44g"),
+		Entry("UUID with wrong hyphen positions",
+			"422c6a2a5-ea9-1083-39f3-3b140fffb444",
+			"422c6a2a5-ea9-1083-39f3-3b140fffb444"),
+		Entry("random string",
+			"not-a-uuid",
+			"not-a-uuid"),
+		Entry("UUID with spaces",
+			"422c6a2a-5ea9-1083-39f3- 3b140fffb444",
+			"422c6a2a-5ea9-1083-39f3- 3b140fffb444"),
+		Entry("partial UUID",
+			"422c6a2a-5ea9",
+			"422c6a2a-5ea9"),
+	)
+
+	Context("edge cases", func() {
+		It("should handle maximum valid hex values", func() {
+			uuid := "ffffffff-ffff-ffff-ffff-ffffffffffff"
+			result := UUIDToVMwareSerial(uuid)
+			Expect(result).To(Equal("VMware-ff ff ff ff ff ff ff ff-ff ff ff ff ff ff ff ff"))
+		})
+
+		It("should handle minimum valid hex values", func() {
+			uuid := "00000000-0000-0000-0000-000000000000"
+			result := UUIDToVMwareSerial(uuid)
+			Expect(result).To(Equal("VMware-00 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00"))
+		})
+	})
+})

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -7,6 +7,7 @@ const (
 	FeatureVsphereIncrementalBackup  = "FEATURE_VSPHERE_INCREMENTAL_BACKUP"
 	FeatureCopyOffload               = "FEATURE_COPY_OFFLOAD"
 	FeatureOCPLiveMigration          = "FEATURE_OCP_LIVE_MIGRATION"
+	FeatureVmwareSystemSerialNumber  = "FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER"
 )
 
 // Feature gates.
@@ -22,6 +23,8 @@ type Features struct {
 	CopyOffload bool
 	// Whether to enable support for OCP cross-cluster live migration.
 	OCPLiveMigration bool
+	// Whether to use VMware system serial number for VM migration from VMware.
+	VmwareSystemSerialNumber bool
 }
 
 // Load settings.
@@ -31,5 +34,6 @@ func (r *Features) Load() (err error) {
 	r.VsphereIncrementalBackup = getEnvBool(FeatureVsphereIncrementalBackup, false)
 	r.CopyOffload = getEnvBool(FeatureCopyOffload, false)
 	r.OCPLiveMigration = getEnvBool(FeatureOCPLiveMigration, false)
+	r.VmwareSystemSerialNumber = getEnvBool(FeatureVmwareSystemSerialNumber, false)
 	return
 }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/CNV-64582

CNV PR: https://github.com/kubevirt/kubevirt/pull/15118 - merged and backported

**Issue**:
On VMWare clusters the VM serial number is set using VMWare specific format,
We currently use VMWare API to get the system UUID.

**Fix**:
On systems that require using the original VMWare system serial verbatim from VMWare env, we can use the UUID to reconstruct the original VMWare system serial 

**For future updates:**
Currently we mutate the system serial to pass Kubevirt verifiaction.
In future when all supported kubevirt deployments will support spaces in the system serail
we can drop the feature flag and always set the formatted system serial

On kubevirt that do not support this feature we will get an error:
```bash
yzamir@fedora:~$ oc get plan test1 -o json | grep "admission webhook"
"admission webhook \"virtualmachine-validator.kubevirt.io\" denied the request: spec.template.spec.domain.firmware.serial must be made up of the following characters [A-Za-z0-9_.+-], if specified"
```

**Example**:
```bash
# source VM on VMWare
dmidecode -s system-serial-number
VMware-42 3e fd 65 a7 3d e1 59-a5 6d dd 25 28 9f 8b 0c 
```

```bash
# fetching UUID
govc vm.info -json mnecas-fedora | jq -r '.virtualMachines[0].config.uuid'
423efd65-a73d-e159-a56d-dd25289f8b0c  
```

**After fix** calling dmidecode -s system-serial-number on the migrated VM should return:
```bash
# target VM on Kubevirt
dmidecode -s system-serial-number
VMware-42 3e fd 65 a7 3d e1 59-a5 6d dd 25 28 9f 8b 0c 
```