### PR TITLE
Add virtualmachineinstances to controller role

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3640,6 +3640,7 @@ rules:
   - kubevirt.io
   resources:
   - kubevirts
+  - virtualmachineinstances
   verbs:
   - get
   - list

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -3640,6 +3640,7 @@ rules:
   - kubevirt.io
   resources:
   - kubevirts
+  - virtualmachineinstances
   verbs:
   - get
   - list

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3640,6 +3640,7 @@ rules:
   - kubevirt.io
   resources:
   - kubevirts
+  - virtualmachineinstances
   verbs:
   - get
   - list

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -87,6 +87,7 @@ rules:
   - kubevirt.io
   resources:
   - kubevirts
+  - virtualmachineinstances
   verbs:
   - get
   - list


### PR DESCRIPTION
Access to get VirtualMachineInstances is missing from the forklift-controller serviceaccount role, which keeps validation from working when the host cluster is the VM source.