### PR TITLE
MTV-2810 | Migrate VM from OCP to OCP hang

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -159,6 +159,8 @@ type Validator interface {
 	PowerState(vmRef ref.Ref) (bool, error)
 	// Validate that the VM is inherently compatible with the migration type.
 	VMMigrationType(vmRef ref.Ref) (bool, error)
+	// Validate that the VM name is valid.
+	ValidVmName(vmRef ref.Ref) (bool, error)
 }
 
 // DestinationClient API.

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/settings"
 	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	cnv "kubevirt.io/api/core/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -233,6 +234,22 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 		}
 	}
 
+	return true, nil
+}
+
+// OCP-to-OCP VM migration requires names that are DNS_RFC_1035 compliant, unlike DNS_RFC_1123 where we modify the VM name as needed.
+func (r *Validator) ValidVmName(vmRef ref.Ref) (ok bool, err error) {
+	// Check if the VM reference name is a valid DNS1123 subdomain
+	if len(k8svalidation.IsDNS1123Subdomain(vmRef.Name)) > 0 {
+		// Not valid
+		return false, nil
+	} else if len(k8svalidation.IsDNS1035Label(vmRef.Name)) > 0 {
+		return false, liberr.Wrap(
+			fmt.Errorf("Invalid VM name %q: must be a valid DNS-1035 label", vmRef.Name),
+			"vm",
+			vmRef.String())
+	}
+	// Valid
 	return true, nil
 }
 

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -6,6 +6,7 @@ import (
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/openstack"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,6 +38,16 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 
 	ok = true
 	return
+}
+
+func (r *Validator) ValidVmName(vmRef ref.Ref) (ok bool, err error) {
+	// Check if the VM reference name is a valid DNS1123 subdomain
+	if len(k8svalidation.IsDNS1123Subdomain(vmRef.Name)) > 0 {
+		// Not valid
+		return false, nil
+	}
+	// Valid
+	return true, nil
 }
 
 // Validate that a VM's networks have been mapped.

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -6,6 +6,7 @@ import (
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ova"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,6 +36,16 @@ func (r *Validator) MigrationType() bool {
 func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, s string, s2 string, err error) {
 	ok = true
 	return
+}
+
+func (r *Validator) ValidVmName(vmRef ref.Ref) (ok bool, err error) {
+	// Check if the VM reference name is a valid DNS1123 subdomain
+	if len(k8svalidation.IsDNS1123Subdomain(vmRef.Name)) > 0 {
+		// Not valid
+		return false, nil
+	}
+	// Valid
+	return true, nil
 }
 
 // Validate that a VM's networks have been mapped.

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -10,6 +10,7 @@ import (
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ovirt"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/kubev2v/forklift/pkg/settings"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -41,6 +42,16 @@ func (r *Validator) MigrationType() bool {
 	default:
 		return false
 	}
+}
+
+func (r *Validator) ValidVmName(vmRef ref.Ref) (ok bool, err error) {
+	// Check if the VM reference name is a valid DNS1123 subdomain
+	if len(k8svalidation.IsDNS1123Subdomain(vmRef.Name)) > 0 {
+		// Not valid
+		return false, nil
+	}
+	// Valid
+	return true, nil
 }
 
 // Validate that a VM's networks have been mapped.

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/validation"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/vmware/govmomi/vim25/types"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,6 +37,16 @@ func (r *Validator) MigrationType() bool {
 	default:
 		return false
 	}
+}
+
+func (r *Validator) ValidVmName(vmRef ref.Ref) (ok bool, err error) {
+	// Check if the VM reference name is a valid DNS1123 subdomain
+	if len(k8svalidation.IsDNS1123Subdomain(vmRef.Name)) > 0 {
+		// Not valid
+		return false, nil
+	}
+	// Valid
+	return true, nil
 }
 
 // Validate that a VM's networks have been mapped.

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -216,9 +216,16 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		if r.isDanglingArchivedPlan(plan) {
 			r.Log.Info("Dangling Plan - Aborting reconcile of plan without source provider.")
 			r.archive(plan)
-			if err = r.updatePlanStatus(plan); err != nil {
-				r.Log.Error(err, "failed to update plan status")
-			}
+		} else {
+			plan.Status.SetCondition(libcnd.Condition{
+				Type:     libcnd.Error,
+				Status:   True,
+				Category: Critical,
+				Message:  err.Error(),
+			})
+		}
+		if err = r.updatePlanStatus(plan); err != nil {
+			r.Log.Error(err, "failed to update plan status")
 		}
 		return
 	}


### PR DESCRIPTION
Issue:
OCP vm name with dots causes the migration to hang. 

Fix:
Add additional validations to inform users during plan creation  that OCP VMs names with dots are not supported.

Ref: https://issues.redhat.com/browse/MTV-2810