### PR TITLE
build: Remove LIBGUESTFS_BACKEND=direct everywhere

### DIFF
--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -1,7 +1,5 @@
 FROM registry.access.redhat.com/ubi9:9.5-1747219013 AS appliance
 
-ENV LIBGUESTFS_BACKEND=direct
-
 RUN subscription-manager refresh && \
     dnf install -y --setopt=install_weak_deps=False \
         qemu-img \
@@ -42,8 +40,6 @@ RUN subscription-manager refresh && \
         virt-v2v \
         virtio-win && \
     dnf clean all
-
-ENV LIBGUESTFS_BACKEND=direct
 
 RUN mkdir -p /usr/lib64/guestfs/appliance
 COPY --from=appliance /usr/local/lib/guestfs/appliance /usr/lib64/guestfs/appliance

--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -5,8 +5,6 @@ RUN yum install -y --setopt=install_weak_deps=False virtio-win-1.9.4-2.el7.2
 
 FROM registry.redhat.io/ubi9:9.6-1747219013 AS appliance
 
-ENV LIBGUESTFS_BACKEND=direct
-
 RUN dnf update -y && \
     dnf install -y --setopt=install_weak_deps=False \
     qemu-img \
@@ -45,7 +43,6 @@ RUN mkdir /disks && \
     virtio-win
 
 ENV PATH="$PATH:/usr/libexec"
-ENV LIBGUESTFS_BACKEND=direct
 
 RUN mkdir -p /usr/lib64/guestfs/appliance
 COPY --from=appliance /usr/local/lib/guestfs/appliance /usr/lib64/guestfs/appliance

--- a/build/virt-v2v/Containerfile-downstream-fssupport
+++ b/build/virt-v2v/Containerfile-downstream-fssupport
@@ -16,8 +16,6 @@ RUN rm /etc/pki/tls/fips_local.cnf && \
 
 ENV PATH="$PATH:/usr/libexec"
 
-ENV LIBGUESTFS_BACKEND=direct
-
 # RHEL 10.1 virt-v2v and deps
 RUN yum install  -y --setopt=sslverify=false \
     https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/virt-v2v/2.8.0/1.el10/x86_64/virt-v2v-2.8.0-1.el10.x86_64.rpm \

--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -17,7 +17,7 @@ RUN rm /etc/pki/tls/fips_local.cnf && \
 
 # The virt-v2v-in-place in centos is not in the bin directory and is not accessible via PATH
 ENV PATH="$PATH:/usr/libexec"
-ENV LIBGUESTFS_BACKEND=direct LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+ENV LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 
 RUN mkdir /disks && \
     source /etc/os-release && \

--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -15,7 +15,7 @@ RUN rm /etc/pki/tls/fips_local.cnf && \
     echo -e '[fips_sect]\ntls1-prf-ems-check = 0\nactivate = 1' > /etc/pki/tls/fips_local.cnf && \
     sed -i '/^\\[ crypto_policy \\]/a Options=RHNoEnforceEMSinFIPS' /etc/pki/tls/openssl.cnf
 
-ENV LIBGUESTFS_BACKEND=direct LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+ENV LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 
 RUN mkdir /disks && \
     source /etc/os-release && \

--- a/build/virt-v2v/Containerfile-upstream-fssupport
+++ b/build/virt-v2v/Containerfile-upstream-fssupport
@@ -17,7 +17,7 @@ RUN rm /etc/pki/tls/fips_local.cnf && \
 
 # The virt-v2v-in-place in centos is not in the bin directory and is not accessible via PATH
 ENV PATH="$PATH:/usr/libexec"
-ENV LIBGUESTFS_BACKEND=direct LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+ENV LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 
 RUN mkdir /disks && \
     source /etc/os-release && \


### PR DESCRIPTION
This should *never* be used.  It causes libguestfs to use an untested code path.  It also stops libvirt from containerizing the qemu subprocess, reducing security.

Wherever this is seen, it should be removed.  If doing so causes a problem (which is unlikely as it puts us back on the tested code path) then file a detailed bug about the problem, but do not reintroduce the environment variable.