### PR TITLE
build: virt-v2v: Simplify package download

### DIFF
--- a/build/virt-v2v/Containerfile-downstream-fssupport
+++ b/build/virt-v2v/Containerfile-downstream-fssupport
@@ -32,7 +32,6 @@ RUN \
       nbdkit:nbdkit-server-1.42.5-1.el10 \
       nbdkit:nbdkit-curl-plugin-1.42.5-1.el10 \
       nbdkit:nbdkit-nbd-plugin-1.42.5-1.el10 \
-      nbdkit:nbdkit-python-plugin-1.42.5-1.el10 \
       nbdkit:nbdkit-ssh-plugin-1.42.5-1.el10 \
       nbdkit:nbdkit-vddk-plugin-1.42.5-1.el10 \
       guestfs-tools:guestfs-tools-1.54.0-2.el10 \

--- a/build/virt-v2v/Containerfile-downstream-fssupport
+++ b/build/virt-v2v/Containerfile-downstream-fssupport
@@ -16,31 +16,39 @@ RUN rm /etc/pki/tls/fips_local.cnf && \
 
 ENV PATH="$PATH:/usr/libexec"
 
-# RHEL 10.1 virt-v2v and deps
-RUN yum install  -y --setopt=sslverify=false \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/virt-v2v/2.8.0/1.el10/x86_64/virt-v2v-2.8.0-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/libguestfs/1.56.0/1.el10.1/x86_64/libguestfs-1.56.0-1.el10.1.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/libguestfs/1.56.0/1.el10.1/x86_64/libguestfs-appliance-1.56.0-1.el10.1.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/libnbd/1.22.2/1.el10/x86_64/libnbd-1.22.2-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/libguestfs/1.56.0/1.el10.1/x86_64/libguestfs-xfs-1.56.0-1.el10.1.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/nbdkit/1.42.5/1.el10/x86_64/nbdkit-1.42.5-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/nbdkit/1.42.5/1.el10/x86_64/nbdkit-basic-filters-1.42.5-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/nbdkit/1.42.5/1.el10/x86_64/nbdkit-basic-plugins-1.42.5-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/nbdkit/1.42.5/1.el10/x86_64/nbdkit-server-1.42.5-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/nbdkit/1.42.5/1.el10/x86_64/nbdkit-curl-plugin-1.42.5-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/nbdkit/1.42.5/1.el10/x86_64/nbdkit-nbd-plugin-1.42.5-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/nbdkit/1.42.5/1.el10/x86_64/nbdkit-python-plugin-1.42.5-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/nbdkit/1.42.5/1.el10/x86_64/nbdkit-ssh-plugin-1.42.5-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/nbdkit/1.42.5/1.el10/x86_64/nbdkit-vddk-plugin-1.42.5-1.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/guestfs-tools/1.54.0/2.el10/x86_64/guestfs-tools-1.54.0-2.el10.x86_64.rpm
-
-# Custom Kernel for libguestfs-fssupport
-RUN dnf install -y --setopt=sslverify=false \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/kernel/6.12.0/95.el10/x86_64/kernel-6.12.0-95.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/kernel/6.12.0/95.el10/x86_64/kernel-modules-core-6.12.0-95.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/kernel/6.12.0/95.el10/x86_64/kernel-core-6.12.0-95.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/kernel/6.12.0/95.el10/x86_64/kernel-modules-6.12.0-95.el10.x86_64.rpm \
-    https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/libguestfs-fssupport/10.1/3.el10/x86_64/libguestfs-fssupport-10.1-3.el10.x86_64.rpm
+# RHEL 10.1 virt-v2v and deps and custom kernel for libguestfs-fssupport
+RUN \
+    brewroot=https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages ; \
+    arch=x86_64 ; \
+    packages=' \
+      virt-v2v:virt-v2v-2.8.0-1.el10 \
+      libguestfs:libguestfs-1.56.0-1.el10.1 \
+      libguestfs:libguestfs-appliance-1.56.0-1.el10.1 \
+      libguestfs:libguestfs-xfs-1.56.0-1.el10.1 \
+      libnbd:libnbd-1.22.2-1.el10 \
+      nbdkit:nbdkit-1.42.5-1.el10 \
+      nbdkit:nbdkit-basic-filters-1.42.5-1.el10 \
+      nbdkit:nbdkit-basic-plugins-1.42.5-1.el10 \
+      nbdkit:nbdkit-server-1.42.5-1.el10 \
+      nbdkit:nbdkit-curl-plugin-1.42.5-1.el10 \
+      nbdkit:nbdkit-nbd-plugin-1.42.5-1.el10 \
+      nbdkit:nbdkit-python-plugin-1.42.5-1.el10 \
+      nbdkit:nbdkit-ssh-plugin-1.42.5-1.el10 \
+      nbdkit:nbdkit-vddk-plugin-1.42.5-1.el10 \
+      guestfs-tools:guestfs-tools-1.54.0-2.el10 \
+      kernel:kernel-6.12.0-95.el10 \
+      kernel:kernel-modules-core-6.12.0-95.el10 \
+      kernel:kernel-core-6.12.0-95.el10 \
+      kernel:kernel-modules-6.12.0-95.el10 \
+      libguestfs-fssupport:libguestfs-fssupport-10.1-3.el10 \
+    ' ; \
+    set -x ; \
+    dnf install  -y --setopt=sslverify=false \
+        $( for p in $packages; do \
+           [[ "$p" =~ ([^:]+):(.+)-([^-]+)-([^-]+) ]] && \
+           echo $brewroot/${BASH_REMATCH[1]}/${BASH_REMATCH[3]}/${BASH_REMATCH[4]}/$arch/${BASH_REMATCH[2]}-${BASH_REMATCH[3]}-${BASH_REMATCH[4]}.$arch.rpm; \
+           done \
+        )
 
 # Create tarball for the appliance.
 RUN mkdir -p /usr/local/lib/guestfs/appliance && \


### PR DESCRIPTION
See individual commit messages for description.

I was only partially able to test this. Download worked (which is the main point of the change), but installation failed because of some broken dependencies.