### PR TITLE
build: virt-v2v: Use LIBGUESTFS_BACKEND=direct temporarily

### DIFF
--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -8,9 +8,13 @@ RUN subscription-manager refresh && \
         libguestfs-xfs
 
 # Create tarball for the appliance.
+#
+# LIBGUESTFS_BACKEND=direct is required to work around the following bug:
+# https://issues.redhat.com/browse/RHEL-104684
+# and it can be removed when that bug gets fixed.
 RUN mkdir -p /usr/local/lib/guestfs/appliance && \
     cd /usr/local/lib/guestfs/appliance && \
-    libguestfs-make-fixed-appliance . && \
+    LIBGUESTFS_BACKEND=direct libguestfs-make-fixed-appliance . && \
     qemu-img convert -c -O qcow2 root root.qcow2 && \
     mv -vf root.qcow2 root
 

--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -13,9 +13,13 @@ RUN dnf update -y && \
     libguestfs-xfs
 
 # Create tarball for the appliance.
+#
+# LIBGUESTFS_BACKEND=direct is required to work around the following bug:
+# https://issues.redhat.com/browse/RHEL-104684
+# and it can be removed when that bug gets fixed.
 RUN mkdir -p /usr/local/lib/guestfs/appliance && \
     cd /usr/local/lib/guestfs/appliance && \
-    libguestfs-make-fixed-appliance . && \
+    LIBGUESTFS_BACKEND=direct libguestfs-make-fixed-appliance . && \
     qemu-img convert -c -O qcow2 root root.qcow2 && \
     mv -vf root.qcow2 root
 

--- a/build/virt-v2v/Containerfile-downstream-fssupport
+++ b/build/virt-v2v/Containerfile-downstream-fssupport
@@ -43,9 +43,13 @@ RUN dnf install -y --setopt=sslverify=false \
     https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/libguestfs-fssupport/10.1/3.el10/x86_64/libguestfs-fssupport-10.1-3.el10.x86_64.rpm
 
 # Create tarball for the appliance.
+#
+# LIBGUESTFS_BACKEND=direct is required to work around the following bug:
+# https://issues.redhat.com/browse/RHEL-104684
+# and it can be removed when that bug gets fixed.
 RUN mkdir -p /usr/local/lib/guestfs/appliance && \
     cd /usr/local/lib/guestfs/appliance && \
-    libguestfs-make-fixed-appliance . && \
+    LIBGUESTFS_BACKEND=direct libguestfs-make-fixed-appliance . && \
     qemu-img convert -c -O qcow2 root root.qcow2 && \
     mv -vf root.qcow2 root
 

--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -33,9 +33,13 @@ dnf -y install libguestfs libguestfs-appliance libguestfs-xfs libguestfs-winsupp
         depmod $(ls /lib/modules/ |tail -n1)
 
 # Create tarball for the appliance.
+#
+# LIBGUESTFS_BACKEND=direct is required to work around the following bug:
+# https://issues.redhat.com/browse/RHEL-104684
+# and it can be removed when that bug gets fixed.
 RUN mkdir -p /usr/lib64/guestfs/appliance && \
         cd /usr/lib64/guestfs/appliance && \
-        libguestfs-make-fixed-appliance . && \
+        LIBGUESTFS_BACKEND=direct libguestfs-make-fixed-appliance . && \
         qemu-img convert -c -O qcow2 root root.qcow2 && \
         mv -vf root.qcow2 root && \
         tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance

--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -31,9 +31,13 @@ RUN dnf -y install btrfs libguestfs libguestfs-appliance libguestfs-xfs qemu-img
         depmod $(ls /lib/modules/ |tail -n1)
 
 # Create tarball for the appliance.
+#
+# LIBGUESTFS_BACKEND=direct is required to work around the following bug:
+# https://issues.redhat.com/browse/RHEL-104684
+# and it can be removed when that bug gets fixed.
 RUN mkdir -p /usr/lib64/guestfs/appliance && \
         cd /usr/lib64/guestfs/appliance && \
-        libguestfs-make-fixed-appliance . && \
+        LIBGUESTFS_BACKEND=direct libguestfs-make-fixed-appliance . && \
         qemu-img convert -c -O qcow2 root root.qcow2 && \
         mv -vf root.qcow2 root && \
         tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance

--- a/build/virt-v2v/Containerfile-upstream-fssupport
+++ b/build/virt-v2v/Containerfile-upstream-fssupport
@@ -43,9 +43,13 @@ RUN dnf install --setopt=sslverify=false -y https://kojihub.stream.centos.org/ko
 RUN test "$(rpm -q kernel)" = "kernel-6.12.0-84.el10.x86_64"
 
 # Create tarball for the appliance.
+#
+# LIBGUESTFS_BACKEND=direct is required to work around the following bug:
+# https://issues.redhat.com/browse/RHEL-104684
+# and it can be removed when that bug gets fixed.
 RUN mkdir -p /usr/lib64/guestfs/appliance && \
         cd /usr/lib64/guestfs/appliance && \
-        libguestfs-make-fixed-appliance . && \
+        LIBGUESTFS_BACKEND=direct libguestfs-make-fixed-appliance . && \
         qemu-img convert -c -O qcow2 root root.qcow2 && \
         mv -vf root.qcow2 root && \
         tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance


### PR DESCRIPTION
The appliance build failed when we tried to use libvirt because of this libvirt bug: https://issues.redhat.com/browse/RHEL-104684

To temporarily work around this, use LIBGUESTFS_BACKEND=direct to run libguestfs-make-fixed-appliance.  We can revert this patch when the libvirt bug is fixed.

Thanks: Martin Necas
Updates: commit 96036cd9d2a77c4cf6d77ded358356b08b5f6218