### PR TITLE
build: Bump golang to 1.24 on Containerfile-downstream-fssupport

### DIFF
--- a/build/virt-v2v/Containerfile-downstream-fssupport
+++ b/build/virt-v2v/Containerfile-downstream-fssupport
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi10/go-toolset:1.23-1749310965 AS builder
+FROM registry.redhat.io/ubi10/go-toolset:1.24-1752559364 AS builder
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"


### PR DESCRIPTION
build: Bump golang to 1.24 on Containerfile-downstream-fssupport