### PR TITLE
MTV-2703 | Migrate VM with nvme direct attached disk, the plan hang

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -159,6 +159,8 @@ type Validator interface {
 	PowerState(vmRef ref.Ref) (bool, error)
 	// Validate that the VM is inherently compatible with the migration type.
 	VMMigrationType(vmRef ref.Ref) (bool, error)
+	// Validate that the VM disks are supported.
+	UnSupportedDisks(vmRef ref.Ref) ([]string, error)
 }
 
 // DestinationClient API.

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -169,6 +169,10 @@ func (r *Validator) MigrationType() bool {
 }
 
 // NOOP
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	return []string{}, nil
+}
+
 func (r *Validator) SharedDisks(vmRef ref.Ref, client k8sclient.Client) (ok bool, s string, s2 string, err error) {
 	ok = true
 	return

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -66,6 +66,10 @@ func (r *Validator) MaintenanceMode(vmRef ref.Ref) (ok bool, err error) {
 }
 
 // NOOP
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	return []string{}, nil
+}
+
 func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, s string, s2 string, err error) {
 	ok = true
 	return

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -32,6 +32,10 @@ func (r *Validator) MigrationType() bool {
 }
 
 // NOOP
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	return []string{}, nil
+}
+
 func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, s string, s2 string, err error) {
 	ok = true
 	return

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -19,6 +19,10 @@ type Validator struct {
 }
 
 // NOOP
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	return []string{}, nil
+}
+
 func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, s string, s2 string, err error) {
 	ok = true
 	return

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -198,6 +198,27 @@ func (r *Validator) findRunningVms(vms []model.VM) []string {
 	return resp
 }
 
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	vm := &model.VM{}
+	err := r.Source.Inventory.Find(vm, vmRef)
+	if err != nil {
+		return nil, liberr.Wrap(err, "vm", vmRef)
+	}
+
+	unsupported := []string{}
+	unsupportedBuses := map[string]bool{
+		"nvme": true,
+	}
+
+	for _, disk := range vm.Disks {
+		if unsupportedBuses[disk.Bus] {
+			unsupported = append(unsupported, disk.Bus)
+		}
+	}
+
+	return unsupported, nil
+}
+
 func (r *Validator) sharedDisksRunningVms(vm *model.VM) (runningVms []string, err error) {
 	sharedDisksVms, err := r.findSharedDisksVms(vm.Disks)
 	if err != nil {


### PR DESCRIPTION
Issue:
NVME disk type isn't supported , hence a migration plan will hang during disk allocation.

Fix:
Add validation to fail plan when unsupported disks (e.g., NVMe) are used

This adds a validation step that checks for unsupported disk types during plan creation. If such disks (currently NVMe) are detected and the user proceeds despite existing warnings, the plan will now explicitly fail to prevent unsupported migrations.

Ref: https://issues.redhat.com/browse/MTV-2703