### PR TITLE
Cherry picking MTV-2774 to 2.9.0

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -257,6 +257,9 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	// The plan is updated as needed to reflect status.
 	result.RequeueAfter, err = r.execute(plan)
 	if err != nil {
+		if updateErr := r.updatePlanStatus(plan); updateErr != nil {
+			r.Log.Error(err, "failed to update plan status")
+		}
 		return
 	}
 


### PR DESCRIPTION
Issue:
Reconciliation of every plan randomly fails if there is a plan that's referring to an inexistent VM

Fix:
1. Set deleted VM status as canceled and propagate it up.
2. Ignore canceled VM's during plans schedule builder.

Ref: https://issues.redhat.com/browse/MTV-2774