### PR TITLE
MTV-2894 | OCP->OCP migrate VM with Pre/Post migration hooks, plan failed in Initialize phase.

### DIFF
--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -444,7 +444,7 @@ func (r *Finder) Workload(ref *base.Ref) (object interface{}, err error) {
 	err = r.ByRef(vm, *ref)
 	if err == nil {
 		ref.ID = vm.UID
-		ref.Name = path.Join(vm.Namespace, vm.Name)
+		ref.Name = vm.Name
 		object = vm
 	}
 
@@ -463,7 +463,7 @@ func (r *Finder) Network(ref *base.Ref) (object interface{}, err error) {
 	err = r.ByRef(nad, *ref)
 	if err == nil {
 		ref.ID = nad.UID
-		ref.Name = path.Join(nad.Namespace, nad.Name)
+		ref.Name = nad.Name
 		object = nad
 	}
 
@@ -515,7 +515,7 @@ func (r *Finder) InstanceType(ref *base.Ref) (object interface{}, err error) {
 	err = r.ByRef(it, *ref)
 	if err == nil {
 		ref.ID = it.UID
-		ref.Name = path.Join(it.Namespace, it.Name)
+		ref.Name = it.Name
 		object = it
 	}
 


### PR DESCRIPTION
 Issue:
    OCP->OCP migrate VM with Pre/Post migration hooks, plan failed in Initialize phase, with the error below:
    
    "invalid resource name "namespace/vm-name": [may not contain '/'], meaning that vm name was concatenated from    namespace and vm-name with / which is illegal.
    
    Fix:
    keep the vm-name as is.
    
    Ref: https://issues.redhat.com/browse/MTV-2894
