### PR TITLE
MTV-2810 | Migrate VM from OCP to OCP hang

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -161,6 +161,8 @@ type Validator interface {
 	VMMigrationType(vmRef ref.Ref) (bool, error)
 	// Validate that the VM disks are supported.
 	UnSupportedDisks(vmRef ref.Ref) ([]string, error)
+	// Validate that the VM name is valid.
+	ValidVmName(vmRef ref.Ref) (bool, error)
 }
 
 // DestinationClient API.

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -6,6 +6,7 @@ import (
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/openstack"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,6 +38,16 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 
 	ok = true
 	return
+}
+
+func (r *Validator) ValidVmName(vmRef ref.Ref) (ok bool, err error) {
+	// Check if the VM reference name is a valid DNS1123 subdomain
+	if len(k8svalidation.IsDNS1123Subdomain(vmRef.Name)) > 0 {
+		// Not valid
+		return false, nil
+	}
+	// Valid
+	return true, nil
 }
 
 // Validate that a VM's networks have been mapped.

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -6,6 +6,7 @@ import (
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ova"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,6 +40,16 @@ func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
 func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, s string, s2 string, err error) {
 	ok = true
 	return
+}
+
+func (r *Validator) ValidVmName(vmRef ref.Ref) (ok bool, err error) {
+	// Check if the VM reference name is a valid DNS1123 subdomain
+	if len(k8svalidation.IsDNS1123Subdomain(vmRef.Name)) > 0 {
+		// Not valid
+		return false, nil
+	}
+	// Valid
+	return true, nil
 }
 
 // Validate that a VM's networks have been mapped.

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -10,6 +10,7 @@ import (
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ovirt"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/kubev2v/forklift/pkg/settings"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,6 +46,16 @@ func (r *Validator) MigrationType() bool {
 	default:
 		return false
 	}
+}
+
+func (r *Validator) ValidVmName(vmRef ref.Ref) (ok bool, err error) {
+	// Check if the VM reference name is a valid DNS1123 subdomain
+	if len(k8svalidation.IsDNS1123Subdomain(vmRef.Name)) > 0 {
+		// Not valid
+		return false, nil
+	}
+	// Valid
+	return true, nil
 }
 
 // Validate that a VM's networks have been mapped.

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/validation"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/vmware/govmomi/vim25/types"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,6 +37,16 @@ func (r *Validator) MigrationType() bool {
 	default:
 		return false
 	}
+}
+
+func (r *Validator) ValidVmName(vmRef ref.Ref) (ok bool, err error) {
+	// Check if the VM reference name is a valid DNS1123 subdomain
+	if len(k8svalidation.IsDNS1123Subdomain(vmRef.Name)) > 0 {
+		// Not valid
+		return false, nil
+	}
+	// Valid
+	return true, nil
 }
 
 // Validate that a VM's networks have been mapped.

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -216,9 +216,16 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		if r.isDanglingArchivedPlan(plan) {
 			r.Log.Info("Dangling Plan - Aborting reconcile of plan without source provider.")
 			r.archive(plan)
-			if err = r.updatePlanStatus(plan); err != nil {
-				r.Log.Error(err, "failed to update plan status")
-			}
+		} else {
+			plan.Status.SetCondition(libcnd.Condition{
+				Type:     libcnd.Error,
+				Status:   True,
+				Category: Critical,
+				Message:  err.Error(),
+			})
+		}
+		if err = r.updatePlanStatus(plan); err != nil {
+			r.Log.Error(err, "failed to update plan status")
 		}
 		return
 	}

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -664,6 +664,20 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		if pErr != nil {
 			return liberr.Wrap(pErr)
 		}
+		pAdapter, err := adapter.New(provider)
+		if err != nil {
+			return liberr.Wrap(pErr)
+		}
+		var ctx *plancontext.Context
+		ctx, err = plancontext.New(r, plan, r.Log)
+		if err != nil {
+			return liberr.Wrap(pErr)
+		}
+		validator, err := pAdapter.Validator(ctx)
+		if err != nil {
+			return liberr.Wrap(pErr)
+		}
+
 		v, pErr := inventory.VM(ref)
 		if pErr != nil {
 			if errors.As(pErr, &web.NotFoundError{}) {
@@ -677,7 +691,11 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 			return liberr.Wrap(pErr)
 		}
 		if vm.TargetName == "" {
-			if len(k8svalidation.IsDNS1123Subdomain(ref.Name)) > 0 {
+			ok, err := validator.ValidVmName(*ref)
+			if err != nil {
+				return err
+			}
+			if !ok {
 				// if source VM name is not valid
 				nameNotValid.Items = append(nameNotValid.Items, ref.String())
 			}
@@ -710,19 +728,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 				}
 			}
 		}
-		pAdapter, err := adapter.New(provider)
-		if err != nil {
-			return err
-		}
-		var ctx *plancontext.Context
-		ctx, err = plancontext.New(r, plan, r.Log)
-		if err != nil {
-			return err
-		}
-		validator, err := pAdapter.Validator(ctx)
-		if err != nil {
-			return err
-		}
+
 		if plan.Referenced.Map.Network != nil {
 			ok, err := validator.NetworksMapped(*ref)
 			if err != nil {


### PR DESCRIPTION
Issue:
OCP vm name with dots causes the migration to hang.

Fix:
Add additional validations to inform users during plan creation that OCP VMs names with dots are not supported.

Ref: https://issues.redhat.com/browse/MTV-2810

