### PR TITLE
MTV-3009 | Add option to disable compatibility mode bus when using RCM

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -2847,6 +2847,14 @@ spec:
                 - warm
                 - live
                 type: string
+              useCompatibilityMode:
+                default: true
+                description: |-
+                  useCompatibilityMode controls whether to use VirtIO devices when skipGuestConversion is true (Raw Copy mode).
+                  This setting has no effect when skipGuestConversion is false (V2V Conversion always uses VirtIO).
+                  - true (default): Use compatibility devices (SATA bus, E1000E NIC) to ensure bootability
+                  - false: Use high-performance VirtIO devices (requires VirtIO drivers already installed in source VM)
+                type: boolean
               vms:
                 description: List of VMs.
                 items:

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -2847,6 +2847,14 @@ spec:
                 - warm
                 - live
                 type: string
+              useCompatibilityMode:
+                default: true
+                description: |-
+                  useCompatibilityMode controls whether to use VirtIO devices when skipGuestConversion is true (Raw Copy mode).
+                  This setting has no effect when skipGuestConversion is false (V2V Conversion always uses VirtIO).
+                  - true (default): Use compatibility devices (SATA bus, E1000E NIC) to ensure bootability
+                  - false: Use high-performance VirtIO devices (requires VirtIO drivers already installed in source VM)
+                type: boolean
               vms:
                 description: List of VMs.
                 items:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -2847,6 +2847,14 @@ spec:
                 - warm
                 - live
                 type: string
+              useCompatibilityMode:
+                default: true
+                description: |-
+                  useCompatibilityMode controls whether to use VirtIO devices when skipGuestConversion is true (Raw Copy mode).
+                  This setting has no effect when skipGuestConversion is false (V2V Conversion always uses VirtIO).
+                  - true (default): Use compatibility devices (SATA bus, E1000E NIC) to ensure bootability
+                  - false: Use high-performance VirtIO devices (requires VirtIO drivers already installed in source VM)
+                type: boolean
               vms:
                 description: List of VMs.
                 items:

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1332,6 +1332,14 @@ spec:
                 - warm
                 - live
                 type: string
+              useCompatibilityMode:
+                default: true
+                description: |-
+                  useCompatibilityMode controls whether to use VirtIO devices when skipGuestConversion is true (Raw Copy mode).
+                  This setting has no effect when skipGuestConversion is false (V2V Conversion always uses VirtIO).
+                  - true (default): Use compatibility devices (SATA bus, E1000E NIC) to ensure bootability
+                  - false: Use high-performance VirtIO devices (requires VirtIO drivers already installed in source VM)
+                type: boolean
               vms:
                 description: List of VMs.
                 items:

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -155,6 +155,12 @@ type PlanSpec struct {
 	// Determines if the plan should skip the guest conversion.
 	// +kubebuilder:default:=false
 	SkipGuestConversion bool `json:"skipGuestConversion,omitempty"`
+	// useCompatibilityMode controls whether to use VirtIO devices when skipGuestConversion is true (Raw Copy mode).
+	// This setting has no effect when skipGuestConversion is false (V2V Conversion always uses VirtIO).
+	// - true (default): Use compatibility devices (SATA bus, E1000E NIC) to ensure bootability
+	// - false: Use high-performance VirtIO devices (requires VirtIO drivers already installed in source VM)
+	// +kubebuilder:default:=true
+	UseCompatibilityMode bool `json:"useCompatibilityMode,omitempty"`
 	// Migration type. e.g. "cold", "warm", "live". Supersedes the `warm` boolean if set.
 	// +optional
 	// +kubebuilder:validation:Enum=cold;warm;live

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -809,7 +809,7 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 		numNetworks++
 		kNetwork := cnv.Network{Name: networkName}
 		interfaceModel := Virtio
-		if r.Plan.Spec.SkipGuestConversion {
+		if useCompatibilityModeBus(r.Plan) {
 			interfaceModel = E1000e
 		}
 		kInterface := cnv.Interface{
@@ -856,7 +856,7 @@ func (r *Builder) findNetworkMapping(nic vsphere.NIC, netMap []api.NetworkPair) 
 
 func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {
 	bus := cnv.InputBusVirtio
-	if r.Plan.Spec.SkipGuestConversion {
+	if useCompatibilityModeBus(r.Plan) {
 		bus = cnv.InputBusUSB
 	}
 	tablet := cnv.Input{
@@ -1055,7 +1055,7 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 			},
 		}
 		bus := cnv.DiskBusVirtio
-		if r.Plan.Spec.SkipGuestConversion {
+		if useCompatibilityModeBus(r.Plan) {
 			bus = cnv.DiskBusSATA
 		}
 		kubevirtDisk := cnv.Disk{

--- a/pkg/controller/plan/adapter/vsphere/utils.go
+++ b/pkg/controller/plan/adapter/vsphere/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	"github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
@@ -102,4 +103,8 @@ func findSharedPVCs(client client.Client, vm *model.VM, targetNamespace string) 
 		}
 	}
 	return pvcs, missingDiskPVCs, err
+}
+
+func useCompatibilityModeBus(plan *api.Plan) bool {
+	return plan.Spec.SkipGuestConversion && plan.Spec.UseCompatibilityMode
 }


### PR DESCRIPTION
**Issue:**
Right now when users migrate the VMs with Raw Copy Mode the VM will always have compatibility mode bus (SATA, E1000E, USB) even if the VM already has the virtio drivers installed before migration. MTV should add an option to use the virtio drivers with Raw Copy mode.

**Fix:**
useCompatibilityMode controls whether to use VirtIO devices when skipGuestConversion is true (Raw Copy mode).
This setting has no effect when skipGuestConversion is false (V2V Conversion always uses VirtIO).
- true (default): Use compatibility devices (SATA bus, E1000E NIC) to ensure bootability
- false: Use high-performance VirtIO devices (requires VirtIO drivers already installed in source VM)

Ref: https://issues.redhat.com/browse/MTV-3009