### PR TITLE
MTV-3025 | Add TargetPowerState to migration plan CR

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -943,6 +943,17 @@ spec:
                         If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                         If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
                       type: string
+                    targetPowerState:
+                      description: |-
+                        TargetPowerState specifies the desired power state of the target VM after migration.
+                        - "on": Target VM will be powered on after migration
+                        - "off": Target VM will be powered off after migration
+                        - "auto" or nil (default): Target VM will match the source VM's power state
+                      enum:
+                      - "on"
+                      - "off"
+                      - auto
+                      type: string
                     type:
                       description: Type used to qualify the name.
                       type: string
@@ -2795,6 +2806,17 @@ spec:
                   See virtual machine instance NodeSelector documentation for more details,
                   https://kubevirt.io/user-guide/compute/node_assignment/#nodeselector
                 type: object
+              targetPowerState:
+                description: |-
+                  TargetPowerState specifies the desired power state of the target VM after migration.
+                  - "on": Target VM will be powered on after migration
+                  - "off": Target VM will be powered off after migration
+                  - "auto" or nil (default): Target VM will match the source VM's power state
+                enum:
+                - "on"
+                - "off"
+                - auto
+                type: string
               transferNetwork:
                 description: The network attachment definition that should be used
                   for disk transfer.
@@ -3020,6 +3042,17 @@ spec:
                         TargetName specifies a custom name for the VM in the target cluster.
                         If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                         If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                      type: string
+                    targetPowerState:
+                      description: |-
+                        TargetPowerState specifies the desired power state of the target VM after migration.
+                        - "on": Target VM will be powered on after migration
+                        - "off": Target VM will be powered off after migration
+                        - "auto" or nil (default): Target VM will match the source VM's power state
+                      enum:
+                      - "on"
+                      - "off"
+                      - auto
                       type: string
                     type:
                       description: Type used to qualify the name.
@@ -3681,6 +3714,17 @@ spec:
                             TargetName specifies a custom name for the VM in the target cluster.
                             If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                             If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                          type: string
+                        targetPowerState:
+                          description: |-
+                            TargetPowerState specifies the desired power state of the target VM after migration.
+                            - "on": Target VM will be powered on after migration
+                            - "off": Target VM will be powered off after migration
+                            - "auto" or nil (default): Target VM will match the source VM's power state
+                          enum:
+                          - "on"
+                          - "off"
+                          - auto
                           type: string
                         type:
                           description: Type used to qualify the name.

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -943,6 +943,17 @@ spec:
                         If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                         If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
                       type: string
+                    targetPowerState:
+                      description: |-
+                        TargetPowerState specifies the desired power state of the target VM after migration.
+                        - "on": Target VM will be powered on after migration
+                        - "off": Target VM will be powered off after migration
+                        - "auto" or nil (default): Target VM will match the source VM's power state
+                      enum:
+                      - "on"
+                      - "off"
+                      - auto
+                      type: string
                     type:
                       description: Type used to qualify the name.
                       type: string
@@ -2795,6 +2806,17 @@ spec:
                   See virtual machine instance NodeSelector documentation for more details,
                   https://kubevirt.io/user-guide/compute/node_assignment/#nodeselector
                 type: object
+              targetPowerState:
+                description: |-
+                  TargetPowerState specifies the desired power state of the target VM after migration.
+                  - "on": Target VM will be powered on after migration
+                  - "off": Target VM will be powered off after migration
+                  - "auto" or nil (default): Target VM will match the source VM's power state
+                enum:
+                - "on"
+                - "off"
+                - auto
+                type: string
               transferNetwork:
                 description: The network attachment definition that should be used
                   for disk transfer.
@@ -3020,6 +3042,17 @@ spec:
                         TargetName specifies a custom name for the VM in the target cluster.
                         If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                         If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                      type: string
+                    targetPowerState:
+                      description: |-
+                        TargetPowerState specifies the desired power state of the target VM after migration.
+                        - "on": Target VM will be powered on after migration
+                        - "off": Target VM will be powered off after migration
+                        - "auto" or nil (default): Target VM will match the source VM's power state
+                      enum:
+                      - "on"
+                      - "off"
+                      - auto
                       type: string
                     type:
                       description: Type used to qualify the name.
@@ -3681,6 +3714,17 @@ spec:
                             TargetName specifies a custom name for the VM in the target cluster.
                             If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                             If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                          type: string
+                        targetPowerState:
+                          description: |-
+                            TargetPowerState specifies the desired power state of the target VM after migration.
+                            - "on": Target VM will be powered on after migration
+                            - "off": Target VM will be powered off after migration
+                            - "auto" or nil (default): Target VM will match the source VM's power state
+                          enum:
+                          - "on"
+                          - "off"
+                          - auto
                           type: string
                         type:
                           description: Type used to qualify the name.

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -943,6 +943,17 @@ spec:
                         If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                         If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
                       type: string
+                    targetPowerState:
+                      description: |-
+                        TargetPowerState specifies the desired power state of the target VM after migration.
+                        - "on": Target VM will be powered on after migration
+                        - "off": Target VM will be powered off after migration
+                        - "auto" or nil (default): Target VM will match the source VM's power state
+                      enum:
+                      - "on"
+                      - "off"
+                      - auto
+                      type: string
                     type:
                       description: Type used to qualify the name.
                       type: string
@@ -2795,6 +2806,17 @@ spec:
                   See virtual machine instance NodeSelector documentation for more details,
                   https://kubevirt.io/user-guide/compute/node_assignment/#nodeselector
                 type: object
+              targetPowerState:
+                description: |-
+                  TargetPowerState specifies the desired power state of the target VM after migration.
+                  - "on": Target VM will be powered on after migration
+                  - "off": Target VM will be powered off after migration
+                  - "auto" or nil (default): Target VM will match the source VM's power state
+                enum:
+                - "on"
+                - "off"
+                - auto
+                type: string
               transferNetwork:
                 description: The network attachment definition that should be used
                   for disk transfer.
@@ -3020,6 +3042,17 @@ spec:
                         TargetName specifies a custom name for the VM in the target cluster.
                         If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                         If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                      type: string
+                    targetPowerState:
+                      description: |-
+                        TargetPowerState specifies the desired power state of the target VM after migration.
+                        - "on": Target VM will be powered on after migration
+                        - "off": Target VM will be powered off after migration
+                        - "auto" or nil (default): Target VM will match the source VM's power state
+                      enum:
+                      - "on"
+                      - "off"
+                      - auto
                       type: string
                     type:
                       description: Type used to qualify the name.
@@ -3681,6 +3714,17 @@ spec:
                             TargetName specifies a custom name for the VM in the target cluster.
                             If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                             If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                          type: string
+                        targetPowerState:
+                          description: |-
+                            TargetPowerState specifies the desired power state of the target VM after migration.
+                            - "on": Target VM will be powered on after migration
+                            - "off": Target VM will be powered off after migration
+                            - "auto" or nil (default): Target VM will match the source VM's power state
+                          enum:
+                          - "on"
+                          - "off"
+                          - auto
                           type: string
                         type:
                           description: Type used to qualify the name.

--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -557,6 +557,17 @@ spec:
                         If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                         If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
                       type: string
+                    targetPowerState:
+                      description: |-
+                        TargetPowerState specifies the desired power state of the target VM after migration.
+                        - "on": Target VM will be powered on after migration
+                        - "off": Target VM will be powered off after migration
+                        - "auto" or nil (default): Target VM will match the source VM's power state
+                      enum:
+                      - "on"
+                      - "off"
+                      - auto
+                      type: string
                     type:
                       description: Type used to qualify the name.
                       type: string

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1280,6 +1280,17 @@ spec:
                   See virtual machine instance NodeSelector documentation for more details,
                   https://kubevirt.io/user-guide/compute/node_assignment/#nodeselector
                 type: object
+              targetPowerState:
+                description: |-
+                  TargetPowerState specifies the desired power state of the target VM after migration.
+                  - "on": Target VM will be powered on after migration
+                  - "off": Target VM will be powered off after migration
+                  - "auto" or nil (default): Target VM will match the source VM's power state
+                enum:
+                - "on"
+                - "off"
+                - auto
+                type: string
               transferNetwork:
                 description: The network attachment definition that should be used
                   for disk transfer.
@@ -1505,6 +1516,17 @@ spec:
                         TargetName specifies a custom name for the VM in the target cluster.
                         If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                         If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                      type: string
+                    targetPowerState:
+                      description: |-
+                        TargetPowerState specifies the desired power state of the target VM after migration.
+                        - "on": Target VM will be powered on after migration
+                        - "off": Target VM will be powered off after migration
+                        - "auto" or nil (default): Target VM will match the source VM's power state
+                      enum:
+                      - "on"
+                      - "off"
+                      - auto
                       type: string
                     type:
                       description: Type used to qualify the name.
@@ -2166,6 +2188,17 @@ spec:
                             TargetName specifies a custom name for the VM in the target cluster.
                             If not provided, the original VM name will be used and automatically adjusted to meet k8s DNS1123 requirements.
                             If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
+                          type: string
+                        targetPowerState:
+                          description: |-
+                            TargetPowerState specifies the desired power state of the target VM after migration.
+                            - "on": Target VM will be powered on after migration
+                            - "off": Target VM will be powered off after migration
+                            - "auto" or nil (default): Target VM will match the source VM's power state
+                          enum:
+                          - "on"
+                          - "off"
+                          - auto
                           type: string
                         type:
                           description: Type used to qualify the name.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -27,10 +27,14 @@ import (
 	cnv "kubevirt.io/api/core/v1"
 )
 
+// MigrationType defines the type of migration to perform
+type MigrationType string
+
 const (
-	MigrationCold = "cold"
-	MigrationWarm = "warm"
-	MigrationLive = "live"
+	// Migration types
+	MigrationCold MigrationType = "cold"
+	MigrationWarm MigrationType = "warm"
+	MigrationLive MigrationType = "live"
 )
 
 // PlanSpec defines the desired state of Plan.
@@ -164,7 +168,14 @@ type PlanSpec struct {
 	// Migration type. e.g. "cold", "warm", "live". Supersedes the `warm` boolean if set.
 	// +optional
 	// +kubebuilder:validation:Enum=cold;warm;live
-	Type string `json:"type,omitempty"`
+	Type MigrationType `json:"type,omitempty"`
+	// TargetPowerState specifies the desired power state of the target VM after migration.
+	// - "on": Target VM will be powered on after migration
+	// - "off": Target VM will be powered off after migration
+	// - "auto" or nil (default): Target VM will match the source VM's power state
+	// +optional
+	// +kubebuilder:validation:Enum=on;off;auto
+	TargetPowerState plan.TargetPowerState `json:"targetPowerState,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -18,6 +18,16 @@ type HookRef struct {
 	Hook core.ObjectReference `json:"hook" ref:"Hook"`
 }
 
+// TargetPowerState defines the desired power state of the target VM after migration
+type TargetPowerState string
+
+const (
+	// Target power state constants
+	TargetPowerStateOn   TargetPowerState = "on"
+	TargetPowerStateOff  TargetPowerState = "off"
+	TargetPowerStateAuto TargetPowerState = "auto"
+)
+
 func (r *HookRef) String() string {
 	return fmt.Sprintf(
 		"%s @%s",
@@ -86,6 +96,13 @@ type VM struct {
 	// If provided, this exact name will be used instead. The migration will fail if the name is not unique or already in use.
 	// +optional
 	TargetName string `json:"targetName,omitempty"`
+	// TargetPowerState specifies the desired power state of the target VM after migration.
+	// - "on": Target VM will be powered on after migration
+	// - "off": Target VM will be powered off after migration
+	// - "auto" or nil (default): Target VM will match the source VM's power state
+	// +optional
+	// +kubebuilder:validation:Enum=on;off;auto
+	TargetPowerState TargetPowerState `json:"targetPowerState,omitempty"`
 }
 
 // Find a Hook for the specified step.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1488,15 +1488,8 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus, sortVolumesByLibvirt bool) 
 		object.ObjectMeta.Annotations = annotations
 	}
 
-	// Set the default run strategy to Halted
-	runStrategy := cnv.RunStrategyHalted
-
-	// If the source VM is powered on, set the destination VM to always run
-	if vm.RestorePowerState == plan.VMPowerStateOn {
-		runStrategy = cnv.RunStrategyAlways
-	}
-
 	// Assign the determined run strategy to the object
+	runStrategy := r.determineRunStrategy(vm)
 	object.Spec.RunStrategy = &runStrategy
 	object.Spec.Running = nil // Ensure running is not set
 
@@ -3021,4 +3014,28 @@ func (r *KubeVirt) IsCopyOffload(pvcs []*core.PersistentVolumeClaim) bool {
 		}
 	}
 	return false
+}
+
+// determineRunStrategy determines the appropriate run strategy based on the target power state configuration
+func (r *KubeVirt) determineRunStrategy(vm *plan.VMStatus) cnv.VirtualMachineRunStrategy {
+	// Determine the target power state based on plan configuration
+	targetPowerState := vm.TargetPowerState
+	if targetPowerState == "" {
+		targetPowerState = r.Plan.Spec.TargetPowerState
+	}
+
+	switch targetPowerState {
+	case plan.TargetPowerStateOn:
+		// Force target VM to be powered on
+		return cnv.RunStrategyAlways
+	case plan.TargetPowerStateOff:
+		// Force target VM to be powered off
+		return cnv.RunStrategyHalted
+	default:
+		// Default behavior: match the source VM's power state
+		if vm.RestorePowerState == plan.VMPowerStateOn {
+			return cnv.RunStrategyAlways
+		}
+		return cnv.RunStrategyHalted
+	}
 }


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-3025

Issue:
Currently there is no user controlled method of ensuring the desired power state of a VM Post Migration.

Per [MTV-811](https://issues.redhat.com/browse/MTV-811), it is currently determined by the power state of the VM on the source environment.  There are circumstances where a user would like to migrate a VM that is running on the source provider, but ensure the VM is powered off post migration in order to preserve start up dependencies between VMs.   Adding this as an option to the plan would be useful for these circumstances

Fix:
  - On plan level:
  Add `TargetPowerState` , `TargetPowerState` specifies the desired power state of all target VM after migration.
      - "on": Target VM will be powered on after migration
      - "off": Target VM will be powered off after migration
      - "auto" or nil (default): Target VM will match the source VM's power state
  - On sngle VM level:
  Add `TargetPowerState` , `TargetPowerState` specifies the desired power state of the target VM after migration.
      - "on": Target VM will be powered on after migration
      - "off": Target VM will be powered off after migration
      - "auto" or nil (default): Target VM will match the source VM's power state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to specify the desired power state ("on", "off", or "auto") for target virtual machines after migration. If set to "auto" or left unset, the target VM will match the source VM's power state.
  * Enhanced migration plans and VM specifications to support this new power state setting.

* **Documentation**
  * Updated descriptions to explain the new power state options and their behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->