### PR TITLE
[MTV-3030] Preserve labels during OCP live migration

### DIFF
--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -1186,7 +1186,9 @@ func (r *Builder) VirtualMachine(vm *planapi.VMStatus) (object *cnv.VirtualMachi
 	key := types.NamespacedName{Namespace: vm.Namespace, Name: source.Name}
 	object.Name = source.Name
 	object.Namespace = r.Plan.Spec.TargetNamespace
+	r.Labeler.SetLabels(object, source.Object.Labels)
 	r.Labeler.SetLabels(object, r.Labeler.VMLabels(vm.Ref))
+	r.Labeler.SetAnnotations(object, source.Object.Annotations)
 	r.Labeler.SetAnnotations(object, r.Labeler.VMLabels(vm.Ref))
 	r.Labeler.SetAnnotation(object, AnnSource, key.String())
 


### PR DESCRIPTION
Labels and annotations were inadvertently being ignored when creating the target VM. This change copies the labels and annotations from the source to the target VM.

https://issues.redhat.com/browse/MTV-3030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Target VirtualMachine resources now inherit original labels and annotations from the source VirtualMachine, in addition to migration-specific metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->