### PR TITLE
MTV-2384 | Migration failed with unexpected error "Another task is already in progress"

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -275,14 +275,32 @@ func (r *Reconciler) updatePlanStatus(plan *api.Plan) error {
 	// Record events.
 	r.Record(plan, plan.Status.Conditions)
 
-	// Apply changes.
-	plan.Status.ObservedGeneration = plan.Generation
+	// Try to fetch latest version first to get current ResourceVersion
+	latest := &api.Plan{}
+	key := client.ObjectKeyFromObject(plan)
+	if err := r.Get(context.TODO(), key, latest); err != nil {
+		r.Log.V(1).Info("Failed to fetch latest plan version, trying update with current version",
+			"plan", plan.Name, "error", err.Error())
+
+		// Fallback: try update with current plan
+		plan.Status.ObservedGeneration = plan.Generation
+		if updateErr := r.Status().Update(context.TODO(), plan.DeepCopy()); updateErr != nil {
+			r.Log.Error(updateErr, "Failed to update plan status with current version")
+			return updateErr
+		}
+		return nil
+	}
+
+	// Preserve our status changes but use latest ResourceVersion and Generation
+	latest.Status = plan.Status
+	latest.Status.ObservedGeneration = latest.Generation
 
 	// At this point, the plan contains data that is not persisted by design, like the Referenced data
 	// and the staged flags in the status, and more data that has been loaded in the validate function,
 	// like the name of the VMs in the spec section, therefore we don't want the plan to be overridden
 	// by data from the server (even the spec section is overridden) and so we pass a copy of the plan
-	if err := r.Status().Update(context.TODO(), plan.DeepCopy()); err != nil {
+	if err := r.Status().Update(context.TODO(), latest.DeepCopy()); err != nil {
+		r.Log.Error(err, "Failed to update plan status with latest ResourceVersion")
 		return err
 	}
 
@@ -365,7 +383,7 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	}
 	defer func() {
 		if err == nil {
-			err = r.Status().Update(context.TODO(), plan)
+			err = r.updatePlanStatus(plan)
 			if err != nil {
 				err = liberr.Wrap(err)
 			}


### PR DESCRIPTION
Issue:
- The Plan controller performed multiple status updates in same reconcile loop
- Race conditions between validation updates and execution updates
- "Operation cannot be fulfilled: object has been modified" errors
- Failed phase transitions led to duplicate snapshot creation attempts
- DNS1123 invalid VM names particularly affected due to additional validation updates

**Root Cause:**
Multiple controller instances reading stale Plan ResourceVersions:
1. Controller A: validation update (Plan v100 → v101)
2. Controller B: reads stale Plan v100, tries update → CONFLICT
3. Controller A: execution update → potential conflict
4. Failed phase transitions caused re-execution of snapshot creation phases

Fix:
1. Proactive conflict prevention: Always fetch latest Plan before status update
2. Resilient fallback: If fetch fails, attempt update with current version
3. Controller-level duplicate prevention: Check existing precopy tasks before snapshot creation
4. vSphere-level duplicate detection: Detect running CreateSnapshot_Task and reuse task ID


Ref: https://issues.redhat.com/browse/MTV-2384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot creation reliability by preventing duplicate snapshot tasks on virtual machines.  
  * Enhanced plan status updates to avoid conflicts by ensuring updates use the latest resource version.
* **Style**
  * Removed unnecessary logging statements for cleaner output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->