### PR TITLE
Add a deprecation note for plan warm flag

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3086,7 +3086,9 @@ spec:
                     "pvc-{{.PVCName}}"
                 type: string
               warm:
-                description: Whether this is a warm migration.
+                description: |-
+                  Whether this is a warm migration.
+                  Deprecated: this field will be deprecated in 2.10. Use Type instead.
                 type: boolean
             required:
             - map

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -3086,7 +3086,9 @@ spec:
                     "pvc-{{.PVCName}}"
                 type: string
               warm:
-                description: Whether this is a warm migration.
+                description: |-
+                  Whether this is a warm migration.
+                  Deprecated: this field will be deprecated in 2.10. Use Type instead.
                 type: boolean
             required:
             - map

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3086,7 +3086,9 @@ spec:
                     "pvc-{{.PVCName}}"
                 type: string
               warm:
-                description: Whether this is a warm migration.
+                description: |-
+                  Whether this is a warm migration.
+                  Deprecated: this field will be deprecated in 2.10. Use Type instead.
                 type: boolean
             required:
             - map

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1560,7 +1560,9 @@ spec:
                     "pvc-{{.PVCName}}"
                 type: string
               warm:
-                description: Whether this is a warm migration.
+                description: |-
+                  Whether this is a warm migration.
+                  Deprecated: this field will be deprecated in 2.10. Use Type instead.
                 type: boolean
             required:
             - map

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -65,6 +65,7 @@ type PlanSpec struct {
 	// List of VMs.
 	VMs []plan.VM `json:"vms"`
 	// Whether this is a warm migration.
+	// Deprecated: this field will be deprecated in 2.10. Use Type instead.
 	Warm bool `json:"warm,omitempty"`
 	// The network attachment definition that should be used for disk transfer.
 	TransferNetwork *core.ObjectReference `json:"transferNetwork,omitempty"`


### PR DESCRIPTION
Issue:
In https://github.com/kubev2v/forklift/pull/1579 we introduced a `Type` plan field overriding the `Warm` field

Fix:
Add a notification for users to move from using  `Warm` to start using the new  `Type`  field instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description of the "warm" field in the Plan resource to indicate it is deprecated and will be removed in version 2.10. Users are advised to use the "Type" field instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->