### PR TITLE
MTV-2728 | Use mapping to map vmaware guestDiskInfo to hw disk

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -811,22 +811,23 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				}
 			case fGuestDisk:
 				if disks, cast := p.Val.(types.ArrayOfGuestDiskInfo); cast {
-					v.model.GuestDisks = make([]model.GuestDisk, len(disks.GuestDiskInfo))
-					for i, info := range disks.GuestDiskInfo {
-						v.model.GuestDisks[i] = model.GuestDisk{
+					for _, info := range disks.GuestDiskInfo {
+						// Default to 0 so the policy can flag missing mappings
+						guestDiskKey := int32(0)
+						if len(info.Mappings) > 0 {
+							// VMware guarantees at least one mapping when non-empty
+							guestDiskKey = info.Mappings[0].Key
+						}
+
+						newGuestDisk := model.GuestDisk{
 							DiskPath:       info.DiskPath,
 							Capacity:       info.Capacity,
 							FreeSpace:      info.FreeSpace,
 							FilesystemType: info.FilesystemType,
+							Key:            guestDiskKey,
 						}
-					}
 
-					// Update matching disk items with Windows drive letters based on index
-					for i, guestDisk := range v.model.GuestDisks {
-						if i < len(v.model.Disks) {
-							winDriveLetter := v.extractWinDriveLetter(guestDisk.DiskPath)
-							v.model.Disks[i].WinDriveLetter = winDriveLetter
-						}
+						v.updateOrAppendGuestDisk(newGuestDisk)
 					}
 				}
 			case fGuestNet:
@@ -990,6 +991,18 @@ func isCBTEnabledForDisks(ctkPerDisk map[string]bool, disks []model.Disk) {
 	}
 }
 
+// extractWindowsDriveLetter extracts the drive letter from a Windows disk path.
+// Returns the lowercase drive letter if the path is a Windows path (e.g., "C:\\"),
+// otherwise returns an empty string.
+func extractWindowsDriveLetter(diskPath string) string {
+	// Check if this looks like a Windows drive letter (e.g., "C:\\")
+	if len(diskPath) == 3 && diskPath[1] == ':' && (diskPath[2] == '\\' || diskPath[2] == '/') {
+		// Extract the drive letter and convert to lowercase
+		return strings.ToLower(string(diskPath[0]))
+	}
+	return ""
+}
+
 // Update virtual disk devices.
 func (v *VmAdapter) updateControllers(devArray *types.ArrayOfVirtualDevice) {
 	controllers := []model.Controller{}
@@ -1059,6 +1072,17 @@ func (v *VmAdapter) getDiskController(key int32) *model.Controller {
 	return nil
 }
 
+// getDiskGuestInfo retrieves the guest disk information for a given device key.
+func (v *VmAdapter) getDiskGuestInfo(deviceKey int32) *model.GuestDisk {
+	for i := range v.model.GuestDisks {
+		if v.model.GuestDisks[i].Key == deviceKey {
+			return &v.model.GuestDisks[i]
+		}
+	}
+
+	return nil
+}
+
 // Update virtual disk devices.
 func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 	disks := []model.Disk{}
@@ -1067,17 +1091,31 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 		case *types.VirtualDisk:
 			disk := dev.(*types.VirtualDisk)
 			controller := v.getDiskController(disk.ControllerKey)
+			guestDiskInfo := v.getDiskGuestInfo(disk.Key)
+
+			// If controller is not nil, get the disk bus from the controller
+			bus := ""
+			if controller != nil {
+				bus = controller.Bus
+			}
+
+			// Try to extract the Windows drive letter from the guest disk info
+			winDriveLetter := ""
+			if guestDiskInfo != nil {
+				winDriveLetter = extractWindowsDriveLetter(guestDiskInfo.DiskPath)
+			}
 
 			switch backing := disk.Backing.(type) {
 			case *types.VirtualDiskFlatVer1BackingInfo:
 				md := model.Disk{
-					Key:           disk.Key,
-					UnitNumber:    *disk.UnitNumber,
-					ControllerKey: disk.ControllerKey,
-					File:          backing.FileName,
-					Capacity:      disk.CapacityInBytes,
-					Mode:          backing.DiskMode,
-					Bus:           controller.Bus,
+					Key:            disk.Key,
+					UnitNumber:     *disk.UnitNumber,
+					ControllerKey:  disk.ControllerKey,
+					File:           backing.FileName,
+					Capacity:       disk.CapacityInBytes,
+					Mode:           backing.DiskMode,
+					Bus:            bus,
+					WinDriveLetter: winDriveLetter,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -1089,15 +1127,16 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskFlatVer2BackingInfo:
 				md := model.Disk{
-					Key:           disk.Key,
-					UnitNumber:    *disk.UnitNumber,
-					ControllerKey: disk.ControllerKey,
-					File:          backing.FileName,
-					Capacity:      disk.CapacityInBytes,
-					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
-					Mode:          backing.DiskMode,
-					Bus:           controller.Bus,
-					Serial:        backing.Uuid,
+					Key:            disk.Key,
+					UnitNumber:     *disk.UnitNumber,
+					ControllerKey:  disk.ControllerKey,
+					File:           backing.FileName,
+					Capacity:       disk.CapacityInBytes,
+					Shared:         backing.Sharing != "sharingNone" && backing.Sharing != "",
+					Mode:           backing.DiskMode,
+					Bus:            bus,
+					Serial:         backing.Uuid,
+					WinDriveLetter: winDriveLetter,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -1109,16 +1148,17 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
 				md := model.Disk{
-					Key:           disk.Key,
-					UnitNumber:    *disk.UnitNumber,
-					ControllerKey: disk.ControllerKey,
-					File:          backing.FileName,
-					Capacity:      disk.CapacityInBytes,
-					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
-					Mode:          backing.DiskMode,
-					RDM:           true,
-					Bus:           controller.Bus,
-					Serial:        backing.Uuid,
+					Key:            disk.Key,
+					UnitNumber:     *disk.UnitNumber,
+					ControllerKey:  disk.ControllerKey,
+					File:           backing.FileName,
+					Capacity:       disk.CapacityInBytes,
+					Shared:         backing.Sharing != "sharingNone" && backing.Sharing != "",
+					Mode:           backing.DiskMode,
+					RDM:            true,
+					Bus:            bus,
+					Serial:         backing.Uuid,
+					WinDriveLetter: winDriveLetter,
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)
@@ -1130,38 +1170,50 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskRawDiskVer2BackingInfo:
 				md := model.Disk{
-					Key:           disk.Key,
-					UnitNumber:    *disk.UnitNumber,
-					ControllerKey: disk.ControllerKey,
-					File:          backing.DescriptorFileName,
-					Capacity:      disk.CapacityInBytes,
-					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
-					RDM:           true,
-					Bus:           controller.Bus,
+					Key:            disk.Key,
+					UnitNumber:     *disk.UnitNumber,
+					ControllerKey:  disk.ControllerKey,
+					File:           backing.DescriptorFileName,
+					Capacity:       disk.CapacityInBytes,
+					Shared:         backing.Sharing != "sharingNone" && backing.Sharing != "",
+					RDM:            true,
+					Bus:            bus,
+					WinDriveLetter: winDriveLetter,
 				}
 				disks = append(disks, md)
 			}
 		}
 	}
 
-	// Update Windows drive letters for all disks based on guest disk information
-	for i := range disks {
-		if i < len(v.model.GuestDisks) {
-			winDriveLetter := v.extractWinDriveLetter(v.model.GuestDisks[i].DiskPath)
-			disks[i].WinDriveLetter = winDriveLetter
-		}
-	}
-
 	v.model.Disks = disks
 }
 
-// extractWinDriveLetter extracts the Windows drive letter from a disk path.
-// For example: "C:\\" returns "c", "/home" returns ""
-func (v *VmAdapter) extractWinDriveLetter(diskPath string) string {
-	// Check if this looks like a Windows drive letter (e.g., "C:\\")
-	if len(diskPath) >= 3 && diskPath[1] == ':' && diskPath[2] == '\\' {
-		// Extract the drive letter and convert to lowercase
-		return strings.ToLower(string(diskPath[0]))
+// updateOrAppendGuestDisk updates an existing guest disk with the same key or appends a new one
+func (v *VmAdapter) updateOrAppendGuestDisk(newDisk model.GuestDisk) {
+	foundExistingDisk := false
+
+	// Find existing disk with the same key (keys are expected to be unique)
+	for i, existingDisk := range v.model.GuestDisks {
+		if existingDisk.Key == newDisk.Key {
+			// Replace existing disk
+			v.model.GuestDisks[i] = newDisk
+
+			foundExistingDisk = true
+			break // Exit the loop when found
+		}
 	}
-	return ""
+
+	// No existing disk found, append new one
+	if !foundExistingDisk {
+		v.model.GuestDisks = append(v.model.GuestDisks, newDisk)
+	}
+
+	// Check for m.model.Disks with the same key (disk keys are expected to be unique)
+	for i, disk := range v.model.Disks {
+		if disk.Key == newDisk.Key {
+			// Update the Disk's WinDriveLetter using the new GuestDisk's DiskPath
+			v.model.Disks[i].WinDriveLetter = extractWindowsDriveLetter(newDisk.DiskPath)
+			return
+		}
+	}
 }

--- a/pkg/controller/provider/container/vsphere/model_test.go
+++ b/pkg/controller/provider/container/vsphere/model_test.go
@@ -1,0 +1,603 @@
+package vsphere
+
+import (
+	"testing"
+
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+)
+
+// Test getDiskGuestInfo method
+func TestVmAdapter_getDiskGuestInfo(t *testing.T) {
+	tests := []struct {
+		name        string
+		guestDisks  []model.GuestDisk
+		deviceKey   int32
+		expected    *model.GuestDisk
+		expectFound bool
+	}{
+		{
+			name: "returns pointer to correct slice element when key exists",
+			guestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            200,
+					DiskPath:       "D:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            300,
+					DiskPath:       "/home",
+					Capacity:       3000000000,
+					FreeSpace:      2000000000,
+					FilesystemType: "ext4",
+				},
+			},
+			deviceKey: 200,
+			expected: &model.GuestDisk{
+				Key:            200,
+				DiskPath:       "D:\\",
+				Capacity:       2000000000,
+				FreeSpace:      1500000000,
+				FilesystemType: "NTFS",
+			},
+			expectFound: true,
+		},
+		{
+			name: "returns pointer to first element when first key matches",
+			guestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            200,
+					DiskPath:       "D:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			deviceKey: 100,
+			expected: &model.GuestDisk{
+				Key:            100,
+				DiskPath:       "C:\\",
+				Capacity:       1000000000,
+				FreeSpace:      500000000,
+				FilesystemType: "NTFS",
+			},
+			expectFound: true,
+		},
+		{
+			name: "returns pointer to last element when last key matches",
+			guestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            200,
+					DiskPath:       "D:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            300,
+					DiskPath:       "/home",
+					Capacity:       3000000000,
+					FreeSpace:      2000000000,
+					FilesystemType: "ext4",
+				},
+			},
+			deviceKey: 300,
+			expected: &model.GuestDisk{
+				Key:            300,
+				DiskPath:       "/home",
+				Capacity:       3000000000,
+				FreeSpace:      2000000000,
+				FilesystemType: "ext4",
+			},
+			expectFound: true,
+		},
+		{
+			name: "returns nil when no matching key is found",
+			guestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            200,
+					DiskPath:       "D:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			deviceKey:   999,
+			expected:    nil,
+			expectFound: false,
+		},
+		{
+			name:        "returns nil when guest disks list is empty",
+			guestDisks:  []model.GuestDisk{},
+			deviceKey:   100,
+			expected:    nil,
+			expectFound: false,
+		},
+		{
+			name:        "returns nil when guest disks list is nil",
+			guestDisks:  nil,
+			deviceKey:   100,
+			expected:    nil,
+			expectFound: false,
+		},
+		{
+			name: "returns nil when searching for zero key that doesn't exist",
+			guestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			deviceKey:   0,
+			expected:    nil,
+			expectFound: false,
+		},
+		{
+			name: "returns pointer when zero key exists",
+			guestDisks: []model.GuestDisk{
+				{
+					Key:            0,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            100,
+					DiskPath:       "D:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			deviceKey: 0,
+			expected: &model.GuestDisk{
+				Key:            0,
+				DiskPath:       "C:\\",
+				Capacity:       1000000000,
+				FreeSpace:      500000000,
+				FilesystemType: "NTFS",
+			},
+			expectFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup VmAdapter with test data
+			v := &VmAdapter{
+				model: model.VM{
+					GuestDisks: tt.guestDisks,
+				},
+			}
+
+			// Call the method under test
+			result := v.getDiskGuestInfo(tt.deviceKey)
+
+			// Verify the result
+			if tt.expectFound {
+				if result == nil {
+					t.Errorf("expected to find guest disk with key %d, but got nil", tt.deviceKey)
+					return
+				}
+
+				// Compare the values (not pointer equality since we're comparing to expected struct)
+				if result.Key != tt.expected.Key ||
+					result.DiskPath != tt.expected.DiskPath ||
+					result.Capacity != tt.expected.Capacity ||
+					result.FreeSpace != tt.expected.FreeSpace ||
+					result.FilesystemType != tt.expected.FilesystemType {
+					t.Errorf("getDiskGuestInfo() returned wrong guest disk data.\nExpected: %+v\nGot: %+v", tt.expected, result)
+				}
+
+				// Verify that we got a pointer to the actual slice element
+				expectedIndex := -1
+				for i, disk := range tt.guestDisks {
+					if disk.Key == tt.deviceKey {
+						expectedIndex = i
+						break
+					}
+				}
+				if expectedIndex >= 0 && result != &v.model.GuestDisks[expectedIndex] {
+					t.Errorf("getDiskGuestInfo() should return pointer to slice element at index %d", expectedIndex)
+				}
+			} else {
+				if result != nil {
+					t.Errorf("expected nil for key %d, but got %+v", tt.deviceKey, result)
+				}
+			}
+		})
+	}
+}
+
+// Test updateOrAppendGuestDisk method
+func TestVmAdapter_updateOrAppendGuestDisk(t *testing.T) {
+	tests := []struct {
+		name               string
+		initialGuestDisks  []model.GuestDisk
+		initialDisks       []model.Disk
+		newDisk            model.GuestDisk
+		expectedGuestDisks []model.GuestDisk
+		expectedDisks      []model.Disk
+		expectedOperation  string // "replace", "append", or "append_and_update_disk"
+	}{
+		{
+			name: "replaces existing GuestDisk when key matches",
+			initialGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            200,
+					DiskPath:       "D:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			initialDisks: []model.Disk{
+				{Key: 300, WinDriveLetter: "e"},
+				{Key: 400, WinDriveLetter: "f"},
+			},
+			newDisk: model.GuestDisk{
+				Key:            100,
+				DiskPath:       "C:\\",
+				Capacity:       1500000000, // Updated capacity
+				FreeSpace:      800000000,  // Updated free space
+				FilesystemType: "NTFS",
+			},
+			expectedGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1500000000,
+					FreeSpace:      800000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            200,
+					DiskPath:       "D:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			expectedDisks: []model.Disk{
+				{Key: 300, WinDriveLetter: "e"},
+				{Key: 400, WinDriveLetter: "f"},
+			},
+			expectedOperation: "replace",
+		},
+		{
+			name: "appends new GuestDisk when no existing key is found",
+			initialGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			initialDisks: []model.Disk{
+				{Key: 300, WinDriveLetter: "e"},
+			},
+			newDisk: model.GuestDisk{
+				Key:            200,
+				DiskPath:       "D:\\",
+				Capacity:       2000000000,
+				FreeSpace:      1500000000,
+				FilesystemType: "NTFS",
+			},
+			expectedGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            200,
+					DiskPath:       "D:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			expectedDisks: []model.Disk{
+				{Key: 300, WinDriveLetter: "e"},
+			},
+			expectedOperation: "append",
+		},
+		{
+			name:              "appends to empty GuestDisk slice",
+			initialGuestDisks: []model.GuestDisk{},
+			initialDisks: []model.Disk{
+				{Key: 300, WinDriveLetter: "e"},
+			},
+			newDisk: model.GuestDisk{
+				Key:            100,
+				DiskPath:       "C:\\",
+				Capacity:       1000000000,
+				FreeSpace:      500000000,
+				FilesystemType: "NTFS",
+			},
+			expectedGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			expectedDisks: []model.Disk{
+				{Key: 300, WinDriveLetter: "e"},
+			},
+			expectedOperation: "append",
+		},
+		{
+			name: "propagates Windows drive letter to matching Disk when key exists",
+			initialGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "E:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			initialDisks: []model.Disk{
+				{Key: 100, WinDriveLetter: ""},  // Empty drive letter initially
+				{Key: 200, WinDriveLetter: "f"}, // Different disk
+			},
+			newDisk: model.GuestDisk{
+				Key:            300,
+				DiskPath:       "C:\\",
+				Capacity:       2000000000,
+				FreeSpace:      1500000000,
+				FilesystemType: "NTFS",
+			},
+			expectedGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "E:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+				{
+					Key:            300,
+					DiskPath:       "C:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			expectedDisks: []model.Disk{
+				{Key: 100, WinDriveLetter: ""},  // Unchanged since new disk has different key
+				{Key: 200, WinDriveLetter: "f"}, // Unchanged
+			},
+			expectedOperation: "append_and_update_disk",
+		},
+		{
+			name:              "propagates Windows drive letter update to matching Disk",
+			initialGuestDisks: []model.GuestDisk{},
+			initialDisks: []model.Disk{
+				{Key: 100, WinDriveLetter: ""},  // Empty drive letter initially
+				{Key: 200, WinDriveLetter: "f"}, // Different disk
+			},
+			newDisk: model.GuestDisk{
+				Key:            100,
+				DiskPath:       "C:\\",
+				Capacity:       2000000000,
+				FreeSpace:      1500000000,
+				FilesystemType: "NTFS",
+			},
+			expectedGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			expectedDisks: []model.Disk{
+				{Key: 100, WinDriveLetter: "c"}, // Updated with extracted drive letter
+				{Key: 200, WinDriveLetter: "f"}, // Unchanged
+			},
+			expectedOperation: "append_and_update_disk",
+		},
+		{
+			name:              "handles non-Windows path without updating drive letter",
+			initialGuestDisks: []model.GuestDisk{},
+			initialDisks: []model.Disk{
+				{Key: 100, WinDriveLetter: ""},
+			},
+			newDisk: model.GuestDisk{
+				Key:            100,
+				DiskPath:       "/home/user",
+				Capacity:       2000000000,
+				FreeSpace:      1500000000,
+				FilesystemType: "ext4",
+			},
+			expectedGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "/home/user",
+					Capacity:       2000000000,
+					FreeSpace:      1500000000,
+					FilesystemType: "ext4",
+				},
+			},
+			expectedDisks: []model.Disk{
+				{Key: 100, WinDriveLetter: ""}, // Unchanged since it's not a Windows path
+			},
+			expectedOperation: "append_and_update_disk",
+		},
+		{
+			name: "replaces existing and updates matching Disk drive letter",
+			initialGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "E:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			initialDisks: []model.Disk{
+				{Key: 100, WinDriveLetter: "e"}, // Will be updated
+				{Key: 200, WinDriveLetter: "f"}, // Different disk, unchanged
+			},
+			newDisk: model.GuestDisk{
+				Key:            100,
+				DiskPath:       "C:\\", // Different drive letter
+				Capacity:       1500000000,
+				FreeSpace:      800000000,
+				FilesystemType: "NTFS",
+			},
+			expectedGuestDisks: []model.GuestDisk{
+				{
+					Key:            100,
+					DiskPath:       "C:\\",
+					Capacity:       1500000000,
+					FreeSpace:      800000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			expectedDisks: []model.Disk{
+				{Key: 100, WinDriveLetter: "c"}, // Updated with new drive letter
+				{Key: 200, WinDriveLetter: "f"}, // Unchanged
+			},
+			expectedOperation: "replace",
+		},
+		{
+			name: "handles edge case with zero key",
+			initialGuestDisks: []model.GuestDisk{
+				{
+					Key:            0,
+					DiskPath:       "C:\\",
+					Capacity:       1000000000,
+					FreeSpace:      500000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			initialDisks: []model.Disk{
+				{Key: 0, WinDriveLetter: "c"},
+			},
+			newDisk: model.GuestDisk{
+				Key:            0,
+				DiskPath:       "D:\\", // Updated path
+				Capacity:       1500000000,
+				FreeSpace:      800000000,
+				FilesystemType: "NTFS",
+			},
+			expectedGuestDisks: []model.GuestDisk{
+				{
+					Key:            0,
+					DiskPath:       "D:\\",
+					Capacity:       1500000000,
+					FreeSpace:      800000000,
+					FilesystemType: "NTFS",
+				},
+			},
+			expectedDisks: []model.Disk{
+				{Key: 0, WinDriveLetter: "d"}, // Updated with new drive letter
+			},
+			expectedOperation: "replace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup VmAdapter with test data (make copies to avoid test interference)
+			v := &VmAdapter{
+				model: model.VM{
+					GuestDisks: make([]model.GuestDisk, len(tt.initialGuestDisks)),
+					Disks:      make([]model.Disk, len(tt.initialDisks)),
+				},
+			}
+			copy(v.model.GuestDisks, tt.initialGuestDisks)
+			copy(v.model.Disks, tt.initialDisks)
+
+			// Call the method under test
+			v.updateOrAppendGuestDisk(tt.newDisk)
+
+			// Verify GuestDisks slice
+			if len(v.model.GuestDisks) != len(tt.expectedGuestDisks) {
+				t.Errorf("expected %d guest disks, got %d", len(tt.expectedGuestDisks), len(v.model.GuestDisks))
+			}
+
+			for i, expected := range tt.expectedGuestDisks {
+				if i >= len(v.model.GuestDisks) {
+					t.Errorf("missing expected guest disk at index %d: %+v", i, expected)
+					continue
+				}
+				actual := v.model.GuestDisks[i]
+				if actual.Key != expected.Key ||
+					actual.DiskPath != expected.DiskPath ||
+					actual.Capacity != expected.Capacity ||
+					actual.FreeSpace != expected.FreeSpace ||
+					actual.FilesystemType != expected.FilesystemType {
+					t.Errorf("guest disk at index %d doesn't match.\nExpected: %+v\nGot: %+v", i, expected, actual)
+				}
+			}
+
+			// Verify Disks slice (drive letter propagation)
+			if len(v.model.Disks) != len(tt.expectedDisks) {
+				t.Errorf("expected %d disks, got %d", len(tt.expectedDisks), len(v.model.Disks))
+			}
+
+			for i, expected := range tt.expectedDisks {
+				if i >= len(v.model.Disks) {
+					t.Errorf("missing expected disk at index %d: %+v", i, expected)
+					continue
+				}
+				actual := v.model.Disks[i]
+				if actual.Key != expected.Key || actual.WinDriveLetter != expected.WinDriveLetter {
+					t.Errorf("disk at index %d doesn't match (Key: %d->%d, WinDriveLetter: %s->%s)",
+						i, expected.Key, actual.Key, expected.WinDriveLetter, actual.WinDriveLetter)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -392,6 +392,11 @@ type GuestIpStack struct {
 
 // Guest disk.
 type GuestDisk struct {
+	// The key of the VirtualDevice.
+	//
+	// `VirtualDevice.key`
+	Key int32 `xml:"key" json:"key"`
+
 	// Name of the virtual disk in the guest operating system.
 	//
 	// For example: C:\\ ( in linux it can by a path like /home ).

--- a/validation/policies/io/konveyor/forklift/vmware/guest_disk_mapping.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/guest_disk_mapping.rego
@@ -1,0 +1,27 @@
+package io.konveyor.forklift.vmware
+import future.keywords.in
+
+# Match any windows disk with missing mappings
+invalid_guest_disk_mappings[idx] {
+    some idx
+
+    lower_id := lower(input.guestId)
+    is_windows := contains(lower_id, "windows")
+    key := object.get(input.guestDisks[idx], "key", 0)
+    missing_disk_mapping := key == 0
+
+    is_windows
+    missing_disk_mapping
+}
+
+# Raise a concern for each invalid disk
+concerns[flag] {
+    invalid_guest_disk_mappings[idx]
+    disk := input.guestDisks[idx]
+    flag := {
+        "id": "vmware.guestDisks.key.not_found",
+        "category": "Information",
+        "label": sprintf("Missing disk key mapping for '%v'", [disk.diskPath]),
+        "assessment": "winDriveLetter cannot be resolved in PVC name templates without a disk key mapping."
+    }
+}

--- a/validation/policies/io/konveyor/forklift/vmware/guest_disk_mapping_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/guest_disk_mapping_test.rego
@@ -1,0 +1,223 @@
+package io.konveyor.forklift.vmware
+import future.keywords.in
+
+# Test data: Windows VM with valid disk mappings (should not trigger)
+test_windows_vm_valid_disks_no_concerns {
+    count(concerns) == 0 with input as {
+        "guestId": "windows2019Server_64Guest",
+        "guestDisks": [
+            {
+                "key": 2000,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            },
+            {
+                "key": 2001,
+                "diskPath": "[datastore1] VM1/VM1_1.vmdk", 
+                "capacity": 42949672960
+            }
+        ]
+    }
+}
+
+# Test: Windows VM with invalid disk mapping (key == 0) should trigger concern
+test_windows_vm_invalid_disk_creates_concern {
+    count(concerns) == 1 with input as {
+        "guestId": "windows2019Server_64Guest",
+        "guestDisks": [
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            }
+        ]
+    }
+}
+
+# Test: Windows VM with missing key property should trigger concern
+test_windows_vm_missing_key_property_creates_concern {
+    count(concerns) == 1 with input as {
+        "guestId": "windows2019Server_64Guest",
+        "guestDisks": [
+            {
+                # "key" intentionally omitted
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            }
+        ]
+    }
+}
+
+# Test: Non-Windows VM with invalid disk mapping (key == 0) should not trigger
+test_non_windows_vm_invalid_disk_no_concern {
+    count(concerns) == 0 with input as {
+        "guestId": "ubuntu64Guest", 
+        "guestDisks": [
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            }
+        ]
+    }
+}
+
+# Test: Windows VM with mixed valid/invalid disks should only flag invalid ones
+test_windows_vm_mixed_disks_partial_concerns {
+    count(concerns) == 2 with input as {
+        "guestId": "windows2016Server_64Guest",
+        "guestDisks": [
+            {
+                "key": 2000,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            },
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1_1.vmdk",
+                "capacity": 42949672960
+            },
+            {
+                "key": 2002,
+                "diskPath": "[datastore1] VM1/VM1_2.vmdk",
+                "capacity": 10737418240
+            },
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1_3.vmdk",
+                "capacity": 5368709120
+            }
+        ]
+    }
+}
+
+# Test: Windows VM identifier case insensitive matching
+test_windows_vm_case_insensitive_matching {
+    count(concerns) == 1 with input as {
+        "guestId": "WINDOWS2019SERVER_64GUEST",
+        "guestDisks": [
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            }
+        ]
+    }
+}
+
+# Test: Various Windows guest ID patterns should all match
+test_various_windows_guest_ids {
+    # Test Windows Server
+    count(concerns) == 1 with input as {
+        "guestId": "windows2022Server_64Guest",
+        "guestDisks": [{"key": 0, "diskPath": "[ds1] vm/disk.vmdk", "capacity": 1000}]
+    }
+    
+    # Test Windows 10
+    count(concerns) == 1 with input as {
+        "guestId": "windows10_64Guest", 
+        "guestDisks": [{"key": 0, "diskPath": "[ds1] vm/disk.vmdk", "capacity": 1000}]
+    }
+    
+    # Test Windows 11
+    count(concerns) == 1 with input as {
+        "guestId": "windows11_64Guest",
+        "guestDisks": [{"key": 0, "diskPath": "[ds1] vm/disk.vmdk", "capacity": 1000}]
+    }
+}
+
+# Test: Empty guest disks array should not cause errors
+test_empty_guest_disks_no_concerns {
+    count(concerns) == 0 with input as {
+        "guestId": "windows2019Server_64Guest",
+        "guestDisks": []
+    }
+}
+
+# Test: Verify concern structure and content
+test_concern_structure_and_content {
+    concerns[_].id == "vmware.guestDisks.key.not_found" with input as {
+        "guestId": "windows2019Server_64Guest",
+        "guestDisks": [
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            }
+        ]
+    }
+    
+    concerns[_].category == "Information" with input as {
+        "guestId": "windows2019Server_64Guest", 
+        "guestDisks": [
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            }
+        ]
+    }
+    
+    contains(concerns[_].label, "Missing disk key mapping") with input as {
+        "guestId": "windows2019Server_64Guest",
+        "guestDisks": [
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1.vmdk", 
+                "capacity": 21474836480
+            }
+        ]
+    }
+    
+    contains(concerns[_].assessment, "winDriveLetter cannot be resolved") with input as {
+        "guestId": "windows2019Server_64Guest",
+        "guestDisks": [
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            }
+        ]
+    }
+}
+
+# Test: Verify invalid_guest_disk_mappings rule works correctly
+test_invalid_guest_disk_mappings_rule {
+    # Should find invalid mappings for Windows VM
+    count(invalid_guest_disk_mappings) == 1 with input as {
+        "guestId": "windows2019Server_64Guest",
+        "guestDisks": [
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            }
+        ]
+    }
+    
+    # Should not find invalid mappings for non-Windows VM
+    count(invalid_guest_disk_mappings) == 0 with input as {
+        "guestId": "ubuntu64Guest",
+        "guestDisks": [
+            {
+                "key": 0,
+                "diskPath": "[datastore1] VM1/VM1.vmdk", 
+                "capacity": 21474836480
+            }
+        ]
+    }
+    
+    # Should not find invalid mappings for Windows VM with valid keys
+    count(invalid_guest_disk_mappings) == 0 with input as {
+        "guestId": "windows2019Server_64Guest",
+        "guestDisks": [
+            {
+                "key": 2000,
+                "diskPath": "[datastore1] VM1/VM1.vmdk",
+                "capacity": 21474836480
+            }
+        ]
+    }
+}
+
+


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-2728

Issue:
For MTV-2403 we need to map guistDiskInfo with hw disk info, the mapping information is sometime missing.

Fix:
  - raise an info message if the mapping is missing
  - use mapping, because it's predictable, even if it's sometime missing.

Demo:

  - With drive letter:
```bash
oc mtv get inventory vms chho2 -o json -q "where any(guestDisks[*].key > 0) and any(guestDisks[*].filesystemType = 'NTFS') limit 1" | jq ".[] | {disks: .disks, guestDisks: .guestDisks, concerns: .concerns}"
```
```json
{
  "disks": [
    {
      "bus": "scsi",
      "capacity": 12884901888,
      "changeTrackingEnabled": true,
      "controllerKey": 1000,
      "datastore": {
        "id": "datastore-16",
        "kind": "Datastore"
      },
      "file": "[mtv-nfs-rhos-v7] mtv-feature-win2019-staticips/mtv-feature-win2019-staticips.vmdk",
      "key": 2000,
      "mode": "persistent",
      "rdm": false,
      "serial": "6000C292-5c18-52d4-ea96-a32068359c73",
      "shared": false,
      "unitNumber": 0,
      "winDriveLetter": "c"
    }
  ],
  "guestDisks": [
    {
      "capacity": 12307132416,
      "diskPath": "C:\\",
      "filesystemType": "NTFS",
      "freeSpace": 1146044416,
      "key": 2000
    }
  ],
  "concerns": [
    {
      "assessment": "This VM is configured with at least one SCSI disk and the disk.EnableUUID parameter is set to TRUE. This may indicate a need for consistent SCSI disk serial numbers, but be advised that these serial numbers will be truncated after migration.",
      "category": "Information",
      "id": "vmware.disk_serial.truncated",
      "label": "Disk serial numbers may be truncated"
    }
  ]
}
```

  - Without drive letter:
```bash
oc mtv get inventory vms chho2 -o json -q "where any(concerns[*].id = 'vmware.guestDisks.key.not_found') limit 1" | jq ".[] | {disks: .disks, guestDisks: .guestDisks, concerns: .concerns}"
```

```json
{
  "disks": [
    {
      "bus": "ide",
      "capacity": 12884901888,
      "changeTrackingEnabled": true,
      "controllerKey": 200,
      "datastore": {
        "id": "datastore-16",
        "kind": "Datastore"
      },
      "file": "[mtv-nfs-rhos-v7] mtv-func-win2019-ipv6/mtv-func-win2019-ipv6_3.vmdk",
      "key": 3000,
      "mode": "persistent",
      "rdm": false,
      "serial": "6000C292-1d72-6a33-57c9-5bc862c677a9",
      "shared": false,
      "unitNumber": 0
    },
    {
      "bus": "ide",
      "capacity": 1073741824,
      "changeTrackingEnabled": true,
      "controllerKey": 200,
      "datastore": {
        "id": "datastore-16",
        "kind": "Datastore"
      },
      "file": "[mtv-nfs-rhos-v7] mtv-func-win2019-ipv6/mtv-func-win2019-ipv6.vmdk",
      "key": 3001,
      "mode": "persistent",
      "rdm": false,
      "serial": "6000C29d-2ec0-7a58-3603-afeddb08fb89",
      "shared": false,
      "unitNumber": 1
    },
    {
      "bus": "ide",
      "capacity": 2147483648,
      "changeTrackingEnabled": true,
      "controllerKey": 201,
      "datastore": {
        "id": "datastore-16",
        "kind": "Datastore"
      },
      "file": "[mtv-nfs-rhos-v7] mtv-func-win2019-ipv6/mtv-func-win2019-ipv6_1.vmdk",
      "key": 3002,
      "mode": "persistent",
      "rdm": false,
      "serial": "6000C292-0db6-7f4d-809f-64f149634ee6",
      "shared": false,
      "unitNumber": 0
    }
  ],
  "guestDisks": [
    {
      "capacity": 12307132416,
      "diskPath": "C:\\",
      "filesystemType": "NTFS",
      "freeSpace": 1388523520,
      "key": 0
    }
  ],
  "concerns": [
    {
      "assessment": "winDriveLetter cannot be resolved in PVC name templates without a disk key mapping.",
      "category": "Information",
      "id": "vmware.guestDisks.key.not_found",
      "label": "Missing disk key mapping for 'C:\\'"
    }
  ]
}
```
 
Note:
Users that have missing mappings can use the file name field `FileName` with regexp and get the win drive letter in cases the drive letter is encoded in the file name, for example:

```
disk-{{ mustRegexReplaceAll \".*[^0-9]([0-9]+).vmdk\" .FileName \"\$1\" }} 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guest disk records are now merged by disk key instead of replaced, preserving existing data and adding per-disk Windows drive-letter metadata for more reliable mappings.

* **Validation**
  * New policy flags Windows VMs missing disk-key mappings and surfaces actionable concerns to aid PVC name templates.

* **Tests**
  * Added unit and Rego tests covering Windows vs non-Windows cases, mixed mappings, case-insensitivity, empty lists, and concern content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->