### PR TITLE
MTV-3075 | Migrating 2 NICs to the same NAD succeeds

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -147,8 +147,9 @@ type Validator interface {
 	WarmMigration() bool
 	// Validate whether the migration type is supported by this provider.
 	MigrationType() bool
-	// Validate that no more than one of a VM's networks is mapped to the pod network.
-	PodNetwork(vmRef ref.Ref) (bool, error)
+	// Validate that no more than one of a VM's networks is mapped to the pod network,
+	// and that Multus networks have unique destination names.
+	NetworkMapping(vmRef ref.Ref) (bool, error)
 	// Validate that we have information about static IPs for every virtual NIC
 	StaticIPs(vmRef ref.Ref) (bool, error)
 	// Validate the shared disk, returns msg and category as the errors depends on the provider implementations

--- a/pkg/controller/plan/adapter/base/network_validation.go
+++ b/pkg/controller/plan/adapter/base/network_validation.go
@@ -1,0 +1,90 @@
+package base
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+)
+
+// Network types
+const (
+	Pod     = "pod"
+	Multus  = "multus"
+	Ignored = "ignored"
+)
+
+// NetworkMappingMatcher is a callback function that providers implement
+// to handle their specific network matching logic.
+// It should return true if the mapping applies to the VM's networks.
+// The vm parameter is the VM object retrieved by the provider.
+type NetworkMappingMatcher func(vm interface{}, mapping *api.NetworkPair) (bool, error)
+
+// VMRetriever is a callback function that providers implement
+// to retrieve VM data in their provider-specific way.
+type VMRetriever func(vmRef ref.Ref) (vm interface{}, err error)
+
+// ValidateNetworkMapping provides shared network mapping validation logic
+// that all providers can use. It validates that:
+// 1. Only one Pod network can be mapped per VM
+// 2. Multus networks must have unique destination names
+// 3. Other network types (like "ignored") have no restrictions
+//
+// The retriever function handles provider-specific VM retrieval.
+// The matcher function allows each provider to implement their specific
+// network matching logic while sharing the common validation rules.
+func ValidateNetworkMapping(ctx *plancontext.Context, vmRef ref.Ref, retriever VMRetriever, matcher NetworkMappingMatcher) (ok bool, err error) {
+	if ctx.Plan.Referenced.Map.Network == nil {
+		ok = true
+		return
+	}
+
+	// Retrieve VM using provider-specific logic
+	vm, err := retriever(vmRef)
+	if err != nil {
+		err = liberr.Wrap(err, "vm", vmRef.String())
+		return
+	}
+
+	mapping := ctx.Plan.Referenced.Map.Network.Spec.Map
+	podMapped := 0
+	multusNames := make(map[string]int) // Track Multus destination names
+
+	for i := range mapping {
+		mapped := &mapping[i]
+
+		// Use provider-specific matching logic
+		matches, fErr := matcher(vm, mapped)
+		if fErr != nil {
+			err = fErr
+			return
+		}
+
+		if matches {
+			switch mapped.Destination.Type {
+			case Pod:
+				podMapped++
+			case Multus:
+				// For Multus, track the destination name to ensure uniqueness
+				multusNames[mapped.Destination.Name]++
+			}
+		}
+	}
+
+	// Check Pod validation: only one Pod network allowed
+	if podMapped > 1 {
+		ok = false
+		return
+	}
+
+	// Check Multus validation: each Multus destination name must be unique
+	for _, count := range multusNames {
+		if count > 1 {
+			ok = false
+			return
+		}
+	}
+
+	ok = true
+	return
+}

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -7,6 +7,7 @@ import (
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web"
 	inventory "github.com/kubev2v/forklift/pkg/controller/provider/web/ocp"
@@ -90,33 +91,32 @@ func (r *Validator) MaintenanceMode(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }
 
-// PodNetwork implements base.Validator
-func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
-		return
-	}
-
-	vm := &cnv.VirtualMachine{}
-	err = r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
-	if err != nil {
-		err = liberr.Wrap(
-			err,
-			VM_NOT_FOUND,
-			"vm",
-			vmRef.String())
-		return
-	}
-	mapping := r.Plan.Referenced.Map.Network.Spec.Map
-	podMapped := 0
-	for i := range mapping {
-		mapped := &mapping[i]
-		if mapped.Destination.Type == Pod {
-			podMapped++
+// NetworkMapping implements base.Validator
+func (r *Validator) NetworkMapping(vmRef ref.Ref) (ok bool, err error) {
+	// Create provider-specific VM retrieval function
+	retriever := func(vmRef ref.Ref) (interface{}, error) {
+		vm := &cnv.VirtualMachine{}
+		err := r.sourceClient.Get(context.TODO(), k8sclient.ObjectKey{Namespace: vmRef.Namespace, Name: vmRef.Name}, vm)
+		if err != nil {
+			err = liberr.Wrap(
+				err,
+				VM_NOT_FOUND,
+				"vm",
+				vmRef.String())
+			return nil, err
 		}
+		return vm, nil
 	}
 
-	ok = podMapped <= 1
-	return
+	// Create provider-specific network matching function
+	// For OCP, we validate all mappings since we're migrating VMs within the cluster
+	matcher := func(vmInterface interface{}, mapping *api.NetworkPair) (bool, error) {
+		// For OCP provider, all mappings apply since we're validating intra-cluster migrations
+		return true, nil
+	}
+
+	// Use shared validation logic
+	return planbase.ValidateNetworkMapping(r.Context, vmRef, retriever, matcher)
 }
 
 // WarmMigration implements base.Validator

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/openstack"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
@@ -109,32 +110,30 @@ func (r *Validator) MigrationType() bool {
 	}
 }
 
-// Validate that no more than one of a VM's networks is mapped to the pod network.
-func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
-		return
-	}
-	vm := &model.Workload{}
-	err = r.Source.Inventory.Find(vm, vmRef)
-	if err != nil {
-		err = liberr.Wrap(err, "vm", vmRef.String())
-		return
+// Validate that no more than one of a VM's networks is mapped to the pod network,
+// and that Multus networks have unique names.
+func (r *Validator) NetworkMapping(vmRef ref.Ref) (ok bool, err error) {
+	// Create provider-specific VM retrieval function
+	retriever := func(vmRef ref.Ref) (interface{}, error) {
+		vm := &model.Workload{}
+		err := r.Source.Inventory.Find(vm, vmRef)
+		return vm, err
 	}
 
-	mapping := r.Plan.Referenced.Map.Network.Spec.Map
-	podMapped := 0
-	for i := range mapping {
-		mapped := &mapping[i]
-		ref := mapped.Source
+	// Create provider-specific network matching function
+	matcher := func(vmInterface interface{}, mapping *api.NetworkPair) (bool, error) {
+		vm := vmInterface.(*model.Workload)
+		ref := mapping.Source
 		for _, network := range vm.Networks {
-			if ref.ID == network.ID && mapped.Destination.Type == "Pod" {
-				podMapped++
+			if ref.ID == network.ID {
+				return true, nil
 			}
 		}
+		return false, nil
 	}
 
-	ok = podMapped <= 1
-	return
+	// Use shared validation logic
+	return planbase.ValidateNetworkMapping(r.Context, vmRef, retriever, matcher)
 }
 
 // NO-OP

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -3,6 +3,7 @@ package ova
 import (
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ova"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
@@ -79,38 +80,36 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	return
 }
 
-// Validate that no more than one of a VM's networks is mapped to the pod network.
-func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
-		return
-	}
-	vm := &model.Workload{}
-	err = r.Source.Inventory.Find(vm, vmRef)
-	if err != nil {
-		err = liberr.Wrap(err, "vm", vmRef.String())
-		return
+// Validate that no more than one of a VM's networks is mapped to the pod network,
+// and that Multus networks have unique names.
+func (r *Validator) NetworkMapping(vmRef ref.Ref) (ok bool, err error) {
+	// Create provider-specific VM retrieval function
+	retriever := func(vmRef ref.Ref) (interface{}, error) {
+		vm := &model.Workload{}
+		err := r.Source.Inventory.Find(vm, vmRef)
+		return vm, err
 	}
 
-	mapping := r.Plan.Referenced.Map.Network.Spec.Map
-	podMapped := 0
-	for i := range mapping {
-		mapped := &mapping[i]
-		ref := mapped.Source
+	// Create provider-specific network matching function
+	matcher := func(vmInterface interface{}, mapping *api.NetworkPair) (bool, error) {
+		vm := vmInterface.(*model.Workload)
+		ref := mapping.Source
 		network := &model.Network{}
 		fErr := r.Source.Inventory.Find(network, ref)
 		if fErr != nil {
-			err = fErr
-			return
+			return false, fErr
 		}
+
 		for _, nic := range vm.NICs {
-			if nic.Network == network.Name && mapped.Destination.Type == Pod {
-				podMapped++
+			if nic.Network == network.Name {
+				return true, nil
 			}
 		}
+		return false, nil
 	}
 
-	ok = podMapped <= 1
-	return
+	// Use shared validation logic
+	return planbase.ValidateNetworkMapping(r.Context, vmRef, retriever, matcher)
 }
 
 // Validate that a VM's disk backing storage has been mapped.

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -5,6 +5,7 @@ import (
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/controller/provider/container"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ovirt"
@@ -85,38 +86,36 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	return
 }
 
-// Validate that no more than one of a VM's networks is mapped to the pod network.
-func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
-		return
-	}
-	vm := &model.Workload{}
-	err = r.Source.Inventory.Find(vm, vmRef)
-	if err != nil {
-		err = liberr.Wrap(err, "vm", vmRef.String())
-		return
+// Validate that no more than one of a VM's networks is mapped to the pod network,
+// and that Multus networks have unique names.
+func (r *Validator) NetworkMapping(vmRef ref.Ref) (ok bool, err error) {
+	// Create provider-specific VM retrieval function
+	retriever := func(vmRef ref.Ref) (interface{}, error) {
+		vm := &model.Workload{}
+		err := r.Source.Inventory.Find(vm, vmRef)
+		return vm, err
 	}
 
-	mapping := r.Plan.Referenced.Map.Network.Spec.Map
-	podMapped := 0
-	for i := range mapping {
-		mapped := &mapping[i]
-		ref := mapped.Source
+	// Create provider-specific network matching function
+	matcher := func(vmInterface interface{}, mapping *api.NetworkPair) (bool, error) {
+		vm := vmInterface.(*model.Workload)
+		ref := mapping.Source
 		network := &model.Network{}
 		fErr := r.Source.Inventory.Find(network, ref)
 		if fErr != nil {
-			err = fErr
-			return
+			return false, fErr
 		}
+
 		for _, nic := range vm.NICs {
-			if nic.Profile.Network == network.ID && mapped.Destination.Type == Pod {
-				podMapped++
+			if nic.Profile.Network == network.ID {
+				return true, nil
 			}
 		}
+		return false, nil
 	}
 
-	ok = podMapped <= 1
-	return
+	// Use shared validation logic
+	return planbase.ValidateNetworkMapping(r.Context, vmRef, retriever, matcher)
 }
 
 // Validate that a VM's disk backing storage has been mapped.

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -59,38 +59,36 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	return
 }
 
-// Validate that no more than one of a VM's networks is mapped to the pod network.
-func (r *Validator) PodNetwork(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
-		return
-	}
-	vm := &model.Workload{}
-	err = r.Source.Inventory.Find(vm, vmRef)
-	if err != nil {
-		err = liberr.Wrap(err, "vm", vmRef.String())
-		return
+// Validate that no more than one of a VM's networks is mapped to the pod network,
+// and that Multus networks have unique names.
+func (r *Validator) NetworkMapping(vmRef ref.Ref) (ok bool, err error) {
+	// Create provider-specific VM retrieval function
+	retriever := func(vmRef ref.Ref) (interface{}, error) {
+		vm := &model.Workload{}
+		err := r.Source.Inventory.Find(vm, vmRef)
+		return vm, err
 	}
 
-	mapping := r.Plan.Referenced.Map.Network.Spec.Map
-	podMapped := 0
-	for i := range mapping {
-		mapped := &mapping[i]
-		ref := mapped.Source
+	// Create provider-specific network matching function
+	matcher := func(vmInterface interface{}, mapping *api.NetworkPair) (bool, error) {
+		vm := vmInterface.(*model.Workload)
+		ref := mapping.Source
 		network := &model.Network{}
 		fErr := r.Source.Inventory.Find(network, ref)
 		if fErr != nil {
-			err = fErr
-			return
+			return false, fErr
 		}
+
 		for _, nic := range vm.NICs {
-			if nic.Network.ID == network.ID && mapped.Destination.Type == Pod {
-				podMapped++
+			if nic.Network.ID == network.ID {
+				return true, nil
 			}
 		}
+		return false, nil
 	}
 
-	ok = podMapped <= 1
-	return
+	// Use shared validation logic
+	return planbase.ValidateNetworkMapping(r.Context, vmRef, retriever, matcher)
 }
 
 // Validate that a VM's disk backing storage has been mapped.

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -546,12 +546,12 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Message:  "VM host is in maintenance mode.",
 		Items:    []string{},
 	}
-	multiplePodNetworkMappings := libcnd.Condition{
+	multipleNetworkMappings := libcnd.Condition{
 		Type:     VMMultiplePodNetworkMappings,
 		Status:   True,
 		Reason:   NotValid,
 		Category: api.CategoryCritical,
-		Message:  "VM has more than one interface mapped to the pod network.",
+		Message:  "VM has invalid network mappings: only one interface can be mapped to a Pod network or to a unique Multus networks.",
 		Items:    []string{},
 	}
 	missingStaticIPs := libcnd.Condition{
@@ -740,12 +740,12 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 			if !ok {
 				unmappedNetwork.Items = append(unmappedNetwork.Items, ref.String())
 			}
-			ok, err = validator.PodNetwork(*ref)
+			ok, err = validator.NetworkMapping(*ref)
 			if err != nil {
 				return err
 			}
 			if !ok {
-				multiplePodNetworkMappings.Items = append(multiplePodNetworkMappings.Items, ref.String())
+				multipleNetworkMappings.Items = append(multipleNetworkMappings.Items, ref.String())
 			}
 		}
 		if plan.Referenced.Map.Storage != nil {
@@ -925,8 +925,8 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 	if len(maintenanceMode.Items) > 0 {
 		plan.Status.SetCondition(maintenanceMode)
 	}
-	if len(multiplePodNetworkMappings.Items) > 0 {
-		plan.Status.SetCondition(multiplePodNetworkMappings)
+	if len(multipleNetworkMappings.Items) > 0 {
+		plan.Status.SetCondition(multipleNetworkMappings)
 	}
 	if len(missingStaticIPs.Items) > 0 {
 		plan.Status.SetCondition(missingStaticIPs)


### PR DESCRIPTION
Issue:
Created a plan with a VM that has multiple NICs assigned to the same target NAD. Migration succeeded when it should have failed. Post-migration, the VM failed to boot properly.

Fix:
Prevent migration when multiple NICs target the same network (not just POD as we had)

Ref: https://issues.redhat.com/browse/MTV-3075

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced network mapping validation for virtual machines, ensuring only one Pod network is mapped per VM and Multus network destination names are unique.

* **Refactor**
  * Unified network mapping validation logic across all providers for improved consistency and maintainability.
  * Renamed validation methods and updated related messages for broader and clearer network mapping checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->