### PR TITLE
MTV-3078 | Power off VM fails due to "VMware Tools is not running"

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -226,6 +226,8 @@ type Validator interface {
 	MacConflicts(vmRef ref.Ref) ([]MacConflict, error)
 	// Validate that the PVC name template is valid
 	PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (bool, error)
+	// Validate guest tools installation and status (e.g., VMware Tools, VirtIO drivers).
+	GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error)
 }
 
 // DestinationClient API.

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -85,6 +85,12 @@ func (r *Validator) VMMigrationType(vmRef ref.Ref) (ok bool, err error) {
 	return
 }
 
+// NO-OP
+func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
+	ok = true
+	return
+}
+
 // MaintenanceMode implements base.Validator
 func (r *Validator) MaintenanceMode(vmRef ref.Ref) (bool, error) {
 	return true, nil

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -220,3 +220,9 @@ func (r *Validator) PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (ok b
 	ok = true
 	return
 }
+
+// NO-OP
+func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
+	ok = true
+	return
+}

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -211,3 +211,9 @@ func (r *Validator) PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (ok b
 	ok = true
 	return
 }
+
+// NO-OP
+func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
+	ok = true
+	return
+}

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -267,3 +267,9 @@ func (r *Validator) PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (ok b
 	ok = true
 	return
 }
+
+// NO-OP
+func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
+	ok = true
+	return
+}

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -25,6 +25,34 @@ type mockInventory struct {
 	vm model.VM
 }
 
+// defaultVM returns a VM with sensible defaults for testing
+func defaultVM() model.VM {
+	return model.VM{
+		ToolsStatus:        ToolsOk,           // default: tools installed
+		ToolsRunningStatus: GuestToolsRunning, // default: tools running
+		ToolsVersionStatus: GuestToolsCurrent, // default: tools current
+		VM1: model.VM1{
+			VM0: model.VM0{
+				ID:   "test-vm-id",
+				Name: "test-vm",
+			},
+			PowerState: "poweredOn", // default state
+			Disks: []vsphere.Disk{
+				{
+					File:           "[datastore1] VMs/test-vm/test-vm-disk1.vmdk",
+					WinDriveLetter: "c",
+					Capacity:       1024,
+				},
+				{
+					File:           "[datastore1] VMs/test-vm/test-vm-disk2.vmdk",
+					WinDriveLetter: "d",
+					Capacity:       2048,
+				},
+			},
+		},
+	}
+}
+
 func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 	switch res := resource.(type) {
 	case *model.Datastore:
@@ -41,12 +69,38 @@ func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 			return base.NotFoundError{}
 		}
 	case *model.VM:
-		*res = m.vm
 		if ref.Name == "missing_from_inventory" {
 			return base.NotFoundError{}
 		}
+		// Use m.vm if set, otherwise use default VM
+		if m.vm.ID != "" {
+			*res = m.vm
+		} else {
+			*res = defaultVM()
+		}
 		if ref.Name == "empty_disk_vm" {
 			res.VM1.Disks = []vsphere.Disk{}
+		}
+		// Test cases for GuestToolsInstalled
+		switch ref.Name {
+		case "tools_not_installed":
+			res.ToolsStatus = ToolsNotInstalled
+		case "tools_not_running":
+			res.ToolsStatus = ToolsOk
+			res.ToolsRunningStatus = GuestToolsNotRunning
+		case "tools_status_unknown":
+			res.ToolsStatus = "" // Empty status (encrypted VM scenario)
+		case "tools_status_null":
+			res.ToolsStatus = "null" // Null status (encrypted VM scenario)
+		case "tools_status_nil":
+			res.ToolsStatus = "<nil>" // fmt.Sprint(nil) result (encrypted VM scenario)
+		case "vm_powered_off":
+			res.PowerState = "poweredOff"
+			res.ToolsStatus = ToolsNotInstalled // Should be ignored when powered off
+		case "tools_unmanaged":
+			res.ToolsVersionStatus = GuestToolsUnmanaged
+		case "missing_from_inventory":
+			return base.NotFoundError{}
 		}
 	}
 	return nil
@@ -280,6 +334,48 @@ var _ = Describe("vsphere validation tests", func() {
 
 			// VM template validation is now done directly with the passed parameter
 		})
+	})
+
+	Describe("GuestToolsInstalled", func() {
+		DescribeTable("should validate VMware Tools status correctly",
+			func(vmName string, expectedOk bool, shouldError bool) {
+				provider := &v1beta1.Provider{Spec: v1beta1.ProviderSpec{Type: &[]v1beta1.ProviderType{v1beta1.VSphere}[0]}}
+				validator := &Validator{
+					Context: &plancontext.Context{},
+				}
+				validator.Source = plancontext.Source{Provider: provider}
+				validator.Source.Inventory = &mockInventory{}
+
+				vmRef := ref.Ref{Name: vmName}
+				ok, err := validator.GuestToolsInstalled(vmRef)
+
+				if shouldError {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ok).To(Equal(expectedOk))
+				}
+			},
+
+			// Success cases
+			Entry("when VMware Tools are installed and running", "default_vm", true, false),
+
+			// Critical cases - powered on VMs with tools issues
+			Entry("when VMware Tools are not installed", "tools_not_installed", false, false),
+			Entry("when VMware Tools are not running", "tools_not_running", false, false),
+			Entry("when VMware Tools are unmanaged", "tools_unmanaged", false, false),
+
+			// Encrypted/unknown tools status must block when VM is powered on
+			Entry("when VMware Tools status is empty (encrypted VM) -> block", "tools_status_unknown", false, false),
+			Entry("when VMware Tools status is null (encrypted VM) -> block", "tools_status_null", false, false),
+			Entry("when VMware Tools status is <nil> (encrypted VM) -> block", "tools_status_nil", false, false),
+
+			// Powered off VMs should pass validation
+			Entry("when VM is powered off (tools status ignored)", "vm_powered_off", true, false),
+
+			// Error cases
+			Entry("when VM is missing from inventory", "missing_from_inventory", false, true),
+		)
 	})
 })
 

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -146,6 +146,11 @@ const (
 	fGuestDisk                = "guest.disk"
 	fGuestIpStack             = "guest.ipStack"
 	fHostName                 = "guest.hostName"
+	// fToolsStatus is deprecated since vSphere API 4.0; use fToolsRunningStatus instead
+	fToolsStatus        = "guest.toolsStatus"
+	fToolsRunningStatus = "guest.toolsRunningStatus"
+	// fToolsVersionStatus is deprecated since vSphere API 5.1; use fToolsVersionStatus2 for more detailed status
+	fToolsVersionStatus = "guest.toolsVersionStatus2"
 )
 
 // Selections
@@ -842,6 +847,9 @@ func (r *Collector) vmPathSet() []string {
 		fChangeTracking,
 		fGuestIpStack,
 		fHostName,
+		fToolsStatus,
+		fToolsRunningStatus,
+		fToolsVersionStatus,
 	}
 
 	apiVer := strings.Split(r.client.ServiceContent.About.ApiVersion, ".")

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -731,6 +731,12 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if s, cast := p.Val.(string); cast {
 					v.model.HostName = s
 				}
+			case fToolsStatus:
+				v.model.ToolsStatus = fmt.Sprint(p.Val)
+			case fToolsRunningStatus:
+				v.model.ToolsRunningStatus = fmt.Sprint(p.Val)
+			case fToolsVersionStatus:
+				v.model.ToolsVersionStatus = fmt.Sprint(p.Val)
 			case fTpmPresent:
 				if b, cast := p.Val.(bool); cast {
 					v.model.TpmEnabled = b

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -326,6 +326,9 @@ type VM struct {
 	GuestDisks               []DiskMountPoint `sql:""`
 	GuestIpStacks            []GuestIpStack   `sql:""`
 	SecureBoot               bool             `sql:""`
+	ToolsStatus              string           `sql:""`
+	ToolsRunningStatus       string           `sql:""`
+	ToolsVersionStatus       string           `sql:""`
 	DiskEnableUuid           bool             `sql:""`
 	NestedHVEnabled          bool             `sql:""`
 }

--- a/pkg/controller/provider/web/vsphere/base_test.go
+++ b/pkg/controller/provider/web/vsphere/base_test.go
@@ -233,3 +233,20 @@ func TestHostPathNestedDatacenterTwoLevels(t *testing.T) {
 
 	g.Expect(pb.Path(&host)).To(Equal("/myfolder/myfolder2/mydc/mycluster/myhost"))
 }
+
+func TestVMWithCopiesToolsFields(t *testing.T) {
+	m := &model.VM{
+		ToolsStatus:        "toolsOk",
+		ToolsRunningStatus: "guestToolsRunning",
+		ToolsVersionStatus: "guestToolsCurrent",
+	}
+	var r VM
+	r.With(m)
+
+	if r.ToolsStatus != m.ToolsStatus ||
+		r.ToolsRunningStatus != m.ToolsRunningStatus ||
+		r.ToolsVersionStatus != m.ToolsVersionStatus {
+		t.Fatalf("With() did not copy tools fields: got %q/%q/%q",
+			r.ToolsStatus, r.ToolsRunningStatus, r.ToolsVersionStatus)
+	}
+}

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -249,8 +249,13 @@ type VM struct {
 	GuestDisks               []model.DiskMountPoint `json:"guestDisks"`
 	GuestIpStacks            []model.GuestIpStack   `json:"guestIpStacks"`
 	SecureBoot               bool                   `json:"secureBoot"`
-	DiskEnableUuid           bool                   `json:"diskEnableUuid"`
-	NestedHVEnabled          bool                   `json:"nestedHVEnabled"`
+	ToolsStatus              string                 `json:"toolsStatus"`
+	ToolsRunningStatus       string                 `json:"toolsRunningStatus"`
+	// Note: vSphere reports version as "toolsVersionStatus2"; we keep the Go field
+	// name ToolsVersionStatus for continuity while serializing as toolsVersionStatus2.
+	ToolsVersionStatus string `json:"toolsVersionStatus2"`
+	DiskEnableUuid     bool   `json:"diskEnableUuid"`
+	NestedHVEnabled    bool   `json:"nestedHVEnabled"`
 }
 
 // Build the resource using the model.
@@ -285,6 +290,9 @@ func (r *VM) With(m *model.VM) {
 	r.GuestDisks = m.GuestDisks
 	r.GuestIpStacks = m.GuestIpStacks
 	r.SecureBoot = m.SecureBoot
+	r.ToolsStatus = m.ToolsStatus
+	r.ToolsRunningStatus = m.ToolsRunningStatus
+	r.ToolsVersionStatus = m.ToolsVersionStatus
 	r.DiskEnableUuid = m.DiskEnableUuid
 	r.NestedHVEnabled = m.NestedHVEnabled
 }


### PR DESCRIPTION
Issue:
Cold migration of a VM with LUKS-encrypted disks and skipGuestConversion: true fails because VMware Tools is not running. VMware Tools cannot start until the encrypted disk is unlocked, but with skipGuestConversion: true, the user typically doesn't have the decryption password and it remains locked.

Fix:
Implemented a  VMware Tools validation in the plan validator that checks powered-on vSphere VMs.
 For encrypted VMs where tools status is null/empty (due to encryption preventing guest info access),
 it shows a Critical validation error that blocks migration until the VM is manually powered off, ensuring safe 
migration workflows.

Ref: https://issues.redhat.com/browse/MTV-3078

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Plan validation now checks per-VM guest tools installation/status and surfaces a consolidated Guest Tools issue when problems are detected.
  - vSphere VM details now expose guest tools status fields in API responses (toolsStatus, toolsRunningStatus, toolsVersionStatus2) for improved visibility.
- Tests
  - Added unit tests covering vSphere guest tools scenarios and validation aggregation across VMs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->