### PR TITLE
MTV-2849 | Need to keep the default gateway setting after migration.

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -280,7 +280,7 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 
 		for _, gn := range vm.GuestNetworks {
 			//IS ipv4
-			if net.IP.To4(net.ParseIP(gn.IP)) != nil {
+			if gn.Origin == string(types.NetIpConfigInfoIpAddressOriginManual) && net.IP.To4(net.ParseIP(gn.IP)) != nil {
 				macIPCount[gn.MAC]++
 			}
 		}

--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
@@ -25,16 +25,99 @@ try {
 
 $routes = $routes | Where-Object { $_.AddressFamily -eq "IPv4" }
 
+# Step 1: Preserve ALL default gateways (0.0.0.0/0) with their interface indexes
+$defaultGateways = $routes | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" }
+Write-Host "Found $($defaultGateways.Count) default gateway(s) to preserve:" -ForegroundColor Cyan
+foreach ($gw in $defaultGateways) {
+    Write-Host "  Gateway: $($gw.NextHop) on Interface $($gw.InterfaceIndex) with metric $($gw.RouteMetric)" -ForegroundColor Cyan
+}
+
+# Step 2: Clean up duplicate routes (including default gateways)
+Write-Host "Analyzing routes for duplicates..." -ForegroundColor Yellow
+
+# Group ALL routes for duplicate detection  
 $groupedRoutes = $routes | Group-Object {
     "$($_.DestinationPrefix)-$($_.NextHop)-$($_.RouteMetric)"
 } | Where-Object { $_.Count -gt 1 }
+
+# Separate default gateway duplicates from other duplicates
+$gatewayDuplicates = $groupedRoutes | Where-Object { $_.Name.Trim().StartsWith("0.0.0.0/0-") }
+$nonGatewayDuplicates = $groupedRoutes | Where-Object { -not $_.Name.Trim().StartsWith("0.0.0.0/0-") }
+
+Write-Host "Found $($gatewayDuplicates.Count) duplicate default gateway groups" -ForegroundColor Cyan
+Write-Host "Found $($nonGatewayDuplicates.Count) duplicate non-gateway route groups" -ForegroundColor Cyan
 
 if (-not $groupedRoutes) {
     Write-Host "No duplicate persistent routes found." -ForegroundColor Green
 } else {
     Write-Host "Cleaning up duplicate persistent routes..." -ForegroundColor Yellow
-
-    foreach ($group in $groupedRoutes) {
+    
+    # First, handle duplicate default gateways
+    foreach ($group in $gatewayDuplicates) {
+        $routes = $group.Group
+        
+        # Choose the route with an interface that actually exists
+        $toKeep = $null
+        foreach ($route in $routes) {
+            $interface = Get-NetAdapter | Where-Object { $_.InterfaceIndex -eq $route.InterfaceIndex } -ErrorAction SilentlyContinue
+            if ($interface) {
+                $toKeep = $route
+                break
+            }
+        }
+        
+        # If no existing interface found, just use the first one
+        if (-not $toKeep) {
+            $toKeep = $routes[0]
+        }
+        
+        $dest = $toKeep.DestinationPrefix
+        $gateway = $toKeep.NextHop
+        $metric = $toKeep.RouteMetric
+        
+        Write-Host "  Cleaning duplicate default gateway: $gateway (metric $metric) - keeping IF $($toKeep.InterfaceIndex)" -ForegroundColor Yellow
+        
+        # Remove ALL instances
+        foreach ($route in $routes) {
+            try {
+                Remove-NetRoute -DestinationPrefix $route.DestinationPrefix -NextHop $route.NextHop -InterfaceIndex $route.InterfaceIndex -PolicyStore PersistentStore -Confirm:$false -ErrorAction Stop
+                Write-Host "    Deleted: $($route.DestinationPrefix) via $($route.NextHop) on IF $($route.InterfaceIndex)" -ForegroundColor Red
+            } catch {
+                Write-Host "      Failed to delete: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+        
+        # Re-add only ONE instance (preserve the first interface)
+        $reAddSucceeded = $false
+        try {
+            New-NetRoute -DestinationPrefix $dest -InterfaceIndex $toKeep.InterfaceIndex -NextHop $gateway -RouteMetric $metric -PolicyStore PersistentStore -ErrorAction Stop
+            Write-Host "    Re-added: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+            $reAddSucceeded = $true
+        } catch {
+            Write-Host "      PolicyStore method failed: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+        
+        # Fallback to route.exe if PolicyStore failed
+        if (-not $reAddSucceeded) {
+            try {
+                $parts = $dest.Split("/")
+                $network = $parts[0]
+                $prefix = [int]$parts[1]
+                $netmask = Convert-PrefixToMask $prefix
+                $metricStr = if ($metric -is [int]) { "METRIC $metric" } else { "" }
+                $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
+                Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
+                cmd /c $command
+                
+                Write-Host "    Re-added with route.exe: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+            } catch {
+                Write-Host "      route.exe also failed: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+    }
+    
+    # Then handle non-gateway duplicates
+    foreach ($group in $nonGatewayDuplicates) {
         $toKeep = $group.Group[0]
         $dest = $toKeep.DestinationPrefix
         $gateway = $toKeep.NextHop
@@ -76,7 +159,6 @@ if (-not $groupedRoutes) {
 
         # Fallback to route.exe if New-NetRoute failed
         if (-not $reAddSucceeded) {
-            # Re-add one preserved route using legacy route.exe
             $command = "route -p ADD $network MASK $netmask $gateway IF $interfaceIndex"
             if ($metricStr -ne "") {
                 $command += " $metricStr"
@@ -92,3 +174,67 @@ if (-not $groupedRoutes) {
     }
 }
 
+# Step 3: Configure default gateways at NIC/IP configuration level
+Write-Host "Configuring default gateways at interface level..." -ForegroundColor Cyan
+
+# Get current default gateways after cleanup
+$currentDefaultGateways = Get-NetRoute -PolicyStore PersistentStore -AddressFamily IPv4 | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" }
+Write-Host "Configuring $($currentDefaultGateways.Count) remaining default gateway(s)..." -ForegroundColor Cyan
+
+foreach ($gateway in $currentDefaultGateways) {
+    $nextHop = $gateway.NextHop
+    $interfaceIndex = $gateway.InterfaceIndex
+    $metric = $gateway.RouteMetric
+
+    # Check if interface still exists
+    $interface = Get-NetAdapter | Where-Object { $_.InterfaceIndex -eq $interfaceIndex } -ErrorAction SilentlyContinue
+    if (-not $interface) {
+        Write-Host "  Skipping Interface $interfaceIndex - Interface no longer exists" -ForegroundColor Gray
+        continue
+    }
+    
+    $interfaceAlias = $interface.Name
+    Write-Host "  Processing Interface $interfaceIndex ($interfaceAlias) - Gateway $nextHop" -ForegroundColor Yellow
+
+    $ipConfig = Get-NetIPConfiguration -InterfaceIndex $interfaceIndex -ErrorAction SilentlyContinue
+    $hasGatewayInConfig = $false
+    if ($ipConfig -and $ipConfig.IPv4DefaultGateway) {
+        $hasGatewayInConfig = $ipConfig.IPv4DefaultGateway.NextHop -contains $nextHop
+    }
+
+    if (-not $hasGatewayInConfig) {
+        Write-Host "    Interface IP config missing gateway, configuring..." -ForegroundColor Yellow
+
+        $currentIP = Get-NetIPAddress -InterfaceIndex $interfaceIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.IPAddress -ne "127.0.0.1" -and -not $_.IPAddress.StartsWith("169.254") }
+
+        if ($currentIP) {
+            $ipAddress = $currentIP.IPAddress
+            $prefixLength = $currentIP.PrefixLength
+
+            Write-Host "    Current IP: $ipAddress/$prefixLength, setting gateway: $nextHop" -ForegroundColor Yellow
+
+            try {
+                $netshCmd = "netsh interface ipv4 set address name=`"$interfaceAlias`" static $ipAddress $(Convert-PrefixToMask $prefixLength) $nextHop $metric"
+                Write-Host "    Executing: $netshCmd" -ForegroundColor Gray
+                $result = cmd /c $netshCmd 2>&1
+                Write-Host "    Configured NIC gateway with netsh: $nextHop on $interfaceAlias" -ForegroundColor Green
+            } catch {
+                Write-Host "    Method 1 failed, trying PowerShell method..." -ForegroundColor Yellow
+                try {
+                    Remove-NetIPAddress -InterfaceIndex $interfaceIndex -AddressFamily IPv4 -Confirm:$false -ErrorAction SilentlyContinue
+                    New-NetIPAddress -InterfaceIndex $interfaceIndex -IPAddress $ipAddress -PrefixLength $prefixLength -DefaultGateway $nextHop -ErrorAction Stop
+                    Write-Host "    Reconfigured IP with gateway: $ipAddress -> $nextHop" -ForegroundColor Green
+                } catch {
+                    Write-Host "    All methods failed for interface gateway configuration: $($_.Exception.Message)" -ForegroundColor Red
+                    Write-Host "    Manual intervention may be required for interface $interfaceAlias" -ForegroundColor Red
+                }
+            }
+        } else {
+            Write-Host "    Could not determine current IP address for interface $interfaceIndex" -ForegroundColor Red
+        }
+    } else {
+        Write-Host "    Interface IP config has gateway: $nextHop" -ForegroundColor Green
+    }
+}
+
+Write-Host "Persistent route cleanup completed!" -ForegroundColor Green


### PR DESCRIPTION
Issue:
Even after previous fix, after cleaning duplicates routing , default gateway setting is still missing.

Fix:
1. Enhance Windows route cleanup to preserve multi-NIC default gateways

    - Detect and remove duplicate default gateway routes while preserving one per unique gateway
    - Implement smart interface selection to choose existing interfaces over missing ones
    - Configure gateways at NIC IP level to ensure visibility in ipconfig /all

2. Verify that the NIC is configured with a manual (static) IPv4 address before setting the V2V_multipleIPsPerNic environment variable.

Ref:https://issues.redhat.com/browse/MTV-2849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate persistent routes on Windows by ensuring only one default gateway route is preserved and properly configured for each interface.
  * Enhanced IP counting logic to consider only manually assigned IPv4 addresses, excluding dynamically assigned or other origin IPs.

* **Chores**
  * Added detailed logging for route and gateway operations to aid in troubleshooting and transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->