### PR TITLE
MTV-2710 | OVA provider crash when adding more ova files to inventory.

### DIFF
--- a/pkg/controller/provider/container/ova/model.go
+++ b/pkg/controller/provider/container/ova/model.go
@@ -153,7 +153,11 @@ func (r *NetworkAdapter) DeleteUnexisting(ctx *Context) (deletions []Updater, er
 			m := &model.Network{
 				Base: model.Base{ID: currentID},
 			}
-			return tx.Delete(m)
+			err = tx.Delete(m)
+			if err != nil && errors.Is(err, libmodel.NotFound) {
+				err = nil
+			}
+			return err
 		}
 		deletions = append(deletions, updater)
 	}
@@ -249,7 +253,11 @@ func (r *VMAdapter) DeleteUnexisting(ctx *Context) (deletions []Updater, err err
 			m := &model.VM{
 				Base: model.Base{ID: currentID},
 			}
-			return tx.Delete(m)
+			err = tx.Delete(m)
+			if err != nil && errors.Is(err, libmodel.NotFound) {
+				err = nil
+			}
+			return err
 		}
 		deletions = append(deletions, updater)
 	}
@@ -343,7 +351,11 @@ func (r *DiskAdapter) DeleteUnexisting(ctx *Context) (deletions []Updater, err e
 			m := &model.Disk{
 				Base: model.Base{ID: currentID},
 			}
-			return tx.Delete(m)
+			err = tx.Delete(m)
+			if err != nil && errors.Is(err, libmodel.NotFound) {
+				err = nil
+			}
+			return err
 		}
 		deletions = append(deletions, updater)
 	}
@@ -438,7 +450,11 @@ func (r *StorageAdapter) DeleteUnexisting(ctx *Context) (deletions []Updater, er
 			m := &model.Storage{
 				Base: model.Base{ID: id},
 			}
-			return tx.Delete(m)
+			err = tx.Delete(m)
+			if err != nil && errors.Is(err, libmodel.NotFound) {
+				err = nil
+			}
+			return err
 		}
 		deletions = append(deletions, updater)
 	}


### PR DESCRIPTION
Issue:
1. When the OVA provider already exists and new OVA files are added to the NFS server, the provider becomes unresponsive, and the OVA pod reports the following error: "Error processing OVF from OVA: unexpected EOF."
2.The OVA VM list became corrupted after adding files to an existing provider, resulting in an empty list of VMs.

Fix:
1. Added isFileComplete check before reading OVA/OVF files to avoid processing files that are still being copied to NFS.
2. Prevents refresh failures when deleting non-existent inventory records.

Ref: https://issues.redhat.com/browse/MTV-2710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a check to ensure files are fully copied and stable before processing, preventing errors from incomplete files.

* **Bug Fixes**
  * Improved error handling during deletion operations to ignore "not found" errors, ensuring smoother resource cleanup.
  * Enhanced logging to better distinguish between files still being copied and other processing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->