### PR TITLE
MTV-2362 | Add cacert to virt-v2v

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -399,9 +399,12 @@ func (r *Builder) getSourceDetails(vm *model.VM, sourceSecret *core.Secret) (lib
 		return
 	}
 
-	sslVerify := ""
+	var sslVerify string
 	if basecontroller.GetInsecureSkipVerifyFlag(sourceSecret) {
 		sslVerify = "no_verify=1"
+	} else {
+		// This path is created by linkCertificates in the v2v container containes either the provider cert or pod certs.
+		sslVerify = "cacert=/opt/ca-bundle.crt"
 	}
 
 	if hostDef, found := r.hosts[host.ID]; found {


### PR DESCRIPTION
Issue:
The guest conversion fails when the provider uses self signed certificates.
```
virt-v2v: error: exception: libvirt: VIR_ERR_INTERNAL_ERROR: VIR_FROM_ESX: internal error: curl_easy_perform() returned an error: SSL peer certificate or SSH remote key was not OK (60) : SSL certificate problem:unable to get local issuer certificate
```

This fix requires fix in libvirt with the `cacert` parameter. This parameter allow us to specify cert for libvirt connection without requiring the root. As the /etc/pki/ca-trust/source/anchors, requires to runn update-ca-trust for which we need root but the conversion has QEMU (107) user.

Ref:
- https://issues.redhat.com/browse/MTV-2362
- https://issues.redhat.com/browse/RHEL-98292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SSL verification settings for vSphere connections, ensuring a default certificate authority bundle is used when TLS verification is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->