### PR TITLE
MTV-2678 | RFE: Implement OpenShift Network Policies in MTV

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -11581,6 +11581,13 @@ rules:
   - networkpolicies
   verbs:
   - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -11646,7 +11653,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: forklift-operator
-  namespace: konveyor-forklift
+  namespace: forklift-operator-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -11761,6 +11768,7 @@ metadata:
   name: forklift-controller
   namespace: openshift-mtv
 spec:
+  feature_network_policies: "false"
   feature_ui_plugin: "true"
   feature_validation: "true"
   feature_volume_populator: "true"
@@ -11906,7 +11914,8 @@ metadata:
         "spec": {
           "feature_ui_plugin": "true",
           "feature_validation": "true",
-          "feature_volume_populator": "true"
+          "feature_volume_populator": "true",
+          "feature_network_policies": "false"
         }
       }
     operatorframework.io/suggested-namespace: openshift-mtv

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -11491,6 +11491,18 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -11556,7 +11568,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: forklift-operator
-  namespace: konveyor-forklift
+  namespace: forklift-operator-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -11671,6 +11683,7 @@ metadata:
   name: forklift-controller
   namespace: openshift-mtv
 spec:
+  feature_network_policies: "false"
   feature_ui_plugin: "true"
   feature_validation: "true"
   feature_volume_populator: "true"
@@ -11816,7 +11829,8 @@ metadata:
         "spec": {
           "feature_ui_plugin": "true",
           "feature_validation": "true",
-          "feature_volume_populator": "true"
+          "feature_volume_populator": "true",
+          "feature_network_policies": "false"
         }
       }
     operatorframework.io/suggested-namespace: openshift-mtv

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -206,6 +206,12 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_network_policies:
+                description: 'Enable network policies for security (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               feature_ocp_live_migration:
                 description: 'Enable OCP live migration (default: false)'
                 enum:
@@ -320,6 +326,11 @@ spec:
               must_gather_image_fqin:
                 description: Must-gather debugging image
                 example: quay.io/kubev2v/forklift-must-gather:latest
+                type: string
+              network_policies_min_ocp_version:
+                description: 'Minimum OCP version to auto-enable network policies
+                  (default: 4.21.0)'
+                example: 4.21.0
                 type: string
               ova_container_limits_cpu:
                 description: 'OVA CPU limit (default: 1000m)'
@@ -7460,6 +7471,18 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -7525,7 +7548,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: forklift-operator
-  namespace: konveyor-forklift
+  namespace: forklift-operator-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -7636,6 +7659,7 @@ metadata:
   name: forklift-controller
   namespace: ${NAMESPACE}
 spec:
+  feature_network_policies: "false"
   feature_ui_plugin: "true"
   feature_validation: "true"
   feature_volume_populator: "true"

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -11491,6 +11491,18 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -11556,7 +11568,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: forklift-operator
-  namespace: konveyor-forklift
+  namespace: forklift-operator-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -11671,6 +11683,7 @@ metadata:
   name: forklift-controller
   namespace: konveyor-forklift
 spec:
+  feature_network_policies: "false"
   feature_ui_plugin: "true"
   feature_validation: "true"
   feature_volume_populator: "true"
@@ -11816,7 +11829,8 @@ metadata:
         "spec": {
           "feature_ui_plugin": "true",
           "feature_validation": "true",
-          "feature_volume_populator": "true"
+          "feature_volume_populator": "true",
+          "feature_network_policies": "false"
         }
       }
     operatorframework.io/suggested-namespace: konveyor-forklift

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -11581,6 +11581,13 @@ rules:
   - networkpolicies
   verbs:
   - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -11646,7 +11653,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: forklift-operator
-  namespace: konveyor-forklift
+  namespace: forklift-operator-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -11761,6 +11768,7 @@ metadata:
   name: forklift-controller
   namespace: konveyor-forklift
 spec:
+  feature_network_policies: "false"
   feature_ui_plugin: "true"
   feature_validation: "true"
   feature_volume_populator: "true"
@@ -11906,7 +11914,8 @@ metadata:
         "spec": {
           "feature_ui_plugin": "true",
           "feature_validation": "true",
-          "feature_volume_populator": "true"
+          "feature_volume_populator": "true",
+          "feature_network_policies": "false"
         }
       }
     operatorframework.io/suggested-namespace: konveyor-forklift

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -367,13 +367,6 @@ spec:
                 - "true"
                 - "false"
                 type: string
-              feature_network_policies:
-                default: "false"
-                description: Enable network policies for Forklift components.
-                enum:
-                - "true"
-                - "false"
-                type: string
               feature_ocp_live_migration:
                 default: "true"
                 description: Enable OCP live migration.

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -367,6 +367,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_network_policies:
+                default: "false"
+                description: Enable network policies for Forklift components.
+                enum:
+                - "true"
+                - "false"
+                type: string
               feature_ocp_live_migration:
                 default: "true"
                 description: Enable OCP live migration.

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -400,6 +400,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable network policies for Forklift components.
+        displayName: Feature Network Policies
+        path: feature_network_policies
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
       - description: Enable OCP live migration.
         displayName: Feature OCPLive Migration
         path: feature_ocp_live_migration

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -105,3 +105,15 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -111,3 +111,10 @@ rules:
   - networkpolicies
   verbs:
   - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/operator/config/rbac/role_binding.yaml
+++ b/operator/config/rbac/role_binding.yaml
@@ -9,4 +9,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: forklift-operator
-  namespace: konveyor-forklift
+  # NOTE: 'system' is a Kustomize template placeholder
+  # It gets replaced with the actual namespace from kustomization.yaml
+  # Example: 'forklift-operator-system', 'openshift-mtv', etc.
+  namespace: system

--- a/operator/config/samples/forklift_v1beta1_forkliftcontroller.yaml
+++ b/operator/config/samples/forklift_v1beta1_forkliftcontroller.yaml
@@ -12,7 +12,4 @@ spec:
   # When enabled, a baseline default‑deny (Ingress+Egress) policy is applied and
   # Forklift policies explicitly allow required traffic.
   feature_network_policies: "false"
-  # Enable NFSv3 support in NetworkPolicies. Set to "true" to allow rpcbind/mountd ports.
-  # Default: NFSv4 only (2049). NFSv3 also requires 111 (rpcbind) and a fixed mountd port (commonly 20048).
-  # Ensure the NFS server config sets a fixed rpc.mountd port that matches the policy.
-  # nfs_v3_support: "false"
+

--- a/operator/config/samples/forklift_v1beta1_forkliftcontroller.yaml
+++ b/operator/config/samples/forklift_v1beta1_forkliftcontroller.yaml
@@ -8,3 +8,11 @@ spec:
   feature_ui_plugin: "true"
   feature_validation: "true"
   feature_volume_populator: "true"
+  # Enable NetworkPolicies. Set to "true" to install policies.
+  # When enabled, a baseline default‑deny (Ingress+Egress) policy is applied and
+  # Forklift policies explicitly allow required traffic.
+  feature_network_policies: "false"
+  # Enable NFSv3 support in NetworkPolicies. Set to "true" to allow rpcbind/mountd ports.
+  # Default: NFSv4 only (2049). NFSv3 also requires 111 (rpcbind) and a fixed mountd port (commonly 20048).
+  # Ensure the NFS server config sets a fixed rpc.mountd port that matches the policy.
+  # nfs_v3_support: "false"

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -4,6 +4,9 @@
 app_name: "{{ lookup('env', 'APP_NAME') or 'forklift' }}"
 app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
 
+# Feature defaults
+feature_network_policies: false
+
 # Container images -- resolved from RELATED_IMAGE_* env vars injected by OLM/CSV.
 controller_image_fqin: "{{ lookup( 'env', 'CONTROLLER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_CONTROLLER') }}"
 validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VALIDATION') }}"
@@ -104,6 +107,7 @@ forklift_resources:
   - ConfigMap
   - Service
   - Route
+  - NetworkPolicy
 
 
 # VDDK build config names (internal).

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -5,7 +5,9 @@ app_name: "{{ lookup('env', 'APP_NAME') or 'forklift' }}"
 app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
 
 # Feature defaults
+# NetworkPolicies: auto-enabled on OCP >= network_policies_min_ocp_version (see tasks/main.yml)
 feature_network_policies: false
+network_policies_min_ocp_version: "4.21.0"
 
 # Container images -- resolved from RELATED_IMAGE_* env vars injected by OLM/CSV.
 controller_image_fqin: "{{ lookup( 'env', 'CONTROLLER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_CONTROLLER') }}"

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -26,56 +26,6 @@
       volume_populator_state: "present"
     when: feature_volume_populator|bool
 
-  - name: "Set version-aware feature_network_policies default based on OCP version"
-    block:
-      - name: "Extract OpenShift cluster version"
-        k8s_info:
-          api_version: config.openshift.io/v1
-          kind: ClusterVersion
-          name: version
-        register: cluster_version_info
-        ignore_errors: yes
-        failed_when: false
-        # Query ClusterVersion resource to find the installed OpenShift version
-        # This allows us to determine the OCP version at runtime
-
-      - name: "Extract OCP version from ClusterVersion results"
-        set_fact:
-          # Determine OpenShift version from ClusterVersion resource
-          # Processing steps:
-          #   1. cluster_version_info.resources | default([]) - Get ClusterVersion resources
-          #   2. map(attribute='status.history') | first | default([]) - Extract history from first resource
-          #   3. selectattr('state', 'equalto', 'Completed') - Filter to completed versions
-          #   4. map(attribute='version') - Extract version strings
-          #   5. first - Take the first (most recent) completed version
-          #   6. default('unknown') - Fallback if version not found
-          # Result: OCP version string (e.g., "4.21.3") or "unknown" if not found
-          detected_ocp_version: >-
-            {{ cluster_version_info.resources
-               | default([])
-               | map(attribute='status.history')
-               | first
-               | default([])
-               | selectattr('state', 'equalto', 'Completed')
-               | map(attribute='version')
-               | first
-               | default('unknown') }}
-        failed_when: false
-
-      - name: "Set feature_network_policies based on OCP version"
-        set_fact:
-          # Enable feature if OCP version meets or exceeds minimum threshold
-          # Uses ansible.builtin.version test for semantic version comparison
-          # Example: "4.21.3" >= "4.21.0" -> true, "4.19.0" >= "4.21.0" -> false
-          feature_network_policies: >-
-            {{ 'true' if (detected_ocp_version != 'unknown' and 
-               detected_ocp_version is ansible.builtin.version(network_policies_min_ocp_version, '>=')) 
-               else 'false' }}
-        failed_when: false
-    when: not (feature_network_policies | default('false') | bool)
-    # Only set version-aware default if user hasn't explicitly enabled it in ForkliftController CR
-    # If user sets feature_network_policies: "true" in CR, that takes precedence
-
   - name: "Load cluster API groups"
     set_fact:
       api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
@@ -102,6 +52,13 @@
     - name: "Obtain ocp cluster version"
       set_fact:
         ocp_version: "{{ cluster_version.resources[0].status.history | selectattr('state', 'equalto', 'Completed') | map(attribute='version') | first }}"
+
+    - name: "Set feature_network_policies based on OCP version"
+      set_fact:
+        feature_network_policies: >-
+          {{ 'true' if ocp_version is ansible.builtin.version(network_policies_min_ocp_version, '>=') else 'false' }}
+      when: not (feature_network_policies | default('false') | bool)
+      # Only set version-aware default if user hasn't explicitly enabled it in ForkliftController CR
 
   - name: "Setup controller config map"
     k8s:
@@ -591,6 +548,18 @@
       definition: "{{ lookup('template', 'security/networkpolicy-validation.yml.j2') }}"
     when: feature_network_policies|bool
 
+  - name: "Setup hooks network policy"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'security/networkpolicy-hooks.yml.j2') }}"
+    when: feature_network_policies|bool
+
+  - name: "Setup UI plugin network policy"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'security/networkpolicy-ui-plugin.yml.j2') }}"
+    when: feature_network_policies|bool
+
   - when: not feature_ui_plugin|bool
     name: "Cleanup {{ ui_plugin_service_name }} if disabled"
     include_tasks: cleanup.yml
@@ -651,11 +620,12 @@
       - forklift-ovirt-populator-policy
       - forklift-openstack-populator-policy
       - forklift-vsphere-xcopy-populator-policy
-      - forklift-vddk-validation-policy
       - forklift-validation-service-policy
       - forklift-image-converter-policy
       - forklift-hooks-policy
       - forklift-ova-server-policy
+      - forklift-hyperv-server-policy
+      - forklift-hyperv-populator-policy
       - forklift-ui-plugin-policy
 
     when: not feature_network_policies|bool

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -26,6 +26,56 @@
       volume_populator_state: "present"
     when: feature_volume_populator|bool
 
+  - name: "Set version-aware feature_network_policies default based on OCP version"
+    block:
+      - name: "Extract OpenShift cluster version"
+        k8s_info:
+          api_version: config.openshift.io/v1
+          kind: ClusterVersion
+          name: version
+        register: cluster_version_info
+        ignore_errors: yes
+        failed_when: false
+        # Query ClusterVersion resource to find the installed OpenShift version
+        # This allows us to determine the OCP version at runtime
+
+      - name: "Extract OCP version from ClusterVersion results"
+        set_fact:
+          # Determine OpenShift version from ClusterVersion resource
+          # Processing steps:
+          #   1. cluster_version_info.resources | default([]) - Get ClusterVersion resources
+          #   2. map(attribute='status.history') | first | default([]) - Extract history from first resource
+          #   3. selectattr('state', 'equalto', 'Completed') - Filter to completed versions
+          #   4. map(attribute='version') - Extract version strings
+          #   5. first - Take the first (most recent) completed version
+          #   6. default('unknown') - Fallback if version not found
+          # Result: OCP version string (e.g., "4.21.3") or "unknown" if not found
+          detected_ocp_version: >-
+            {{ cluster_version_info.resources
+               | default([])
+               | map(attribute='status.history')
+               | first
+               | default([])
+               | selectattr('state', 'equalto', 'Completed')
+               | map(attribute='version')
+               | first
+               | default('unknown') }}
+        failed_when: false
+
+      - name: "Set feature_network_policies based on OCP version"
+        set_fact:
+          # Enable feature if OCP version meets or exceeds minimum threshold
+          # Uses ansible.builtin.version test for semantic version comparison
+          # Example: "4.21.3" >= "4.21.0" -> true, "4.19.0" >= "4.21.0" -> false
+          feature_network_policies: >-
+            {{ 'true' if (detected_ocp_version != 'unknown' and 
+               detected_ocp_version is ansible.builtin.version(network_policies_min_ocp_version, '>=')) 
+               else 'false' }}
+        failed_when: false
+    when: not (feature_network_policies | default('false') | bool)
+    # Only set version-aware default if user hasn't explicitly enabled it in ForkliftController CR
+    # If user sets feature_network_policies: "true" in CR, that takes precedence
+
   - name: "Load cluster API groups"
     set_fact:
       api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"

--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -510,6 +510,37 @@
       definition: "{{ lookup('template', 'controller/imagestream-vddk.yml.j2') }}"
     when: not k8s_cluster|bool
 
+
+  - name: "Setup operator network policy"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'security/networkpolicy-operator.yml.j2') }}"
+    when: feature_network_policies|bool
+
+  - name: "Setup controller network policy"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'security/networkpolicy-controller.yml.j2') }}"
+    when: feature_network_policies|bool
+
+  - name: "Setup API network policy"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'security/networkpolicy-api.yml.j2') }}"
+    when: feature_network_policies|bool
+
+  - name: "Setup migration workloads network policies"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'security/networkpolicy-migration-workloads.yml.j2') }}"
+    when: feature_network_policies|bool
+
+  - name: "Setup validation network policies"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'security/networkpolicy-validation.yml.j2') }}"
+    when: feature_network_policies|bool
+
   - when: not feature_ui_plugin|bool
     name: "Cleanup {{ ui_plugin_service_name }} if disabled"
     include_tasks: cleanup.yml
@@ -554,6 +585,30 @@
       name: forklift-must-gather-api
       state: absent
     when: finalize is not defined
+
+  - name: "Cleanup network policies if disabled"
+    k8s:
+      api_version: networking.k8s.io/v1
+      kind: NetworkPolicy
+      namespace: "{{ app_namespace }}"
+      name: "{{ item }}"
+      state: absent
+    loop:
+      - forklift-operator-policy
+      - forklift-controller-policy
+      - forklift-api-policy
+      - forklift-virt-v2v-policy
+      - forklift-ovirt-populator-policy
+      - forklift-openstack-populator-policy
+      - forklift-vsphere-xcopy-populator-policy
+      - forklift-vddk-validation-policy
+      - forklift-validation-service-policy
+      - forklift-image-converter-policy
+      - forklift-hooks-policy
+      - forklift-ova-server-policy
+      - forklift-ui-plugin-policy
+
+    when: not feature_network_policies|bool
 
 - block:
   - name: "Remove webhook configuration"

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-api.yml.j2
@@ -14,36 +14,11 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow controller to communicate with API webhooks
-    - from:
-      - podSelector:
-          matchLabels:
-            control-plane: controller-manager
-      ports:
-      - protocol: TCP
-        port: 8443
-    # Allow OpenShift Console to access API webhooks
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: openshift-console
-      ports:
-      - protocol: TCP
-        port: 8443
-    {% if not k8s_cluster|bool %}
-    # Allow monitoring to access API metrics
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: openshift-monitoring
-      ports:
-      - protocol: TCP
-        port: 8443
-    {% endif %}
     # Allow 8443 from anywhere:
-    # Required because Kubernetes/OpenShift API server webhook calls do not
-    # originate from a Pod/Namespace that NetworkPolicy can match. Without
-    # this, admission webhooks (e.g. Forklift API validation) would be blocked.
+    # Required for admission webhooks. Flow: user -> k8s API server -> webhook -> k8s API server -> user
+    # The API server calls the webhook, but API server traffic does not originate from a Pod/Namespace
+    # that NetworkPolicy can match (API server runs on control plane nodes). Without this open ingress
+    # rule, admission webhooks (e.g. Forklift API validation) would be blocked.
     - ports:
       - protocol: TCP
         port: 8443

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-api.yml.j2
@@ -1,0 +1,64 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-api-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      service: {{ api_service_name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow controller to communicate with API webhooks
+    - from:
+      - podSelector:
+          matchLabels:
+            control-plane: controller-manager
+      ports:
+      - protocol: TCP
+        port: 8443
+    # Allow OpenShift Console to access API webhooks
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: openshift-console
+      ports:
+      - protocol: TCP
+        port: 8443
+    {% if not k8s_cluster|bool %}
+    # Allow monitoring to access API metrics
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: openshift-monitoring
+      ports:
+      - protocol: TCP
+        port: 8443
+    {% endif %}
+    # Allow 8443 from anywhere:
+    # Required because Kubernetes/OpenShift API server webhook calls do not
+    # originate from a Pod/Namespace that NetworkPolicy can match. Without
+    # this, admission webhooks (e.g. Forklift API validation) would be blocked.
+    - ports:
+      - protocol: TCP
+        port: 8443
+    # Allow ValidatingAdmissionWebhook and MutatingAdmissionWebhook access via service port 443
+    - ports:
+      - protocol: TCP
+        port: 443
+    # Allow internal cluster access to services endpoint (port 8444)
+    # UI plugin needs this for certificate retrieval service
+    - from:
+      - namespaceSelector: {}
+      ports:
+      - protocol: TCP
+        port: 8444
+  egress:
+    # Allow all egress - API pod needs to reach external OCP clusters for validation
+    # and certificate retrieval from arbitrary endpoints
+    - {}

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-controller.yml.j2
@@ -1,0 +1,47 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-controller-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ app_name }}
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow Forklift components to communicate with controller
+    - from:
+      - podSelector:
+          matchLabels:
+            app: {{ app_name }}
+      ports:
+      - protocol: TCP
+        port: 8443  # Controller inventory service
+    # Allow OpenShift Console to access controller
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: openshift-console
+      ports:
+      - protocol: TCP
+        port: 8443  # Controller inventory service
+    {% if not k8s_cluster|bool %}
+    # Allow monitoring to access controller metrics
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: openshift-monitoring
+      ports:
+      - protocol: TCP
+        port: 2112  # Conversion pod metrics
+    {% endif %}
+  egress:
+    # Allow all egress - controller needs to communicate with external providers
+    # and internal services for inventory collection and migration operations
+    - {}

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-controller.yml.j2
@@ -39,7 +39,11 @@ spec:
             kubernetes.io/metadata.name: openshift-monitoring
       ports:
       - protocol: TCP
-        port: 2112  # Conversion pod metrics
+        port: 8081  # Main container metrics
+      - protocol: TCP
+        port: 8082  # Inventory container metrics
+      - protocol: TCP
+        port: 2112  # Controller metrics (Prometheus endpoint)
     {% endif %}
   egress:
     # Allow all egress - controller needs to communicate with external providers

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-hooks.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-hooks.yml.j2
@@ -1,0 +1,57 @@
+# Network policy for MTV Hook Jobs (both PreHook and PostHook)
+# Provides permissive access for custom Ansible playbooks and container images
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-hooks-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchExpressions:
+    - key: step
+      operator: In
+      values: ["PreHook", "PostHook"]
+  policyTypes:
+  - Egress
+  egress:
+  # Service Discovery and Authentication
+  - ports:
+    - protocol: UDP
+      port: 53  # DNS - Service discovery
+    - protocol: TCP
+      port: 53  # DNS - Service discovery
+  
+  # Forklift Platform Communication
+  - to:
+    - podSelector:
+        matchLabels:
+          app: {{ app_name }}
+          control-plane: controller-manager
+    ports:
+    - protocol: TCP
+      port: 8443  # Controller inventory - Status updates
+  - to:
+    - podSelector:
+        matchLabels:
+          service: {{ api_service_name }}
+    ports:
+    - protocol: TCP
+      port: 8443  # API - Resource access
+  
+  # Kubernetes Operations
+  - ports:
+    - protocol: TCP
+      port: 6443  # K8s API - Custom operations
+  
+  # External Dependencies
+  - ports:
+    - protocol: TCP
+      port: 443  # HTTPS - Git repos, packages
+    - protocol: TCP
+      port: 80  # HTTP - Package repositories
+  
+  # Internal Cluster Access
+  - to:
+    - namespaceSelector: {}  # All namespaces - Custom integrations

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-hooks.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-hooks.yml.j2
@@ -14,44 +14,9 @@ spec:
       operator: In
       values: ["PreHook", "PostHook"]
   policyTypes:
+  - Ingress
   - Egress
+  # No ingress rules
   egress:
-  # Service Discovery and Authentication
-  - ports:
-    - protocol: UDP
-      port: 53  # DNS - Service discovery
-    - protocol: TCP
-      port: 53  # DNS - Service discovery
-  
-  # Forklift Platform Communication
-  - to:
-    - podSelector:
-        matchLabels:
-          app: {{ app_name }}
-          control-plane: controller-manager
-    ports:
-    - protocol: TCP
-      port: 8443  # Controller inventory - Status updates
-  - to:
-    - podSelector:
-        matchLabels:
-          service: {{ api_service_name }}
-    ports:
-    - protocol: TCP
-      port: 8443  # API - Resource access
-  
-  # Kubernetes Operations
-  - ports:
-    - protocol: TCP
-      port: 6443  # K8s API - Custom operations
-  
-  # External Dependencies
-  - ports:
-    - protocol: TCP
-      port: 443  # HTTPS - Git repos, packages
-    - protocol: TCP
-      port: 80  # HTTP - Package repositories
-  
-  # Internal Cluster Access
-  - to:
-    - namespaceSelector: {}  # All namespaces - Custom integrations
+  # Allow all egress
+  - {}

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-migration-workloads.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-migration-workloads.yml.j2
@@ -1,0 +1,315 @@
+# Network policies for virt-v2v conversion workloads
+# Applies to virt-v2v pods used by VMware and OVA migrations for guest conversion
+#
+# NFS Configuration:
+# - Default: NFSv4 (port 2049 TCP/UDP only)
+# - NFSv3: Set nfs_v3_support=true to enable ports 111 (rpcbind) and 20048 (mountd)
+# - Note: NFSv3 mountd port may vary depending on server configuration
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-virt-v2v-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      forklift.app: virt-v2v
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow controller communication
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # all ports allowed (ports omitted)
+  egress:
+  # Allow communication with controller
+  - to:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # Allow external provider access (vSphere + OVA)
+  - ports:
+    - protocol: TCP
+      port: 80    # HTTP (Certificate validation, CRL, package repos)
+    - protocol: TCP
+      port: 443   # HTTPS (vSphere API + OVA downloads)
+    - protocol: TCP
+      port: 8443  # vSphere API HTTPS Development
+    - protocol: TCP
+      port: 902   # vSphere NFC storage transfer
+    - protocol: TCP
+      port: 8080  # OVA downloads HTTP
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-ova-server-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      provider: ova-provider
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow controller communication
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # Allow OVA file access from migration workloads
+  - from:
+    - podSelector:
+        matchLabels:
+          forklift.app: migration-workload
+    ports:
+    - protocol: TCP
+      port: 8080  # OVA server HTTP port
+  egress:
+  # Allow communication with controller
+  - to:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # OVA server serves files from NFS storage, no external HTTP/HTTPS needed
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow NFS storage access
+  # NFSv4: Port 2049 TCP/UDP (default configuration)
+  # NFSv3: Add ports 111 (rpcbind) and mountd if needed
+  - ports:
+    - protocol: TCP
+      port: 2049  # NFS (NFSv4/NFSv3 data)
+    - protocol: UDP
+      port: 2049  # NFS (NFSv4/NFSv3 data)
+{% if nfs_v3_support|default(false)|bool %}
+    # NFSv3 additional ports (enable with nfs_v3_support: true)
+    - protocol: TCP
+      port: 111   # rpcbind
+    - protocol: UDP
+      port: 111   # rpcbind
+    - protocol: TCP
+      port: 20048 # mountd (default port, may vary)
+    - protocol: UDP
+      port: 20048 # mountd (default port, may vary)
+{% endif %}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-ovirt-populator-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      populator: ovirt
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow controller communication
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # Allow monitoring access to metrics
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8080  # oVirt populator metrics
+  egress:
+  # Allow communication with controller
+  - to:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # Allow oVirt API and imageio access
+  - ports:
+    - protocol: TCP
+      port: 443     # oVirt Engine API + modern proxy transfers
+    - protocol: TCP
+      port: 54323   # oVirt imageio-daemon (direct streaming from hosts)
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-openstack-populator-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      populator: openstack
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow controller communication
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # Allow monitoring access to metrics
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8081  # OpenStack populator metrics
+  egress:
+  # Allow communication with controller
+  - to:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # Allow OpenStack API access
+  - ports:
+    - protocol: TCP
+      port: 80    # HTTP for OpenStack APIs
+    - protocol: TCP
+      port: 443   # HTTPS for OpenStack APIs
+    - protocol: TCP
+      port: 5000  # Keystone (Identity service)
+    - protocol: TCP
+      port: 8774  # Nova (Compute service)
+    - protocol: TCP
+      port: 8776  # Cinder (Block Storage service)
+    - protocol: TCP
+      port: 9696  # Neutron (Network service)
+    - protocol: TCP
+      port: 13000 # Custom OpenStack service port
+    - protocol: TCP
+      port: 13292 # Custom OpenStack service port
+    - protocol: TCP
+      port: 13774 # Custom OpenStack service port
+    - protocol: TCP
+      port: 13776 # Custom OpenStack service port
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53    # DNS resolution
+    - protocol: TCP
+      port: 53    # DNS resolution
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-vsphere-xcopy-populator-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      populator: vsphere-xcopy
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow controller communication
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # Allow monitoring access to metrics
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8082  # vSphere Xcopy populator metrics
+  egress:
+  # Allow communication with controller
+  - to:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # Allow vSphere API and NFC access
+  - ports:
+    - protocol: TCP
+      port: 443   # vSphere API
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+# Image Converter Policy
+# 
+# The image converter is used during OpenStack migrations (PhaseConvertOpenstackSnapshot)
+# to convert disk formats to RAW format required by KubeVirt. It performs local disk
+# format conversion using qemu-img on locally mounted PVCs without requiring external
+# network access.
+#
+# This policy is required when:
+# - OpenStack migrations are performed
+# - Source disks are in non-RAW formats (qcow2, vmdk, etc.)
+# - Disk format conversion is needed before VM creation
+#
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-image-converter-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      forklift.app: image-converter
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow controller communication
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  egress:
+  # Image converter works with locally mounted PVCs - no network storage access needed
+  # No external egress required

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-migration-workloads.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-migration-workloads.yml.j2
@@ -1,10 +1,6 @@
 # Network policies for virt-v2v conversion workloads
 # Applies to virt-v2v pods used by VMware and OVA migrations for guest conversion
 #
-# NFS Configuration:
-# - Default: NFSv4 (port 2049 TCP/UDP only)
-# - NFSv3: Set nfs_v3_support=true to enable ports 111 (rpcbind) and 20048 (mountd)
-# - Note: NFSv3 mountd port may vary depending on server configuration
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -26,14 +22,14 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # all ports allowed (ports omitted)
+    ports: []  # All ports allowed
   egress:
   # Allow communication with controller
   - to:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
+    ports: []  # All ports allowed
   # Allow external provider access (vSphere + OVA)
   - ports:
     - protocol: TCP
@@ -44,8 +40,9 @@ spec:
       port: 8443  # vSphere API HTTPS Development
     - protocol: TCP
       port: 902   # vSphere NFC storage transfer
+    # Optional: allow TCP 8080 only if OVA/image sources are served over HTTP on nonstandard ports
     - protocol: TCP
-      port: 8080  # OVA downloads HTTP
+      port: 8080  
   # Allow DNS resolution
   - ports:
     - protocol: UDP
@@ -73,12 +70,12 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
-  # Allow OVA file access from migration workloads
+    ports: []  # All ports allowed
+  # Allow OVA file access from virt-v2v pods
   - from:
     - podSelector:
         matchLabels:
-          forklift.app: migration-workload
+          forklift.app: virt-v2v
     ports:
     - protocol: TCP
       port: 8080  # OVA server HTTP port
@@ -88,7 +85,7 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
+    ports: []  # All ports allowed
   # OVA server serves files from NFS storage, no external HTTP/HTTPS needed
   # Allow DNS resolution
   - ports:
@@ -96,25 +93,7 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  # Allow NFS storage access
-  # NFSv4: Port 2049 TCP/UDP (default configuration)
-  # NFSv3: Add ports 111 (rpcbind) and mountd if needed
-  - ports:
-    - protocol: TCP
-      port: 2049  # NFS (NFSv4/NFSv3 data)
-    - protocol: UDP
-      port: 2049  # NFS (NFSv4/NFSv3 data)
-{% if nfs_v3_support|default(false)|bool %}
-    # NFSv3 additional ports (enable with nfs_v3_support: true)
-    - protocol: TCP
-      port: 111   # rpcbind
-    - protocol: UDP
-      port: 111   # rpcbind
-    - protocol: TCP
-      port: 20048 # mountd (default port, may vary)
-    - protocol: UDP
-      port: 20048 # mountd (default port, may vary)
-{% endif %}
+
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -136,7 +115,7 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
+    ports: []  # All ports allowed
   # Allow monitoring access to metrics
   - from:
     - namespaceSelector:
@@ -151,7 +130,7 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
+    ports: []  # All ports allowed
   # Allow oVirt API and imageio access
   - ports:
     - protocol: TCP
@@ -185,7 +164,7 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
+    ports: []  # All ports allowed
   # Allow monitoring access to metrics
   - from:
     - namespaceSelector:
@@ -200,35 +179,11 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
-  # Allow OpenStack API access
-  - ports:
-    - protocol: TCP
-      port: 80    # HTTP for OpenStack APIs
-    - protocol: TCP
-      port: 443   # HTTPS for OpenStack APIs
-    - protocol: TCP
-      port: 5000  # Keystone (Identity service)
-    - protocol: TCP
-      port: 8774  # Nova (Compute service)
-    - protocol: TCP
-      port: 8776  # Cinder (Block Storage service)
-    - protocol: TCP
-      port: 9696  # Neutron (Network service)
-    - protocol: TCP
-      port: 13000 # Custom OpenStack service port
-    - protocol: TCP
-      port: 13292 # Custom OpenStack service port
-    - protocol: TCP
-      port: 13774 # Custom OpenStack service port
-    - protocol: TCP
-      port: 13776 # Custom OpenStack service port
-  # Allow DNS resolution
-  - ports:
-    - protocol: UDP
-      port: 53    # DNS resolution
-    - protocol: TCP
-      port: 53    # DNS resolution
+    ports: []  # All ports allowed
+  # Allow all egress - OpenStack uses dynamic service discovery with unpredictable ports
+  # OpenStack deployments can use custom ports for any service (Keystone, Nova, Cinder, Neutron, etc.)
+  # Attempting to list all possible ports would be incomplete and cause migration failures
+  - {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -250,7 +205,7 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
+    ports: []  # All ports allowed
   # Allow monitoring access to metrics
   - from:
     - namespaceSelector:
@@ -265,7 +220,7 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
+    ports: []  # All ports allowed
   # Allow vSphere API and NFC access
   - ports:
     - protocol: TCP
@@ -309,7 +264,10 @@ spec:
     - podSelector:
         matchLabels:
           control-plane: controller-manager
-    # All ports allowed (ports omitted)
+    ports: []  # All ports allowed
   egress:
   # Image converter works with locally mounted PVCs - no network storage access needed
   # No external egress required
+
+
+

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-migration-workloads.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-migration-workloads.yml.j2
@@ -30,7 +30,7 @@ spec:
         matchLabels:
           control-plane: controller-manager
     ports: []  # All ports allowed
-  # Allow external provider access (vSphere + OVA)
+  # Allow external provider access (vSphere, OVA, HyperV)
   - ports:
     - protocol: TCP
       port: 80    # HTTP (Certificate validation, CRL, package repos)
@@ -40,9 +40,12 @@ spec:
       port: 8443  # vSphere API HTTPS Development
     - protocol: TCP
       port: 902   # vSphere NFC storage transfer
-    # Optional: allow TCP 8080 only if OVA/image sources are served over HTTP on nonstandard ports
     - protocol: TCP
-      port: 8080  
+      port: 445   # SMB over TCP (HyperV disk access)
+    - protocol: TCP
+      port: 3260  # iSCSI (HyperV iSCSI disk transfer)
+    - protocol: TCP
+      port: 8080  # OVA/image HTTP sources
   # Allow DNS resolution
   - ports:
     - protocol: UDP
@@ -94,6 +97,92 @@ spec:
     - protocol: TCP
       port: 53
 
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-hyperv-server-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      subapp: hyperv-server
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow controller communication
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    ports: []  # All ports allowed
+  egress:
+  # Allow communication with controller
+  - to:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    ports: []  # All ports allowed
+  # Allow SMB access to external HyperV/Windows server
+  - ports:
+    - protocol: TCP
+      port: 445   # SMB over TCP
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-hyperv-populator-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      populator: hyperv
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow controller communication
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    ports: []  # All ports allowed
+  # Allow monitoring access to metrics
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8083  # HyperV populator metrics
+  egress:
+  # Allow communication with controller
+  - to:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    ports: []  # All ports allowed
+  # Allow iSCSI target access
+  - ports:
+    - protocol: TCP
+      port: 3260  # iSCSI target
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -257,7 +346,6 @@ spec:
       forklift.app: image-converter
   policyTypes:
   - Ingress
-  - Egress
   ingress:
   # Allow controller communication
   - from:
@@ -265,9 +353,3 @@ spec:
         matchLabels:
           control-plane: controller-manager
     ports: []  # All ports allowed
-  egress:
-  # Image converter works with locally mounted PVCs - no network storage access needed
-  # No external egress required
-
-
-

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-operator.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-operator.yml.j2
@@ -14,20 +14,6 @@ spec:
       app: forklift
   policyTypes:
   - Egress
-{% if not k8s_cluster|bool %}
-  - Ingress
-{% endif %}
-{% if not k8s_cluster|bool %}
-  ingress:
-  # Allow monitoring access
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-monitoring
-    ports:
-    - protocol: TCP
-      port: 2112  # Conversion pod metrics
-{% endif %}
   egress:
   # Allow Kubernetes API access (critical for operator functionality)
   - ports:

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-operator.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-operator.yml.j2
@@ -1,0 +1,48 @@
+# Network policy for Forklift Operator
+# Allows operator to manage cluster resources and NetworkPolicies
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-operator-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app: forklift
+  policyTypes:
+  - Egress
+{% if not k8s_cluster|bool %}
+  - Ingress
+{% endif %}
+{% if not k8s_cluster|bool %}
+  ingress:
+  # Allow monitoring access
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 2112  # Conversion pod metrics
+{% endif %}
+  egress:
+  # Allow Kubernetes API access (critical for operator functionality)
+  - ports:
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 443
+  # Allow DNS resolution (both OpenShift and Kubernetes)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow communication with Forklift components for management
+  - to:
+    - podSelector:
+        matchLabels:
+          app: {{ app_name }}

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-ui-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-ui-plugin.yml.j2
@@ -1,0 +1,36 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-ui-plugin-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      service: {{ ui_plugin_service_name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+  # Allow OpenShift Console to access UI plugin
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-console
+    ports:
+    - protocol: TCP
+      port: 9443
+  # Allow monitoring access
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 9443
+  egress:
+  # Allow all egress for UI plugin functionality
+  # The UI plugin needs to access various internal services dynamically
+  - {}

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-validation.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-validation.yml.j2
@@ -1,0 +1,67 @@
+# Network policies for validation pods
+# Includes VDDK validation jobs and validation service
+#
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-vddk-validation-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      forklift.app: vddk-validation
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow controller communication
+  - from:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  egress:
+  # Allow communication with controller
+  - to:
+    - podSelector:
+        matchLabels:
+          control-plane: controller-manager
+    # All ports allowed (ports omitted)
+  # VDDK validation only checks local files - no external access needed
+  # No additional egress rules required
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forklift-validation-service-policy
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+spec:
+  podSelector:
+    matchLabels:
+      service: {{ validation_service_name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow controller-manager to communicate with validation service
+    - from:
+        - podSelector:
+            matchLabels:
+              control-plane: controller-manager
+      ports:
+        - protocol: TCP
+          port: 8181
+    # Allow forklift-api service to communicate with validation service
+    - from:
+        - podSelector:
+            matchLabels:
+              service: {{ api_service_name }}
+      ports:
+        - protocol: TCP
+          port: 8181
+  # No egress restrictions - validation service doesn't need outbound connections
+

--- a/operator/roles/forkliftcontroller/templates/security/networkpolicy-validation.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/security/networkpolicy-validation.yml.j2
@@ -1,37 +1,7 @@
-# Network policies for validation pods
-# Includes VDDK validation jobs and validation service
+# Network policies for validation service
+# Note: VDDK validation pods don't need a network policy - they only check file existence
+# and have no network communication requirements
 #
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: forklift-vddk-validation-policy
-  namespace: {{ app_namespace }}
-  labels:
-    app: {{ app_name }}
-spec:
-  podSelector:
-    matchLabels:
-      forklift.app: vddk-validation
-  policyTypes:
-  - Ingress
-  - Egress
-  ingress:
-  # Allow controller communication
-  - from:
-    - podSelector:
-        matchLabels:
-          control-plane: controller-manager
-    # All ports allowed (ports omitted)
-  egress:
-  # Allow communication with controller
-  - to:
-    - podSelector:
-        matchLabels:
-          control-plane: controller-manager
-    # All ports allowed (ports omitted)
-  # VDDK validation only checks local files - no external access needed
-  # No additional egress rules required
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -52,14 +22,6 @@ spec:
         - podSelector:
             matchLabels:
               control-plane: controller-manager
-      ports:
-        - protocol: TCP
-          port: 8181
-    # Allow forklift-api service to communicate with validation service
-    - from:
-        - podSelector:
-            matchLabels:
-              service: {{ api_service_name }}
       ports:
         - protocol: TCP
           port: 8181

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -37,7 +37,8 @@ metadata:
         "spec": {
           "feature_ui_plugin": "true",
           "feature_validation": "true",
-          "feature_volume_populator": "true"
+          "feature_volume_populator": "true",
+          "feature_network_policies": "false"
         }
       }
 spec:

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -37,7 +37,8 @@ metadata:
         "spec": {
           "feature_ui_plugin": "true",
           "feature_validation": "true",
-          "feature_volume_populator": "true"
+          "feature_volume_populator": "true",
+          "feature_network_policies": "false"
         }
       }
 spec:


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-2678
 Signed-off-by: Elad Hazan <ehazan@redhat.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds a configurable NetworkPolicies feature (off by default) to manage ingress/egress for operator, controller, API, migration workloads, and validation components.
  - Provides templated NetworkPolicy manifests for operator, controller, API, migration workloads, and validation components.
  - Adds optional NFSv3 port support behind a toggle and automatic cleanup of NetworkPolicy resources when the feature is disabled.

- **Chores**
  - Grants RBAC permissions to manage networking.k8s.io/networkpolicies.
  - Surfaces the feature flag across sample and installation manifests (including CSVs) for easier configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->