### PR TITLE
ECOPROJECT-3192 | feat: Add host memory size collection from vSphere MOB

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -86,6 +86,7 @@ const (
 	fInMaintMode    = "summary.runtime.inMaintenanceMode"
 	fCpuSockets     = "summary.hardware.numCpuPkgs"
 	fCpuCores       = "summary.hardware.numCpuCores"
+	fHostMemorySize = "summary.hardware.memorySize"
 	fThumbprint     = "summary.config.sslThumbprint"
 	fMgtServerIp    = "summary.managementServerIp"
 	fScsiLun        = "config.storageDevice.scsiLun"
@@ -738,6 +739,7 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 				fInMaintMode,
 				fCpuSockets,
 				fCpuCores,
+				fHostMemorySize,
 				fDatastore,
 				fNetwork,
 				fVSwitch,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -278,6 +278,10 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 				if b, cast := p.Val.(int16); cast {
 					v.model.CpuCores = b
 				}
+			case fHostMemorySize:
+				if n, cast := p.Val.(int64); cast {
+					v.model.MemoryBytes = n
+				}
 			case fProductName:
 				if s, cast := p.Val.(string); cast {
 					v.model.ProductName = s

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -146,6 +146,7 @@ type Host struct {
 	Timezone           string             `sql:""`
 	CpuSockets         int16              `sql:""`
 	CpuCores           int16              `sql:""`
+	MemoryBytes        int64              `sql:""`
 	ProductName        string             `sql:""`
 	ProductVersion     string             `sql:""`
 	Model              string             `sql:""`

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -242,6 +242,7 @@ type Host struct {
 	Timezone           string               `json:"timezone"`
 	CpuSockets         int16                `json:"cpuSockets"`
 	CpuCores           int16                `json:"cpuCores"`
+	MemoryBytes        int64                `json:"memoryBytes"`
 	ProductName        string               `json:"productName"`
 	ProductVersion     string               `json:"productVersion"`
 	Network            model.HostNetwork    `json:"networking"`
@@ -269,6 +270,7 @@ func (r *Host) With(m *model.Host) {
 	r.Timezone = m.Timezone
 	r.CpuSockets = m.CpuSockets
 	r.CpuCores = m.CpuCores
+	r.MemoryBytes = m.MemoryBytes
 	r.ProductVersion = m.ProductVersion
 	r.ProductName = m.ProductName
 	r.Network = m.Network


### PR DESCRIPTION
Add MemoryBytes field to Host model to collect host memory size from vSphere MOB path: summary.hardware.memorySize. 
This enables Assisted Installer to provide accurate memory information to the ODF sizing  tool for proper storage planning. Value stored in bytes as returned by the vSphere API.

Technical note for reviewers: The field constant is named fHostMemorySize 
instead of fMemorySize because fMemorySize is already taken for VM 
memory collection (config.hardware.memoryMB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Hosts now report total memory capacity, enabling visibility of memory size alongside existing host details.
  - The Host API adds a memoryBytes field, allowing clients to retrieve host memory in bytes.
  - Data collection and mapping have been extended to include host memory, ensuring the value is consistently exposed across the platform.
  - Backward compatible: no breaking changes to existing endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->