### PR TITLE
MTV-3112 | Add NADs from default namespace in restricted namespaces

### DIFF
--- a/pkg/controller/provider/web/ocp/base.go
+++ b/pkg/controller/provider/web/ocp/base.go
@@ -275,6 +275,7 @@ func (h Handler) NetworkAttachmentDefinitions(ctx *gin.Context, provider *api.Pr
 	options := h.ListOptions(ctx)
 	if provider != nil && provider.IsRestrictedHost() {
 		options = append(options, ocpclient.InNamespace(provider.GetNamespace()))
+		options = append(options, ocpclient.InNamespace(core.NamespaceDefault))
 	}
 	err = client.List(context.TODO(), &list, options...)
 	if err != nil {


### PR DESCRIPTION
Issue:
The `host` provider in different than default namespace filters all NADs and keeps only the one in the provider namespace. But the NADs in `default` namespaces are cluster wide, this is only specific to NADs.

Fix:
Add `default` namespace filter when getting the NADs.

Ref: https://issues.redhat.com/browse/MTV-3112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery of NetworkAttachmentDefinitions on restricted hosts by also scanning the default namespace in addition to the provider’s namespace.
  * Ensures network attachments defined in the default project are recognized and applied, reducing missing configuration issues.
  * Users should see more consistent networking behavior and fewer errors when deploying workloads relying on default-namespace network attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->