### PR TITLE
MTV-2775 | Allow multiple concurrent reconciles

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -47,6 +47,7 @@ controller_filesystem_overhead: 10
 controller_block_overhead: 0
 controller_vddk_job_active_deadline_sec: 300
 controller_tls_connection_timeout_sec: 5
+controller_max_concurrent_reconciles: 10
 profiler_volume_path: "/var/cache/profiler"
 
 inventory_volume_path: "/var/cache/inventory"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -101,6 +101,10 @@ spec:
         - name: TLS_CONNECTION_TIMEOUT
           value: "{{ controller_tls_connection_timeout_sec }}"
 {% endif %}
+{% if controller_max_concurrent_reconciles is number %}
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "{{ controller_max_concurrent_reconciles }}"
+{% endif %}
 {% if controller_cdi_export_token_ttl is number %}
         - name: CDI_EXPORT_TOKEN_TTL
           value: "{{ controller_cdi_export_token_ttl }}"

--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -61,7 +61,8 @@ func Add(mgr manager.Manager) error {
 		Name,
 		mgr,
 		controller.Options{
-			Reconciler: reconciler,
+			Reconciler:              reconciler,
+			MaxConcurrentReconciles: Settings.MaxConcurrentReconciles,
 		})
 	if err != nil {
 		log.Trace(err)

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -69,7 +69,8 @@ func Add(mgr manager.Manager) error {
 		Name,
 		mgr,
 		controller.Options{
-			Reconciler: reconciler,
+			Reconciler:              reconciler,
+			MaxConcurrentReconciles: Settings.MaxConcurrentReconciles,
 		})
 	if err != nil {
 		log.Trace(err)

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -97,7 +97,7 @@ func Add(mgr manager.Manager) error {
 		Name,
 		mgr,
 		controller.Options{
-			MaxConcurrentReconciles: 10,
+			MaxConcurrentReconciles: Settings.MaxConcurrentReconciles,
 			Reconciler:              reconciler,
 		})
 	if err != nil {

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -46,6 +46,7 @@ const (
 	OvaContainerRequestsCpu        = "OVA_CONTAINER_REQUESTS_CPU"
 	OvaContainerRequestsMemory     = "OVA_CONTAINER_REQUESTS_MEMORY"
 	TlsConnectionTimeout           = "TLS_CONNECTION_TIMEOUT"
+	MaxConcurrentReconciles        = "MAX_CONCURRENT_RECONCILES"
 )
 
 // Migration settings
@@ -106,6 +107,8 @@ type Migration struct {
 	VddkImage string
 	// TlsConnectionTimeout is the timeout for TLS connections in seconds
 	TlsConnectionTimeout int
+	// MaxConcurrentReconciles is the limit of how many reconciles can run at once
+	MaxConcurrentReconciles int
 }
 
 // Load settings.
@@ -255,6 +258,10 @@ func (r *Migration) Load() (err error) {
 		r.OvaContainerRequestsMemory = val
 	} else {
 		r.OvaContainerRequestsMemory = "150Mi"
+	}
+	r.MaxConcurrentReconciles, err = getPositiveEnvLimit(MaxConcurrentReconciles, 10)
+	if err != nil {
+		return liberr.Wrap(err)
 	}
 	return
 }


### PR DESCRIPTION
Issue:
When running multiple plans at once the reconcile loop can get halted and it takes 3 seconds before another plan gets reconciled. We should allow to have concurrent reconciles, the default is 1.

Fix:
Add `controller_max_concurrent_reconciles` which defaults to 10. This is propagated to the forklift controller and set on the reconcilers. This way we can manipulate at multiple plans at once.

Ref: https://issues.redhat.com/browse/MTV-2775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting and environment variable to control the maximum number of concurrent reconciles (default: 10), with controllers honoring this setting for consistent, tunable concurrency.

* **Chores**
  * Updated default configuration to include the new concurrency limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->