### PR TITLE
chore | Add a dev env var INVENTORY_SERVICE_SCHEME to allow dev env without tls

### DIFF
--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -340,7 +340,7 @@ func (c *RestClient) url(path string) string {
 	path = (&Handler{}).Link(path, c.Params)
 	url, _ := liburl.Parse(path)
 	if url.Host == "" {
-		url.Scheme = "https"
+		url.Scheme = Settings.Inventory.Scheme
 		url.Host = c.Host
 	}
 

--- a/pkg/controller/provider/web/base/client_test.go
+++ b/pkg/controller/provider/web/base/client_test.go
@@ -1,0 +1,57 @@
+package base
+
+import (
+	"testing"
+)
+
+func TestRestClientURL_UsesConfiguredScheme(t *testing.T) {
+	tests := []struct {
+		name   string
+		scheme string
+		host   string
+		port   int
+		path   string
+		want   string
+	}{
+		{
+			name:   "http scheme",
+			scheme: "http",
+			host:   "api.example.com",
+			port:   8080,
+			path:   "/api/v1/vms",
+			want:   "http://api.example.com:8080/api/v1/vms",
+		},
+		{
+			name:   "https scheme",
+			scheme: "https",
+			host:   "api.example.com",
+			port:   8443,
+			path:   "/api/v1/providers",
+			want:   "https://api.example.com:8443/api/v1/providers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore globals to avoid cross-test interference.
+			origHost, origPort, origScheme := Settings.Inventory.Host, Settings.Inventory.Port, Settings.Inventory.Scheme
+			t.Cleanup(func() {
+				Settings.Inventory.Host = origHost
+				Settings.Inventory.Port = origPort
+				Settings.Inventory.Scheme = origScheme
+			})
+
+			// Set up inventory settings
+			Settings.Inventory.Host = tt.host
+			Settings.Inventory.Port = tt.port
+			Settings.Inventory.Scheme = tt.scheme
+
+			c := &RestClient{Host: ""} // Empty Host forces use of Settings
+			got := c.url(tt.path)
+
+			if got != tt.want {
+				t.Fatalf("expected URL %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/settings/inventory.go
+++ b/pkg/settings/inventory.go
@@ -12,6 +12,11 @@ const (
 	ServiceCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 )
 
+// DefaultScheme is the default scheme for the inventory service.
+const (
+	DefaultScheme = "https"
+)
+
 // Environment variables.
 const (
 	AllowedOrigins = "CORS_ALLOWED_ORIGINS"
@@ -20,6 +25,7 @@ const (
 	Host           = "API_HOST"
 	Namespace      = "POD_NAMESPACE"
 	Port           = "API_PORT"
+	Scheme         = "INVENTORY_SERVICE_SCHEME"
 	TLSCertificate = "API_TLS_CERTIFICATE"
 	TLSKey         = "API_TLS_KEY"
 	TLSCa          = "API_TLS_CA"
@@ -45,6 +51,8 @@ type Inventory struct {
 	Namespace string
 	// Port
 	Port int
+	// URL Scheme (http or https)
+	Scheme string
 	// TLS
 	TLS struct {
 		// Certificate path
@@ -93,6 +101,18 @@ func (r *Inventory) Load() error {
 		r.Port, _ = strconv.Atoi(s)
 	} else {
 		r.Port = 8080
+	}
+	// Scheme
+	if s, found := os.LookupEnv(Scheme); found {
+		s = strings.ToLower(strings.TrimSpace(s))
+		switch s {
+		case "http", "https":
+			r.Scheme = s
+		default:
+			r.Scheme = DefaultScheme
+		}
+	} else {
+		r.Scheme = DefaultScheme
 	}
 	// TLS
 	if s, found := os.LookupEnv(TLSCertificate); found {

--- a/pkg/settings/inventory_test.go
+++ b/pkg/settings/inventory_test.go
@@ -1,0 +1,39 @@
+package settings
+
+import (
+	"os"
+	"testing"
+)
+
+func TestInventoryLoad_SchemeNormalization(t *testing.T) {
+	tests := []struct {
+		name  string
+		env   string
+		unset bool
+		want  string
+	}{
+		{"unset => https", "", true, "https"},
+		{"http", "http", false, "http"},
+		{"HTTPS upper", "HTTPS", false, "https"},
+		{"trimmed http", "  http  ", false, "http"},
+		{"invalid => https", "ftp", false, "https"},
+		{"empty string => https", "   ", false, "https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unset {
+				_ = os.Unsetenv(Scheme)
+			} else {
+				t.Setenv(Scheme, tt.env)
+			}
+			var inv Inventory
+			if err := inv.Load(); err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if inv.Scheme != tt.want {
+				t.Fatalf("Scheme = %q, want %q", inv.Scheme, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue:
When running local development we may want to run the inventory without tls, but we don't have a way to indicate to the controller that we have a local inventory running on http instead of https.

Fix:
  - Add a new env var INVENTORY_SERVICE_SCHEME to be used on dev environment that can control the inventory schema.
  - In the makefile, also add a different WORKING_DIR for the controller and inventory endpoint to avoid them trying to use the same data dir.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Inventory service URL scheme is configurable via an environment variable (accepts http/https, normalized; defaults to HTTPS); client requests honor the configured scheme.

- **Chores**
  - Ensures secure temporary directories for local runs; run and run-inventory now create/use per-component working dirs and propagate the inventory scheme when launching services.

- **Tests**
  - Added tests validating scheme normalization and that the client uses the configured scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->