### PR TITLE
MTV-3146 | Use Powerflex's systemId in the populator

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/README.md
+++ b/cmd/vsphere-xcopy-volume-populator/README.md
@@ -175,6 +175,10 @@ Add these keys to the secret mentioned in the storage map:
 `POWERMAX_SYMMETRIX_ID` - the symmetrix id of the storage array. Can be taken
 from the ConfigMap under the 'powermax' namespace, which the CSI driver uses.
 
+## Dell PowerFlex
+
+`POWERFLEX_SYSTEM_ID` - the system id of the storage array. Can be taken from `vxflexos-config` from the `vxflexos` namespace
+or the openshift-operators namespace.
 
 # Setup copy offload
 - Set the feature flag

--- a/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator.go
+++ b/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator.go
@@ -97,8 +97,9 @@ func main() {
 		}
 		storageApi = &sm
 	case forklift.StorageVendorProductPowerFlex:
+		systemId := os.Getenv(powerflex.SYSTEM_ID_ENV_KEY)
 		sm, err := powerflex.NewPowerflexClonner(
-			storageHostname, storageUsername, storagePassword, storageSkipSSLVerification == "true")
+			storageHostname, storageUsername, storagePassword, storageSkipSSLVerification == "true", systemId)
 		if err != nil {
 			klog.Fatalf("failed to initialize PowerFlex clonner with %s", err)
 		}


### PR DESCRIPTION
https://issues.redhat.com/browse/MTV-3146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for targeting a specific PowerFlex system by System ID, enabling operation in multi-system environments.
  * Added a required environment variable POWERFLEX_SYSTEM_ID to select the target system; clear error messaging guides configuration when it's missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->