### PR TITLE
[MTV-3131] Fix default return from VMMigrationType validation

### DIFF
--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -80,9 +80,8 @@ func (r *Validator) VMMigrationType(vmRef ref.Ref) (ok bool, err error) {
 				}
 			}
 		}
-	default:
-		ok = true
 	}
+	ok = true
 	return
 }
 


### PR DESCRIPTION
A logic bug resulted in the value from the OCP validator's VMMigrationType always being false for Live migration, which has been preventing migration with the latest build. This corrects the logic bug.

(the defensive `ok = false` in the switch body is redundant but left for clarity and future proofing against changes)

Fixes https://issues.redhat.com/browse/MTV-3131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified migration validation control flow to reduce branching and clarify logic.
  - Internal adjustment to how validation success is determined across live and non-live migrations.
  - No changes to public APIs or configuration; user-visible behavior and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->