### PR TITLE
MTV-3165 | Add  deleteVmOnFailMigration field to plan

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -623,6 +623,16 @@ spec:
                         - type
                         type: object
                       type: array
+                    deleteVmOnFailMigration:
+                      description: |-
+                        DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                        When true and the migration fails after the target VM has been created, the controller
+                        will delete the target VM (and related target-side resources) during failed-migration cleanup
+                        and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                        troubleshooting. The source VM is never modified.
+
+                        Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                      type: boolean
                     error:
                       description: Errors
                       properties:
@@ -1589,6 +1599,16 @@ spec:
                   Note:
                     - If this option is enabled and migration succeeds then the pod will get deleted. However the VM could still not boot and the virt-v2v logs, with additional information, will be deleted alongside guest conversion pod.
                     - If migration fails the conversion pod will remain present even if this option is enabled.
+                type: boolean
+              deleteVmOnFailMigration:
+                description: |-
+                  DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                  When true and the migration fails after the target VM has been created, the controller
+                  will delete the target VM (and related target-side resources) during failed-migration cleanup
+                  and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                  troubleshooting. The source VM is never modified.
+
+                  Note: If the Plan-level option is set to true, the VM-level option will be ignored.
                 type: boolean
               description:
                 description: Description
@@ -2883,6 +2903,16 @@ spec:
                 items:
                   description: A VM listed on the plan.
                   properties:
+                    deleteVmOnFailMigration:
+                      description: |-
+                        DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                        When true and the migration fails after the target VM has been created, the controller
+                        will delete the target VM (and related target-side resources) during failed-migration cleanup
+                        and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                        troubleshooting. The source VM is never modified.
+
+                        Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                      type: boolean
                     hooks:
                       description: Enable hooks.
                       items:
@@ -3397,6 +3427,16 @@ spec:
                             - type
                             type: object
                           type: array
+                        deleteVmOnFailMigration:
+                          description: |-
+                            DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                            When true and the migration fails after the target VM has been created, the controller
+                            will delete the target VM (and related target-side resources) during failed-migration cleanup
+                            and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                            troubleshooting. The source VM is never modified.
+
+                            Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                          type: boolean
                         error:
                           description: Errors
                           properties:

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -623,6 +623,16 @@ spec:
                         - type
                         type: object
                       type: array
+                    deleteVmOnFailMigration:
+                      description: |-
+                        DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                        When true and the migration fails after the target VM has been created, the controller
+                        will delete the target VM (and related target-side resources) during failed-migration cleanup
+                        and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                        troubleshooting. The source VM is never modified.
+
+                        Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                      type: boolean
                     error:
                       description: Errors
                       properties:
@@ -1589,6 +1599,16 @@ spec:
                   Note:
                     - If this option is enabled and migration succeeds then the pod will get deleted. However the VM could still not boot and the virt-v2v logs, with additional information, will be deleted alongside guest conversion pod.
                     - If migration fails the conversion pod will remain present even if this option is enabled.
+                type: boolean
+              deleteVmOnFailMigration:
+                description: |-
+                  DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                  When true and the migration fails after the target VM has been created, the controller
+                  will delete the target VM (and related target-side resources) during failed-migration cleanup
+                  and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                  troubleshooting. The source VM is never modified.
+
+                  Note: If the Plan-level option is set to true, the VM-level option will be ignored.
                 type: boolean
               description:
                 description: Description
@@ -2883,6 +2903,16 @@ spec:
                 items:
                   description: A VM listed on the plan.
                   properties:
+                    deleteVmOnFailMigration:
+                      description: |-
+                        DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                        When true and the migration fails after the target VM has been created, the controller
+                        will delete the target VM (and related target-side resources) during failed-migration cleanup
+                        and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                        troubleshooting. The source VM is never modified.
+
+                        Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                      type: boolean
                     hooks:
                       description: Enable hooks.
                       items:
@@ -3397,6 +3427,16 @@ spec:
                             - type
                             type: object
                           type: array
+                        deleteVmOnFailMigration:
+                          description: |-
+                            DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                            When true and the migration fails after the target VM has been created, the controller
+                            will delete the target VM (and related target-side resources) during failed-migration cleanup
+                            and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                            troubleshooting. The source VM is never modified.
+
+                            Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                          type: boolean
                         error:
                           description: Errors
                           properties:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -623,6 +623,16 @@ spec:
                         - type
                         type: object
                       type: array
+                    deleteVmOnFailMigration:
+                      description: |-
+                        DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                        When true and the migration fails after the target VM has been created, the controller
+                        will delete the target VM (and related target-side resources) during failed-migration cleanup
+                        and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                        troubleshooting. The source VM is never modified.
+
+                        Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                      type: boolean
                     error:
                       description: Errors
                       properties:
@@ -1589,6 +1599,16 @@ spec:
                   Note:
                     - If this option is enabled and migration succeeds then the pod will get deleted. However the VM could still not boot and the virt-v2v logs, with additional information, will be deleted alongside guest conversion pod.
                     - If migration fails the conversion pod will remain present even if this option is enabled.
+                type: boolean
+              deleteVmOnFailMigration:
+                description: |-
+                  DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                  When true and the migration fails after the target VM has been created, the controller
+                  will delete the target VM (and related target-side resources) during failed-migration cleanup
+                  and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                  troubleshooting. The source VM is never modified.
+
+                  Note: If the Plan-level option is set to true, the VM-level option will be ignored.
                 type: boolean
               description:
                 description: Description
@@ -2883,6 +2903,16 @@ spec:
                 items:
                   description: A VM listed on the plan.
                   properties:
+                    deleteVmOnFailMigration:
+                      description: |-
+                        DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                        When true and the migration fails after the target VM has been created, the controller
+                        will delete the target VM (and related target-side resources) during failed-migration cleanup
+                        and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                        troubleshooting. The source VM is never modified.
+
+                        Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                      type: boolean
                     hooks:
                       description: Enable hooks.
                       items:
@@ -3397,6 +3427,16 @@ spec:
                             - type
                             type: object
                           type: array
+                        deleteVmOnFailMigration:
+                          description: |-
+                            DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                            When true and the migration fails after the target VM has been created, the controller
+                            will delete the target VM (and related target-side resources) during failed-migration cleanup
+                            and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                            troubleshooting. The source VM is never modified.
+
+                            Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                          type: boolean
                         error:
                           description: Errors
                           properties:

--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -237,6 +237,16 @@ spec:
                         - type
                         type: object
                       type: array
+                    deleteVmOnFailMigration:
+                      description: |-
+                        DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                        When true and the migration fails after the target VM has been created, the controller
+                        will delete the target VM (and related target-side resources) during failed-migration cleanup
+                        and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                        troubleshooting. The source VM is never modified.
+
+                        Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                      type: boolean
                     error:
                       description: Errors
                       properties:

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -64,6 +64,16 @@ spec:
                     - If this option is enabled and migration succeeds then the pod will get deleted. However the VM could still not boot and the virt-v2v logs, with additional information, will be deleted alongside guest conversion pod.
                     - If migration fails the conversion pod will remain present even if this option is enabled.
                 type: boolean
+              deleteVmOnFailMigration:
+                description: |-
+                  DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                  When true and the migration fails after the target VM has been created, the controller
+                  will delete the target VM (and related target-side resources) during failed-migration cleanup
+                  and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                  troubleshooting. The source VM is never modified.
+
+                  Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                type: boolean
               description:
                 description: Description
                 type: string
@@ -1357,6 +1367,16 @@ spec:
                 items:
                   description: A VM listed on the plan.
                   properties:
+                    deleteVmOnFailMigration:
+                      description: |-
+                        DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                        When true and the migration fails after the target VM has been created, the controller
+                        will delete the target VM (and related target-side resources) during failed-migration cleanup
+                        and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                        troubleshooting. The source VM is never modified.
+
+                        Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                      type: boolean
                     hooks:
                       description: Enable hooks.
                       items:
@@ -1871,6 +1891,16 @@ spec:
                             - type
                             type: object
                           type: array
+                        deleteVmOnFailMigration:
+                          description: |-
+                            DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+                            When true and the migration fails after the target VM has been created, the controller
+                            will delete the target VM (and related target-side resources) during failed-migration cleanup
+                            and when the Plan is deleted. When false (default), the target VM is preserved to aid
+                            troubleshooting. The source VM is never modified.
+
+                            Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+                          type: boolean
                         error:
                           description: Errors
                           properties:

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -141,6 +141,16 @@ type PlanSpec struct {
 	//   - If migration fails the conversion pod will remain present even if this option is enabled.
 	// +optional
 	DeleteGuestConversionPod bool `json:"deleteGuestConversionPod,omitempty"`
+	// DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+	// When true and the migration fails after the target VM has been created, the controller
+	// will delete the target VM (and related target-side resources) during failed-migration cleanup
+	// and when the Plan is deleted. When false (default), the target VM is preserved to aid
+	// troubleshooting. The source VM is never modified.
+	//
+	// Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+	//
+	// +optional
+	DeleteVmOnFailMigration bool `json:"deleteVmOnFailMigration,omitempty"`
 	// InstallLegacyDrivers determines whether to install legacy windows drivers in the VM.
 	//The following Vm's are lack of SHA-2 support and need legacy drivers:
 	// Windows XP (all)

--- a/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -103,6 +103,16 @@ type VM struct {
 	// +optional
 	// +kubebuilder:validation:Enum=on;off;auto
 	TargetPowerState TargetPowerState `json:"targetPowerState,omitempty"`
+	// DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+	// When true and the migration fails after the target VM has been created, the controller
+	// will delete the target VM (and related target-side resources) during failed-migration cleanup
+	// and when the Plan is deleted. When false (default), the target VM is preserved to aid
+	// troubleshooting. The source VM is never modified.
+	//
+	// Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+	//
+	// +optional
+	DeleteVmOnFailMigration bool `json:"deleteVmOnFailMigration,omitempty"`
 }
 
 // Find a Hook for the specified step.

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -385,7 +385,9 @@ func (r *Migration) deletePopulatorPVCs(vm *plan.VMStatus) (err error) {
 
 // Delete left over migration resources associated with a VM.
 func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool) error {
-	if !vm.HasCondition(api.ConditionSucceeded) {
+	// If the migration fails and the DeleteVmOnFailMigration is enabled, clean up the VM.
+	// When DeleteVmOnFailMigration is disabled, VM resources are preserved on failure.
+	if !vm.HasCondition(api.ConditionSucceeded) && (r.Plan.Spec.DeleteVmOnFailMigration || vm.DeleteVmOnFailMigration) {
 		if err := r.kubevirt.DeleteVM(vm); failOnErr(err) {
 			return err
 		}
@@ -396,6 +398,7 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool) error
 			return err
 		}
 	}
+
 	if err := r.deleteImporterPods(vm); failOnErr(err) {
 		return err
 	}


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-3165

**Issue:**
VMs the were migrated, and the migration plan failed after the VM was created, are getting cleaned up by default.

**Fix:**
Add a field  `deleteVmOnFailMigration`, default to false, if set to true, the VMs will get deleted, o/w vms that were created will not get deleted even if the plan failed and was deleted.

**Example:**

**A. create a failing hook:**

``` bash
kubectl-mtv create hook failing-post-hook -n demo \
    --image quay.io/kubev2v/hook-runner \
    --playbook "---\n- name: Failing post migration hook\n      hosts: localhost\n  tasks:\n    - name: Task that will fail\n      fail:\n        msg: \"This hook is designed to fail for testing purposes\""
```

**B. create a plan:**

```bash
kubectl-mtv create plan mnecas-migration-failing -n demo \
   --source chho2 --target host --vms mnecas-rhel9 \
   --post-hook failing-post-hook \
   --description "Migration plan for mnecas machine with failing post hook and virtualization storage" \
   --default-target-storage-class ocs-storagecluster-ceph-rbd-virtualization
```

**C. run the plan, ane wait for it to fail:**

```bash
oc mtv start plan mnecas-migration-failing
```

**D. delete the plan:**

```bash
oc mtv delete plan mnecas-migration-failing
```

**Expected result:**
VM is not deleted, although the plan filed.

**Note:**
adding `deleteVmOnFailMigration: true` to the plan spec before deleting, will result in the VM getting deleted with the plan.
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan-level option to control deletion of destination VMs when a migration fails after the target VM is created (default: disabled).
  * Per-VM override to control deletion behavior for individual VMs; global setting overrides VM-level choices.
  * Migration status now reflects the configured per-VM deletion policy.

* **Tests**
  * Comprehensive test suite validating conditional VM deletion, cleanup sequencing, provider interactions, and error-handling paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->