### PR TITLE
storage-offload: revert a change to the vib upload path

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	vibName     = "vmkfstools-wrapper"
-	vibLocation = "/tmp/vmkfstools-wrapper.vib"
+	vibLocation = "/bin/vmkfstools-wrapper.vib"
 )
 
 // VibVersion is set by ldflags


### PR DESCRIPTION
Signed-off-by: Roy Golan <rgolan@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved VIB installation failures caused by an incorrect package location, improving reliability during volume population on vSphere.
  - Ensures consistent behavior across environments by using a stable, built-in location for the required component.
  - Reduces transient install errors and improves clarity in deployment logs.
  - No changes to user workflow or configuration are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->