### PR TITLE
MTV-21669 | Fix vib tmp 2.9

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	vibName     = "vmkfstools-wrapper"
-	vibLocation = "/tmp/vmkfstools-wrapper.vib"
+	vibLocation = "/bin/vmkfstools-wrapper.vib"
 )
 
 // VibVersion is set by ldflags


### PR DESCRIPTION
Reverting a path change in the vib installation.

https://issues.redhat.com/browse/MTV-3181