### PR TITLE
MTV-3183 | Fix Pure FlashArray naa handling

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray.go
@@ -124,6 +124,6 @@ func (f *FlashArrayClonner) ResolvePVToLUN(pv populator.PersistentVolume) (popul
 		return populator.LUN{}, err
 	}
 	klog.Infof("volume %+v\n", v)
-	l := populator.LUN{Name: v.Name, SerialNumber: v.Serial, NAA: FlashProviderID + strings.ToLower(v.Serial)}
+	l := populator.LUN{Name: v.Name, SerialNumber: v.Serial, NAA: fmt.Sprintf("naa.%s%s", FlashProviderID, strings.ToLower(v.Serial))}
 	return l, nil
 }


### PR DESCRIPTION
Add missing 'naa.' prefix for Pure FlashArray.

After adding powerflex provider that handling became a part of the
ResolvePVToLun method where each providers add its own prefix (usually 'naa')
to the NAA id to represent how the device will show up when attaching it.

Signed-off-by: Roy Golan <rgolan@redhat.com>
