### PR TITLE
Fix for Vsphere to work with powerflex

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/storage.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/storage.go
@@ -22,3 +22,7 @@ type StorageMapper interface {
 type StorageResolver interface {
 	ResolvePVToLUN(persistentVolume PersistentVolume) (LUN, error)
 }
+
+type SciniAware interface {
+	SciniRequired() bool
+}


### PR DESCRIPTION
1. For VsphereXcopyPopulator we should not restart the populator container when it fails, it makes no sense and hides root issues.
2. When a provider requires scinin adapter - we should fail when it is not found on the esxi
3. Fixed unmapping issues
4. Fixed mapping volume to multipel Sdcs (AllowMultiple)

Co-Authored with: Roy Golan <rgolan@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scini-aware HBA discovery for ESXi, with Scini-driven mapping when required.
  * Two-phase cleanup: partial unmap by default and a full unmap-and-remap fallback.
  * Support for mapping to a specific SDC and optional “unmap all” behavior.
  * VSphere populator now emits a dedicated “VSphere xcopy populator failed (no retry)” event.

* **Bug Fixes**
  * Improved HBA UID detection and validation; explicit errors if none found.
  * Stricter handling when no ESXi SDC mappings exist.
  * Short delay added to stabilize CSI mapping timing and reduce transient failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->