### PR TITLE
MTV-3186 [backport] Fix for Vsphere to work with powerflex

### DIFF
--- a/.konflux/validation/go.sum
+++ b/.konflux/validation/go.sum
@@ -321,10 +321,11 @@ google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLY
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
-google.golang.org/protobuf v1.23.6/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.23.6/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=

--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/storage.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/storage.go
@@ -22,3 +22,7 @@ type StorageMapper interface {
 type StorageResolver interface {
 	ResolvePVToLUN(persistentVolume PersistentVolume) (LUN, error)
 }
+
+type SciniAware interface {
+	SciniRequired() bool
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/MTV-3186

1. For VsphereXcopyPopulator we should not restart the populator container when it fails, it makes no sense and hides root issues.
2. When a provider requires scinin adapter - we should fail when it is not found on the esxi
3. Fixed unmapping issues
4. Fixed mapping volume to multipel Sdcs (AllowMultiple)

Co-Authored with: Roy Golan <rgolan@redhat.com>