### PR TITLE
A github workflow to backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,72 @@
+name: Backport
+
+on:
+  workflow_dispatch:
+    inputs:
+      targetBranch:
+        description: 'Target branch'
+        required: true
+        type: string
+      pullRequest:
+        description: 'Pull request'
+        required: true
+        type: string
+      dryRun:
+        description: 'Dry run'
+        required: false
+        default: "true"
+        type: string
+  issue_comment:
+    types:
+      - created
+
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request != '' &&
+      startsWith(github.event.comment.body, '/backport'))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get target branch and PR number
+        id: target_info
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            pr_number="${{ github.event.inputs.pullRequest}}"
+            branch_name="${{ github.event.inputs.targetBranch }}"
+          else
+            pr_number="${{ github.event.issue.number }}"
+            branch_name=$(echo "${{ github.event.comment.body }}" | awk '{print $2}')
+          fi
+          if [[ -z "$branch_name" ]]; then
+            echo "Target branch is not specified"
+            exit 1
+          fi
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+          echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
+
+
+      - name: Backporting
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.target_info.outputs.pr_number }}
+          BRANCH_NAME: ${{ steps.target_info.outputs.branch_name }}
+        uses: kiegroup/git-backporting@main
+        with:
+          target-branch: ${{ steps.target_info.outputs.branch_name }}
+          pull-request: ${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.target_info.outputs.pr_number }}
+          no-squash: true
+          auth: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: ${{ inputs.dryRun }}
+
+


### PR DESCRIPTION
This is a github workflow to backport PRs.

USAGE
1. Leave a comment on a merged PR saying /backport <BRANCH>, for example
   /backport release-2.9
2. Use the github workflow UI to invoke it on demend. Supply the PR
   number and the name of the branch
3. Use `gh` command line tool to execute it
   gh workflow  run .github/workflows/backport.yml -f targetBranch=release-1.0 -f pullRequest=22

Kudos for github.com/kiegroup/git-backporting for the nice action.

Signed-off-by: Roy Golan <rgolan@redhat.com>
