### PR TITLE
Update storage-offload README

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/README.md
+++ b/cmd/vsphere-xcopy-volume-populator/README.md
@@ -138,10 +138,16 @@ spec:
 
 The vSphere user requires a role with the following privileges (a role named `StorageOffloader` is recommended):
 
-* Global -> Settings
-* Host -> Configuration -> Advanced settings
-* Host -> Configuration -> Query patch
-* Host -> Configuration -> Storage partition configuration
+* Global
+  * Settings
+* Datastore
+  * Browse datastore
+  * Low level file operations
+* Host
+   Configuration
+     * Advanced settings
+     * Query patch
+     * Storage partition configuration
 
 # Secret with storage provider credentials
 
@@ -149,12 +155,13 @@ Create a secret where the migration provider is setup, usually openshift-mtv
 and put the credentials of the storage system. All of the provider are required
 to have a secret with those required fields
 
-```
-STORAGE_HOSTNAME
-STORAGE_USERNAME
-STORAGE_PASSWORD
-STORAGE_SKIP_SSL_VERIFICATION
-```
+| Key | Value | Mandatory |
+| --- | --- | --- |
+| STORAGE_HOSTNAME | ip/hostname | y |
+| STORAGE_USERNAME | string | y |
+| STORAGE_PASSWORD | string | y |
+| STORAGE_SKIP_SSL_VERIFICATION | true/false | n |
+
 
 Provider specific entries in the secret shall be documented below:
 
@@ -163,22 +170,31 @@ Provider specific entries in the secret shall be documented below:
 
 ## NetApp ONTAP
 
-Add these keys to the secret mentioned in the storage map:
+| Key | Value | Description |
+| --- | --- | --- |
+| ONTAP_SVM | string | the SVM to use in all the client interactions. Can be taken from trident.netapp.io/v1/TridentBackend.config.ontap_config.svm resource field. |
 
-`ONTAP_SVM` - the SVM to use in all the client interactions. Can be taken from 
-trident.netapp.io/v1/TridentBackend.config.ontap_config.svm resource field.
+
+## Pure FlashArray
+
+| Key | Value | Description |
+| --- | --- | --- |
+| PURE_CLUSTER_PREFIX | string | Cluster prefix is set in the StorageCluster resource. Get it with  `printf "px_%.8s" $(oc get storagecluster -A -o=jsonpath='{.items[?(@.spec.cloudStorage.provider=="pure")].status.clusterUid}')` |
+
 
 ## Dell PowerMax
 
-Add these keys to the secret mentioned in the storage map:
+| Key | Value | Description |
+| --- | --- | --- |
+| POWERMAX_SYMMETRIX_ID | string | the symmetrix id of the storage array. Can be taken from the ConfigMap under the 'powermax' namespace, which the CSI driver uses. |
 
-`POWERMAX_SYMMETRIX_ID` - the symmetrix id of the storage array. Can be taken
-from the ConfigMap under the 'powermax' namespace, which the CSI driver uses.
 
 ## Dell PowerFlex
 
-`POWERFLEX_SYSTEM_ID` - the system id of the storage array. Can be taken from `vxflexos-config` from the `vxflexos` namespace
-or the openshift-operators namespace.
+| Key | Value | Description |
+| --- | --- | --- |
+| POWERFLEX_SYSTEM_ID | string | the system id of the storage array. Can be taken from `vxflexos-config` from the `vxflexos` namespace or the openshift-operators namespace. |
+
 
 # Setup copy offload
 - Set the feature flag

--- a/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray.go
@@ -1,6 +1,7 @@
 package pure
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -18,13 +19,14 @@ type FlashArrayClonner struct {
 }
 
 const ClusterPrefixEnv = "PURE_CLUSTER_PREFIX"
-const helpMessage = `clusterPrefix is missing. Please copy the cluster uuid and pass it in the pure secret under PURE_CLUSTER_PREFIX. use that to help \
-oc get storagecluster -o yaml -A -o=jsonpath='{.items[?(@.spec.cloudStorage.provider=="pure")].status.clusterUid} | head -c 8'
+const helpMessage = `clusterPrefix is missing and PURE_CLUSTER_PREFIX is not set.
+Use this to extract the value:
+printf "px_%.8s" $(oc get storagecluster -A -o=jsonpath='{.items[?(@.spec.cloudStorage.provider=="pure")].status.clusterUid}')
 `
 
 func NewFlashArrayClonner(hostname, username, password string, skipSSLVerification bool, clusterPrefix string) (FlashArrayClonner, error) {
 	if clusterPrefix == "" {
-		return FlashArrayClonner{}, fmt.Errorf(helpMessage)
+		return FlashArrayClonner{}, errors.New(helpMessage)
 	}
 	client, err := flasharray.NewClient(
 		hostname, username, password, "", "", true, false, "", map[string]string{})


### PR DESCRIPTION

- **storage-offload: update README**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Improved the help message shown when the cluster prefix is not configured: it now explicitly names the missing setting, references the expected environment variable, and gives a simple command to derive the prefix (px_ plus the first 8 characters of the cluster UID). Outdated guidance removed. No behavioral or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->