### PR TITLE
OCP Live: migrate AccessCredential secrets

### DIFF
--- a/pkg/controller/plan/ensurer/ensurer.go
+++ b/pkg/controller/plan/ensurer/ensurer.go
@@ -121,6 +121,7 @@ func (r *Ensurer) SharedConfigMaps(vm *planapi.VMStatus, configMaps []core.Confi
 							configMap.Name),
 						"forklift-created", false)
 				}
+				err = nil
 				continue
 			}
 			err = liberr.Wrap(err, "Failed to create ConfigMap.", "configMap",
@@ -162,6 +163,7 @@ func (r *Ensurer) SharedSecrets(vm *planapi.VMStatus, secrets []core.Secret) (er
 							secret.Name),
 						"forklift-created", false)
 				}
+				err = nil
 				continue
 			}
 			err = liberr.Wrap(err, "Failed to create Secret.", "secret",

--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -1507,6 +1507,20 @@ func (r *Builder) Secrets(vm *planapi.VMStatus) (list []core.Secret, err error) 
 		return
 	}
 	sources := []types.NamespacedName{}
+	for _, cred := range virtualMachine.Object.Spec.Template.Spec.AccessCredentials {
+		switch {
+		case cred.SSHPublicKey != nil:
+			if cred.SSHPublicKey.Source.Secret != nil {
+				key := types.NamespacedName{Namespace: virtualMachine.Namespace, Name: cred.SSHPublicKey.Source.Secret.SecretName}
+				sources = append(sources, key)
+			}
+		case cred.UserPassword != nil:
+			if cred.UserPassword.Source.Secret != nil {
+				key := types.NamespacedName{Namespace: virtualMachine.Namespace, Name: cred.UserPassword.Source.Secret.SecretName}
+				sources = append(sources, key)
+			}
+		}
+	}
 	for _, vol := range virtualMachine.Object.Spec.Template.Spec.Volumes {
 		switch {
 		case vol.Secret != nil:


### PR DESCRIPTION
The source VM can have relationships to shared secrets through the accessCredentials field in its spec. These secrets need to be copied into the source namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects and copies secrets referenced by VM access credentials (e.g., SSH keys, user passwords) during migration to prevent missing credentials.
  * Avoids migration failures when credentials are defined outside volumes or cloud-init.

* **Chores**
  * Treats existing shared configmaps/secrets as non-fatal duplicates, allowing processing to continue without error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->