### PR TITLE
Fix hanging provider caused by runtime error check

### DIFF
--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -296,6 +296,9 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		r.Log.Info(
 			"Waiting connection tested or inventory created.")
 		result.RequeueAfter = base.SlowReQ
+	} else {
+		// requeue so that connections are re-tested periodically
+		result.RequeueAfter = base.LongReQ
 	}
 
 	// Done

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -367,24 +367,6 @@ func (r *Reconciler) inventoryCreated(provider *api.Provider) error {
 		return nil
 	}
 	if r, found := r.container.Get(provider); found {
-		// Check for runtime errors from any collector that supports them
-		if errors := r.GetRuntimeErrors(); len(errors) > 0 {
-			// Set inventory error condition for any runtime errors
-			var errorMessages []string
-			for kind, err := range errors {
-				errorMessages = append(errorMessages, fmt.Sprintf("%s: %s", kind, err.Error()))
-			}
-			provider.Status.SetCondition(
-				libcnd.Condition{
-					Type:     InventoryError,
-					Status:   True,
-					Reason:   "RuntimeError",
-					Category: Error,
-					Message:  fmt.Sprintf("Inventory runtime errors: %v", errorMessages),
-				})
-			return nil
-		}
-
 		if r.HasParity() {
 			provider.Status.SetCondition(
 				libcnd.Condition{


### PR DESCRIPTION
This patch resolves two related problems. The first is that a connection failure due to certificate or token expiration can go unnoticed because the connection test is only run when a provider is reconciled. This is resolved by adding a requeue with a 30-second timer to the provider reconcile loop. The second is that accumulated runtime errors can trap the provider is a failed state after the cause of the connection failure is resolved:

PR #2097 introduced a check for inventory runtime errors during the validation step in the Provider controller reconciliation loop. Runtime errors are accumulated when the inventory API endpoints fail, and the intention is to surface those errors in the Provider CR status. Unfortunately, this does not work as intended.

The connection test for OCP providers checks that it is possible to access the resources needed by the inventory API. Because the check for runtime errors occurs after the connection test, only two outcomes are possible:

A) The connection test fails, in which case any accumulated runtime errors will not be exposed because the validation process aborts before that point. In this case the failed connection test condition will report the same sort of errors and no information has been lost.

B) The connection test succeeds, implying that the credentials or other issue has been solved. In this case the validation process will move to the next step and any accumulated runtime errors will now cause validation to fail. However, the successful connection test almost certainly means that any runtime errors that accumulated since the last reconcile are out-of-date and irrelevant. This causes the following error condition for OCP providers:

1. Token expires
2. Runtime errors accumulate as inventory accesses fail
3. Secret is updated with a new token, triggering reconcile
4. Connection test passes, but runtime errors that accumulated previously result in a blocker condition.
5. Blocker condition prevents the inventory collector from being updated.
6. Provider remains trapped in an error state despite the token being valid and controller logs reporting that the connection test is succeeding.

https://issues.redhat.com/browse/MTV-2377
https://issues.redhat.com/browse/MTV-2711
https://issues.redhat.com/browse/MTV-3036