### PR TITLE
MTV-3229 |  Default PVC name handling for cold migration

### DIFF
--- a/build/vsphere-xcopy-volume-populator/Containerfile
+++ b/build/vsphere-xcopy-volume-populator/Containerfile
@@ -3,7 +3,7 @@ USER root
 WORKDIR /usr/src/app
 
 # Make python available in the builder image ( o/w only python3 is available )
-RUN dnf install python -y
+RUN dnf install -y python && dnf clean all && rm -rf /var/cache/dnf
 
 # pre-copy/cache go.mod for pre-downloading dependencies and only redownloading
 # them in subsequent builds if they change
@@ -15,9 +15,6 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/.cache/go-build \
     make build
 
-RUN dnf install -y \
-    # install python for vmkfstools-wrapper tests \
-    python
 RUN make vmkfstools-wrapper
 
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1256,6 +1256,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 					"vmdkKey": fmt.Sprint(disk.Key),
 					"vmID":    vmRef.ID,
 				}
+
 				r.Log.Info("target namespace for migration", "namespace", namespace)
 				pvc := core.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1292,7 +1293,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				pvc.Annotations["copy-offload"] = baseVolume(disk.File, false)
 
 				// Apply PVC template naming if configured, replacing the commonName
-				if err := r.setPVCNameFromTemplate(&pvc.ObjectMeta, vm, diskIndex, disk); err != nil {
+				if err := r.setColdMigrationDefaultPVCName(&pvc.ObjectMeta, vm, diskIndex, disk); err != nil {
 					r.Log.Info("Failed to set PVC name from template for populator volume, using default name", "error", err)
 				}
 
@@ -1506,6 +1507,38 @@ func (r *Builder) setObjectNameFromTemplate(objectMeta *metav1.ObjectMeta, templ
 	}
 
 	return nil
+}
+
+func (r *Builder) setColdMigrationDefaultPVCName(objectMeta *metav1.ObjectMeta, vm *model.VM, diskIndex int, disk vsphere.Disk) error {
+	pvcNameTemplate := r.getPVCNameTemplate(vm)
+	if pvcNameTemplate == "" {
+		pvcNameTemplate = "{{.PlanName}}-{{.VmName}}-disk-{{.DiskIndex}}"
+	}
+
+	planVM := r.getPlanVM(vm)
+	rootDiskIndex := 0
+	if planVM != nil {
+		rootDiskIndex = utils.GetBootDiskNumber(planVM.RootDisk)
+	}
+
+	templateData := api.PVCNameTemplateData{
+		VmName:         r.getPlanVMSafeName(vm),
+		PlanName:       r.Plan.Name,
+		DiskIndex:      diskIndex,
+		RootDiskIndex:  rootDiskIndex,
+		Shared:         disk.Shared,
+		FileName:       extractDiskFileName(baseVolume(disk.File, false)),
+		WinDriveLetter: disk.WinDriveLetter,
+	}
+
+	templateConfig := TemplateConfig{
+		Template:        pvcNameTemplate,
+		UseGenerateName: r.Plan.Spec.PVCNameTemplateUseGenerateName,
+		TemplateType:    "PVC",
+	}
+
+	return r.setObjectNameFromTemplate(objectMeta, templateConfig, &templateData)
+
 }
 
 // setPVCNameFromTemplate sets PVC name/generateName using the PVC template


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-3229

Note: an issue with warm migration found while adding this tests and also fixed in this PR

-------------------

Add test cases to cover
-  vphere's mergeSecret
- PopulatorVolumes default accessMode
- PopulatorVolumes PVC template name


It also changes the way the mockInventory is setup, now that mock is fed
with objects during construction. For example, to create a vsphere
inventory with a vm named "my-server" with 'poweredOn' state do this:

```go
mockInventory{
    vm: model.VM{
        VM1: model.VM1{
            VM0: model.VM0{
                Name: "my-server",
            },
            PowerState: "poweredOn",
        },
        GuestNetworks: []vsphere.GuestNetwork{
            {MAC: "mac1"},
            {MAC: "mac2"},
        },
        NICs: []vsphere.NIC{
            {MAC: "mac1"},
            {MAC: "mac2"},
        },
    },
}

```
Signed-off-by: Roy Golan <rgolan@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cold-migration PVCs now get sensible default names when no template is provided.
  * Block-volume PVCs default to ReadWriteMany access mode and block volume mode.

* **Tests**
  * Added tests covering secret merging, PVC naming, and block-volume behavior.
  * Validator tests now use a richer, stateful mock inventory with realistic VM data to exercise static IPs and PVC name scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->