### PR TITLE
chore | Restricted host fetch NADs from multiple namespaces

### DIFF
--- a/pkg/controller/provider/web/ocp/base.go
+++ b/pkg/controller/provider/web/ocp/base.go
@@ -271,23 +271,40 @@ func (h Handler) NetworkAttachmentDefinitions(ctx *gin.Context, provider *api.Pr
 	if err != nil {
 		return
 	}
-	list := net.NetworkAttachmentDefinitionList{}
-	options := h.ListOptions(ctx)
+
+	// Determine which namespaces to query
+	var namespacesToQuery []string
 	if provider != nil && provider.IsRestrictedHost() {
-		options = append(options, ocpclient.InNamespace(provider.GetNamespace()))
-		options = append(options, ocpclient.InNamespace(core.NamespaceDefault))
+		// For restricted host providers, query specific namespaces
+		namespacesToQuery = []string{provider.GetNamespace(), core.NamespaceDefault}
+	} else {
+		// For non-restricted providers, query all namespaces (empty slice means no namespace restriction)
+		namespacesToQuery = []string{""}
 	}
-	err = client.List(context.TODO(), &list, options...)
-	if err != nil {
-		h.setError(ref.ToKind(&net.NetworkAttachmentDefinition{}), err)
-		return
+
+	// Query each namespace and collect results, empty namespace means all namespaces
+	for _, ns := range namespacesToQuery {
+		list := net.NetworkAttachmentDefinitionList{}
+		options := h.ListOptions(ctx)
+		if ns != "" {
+			options = append(options, ocpclient.InNamespace(ns))
+		}
+
+		err = client.List(context.TODO(), &list, options...)
+		if err != nil {
+			h.setError(ref.ToKind(&net.NetworkAttachmentDefinition{}), err)
+			return
+		}
+
+		// Convert items to model objects and append to results
+		for _, nad := range list.Items {
+			m := model.NetworkAttachmentDefinition{}
+			m.With(&nad)
+			nets = append(nets, m)
+		}
 	}
+
 	h.clearError(ref.ToKind(&net.NetworkAttachmentDefinition{}))
-	for _, nad := range list.Items {
-		m := model.NetworkAttachmentDefinition{}
-		m.With(&nad)
-		nets = append(nets, m)
-	}
 	return
 }
 


### PR DESCRIPTION
Issue:
`client.List` does not support multiple `InNamespace` restrictions, when we look for Network Attachment Definitions (NADs) in a restricted host, we need to fetch NADs from all the namespaces this host has privileges to list.

Fix:
Replace the multiple `InNamespace` calls with a loop, calling `client.List` with single `InNamespace` for each namespace.

Example:
Before:
```bash
# Unrestricted host provider
14:55 $ kubectl-mtv get inventory network host -n openshift-mtv
NAME        NAMESPACE          ID                                    CREATED
test-nad-1  kubectl-mtv-tests  d40484f8-6c09-4de4-868a-d25ff17f54f4  2025-08-24T11:29:01Z
test-nad-2  kubectl-mtv-tests  20fd14b7-9ebf-40e9-9062-cd7f15d9b3b0  2025-08-24T11:29:02Z

# Restricted host provider
14:53 $ kubectl-mtv get inventory network test-openshift-skip-verify -n kubectl-mtv-tests
No networks found for provider test-openshift-skip-verify
```

After:
```bash
# Unrestricted host provider
14:55 $ kubectl-mtv get inventory network host -n openshift-mtv
NAME        NAMESPACE          ID                                    CREATED
test-nad-1  kubectl-mtv-tests  d40484f8-6c09-4de4-868a-d25ff17f54f4  2025-08-24T11:29:01Z
test-nad-2  kubectl-mtv-tests  20fd14b7-9ebf-40e9-9062-cd7f15d9b3b0  2025-08-24T11:29:02Z

# Restricted host provider
14:55 $ kubectl-mtv get inventory network test-openshift-skip-verify -n kubectl-mtv-tests
NAME        NAMESPACE          ID                                    CREATED
test-nad-1  kubectl-mtv-tests  d40484f8-6c09-4de4-868a-d25ff17f54f4  2025-08-24T11:29:01Z
test-nad-2  kubectl-mtv-tests  20fd14b7-9ebf-40e9-9062-cd7f15d9b3b0  2025-08-24T11:29:02Z
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More comprehensive discovery of network attachments across namespaces.
- Bug Fixes
  - Ensures restricted providers include both provider and default namespaces when listing network attachments.
  - Improves reliability by handling errors per-namespace, reducing partial failures.
- Refactor
  - Switched to per-namespace queries for network attachments, consolidating results after all targets are checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->