### PR TITLE
storage-offload: bump goscalio (powerlfex) module to 1.20.0

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/go.mod
+++ b/cmd/vsphere-xcopy-volume-populator/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.4
 
 require (
 	github.com/dell/gopowermax/v2 v2.9.0
-	github.com/dell/goscaleio v1.19.1
+	github.com/dell/goscaleio v1.20.0
 	github.com/devans10/pugo/flasharray v0.0.0-20241116160615-6bb8c469c9a0
 	github.com/kubev2v/forklift v0.0.0-20250620125157-d13e1d020ae9
 	github.com/netapp/trident v0.0.0-20240628081112-cb68cb389d9d

--- a/cmd/vsphere-xcopy-volume-populator/go.sum
+++ b/cmd/vsphere-xcopy-volume-populator/go.sum
@@ -70,8 +70,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dell/gopowermax/v2 v2.9.0 h1:hF8AI6+et/Rq4jbQQ/u8P64W/3dx/51i0shfGtF6R7o=
 github.com/dell/gopowermax/v2 v2.9.0/go.mod h1:snOhGKDyMPO4rVUNwEMH2fOwwMNyPP8DtBtafIs8WCs=
-github.com/dell/goscaleio v1.19.1 h1:FZQAAu+A5/prbGQfuHarTLuDny6g/PqA9bbNYRh9pmU=
-github.com/dell/goscaleio v1.19.1/go.mod h1:RTBLZAFRVeAvaqoJoUyzftGOE1L09irvOwIOFn/JPhw=
+github.com/dell/goscaleio v1.20.0 h1:/g0zxlJiGzw5AZEqxjgwaYVc4fmv+DBoAU2PPueZxxE=
+github.com/dell/goscaleio v1.20.0/go.mod h1:XAHq2m2QNJH2l9gu47gQX2m6HjZZlzc1LIa0lrWvSkA=
 github.com/devans10/pugo/flasharray v0.0.0-20241116160615-6bb8c469c9a0 h1:iywqp5xOufeydKSioTnPN8MctrbDmdLjatSHV80j/z8=
 github.com/devans10/pugo/flasharray v0.0.0-20241116160615-6bb8c469c9a0/go.mod h1:7dF4rgfqItyj4bkbwZkwp/Ul+bM4lku/CQvS9OIYF4o=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/Makefile
@@ -20,3 +20,20 @@ check: gosec
 
 gosec:
 	gosec -quiet -log gosec.log -out=gosecresults.csv -fmt=csv ./...
+
+.PHONY: actions action-help
+actions: ## Run all GitHub Action checks that run on a pull request creation
+	@echo "Running all GitHub Action checks for pull request events..."
+	@act -l | grep -v ^Stage | grep pull_request | grep -v image_security_scan | awk '{print $$2}' | while read WF; do \
+		echo "Running workflow: $${WF}"; \
+		act pull_request --no-cache-server --platform ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest --job "$${WF}"; \
+	done
+
+action-help: ## Echo instructions to run one specific workflow locally
+	@echo "GitHub Workflows can be run locally with the following command:"
+	@echo "act pull_request --no-cache-server --platform ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest --job <jobid>"
+	@echo ""
+	@echo "Where '<jobid>' is a Job ID returned by the command:"
+	@echo "act -l"
+	@echo ""
+	@echo "NOTE: if act is not installed, it can be downloaded from https://github.com/nektos/act"

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/api/api_logging.go
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/api/api_logging.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
+
+	"github.com/dell/goscaleio/log"
 )
 
 func isBinOctetBody(h http.Header) bool {
@@ -48,7 +50,7 @@ func logRequest(
 		fmt.Printf("WriteIndented returned error: %s", err.Error())
 	}
 	if lf != nil {
-		lf(logger.Debug, w.String())
+		lf(log.Log.Debug, w.String())
 	}
 }
 
@@ -83,7 +85,7 @@ func logResponse(
 		fmt.Fprintln(w, scanner.Text())
 	}
 	if lf != nil {
-		lf(logger.Debug, w.String())
+		lf(log.Log.Debug, w.String())
 	}
 }
 

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/instance.go
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/instance.go
@@ -108,6 +108,10 @@ func (c *Client) GetVolume(
 
 // FindVolumeID returns a VolumeID
 func (c *Client) FindVolumeID(volumename string) (string, error) {
+	return findVolumeIDFunc(c, volumename)
+}
+
+var findVolumeIDFunc = func(c *Client, volumename string) (string, error) {
 	defer TimeSpent("FindVolumeID", time.Now())
 
 	volumeQeryIDByKeyParam := &types.VolumeQeryIDByKeyParam{
@@ -221,10 +225,14 @@ func NewSnapshotPolicy(client *Client) *SnapshotPolicy {
 
 // FindSnapshotPolicyID retruns a Snapshot Policy ID based on name
 func (c *Client) FindSnapshotPolicyID(spname string) (string, error) {
+	return findSnapshotPolicyByIDFunc(c, spname)
+}
+
+var findSnapshotPolicyByIDFunc = func(c *Client, spid string) (string, error) {
 	defer TimeSpent("FindSnapshotPolicyID", time.Now())
 
 	SnapshotPolicyQueryIDByKeyParam := &types.SnapshotPolicyQueryIDByKeyParam{
-		Name: spname,
+		Name: spid,
 	}
 
 	path := fmt.Sprintf("/api/types/SnapshotPolicy/instances/action/queryIdByKey")

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/log/log.go
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/log/log.go
@@ -1,0 +1,47 @@
+// Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+)
+
+var (
+	mu       sync.Mutex           // guards logLevel
+	logLevel = new(slog.LevelVar) // Info by default
+	// Log is a logger for goscaleio and api packages to use
+	Log   = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
+	debug = false // False by default, will turn true if level is set to debug
+)
+
+func SetLogLevel(level slog.Level) {
+	mu.Lock()
+	defer mu.Unlock()
+	logLevel.Set(level)
+	if level == slog.LevelDebug {
+		debug = true
+	} else {
+		debug = false
+	}
+}
+
+func DoLog(
+	l func(msg string, args ...any),
+	msg string,
+) {
+	if debug {
+		l(msg)
+	}
+}

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/resource_credentials.go
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/resource_credentials.go
@@ -1,0 +1,461 @@
+/*
+ * Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package goscaleio
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	types "github.com/dell/goscaleio/types/v1"
+)
+
+// GetResourceCredentials returns all the resource credentials
+func (s *System) GetResourceCredentials() (*types.ResourceCredentials, error) {
+	defer TimeSpent("GetResourceCredentials", time.Now())
+
+	path := fmt.Sprintf(
+		"/api/v1/Credential")
+
+	var credentialsResult types.ResourceCredentials
+	err := s.client.getJSONWithRetry(
+		http.MethodGet, path, nil, &credentialsResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialsResult, nil
+}
+
+// GetResourceCredential returns a specific credential using resource credential ID
+func (s *System) GetResourceCredential(id string) (*types.ResourceCredential, error) {
+	defer TimeSpent("GetResourceCredential", time.Now())
+
+	path := fmt.Sprintf(
+		"/api/v1/Credential/%v", id)
+
+	var credentialResult types.ResourceCredential
+	err := s.client.getJSONWithRetry(
+		http.MethodGet, path, nil, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+func validateNodeCred(body types.ServerCredential) (*types.ServerCredential, error) {
+	// If the SNMPv2CommunityString and Snmpv3SecurityName are not empty, Default to SNMPv2Protocol
+	if body.SNMPv2CommunityString == "" && body.SNMPv3SecurityName == "" {
+		body.SNMPv2CommunityString = "public"
+		body.SNMPv2Protocol = "SSH"
+	} else if body.SNMPv2CommunityString != "" {
+		body.SNMPv2Protocol = "SSH"
+	} else {
+		switch body.SNMPv3SecurityLevel {
+		case "1":
+		// No validations needed
+		case "2":
+			// MD5 Auth Password needes to be set
+			if body.SNMPv3MD5AuthenticationPassword == "" {
+				return nil, fmt.Errorf("If SNMPv3Security level is 2 the MD5AuthentiacionPassword must be set")
+			}
+		case "3":
+			// MD5 Auth Password and DESPrivatePassword needes to be set
+			if body.SNMPv3MD5AuthenticationPassword == "" || body.SNMPv3DesPrivatePassword == "" {
+				return nil, fmt.Errorf("If SNMPv3Security level is 3 the MD5AuthentiacionPassword and DESPrivatePassword must be set")
+			}
+		default:
+			return nil, fmt.Errorf("invalid SNMPv3SecurityLevel: %v, should be 1,2 or 3", body.SNMPv3SecurityLevel)
+		}
+	}
+
+	if (body.SSHPrivateKey != "" && body.KeyPairName == "") || (body.SSHPrivateKey == "" && body.KeyPairName != "") {
+		return nil, fmt.Errorf("If using an SSHPrivateKey then both KeyPairName and SSHPrivateKey must be set")
+	}
+
+	return &body, nil
+}
+
+// CreateNodeResourceCredential creates a new Resource Credential
+func (s *System) CreateNodeResourceCredential(body types.ServerCredential) (*types.ResourceCredential, error) {
+	valBody, errVal := validateNodeCred(body)
+	if errVal != nil {
+		return nil, errVal
+	}
+	fullBody := types.NodeCredentialWrapper{
+		ServerCredential: *valBody,
+	}
+	defer TimeSpent("CreateNodeResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential")
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPost, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// ModifyNodeResourceCredential creates a new Resource Credential
+func (s *System) ModifyNodeResourceCredential(body types.ServerCredential, id string) (*types.ResourceCredential, error) {
+	valBody, errVal := validateNodeCred(body)
+	if errVal != nil {
+		return nil, errVal
+	}
+
+	fullBody := types.NodeCredentialWrapper{
+		ServerCredential: *valBody,
+	}
+	defer TimeSpent("ModifyNodeResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential/%v", id)
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPut, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// CreateSwitchResourceCredential creates a new Resource Credential
+func (s *System) CreateSwitchResourceCredential(body types.IomCredential) (*types.ResourceCredential, error) {
+	// Validations
+	if (body.SSHPrivateKey != "" && body.KeyPairName == "") || (body.SSHPrivateKey == "" && body.KeyPairName != "") {
+		return nil, fmt.Errorf("If using an SSHPrivateKey then both KeyPairName and SSHPrivateKey must be set")
+	}
+	// Set to default SNMPv2CommunityString if empty, set the SNMPv2Protocol to "SSH"
+	if body.SNMPv2CommunityString == "" {
+		body.SNMPv2CommunityString = "public"
+	}
+	body.SNMPv2Protocol = "SSH"
+
+	fullBody := types.SwitchCredentialWrapper{
+		IomCredential: body,
+	}
+	defer TimeSpent("CreateSwitchResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential")
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPost, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// ModifySwitchResourceCredential creates a new Resource Credential
+func (s *System) ModifySwitchResourceCredential(body types.IomCredential, id string) (*types.ResourceCredential, error) {
+	// Validations
+	if (body.SSHPrivateKey != "" && body.KeyPairName == "") || (body.SSHPrivateKey == "" && body.KeyPairName != "") {
+		return nil, fmt.Errorf("If using an SSHPrivateKey then both KeyPairName and SSHPrivateKey must be set")
+	}
+	// Set to default SNMPv2CommunityString if empty, set the SNMPv2Protocol to "SSH"
+	if body.SNMPv2CommunityString == "" {
+		body.SNMPv2CommunityString = "public"
+	}
+	body.SNMPv2Protocol = "SSH"
+
+	fullBody := types.SwitchCredentialWrapper{
+		IomCredential: body,
+	}
+	defer TimeSpent("ModifySwitchResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential/%v", id)
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPut, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// CreateVCenterResourceCredential creates a new Resource Credential
+func (s *System) CreateVCenterResourceCredential(body types.VCenterCredential) (*types.ResourceCredential, error) {
+	fullBody := types.VCenterCredentialWrapper{
+		VCenterCredential: body,
+	}
+	defer TimeSpent("CreateVCenterResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential")
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPost, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// ModifyVCenterResourceCredential creates a new Resource Credential
+func (s *System) ModifyVCenterResourceCredential(body types.VCenterCredential, id string) (*types.ResourceCredential, error) {
+	fullBody := types.VCenterCredentialWrapper{
+		VCenterCredential: body,
+	}
+	defer TimeSpent("ModifyVCenterResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential/%v", id)
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPut, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// CreateElementManagerResourceCredential creates a new Resource Credential
+func (s *System) CreateElementManagerResourceCredential(body types.EMCredential) (*types.ResourceCredential, error) {
+	// Validations
+	// Set to default SNMPv2CommunityString if empty, set the SNMPv2Protocol to "SSH"
+	if body.SNMPv2CommunityString == "" {
+		body.SNMPv2CommunityString = "public"
+	}
+	body.SNMPv2Protocol = "SSH"
+
+	fullBody := types.ElementManagerCredentialWrapper{
+		EMCredential: body,
+	}
+	defer TimeSpent("CreateElementManagerResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential")
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPost, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// ModifyElementManagerResourceCredential creates a new Resource Credential
+func (s *System) ModifyElementManagerResourceCredential(body types.EMCredential, id string) (*types.ResourceCredential, error) {
+	// Validations
+	// Set to default SNMPv2CommunityString if empty, set the SNMPv2Protocol to "SSH"
+	if body.SNMPv2CommunityString == "" {
+		body.SNMPv2CommunityString = "public"
+	}
+	body.SNMPv2Protocol = "SSH"
+
+	fullBody := types.ElementManagerCredentialWrapper{
+		EMCredential: body,
+	}
+	defer TimeSpent("ModifyElementManagerResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential/%v", id)
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPut, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// CreateScaleIOResourceCredential creates a new Resource Credential
+func (s *System) CreateScaleIOResourceCredential(body types.ScaleIOCredential) (*types.ResourceCredential, error) {
+	fullBody := types.GatewayCredentialWrapper{
+		ScaleIOCredential: body,
+	}
+	defer TimeSpent("CreateScaleIOResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential")
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPost, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// ModifyScaleIOResourceCredential creates a new Resource Credential
+func (s *System) ModifyScaleIOResourceCredential(body types.ScaleIOCredential, id string) (*types.ResourceCredential, error) {
+	fullBody := types.GatewayCredentialWrapper{
+		ScaleIOCredential: body,
+	}
+	defer TimeSpent("ModifyScaleIOResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential/%v", id)
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPut, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// CreatePresentationServerResourceCredential creates a new Resource Credential
+func (s *System) CreatePresentationServerResourceCredential(body types.PSCredential) (*types.ResourceCredential, error) {
+	fullBody := types.PresentationServerCredentialWrapper{
+		PSCredential: body,
+	}
+	defer TimeSpent("CreatePresentationServerResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential")
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPost, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// ModifyPresentationServerResourceCredential creates a new Resource Credential
+func (s *System) ModifyPresentationServerResourceCredential(body types.PSCredential, id string) (*types.ResourceCredential, error) {
+	fullBody := types.PresentationServerCredentialWrapper{
+		PSCredential: body,
+	}
+	defer TimeSpent("ModifyPresentationServerResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential/%v", id)
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPut, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// CreateOsAdminResourceCredential creates a new Resource Credential
+func (s *System) CreateOsAdminResourceCredential(body types.OSAdminCredential) (*types.ResourceCredential, error) {
+	// Validations
+	if (body.SSHPrivateKey != "" && body.KeyPairName == "") || (body.SSHPrivateKey == "" && body.KeyPairName != "") {
+		return nil, fmt.Errorf("If using an SSHPrivateKey then both KeyPairName and SSHPrivateKey must be set")
+	}
+	// For Admin the username is defaulted "root"
+	if body.Username == "" {
+		body.Username = "root"
+	}
+	fullBody := types.OsAdminCredentialWrapper{
+		OSAdminCredential: body,
+	}
+	defer TimeSpent("CreateOsAdminResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential")
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPost, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// ModifyOsAdminResourceCredential creates a new Resource Credential
+func (s *System) ModifyOsAdminResourceCredential(body types.OSAdminCredential, id string) (*types.ResourceCredential, error) {
+	// Validations
+	if (body.SSHPrivateKey != "" && body.KeyPairName == "") || (body.SSHPrivateKey == "" && body.KeyPairName != "") {
+		return nil, fmt.Errorf("If using an SSHPrivateKey then both KeyPairName and SSHPrivateKey must be set")
+	}
+	// For Admin the username is defaulted "root"
+	if body.Username == "" {
+		body.Username = "root"
+	}
+
+	fullBody := types.OsAdminCredentialWrapper{
+		OSAdminCredential: body,
+	}
+	defer TimeSpent("ModifyOsAdminResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential/%v", id)
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPut, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// CreateOsUserResourceCredential creates a new Resource Credential
+func (s *System) CreateOsUserResourceCredential(body types.OSUserCredential) (*types.ResourceCredential, error) {
+	// Validations
+	if (body.SSHPrivateKey != "" && body.KeyPairName == "") || (body.SSHPrivateKey == "" && body.KeyPairName != "") {
+		return nil, fmt.Errorf("If using an SSHPrivateKey then both KeyPairName and SSHPrivateKey must be set")
+	}
+	fullBody := types.OsUserCredentialWrapper{
+		OSUserCredential: body,
+	}
+	defer TimeSpent("CreateOsUserResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential")
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPost, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+// ModifyOsUserResourceCredential creates a new Resource Credential
+func (s *System) ModifyOsUserResourceCredential(body types.OSUserCredential, id string) (*types.ResourceCredential, error) {
+	// Validations
+	if (body.SSHPrivateKey != "" && body.KeyPairName == "") || (body.SSHPrivateKey == "" && body.KeyPairName != "") {
+		return nil, fmt.Errorf("If using an SSHPrivateKey then both KeyPairName and SSHPrivateKey must be set")
+	}
+	fullBody := types.OsUserCredentialWrapper{
+		OSUserCredential: body,
+	}
+	defer TimeSpent("ModifyOsUserResourceCredential", time.Now())
+
+	path := fmt.Sprintf("/api/v1/Credential/%v", id)
+
+	var credentialResult types.ResourceCredential
+	_, err := s.client.xmlRequest(http.MethodPut, path, fullBody, &credentialResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credentialResult, nil
+}
+
+func (s *System) DeleteResourceCredential(id string) error {
+	path := fmt.Sprintf(
+		"/api/v1/Credential/%v", id)
+	param := &types.EmptyPayload{}
+	err := s.client.getJSONWithRetry(
+		http.MethodDelete, path, param, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/sdc.go
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/sdc.go
@@ -30,6 +30,10 @@ type Sdc struct {
 	client *Client
 }
 
+var execCmd = func(cmd string, args ...string) ([]byte, error) {
+	return exec.Command(cmd, args...).Output()
+}
+
 // NewSdc returns a new Sdc
 func NewSdc(client *Client, sdc *types.Sdc) *Sdc {
 	return &Sdc{
@@ -217,7 +221,7 @@ func GetSdcLocalGUID() (string, error) {
 	// /bin/emc/scaleio/drv_cfg --query_guid
 	// sdcKernelGuid := "271bad82-08ee-44f2-a2b1-7e2787c27be1"
 
-	out, err := exec.Command("/opt/emc/scaleio/sdc/bin/drv_cfg", "--query_guid").Output()
+	out, err := execCmd("/opt/emc/scaleio/sdc/bin/drv_cfg", "--query_guid")
 	if err != nil {
 		return "", fmt.Errorf("GetSdcLocalGUID: query vols failed: %v", err)
 	}

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/service.go
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/service.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/dell/goscaleio/log"
 	types "github.com/dell/goscaleio/types/v1"
 	"github.com/google/uuid"
 )
@@ -449,7 +450,7 @@ func (gc *GatewayClient) GetServiceDetailsByID(deploymentID string, newToken boo
 
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
-				doLog(logger.Error, err.Error())
+				log.DoLog(log.Log.Error, err.Error())
 			}
 		}()
 

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/template.go
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/template.go
@@ -159,3 +159,26 @@ func (gc *GatewayClient) GetTemplateByFilters(key string, value string) ([]types
 
 	return templates.TemplateDetails, nil
 }
+
+// CloneTemplate Creates a new Template based on a preexisting Template using the original template id
+func (gc *GatewayClient) CloneTemplate(s *System, originTemplateID string, templateName string) error {
+	defer TimeSpent("CloneTemplate", time.Now())
+	path := `/Api/V1/ServiceTemplate/cloneTemplate`
+
+	template, err := gc.GetTemplateByFilters("originalTemplateId", originTemplateID)
+	if err != nil {
+		return fmt.Errorf("Error While Cloning Template: %s", err.Error())
+	}
+
+	template[0].TemplateLocked = false
+	template[0].Draft = true
+	template[0].TemplateName = templateName
+	template[0].InConfiguration = false
+
+	errCT := s.client.getJSONWithRetry(http.MethodPost, path, template[0], nil)
+	if errCT != nil {
+		return fmt.Errorf("Error While Cloning Template: Template already exists please use a different name")
+	}
+
+	return nil
+}

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/types/v1/types.go
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/dell/goscaleio/types/v1/types.go
@@ -14,6 +14,7 @@ package goscaleio
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"net/http"
 	"sync"
@@ -60,7 +61,6 @@ func (e Error) Error() string {
 			translation := TranslateErrorCodeToErrorMessage(e.ErrorDetails[0].Error)
 			if translation != "" {
 				e.Message = translation
-				e.Message = e.ErrorDetails[0].ErrorMessage
 				return translation
 			}
 		}
@@ -687,6 +687,39 @@ type SdsName struct {
 // SdsPort defines struct for Sds Port
 type SdsPort struct {
 	SdsPort string `json:"sdsPort"`
+}
+
+// ResourceCredentials defines struct for list of resource credential
+type ResourceCredentials struct {
+	TotalRecords int                  `json:"totalRecords"`
+	Credentials  []ResourceCredential `json:"credentialList"`
+}
+
+// ResourceCredential defines struct for resource credential
+type ResourceCredential struct {
+	Link       Link    `json:"link"`
+	Credential CredObj `json:"credential"`
+	Reference  CredRef `json:"reference"`
+}
+
+// CredObj defines struct for credential object
+type CredObj struct {
+	Type        string `json:"type"`
+	CreateDate  string `json:"createdDate"`
+	CreatedBy   string `json:"createdBy"`
+	UpdatedBy   string `json:"updatedBy"`
+	UpdatedDate string `json:"updatedDate"`
+	Label       string `json:"label"`
+	Domain      string `json:"domain"`
+	Link        Link   `json:"link"`
+	Username    string `json:"username"`
+	ID          string `json:"id"`
+}
+
+// CredRef defines struct for credential reference
+type CredRef struct {
+	Devices  int `json:"devices"`
+	Policies int `json:"policies"`
 }
 
 // Device defines struct of Device for PowerFlex Array
@@ -2190,4 +2223,142 @@ type LcmStatus struct {
 	LcmStatus      string `json:"lcmStatus"`
 	ClusterVersion string `json:"clusterVersion"`
 	ClusterBuild   string `json:"clusterBuild"`
+}
+
+type NodeCredentialWrapper struct {
+	XMLName          xml.Name         `xml:"asmCredential"`
+	ServerCredential ServerCredential `xml:"serverCredential"`
+}
+
+type ServerCredential struct {
+	XMLName  xml.Name `xml:"serverCredential"`
+	Username string   `xml:"username"`
+	Password string   `xml:"password"`
+	Label    string   `xml:"label"`
+	// Needed for SNMPv2
+	SNMPv2CommunityString string `xml:"snmpCommunityString,omitempty"`
+	// If SNMPv2 is Set this should be set to SSH
+	SNMPv2Protocol string `xml:"protocol,omitempty"`
+	// Needed for SNMPv3
+	SNMPv3SecurityName string `xml:"snmpv3UserName,omitempty"`
+	// Sets the level 1 2 or 3 for SNMPv3
+	SNMPv3SecurityLevel string `xml:"securityLevel,omitempty"`
+	// Required for SNMPv3 level 2 and 3
+	SNMPv3MD5AuthenticationPassword string `xml:"md5AuthenticationPassword,omitempty"`
+	// Required for SNMPv3 level 3
+	SNMPv3DesPrivatePassword string `xml:"desPrivacyPassword,omitempty"`
+	// Private Key Stringified in the .pem format
+	SSHPrivateKey string `xml:"sshPrivateKey,omitempty"`
+	// Required if Private Key is set
+	KeyPairName string `xml:"keyPairName,omitempty"`
+}
+
+type SwitchCredentialWrapper struct {
+	XMLName       xml.Name      `xml:"asmCredential"`
+	IomCredential IomCredential `xml:"iomCredential"`
+}
+
+type IomCredential struct {
+	XMLName  xml.Name `xml:"iomCredential"`
+	Username string   `xml:"username"`
+	Password string   `xml:"password"`
+	Label    string   `xml:"label"`
+	// Needed for SNMPv2
+	SNMPv2CommunityString string `xml:"snmpCommunityString"`
+	// For SNMPv2 this should be set to SSH
+	SNMPv2Protocol string `xml:"protocol"`
+	// Private Key Stringified in the .pem format
+	SSHPrivateKey string `xml:"sshPrivateKey,omitempty"`
+	// Required if Private Key is set
+	KeyPairName string `xml:"keyPairName,omitempty"`
+}
+
+type VCenterCredentialWrapper struct {
+	XMLName           xml.Name          `xml:"asmCredential"`
+	VCenterCredential VCenterCredential `xml:"vCenterCredential"`
+}
+
+type VCenterCredential struct {
+	XMLName  xml.Name `xml:"vCenterCredential"`
+	Username string   `xml:"username"`
+	Password string   `xml:"password"`
+	Label    string   `xml:"label"`
+	Domain   string   `xml:"domain"`
+}
+
+type ElementManagerCredentialWrapper struct {
+	XMLName      xml.Name     `xml:"asmCredential"`
+	EMCredential EMCredential `xml:"emCredential"`
+}
+
+type EMCredential struct {
+	XMLName  xml.Name `xml:"emCredential"`
+	Username string   `xml:"username"`
+	Password string   `xml:"password"`
+	Domain   string   `xml:"domain"`
+	Label    string   `xml:"label"`
+	// Needed for SNMPv2
+	SNMPv2CommunityString string `xml:"snmpCommunityString"`
+	// If SNMPv2 is Set this should be set to SSH
+	SNMPv2Protocol string `xml:"protocol"`
+}
+
+type GatewayCredentialWrapper struct {
+	XMLName           xml.Name          `xml:"asmCredential"`
+	ScaleIOCredential ScaleIOCredential `xml:"scaleIOCredential"`
+}
+
+type ScaleIOCredential struct {
+	XMLName       xml.Name `xml:"scaleIOCredential"`
+	AdminUsername string   `xml:"username"`
+	AdminPassword string   `xml:"password"`
+	Label         string   `xml:"label"`
+	OSUsername    string   `xml:"osUsername"`
+	OSPassword    string   `xml:"osPassword"`
+}
+
+type PresentationServerCredentialWrapper struct {
+	XMLName      xml.Name     `xml:"asmCredential"`
+	PSCredential PSCredential `xml:"PSCredential"`
+}
+
+type PSCredential struct {
+	XMLName  xml.Name `xml:"PSCredential"`
+	Label    string   `xml:"label"`
+	Username string   `xml:"username"`
+	Password string   `xml:"password"`
+}
+
+type OsAdminCredentialWrapper struct {
+	XMLName           xml.Name          `xml:"asmCredential"`
+	OSAdminCredential OSAdminCredential `xml:"OSCredential"`
+}
+
+type OSAdminCredential struct {
+	XMLName xml.Name `xml:"OSCredential"`
+	// Gets defaulted to root if not set
+	Username string `xml:"username"`
+	Password string `xml:"password"`
+	Label    string `xml:"label"`
+	// Private Key Stringified in the .pem format
+	SSHPrivateKey string `xml:"sshPrivateKey,omitempty"`
+	// Required if Private Key is set
+	KeyPairName string `xml:"keyPairName,omitempty"`
+}
+
+type OsUserCredentialWrapper struct {
+	XMLName          xml.Name         `xml:"asmCredential"`
+	OSUserCredential OSUserCredential `xml:"OSUserCredential"`
+}
+
+type OSUserCredential struct {
+	XMLName  xml.Name `xml:"OSUserCredential"`
+	Username string   `xml:"username"`
+	Password string   `xml:"password"`
+	Domain   string   `xml:"domain"`
+	Label    string   `xml:"label"`
+	// Private Key Stringified in the .pem format
+	SSHPrivateKey string `xml:"sshPrivateKey,omitempty"`
+	// Required if Private Key is set
+	KeyPairName string `xml:"keyPairName,omitempty"`
 }

--- a/cmd/vsphere-xcopy-volume-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -54,8 +54,10 @@ type VM struct {
 	//   - .VmName: name of the VM
 	//   - .PlanName: name of the migration plan
 	//   - .DiskIndex: initial volume index of the disk
+	//   - .WinDriveLetter: Windows drive letter (lowercase, if applicable, e.g. "c", requires guest agent)
 	//   - .RootDiskIndex: index of the root disk
 	//   - .Shared: true if the volume is shared by multiple VMs, false otherwise
+	//   - .FileName: name of the file in the source provider (VMware only, filename includes the .vmdk suffix)
 	// Note:
 	//   This template overrides the plan level template.
 	// Examples:
@@ -103,6 +105,16 @@ type VM struct {
 	// +optional
 	// +kubebuilder:validation:Enum=on;off;auto
 	TargetPowerState TargetPowerState `json:"targetPowerState,omitempty"`
+	// DeleteVmOnFailMigration controls whether the target VM created by this Plan is deleted when a migration fails.
+	// When true and the migration fails after the target VM has been created, the controller
+	// will delete the target VM (and related target-side resources) during failed-migration cleanup
+	// and when the Plan is deleted. When false (default), the target VM is preserved to aid
+	// troubleshooting. The source VM is never modified.
+	//
+	// Note: If the Plan-level option is set to true, the VM-level option will be ignored.
+	//
+	// +optional
+	DeleteVmOnFailMigration bool `json:"deleteVmOnFailMigration,omitempty"`
 }
 
 // Find a Hook for the specified step.

--- a/cmd/vsphere-xcopy-volume-populator/vendor/modules.txt
+++ b/cmd/vsphere-xcopy-volume-populator/vendor/modules.txt
@@ -26,10 +26,11 @@ github.com/davecgh/go-spew/spew
 github.com/dell/gopowermax/v2
 github.com/dell/gopowermax/v2/api
 github.com/dell/gopowermax/v2/types/v100
-# github.com/dell/goscaleio v1.19.1
-## explicit; go 1.23
+# github.com/dell/goscaleio v1.20.0
+## explicit; go 1.24
 github.com/dell/goscaleio
 github.com/dell/goscaleio/api
+github.com/dell/goscaleio/log
 github.com/dell/goscaleio/types/v1
 # github.com/devans10/pugo/flasharray v0.0.0-20241116160615-6bb8c469c9a0
 ## explicit; go 1.12


### PR DESCRIPTION
Dell decided to delete 1.19.1 from github, no clue why. Bumping to 1.20
which is only different in a github workflow file (see changelog
https://github.com/dell/goscaleio/compare/v1.19.0...v1.20.0https://github.com/dell/goscaleio/compare/v1.19.0...v1.20.0)

Signed-off-by: Roy Golan <rgolan@redhat.com>
