### PR TITLE
MTV-1324 | Convertion pod service - II

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -124,6 +124,13 @@ const (
 	VddkAioBufCountDefault = "4"
 )
 
+// Service and Port constants
+const (
+	ServiceNameSuffix = "-service"
+	HTTPPort          = 8080
+	MetricsPort       = 2112
+)
+
 // Map of VirtualMachines keyed by vmID.
 type VirtualMachineMap map[string]VirtualMachine
 
@@ -1020,6 +1027,36 @@ func (r *KubeVirt) EnsureGuestConversionPod(vm *plan.VMStatus, vmCr *VirtualMach
 				pod.Name),
 			"vm",
 			vm.String())
+
+		// Create matching service for the pod
+		service := r.guestConversionService(vm, pod)
+		err = r.Destination.Client.Create(context.TODO(), service)
+		if err != nil {
+			r.Log.Error(err, "Failed to create service for virt-v2v pod",
+				"service", path.Join(service.Namespace, service.Name),
+				"pod", path.Join(pod.Namespace, pod.Name))
+
+			// Clean up the pod since service creation failed
+			deleteErr := r.Destination.Client.Delete(context.TODO(), pod)
+			if deleteErr != nil {
+				r.Log.Error(deleteErr, "Failed to cleanup pod after service creation failure",
+					"pod", path.Join(pod.Namespace, pod.Name))
+			} else {
+				r.Log.Info("Cleaned up pod after service creation failure",
+					"pod", path.Join(pod.Namespace, pod.Name))
+			}
+
+			err = liberr.Wrap(err)
+			return
+		}
+		r.Log.Info(
+			"Created virt-v2v service.",
+			"service",
+			path.Join(
+				service.Namespace,
+				service.Name),
+			"vm",
+			vm.String())
 	}
 
 	return
@@ -1100,8 +1137,9 @@ func (r *KubeVirt) getInspectionXml(pod *core.Pod) (string, error) {
 	if pod == nil {
 		return "", liberr.New("no pod found to get the inspection")
 	}
-	inspectionUrl := fmt.Sprintf("http://%s:8080/inspection", pod.Status.PodIP)
-	resp, err := http.Get(inspectionUrl)
+	inspectionURL := r.guestConversionServiceURL(pod, HTTPPort) + "/inspection"
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(inspectionURL)
 	if err != nil {
 		return "", liberr.Wrap(err)
 	}
@@ -1114,12 +1152,13 @@ func (r *KubeVirt) getInspectionXml(pod *core.Pod) (string, error) {
 }
 
 func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, step *plan.Step) error {
-	if pod == nil || pod.Status.PodIP == "" {
-		//we need the IP for fetching the configuration of the convered VM.
+	if pod == nil {
+		//we need the pod for fetching the configuration of the converted VM.
 		return nil
 	}
 
-	url := fmt.Sprintf("http://%s:8080/vm", pod.Status.PodIP)
+	url := r.guestConversionServiceURL(pod, HTTPPort) + "/vm"
+	client := &http.Client{Timeout: 20 * time.Second}
 
 	/* Due to the virt-v2v operation, the ovf file is only available after the command's execution,
 	meaning it appears following the copydisks phase.
@@ -1128,7 +1167,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 	Once the VM server is running, we can make a single call to obtain the OVF configuration,
 	followed by a shutdown request. This will complete the pod process, allowing us to move to the next phase.
 	*/
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return nil
@@ -1157,8 +1196,8 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 		r.Log.Info("Setting the vm OS ", vm.OperatingSystem, "vmId", vm.ID)
 	}
 
-	shutdownURL := fmt.Sprintf("http://%s:8080/shutdown", pod.Status.PodIP)
-	resp, err = http.Post(shutdownURL, "application/json", nil)
+	shutdownURL := r.guestConversionServiceURL(pod, HTTPPort) + "/shutdown"
+	resp, err = client.Post(shutdownURL, "application/json", nil)
 	if err == nil {
 		defer resp.Body.Close()
 	} else {
@@ -2053,8 +2092,13 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 					VolumeDevices: volumeDevices,
 					Ports: []core.ContainerPort{
 						{
+							Name:          "http",
+							ContainerPort: HTTPPort,
+							Protocol:      core.ProtocolTCP,
+						},
+						{
 							Name:          "metrics",
-							ContainerPort: 2112,
+							ContainerPort: MetricsPort,
 							Protocol:      core.ProtocolTCP,
 						},
 					},
@@ -2075,6 +2119,48 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	r.setKvmOnPodSpec(&pod.Spec)
 
 	return
+}
+
+// guestConversionService creates a service for the guest conversion (virt-v2v) pod.
+func (r *KubeVirt) guestConversionService(vm *plan.VMStatus, pod *core.Pod) *core.Service {
+	labels := r.conversionLabels(vm.Ref, false)
+	service := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Namespace: pod.Namespace,
+			Labels:    labels,
+			Name:      pod.Name + ServiceNameSuffix,
+			OwnerReferences: []meta.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       pod.Name,
+					UID:        pod.UID,
+				},
+			},
+		},
+		Spec: core.ServiceSpec{
+			Selector: labels,
+			Ports: []core.ServicePort{
+				{
+					Name:     "http",
+					Port:     HTTPPort,
+					Protocol: core.ProtocolTCP,
+				},
+				{
+					Name:     "metrics",
+					Port:     MetricsPort,
+					Protocol: core.ProtocolTCP,
+				},
+			},
+		},
+	}
+	return service
+}
+
+// guestConversionServiceURL generates the service URL for a given pod and port
+func (r *KubeVirt) guestConversionServiceURL(pod *core.Pod, port int) string {
+	serviceName := pod.Name + ServiceNameSuffix
+	return fmt.Sprintf("http://%s.%s.svc:%d", serviceName, pod.Namespace, port)
 }
 
 func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, libvirtConfigMap *core.ConfigMap, vddkConfigmap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, vm *plan.VMStatus) (volumes []core.Volume, mounts []core.VolumeMount, devices []core.VolumeDevice, err error) {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1577,11 +1577,6 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 		step.MarkCompleted()
 		step.AddError("Guest conversion failed. See pod logs for details.")
 	default:
-		if pod.Status.PodIP == "" {
-			// we get the progress from the pod and we cannot connect to the pod without PodIP
-			break
-		}
-
 		useV2vForTransfer, err := r.Context.Plan.ShouldUseV2vForTransfer()
 		switch {
 		case err != nil:
@@ -1599,7 +1594,8 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 
 func (r *Migration) updateConversionProgressV2vMonitor(pod *core.Pod, step *plan.Step) (err error) {
 	var diskRegex = regexp.MustCompile(`v2v_disk_transfers\{disk_id="(\d+)"\} (\d{1,3}\.?\d*)`)
-	url := fmt.Sprintf("http://%s:2112/metrics", pod.Status.PodIP)
+	serviceName := pod.Name + ServiceNameSuffix
+	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/metrics", serviceName, pod.Namespace, MetricsPort)
 	resp, err := http.Get(url)
 	switch {
 	case err == nil:


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-1324

Isseu:
We use pod IP to communicate with virtv2v pod, using IP can have issues, for example, in cases we use secondary networks.

UDN:
With UDN cross namespace communication is different, need to wait with this fix, until we know how UDN support work, and if it is compatible with this new service.

Fix:
Add a service to the convertion and communicate via the service, it is now k8s responsibility to expose the port.

History:
https://github.com/kubev2v/forklift/pull/2469 - first try, cased a cross namespace migration issue
https://github.com/kubev2v/forklift/pull/2668 - revert due to the cross namespace migration issue
https://github.com/kubev2v/forklift/pull/1947 - UDN support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds stable per-pod service endpoints for guest conversion, exposing HTTP and metrics over cluster DNS for improved reliability and observability.
* **Bug Fixes**
  * Progress tracking no longer stalls when a conversion pod lacks an IP; monitoring now works via DNS-based metrics.
  * Conversion pods are cleaned up and errors surfaced if service setup fails.
* **Refactor**
  * Guest-conversion interactions now use service-based addresses instead of direct pod IPs for consistency and resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->