### PR TITLE
NO JIRA | migrate policies to Rego v1 syntax and bump OPA to v1.8.0

### DIFF
--- a/build/validation/Containerfile
+++ b/build/validation/Containerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
-RUN curl -L https://github.com/open-policy-agent/opa/releases/download/v0.62.1/opa_linux_amd64 > /usr/bin/opa
+RUN curl -L https://github.com/open-policy-agent/opa/releases/download/v1.8.0/opa_linux_amd64 > /usr/bin/opa
 RUN chmod +x /usr/bin/opa
 COPY validation/policies /usr/share/opa/policies/
 COPY validation/entrypoint.sh /usr/bin/

--- a/validation/policies/io/konveyor/forklift/openstack/bios_boot_menu.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/bios_boot_menu.rego
@@ -1,12 +1,12 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
+import rego.v1
 
-default has_boot_menu_enabled = false
+default has_boot_menu_enabled := false
 
 has_boot_menu_enabled if input.image.properties.hw_boot_menu == "true"
 
-concerns[flag] {
+concerns contains flag if {
 	has_boot_menu_enabled
 	flag := {
 		"id": "openstack.bios.boot_menu.enabled",

--- a/validation/policies/io/konveyor/forklift/openstack/bios_boot_menu_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/bios_boot_menu_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_without_boot_menu_enabled {
+import rego.v1
+
+test_without_boot_menu_enabled if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"hw_boot_menu": "false"}},
@@ -9,7 +11,7 @@ test_without_boot_menu_enabled {
 	count(results) == 0
 }
 
-test_with_boot_menu_enabled {
+test_with_boot_menu_enabled if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"hw_boot_menu": "true"}},

--- a/validation/policies/io/konveyor/forklift/openstack/cpu_shares.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/cpu_shares.rego
@@ -1,13 +1,12 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
-default has_cpushares_enabled = false
+default has_cpushares_enabled := false
 
 has_cpushares_enabled if "quota:cpu_shares" in object.keys(input.flavor.extraSpecs)
 
-concerns[flag] {
+concerns contains flag if {
 	has_cpushares_enabled
 	flag := {
 		"id": "openstack.cpu.shares.defined",

--- a/validation/policies/io/konveyor/forklift/openstack/cpu_shares_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/cpu_shares_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_without_cpushares_defined {
+import rego.v1
+
+test_without_cpushares_defined if {
 	mock_vm := {
 		"name": "test",
 		"flavor": {"extraSpecs": {}},
@@ -9,7 +11,7 @@ test_without_cpushares_defined {
 	count(results) == 0
 }
 
-test_with_cpushares_enabled {
+test_with_cpushares_enabled if {
 	mock_vm := {
 		"name": "test",
 		"flavor": {"extraSpecs": {"quota:cpu_shares": "1000"}},
@@ -18,7 +20,7 @@ test_with_cpushares_enabled {
 	count(results) == 1
 }
 
-test_with_cpushares_empty {
+test_with_cpushares_empty if {
 	mock_vm := {
 		"name": "test",
 		"flavor": {"extraSpecs": {"quota:cpu_shares": ""}},

--- a/validation/policies/io/konveyor/forklift/openstack/debug.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/debug.rego
@@ -1,5 +1,7 @@
 package io.konveyor.forklift.openstack
 
-debug {
+import rego.v1
+
+debug if {
 	trace(sprintf("** debug ** vm name: %v", [input.name]))
 }

--- a/validation/policies/io/konveyor/forklift/openstack/disk_interface_type.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_interface_type.rego
@@ -1,17 +1,17 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
+import rego.v1
 
-default invalid_disk_interface = false
+default invalid_disk_interface := false
 
 invalid_disk_interface if {
 	not regex.match(`sata|scsi|virtio`, input.image.properties.hw_disk_bus)
 }
 
-concerns[flag] {
+concerns contains flag if {
 	invalid_disk_interface
 	flag := {
-	    "id": "openstack.disk.unsupported_interface",
+		"id": "openstack.disk.unsupported_interface",
 		"category": "Warning",
 		"label": "Unsupported disk interface type detected",
 		"assessment": "The disk interface type is not supported by OpenShift Virtualization (only sata, scsi and virtio interface types are currently supported). The migrated VM will be given a virtio disk interface type.",

--- a/validation/policies/io/konveyor/forklift/openstack/disk_interface_type_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_interface_type_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_with_first_valid_disk_interface_type {
+import rego.v1
+
+test_with_first_valid_disk_interface_type if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"hw_disk_bus": "sata"}},
@@ -9,7 +11,7 @@ test_with_first_valid_disk_interface_type {
 	count(results) == 0
 }
 
-test_with_second_valid_disk_interface_type {
+test_with_second_valid_disk_interface_type if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"hw_disk_bus": "scsi"}},
@@ -18,7 +20,7 @@ test_with_second_valid_disk_interface_type {
 	count(results) == 0
 }
 
-test_with_third_valid_disk_interface_type {
+test_with_third_valid_disk_interface_type if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"hw_disk_bus": "virtio"}},
@@ -27,7 +29,7 @@ test_with_third_valid_disk_interface_type {
 	count(results) == 0
 }
 
-test_with_invalid_disk_interface_type {
+test_with_invalid_disk_interface_type if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"hw_disk_bus": "ide"}},

--- a/validation/policies/io/konveyor/forklift/openstack/disk_size.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_size.rego
@@ -1,20 +1,21 @@
 package io.konveyor.forklift.openstack
-import future.keywords.in
+
+import rego.v1
 
 # Match any volume with zero or negative size
-invalid_volumes[idx] {
-    some idx
-    input.volumes[idx].size <= 0
+invalid_volumes contains idx if {
+	some idx
+	input.volumes[idx].size <= 0
 }
 
 # Raise a concern for each invalid volume
-concerns[flag] {
-    invalid_volumes[idx]
-    volume := input.volumes[idx]
-    flag := {
-        "id": "openstack.disk.capacity.invalid", 
-        "category": "Critical",
-        "label": sprintf("Volume '%v' has an invalid size of %v GB", [volume.name, volume.size]),
-        "assessment": sprintf("Volume '%v' has a size of %v GB, which is not allowed. Size must be greater than zero.", [volume.name, volume.size])
-    }
-} 
+concerns contains flag if {
+	invalid_volumes[idx]
+	volume := input.volumes[idx]
+	flag := {
+		"id": "openstack.disk.capacity.invalid",
+		"category": "Critical",
+		"label": sprintf("Volume '%v' has an invalid size of %v GB", [volume.name, volume.size]),
+		"assessment": sprintf("Volume '%v' has a size of %v GB, which is not allowed. Size must be greater than zero.", [volume.name, volume.size]),
+	}
+}

--- a/validation/policies/io/konveyor/forklift/openstack/disk_size_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_size_test.rego
@@ -1,50 +1,39 @@
 package io.konveyor.forklift.openstack
-import future.keywords.in
 
-test_invalid_size_zero {
-    input := {
-        "volumes": [
-            {
-                "id": "volume1-id",
-                "name": "volume1",
-                "size": 0,
-                "status": "available"
-            }
-        ]
-    }
+import rego.v1
 
-    results := concerns with input as input
-    count(results) == 1
+test_invalid_size_zero if {
+	test_input := {"volumes": [{
+		"id": "volume1-id",
+		"name": "volume1",
+		"size": 0,
+		"status": "available",
+	}]}
+
+	results := concerns with input as test_input
+	count(results) == 1
 }
 
-test_invalid_size_negative {
-    input := {
-        "volumes": [
-            {
-                "id": "volume2-id",
-                "name": "volume2", 
-                "size": -10,
-                "status": "available"
-            }
-        ]
-    }
+test_invalid_size_negative if {
+	test_input := {"volumes": [{
+		"id": "volume2-id",
+		"name": "volume2",
+		"size": -10,
+		"status": "available",
+	}]}
 
-    results := concerns with input as input
-    count(results) == 1
+	results := concerns with input as test_input
+	count(results) == 1
 }
 
-test_valid_size {
-    input := {
-        "volumes": [
-            {
-                "id": "volume3-id",
-                "name": "volume3",
-                "size": 20,
-                "status": "available"
-            }
-        ]
-    }
+test_valid_size if {
+	test_input := {"volumes": [{
+		"id": "volume3-id",
+		"name": "volume3",
+		"size": 20,
+		"status": "available",
+	}]}
 
-    results := concerns with input as input
-    count(results) == 0
-} 
+	results := concerns with input as test_input
+	count(results) == 0
+}

--- a/validation/policies/io/konveyor/forklift/openstack/disk_status.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_status.rego
@@ -1,11 +1,13 @@
 package io.konveyor.forklift.openstack
 
-valid_disk_status[i] {
+import rego.v1
+
+valid_disk_status contains i if {
 	some i
 	regex.match(`available|in-use`, input.volumes[i].status)
 }
 
-concerns[flag] {
+concerns contains flag if {
 	count(valid_disk_status) != count(input.volumes)
 	flag := {
 		"id": "openstack.disk.status.unsupported",

--- a/validation/policies/io/konveyor/forklift/openstack/disk_status_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_status_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_with_valid_disk_status {
+import rego.v1
+
+test_with_valid_disk_status if {
 	mock_vm := {
 		"name": "test",
 		"volumes": [
@@ -22,7 +24,7 @@ test_with_valid_disk_status {
 	count(results) == 0
 }
 
-test_with_one_invalid_disk_status {
+test_with_one_invalid_disk_status if {
 	mock_vm := {
 		"name": "test",
 		"volumes": [
@@ -44,7 +46,7 @@ test_with_one_invalid_disk_status {
 	count(results) == 1
 }
 
-test_with_two_invalid_disk_status {
+test_with_two_invalid_disk_status if {
 	mock_vm := {
 		"name": "test",
 		"volumes": [

--- a/validation/policies/io/konveyor/forklift/openstack/floating_ips.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/floating_ips.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.openstack
 
+import rego.v1
+
 addresses := input.addresses
 
-floating_ips[i] {
-  some i
+floating_ips contains i if {
+	some i
 	addresses[i][_]["OS-EXT-IPS:type"] == "floating"
 }
 
-concerns[flag] {
+concerns contains flag if {
 	count(floating_ips) != 0
 	flag := {
 		"id": "openstack.network.floating_ips.detected",

--- a/validation/policies/io/konveyor/forklift/openstack/floating_ips_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/floating_ips_test.rego
@@ -1,54 +1,38 @@
 package io.konveyor.forklift.openstack
 
-test_without_floating_ips {
+import rego.v1
+
+test_without_floating_ips if {
 	mock_vm := {
 		"name": "test",
 		"addresses": {
-      "network1": [
-        {
-          "OS-EXT-IPS:type": "fixed",
-        },
-        {
-          "OS-EXT-IPS:type": "fixed",
-        },
-      ],
-      "network2": [
-        {
-          "OS-EXT-IPS:type": "fixed",
-        },
-        {
-          "OS-EXT-IPS:type": "fixed",
-        }
-      ]
+			"network1": [
+				{"OS-EXT-IPS:type": "fixed"},
+				{"OS-EXT-IPS:type": "fixed"},
+			],
+			"network2": [
+				{"OS-EXT-IPS:type": "fixed"},
+				{"OS-EXT-IPS:type": "fixed"},
+			],
 		},
 	}
 	results := concerns with input as mock_vm
 	count(results) == 0
 }
 
-test_with_floating_ips {
+test_with_floating_ips if {
 	mock_vm := {
 		"name": "test",
 		"addresses": {
-      "network1": [
-        {
-          "OS-EXT-IPS:type": "fixed",
-        },
-        {
-          "OS-EXT-IPS:type": "fixed",
-        },
-        {
-          "OS-EXT-IPS:type": "floating",
-        }
-      ],
-      "network2": [
-        {
-          "OS-EXT-IPS:type": "fixed",
-        },
-        {
-          "OS-EXT-IPS:type": "fixed",
-        }
-      ]
+			"network1": [
+				{"OS-EXT-IPS:type": "fixed"},
+				{"OS-EXT-IPS:type": "fixed"},
+				{"OS-EXT-IPS:type": "floating"},
+			],
+			"network2": [
+				{"OS-EXT-IPS:type": "fixed"},
+				{"OS-EXT-IPS:type": "fixed"},
+			],
 		},
 	}
 	results := concerns with input as mock_vm

--- a/validation/policies/io/konveyor/forklift/openstack/host_devices.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/host_devices.rego
@@ -1,13 +1,12 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
-default host_devices = false
+default host_devices := false
 
 host_devices if "pci_passthrough:alias" in object.keys(input.flavor.extraSpecs)
 
-concerns[flag] {
+concerns contains flag if {
 	host_devices
 	flag := {
 		"id": "openstack.host_devices.mapped",

--- a/validation/policies/io/konveyor/forklift/openstack/host_devices_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/host_devices_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_without_host_devices {
+import rego.v1
+
+test_without_host_devices if {
 	mock_vm := {
 		"name": "test",
 		"flavor": {"extraSpecs": {}},
@@ -9,7 +11,7 @@ test_without_host_devices {
 	count(results) == 0
 }
 
-test_with_host_devices {
+test_with_host_devices if {
 	mock_vm := {
 		"name": "test",
 		"flavor": {"extraSpecs": {"pci_passthrough:alias": "alias1:2"}},

--- a/validation/policies/io/konveyor/forklift/openstack/name.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/name.rego
@@ -1,25 +1,27 @@
 package io.konveyor.forklift.openstack
 
-default valid_input = true
+import rego.v1
 
-valid_input = false {
+default valid_input := true
+
+valid_input := false if {
 	is_null(input)
 }
 
-default valid_vm_string = false
+default valid_vm_string := false
 
-valid_vm_string {
+valid_vm_string if {
 	is_string(input.name)
 }
 
-default valid_vm_name = false
+default valid_vm_name := false
 
-valid_vm_name {
+valid_vm_name if {
 	regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
 	count(input.name) < 64
 }
 
-concerns[flag] {
+concerns contains flag if {
 	valid_input
 	valid_vm_string
 	not valid_vm_name

--- a/validation/policies/io/konveyor/forklift/openstack/name_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/name_test.rego
@@ -1,24 +1,26 @@
 package io.konveyor.forklift.openstack
 
-test_valid_vm_name {
+import rego.v1
+
+test_valid_vm_name if {
 	mock_vm := {"name": "test"}
 	results := concerns with input as mock_vm
 	count(results) == 0
 }
 
-test_vm_name_too_long {
+test_vm_name_too_long if {
 	mock_vm := {"name": "my-vm-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
 	results := concerns with input as mock_vm
 	count(results) == 1
 }
 
-test_vm_name_invalid_char_underscore {
+test_vm_name_invalid_char_underscore if {
 	mock_vm := {"name": "my_vm"}
 	results := concerns with input as mock_vm
 	count(results) == 1
 }
 
-test_vm_name_invalid_char_slash {
+test_vm_name_invalid_char_slash if {
 	mock_vm := {"name": "my/vm"}
 	results := concerns with input as mock_vm
 	count(results) == 1

--- a/validation/policies/io/konveyor/forklift/openstack/numa_tune.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/numa_tune.rego
@@ -1,15 +1,14 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
-default has_numa_enabled = false
+default has_numa_enabled := false
 
 has_numa_enabled if "hw:pci_numa_affinity_policy" in object.keys(input.flavor.extraSpecs)
 
 has_numa_enabled if "hw:numa_nodes" in object.keys(input.flavor.extraSpecs)
 
-concerns[flag] {
+concerns contains flag if {
 	has_numa_enabled
 	flag := {
 		"id": "openstack.numa_tuning.detected",

--- a/validation/policies/io/konveyor/forklift/openstack/numa_tune_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/numa_tune_test.rego
@@ -1,24 +1,26 @@
 package io.konveyor.forklift.openstack
 
-test_without_numa {
+import rego.v1
+
+test_without_numa if {
 	mock_vm := {"name": "test", "flavor": {"extraSpecs": {}}}
 	results = concerns with input as mock_vm
 	count(results) == 0
 }
 
-test_with_pci_numa_affinity {
+test_with_pci_numa_affinity if {
 	mock_vm := {"name": "test", "flavor": {"extraSpecs": {"hw:pci_numa_affinity_policy": "required"}}}
 	results = concerns with input as mock_vm
 	count(results) == 1
 }
 
-test_with_numa_nodes {
+test_with_numa_nodes if {
 	mock_vm := {"name": "test", "flavor": {"extraSpecs": {"hw:numa_nodes": "2"}}}
 	results = concerns with input as mock_vm
 	count(results) == 1
 }
 
-test_with_all_numa {
+test_with_all_numa if {
 	mock_vm := {"name": "test", "flavor": {"extraSpecs": {"hw:numa_nodes": "2", "hw:pci_numa_affinity_policy": "required"}}}
 	results = concerns with input as mock_vm
 	count(results) == 1

--- a/validation/policies/io/konveyor/forklift/openstack/rules_version.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/rules_version.rego
@@ -1,5 +1,7 @@
 package io.konveyor.forklift.openstack
 
+import rego.v1
+
 RULES_VERSION := 6
 
-rules_version = {"rules_version": RULES_VERSION}
+rules_version := {"rules_version": RULES_VERSION}

--- a/validation/policies/io/konveyor/forklift/openstack/secure_boot.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/secure_boot.rego
@@ -1,14 +1,14 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
+import rego.v1
 
-default secure_boot_enabled = false
+default secure_boot_enabled := false
 
 secure_boot_enabled if input.image.properties.os_secure_boot == "required"
 
 secure_boot_enabled if input.flavor.extraSpecs["os:secure_boot"] == "required"
 
-concerns[flag] {
+concerns contains flag if {
 	secure_boot_enabled
 	flag := {
 		"id": "openstack.secure_boot.detected",

--- a/validation/policies/io/konveyor/forklift/openstack/secure_boot_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/secure_boot_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_with_flavor_secure_boot {
+import rego.v1
+
+test_with_flavor_secure_boot if {
 	mock_vm := {
 		"name": "test",
 		"flavor": {"extraSpecs": {"os:secure_boot": "required"}},
@@ -9,7 +11,7 @@ test_with_flavor_secure_boot {
 	count(results) == 1
 }
 
-test_with_image_secure_boot {
+test_with_image_secure_boot if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_secure_boot": "required"}},
@@ -18,7 +20,7 @@ test_with_image_secure_boot {
 	count(results) == 1
 }
 
-test_with_optional_secure_boot {
+test_with_optional_secure_boot if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_secure_boot": "optional"}},
@@ -27,7 +29,7 @@ test_with_optional_secure_boot {
 	count(results) == 0
 }
 
-test_with_disabled_secure_boot {
+test_with_disabled_secure_boot if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_secure_boot": "disabled"}},
@@ -36,7 +38,7 @@ test_with_disabled_secure_boot {
 	count(results) == 0
 }
 
-test_without_secure_boot {
+test_without_secure_boot if {
 	mock_vm := {"name": "test"}
 	results := concerns with input as mock_vm
 	count(results) == 0

--- a/validation/policies/io/konveyor/forklift/openstack/shared_disk.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/shared_disk.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.openstack
 
+import rego.v1
+
 volumes := input.volumes
 
-shared_disks[i] {
+shared_disks contains i if {
 	some i
 	count(volumes[i].attachments) > 1
 }
 
-concerns[flag] {
+concerns contains flag if {
 	count(shared_disks) > 0
 	flag := {
-	    "id": "openstack.disk.shared.detected",
+		"id": "openstack.disk.shared.detected",
 		"category": "Warning",
 		"label": "Shared disk detected",
 		"assessment": "The VM has a disk that is shared. Shared disks are not currently supported by OpenShift Virtualization.",

--- a/validation/policies/io/konveyor/forklift/openstack/shared_disk_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/shared_disk_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_with_no_volumes {
+import rego.v1
+
+test_with_no_volumes if {
 	mock_vm := {
 		"name": "test",
 		"volumes": [],
@@ -9,7 +11,7 @@ test_with_no_volumes {
 	count(results) == 0
 }
 
-test_without_shared_disk {
+test_without_shared_disk if {
 	mock_vm := {
 		"name": "test",
 		"volumes": [
@@ -17,14 +19,14 @@ test_without_shared_disk {
 			{"id": "2", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "3", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "4", "status": "in-use", "attachments": []},
-			{"id": "5", "status": "in-use" },
+			{"id": "5", "status": "in-use"},
 		],
 	}
 	results := concerns with input as mock_vm
 	count(results) == 0
 }
 
-test_with_shared_disk {
+test_with_shared_disk if {
 	mock_vm := {
 		"name": "test",
 		"volumes": [
@@ -32,7 +34,7 @@ test_with_shared_disk {
 			{"id": "2", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "3", "status": "in-use", "attachments": [{"AttachmentID": "1"}]},
 			{"id": "4", "status": "in-use", "attachments": []},
-			{"id": "5", "status": "in-use" },
+			{"id": "5", "status": "in-use"},
 		],
 	}
 	results := concerns with input as mock_vm

--- a/validation/policies/io/konveyor/forklift/openstack/validate.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/validate.rego
@@ -1,12 +1,14 @@
 package io.konveyor.forklift.openstack
 
-validate = {
+import rego.v1
+
+validate := {
 	"rules_version": RULES_VERSION,
 	"errors": errors,
 	"concerns": concerns,
 }
 
-errors[message] {
+errors contains message if {
 	not valid_vm_string
 	message := "No VM name found in input body"
 }

--- a/validation/policies/io/konveyor/forklift/openstack/vif_models.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vif_models.rego
@@ -1,17 +1,17 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
+import rego.v1
 
-default invalid_vif_model = false
+default invalid_vif_model := false
 
 invalid_vif_model if {
 	not regex.match(`e1000|e1000e|rtl8139|virtio|ne2k_pci|pcnet`, input.image.properties.hw_vif_model)
 }
 
-concerns[flag] {
+concerns contains flag if {
 	invalid_vif_model
 	flag := {
-	    "id": "openstack.network.vif_model.unsupported",
+		"id": "openstack.network.vif_model.unsupported",
 		"category": "Warning",
 		"label": "Unsupported VIF model detected",
 		"assessment": "The VIF model is not supported by OpenShift Virtualization (only e1000, e1000e, rtl8139, ne2k_pci, pcnet and virtio VIF models are currently supported). The migrated VM will be given a virtio VIF model.",

--- a/validation/policies/io/konveyor/forklift/openstack/vif_models_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vif_models_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_with_no_vif_model {
+import rego.v1
+
+test_with_no_vif_model if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {}},
@@ -9,7 +11,7 @@ test_with_no_vif_model {
 	count(results) == 0
 }
 
-test_with_supported_e1000 {
+test_with_supported_e1000 if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"hw_vif_model": "e1000"}},
@@ -18,7 +20,7 @@ test_with_supported_e1000 {
 	count(results) == 0
 }
 
-test_with_unsupported_virtual_e1000 {
+test_with_unsupported_virtual_e1000 if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"hw_vif_model": "VirtualE1000"}},

--- a/validation/policies/io/konveyor/forklift/openstack/vm_os.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vm_os.rego
@@ -1,30 +1,29 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
-default is_supported_redhat_guest = false
+default is_supported_redhat_guest := false
 
 is_supported_redhat_guest if {
 	regex.match(`rhel|centos`, input.image.properties.os_distro)
 	regex.match(`^9|^8|^7`, input.image.properties.os_version)
 }
 
-default is_supported_windows_guest = false
+default is_supported_windows_guest := false
 
 is_supported_windows_guest if {
 	regex.match(`windows`, input.image.properties.os_distro)
 	regex.match(`2008|2012|2016|2019|2022|2k8|2k12|2k16|2k19|2k22|^7|^8|^10|^11`, input.image.properties.os_version)
 }
 
-default is_supported_fedora_guest = false
+default is_supported_fedora_guest := false
 
 is_supported_fedora_guest if {
 	regex.match(`fedora`, input.image.properties.os_distro)
 	regex.match(`^3[678]$`, input.image.properties.os_version)
 }
 
-default has_unsupported_guest_os = false
+default has_unsupported_guest_os := false
 
 has_unsupported_guest_os if {
 	"os_distro" in object.keys(input.image.properties)
@@ -34,10 +33,10 @@ has_unsupported_guest_os if {
 	not is_supported_fedora_guest
 }
 
-concerns[flag] {
+concerns contains flag if {
 	has_unsupported_guest_os
 	flag := {
-	    "id": "openstack.os.unsupported",
+		"id": "openstack.os.unsupported",
 		"category": "Warning",
 		"label": "Unsupported operative system detected",
 		"assessment": "The VM is running an operative system that is not currently supported by OpenShift Virtualization.",

--- a/validation/policies/io/konveyor/forklift/openstack/vm_os_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vm_os_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_without_os_distro_defined {
+import rego.v1
+
+test_without_os_distro_defined if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_version": "6"}},
@@ -9,7 +11,7 @@ test_without_os_distro_defined {
 	count(results) == 0
 }
 
-test_without_os_version_defined {
+test_without_os_version_defined if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_distro": "rhel"}},
@@ -18,7 +20,7 @@ test_without_os_version_defined {
 	count(results) == 0
 }
 
-test_with_unsupported_os_distro {
+test_with_unsupported_os_distro if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_distro": "debian", "os_version": "10"}},
@@ -27,7 +29,7 @@ test_with_unsupported_os_distro {
 	count(results) == 1
 }
 
-test_with_unsupported_os_version {
+test_with_unsupported_os_version if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_distro": "rhel", "os_version": "6"}},
@@ -36,7 +38,7 @@ test_with_unsupported_os_version {
 	count(results) == 1
 }
 
-test_with_supported_rhel {
+test_with_supported_rhel if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_distro": "rhel", "os_version": "9"}},
@@ -45,7 +47,7 @@ test_with_supported_rhel {
 	count(results) == 0
 }
 
-test_with_supported_centos {
+test_with_supported_centos if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_distro": "centos", "os_version": "8-stream"}},
@@ -54,7 +56,7 @@ test_with_supported_centos {
 	count(results) == 0
 }
 
-test_with_supported_fedora {
+test_with_supported_fedora if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_distro": "fedora", "os_version": "38"}},
@@ -63,7 +65,7 @@ test_with_supported_fedora {
 	count(results) == 0
 }
 
-test_with_supported_windows {
+test_with_supported_windows if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"os_distro": "windows", "os_version": "10"}},

--- a/validation/policies/io/konveyor/forklift/openstack/vm_status.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vm_status.rego
@@ -1,20 +1,20 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
+import rego.v1
 
-default valid_status_string = false
+default valid_status_string := false
 
-default legal_vm_status = false
+default legal_vm_status := false
 
 valid_status_string if is_string(input.status)
 
 legal_vm_status if regex.match(`ACTIVE|SHUTOFF`, input.status)
 
-concerns[flag] {
+concerns contains flag if {
 	valid_status_string
 	not legal_vm_status
 	flag := {
-	    "id": "openstack.vm.status.invalid",
+		"id": "openstack.vm.status.invalid",
 		"category": "Critical",
 		"label": "VM has a status condition that may prevent successful migration",
 		"assessment": "The VM's status is not 'ACTIVE' or 'SHUTOFF'. Attempting to migrate this VM may fail.",

--- a/validation/policies/io/konveyor/forklift/openstack/vm_status_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vm_status_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_with_first_valid_status {
+import rego.v1
+
+test_with_first_valid_status if {
 	mock_vm := {
 		"name": "test",
 		"status": "ACTIVE",
@@ -9,7 +11,7 @@ test_with_first_valid_status {
 	count(results) == 0
 }
 
-test_with_second_valid_status {
+test_with_second_valid_status if {
 	mock_vm := {
 		"name": "test",
 		"status": "SHUTOFF",
@@ -18,7 +20,7 @@ test_with_second_valid_status {
 	count(results) == 0
 }
 
-test_with_invalid_status {
+test_with_invalid_status if {
 	mock_vm := {
 		"name": "test",
 		"status": "PAUSED",

--- a/validation/policies/io/konveyor/forklift/openstack/watchdog.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/watchdog.rego
@@ -1,18 +1,17 @@
 package io.konveyor.forklift.openstack
 
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
-default has_watchdog_enabled = false
+default has_watchdog_enabled := false
 
 has_watchdog_enabled if "hw:watchdog_action" in object.keys(input.flavor.extraSpecs)
 
 has_watchdog_enabled if input.image.properties.hw_watchdog_action
 
-concerns[flag] {
+concerns contains flag if {
 	has_watchdog_enabled
 	flag := {
-	    "id": "openstack.watchdog.detected",
+		"id": "openstack.watchdog.detected",
 		"category": "Warning",
 		"label": "Watchdog detected",
 		"assessment": "The VM is configured with a watchdog device, which is not currently supported by OpenShift Virtualization. A watchdog device will not be present in the destination VM.",

--- a/validation/policies/io/konveyor/forklift/openstack/watchdog_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/watchdog_test.rego
@@ -1,6 +1,8 @@
 package io.konveyor.forklift.openstack
 
-test_without_watchdog {
+import rego.v1
+
+test_without_watchdog if {
 	mock_vm := {
 		"name": "test",
 		"flavor": {"extraSpecs": {}},
@@ -10,7 +12,7 @@ test_without_watchdog {
 	count(results) == 0
 }
 
-test_with_flavor_watchdog {
+test_with_flavor_watchdog if {
 	mock_vm := {
 		"name": "test",
 		"flavor": {"extraSpecs": {"hw:watchdog_action": "reset"}},
@@ -19,7 +21,7 @@ test_with_flavor_watchdog {
 	count(results) == 1
 }
 
-test_with_image_watchdog {
+test_with_image_watchdog if {
 	mock_vm := {
 		"name": "test",
 		"image": {"properties": {"hw_watchdog_action": "reset"}},
@@ -28,7 +30,7 @@ test_with_image_watchdog {
 	count(results) == 1
 }
 
-test_with_flavor_and_image_watchdogs {
+test_with_flavor_and_image_watchdogs if {
 	mock_vm := {
 		"name": "test",
 		"flavor": {"extraSpecs": {"hw:watchdog_action": "reset"}},

--- a/validation/policies/io/konveyor/forklift/ova/cpu_affinity.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_affinity.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.ova
 
-has_cpu_affinity {
-    count(input.cpuAffinity) != 0
+import rego.v1
+
+has_cpu_affinity if {
+	count(input.cpuAffinity) != 0
 }
 
-concerns[flag] {
-    has_cpu_affinity
-    flag := {
-        "id": "ova.cpu_affinity.detected",
-        "category": "Warning",
-        "label": "CPU affinity detected",
-        "assessment": "The VM will be migrated without CPU affinity, but administrators can set it after migration."
-    }
+concerns contains flag if {
+	has_cpu_affinity
+	flag := {
+		"id": "ova.cpu_affinity.detected",
+		"category": "Warning",
+		"label": "CPU affinity detected",
+		"assessment": "The VM will be migrated without CPU affinity, but administrators can set it after migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ova/cpu_affinity_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_affinity_test.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.ova
- 
-test_without_cpu_affinity {
-    mock_vm := { "name": "test", "cpuAffinity": [] }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_cpu_affinity if {
+	mock_vm := {"name": "test", "cpuAffinity": []}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_cpu_affinity {
-    mock_vm := { "name": "test", "cpuAffinity": [0,2] }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_cpu_affinity if {
+	mock_vm := {"name": "test", "cpuAffinity": [0, 2]}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug.rego
@@ -1,25 +1,27 @@
 package io.konveyor.forklift.ova
 
-default has_hotplug_enabled = false
+import rego.v1
 
-has_hotplug_enabled = true {
-    input.cpuHotAddEnabled == true
+default has_hotplug_enabled := false
+
+has_hotplug_enabled if {
+	input.cpuHotAddEnabled == true
 }
 
-has_hotplug_enabled = true {
-    input.cpuHotRemoveEnabled == true
+has_hotplug_enabled if {
+	input.cpuHotRemoveEnabled == true
 }
 
-has_hotplug_enabled = true {
-    input.memoryHotAddEnabled == true
+has_hotplug_enabled if {
+	input.memoryHotAddEnabled == true
 }
 
-concerns[flag] {
-    has_hotplug_enabled
-    flag := {
-        "id": "ova.cpu_memory.hotplug.enabled",
-        "category": "Warning",
-        "label": "CPU/Memory hotplug detected",
-        "assessment": "Hot pluggable CPU or memory is not currently supported by Migration Toolkit for Virtualization. You can reconfigure CPU or memory after migration."
-    }
+concerns contains flag if {
+	has_hotplug_enabled
+	flag := {
+		"id": "ova.cpu_memory.hotplug.enabled",
+		"category": "Warning",
+		"label": "CPU/Memory hotplug detected",
+		"assessment": "Hot pluggable CPU or memory is not currently supported by Migration Toolkit for Virtualization. You can reconfigure CPU or memory after migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/cpu_memory_hotplug_test.rego
@@ -1,45 +1,47 @@
 package io.konveyor.forklift.ova
 
-test_with_hotplug_disabled {
-    mock_vm := {
-        "name": "test",
-        "cpuHotAddEnabled": false,
-        "cpuHotRemoveEnabled": false,
-        "memoryHotAddEnabled": false
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_hotplug_disabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuHotAddEnabled": false,
+		"cpuHotRemoveEnabled": false,
+		"memoryHotAddEnabled": false,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_cpu_hot_add_enabled {
-    mock_vm := {
-        "name": "test",
-        "cpuHotAddEnabled": true,
-        "cpuHotRemoveEnabled": false,
-        "memoryHotAddEnabled": false
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_cpu_hot_add_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuHotAddEnabled": true,
+		"cpuHotRemoveEnabled": false,
+		"memoryHotAddEnabled": false,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_cpu_hot_remove_enabled {
-    mock_vm := {
-        "name": "test",
-        "cpuHotAddEnabled": false,
-        "cpuHotRemoveEnabled": true,
-        "memoryHotAddEnabled": false
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_cpu_hot_remove_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuHotAddEnabled": false,
+		"cpuHotRemoveEnabled": true,
+		"memoryHotAddEnabled": false,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_memory_hot_add_enabled {
-    mock_vm := {
-        "name": "test",
-        "cpuHotAddEnabled": false,
-        "cpuHotRemoveEnabled": false,
-        "memoryHotAddEnabled": true
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_memory_hot_add_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuHotAddEnabled": false,
+		"cpuHotRemoveEnabled": false,
+		"memoryHotAddEnabled": true,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ova/debug.rego
+++ b/validation/policies/io/konveyor/forklift/ova/debug.rego
@@ -1,5 +1,7 @@
 package io.konveyor.forklift.ova
 
-debug {
+import rego.v1
+
+debug if {
 	trace(sprintf("** debug ** vm name: %v", [input.name]))
 }

--- a/validation/policies/io/konveyor/forklift/ova/disk_size.rego
+++ b/validation/policies/io/konveyor/forklift/ova/disk_size.rego
@@ -1,20 +1,21 @@
 package io.konveyor.forklift.ova
-import future.keywords.in
+
+import rego.v1
 
 # Match any disk with zero or negative capacity
-invalid_disks[idx] {
-    some idx
-    input.disks[idx].capacity <= 0
+invalid_disks contains idx if {
+	some idx
+	input.disks[idx].capacity <= 0
 }
 
 # Raise a concern for each invalid disk
-concerns[flag] {
-    invalid_disks[idx]
-    disk := input.disks[idx]
-    flag := {
-        "id": "ova.disk.capacity.invalid",
-        "category": "Critical", 
-        "label": sprintf("Disk '%v' has an invalid capacity of %v bytes", [disk.filePath, disk.capacity]),
-        "assessment": sprintf("Disk '%v' has a capacity of %v bytes, which is not allowed. Capacity must be greater than zero.", [disk.filePath, disk.capacity])
-    }
-} 
+concerns contains flag if {
+	invalid_disks[idx]
+	disk := input.disks[idx]
+	flag := {
+		"id": "ova.disk.capacity.invalid",
+		"category": "Critical",
+		"label": sprintf("Disk '%v' has an invalid capacity of %v bytes", [disk.filePath, disk.capacity]),
+		"assessment": sprintf("Disk '%v' has a capacity of %v bytes, which is not allowed. Capacity must be greater than zero.", [disk.filePath, disk.capacity]),
+	}
+}

--- a/validation/policies/io/konveyor/forklift/ova/disk_size_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/disk_size_test.rego
@@ -1,47 +1,36 @@
 package io.konveyor.forklift.ova
-import future.keywords.in
 
-test_invalid_capacity_zero {
-    input := {
-        "disks": [
-            {
-                "filePath": "disk1.vmdk",
-                "capacity": 0,
-                "format": "vmdk"
-            }
-        ]
-    }
+import rego.v1
 
-    results := concerns with input as input
-    count(results) == 1
+test_invalid_capacity_zero if {
+	test_input := {"disks": [{
+		"filePath": "disk1.vmdk",
+		"capacity": 0,
+		"format": "vmdk",
+	}]}
+
+	results := concerns with input as test_input
+	count(results) == 1
 }
 
-test_invalid_capacity_negative {
-    input := {
-        "disks": [
-            {
-                "filePath": "disk2.vmdk",
-                "capacity": -1024,
-                "format": "vmdk"
-            }
-        ]
-    }
+test_invalid_capacity_negative if {
+	test_input := {"disks": [{
+		"filePath": "disk2.vmdk",
+		"capacity": -1024,
+		"format": "vmdk",
+	}]}
 
-    results := concerns with input as input
-    count(results) == 1
+	results := concerns with input as test_input
+	count(results) == 1
 }
 
-test_valid_capacity {
-    input := {
-        "disks": [
-            {
-                "filePath": "disk3.vmdk", 
-                "capacity": 17179869184,
-                "format": "vmdk"
-            }
-        ]
-    }
+test_valid_capacity if {
+	test_input := {"disks": [{
+		"filePath": "disk3.vmdk",
+		"capacity": 17179869184,
+		"format": "vmdk",
+	}]}
 
-    results := concerns with input as input
-    count(results) == 0
-} 
+	results := concerns with input as test_input
+	count(results) == 0
+}

--- a/validation/policies/io/konveyor/forklift/ova/export_source.rego
+++ b/validation/policies/io/konveyor/forklift/ova/export_source.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.ova
 
-unsupported_export_source {
-    input.ovaSource != "VMware"
+import rego.v1
+
+unsupported_export_source if {
+	input.ovaSource != "VMware"
 }
 
-concerns[flag] {
-    unsupported_export_source
-    flag := {
-        "id": "ova.source.unsupported",
-        "category": "Warning",
-        "label": "Unsupported OVA source",
-        "assessment": "This OVA may not have been exported from a VMware source, and may have issues during import."
-    }
+concerns contains flag if {
+	unsupported_export_source
+	flag := {
+		"id": "ova.source.unsupported",
+		"category": "Warning",
+		"label": "Unsupported OVA source",
+		"assessment": "This OVA may not have been exported from a VMware source, and may have issues during import.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ova/export_source_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/export_source_test.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.ova
 
-test_with_unsupported_source {
-    mock_vm := { "name": "test", "ovaSource": "Unknown" }
-    results = concerns with input as mock_vm
-    count(results) == 1
+import rego.v1
+
+test_with_unsupported_source if {
+	mock_vm := {"name": "test", "ovaSource": "Unknown"}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_supported_source {
-    mock_vm := { "name": "test", "ovaSource": "VMware" }
-    results = concerns with input as mock_vm
-    count(results) == 0
+test_with_supported_source if {
+	mock_vm := {"name": "test", "ovaSource": "VMware"}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }

--- a/validation/policies/io/konveyor/forklift/ova/name.rego
+++ b/validation/policies/io/konveyor/forklift/ova/name.rego
@@ -1,30 +1,34 @@
 package io.konveyor.forklift.ova
 
-default valid_input   = true
-default valid_vm      = false
-default valid_vm_name = false
+import rego.v1
 
-valid_input = false {
-    is_null(input)
+default valid_input := true
+
+default valid_vm := false
+
+default valid_vm_name := false
+
+valid_input := false if {
+	is_null(input)
 }
 
-valid_vm = true {
-    is_string(input.name)
+valid_vm if {
+	is_string(input.name)
 }
 
-valid_vm_name = true {
-    regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
-    count(input.name) < 64
+valid_vm_name if {
+	regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
+	count(input.name) < 64
 }
 
-concerns[flag] {
-    valid_input
-    valid_vm
-    not valid_vm_name
-    flag := {
-        "id": "ova.name.invalid",
-        "category": "Warning",
-        "label": "Invalid VM Name",
-        "assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters."
-    }
+concerns contains flag if {
+	valid_input
+	valid_vm
+	not valid_vm_name
+	flag := {
+		"id": "ova.name.invalid",
+		"category": "Warning",
+		"label": "Invalid VM Name",
+		"assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ova/name_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/name_test.rego
@@ -1,25 +1,27 @@
 package io.konveyor.forklift.ova
 
-test_valid_vm_name {
-    mock_vm := { "name": "test" }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_valid_vm_name if {
+	mock_vm := {"name": "test"}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_vm_name_too_long {
-    mock_vm := { "name": "my-vm-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_vm_name_too_long if {
+	mock_vm := {"name": "my-vm-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_vm_name_invalid_char_underscore {
-    mock_vm := { "name": "my_vm" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_vm_name_invalid_char_underscore if {
+	mock_vm := {"name": "my_vm"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_vm_name_invalid_char_slash {
-    mock_vm := { "name": "my/vm" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_vm_name_invalid_char_slash if {
+	mock_vm := {"name": "my/vm"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ova/rules_version.rego
+++ b/validation/policies/io/konveyor/forklift/ova/rules_version.rego
@@ -1,7 +1,7 @@
 package io.konveyor.forklift.ova
 
+import rego.v1
+
 RULES_VERSION := 5
 
-rules_version = {
-    "rules_version": RULES_VERSION
-}
+rules_version := {"rules_version": RULES_VERSION}

--- a/validation/policies/io/konveyor/forklift/ova/validate.rego
+++ b/validation/policies/io/konveyor/forklift/ova/validate.rego
@@ -1,12 +1,14 @@
 package io.konveyor.forklift.ova
 
-validate = {
-    "rules_version": RULES_VERSION,
-    "errors": errors,
-    "concerns": concerns
+import rego.v1
+
+validate := {
+	"rules_version": RULES_VERSION,
+	"errors": errors,
+	"concerns": concerns,
 }
 
-errors[message] {
-    not valid_vm
-    message := "No VM name found in input body"
+errors contains message if {
+	not valid_vm
+	message := "No VM name found in input body"
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/ballooned_memory.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ballooned_memory.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_ballooned_memory = false
+import rego.v1
 
-has_ballooned_memory = value {
-    value := input.balloonedMemory
+default has_ballooned_memory := false
+
+has_ballooned_memory := value if {
+	value := input.balloonedMemory
 }
 
-concerns[flag] {
-    has_ballooned_memory
-    flag := {
-        "id": "ovirt.memory.ballooning.enabled",
-        "category": "Information",
-        "label": "VM has memory ballooning enabled",
-        "assessment": "The VM has memory ballooning enabled. This is not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	has_ballooned_memory
+	flag := {
+		"id": "ovirt.memory.ballooning.enabled",
+		"category": "Information",
+		"label": "VM has memory ballooning enabled",
+		"assessment": "The VM has memory ballooning enabled. This is not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/ballooned_memory_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ballooned_memory_test.rego
@@ -1,17 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_ballooned_memory {
-    mock_vm := { "name": "test",
-                 "balloonedMemory": false
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_ballooned_memory if {
+	mock_vm := {
+		"name": "test",
+		"balloonedMemory": false,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_ballooned_memory {
-    mock_vm := { "name": "test",
-                 "balloonedMemory": true
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_ballooned_memory if {
+	mock_vm := {
+		"name": "test",
+		"balloonedMemory": true,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/bios_boot_menu.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/bios_boot_menu.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_boot_menu_enabled = false
+import rego.v1
 
-has_boot_menu_enabled = value {
-    value := input.bootMenuEnabled
+default has_boot_menu_enabled := false
+
+has_boot_menu_enabled := value if {
+	value := input.bootMenuEnabled
 }
 
-concerns[flag] {
-    has_boot_menu_enabled
-    flag := {
-        "id": "ovirt.bios.boot_menu.enabled",
-        "category": "Warning",
-        "label": "VM has BIOS boot menu enabled",
-        "assessment": "The VM has a BIOS boot menu enabled. This is not currently supported by OpenShift Virtualization. The VM can be migrated but the BIOS boot menu will not be enabled in the target environment."
-    }
+concerns contains flag if {
+	has_boot_menu_enabled
+	flag := {
+		"id": "ovirt.bios.boot_menu.enabled",
+		"category": "Warning",
+		"label": "VM has BIOS boot menu enabled",
+		"assessment": "The VM has a BIOS boot menu enabled. This is not currently supported by OpenShift Virtualization. The VM can be migrated but the BIOS boot menu will not be enabled in the target environment.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/bios_boot_menu_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/bios_boot_menu_test.rego
@@ -1,17 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_boot_menu_enabled {
-    mock_vm := {  "name": "test",
-                  "bootMenuEnabled" : false
-               }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_boot_menu_enabled if {
+	mock_vm := {
+		"name": "test",
+		"bootMenuEnabled": false,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_boot_menu_enabled {
-    mock_vm := {  "name": "test",
-                  "bootMenuEnabled" : true
-               }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_boot_menu_enabled if {
+	mock_vm := {
+		"name": "test",
+		"bootMenuEnabled": true,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_custom_model.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_custom_model.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default custom_cpu_model = false
+import rego.v1
 
-custom_cpu_model = true {
-    count(input.customCpuModel) != 0
+default custom_cpu_model := false
+
+custom_cpu_model if {
+	count(input.customCpuModel) != 0
 }
 
-concerns[flag] {
-    custom_cpu_model
-    flag := {
-        "id": "ovirt.cpu.custom_model.detected",
-        "category": "Warning",
-        "label": "Custom CPU Model detected",
-        "assessment": "The VM is configured with a custom CPU model. This configuration will apply to the migrated VM and may not be supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	custom_cpu_model
+	flag := {
+		"id": "ovirt.cpu.custom_model.detected",
+		"category": "Warning",
+		"label": "Custom CPU Model detected",
+		"assessment": "The VM is configured with a custom CPU model. This configuration will apply to the migrated VM and may not be supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_custom_model_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_custom_model_test.rego
@@ -1,15 +1,18 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_customcpu {
-    mock_vm := { "name": "test" }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_customcpu if {
+	mock_vm := {"name": "test"}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_customcpu {
-    mock_vm := { "name": "test",
-                 "customCpuModel": "Icelake-Server-noTSX,-mpx"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_customcpu if {
+	mock_vm := {
+		"name": "test",
+		"customCpuModel": "Icelake-Server-noTSX,-mpx",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_policy.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_policy.rego
@@ -1,18 +1,20 @@
 package io.konveyor.forklift.ovirt
 
-default not_supported_cpu_policy = false
+import rego.v1
+
+default not_supported_cpu_policy := false
 
 # no need to check for 'manual' pinning policy because 'cpuAffinity' is validated by the 'cpu_tune' policy
-not_supported_cpu_policy = true {
-    regex.match(`resize_and_pin_numa|isolate_threads`, input.cpuPinningPolicy)
+not_supported_cpu_policy if {
+	regex.match(`resize_and_pin_numa|isolate_threads`, input.cpuPinningPolicy)
 }
 
-concerns[flag] {
-    not_supported_cpu_policy
-    flag := {
-        "id": "ovirt.cpu.pinning_policy.unsupported",
-        "category": "Warning",
-        "label": "Unsupported CPU pinning policy detected",
-        "assessment": "Resize and Pin NUMA and Isolated Threads are not supported by OpenShift Virtualization. Some functionality may be missing after the VM is migrated."
-    }
+concerns contains flag if {
+	not_supported_cpu_policy
+	flag := {
+		"id": "ovirt.cpu.pinning_policy.unsupported",
+		"category": "Warning",
+		"label": "Unsupported CPU pinning policy detected",
+		"assessment": "Resize and Pin NUMA and Isolated Threads are not supported by OpenShift Virtualization. Some functionality may be missing after the VM is migrated.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_policy_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_policy_test.rego
@@ -1,47 +1,49 @@
 package io.konveyor.forklift.ovirt
 
-test_with_none {
-    mock_vm := {
-        "name": "test",
-        "cpuPinningPolicy": "none"
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_none if {
+	mock_vm := {
+		"name": "test",
+		"cpuPinningPolicy": "none",
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_dedicated {
-    mock_vm := {
-        "name": "test",
-        "cpuPinningPolicy": "dedicated"
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_dedicated if {
+	mock_vm := {
+		"name": "test",
+		"cpuPinningPolicy": "dedicated",
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_manual {
-    mock_vm := {
-        "name": "test",
-        "cpuPinningPolicy": "manual",
-        "cpuAffinity": [0,2]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_manual if {
+	mock_vm := {
+		"name": "test",
+		"cpuPinningPolicy": "manual",
+		"cpuAffinity": [0, 2],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_resize_and_pin_numa {
-    mock_vm := {
-        "name": "test",
-        "cpuPinningPolicy": "resize_and_pin_numa"
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_resize_and_pin_numa if {
+	mock_vm := {
+		"name": "test",
+		"cpuPinningPolicy": "resize_and_pin_numa",
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_isolate_threads {
-    mock_vm := {
-        "name": "test",
-        "cpuPinningPolicy": "isolate_threads"
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_isolate_threads if {
+	mock_vm := {
+		"name": "test",
+		"cpuPinningPolicy": "isolate_threads",
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_shares.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_shares.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_cpushares_enabled = false
+import rego.v1
 
-has_cpushares_enabled = true {
-    input.cpuShares > 0
+default has_cpushares_enabled := false
+
+has_cpushares_enabled if {
+	input.cpuShares > 0
 }
 
-concerns[flag] {
-    has_cpushares_enabled
-    flag := {
-        "id": "ovirt.cpu.shares.defined",
-        "category": "Warning",
-        "label": "VM has CPU Shares Defined",
-        "assessment": "The VM has CPU shares defined. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but the CPU shares configuration will be missing in the target environment."
-    }
+concerns contains flag if {
+	has_cpushares_enabled
+	flag := {
+		"id": "ovirt.cpu.shares.defined",
+		"category": "Warning",
+		"label": "VM has CPU Shares Defined",
+		"assessment": "The VM has CPU shares defined. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but the CPU shares configuration will be missing in the target environment.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_shares_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_shares_test.rego
@@ -1,17 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_cpushares_enabled {
-    mock_vm := { "name": "test",
-                 "cpuShares": 0
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_cpushares_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuShares": 0,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_cpushares_enabled {
-    mock_vm := { "name": "test",
-                 "cpuShares": 3
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_cpushares_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuShares": 3,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_tune.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_tune.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_cpu_affinity = false
+import rego.v1
 
-has_cpu_affinity = true {
-    count(input.cpuAffinity) != 0
+default has_cpu_affinity := false
+
+has_cpu_affinity if {
+	count(input.cpuAffinity) != 0
 }
 
-concerns[flag] {
-    has_cpu_affinity
-    flag := {
-        "id": "ovirt.cpu.tuning.detected",
-        "category": "Warning",
-        "label": "CPU tuning detected",
-        "assessment": "CPU tuning other than 1 vCPU - 1 pCPU is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment."
-    }
+concerns contains flag if {
+	has_cpu_affinity
+	flag := {
+		"id": "ovirt.cpu.tuning.detected",
+		"category": "Warning",
+		"label": "CPU tuning detected",
+		"assessment": "CPU tuning other than 1 vCPU - 1 pCPU is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/cpu_tune_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/cpu_tune_test.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_cpu_affinity {
-    mock_vm := { "name": "test", "cpuAffinity": [] }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_cpu_affinity if {
+	mock_vm := {"name": "test", "cpuAffinity": []}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_cpu_affinity {
-    mock_vm := { "name": "test", "cpuAffinity": [0,2] }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_cpu_affinity if {
+	mock_vm := {"name": "test", "cpuAffinity": [0, 2]}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/custom_properties.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/custom_properties.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default vm_has_custom_properties = false
+import rego.v1
 
-vm_has_custom_properties = true {
-    count(input.properties) != 0
+default vm_has_custom_properties := false
+
+vm_has_custom_properties if {
+	count(input.properties) != 0
 }
 
-concerns[flag] {
-    vm_has_custom_properties
-    flag := {
-        "id": "ovirt.vm.custom_properties.detected",
-        "category": "Warning",
-        "label": "VM custom properties detected",
-        "assessment": "The VM is configured with custom properties, which are not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	vm_has_custom_properties
+	flag := {
+		"id": "ovirt.vm.custom_properties.detected",
+		"category": "Warning",
+		"label": "VM custom properties detected",
+		"assessment": "The VM is configured with custom properties, which are not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/custom_properties_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/custom_properties_test.rego
@@ -1,22 +1,24 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_vm_custom_properties {
-    mock_vm := { "name": "test",
-                 "properties": []
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_vm_custom_properties if {
+	mock_vm := {
+		"name": "test",
+		"properties": [],
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_vm_custom_properties {
-    mock_vm := { "name": "test",
-                 "properties": [
-                    {
-                        "name": "viodiskcache",
-                        "value": "writeback"
-                    }
-                  ]
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_vm_custom_properties if {
+	mock_vm := {
+		"name": "test",
+		"properties": [{
+			"name": "viodiskcache",
+			"value": "writeback",
+		}],
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/debug.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/debug.rego
@@ -1,5 +1,7 @@
 package io.konveyor.forklift.ovirt
 
-debug {
+import rego.v1
+
+debug if {
 	trace(sprintf("** debug ** vm name: %v", [input.name]))
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_interface_type.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_interface_type.rego
@@ -1,21 +1,23 @@
 package io.konveyor.forklift.ovirt
 
-valid_disk_interfaces [i] {
-    some i
-    regex.match(`sata|virtio_scsi|virtio`, input.diskAttachments[i].interface)
+import rego.v1
+
+valid_disk_interfaces contains i if {
+	some i
+	regex.match(`sata|virtio_scsi|virtio`, input.diskAttachments[i].interface)
 }
 
-number_of_disks [i] {
-    some i
-    input.diskAttachments[i].id
+number_of_disks contains i if {
+	some i
+	input.diskAttachments[i].id
 }
 
-concerns[flag] {
-    count(valid_disk_interfaces) != count(number_of_disks)
-    flag := {
-        "id": "ovirt.disk.interface_type.unsupported",
-        "category": "Warning",
-        "label": "Unsupported disk interface type detected",
-        "assessment": "The disk interface type is not supported by OpenShift Virtualization (only sata, virtio_scsi and virtio interface types are currently supported). The migrated VM will be given a virtio disk interface type."
-    }
+concerns contains flag if {
+	count(valid_disk_interfaces) != count(number_of_disks)
+	flag := {
+		"id": "ovirt.disk.interface_type.unsupported",
+		"category": "Warning",
+		"label": "Unsupported disk interface type detected",
+		"assessment": "The disk interface type is not supported by OpenShift Virtualization (only sata, virtio_scsi and virtio interface types are currently supported). The migrated VM will be given a virtio disk interface type.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_interface_type_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_interface_type_test.rego
@@ -1,86 +1,79 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # These tests have both interface, disk.storageType & disk.status included to satisfy the disk_storage_type, disk_status and disk_interface_type tests
 # diskAttachmennt.id is included to satisfy the number_of_disks rule in disk_interface_type.rego
 
-test_with_first_valid_disk_interface_type {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "sata",
-              "disk":
-                { "storageType": "image",
-                  "status": "ok"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_first_valid_disk_interface_type if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{
+			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+			"interface": "sata",
+			"disk": {
+				"storageType": "image",
+				"status": "ok",
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_second_valid_disk_interface_type {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "virtio_scsi",
-              "disk":
-                { "storageType": "image",
-                  "status": "ok"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_second_valid_disk_interface_type if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{
+			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+			"interface": "virtio_scsi",
+			"disk": {
+				"storageType": "image",
+				"status": "ok",
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_third_valid_disk_interface_type {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "virtio",
-              "disk":
-                { "storageType": "image",
-                  "status": "ok"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_third_valid_disk_interface_type if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{
+			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+			"interface": "virtio",
+			"disk": {
+				"storageType": "image",
+				"status": "ok",
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_invalid_disk_interface_type {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "virtio_scsi",
-              "disk":
-                { "storageType": "image" }
-            },
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e22",
-              "interface": "raw",
-              "disk":
-                { "storageType": "image" }
-            },
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e23",
-              "interface": "virtio",
-              "disk":
-                { "storageType": "image" }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_invalid_disk_interface_type if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [
+			{
+				"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+				"interface": "virtio_scsi",
+				"disk": {"storageType": "image"},
+			},
+			{
+				"id": "b749c132-bb97-4145-b86e-a1751cf75e22",
+				"interface": "raw",
+				"disk": {"storageType": "image"},
+			},
+			{
+				"id": "b749c132-bb97-4145-b86e-a1751cf75e23",
+				"interface": "virtio",
+				"disk": {"storageType": "image"},
+			},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_size.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_size.rego
@@ -1,20 +1,21 @@
 package io.konveyor.forklift.ovirt
-import future.keywords.in
+
+import rego.v1
 
 # Match any disk with zero or negative provisioned size
-invalid_disks[idx] {
-    some idx
-    input.diskAttachments[idx].disk.provisionedSize <= 0
+invalid_disks contains idx if {
+	some idx
+	input.diskAttachments[idx].disk.provisionedSize <= 0
 }
 
 # Raise a concern for each invalid disk
-concerns[flag] {
-    invalid_disks[idx]
-    disk := input.diskAttachments[idx].disk
-    flag := {
-        "id": "ovirt.disk.capacity.invalid",
-        "category": "Critical",
-        "label": sprintf("Disk has an invalid capacity of %v bytes", [disk.provisionedSize]),
-        "assessment": sprintf("Disk has a provisioned size of %v bytes, which is not allowed. Capacity must be greater than zero.", [disk.provisionedSize])
-    }
-} 
+concerns contains flag if {
+	invalid_disks[idx]
+	disk := input.diskAttachments[idx].disk
+	flag := {
+		"id": "ovirt.disk.capacity.invalid",
+		"category": "Critical",
+		"label": sprintf("Disk has an invalid capacity of %v bytes", [disk.provisionedSize]),
+		"assessment": sprintf("Disk has a provisioned size of %v bytes, which is not allowed. Capacity must be greater than zero.", [disk.provisionedSize]),
+	}
+}

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_size_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_size_test.rego
@@ -1,59 +1,48 @@
 package io.konveyor.forklift.ovirt
-import future.keywords.in
 
-test_invalid_capacity_zero {
-    input := {
-        "diskAttachments": [
-            {
-                "id": "disk1-id",
-                "interface": "sata",
-                "disk": {
-                    "storageType": "image",
-                    "status": "ok",
-                    "provisionedSize": 0
-                }
-            }
-        ]
-    }
+import rego.v1
 
-    results := concerns with input as input
-    count(results) == 1
+test_invalid_capacity_zero if {
+	test_input := {"diskAttachments": [{
+		"id": "disk1-id",
+		"interface": "sata",
+		"disk": {
+			"storageType": "image",
+			"status": "ok",
+			"provisionedSize": 0,
+		},
+	}]}
+
+	results := concerns with input as test_input
+	count(results) == 1
 }
 
-test_invalid_capacity_negative {
-    input := {
-        "diskAttachments": [
-            {
-                "id": "disk2-id", 
-                "interface": "sata",
-                "disk": {
-                    "storageType": "image",
-                    "status": "ok",
-                    "provisionedSize": -1024
-                }
-            }
-        ]
-    }
+test_invalid_capacity_negative if {
+	test_input := {"diskAttachments": [{
+		"id": "disk2-id",
+		"interface": "sata",
+		"disk": {
+			"storageType": "image",
+			"status": "ok",
+			"provisionedSize": -1024,
+		},
+	}]}
 
-    results := concerns with input as input
-    count(results) == 1
+	results := concerns with input as test_input
+	count(results) == 1
 }
 
-test_valid_capacity {
-    input := {
-        "diskAttachments": [
-            {
-                "id": "disk3-id",
-                "interface": "sata", 
-                "disk": {
-                    "storageType": "image",
-                    "status": "ok",
-                    "provisionedSize": 17179869184
-                }
-            }
-        ]
-    }
+test_valid_capacity if {
+	test_input := {"diskAttachments": [{
+		"id": "disk3-id",
+		"interface": "sata",
+		"disk": {
+			"storageType": "image",
+			"status": "ok",
+			"provisionedSize": 17179869184,
+		},
+	}]}
 
-    results := concerns with input as input
-    count(results) == 0
-} 
+	results := concerns with input as test_input
+	count(results) == 0
+}

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_status.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_status.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.ovirt
 
-invalid_disk_status [i] {
-    some i
-    regex.match(`illegal|locked`, input.diskAttachments[i].disk.status)
+import rego.v1
+
+invalid_disk_status contains i if {
+	some i
+	regex.match(`illegal|locked`, input.diskAttachments[i].disk.status)
 }
 
-concerns[flag] {
-    count(invalid_disk_status) > 0
-    flag := {
-        "id": "ovirt.disk.illegal_or_locked_status",
-        "category": "Critical",
-        "label": "VM has an illegal or locked disk status condition",
-        "assessment": "One or more of the VM's disks has an illegal or locked status condition. The VM disk transfer is likely to fail."
-    }
+concerns contains flag if {
+	count(invalid_disk_status) > 0
+	flag := {
+		"id": "ovirt.disk.illegal_or_locked_status",
+		"category": "Critical",
+		"label": "VM has an illegal or locked disk status condition",
+		"assessment": "One or more of the VM's disks has an illegal or locked status condition. The VM disk transfer is likely to fail.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_status_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_status_test.rego
@@ -1,58 +1,54 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # These tests have both interface, disk.storageType & disk.status included to satisfy the disk_storage_type, disk_status and disk_interface_type tests
 # diskAttachmennt.id is included to satisfy the number_of_disks rule in disk_interface_type.rego
 
-test_with_valid_disk_status {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "sata",
-              "disk":
-                { "storageType": "image",
-                  "status": "ok"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_valid_disk_status if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{
+			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+			"interface": "sata",
+			"disk": {
+				"storageType": "image",
+				"status": "ok",
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_first_invalid_disk_status {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "sata",
-              "disk":
-                { "storageType": "image",
-                  "status": "locked"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_first_invalid_disk_status if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{
+			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+			"interface": "sata",
+			"disk": {
+				"storageType": "image",
+				"status": "locked",
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_second_invalid_disk_status {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "sata",
-              "disk":
-                { "storageType": "image",
-                  "status": "illegal"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_second_invalid_disk_status if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{
+			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+			"interface": "sata",
+			"disk": {
+				"storageType": "image",
+				"status": "illegal",
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type.rego
@@ -1,21 +1,23 @@
 package io.konveyor.forklift.ovirt
 
-valid_disk_storage_type [i] {
-    some i
-    input.diskAttachments[i].disk.storageType == "image"
+import rego.v1
+
+valid_disk_storage_type contains i if {
+	some i
+	input.diskAttachments[i].disk.storageType == "image"
 }
 
-valid_disk_storage_type_lun [i] {
-    some i
-    input.diskAttachments[i].disk.storageType == "lun"
+valid_disk_storage_type_lun contains i if {
+	some i
+	input.diskAttachments[i].disk.storageType == "lun"
 }
 
-concerns[flag] {
-    count(valid_disk_storage_type) + count(valid_disk_storage_type_lun) != count(number_of_disks)
-    flag := {
-        "id": "ovirt.disk.storage_type.unsupported",
-        "category": "Critical",
-        "label": "Unsupported disk storage type detected",
-        "assessment": "The VM has a disk with a storage type other than 'image' or 'lun', which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."
-    }
+concerns contains flag if {
+	count(valid_disk_storage_type) + count(valid_disk_storage_type_lun) != count(number_of_disks)
+	flag := {
+		"id": "ovirt.disk.storage_type.unsupported",
+		"category": "Critical",
+		"label": "Unsupported disk storage type detected",
+		"assessment": "The VM has a disk with a storage type other than 'image' or 'lun', which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_storage_type_test.rego
@@ -1,66 +1,64 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # These tests have both interface, disk.storageType & disk.status included to satisfy the disk_storage_type, disk_status and disk_interface_type tests
 # diskAttachmennt.id is included to satisfy the number_of_disks rule in disk_interface_type.rego
 
-test_with_valid_storage_type {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "virtio_scsi",
-              "disk":
-                { "storageType": "image",
-                  "status": "ok"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_valid_storage_type if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{
+			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+			"interface": "virtio_scsi",
+			"disk": {
+				"storageType": "image",
+				"status": "ok",
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_invalid_storage_type {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "virtio_scsi",
-              "disk":
-                { "storageType": "image",
-                  "status": "ok"
-                }
-            },
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e22",
-              "interface": "virtio_scsi",
-              "disk":
-                { "storageType": "raw",
-                  "status": "ok"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_invalid_storage_type if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [
+			{
+				"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+				"interface": "virtio_scsi",
+				"disk": {
+					"storageType": "image",
+					"status": "ok",
+				},
+			},
+			{
+				"id": "b749c132-bb97-4145-b86e-a1751cf75e22",
+				"interface": "virtio_scsi",
+				"disk": {
+					"storageType": "raw",
+					"status": "ok",
+				},
+			},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_valid_lun_storage_type {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            {
-              "id": "b749c132-bb97-4145-b86e-a1751cf75e21",
-              "interface": "virtio_scsi",
-              "disk":
-                { "storageType": "lun",
-                  "status": "ok"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_valid_lun_storage_type if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{
+			"id": "b749c132-bb97-4145-b86e-a1751cf75e21",
+			"interface": "virtio_scsi",
+			"disk": {
+				"storageType": "lun",
+				"status": "ok",
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/display_type.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/display_type.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_spice_display_enabled = false
+import rego.v1
 
-has_spice_display_enabled = true {
-    input.display == "spice"
+default has_spice_display_enabled := false
+
+has_spice_display_enabled if {
+	input.display == "spice"
 }
 
-concerns[flag] {
-    has_spice_display_enabled
-    flag := {
-        "id": "ovirt.display_type.spice.enabled",
-        "category": "Information",
-        "label": "VM Display Type",
-        "assessment": "The VM is using the SPICE protocol for video display. This is not supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	has_spice_display_enabled
+	flag := {
+		"id": "ovirt.display_type.spice.enabled",
+		"category": "Information",
+		"label": "VM Display Type",
+		"assessment": "The VM is using the SPICE protocol for video display. This is not supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/display_type_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/display_type_test.rego
@@ -1,17 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_spice_enabled {
-    mock_vm := { "name": "test",
-                 "display": "vnc"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_spice_enabled if {
+	mock_vm := {
+		"name": "test",
+		"display": "vnc",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_spice_enabled {
-    mock_vm := { "name": "test",
-                 "display": "spice"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_spice_enabled if {
+	mock_vm := {
+		"name": "test",
+		"display": "spice",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/ha.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ha.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_ha_enabled = false
+import rego.v1
 
-has_ha_enabled = value {
-   value :=  input.haEnabled
+default has_ha_enabled := false
+
+has_ha_enabled := value if {
+	value := input.haEnabled
 }
 
-concerns[flag] {
-    has_ha_enabled
-    flag := {
-        "id": "ovirt.ha.enabled",
-        "category": "Warning",
-        "label": "VM configured as HA",
-        "assessment": "The VM is configured to be highly available. High availability is not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	has_ha_enabled
+	flag := {
+		"id": "ovirt.ha.enabled",
+		"category": "Warning",
+		"label": "VM configured as HA",
+		"assessment": "The VM is configured to be highly available. High availability is not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/ha_reservation.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ha_reservation.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_ha_reservation = false
+import rego.v1
 
-has_ha_reservation = value {
-    value := input.cluster.haReservation
+default has_ha_reservation := false
+
+has_ha_reservation := value if {
+	value := input.cluster.haReservation
 }
 
-concerns[flag] {
-    has_ha_reservation
-    flag := {
-        "id": "ovirt.ha.reservation.enabled",
-        "category": "Warning",
-        "label": "Cluster has HA reservation",
-        "assessment": "The cluster running the source VM has a resource reservation to allow highly available VMs to be started. This feature is not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	has_ha_reservation
+	flag := {
+		"id": "ovirt.ha.reservation.enabled",
+		"category": "Warning",
+		"label": "Cluster has HA reservation",
+		"assessment": "The cluster running the source VM has a resource reservation to allow highly available VMs to be started. This feature is not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/ha_reservation_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ha_reservation_test.rego
@@ -1,21 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_ha_reservation {
-    mock_vm := { "name": "test",
-                  "cluster": {
-                      "haReservation": false
-                  }
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_ha_reservation if {
+	mock_vm := {
+		"name": "test",
+		"cluster": {"haReservation": false},
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_ha_reservation {
-    mock_vm := { "name": "test",
-                 "cluster": {
-                     "haReservation": true
-                  }
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_ha_reservation if {
+	mock_vm := {
+		"name": "test",
+		"cluster": {"haReservation": true},
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/ha_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ha_test.rego
@@ -1,17 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_ha_enabled {
-    mock_vm := { "name": "test",
-                 "haEnabled": false
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_ha_enabled if {
+	mock_vm := {
+		"name": "test",
+		"haEnabled": false,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_ha_enabled {
-    mock_vm := { "name": "test",
-                 "haEnabled": true
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_ha_enabled if {
+	mock_vm := {
+		"name": "test",
+		"haEnabled": true,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/host_devices.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/host_devices.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_host_devices = false
+import rego.v1
 
-has_host_devices = true {
-    count(input.hostDevices) != 0
+default has_host_devices := false
+
+has_host_devices if {
+	count(input.hostDevices) != 0
 }
 
-concerns[flag] {
-    has_host_devices
-    flag := {
-        "id": "ovirt.host_devices.mapped",
-        "category": "Warning",
-        "label": "VM has mapped host devices",
-        "assessment": "The VM is configured with hardware devices mapped from the host. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have any host device attached to it in the target environment."
-    }
+concerns contains flag if {
+	has_host_devices
+	flag := {
+		"id": "ovirt.host_devices.mapped",
+		"category": "Warning",
+		"label": "VM has mapped host devices",
+		"assessment": "The VM is configured with hardware devices mapped from the host. This functionality is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have any host device attached to it in the target environment.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/host_devices_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/host_devices_test.rego
@@ -1,17 +1,18 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_host_devices {
-    mock_vm := { "name": "test", "hostDevices": [] }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_host_devices if {
+	mock_vm := {"name": "test", "hostDevices": []}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_host_devices {
-    mock_vm := { "name": "test",
-                 "hostDevices": [
-                    { "capability": "thing" }
-                  ]
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_host_devices if {
+	mock_vm := {
+		"name": "test",
+		"hostDevices": [{"capability": "thing"}],
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/illegal_images.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/illegal_images.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_illegal_images = false
+import rego.v1
 
-has_illegal_images = value {
-    value := input.hasIllegalImages
+default has_illegal_images := false
+
+has_illegal_images := value if {
+	value := input.hasIllegalImages
 }
 
-concerns[flag] {
-    has_illegal_images
-    flag := {
-        "id": "ovirt.disk.illegal_images.detected",
-        "category": "Critical",
-        "label": "Illegal disk images detected",
-        "assessment": "The VM has one or more snapshots with disks in ILLEGAL state, which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."
-    }
+concerns contains flag if {
+	has_illegal_images
+	flag := {
+		"id": "ovirt.disk.illegal_images.detected",
+		"category": "Critical",
+		"label": "Illegal disk images detected",
+		"assessment": "The VM has one or more snapshots with disks in ILLEGAL state, which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/illegal_images_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/illegal_images_test.rego
@@ -1,17 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_illegal_images {
-    mock_vm := { "name": "test",
-                 "hasIllegalImages": false
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_illegal_images if {
+	mock_vm := {
+		"name": "test",
+		"hasIllegalImages": false,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_illegal_images {
-    mock_vm := { "name": "test",
-                 "hasIllegalImages": true
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_illegal_images if {
+	mock_vm := {
+		"name": "test",
+		"hasIllegalImages": true,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/io_threads.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/io_threads.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_iothreads_enabled = false
+import rego.v1
 
-has_iothreads_enabled = true {
-    input.ioThreads > 1
+default has_iothreads_enabled := false
+
+has_iothreads_enabled if {
+	input.ioThreads > 1
 }
 
-concerns[flag] {
-    has_iothreads_enabled
-    flag := {
-        "id": "ovirt.iothreads.configured",
-        "category": "Information",
-        "label": "IO Threads configuration detected",
-        "assessment": "The VM is configured to use I/O threads. This configuration will not be automatically applied to the migrated VM, and must be manually re-applied if required."
-    }
+concerns contains flag if {
+	has_iothreads_enabled
+	flag := {
+		"id": "ovirt.iothreads.configured",
+		"category": "Information",
+		"label": "IO Threads configuration detected",
+		"assessment": "The VM is configured to use I/O threads. This configuration will not be automatically applied to the migrated VM, and must be manually re-applied if required.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/io_threads_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/io_threads_test.rego
@@ -1,17 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_iothreads_enabled {
-    mock_vm := { "name": "test",
-                 "ioThreads": 1
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_iothreads_enabled if {
+	mock_vm := {
+		"name": "test",
+		"ioThreads": 1,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_iothreads_enabled {
-    mock_vm := { "name": "test",
-                 "ioThreads": 3
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_iothreads_enabled if {
+	mock_vm := {
+		"name": "test",
+		"ioThreads": 3,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/ksm.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ksm.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_ksm_enabled = false
+import rego.v1
 
-has_ksm_enabled = value {
-    value := input.cluster.ksmEnabled
+default has_ksm_enabled := false
+
+has_ksm_enabled := value if {
+	value := input.cluster.ksmEnabled
 }
 
-concerns[flag] {
-    has_ksm_enabled
-    flag := {
-        "id": "ovirt.cluster.ksm_enabled",
-        "category": "Warning",
-        "label": "Cluster has KSM enabled",
-        "assessment": "The host running the source VM has kernel samepage merging enabled for more efficient memory utilization. This feature is not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	has_ksm_enabled
+	flag := {
+		"id": "ovirt.cluster.ksm_enabled",
+		"category": "Warning",
+		"label": "Cluster has KSM enabled",
+		"assessment": "The host running the source VM has kernel samepage merging enabled for more efficient memory utilization. This feature is not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/ksm_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/ksm_test.rego
@@ -1,21 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_ksm_enabled {
-    mock_vm := { "name": "test",
-                 "cluster": {
-                      "ksmEnabled": false
-                  }
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_ksm_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cluster": {"ksmEnabled": false},
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_ksm_enabled {
-    mock_vm := { "name": "test",
-                 "cluster": {
-                      "ksmEnabled": true
-                  }
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_ksm_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cluster": {"ksmEnabled": true},
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name.rego
@@ -1,30 +1,34 @@
 package io.konveyor.forklift.ovirt
 
-default valid_input   = true
-default valid_vm_string = false
-default valid_vm_name = false
+import rego.v1
 
-valid_input = false {
-    is_null(input)
+default valid_input := true
+
+default valid_vm_string := false
+
+default valid_vm_name := false
+
+valid_input := false if {
+	is_null(input)
 }
 
-valid_vm_string = true {
-    is_string(input.name)
+valid_vm_string if {
+	is_string(input.name)
 }
 
-valid_vm_name = true {
-    regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
-    count(input.name) < 64
+valid_vm_name if {
+	regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
+	count(input.name) < 64
 }
 
-concerns[flag] {
-    valid_input
-    valid_vm_string
-    not valid_vm_name
-    flag := {
-        "id": "ovirt.name.invalid",
-        "category": "Warning",
-        "label": "Invalid VM Name",
-        "assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters. "
-    }
+concerns contains flag if {
+	valid_input
+	valid_vm_string
+	not valid_vm_name
+	flag := {
+		"id": "ovirt.name.invalid",
+		"category": "Warning",
+		"label": "Invalid VM Name",
+		"assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters. ",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/name_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/name_test.rego
@@ -1,25 +1,27 @@
 package io.konveyor.forklift.ovirt
 
-test_valid_vm_name {
-    mock_vm := { "name": "test" }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_valid_vm_name if {
+	mock_vm := {"name": "test"}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_vm_name_too_long {
-    mock_vm := { "name": "my-vm-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_vm_name_too_long if {
+	mock_vm := {"name": "my-vm-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_vm_name_invalid_char_underscore {
-    mock_vm := { "name": "my_vm" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_vm_name_invalid_char_underscore if {
+	mock_vm := {"name": "my_vm"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_vm_name_invalid_char_slash {
-    mock_vm := { "name": "my/vm" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_vm_name_invalid_char_slash if {
+	mock_vm := {"name": "my/vm"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_custom_properties.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_custom_properties.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default vnic_has_custom_properties = false
+import rego.v1
 
-vnic_has_custom_properties = true {
-    count(input.nics[i].profile.properties) != 0
+default vnic_has_custom_properties := false
+
+vnic_has_custom_properties if {
+	count(input.nics[i].profile.properties) != 0
 }
 
-concerns[flag] {
-    vnic_has_custom_properties
-    flag := {
-        "id": "ovirt.nic.custom_properties.detected",
-        "category": "Warning",
-        "label": "vNIC custom properties detected",
-        "assessment": "The VM's vNIC Profile is configured with custom properties, which are not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	vnic_has_custom_properties
+	flag := {
+		"id": "ovirt.nic.custom_properties.detected",
+		"category": "Warning",
+		"label": "vNIC custom properties detected",
+		"assessment": "The VM's vNIC Profile is configured with custom properties, which are not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_custom_properties_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_custom_properties_test.rego
@@ -1,50 +1,46 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # NIC tests contain the attributes to match each and all of the NIC rules
- 
-test_without_nic_custom_properties {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+
+test_without_nic_custom_properties if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "e1000",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_nic_custom_properties {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": [
-                        {
-                          "name" : "duplex",
-                          "value" : "full"
-                        }
-                    ]
-                }
-            }
-        ]
-    }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_nic_custom_properties if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "e1000",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [{
+					"name": "duplex",
+					"value": "full",
+				}],
+			},
+		}],
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_interface_type.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_interface_type.rego
@@ -1,22 +1,23 @@
 package io.konveyor.forklift.ovirt
 
-valid_nic_interfaces [i] {
-    some i
-    regex.match(`e1000|rtl8139|virtio`, input.nics[i].interface)
+import rego.v1
+
+valid_nic_interfaces contains i if {
+	some i
+	regex.match(`e1000|rtl8139|virtio`, input.nics[i].interface)
 }
 
-number_of_nics [i] {
-    some i
-    input.nics[i].id
+number_of_nics contains i if {
+	some i
+	input.nics[i].id
 }
 
-concerns[flag] {
-    count(valid_nic_interfaces) != count(number_of_nics)
-    flag := {
-        "id": "ovirt.nic.interface_type.unsupported",
-        "category": "Warning",
-        "label": "Unsupported NIC interface type detected",
-        "assessment": "The NIC interface type is not supported by OpenShift Virtualization (only e1000, rtl8139 and virtio interface types are currently supported). The migrated VM will be given a virtio NIC interface type."
-    }
+concerns contains flag if {
+	count(valid_nic_interfaces) != count(number_of_nics)
+	flag := {
+		"id": "ovirt.nic.interface_type.unsupported",
+		"category": "Warning",
+		"label": "Unsupported NIC interface type detected",
+		"assessment": "The NIC interface type is not supported by OpenShift Virtualization (only e1000, rtl8139 and virtio interface types are currently supported). The migrated VM will be given a virtio NIC interface type.",
+	}
 }
-

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_interface_type_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_interface_type_test.rego
@@ -1,87 +1,81 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # NIC tests contain the attributes to match each and all of the NIC rules
 
-test_with_first_valid_nic_interface_type {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_first_valid_nic_interface_type if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "e1000",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_second_valid_nic_interface_type {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "rtl8139",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_second_valid_nic_interface_type if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "rtl8139",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_third_valid_nic_interface_type {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "virtio",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_third_valid_nic_interface_type if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "virtio",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_invalid_nic_interface_type {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "broadcom",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_invalid_nic_interface_type if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "broadcom",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_network_filter.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_network_filter.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.ovirt
 
-nics_with_nework_filter_enabled [i] {
-    some i
-    input.nics[i].profile.networkFilter != ""
+import rego.v1
+
+nics_with_nework_filter_enabled contains i if {
+	some i
+	input.nics[i].profile.networkFilter != ""
 }
 
-concerns[flag] {
-    count(nics_with_nework_filter_enabled) > 0
-    flag := {
-        "id": "ovirt.nic.network_filter.detected",
-        "category": "Warning",
-        "label": "NIC with network filter detected",
-        "assessment": "The VM is using a vNIC Profile configured with a network filter. These are not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	count(nics_with_nework_filter_enabled) > 0
+	flag := {
+		"id": "ovirt.nic.network_filter.detected",
+		"category": "Warning",
+		"label": "NIC with network filter detected",
+		"assessment": "The VM is using a vNIC Profile configured with a network filter. These are not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_network_filter_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_network_filter_test.rego
@@ -1,56 +1,56 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # NIC tests contain the attributes to match each and all of the NIC rules
 
-test_without_network_filter {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "rtl8139",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_without_network_filter if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "rtl8139",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_network_filter {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "rtl8139",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            },
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "rtl8139",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "343f43d2-23eb-11e8-a056-00163e18b6f7",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_network_filter if {
+	mock_vm := {
+		"name": "test",
+		"nics": [
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a31",
+				"interface": "rtl8139",
+				"plugged": true,
+				"profile": {
+					"portMirroring": false,
+					"networkFilter": "",
+					"qos": "",
+					"properties": [],
+				},
+			},
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a31",
+				"interface": "rtl8139",
+				"plugged": true,
+				"profile": {
+					"portMirroring": false,
+					"networkFilter": "343f43d2-23eb-11e8-a056-00163e18b6f7",
+					"qos": "",
+					"properties": [],
+				},
+			},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_pci_passthrough.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_pci_passthrough.rego
@@ -1,17 +1,18 @@
 package io.konveyor.forklift.ovirt
 
-nic_set_to_pci_passthrough [i] {
-    some i
-    regex.match(`pci_passthrough`, input.nics[i].interface)
+import rego.v1
+
+nic_set_to_pci_passthrough contains i if {
+	some i
+	regex.match(`pci_passthrough`, input.nics[i].interface)
 }
 
-concerns[flag] {
-    count(nic_set_to_pci_passthrough) > 0
-    flag := {
-        "id": "ovirt.nic.pci_passthrough.detected",
-        "category": "Warning",
-        "label": "NIC with host device passthrough detected",
-        "assessment": "The VM is using a vNIC profile configured for host device passthrough, which is not currently supported by OpenShift Virtualization. The VM will be configured with an SRIOV NIC, but the destination network will need to be set up correctly."
-    }
+concerns contains flag if {
+	count(nic_set_to_pci_passthrough) > 0
+	flag := {
+		"id": "ovirt.nic.pci_passthrough.detected",
+		"category": "Warning",
+		"label": "NIC with host device passthrough detected",
+		"assessment": "The VM is using a vNIC profile configured for host device passthrough, which is not currently supported by OpenShift Virtualization. The VM will be configured with an SRIOV NIC, but the destination network will need to be set up correctly.",
+	}
 }
-

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_pci_passthrough_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_pci_passthrough_test.rego
@@ -1,46 +1,45 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # NIC tests contain the attributes to match each and all of the NIC rules
 
-test_with_no_pci_passthrough {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_no_pci_passthrough if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "e1000",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_no_pci_passthrough  {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "pci_passthrough",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    # count should be 2 as this test also invalidates the nic_interface_type rule
-    count(results) == 2
+test_with_no_pci_passthrough if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "pci_passthrough",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+
+	# count should be 2 as this test also invalidates the nic_interface_type rule
+	count(results) == 2
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_plugged.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_plugged.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.ovirt
 
-unplugged_nics [i] {
-    some i
-    input.nics[i].plugged == false
+import rego.v1
+
+unplugged_nics contains i if {
+	some i
+	input.nics[i].plugged == false
 }
 
-concerns[flag] {
-    count(unplugged_nics) > 0
-    flag := {
-        "id": "ovirt.nic.unplugged.detected",
-        "category": "Warning",
-        "label": "Unplugged NIC detected",
-        "assessment": "The VM has a NIC that is unplugged from a network. This is not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	count(unplugged_nics) > 0
+	flag := {
+		"id": "ovirt.nic.unplugged.detected",
+		"category": "Warning",
+		"label": "Unplugged NIC detected",
+		"assessment": "The VM has a NIC that is unplugged from a network. This is not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_plugged_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_plugged_test.rego
@@ -1,88 +1,88 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # NIC tests contain the attributes to match each and all of the NIC rules
 
-test_with_one_plugged_nic {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_one_plugged_nic if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "e1000",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_two_plugged_nics {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            },
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a32",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_two_plugged_nics if {
+	mock_vm := {
+		"name": "test",
+		"nics": [
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a31",
+				"interface": "e1000",
+				"plugged": true,
+				"profile": {
+					"portMirroring": false,
+					"networkFilter": "",
+					"qos": "",
+					"properties": [],
+				},
+			},
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a32",
+				"interface": "e1000",
+				"plugged": true,
+				"profile": {
+					"portMirroring": false,
+					"networkFilter": "",
+					"qos": "",
+					"properties": [],
+				},
+			},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_unplugged_nic {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            },
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a32",
-                "interface": "e1000",
-                "plugged": false,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_unplugged_nic if {
+	mock_vm := {
+		"name": "test",
+		"nics": [
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a31",
+				"interface": "e1000",
+				"plugged": true,
+				"profile": {
+					"portMirroring": false,
+					"networkFilter": "",
+					"qos": "",
+					"properties": [],
+				},
+			},
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a32",
+				"interface": "e1000",
+				"plugged": false,
+				"profile": {
+					"portMirroring": false,
+					"networkFilter": "",
+					"qos": "",
+					"properties": [],
+				},
+			},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_port_mirroring.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_port_mirroring.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.ovirt
 
-nics_with_port_mirroring_enabled [i] {
-    some i
-    input.nics[i].profile.portMirroring == true
+import rego.v1
+
+nics_with_port_mirroring_enabled contains i if {
+	some i
+	input.nics[i].profile.portMirroring == true
 }
 
-concerns[flag] {
-    count(nics_with_port_mirroring_enabled) > 0
-    flag := {
-        "id": "ovirt.nic.port_mirroring.detected",
-        "category": "Warning",
-        "label": "NIC with port mirroring detected",
-        "assessment": "The VM is using a vNIC Profile configured with port mirroring. This is not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	count(nics_with_port_mirroring_enabled) > 0
+	flag := {
+		"id": "ovirt.nic.port_mirroring.detected",
+		"category": "Warning",
+		"label": "NIC with port mirroring detected",
+		"assessment": "The VM is using a vNIC Profile configured with port mirroring. This is not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_port_mirroring_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_port_mirroring_test.rego
@@ -1,56 +1,56 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # NIC tests contain the attributes to match each and all of the NIC rules
 
-test_without_port_mirroring {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_without_port_mirroring if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "e1000",
+			"plugged": true,
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+				"properties": [],
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_port_mirroring {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            },
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a32",
-                "interface": "e1000",
-                "plugged": true,
-                "profile": {
-                    "portMirroring": true,
-                    "networkFilter": "",
-                    "qos": "",
-                    "properties": []
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_port_mirroring if {
+	mock_vm := {
+		"name": "test",
+		"nics": [
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a31",
+				"interface": "e1000",
+				"plugged": true,
+				"profile": {
+					"portMirroring": false,
+					"networkFilter": "",
+					"qos": "",
+					"properties": [],
+				},
+			},
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a32",
+				"interface": "e1000",
+				"plugged": true,
+				"profile": {
+					"portMirroring": true,
+					"networkFilter": "",
+					"qos": "",
+					"properties": [],
+				},
+			},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_qos.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_qos.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.ovirt
 
-nics_with_qos_enabled [i] {
-    some i
-    input.nics[i].profile.qos != ""
+import rego.v1
+
+nics_with_qos_enabled contains i if {
+	some i
+	input.nics[i].profile.qos != ""
 }
 
-concerns[flag] {
-    count(nics_with_qos_enabled) > 0
-    flag := {
-        "id": "ovirt.nic.qos.detected",
-        "category": "Warning",
-        "label": "NIC with QoS settings detected",
-        "assessment": "The VM has a vNIC Profile that includes Quality of Service settings. This is not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	count(nics_with_qos_enabled) > 0
+	flag := {
+		"id": "ovirt.nic.qos.detected",
+		"category": "Warning",
+		"label": "NIC with QoS settings detected",
+		"assessment": "The VM has a vNIC Profile that includes Quality of Service settings. This is not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/nic_qos_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/nic_qos_test.rego
@@ -1,56 +1,56 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 # NIC tests contain the attributes to match each and all of the NIC rules
 
-test_without_qos {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "properties": [],
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": ""
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_without_qos if {
+	mock_vm := {
+		"name": "test",
+		"nics": [{
+			"id": "656e7031-7330-3030-3a31-613a34613a31",
+			"interface": "e1000",
+			"plugged": true,
+			"properties": [],
+			"profile": {
+				"portMirroring": false,
+				"networkFilter": "",
+				"qos": "",
+			},
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_qos {
-    mock_vm := {
-        "name": "test",
-        "nics": [
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a31",
-                "interface": "e1000",
-                "plugged": true,
-                "properties": [],
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": ""
-                }
-            },
-            {
-                "id" : "656e7031-7330-3030-3a31-613a34613a32",
-                "interface": "e1000",
-                "plugged": true,
-                "properties": [],
-                "profile": {
-                    "portMirroring": false,
-                    "networkFilter": "",
-                    "qos": "something"
-                }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_qos if {
+	mock_vm := {
+		"name": "test",
+		"nics": [
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a31",
+				"interface": "e1000",
+				"plugged": true,
+				"properties": [],
+				"profile": {
+					"portMirroring": false,
+					"networkFilter": "",
+					"qos": "",
+				},
+			},
+			{
+				"id": "656e7031-7330-3030-3a31-613a34613a32",
+				"interface": "e1000",
+				"plugged": true,
+				"properties": [],
+				"profile": {
+					"portMirroring": false,
+					"networkFilter": "",
+					"qos": "something",
+				},
+			},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/numa_tune.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/numa_tune.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_numa_affinity = false
+import rego.v1
 
-has_numa_affinity = true {
-    count(input.numaNodeAffinity) != 0
+default has_numa_affinity := false
+
+has_numa_affinity if {
+	count(input.numaNodeAffinity) != 0
 }
 
-concerns[flag] {
-    has_numa_affinity
-    flag := {
-        "id": "ovirt.numa.tuning.detected",
-        "category": "Warning",
-        "label": "NUMA tuning detected",
-        "assessment": "NUMA tuning is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this NUMA mapping in the target environment."
-    }
+concerns contains flag if {
+	has_numa_affinity
+	flag := {
+		"id": "ovirt.numa.tuning.detected",
+		"category": "Warning",
+		"label": "NUMA tuning detected",
+		"assessment": "NUMA tuning is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this NUMA mapping in the target environment.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/numa_tune_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/numa_tune_test.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_numa_affinity {
-    mock_vm := { "name": "test", "numaNodeAffinity": [] }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_numa_affinity if {
+	mock_vm := {"name": "test", "numaNodeAffinity": []}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_numa_affinity {
-    mock_vm := { "name": "test", "numaNodeAffinity": [0,2] }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_numa_affinity if {
+	mock_vm := {"name": "test", "numaNodeAffinity": [0, 2]}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/online_snapshot.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/online_snapshot.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.ovirt
 
-online_snapshots [i] {
-    some i
-    input.snapshots[i].persistMemory
+import rego.v1
+
+online_snapshots contains i if {
+	some i
+	input.snapshots[i].persistMemory
 }
 
-concerns[flag] {
-    count(online_snapshots) > 0
-    flag := {
-        "id": "ovirt.snapshot.online_memory.detected",
-        "category": "Warning",
-        "label": "Online (memory) snapshot detected",
-        "assessment": "The VM has a snapshot that contains a memory copy. Online snapshots such as this are not curently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	count(online_snapshots) > 0
+	flag := {
+		"id": "ovirt.snapshot.online_memory.detected",
+		"category": "Warning",
+		"label": "Online (memory) snapshot detected",
+		"assessment": "The VM has a snapshot that contains a memory copy. Online snapshots such as this are not curently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/online_snapshot_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/online_snapshot_test.rego
@@ -1,45 +1,45 @@
 package io.konveyor.forklift.ovirt
 
-test_with_no_online_snapshot {
-    mock_vm := {
-        "name": "test",
-        "snapshots": [
-            {
-                "id": "8a678302-003c-442f-a86d-8f6eb874ed2d",
-                "description": "Active VM",
-                "type": "active",
-                "persistMemory": false
-            },
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_no_online_snapshot if {
+	mock_vm := {
+		"name": "test",
+		"snapshots": [{
+			"id": "8a678302-003c-442f-a86d-8f6eb874ed2d",
+			"description": "Active VM",
+			"type": "active",
+			"persistMemory": false,
+		}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_online_snapshot {
-    mock_vm := {
-        "name": "test",
-        "snapshots": [
-            {
-                "id": "8a678302-003c-442f-a86d-8f6eb874ed2d",
-                "description": "Active VM",
-                "type": "active",
-                "persistMemory": false
-            },
-            {
-                "id": "26950c1d-01e6-4c71-9eae-02842f341f1b",
-                "description": "online",
-                "type": "regular",
-                "persistMemory": true
-            },
-            {
-                "id": "2ef746c2-7238-4e74-b45b-bfd2ad6447e2",
-                "description": "Next Run configuration snapshot",
-                "type": "",
-                "persistMemory": false
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_online_snapshot if {
+	mock_vm := {
+		"name": "test",
+		"snapshots": [
+			{
+				"id": "8a678302-003c-442f-a86d-8f6eb874ed2d",
+				"description": "Active VM",
+				"type": "active",
+				"persistMemory": false,
+			},
+			{
+				"id": "26950c1d-01e6-4c71-9eae-02842f341f1b",
+				"description": "online",
+				"type": "regular",
+				"persistMemory": true,
+			},
+			{
+				"id": "2ef746c2-7238-4e74-b45b-bfd2ad6447e2",
+				"description": "Next Run configuration snapshot",
+				"type": "",
+				"persistMemory": false,
+			},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/placement_policy.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/placement_policy.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default warn_placement_policy = false
+import rego.v1
 
-warn_placement_policy = true {
-    regex.match(`\bmigratable\b`, input.placementPolicyAffinity)
+default warn_placement_policy := false
+
+warn_placement_policy if {
+	regex.match(`\bmigratable\b`, input.placementPolicyAffinity)
 }
 
-concerns[flag] {
-    warn_placement_policy
-    flag := {
-        "id": "ovirt.placement_policy.affinity_set",
-        "category": "Warning",
-        "label": "Placement policy affinity",
-        "assessment": "The VM has a placement policy affinity setting that requires live migration to be enabled in OpenShift Virtualization for compatibility. The target storage classes must also support RWX access mode."
-    }
+concerns contains flag if {
+	warn_placement_policy
+	flag := {
+		"id": "ovirt.placement_policy.affinity_set",
+		"category": "Warning",
+		"label": "Placement policy affinity",
+		"assessment": "The VM has a placement policy affinity setting that requires live migration to be enabled in OpenShift Virtualization for compatibility. The target storage classes must also support RWX access mode.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/placement_policy_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/placement_policy_test.rego
@@ -1,25 +1,30 @@
 package io.konveyor.forklift.ovirt
- 
-test_with_first_legal_placement_policy_affinity {
-    mock_vm := { "name": "test",
-                 "placementPolicyAffinity": "user_migratable"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_with_first_legal_placement_policy_affinity if {
+	mock_vm := {
+		"name": "test",
+		"placementPolicyAffinity": "user_migratable",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_second_legal_placement_policy_affinity {
-    mock_vm := { "name": "test",
-                 "placementPolicyAffinity": "pinned"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+test_with_second_legal_placement_policy_affinity if {
+	mock_vm := {
+		"name": "test",
+		"placementPolicyAffinity": "pinned",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_illegal_placement_policy_affinity {
-    mock_vm := { "name": "test",
-                 "placementPolicyAffinity": "migratable"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_illegal_placement_policy_affinity if {
+	mock_vm := {
+		"name": "test",
+		"placementPolicyAffinity": "migratable",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/rules_version.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/rules_version.rego
@@ -1,7 +1,7 @@
 package io.konveyor.forklift.ovirt
 
+import rego.v1
+
 RULES_VERSION := 6
 
-rules_version = {
-    "rules_version": RULES_VERSION
-}
+rules_version := {"rules_version": RULES_VERSION}

--- a/validation/policies/io/konveyor/forklift/ovirt/scsi_reservation.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/scsi_reservation.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.ovirt
 
-disks_with_scsi_reservation [i] {
-    some i
-    input.diskAttachments[i].scsiReservation == true
+import rego.v1
+
+disks_with_scsi_reservation contains i if {
+	some i
+	input.diskAttachments[i].scsiReservation == true
 }
 
-concerns[flag] {
-    count(disks_with_scsi_reservation) > 0
-    flag := {
-        "id": "ovirt.disk.scsi_reservation.enabled",
-        "category": "Warning",
-        "label": "Shared disk detected",
-        "assessment": "The VM has a disk that is shared. Shared disks are not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	count(disks_with_scsi_reservation) > 0
+	flag := {
+		"id": "ovirt.disk.scsi_reservation.enabled",
+		"category": "Warning",
+		"label": "Shared disk detected",
+		"assessment": "The VM has a disk that is shared. Shared disks are not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/scsi_reservation_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/scsi_reservation_test.rego
@@ -1,24 +1,24 @@
 package io.konveyor.forklift.ovirt
 
-test_without_scsi_reservation {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            { "scsiReservation": false }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_without_scsi_reservation if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{"scsiReservation": false}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_scsi_reservation {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            { "scsiReservation": false },
-            { "scsiReservation": true }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_scsi_reservation if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [
+			{"scsiReservation": false},
+			{"scsiReservation": true},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/secure_boot.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/secure_boot.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default secure_boot_enabled = false
+import rego.v1
 
-secure_boot_enabled = true {
-    input.bios == "q35_secure_boot"
+default secure_boot_enabled := false
+
+secure_boot_enabled if {
+	input.bios == "q35_secure_boot"
 }
 
-concerns[flag] {
-    secure_boot_enabled
-    flag := {
-        "id": "ovirt.secure_boot.detected",
-        "category": "Warning",
-        "label": "UEFI secure boot detected",
-        "assessment": "UEFI secure boot is currently only partially supported by OpenShift Virtualization. Some functionality may be missing after the VM is migrated."
-    }
+concerns contains flag if {
+	secure_boot_enabled
+	flag := {
+		"id": "ovirt.secure_boot.detected",
+		"category": "Warning",
+		"label": "UEFI secure boot detected",
+		"assessment": "UEFI secure boot is currently only partially supported by OpenShift Virtualization. Some functionality may be missing after the VM is migrated.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/secure_boot_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/secure_boot_test.rego
@@ -1,19 +1,21 @@
 package io.konveyor.forklift.ovirt
 
-test_with_i440fx_sea_bios {
-    mock_vm := {
-        "name": "test",
-        "bios": "i440fx_sea_bios"
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_i440fx_sea_bios if {
+	mock_vm := {
+		"name": "test",
+		"bios": "i440fx_sea_bios",
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_q35_secure_boot_bios {
-    mock_vm := {
-        "name": "test",
-        "bios": "q35_secure_boot"
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_q35_secure_boot_bios if {
+	mock_vm := {
+		"name": "test",
+		"bios": "q35_secure_boot",
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/shared_disk.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/shared_disk.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.ovirt
 
-shared_disks [i] {
-    some i
-    input.diskAttachments[i].disk.shared == true
+import rego.v1
+
+shared_disks contains i if {
+	some i
+	input.diskAttachments[i].disk.shared == true
 }
 
-concerns[flag] {
-    count(shared_disks) > 0
-    flag := {
-        "id": "ovirt.disk.shared.detected",
-        "category": "Warning",
-        "label": "Shared disk detected",
-        "assessment": "The VM has a disk that is shared. Shared disks are not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	count(shared_disks) > 0
+	flag := {
+		"id": "ovirt.disk.shared.detected",
+		"category": "Warning",
+		"label": "Shared disk detected",
+		"assessment": "The VM has a disk that is shared. Shared disks are not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/shared_disk_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/shared_disk_test.rego
@@ -1,30 +1,24 @@
 package io.konveyor.forklift.ovirt
 
-test_without_shared_disk {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            { "disk":
-              { "shared": false }
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_without_shared_disk if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [{"disk": {"shared": false}}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_shared_disk {
-    mock_vm := {
-        "name": "test",
-        "diskAttachments": [
-            { "disk":
-              { "shared": false }
-            },
-            { "disk":
-              { "shared": true },
-            }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_shared_disk if {
+	mock_vm := {
+		"name": "test",
+		"diskAttachments": [
+			{"disk": {"shared": false}},
+			{"disk": {"shared": true}},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/storage_error_resume_behaviour.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/storage_error_resume_behaviour.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default storage_error_resume_behaviour = false
+import rego.v1
 
-storage_error_resume_behaviour = true {
-    input.storageErrorResumeBehaviour != "auto_resume"
+default storage_error_resume_behaviour := false
+
+storage_error_resume_behaviour if {
+	input.storageErrorResumeBehaviour != "auto_resume"
 }
 
-concerns[flag] {
-    storage_error_resume_behaviour
-    flag := {
-        "id": "ovirt.storage.resume_behavior.unsupported",
-        "category": "Information",
-        "label": "VM storage error resume behavior",
-        "assessment": sprintf("The VM has storage error resume behavior set to '%v', which is not currently supported by OpenShift Virtualization", [input.storageErrorResumeBehaviour])
-    }
+concerns contains flag if {
+	storage_error_resume_behaviour
+	flag := {
+		"id": "ovirt.storage.resume_behavior.unsupported",
+		"category": "Information",
+		"label": "VM storage error resume behavior",
+		"assessment": sprintf("The VM has storage error resume behavior set to '%v', which is not currently supported by OpenShift Virtualization", [input.storageErrorResumeBehaviour]),
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/storage_error_resume_behaviour_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/storage_error_resume_behaviour_test.rego
@@ -1,17 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_with_auto_resume {
-    mock_vm := { "name": "test",
-                 "storageErrorResumeBehaviour": "auto_resume"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_with_auto_resume if {
+	mock_vm := {
+		"name": "test",
+		"storageErrorResumeBehaviour": "auto_resume",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_without_auto_resume {
-    mock_vm := { "name": "test",
-                 "storageErrorResumeBehaviour": "pause"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_without_auto_resume if {
+	mock_vm := {
+		"name": "test",
+		"storageErrorResumeBehaviour": "pause",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/tpm.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/tpm.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_tpm_os = false
+import rego.v1
 
-has_tpm_os = true {
-    regex.match(`windows_2022|windows_11`, input.osType)
+default has_tpm_os := false
+
+has_tpm_os if {
+	regex.match(`windows_2022|windows_11`, input.osType)
 }
 
-concerns[flag] {
-    has_tpm_os
-    flag := {
-        "id": "ovirt.tpm.required_by_os",
-        "category": "Warning",
-        "label": "TPM detected",
-        "assessment": "The VM is detected with an operation system that must have a TPM device. TPM data is not transferred during the migration."
-    }
+concerns contains flag if {
+	has_tpm_os
+	flag := {
+		"id": "ovirt.tpm.required_by_os",
+		"category": "Warning",
+		"label": "TPM detected",
+		"assessment": "The VM is detected with an operation system that must have a TPM device. TPM data is not transferred during the migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/tpm_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/tpm_test.rego
@@ -1,25 +1,30 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_tpm_enabled {
-    mock_vm := { "name": "test",
-                 "osType": "rhel_9x64"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_tpm_enabled if {
+	mock_vm := {
+		"name": "test",
+		"osType": "rhel_9x64",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_tpm_enabled_w11 {
-    mock_vm := { "name": "test",
-                 "osType": "windows_11"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_tpm_enabled_w11 if {
+	mock_vm := {
+		"name": "test",
+		"osType": "windows_11",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_tpm_enabled_w2k22 {
-    mock_vm := { "name": "test",
-                 "osType": "windows_2022"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_tpm_enabled_w2k22 if {
+	mock_vm := {
+		"name": "test",
+		"osType": "windows_2022",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/usb.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/usb.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_usb_enabled = false
+import rego.v1
 
-has_usb_enabled = value {
-   value :=  input.usbEnabled
+default has_usb_enabled := false
+
+has_usb_enabled := value if {
+	value := input.usbEnabled
 }
 
-concerns[flag] {
-    has_usb_enabled
-    flag := {
-        "id": "ovirt.usb.enabled",
-        "category": "Warning",
-        "label": "USB support enabled",
-        "assessment": "The VM has USB support enabled, but USB device attachment is not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	has_usb_enabled
+	flag := {
+		"id": "ovirt.usb.enabled",
+		"category": "Warning",
+		"label": "USB support enabled",
+		"assessment": "The VM has USB support enabled, but USB device attachment is not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/usb_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/usb_test.rego
@@ -1,17 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_usb_enabled {
-    mock_vm := { "name": "test",
-                 "usbEnabled": false
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_usb_enabled if {
+	mock_vm := {
+		"name": "test",
+		"usbEnabled": false,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_usb_enabled {
-    mock_vm := { "name": "test",
-                 "usbEnabled": true
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_usb_enabled if {
+	mock_vm := {
+		"name": "test",
+		"usbEnabled": true,
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/validate.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/validate.rego
@@ -1,12 +1,14 @@
 package io.konveyor.forklift.ovirt
 
-validate = {
-    "rules_version": RULES_VERSION,
-    "errors": errors,
-    "concerns": concerns
+import rego.v1
+
+validate := {
+	"rules_version": RULES_VERSION,
+	"errors": errors,
+	"concerns": concerns,
 }
 
-errors[message] {
-    not valid_vm_string
-    message := "No VM name found in input body"
+errors contains message if {
+	not valid_vm_string
+	message := "No VM name found in input body"
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/vm_os.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/vm_os.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_unsupported_os = false
+import rego.v1
 
-has_unsupported_os = true {
-    regex.match(`rhel_6|rhel_6x64`, input.osType)
+default has_unsupported_os := false
+
+has_unsupported_os if {
+	regex.match(`rhel_6|rhel_6x64`, input.osType)
 }
 
-concerns[flag] {
-    has_unsupported_os
-    flag := {
-        "id": "ovirt.os.unsupported",
-        "category": "Warning",
-        "label": "Unsupported operating system detected",
-        "assessment": "The guest operating system is RHEL6 which is not currently supported by OpenShift Virtualization."
-    }
+concerns contains flag if {
+	has_unsupported_os
+	flag := {
+		"id": "ovirt.os.unsupported",
+		"category": "Warning",
+		"label": "Unsupported operating system detected",
+		"assessment": "The guest operating system is RHEL6 which is not currently supported by OpenShift Virtualization.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/vm_os_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/vm_os_test.rego
@@ -1,33 +1,39 @@
 package io.konveyor.forklift.ovirt
- 
-test_unsupported_el6_64 {
-    mock_vm := { "name": "test",
-                 "osType": "rhel_6x64"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+
+import rego.v1
+
+test_unsupported_el6_64 if {
+	mock_vm := {
+		"name": "test",
+		"osType": "rhel_6x64",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_supported_el7 {
-    mock_vm := { "name": "test",
-                 "osType": "rhel_7x64"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+test_supported_el7 if {
+	mock_vm := {
+		"name": "test",
+		"osType": "rhel_7x64",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_unsupported_el6 {
-    mock_vm := { "name": "test",
-                 "osType": "rhel_6"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_unsupported_el6 if {
+	mock_vm := {
+		"name": "test",
+		"osType": "rhel_6",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_supported_windows {
-    mock_vm := { "name": "test",
-                 "osType": "windows_2019x64"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+test_supported_windows if {
+	mock_vm := {
+		"name": "test",
+		"osType": "windows_2019x64",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/vm_status.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/vm_status.rego
@@ -1,23 +1,26 @@
 package io.konveyor.forklift.ovirt
 
-default valid_status_string = false
-default legal_vm_status = false
+import rego.v1
 
-valid_status_string = true {
-    is_string(input.status)
+default valid_status_string := false
+
+default legal_vm_status := false
+
+valid_status_string if {
+	is_string(input.status)
 }
 
-legal_vm_status = true {
-    regex.match(`up|down`, input.status)
+legal_vm_status if {
+	regex.match(`up|down`, input.status)
 }
 
-concerns[flag] {
-    valid_status_string
-    not legal_vm_status
-    flag := {
-        "id": "ovirt.vm.status_invalid",
-        "category": "Critical",
-        "label": "VM has a status condition that may prevent successful migration",
-        "assessment": "The VM's status is not 'up' or 'down'. Attempting to migrate this VM may fail."
-    }
+concerns contains flag if {
+	valid_status_string
+	not legal_vm_status
+	flag := {
+		"id": "ovirt.vm.status_invalid",
+		"category": "Critical",
+		"label": "VM has a status condition that may prevent successful migration",
+		"assessment": "The VM's status is not 'up' or 'down'. Attempting to migrate this VM may fail.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/vm_status_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/vm_status_test.rego
@@ -1,28 +1,30 @@
 package io.konveyor.forklift.ovirt
 
-test_with_first_valid_status {
-    mock_vm := {
-        "name": "test",
-        "status": "up"
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_first_valid_status if {
+	mock_vm := {
+		"name": "test",
+		"status": "up",
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_second_valid_status {
-    mock_vm := {
-        "name": "test",
-        "status": "down"
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_second_valid_status if {
+	mock_vm := {
+		"name": "test",
+		"status": "down",
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_invalid_status {
-    mock_vm := {
-        "name": "test",
-        "status": "paused"
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_invalid_status if {
+	mock_vm := {
+		"name": "test",
+		"status": "paused",
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/watchdog.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/watchdog.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.ovirt
 
-default has_watchdog_enabled = false
+import rego.v1
 
-has_watchdog_enabled = true {
-    count(input.watchDogs) != 0
+default has_watchdog_enabled := false
+
+has_watchdog_enabled if {
+	count(input.watchDogs) != 0
 }
 
-concerns[flag] {
-    has_watchdog_enabled
-    flag := {
-        "id": "ovirt.watchdog.enabled",
-        "category": "Warning",
-        "label": "Watchdog detected",
-        "assessment": "The VM is configured with a watchdog device, which is not currently supported by OpenShift Virtualization. A watchdog device will not be present in the destination VM."
-    }
+concerns contains flag if {
+	has_watchdog_enabled
+	flag := {
+		"id": "ovirt.watchdog.enabled",
+		"category": "Warning",
+		"label": "Watchdog detected",
+		"assessment": "The VM is configured with a watchdog device, which is not currently supported by OpenShift Virtualization. A watchdog device will not be present in the destination VM.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/watchdog_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/watchdog_test.rego
@@ -1,19 +1,21 @@
 package io.konveyor.forklift.ovirt
- 
-test_without_watchdog {
-    mock_vm := { "name": "test",
-                 "watchDogs": []
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_watchdog if {
+	mock_vm := {
+		"name": "test",
+		"watchDogs": [],
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_watchdog {
-    mock_vm := { "name": "test",
-                 "watchDogs": [
-                     { "model": "i6300esb", "action": "reset" }
-                  ]
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_watchdog if {
+	mock_vm := {
+		"name": "test",
+		"watchDogs": [{"model": "i6300esb", "action": "reset"}],
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.vmware
 
-change_tracking_disabled {
-    input.changeTrackingEnabled == false
+import rego.v1
+
+change_tracking_disabled if {
+	input.changeTrackingEnabled == false
 }
 
-concerns[flag] {
-    change_tracking_disabled
-    flag := {
-        "id": "vmware.changed_block_tracking.disabled",
-        "category": "Warning",
-        "label": "Changed Block Tracking (CBT) not enabled",
-        "assessment": "For VM warm migration, Changed Block Tracking (CBT) must be enabled in VMware."
-    }
+concerns contains flag if {
+	change_tracking_disabled
+	flag := {
+		"id": "vmware.changed_block_tracking.disabled",
+		"category": "Warning",
+		"label": "Changed Block Tracking (CBT) not enabled",
+		"assessment": "For VM warm migration, Changed Block Tracking (CBT) must be enabled in VMware.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disk.rego
@@ -1,26 +1,27 @@
 package io.konveyor.forklift.vmware
-import future.keywords.in
 
-change_tracking_disabled_per_disk(disk) {
-    disk.changeTrackingEnabled == false
+import rego.v1
+
+change_tracking_disabled_per_disk(disk) if {
+	disk.changeTrackingEnabled == false
 }
 
-concerns[flag] {
-    some disk in input.disks
-    change_tracking_disabled_per_disk(disk)
+concerns contains flag if {
+	some disk in input.disks
+	change_tracking_disabled_per_disk(disk)
 
-    path_parts := split(disk.file, "/")
-    filename := trim(path_parts[count(path_parts) - 1], "] ")
+	path_parts := split(disk.file, "/")
+	filename := trim(path_parts[count(path_parts) - 1], "] ")
 
-    baseKey := (disk.controllerKey / 100) * 100
-    controllerIndex := disk.controllerKey - baseKey
+	baseKey := (disk.controllerKey / 100) * 100
+	controllerIndex := disk.controllerKey - baseKey
 
-    deviceKey := sprintf("%s%d:%d", [disk.bus, controllerIndex, disk.unitNumber])
+	deviceKey := sprintf("%s%d:%d", [disk.bus, controllerIndex, disk.unitNumber])
 
-    flag := {
-        "id": "vmware.changed_block_tracking.disk.disabled",
-        "category": "Warning",
-        "label": sprintf("Disk - %s does not have CBT enabled", [deviceKey]),
-        "assessment": "Changed Block Tracking (CBT) has not been enabled for this device. This feature is a prerequisite for VM warm migration."
-    }
+	flag := {
+		"id": "vmware.changed_block_tracking.disk.disabled",
+		"category": "Warning",
+		"label": sprintf("Disk - %s does not have CBT enabled", [deviceKey]),
+		"assessment": "Changed Block Tracking (CBT) has not been enabled for this device. This feature is a prerequisite for VM warm migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disks_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_per_disks_test.rego
@@ -1,166 +1,162 @@
 package io.konveyor.forklift.vmware
 
-test_with_cbt_enabled_disk {
-     mock_vm := {
-        "name": "test",
-        "disks": [
-            {
-                "key": 2000,
-                "file": "[datastore1] vm-folder/vm.vmdk",
-                "datastore": {
-                    "id": "datastore-101",
-                    "kind": "Datastore"
-                },
-                "changeTrackingEnabled": true,
-                "controllerKey": 1000,
-                "bus": "scsi",
-                "unitNumber": 0,
-            }
-        ]
-    }
+import rego.v1
 
-    results := concerns with input as mock_vm
-    count(results) == 0
-    
+test_with_cbt_enabled_disk if {
+	mock_vm := {
+		"name": "test",
+		"disks": [{
+			"key": 2000,
+			"file": "[datastore1] vm-folder/vm.vmdk",
+			"datastore": {
+				"id": "datastore-101",
+				"kind": "Datastore",
+			},
+			"changeTrackingEnabled": true,
+			"controllerKey": 1000,
+			"bus": "scsi",
+			"unitNumber": 0,
+		}],
+	}
+
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_cbt_disabled_disk {
-     mock_vm := {
-        "name": "test",
-        "disks": [
-            {
-                "key": 2000,
-                "file": "[datastore1] vm-folder/vm.vmdk",
-                "datastore": {
-                    "id": "datastore-101",
-                    "kind": "Datastore"
-                },
-                "changeTrackingEnabled": false,
-                "controllerKey": 1000,
-                "bus": "scsi",
-                "unitNumber": 0
-            }
-        ]
-    }
+test_with_cbt_disabled_disk if {
+	mock_vm := {
+		"name": "test",
+		"disks": [{
+			"key": 2000,
+			"file": "[datastore1] vm-folder/vm.vmdk",
+			"datastore": {
+				"id": "datastore-101",
+				"kind": "Datastore",
+			},
+			"changeTrackingEnabled": false,
+			"controllerKey": 1000,
+			"bus": "scsi",
+			"unitNumber": 0,
+		}],
+	}
 
-    results := concerns with input as mock_vm
-    count(results) == 1
-
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_all_disks_cbt_enabled {
-    mock_vm := {
-        "name": "test-multi-all-enabled",
-        "disks": [
-            {
-                "key": 2000,
-                "file": "[datastore1] vm-folder/vm1.vmdk",
-                "datastore": {
-                    "id": "datastore-101",
-                    "kind": "Datastore"
-                },
-                "changeTrackingEnabled": true,
-                "controllerKey": 1000,
-                "bus": "scsi",
-                "unitNumber": 0
-            },
-            {
-                "key": 2001,
-                "file": "[datastore1] vm-folder/vm2.vmdk",
-                "datastore": {
-                    "id": "datastore-101",
-                    "kind": "Datastore"
-                },
-                "changeTrackingEnabled": true,
-                "controllerKey": 1000,
-                "bus": "scsi",
-                "unitNumber": 1
-            }
-        ]
-    }
+test_with_all_disks_cbt_enabled if {
+	mock_vm := {
+		"name": "test-multi-all-enabled",
+		"disks": [
+			{
+				"key": 2000,
+				"file": "[datastore1] vm-folder/vm1.vmdk",
+				"datastore": {
+					"id": "datastore-101",
+					"kind": "Datastore",
+				},
+				"changeTrackingEnabled": true,
+				"controllerKey": 1000,
+				"bus": "scsi",
+				"unitNumber": 0,
+			},
+			{
+				"key": 2001,
+				"file": "[datastore1] vm-folder/vm2.vmdk",
+				"datastore": {
+					"id": "datastore-101",
+					"kind": "Datastore",
+				},
+				"changeTrackingEnabled": true,
+				"controllerKey": 1000,
+				"bus": "scsi",
+				"unitNumber": 1,
+			},
+		],
+	}
 
-    results := concerns with input as mock_vm
-    count(results) == 0
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_all_disks_cbt_disabled {
-    mock_vm := {
-        "name": "test-multi-all-disabled",
-        "disks": [
-            {
-                "key": 2000,
-                "file": "[datastore1] vm-folder/vm1.vmdk",
-                "datastore": {
-                    "id": "datastore-101",
-                    "kind": "Datastore"
-                },
-                "changeTrackingEnabled": false,
-                "controllerKey": 1000,
-                "bus": "scsi",
-                "unitNumber": 0
-            },
-            {
-                "key": 2001,
-                "file": "[datastore1] vm-folder/vm2.vmdk",
-                "datastore": {
-                    "id": "datastore-101",
-                    "kind": "Datastore"
-                },
-                "changeTrackingEnabled": false,
-                "controllerKey": 1000,
-                "bus": "scsi",
-                "unitNumber": 1
-            }
-        ]
-    }
+test_with_all_disks_cbt_disabled if {
+	mock_vm := {
+		"name": "test-multi-all-disabled",
+		"disks": [
+			{
+				"key": 2000,
+				"file": "[datastore1] vm-folder/vm1.vmdk",
+				"datastore": {
+					"id": "datastore-101",
+					"kind": "Datastore",
+				},
+				"changeTrackingEnabled": false,
+				"controllerKey": 1000,
+				"bus": "scsi",
+				"unitNumber": 0,
+			},
+			{
+				"key": 2001,
+				"file": "[datastore1] vm-folder/vm2.vmdk",
+				"datastore": {
+					"id": "datastore-101",
+					"kind": "Datastore",
+				},
+				"changeTrackingEnabled": false,
+				"controllerKey": 1000,
+				"bus": "scsi",
+				"unitNumber": 1,
+			},
+		],
+	}
 
-    results := concerns with input as mock_vm
-    count(results) == 2
+	results := concerns with input as mock_vm
+	count(results) == 2
 }
 
-test_with_mixed_cbt_disks {
-    mock_vm := {
-        "name": "test-multi-mixed",
-        "disks": [
-            {
-                "key": 2000,
-                "file": "[datastore1] vm-folder/vm1.vmdk",
-                "datastore": {
-                    "id": "datastore-101",
-                    "kind": "Datastore"
-                },
-                "changeTrackingEnabled": false,
-                "controllerKey": 1000,
-                "bus": "scsi",
-                "unitNumber": 0
-            },
-            {
-                "key": 2001,
-                "file": "[datastore1] vm-folder/vm2.vmdk",
-                "datastore": {
-                    "id": "datastore-101",
-                    "kind": "Datastore"
-                },
-                "changeTrackingEnabled": true,
-                "controllerKey": 1000,
-                "bus": "scsi",
-                "unitNumber": 1
-            },
-            {
-                "key": 2002,
-                "file": "[datastore1] vm-folder/vm3.vmdk",
-                "datastore": {
-                    "id": "datastore-101",
-                    "kind": "Datastore"
-                },
-                "changeTrackingEnabled": false,
-                "controllerKey": 1000,
-                "bus": "scsi",
-                "unitNumber": 2
-            }
-        ]
-    }
+test_with_mixed_cbt_disks if {
+	mock_vm := {
+		"name": "test-multi-mixed",
+		"disks": [
+			{
+				"key": 2000,
+				"file": "[datastore1] vm-folder/vm1.vmdk",
+				"datastore": {
+					"id": "datastore-101",
+					"kind": "Datastore",
+				},
+				"changeTrackingEnabled": false,
+				"controllerKey": 1000,
+				"bus": "scsi",
+				"unitNumber": 0,
+			},
+			{
+				"key": 2001,
+				"file": "[datastore1] vm-folder/vm2.vmdk",
+				"datastore": {
+					"id": "datastore-101",
+					"kind": "Datastore",
+				},
+				"changeTrackingEnabled": true,
+				"controllerKey": 1000,
+				"bus": "scsi",
+				"unitNumber": 1,
+			},
+			{
+				"key": 2002,
+				"file": "[datastore1] vm-folder/vm3.vmdk",
+				"datastore": {
+					"id": "datastore-101",
+					"kind": "Datastore",
+				},
+				"changeTrackingEnabled": false,
+				"controllerKey": 1000,
+				"bus": "scsi",
+				"unitNumber": 2,
+			},
+		],
+	}
 
-    results := concerns with input as mock_vm
-    count(results) == 2
+	results := concerns with input as mock_vm
+	count(results) == 2
 }

--- a/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/changed_block_tracking_test.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.vmware
 
-test_with_changed_block_tracking_enabled {
-    mock_vm := { "name": "test", "changeTrackingEnabled": true }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_changed_block_tracking_enabled if {
+	mock_vm := {"name": "test", "changeTrackingEnabled": true}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_changed_block_tracking_disabled {
-    mock_vm := { "name": "test", "changeTrackingEnabled": false }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_changed_block_tracking_disabled if {
+	mock_vm := {"name": "test", "changeTrackingEnabled": false}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/cpu_affinity.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/cpu_affinity.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.vmware
 
-has_cpu_affinity {
-    count(input.cpuAffinity) != 0
+import rego.v1
+
+has_cpu_affinity if {
+	count(input.cpuAffinity) != 0
 }
 
-concerns[flag] {
-    has_cpu_affinity
-    flag := {
-        "id": "vmware.cpu_affinity.detected",
-        "category": "Warning",
-        "label": "CPU affinity detected",
-        "assessment": "The VM will be migrated without CPU affinity, but administrators can set it after migration."
-    }
+concerns contains flag if {
+	has_cpu_affinity
+	flag := {
+		"id": "vmware.cpu_affinity.detected",
+		"category": "Warning",
+		"label": "CPU affinity detected",
+		"assessment": "The VM will be migrated without CPU affinity, but administrators can set it after migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/cpu_affinity_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/cpu_affinity_test.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.vmware
- 
-test_without_cpu_affinity {
-    mock_vm := { "name": "test", "cpuAffinity": [] }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_cpu_affinity if {
+	mock_vm := {"name": "test", "cpuAffinity": []}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_cpu_affinity {
-    mock_vm := { "name": "test", "cpuAffinity": [0,2] }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_cpu_affinity if {
+	mock_vm := {"name": "test", "cpuAffinity": [0, 2]}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/cpu_memory_hotplug.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/cpu_memory_hotplug.rego
@@ -1,25 +1,27 @@
 package io.konveyor.forklift.vmware
 
-default has_hotplug_enabled = false
+import rego.v1
 
-has_hotplug_enabled = true {
-    input.cpuHotAddEnabled == true
+default has_hotplug_enabled := false
+
+has_hotplug_enabled if {
+	input.cpuHotAddEnabled == true
 }
 
-has_hotplug_enabled = true {
-    input.cpuHotRemoveEnabled == true
+has_hotplug_enabled if {
+	input.cpuHotRemoveEnabled == true
 }
 
-has_hotplug_enabled = true {
-    input.memoryHotAddEnabled == true
+has_hotplug_enabled if {
+	input.memoryHotAddEnabled == true
 }
 
-concerns[flag] {
-    has_hotplug_enabled
-    flag := {
-        "id": "vmware.cpu_memory.hotplug.enabled",
-        "category": "Warning",
-        "label": "CPU/Memory hotplug detected",
-        "assessment": "Hot pluggable CPU or memory is not currently supported by Migration Toolkit for Virtualization. You can reconfigure CPU or memory after migration."
-    }
+concerns contains flag if {
+	has_hotplug_enabled
+	flag := {
+		"id": "vmware.cpu_memory.hotplug.enabled",
+		"category": "Warning",
+		"label": "CPU/Memory hotplug detected",
+		"assessment": "Hot pluggable CPU or memory is not currently supported by Migration Toolkit for Virtualization. You can reconfigure CPU or memory after migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/cpu_memory_hotplug_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/cpu_memory_hotplug_test.rego
@@ -1,45 +1,47 @@
 package io.konveyor.forklift.vmware
 
-test_with_hotplug_disabled {
-    mock_vm := {
-        "name": "test",
-        "cpuHotAddEnabled": false,
-        "cpuHotRemoveEnabled": false,
-        "memoryHotAddEnabled": false
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_hotplug_disabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuHotAddEnabled": false,
+		"cpuHotRemoveEnabled": false,
+		"memoryHotAddEnabled": false,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_cpu_hot_add_enabled {
-    mock_vm := {
-        "name": "test",
-        "cpuHotAddEnabled": true,
-        "cpuHotRemoveEnabled": false,
-        "memoryHotAddEnabled": false
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_cpu_hot_add_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuHotAddEnabled": true,
+		"cpuHotRemoveEnabled": false,
+		"memoryHotAddEnabled": false,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_cpu_hot_remove_enabled {
-    mock_vm := {
-        "name": "test",
-        "cpuHotAddEnabled": false,
-        "cpuHotRemoveEnabled": true,
-        "memoryHotAddEnabled": false
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_cpu_hot_remove_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuHotAddEnabled": false,
+		"cpuHotRemoveEnabled": true,
+		"memoryHotAddEnabled": false,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_memory_hot_add_enabled {
-    mock_vm := {
-        "name": "test",
-        "cpuHotAddEnabled": false,
-        "cpuHotRemoveEnabled": false,
-        "memoryHotAddEnabled": true
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_memory_hot_add_enabled if {
+	mock_vm := {
+		"name": "test",
+		"cpuHotAddEnabled": false,
+		"cpuHotRemoveEnabled": false,
+		"memoryHotAddEnabled": true,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/datastore.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/datastore.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.vmware
 
-null_datastore {
-    some i
-    count(input.disks[i].datastore.id) == 0
+import rego.v1
+
+null_datastore if {
+	some i
+	count(input.disks[i].datastore.id) == 0
 }
 
-concerns[flag] {
-    null_datastore
-    flag := {
-        "id": "vmware.datastore.missing",
-        "category": "Critical",
-        "label": "Disk is not located on a datastore",
-        "assessment": "The VM is configured with a disk that is not located on a datastore. The VM cannot be migrated."
-    }
+concerns contains flag if {
+	null_datastore
+	flag := {
+		"id": "vmware.datastore.missing",
+		"category": "Critical",
+		"label": "Disk is not located on a datastore",
+		"assessment": "The VM is configured with a disk that is not located on a datastore. The VM cannot be migrated.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/datastore_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/datastore_test.rego
@@ -1,33 +1,33 @@
 package io.konveyor.forklift.vmware
 
-test_with_no_disks {
-    mock_vm := {
-        "name": "test",
-        "disks": []
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_no_disks if {
+	mock_vm := {
+		"name": "test",
+		"disks": [],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_valid_disk {
-    mock_vm := {
-        "name": "test",
-        "disks": [
-            { "datastore": { "kind": "datastore", "id": "datastore-1" } }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_valid_disk if {
+	mock_vm := {
+		"name": "test",
+		"disks": [{"datastore": {"kind": "datastore", "id": "datastore-1"}}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_invalid_disk {
-    mock_vm := {
-        "name": "test",
-        "disks": [
-            { "datastore": { "kind": "datastore", "id": "datastore-1" } },
-            { "datastore": { "kind": "", "id": "" } },
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_invalid_disk if {
+	mock_vm := {
+		"name": "test",
+		"disks": [
+			{"datastore": {"kind": "datastore", "id": "datastore-1"}},
+			{"datastore": {"kind": "", "id": ""}},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/debug.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/debug.rego
@@ -1,5 +1,7 @@
 package io.konveyor.forklift.vmware
 
-debug {
+import rego.v1
+
+debug if {
 	trace(sprintf("** debug ** vm name: %v", [input.name]))
 }

--- a/validation/policies/io/konveyor/forklift/vmware/disk_mode.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_mode.rego
@@ -1,17 +1,18 @@
 package io.konveyor.forklift.vmware
-import future.keywords.in
 
-independent_disk {
-    some i
-    input.disks[i].mode in ["independent_persistent", "independent_nonpersistent"]
+import rego.v1
+
+independent_disk if {
+	some i
+	input.disks[i].mode in ["independent_persistent", "independent_nonpersistent"]
 }
 
-concerns[flag] {
-    independent_disk
-    flag := {
-        "id": "vmware.disk_mode.independent",
-        "category": "Critical",
-        "label": "Independent disk detected",
-        "assessment": "Independent disks cannot be transferred using recent versions of VDDK. The VM cannot be migrated unless disks are changed to 'Dependent' mode in VMware."
-    }
+concerns contains flag if {
+	independent_disk
+	flag := {
+		"id": "vmware.disk_mode.independent",
+		"category": "Critical",
+		"label": "Independent disk detected",
+		"assessment": "Independent disks cannot be transferred using recent versions of VDDK. The VM cannot be migrated unless disks are changed to 'Dependent' mode in VMware.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/disk_mode_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_mode_test.rego
@@ -1,47 +1,46 @@
 package io.konveyor.forklift.vmware
 
-test_with_no_disks {
-    mock_vm := {
-        "name": "test",
-        "disks": []
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_no_disks if {
+	mock_vm := {
+		"name": "test",
+		"disks": [],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_no_independent_disk {
-    mock_vm := {
-        "name": "test",
-        "disks": [
-            { "shared": false },
-            { "shared": false, "mode": "dependent" }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_no_independent_disk if {
+	mock_vm := {
+		"name": "test",
+		"disks": [
+			{"shared": false},
+			{"shared": false, "mode": "dependent"},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_independent_persistent_disk {
-    mock_vm := {
-        "name": "test",
-        "disks": [
-            { "shared": false },
-            { "shared": false, "mode": "dependent" },
-            { "shared": false, "mode": "independent_persistent" }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_independent_persistent_disk if {
+	mock_vm := {
+		"name": "test",
+		"disks": [
+			{"shared": false},
+			{"shared": false, "mode": "dependent"},
+			{"shared": false, "mode": "independent_persistent"},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_independent_nonpersistent_disk {
-    mock_vm := {
-        "name": "test",
-        "disks": [
-            { "shared": false, "mode": "independent_nonpersistent" }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_independent_nonpersistent_disk if {
+	mock_vm := {
+		"name": "test",
+		"disks": [{"shared": false, "mode": "independent_nonpersistent"}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
-

--- a/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.vmware
 
-disk_uuid_enabled {
-    some i
-    input.diskEnableUuid == true
-    input.disks[i].bus == "scsi"
+import rego.v1
+
+disk_uuid_enabled if {
+	some i
+	input.diskEnableUuid == true
+	input.disks[i].bus == "scsi"
 }
 
-concerns[flag] {
-    disk_uuid_enabled
-    flag := {
-        "id": "vmware.disk_serial.truncated",
-        "category": "Information",
-        "label": "Disk serial numbers may be truncated",
-        "assessment": "This VM is configured with at least one SCSI disk and the disk.EnableUUID parameter is set to TRUE. This may indicate a need for consistent SCSI disk serial numbers, but be advised that these serial numbers will be truncated after migration."
-    }
+concerns contains flag if {
+	disk_uuid_enabled
+	flag := {
+		"id": "vmware.disk_serial.truncated",
+		"category": "Information",
+		"label": "Disk serial numbers may be truncated",
+		"assessment": "This VM is configured with at least one SCSI disk and the disk.EnableUUID parameter is set to TRUE. This may indicate a need for consistent SCSI disk serial numbers, but be advised that these serial numbers will be truncated after migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_serial_numbers_test.rego
@@ -1,30 +1,32 @@
 package io.konveyor.forklift.vmware
 
-test_with_uuid_enabled_scsi {
-    mock_vm := {
-        "name": "test",
-	"diskEnableUuid": true,
-	"disks": [{ "bus": "scsi" }]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+import rego.v1
+
+test_with_uuid_enabled_scsi if {
+	mock_vm := {
+		"name": "test",
+		"diskEnableUuid": true,
+		"disks": [{"bus": "scsi"}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_with_uuid_enabled_sata {
-    mock_vm := {
-        "name": "test",
-	"diskEnableUuid": true,
-	"disks": [{ "bus": "sata" }]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_uuid_enabled_sata if {
+	mock_vm := {
+		"name": "test",
+		"diskEnableUuid": true,
+		"disks": [{"bus": "sata"}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_uuid_disabled {
-    mock_vm := {
-        "name": "test",
-	"diskEnableUuid": false
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_uuid_disabled if {
+	mock_vm := {
+		"name": "test",
+		"diskEnableUuid": false,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }

--- a/validation/policies/io/konveyor/forklift/vmware/disk_size.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_size.rego
@@ -1,20 +1,21 @@
 package io.konveyor.forklift.vmware
-import future.keywords.in
+
+import rego.v1
 
 # Match any disk with zero or negative capacity
-invalid_disks[idx] {
-    some idx
-    input.disks[idx].capacity <= 0
+invalid_disks contains idx if {
+	some idx
+	input.disks[idx].capacity <= 0
 }
 
 # Raise a concern for each invalid disk
-concerns[flag] {
-    invalid_disks[idx]
-    disk := input.disks[idx]
-    flag := {
-        "id": "vmware.disk.capacity.invalid",
-        "category": "Critical",
-        "label": sprintf("Disk '%v' has an invalid capacity of %v bytes", [disk.file, disk.capacity]),
-        "assessment": sprintf("Disk '%v' has a capacity of %v bytes, which is not allowed. Capacity must be greater than zero.", [disk.file, disk.capacity])
-    }
+concerns contains flag if {
+	invalid_disks[idx]
+	disk := input.disks[idx]
+	flag := {
+		"id": "vmware.disk.capacity.invalid",
+		"category": "Critical",
+		"label": sprintf("Disk '%v' has an invalid capacity of %v bytes", [disk.file, disk.capacity]),
+		"assessment": sprintf("Disk '%v' has a capacity of %v bytes, which is not allowed. Capacity must be greater than zero.", [disk.file, disk.capacity]),
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/disk_size_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_size_test.rego
@@ -1,45 +1,33 @@
 package io.konveyor.forklift.vmware
-import future.keywords.in
 
+import rego.v1
 
-test_invalid_capacity_zero {
-    input := {
-        "disks": [
-            {
-                "file": "disk1.vmdk",
-                "capacity": 0
-            }
-        ]
-    }
+test_invalid_capacity_zero if {
+	test_input := {"disks": [{
+		"file": "disk1.vmdk",
+		"capacity": 0,
+	}]}
 
-    results := concerns with input as input
-    count(results) == 1
+	results := concerns with input as test_input
+	count(results) == 1
 }
 
-test_invalid_capacity_negative {
-    input := {
-        "disks": [
-            {
-                "file": "disk2.vmdk",
-                "capacity": -1024
-            }
-        ]
-    }
+test_invalid_capacity_negative if {
+	test_input := {"disks": [{
+		"file": "disk2.vmdk",
+		"capacity": -1024,
+	}]}
 
-    results := concerns with input as input
-    count(results) == 1
+	results := concerns with input as test_input
+	count(results) == 1
 }
 
-test_valid_capacity {
-    input := {
-        "disks": [
-            {
-                "file": "disk3.vmdk",
-                "capacity": 17179869184
-            }
-        ]
-    }
+test_valid_capacity if {
+	test_input := {"disks": [{
+		"file": "disk3.vmdk",
+		"capacity": 17179869184,
+	}]}
 
-    results := concerns with input as input
-    count(results) == 0
+	results := concerns with input as test_input
+	count(results) == 0
 }

--- a/validation/policies/io/konveyor/forklift/vmware/dpm_enabled.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/dpm_enabled.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.vmware
 
-has_dpm_enabled {
-    input.host.cluster.dpmEnabled
+import rego.v1
+
+has_dpm_enabled if {
+	input.host.cluster.dpmEnabled
 }
 
-concerns[flag] {
-    has_dpm_enabled
-    flag := {
-        "id": "vmware.dpm.enabled",
-        "category": "Information",
-        "label": "vSphere DPM detected",
-        "assessment": "Distributed Power Management is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment. "
-    }
+concerns contains flag if {
+	has_dpm_enabled
+	flag := {
+		"id": "vmware.dpm.enabled",
+		"category": "Information",
+		"label": "vSphere DPM detected",
+		"assessment": "Distributed Power Management is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment. ",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/dpm_enabled_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/dpm_enabled_test.rego
@@ -1,33 +1,33 @@
 package io.konveyor.forklift.vmware
 
-test_without_dpm_enabled {
-    mock_vm := {
-        "name": "test",
-        "host": {
-            "name": "test_host",
-            "cluster": {
-                "name": "test_cluster",
-                "dpmEnabled": false
-                
-            }
-        }
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_without_dpm_enabled if {
+	mock_vm := {
+		"name": "test",
+		"host": {
+			"name": "test_host",
+			"cluster": {
+				"name": "test_cluster",
+				"dpmEnabled": false,
+			},
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_dpm_enabled {
-    mock_vm := {
-        "name": "test",
-        "host": {
-            "name": "test_host",
-            "cluster": {
-                "name": "test_cluster",
-                "dpmEnabled": true
-                
-            }
-        }
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_dpm_enabled if {
+	mock_vm := {
+		"name": "test",
+		"host": {
+			"name": "test_host",
+			"cluster": {
+				"name": "test_cluster",
+				"dpmEnabled": true,
+			},
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/drs_enabled.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/drs_enabled.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.vmware
 
-has_drs_enabled {
-    input.host.cluster.drsEnabled
+import rego.v1
+
+has_drs_enabled if {
+	input.host.cluster.drsEnabled
 }
 
-concerns[flag] {
-    has_drs_enabled
-    flag := {
-        "id": "vmware.drs.enabled",
-        "category": "Information",
-        "label": "VM running in a DRS-enabled cluster",
-        "assessment": "Distributed resource scheduling is not currently supported by Migration Toolkit for Virtualization. The VM can be migrated but it will not have this feature in the target environment."
-    }
+concerns contains flag if {
+	has_drs_enabled
+	flag := {
+		"id": "vmware.drs.enabled",
+		"category": "Information",
+		"label": "VM running in a DRS-enabled cluster",
+		"assessment": "Distributed resource scheduling is not currently supported by Migration Toolkit for Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/drs_enabled_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/drs_enabled_test.rego
@@ -1,33 +1,33 @@
 package io.konveyor.forklift.vmware
 
-test_without_drs_enabled {
-    mock_vm := {
-        "name": "test",
-        "host": {
-            "name": "test_host",
-            "cluster": {
-                "name": "test_cluster",
-                "drsEnabled": false
-                
-            }
-        }
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_without_drs_enabled if {
+	mock_vm := {
+		"name": "test",
+		"host": {
+			"name": "test_host",
+			"cluster": {
+				"name": "test_cluster",
+				"drsEnabled": false,
+			},
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_drs_enabled {
-    mock_vm := {
-        "name": "test",
-        "host": {
-            "name": "test_host",
-            "cluster": {
-                "name": "test_cluster",
-                "drsEnabled": true
-                
-            }
-        }
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_drs_enabled if {
+	mock_vm := {
+		"name": "test",
+		"host": {
+			"name": "test_host",
+			"cluster": {
+				"name": "test_cluster",
+				"drsEnabled": true,
+			},
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/fault_tolerance.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/fault_tolerance.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.vmware
 
-has_fault_tolerance_enabled {
-    input.faultToleranceEnabled
+import rego.v1
+
+has_fault_tolerance_enabled if {
+	input.faultToleranceEnabled
 }
 
-concerns[flag] {
-    has_fault_tolerance_enabled
-    flag := {
-        "id": "vmware.fault_tolerance.enabled",
-        "category": "Information",
-        "label": "Fault tolerance",
-        "assessment": "Fault tolerance is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment."
-    }
+concerns contains flag if {
+	has_fault_tolerance_enabled
+	flag := {
+		"id": "vmware.fault_tolerance.enabled",
+		"category": "Information",
+		"label": "Fault tolerance",
+		"assessment": "Fault tolerance is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/fault_tolerance_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/fault_tolerance_test.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.vmware
 
-test_with_fault_tolerance_disabled {
-    mock_vm := { "name": "test", "faultToleranceEnabled": false }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_fault_tolerance_disabled if {
+	mock_vm := {"name": "test", "faultToleranceEnabled": false}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_fault_tolerance_enabled {
-    mock_vm := { "name": "test", "faultToleranceEnabled": true }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_fault_tolerance_enabled if {
+	mock_vm := {"name": "test", "faultToleranceEnabled": true}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/guest_disk_mapping.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/guest_disk_mapping.rego
@@ -1,27 +1,28 @@
 package io.konveyor.forklift.vmware
-import future.keywords.in
+
+import rego.v1
 
 # Match any windows disk with missing mappings
-invalid_guest_disk_mappings[idx] {
-    some idx
+invalid_guest_disk_mappings contains idx if {
+	some idx
 
-    lower_id := lower(input.guestId)
-    is_windows := contains(lower_id, "windows")
-    key := object.get(input.guestDisks[idx], "key", 0)
-    missing_disk_mapping := key == 0
+	lower_id := lower(input.guestId)
+	is_windows := contains(lower_id, "windows")
+	key := object.get(input.guestDisks[idx], "key", 0)
+	missing_disk_mapping := key == 0
 
-    is_windows
-    missing_disk_mapping
+	is_windows
+	missing_disk_mapping
 }
 
 # Raise a concern for each invalid disk
-concerns[flag] {
-    invalid_guest_disk_mappings[idx]
-    disk := input.guestDisks[idx]
-    flag := {
-        "id": "vmware.guestDisks.key.not_found",
-        "category": "Information",
-        "label": sprintf("Missing disk key mapping for '%v'", [disk.diskPath]),
-        "assessment": "winDriveLetter cannot be resolved in PVC name templates without a disk key mapping."
-    }
+concerns contains flag if {
+	invalid_guest_disk_mappings[idx]
+	disk := input.guestDisks[idx]
+	flag := {
+		"id": "vmware.guestDisks.key.not_found",
+		"category": "Information",
+		"label": sprintf("Missing disk key mapping for '%v'", [disk.diskPath]),
+		"assessment": "winDriveLetter cannot be resolved in PVC name templates without a disk key mapping.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/guest_disk_mapping_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/guest_disk_mapping_test.rego
@@ -1,223 +1,200 @@
 package io.konveyor.forklift.vmware
-import future.keywords.in
+
+import rego.v1
 
 # Test data: Windows VM with valid disk mappings (should not trigger)
-test_windows_vm_valid_disks_no_concerns {
-    count(concerns) == 0 with input as {
-        "guestId": "windows2019Server_64Guest",
-        "guestDisks": [
-            {
-                "key": 2000,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            },
-            {
-                "key": 2001,
-                "diskPath": "[datastore1] VM1/VM1_1.vmdk", 
-                "capacity": 42949672960
-            }
-        ]
-    }
+test_windows_vm_valid_disks_no_concerns if {
+	count(concerns) == 0 with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [
+			{
+				"key": 2000,
+				"diskPath": "[datastore1] VM1/VM1.vmdk",
+				"capacity": 21474836480,
+			},
+			{
+				"key": 2001,
+				"diskPath": "[datastore1] VM1/VM1_1.vmdk",
+				"capacity": 42949672960,
+			},
+		],
+	}
 }
 
 # Test: Windows VM with invalid disk mapping (key == 0) should trigger concern
-test_windows_vm_invalid_disk_creates_concern {
-    count(concerns) == 1 with input as {
-        "guestId": "windows2019Server_64Guest",
-        "guestDisks": [
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            }
-        ]
-    }
+test_windows_vm_invalid_disk_creates_concern if {
+	count(concerns) == 1 with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [{
+			"key": 0,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
 }
 
 # Test: Windows VM with missing key property should trigger concern
-test_windows_vm_missing_key_property_creates_concern {
-    count(concerns) == 1 with input as {
-        "guestId": "windows2019Server_64Guest",
-        "guestDisks": [
-            {
-                # "key" intentionally omitted
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            }
-        ]
-    }
+test_windows_vm_missing_key_property_creates_concern if {
+	count(concerns) == 1 with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [{
+			# "key" intentionally omitted
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
 }
 
 # Test: Non-Windows VM with invalid disk mapping (key == 0) should not trigger
-test_non_windows_vm_invalid_disk_no_concern {
-    count(concerns) == 0 with input as {
-        "guestId": "ubuntu64Guest", 
-        "guestDisks": [
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            }
-        ]
-    }
+test_non_windows_vm_invalid_disk_no_concern if {
+	count(concerns) == 0 with input as {
+		"guestId": "ubuntu64Guest",
+		"guestDisks": [{
+			"key": 0,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
 }
 
 # Test: Windows VM with mixed valid/invalid disks should only flag invalid ones
-test_windows_vm_mixed_disks_partial_concerns {
-    count(concerns) == 2 with input as {
-        "guestId": "windows2016Server_64Guest",
-        "guestDisks": [
-            {
-                "key": 2000,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            },
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1_1.vmdk",
-                "capacity": 42949672960
-            },
-            {
-                "key": 2002,
-                "diskPath": "[datastore1] VM1/VM1_2.vmdk",
-                "capacity": 10737418240
-            },
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1_3.vmdk",
-                "capacity": 5368709120
-            }
-        ]
-    }
+test_windows_vm_mixed_disks_partial_concerns if {
+	count(concerns) == 2 with input as {
+		"guestId": "windows2016Server_64Guest",
+		"guestDisks": [
+			{
+				"key": 2000,
+				"diskPath": "[datastore1] VM1/VM1.vmdk",
+				"capacity": 21474836480,
+			},
+			{
+				"key": 0,
+				"diskPath": "[datastore1] VM1/VM1_1.vmdk",
+				"capacity": 42949672960,
+			},
+			{
+				"key": 2002,
+				"diskPath": "[datastore1] VM1/VM1_2.vmdk",
+				"capacity": 10737418240,
+			},
+			{
+				"key": 0,
+				"diskPath": "[datastore1] VM1/VM1_3.vmdk",
+				"capacity": 5368709120,
+			},
+		],
+	}
 }
 
 # Test: Windows VM identifier case insensitive matching
-test_windows_vm_case_insensitive_matching {
-    count(concerns) == 1 with input as {
-        "guestId": "WINDOWS2019SERVER_64GUEST",
-        "guestDisks": [
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            }
-        ]
-    }
+test_windows_vm_case_insensitive_matching if {
+	count(concerns) == 1 with input as {
+		"guestId": "WINDOWS2019SERVER_64GUEST",
+		"guestDisks": [{
+			"key": 0,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
 }
 
 # Test: Various Windows guest ID patterns should all match
-test_various_windows_guest_ids {
-    # Test Windows Server
-    count(concerns) == 1 with input as {
-        "guestId": "windows2022Server_64Guest",
-        "guestDisks": [{"key": 0, "diskPath": "[ds1] vm/disk.vmdk", "capacity": 1000}]
-    }
-    
-    # Test Windows 10
-    count(concerns) == 1 with input as {
-        "guestId": "windows10_64Guest", 
-        "guestDisks": [{"key": 0, "diskPath": "[ds1] vm/disk.vmdk", "capacity": 1000}]
-    }
-    
-    # Test Windows 11
-    count(concerns) == 1 with input as {
-        "guestId": "windows11_64Guest",
-        "guestDisks": [{"key": 0, "diskPath": "[ds1] vm/disk.vmdk", "capacity": 1000}]
-    }
+test_various_windows_guest_ids if {
+	# Test Windows Server
+	count(concerns) == 1 with input as {
+		"guestId": "windows2022Server_64Guest",
+		"guestDisks": [{"key": 0, "diskPath": "[ds1] vm/disk.vmdk", "capacity": 1000}],
+	}
+
+	# Test Windows 10
+	count(concerns) == 1 with input as {
+		"guestId": "windows10_64Guest",
+		"guestDisks": [{"key": 0, "diskPath": "[ds1] vm/disk.vmdk", "capacity": 1000}],
+	}
+
+	# Test Windows 11
+	count(concerns) == 1 with input as {
+		"guestId": "windows11_64Guest",
+		"guestDisks": [{"key": 0, "diskPath": "[ds1] vm/disk.vmdk", "capacity": 1000}],
+	}
 }
 
 # Test: Empty guest disks array should not cause errors
-test_empty_guest_disks_no_concerns {
-    count(concerns) == 0 with input as {
-        "guestId": "windows2019Server_64Guest",
-        "guestDisks": []
-    }
+test_empty_guest_disks_no_concerns if {
+	count(concerns) == 0 with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [],
+	}
 }
 
 # Test: Verify concern structure and content
-test_concern_structure_and_content {
-    concerns[_].id == "vmware.guestDisks.key.not_found" with input as {
-        "guestId": "windows2019Server_64Guest",
-        "guestDisks": [
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            }
-        ]
-    }
-    
-    concerns[_].category == "Information" with input as {
-        "guestId": "windows2019Server_64Guest", 
-        "guestDisks": [
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            }
-        ]
-    }
-    
-    contains(concerns[_].label, "Missing disk key mapping") with input as {
-        "guestId": "windows2019Server_64Guest",
-        "guestDisks": [
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1.vmdk", 
-                "capacity": 21474836480
-            }
-        ]
-    }
-    
-    contains(concerns[_].assessment, "winDriveLetter cannot be resolved") with input as {
-        "guestId": "windows2019Server_64Guest",
-        "guestDisks": [
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            }
-        ]
-    }
+test_concern_structure_and_content if {
+	concerns[_].id == "vmware.guestDisks.key.not_found" with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [{
+			"key": 0,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
+
+	concerns[_].category == "Information" with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [{
+			"key": 0,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
+
+	contains(concerns[_].label, "Missing disk key mapping") with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [{
+			"key": 0,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
+
+	contains(concerns[_].assessment, "winDriveLetter cannot be resolved") with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [{
+			"key": 0,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
 }
 
 # Test: Verify invalid_guest_disk_mappings rule works correctly
-test_invalid_guest_disk_mappings_rule {
-    # Should find invalid mappings for Windows VM
-    count(invalid_guest_disk_mappings) == 1 with input as {
-        "guestId": "windows2019Server_64Guest",
-        "guestDisks": [
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            }
-        ]
-    }
-    
-    # Should not find invalid mappings for non-Windows VM
-    count(invalid_guest_disk_mappings) == 0 with input as {
-        "guestId": "ubuntu64Guest",
-        "guestDisks": [
-            {
-                "key": 0,
-                "diskPath": "[datastore1] VM1/VM1.vmdk", 
-                "capacity": 21474836480
-            }
-        ]
-    }
-    
-    # Should not find invalid mappings for Windows VM with valid keys
-    count(invalid_guest_disk_mappings) == 0 with input as {
-        "guestId": "windows2019Server_64Guest",
-        "guestDisks": [
-            {
-                "key": 2000,
-                "diskPath": "[datastore1] VM1/VM1.vmdk",
-                "capacity": 21474836480
-            }
-        ]
-    }
+test_invalid_guest_disk_mappings_rule if {
+	# Should find invalid mappings for Windows VM
+	count(invalid_guest_disk_mappings) == 1 with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [{
+			"key": 0,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
+
+	# Should not find invalid mappings for non-Windows VM
+	count(invalid_guest_disk_mappings) == 0 with input as {
+		"guestId": "ubuntu64Guest",
+		"guestDisks": [{
+			"key": 0,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
+
+	# Should not find invalid mappings for Windows VM with valid keys
+	count(invalid_guest_disk_mappings) == 0 with input as {
+		"guestId": "windows2019Server_64Guest",
+		"guestDisks": [{
+			"key": 2000,
+			"diskPath": "[datastore1] VM1/VM1.vmdk",
+			"capacity": 21474836480,
+		}],
+	}
 }
-
-

--- a/validation/policies/io/konveyor/forklift/vmware/host_affinity.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/host_affinity.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.vmware
 
-has_host_affinity {
-    some i
-    input.host.cluster.hostAffinityVms[i].id == input.id
+import rego.v1
+
+has_host_affinity if {
+	some i
+	input.host.cluster.hostAffinityVms[i].id == input.id
 }
 
-concerns[flag] {
-    has_host_affinity
-    flag := {
-        "id": "vmware.host_affinity.detected",
-        "category": "Warning",
-        "label": "VM-Host affinity detected",
-        "assessment": "The VM will be migrated without node affinity, but administrators can set it after migration."
-    }
+concerns contains flag if {
+	has_host_affinity
+	flag := {
+		"id": "vmware.host_affinity.detected",
+		"category": "Warning",
+		"label": "VM-Host affinity detected",
+		"assessment": "The VM will be migrated without node affinity, but administrators can set it after migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/host_affinity_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/host_affinity_test.rego
@@ -1,63 +1,63 @@
 package io.konveyor.forklift.vmware
 
-test_without_host_affinity_vms {
-    mock_vm := {
-        "name": "test",
-        "id": "vm-123",
-        "host": {
-            "name": "test_host",
-            "cluster": {
-                "name": "test_cluster",
-                "hostAffinityVms": []
-            }
-        }
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_without_host_affinity_vms if {
+	mock_vm := {
+		"name": "test",
+		"id": "vm-123",
+		"host": {
+			"name": "test_host",
+			"cluster": {
+				"name": "test_cluster",
+				"hostAffinityVms": [],
+			},
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_other_host_affinity_vms {
-    mock_vm := {
-        "name": "test",
-        "id": "vm-123",
-        "host": {
-            "name": "test_host",
-            "cluster": {
-                "name": "test_cluster",
-                "hostAffinityVms": [
-                {
-                    "kind": "VM",
-                    "id": "vm-2050"
-                },
-                {
-                    "kind": "VM",
-                    "id": "vm-2696"
-                }
-                ]
-            }
-        }
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_other_host_affinity_vms if {
+	mock_vm := {
+		"name": "test",
+		"id": "vm-123",
+		"host": {
+			"name": "test_host",
+			"cluster": {
+				"name": "test_cluster",
+				"hostAffinityVms": [
+					{
+						"kind": "VM",
+						"id": "vm-2050",
+					},
+					{
+						"kind": "VM",
+						"id": "vm-2696",
+					},
+				],
+			},
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_host_affinity_vm {
-    mock_vm := {
-        "name": "test",
-        "id": "vm-123",
-        "host": {
-            "name": "test_host",
-            "cluster": {
-                "name": "test_cluster",
-                "hostAffinityVms": [
-                {
-                    "kind": "VM",
-                    "id": "vm-123"
-                }
-                ]
-            }
-        }
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_host_affinity_vm if {
+	mock_vm := {
+		"name": "test",
+		"id": "vm-123",
+		"host": {
+			"name": "test_host",
+			"cluster": {
+				"name": "test_cluster",
+				"hostAffinityVms": [{
+					"kind": "VM",
+					"id": "vm-123",
+				}],
+			},
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/hostname.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/hostname.rego
@@ -1,33 +1,31 @@
 package io.konveyor.forklift.vmware
 
-import future.keywords.in
+import rego.v1
 
-is_empty_hostname {
-    input.hostName == ""
+is_empty_hostname if {
+	input.hostName == ""
 }
 
-
-is_localhost_hostname {
-    input.hostName == "localhost.localdomain"
+is_localhost_hostname if {
+	input.hostName == "localhost.localdomain"
 }
 
-concerns[flag] {
-    is_empty_hostname
-    flag := {
-        "id": "vmware.hostname.empty",
-        "category": "Warning",
-        "label": "Empty Host Name",
-        "assessment": "The 'hostname' field is missing or empty. The hostname might be renamed during migration."
-    }
+concerns contains flag if {
+	is_empty_hostname
+	flag := {
+		"id": "vmware.hostname.empty",
+		"category": "Warning",
+		"label": "Empty Host Name",
+		"assessment": "The 'hostname' field is missing or empty. The hostname might be renamed during migration.",
+	}
 }
 
-
-concerns[flag] {
-    is_localhost_hostname
-    flag := {
-        "id": "vmware.hostname.default",
-        "category": "Warning",
-        "label": "Default Host Name",
-        "assessment": "The 'hostname' is set to 'localhost.localdomain', which is a default value. The hostname might be renamed during migration."
-    }
+concerns contains flag if {
+	is_localhost_hostname
+	flag := {
+		"id": "vmware.hostname.default",
+		"category": "Warning",
+		"label": "Default Host Name",
+		"assessment": "The 'hostname' is set to 'localhost.localdomain', which is a default value. The hostname might be renamed during migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/hostname_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/hostname_test.rego
@@ -1,19 +1,21 @@
 package io.konveyor.forklift.vmware
 
+import rego.v1
+
 import data.io.konveyor.forklift.vmware.concerns
 
 # Test for empty hostname
-test_empty_hostName {
-     mock_vm := {
-        "name": "test",
-        "hostName": ""
-    }
-    results =  concerns with input as mock_vm
-    count(results) == 1
+test_empty_hostName if {
+	mock_vm := {
+		"name": "test",
+		"hostName": "",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_localhost_hostname {
-    mock_vm := { "hostName": "localhost.localdomain" }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_localhost_hostname if {
+	mock_vm := {"hostName": "localhost.localdomain"}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/name.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/name.rego
@@ -1,30 +1,34 @@
 package io.konveyor.forklift.vmware
 
-default valid_input   = true
-default valid_vm      = false
-default valid_vm_name = false
+import rego.v1
 
-valid_input = false {
-    is_null(input)
+default valid_input := true
+
+default valid_vm := false
+
+default valid_vm_name := false
+
+valid_input := false if {
+	is_null(input)
 }
 
-valid_vm = true {
-    is_string(input.name)
+valid_vm if {
+	is_string(input.name)
 }
 
-valid_vm_name = true {
-    regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
-    count(input.name) < 64
+valid_vm_name if {
+	regex.match("^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$", input.name)
+	count(input.name) < 64
 }
 
-concerns[flag] {
-    valid_input
-    valid_vm
-    not valid_vm_name
-    flag := {
-        "id": "vmware.vm.name.invalid",
-        "category": "Warning",
-        "label": "Invalid VM Name",
-        "assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters."
-    }
+concerns contains flag if {
+	valid_input
+	valid_vm
+	not valid_vm_name
+	flag := {
+		"id": "vmware.vm.name.invalid",
+		"category": "Warning",
+		"label": "Invalid VM Name",
+		"assessment": "The VM name does not comply with the DNS subdomain name format. Edit the name or it will be renamed automatically during the migration to meet RFC 1123. The VM name must be a maximum of 63 characters containing lowercase letters (a-z), numbers (0-9), periods (.), and hyphens (-). The first and last character must be a letter or number. The name cannot contain uppercase letters, spaces or special characters.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/name_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/name_test.rego
@@ -1,25 +1,27 @@
 package io.konveyor.forklift.vmware
 
-test_valid_vm_name {
-    mock_vm := { "name": "test" }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_valid_vm_name if {
+	mock_vm := {"name": "test"}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_vm_name_too_long {
-    mock_vm := { "name": "my-vm-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_vm_name_too_long if {
+	mock_vm := {"name": "my-vm-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_vm_name_invalid_char_underscore {
-    mock_vm := { "name": "my_vm" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_vm_name_invalid_char_underscore if {
+	mock_vm := {"name": "my_vm"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_vm_name_invalid_char_slash {
-    mock_vm := { "name": "my/vm" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_vm_name_invalid_char_slash if {
+	mock_vm := {"name": "my/vm"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/numa_affinity.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/numa_affinity.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.vmware
 
-has_numa_node_affinity {
-    count(input.numaNodeAffinity) != 0
+import rego.v1
+
+has_numa_node_affinity if {
+	count(input.numaNodeAffinity) != 0
 }
 
-concerns[flag] {
-    has_numa_node_affinity
-    flag := {
-        "id": "vmware.numa_affinity.detected",
-        "category": "Warning",
-        "label": "NUMA node affinity detected",
-        "assessment": "NUMA node affinity is not currently supported by Migration Toolkit for Virtualization. The VM can be migrated but it will not have this feature in the target environment."
-    }
+concerns contains flag if {
+	has_numa_node_affinity
+	flag := {
+		"id": "vmware.numa_affinity.detected",
+		"category": "Warning",
+		"label": "NUMA node affinity detected",
+		"assessment": "NUMA node affinity is not currently supported by Migration Toolkit for Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/numa_affinity_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/numa_affinity_test.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.vmware
- 
-test_without_cpu_affinity {
-    mock_vm := { "name": "test", "numaNodeAffinity": [] }
-    results = concerns with input as mock_vm
-    count(results) == 0
+
+import rego.v1
+
+test_without_cpu_affinity if {
+	mock_vm := {"name": "test", "numaNodeAffinity": []}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_cpu_affinity {
-    mock_vm := { "name": "test", "numaNodeAffinity": [1,2] }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_with_cpu_affinity if {
+	mock_vm := {"name": "test", "numaNodeAffinity": [1, 2]}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/nvme_disk test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/nvme_disk test.rego
@@ -1,26 +1,26 @@
 package io.konveyor.forklift.vmware
 
-test_has_nvme_bus {
-     mock_vm := {
-        "name": "test",
-	"disks": [
-        { "bus": "scsi" },
-        { "bus": "nvme" }]
-    }
+import rego.v1
 
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_has_nvme_bus if {
+	mock_vm := {
+		"name": "test",
+		"disks": [
+			{"bus": "scsi"},
+			{"bus": "nvme"},
+		],
+	}
+
+	results := concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_has_no_nvme_bus {
-    mock_vm := {
-        "name": "test",
-	"disks": [
-        { "bus": "scsi" }
-        ]
-    }
+test_has_no_nvme_bus if {
+	mock_vm := {
+		"name": "test",
+		"disks": [{"bus": "scsi"}],
+	}
 
-    results := concerns with input as mock_vm
-    count(results) == 0
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
-

--- a/validation/policies/io/konveyor/forklift/vmware/nvme_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/nvme_disk.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.vmware
 
-has_nvme_bus {
-    some i
-    input.disks[i].bus == "nvme"
+import rego.v1
+
+has_nvme_bus if {
+	some i
+	input.disks[i].bus == "nvme"
 }
 
-concerns[flag] {
-    has_nvme_bus
-    flag := {
-        "id": "vmware.disk.nvme.detected",
-        "category": "Critical",
-        "label": "Disk NVMe was detcted",
-        "assessment": "NVMe disks are not currently supported by MTV. The VM cannot be migrated"
-    }
+concerns contains flag if {
+	has_nvme_bus
+	flag := {
+		"id": "vmware.disk.nvme.detected",
+		"category": "Critical",
+		"label": "Disk NVMe was detcted",
+		"assessment": "NVMe disks are not currently supported by MTV. The VM cannot be migrated",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/passthrough_device.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/passthrough_device.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.vmware
 
-has_passthrough_device {
-    some i
-    input.devices[i].kind == "VirtualPCIPassthrough"
+import rego.v1
+
+has_passthrough_device if {
+	some i
+	input.devices[i].kind == "VirtualPCIPassthrough"
 }
 
-concerns[flag] {
-    has_passthrough_device
-    flag := {
-        "id": "vmware.passthrough_device.detected",
-        "category": "Critical",
-        "label": "Passthrough device detected",
-        "assessment": "SCSI or PCI passthrough devices are not currently supported by Migration Toolkit for Virtualization. The VM cannot be migrated unless the passthrough device is removed."
-    }
+concerns contains flag if {
+	has_passthrough_device
+	flag := {
+		"id": "vmware.passthrough_device.detected",
+		"category": "Critical",
+		"label": "Passthrough device detected",
+		"assessment": "SCSI or PCI passthrough devices are not currently supported by Migration Toolkit for Virtualization. The VM cannot be migrated unless the passthrough device is removed.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/passthrough_device_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/passthrough_device_test.rego
@@ -1,32 +1,30 @@
 package io.konveyor.forklift.vmware
 
-test_with_no_device {
-    mock_vm := {
-        "name": "test",
-        "devices": []
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_no_device if {
+	mock_vm := {
+		"name": "test",
+		"devices": [],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_other_xyz_device {
-    mock_vm := {
-        "name": "test",
-        "devices": [
-            { "kind": "VirtualXYZEthernetCard" }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_other_xyz_device if {
+	mock_vm := {
+		"name": "test",
+		"devices": [{"kind": "VirtualXYZEthernetCard"}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_pci_passthrough_device {
-    mock_vm := {
-        "name": "test",
-        "devices": [
-            { "kind": "VirtualPCIPassthrough" }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_pci_passthrough_device if {
+	mock_vm := {
+		"name": "test",
+		"devices": [{"kind": "VirtualPCIPassthrough"}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/power_state.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/power_state.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.vmware
 
-is_vm_powered_off {
-    input.powerState == "poweredOff"
+import rego.v1
+
+is_vm_powered_off if {
+	input.powerState == "poweredOff"
 }
 
-concerns[flag] {
-    is_vm_powered_off
-    flag := {
-        "id": "vmware.vm_powered_off.detected",
-        "category": "Warning",
-        "label": "VM is powered off - Static IP preservation requires the VM to be powered on",
-        "assessment": "Static IP preservation requires the VM to be powered on."
-    }
+concerns contains flag if {
+	is_vm_powered_off
+	flag := {
+		"id": "vmware.vm_powered_off.detected",
+		"category": "Warning",
+		"label": "VM is powered off - Static IP preservation requires the VM to be powered on",
+		"assessment": "Static IP preservation requires the VM to be powered on.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/power_state_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/power_state_test.rego
@@ -1,13 +1,15 @@
 package io.konveyor.forklift.vmware
 
-test_with_power_state_powered_on {
-    mock_vm := { "name": "test", "powerState": "poweredOn" }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_power_state_powered_on if {
+	mock_vm := {"name": "test", "powerState": "poweredOn"}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_power_state_powered_off {
-    mock_vm := { "name": "test", "powerState": "poweredOff" }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_power_state_powered_off if {
+	mock_vm := {"name": "test", "powerState": "poweredOff"}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.vmware
 
-has_rdm_disk {
-    some i
-    input.disks[i].rdm
+import rego.v1
+
+has_rdm_disk if {
+	some i
+	input.disks[i].rdm
 }
 
-concerns[flag] {
-    has_rdm_disk
-    flag := {
-        "id": "vmware.disk.rdm.detected",
-        "category": "Critical",
-        "label": "Raw Device Mapped disk detected",
-        "assessment": "RDM disks are not currently supported by Migration Toolkit for Virtualization. The VM cannot be migrated unless the RDM disks are removed. You can reattach them to the VM after migration."
-    }
+concerns contains flag if {
+	has_rdm_disk
+	flag := {
+		"id": "vmware.disk.rdm.detected",
+		"category": "Critical",
+		"label": "Raw Device Mapped disk detected",
+		"assessment": "RDM disks are not currently supported by Migration Toolkit for Virtualization. The VM cannot be migrated unless the RDM disks are removed. You can reattach them to the VM after migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/rdm_disk_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/rdm_disk_test.rego
@@ -1,34 +1,34 @@
 package io.konveyor.forklift.vmware
 
-test_with_no_disks {
-    mock_vm := {
-        "name": "test",
-        "disks": []
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_no_disks if {
+	mock_vm := {
+		"name": "test",
+		"disks": [],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_no_shareable_disk {
-    mock_vm := {
-        "name": "test",
-        "disks": [
-            { "rdm": false }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_no_shareable_disk if {
+	mock_vm := {
+		"name": "test",
+		"disks": [{"rdm": false}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_shareable_disk {
-    mock_vm := {
-        "name": "test",
-        "disks": [
-            { "rdm": false },
-            { "rdm": true },
-            { "rdm": false }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_shareable_disk if {
+	mock_vm := {
+		"name": "test",
+		"disks": [
+			{"rdm": false},
+			{"rdm": true},
+			{"rdm": false},
+		],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/rules_version.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/rules_version.rego
@@ -1,7 +1,7 @@
 package io.konveyor.forklift.vmware
 
+import rego.v1
+
 RULES_VERSION := 5
 
-rules_version = {
-    "rules_version": RULES_VERSION
-}
+rules_version := {"rules_version": RULES_VERSION}

--- a/validation/policies/io/konveyor/forklift/vmware/snapshot.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/snapshot.rego
@@ -1,15 +1,17 @@
 package io.konveyor.forklift.vmware
 
-has_snapshot {
-    input.snapshot.kind == "VirtualMachineSnapshot"
+import rego.v1
+
+has_snapshot if {
+	input.snapshot.kind == "VirtualMachineSnapshot"
 }
 
-concerns[flag] {
-    has_snapshot
-    flag := {
-        "id": "vmware.snapshot.detected",
-        "category": "Information",
-        "label": "VM snapshot detected",
-        "assessment": "Online snapshots are not currently supported by OpenShift Virtualization. VM will be migrated with current snapshot."
-    }
+concerns contains flag if {
+	has_snapshot
+	flag := {
+		"id": "vmware.snapshot.detected",
+		"category": "Information",
+		"label": "VM snapshot detected",
+		"assessment": "Online snapshots are not currently supported by OpenShift Virtualization. VM will be migrated with current snapshot.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/snapshot_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/snapshot_test.rego
@@ -1,25 +1,27 @@
 package io.konveyor.forklift.vmware
 
-test_with_no_snapshot {
-    mock_vm := {
-        "name": "test",
-        "snapshot": {
-            "kind": "",
-            "id": ""
-        },
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_no_snapshot if {
+	mock_vm := {
+		"name": "test",
+		"snapshot": {
+			"kind": "",
+			"id": "",
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_snapshot {
-    mock_vm := {
-        "name": "test",
-        "snapshot": {
-            "kind": "VirtualMachineSnapshot",
-            "id": "snapshot-3134"
-        },
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_snapshot if {
+	mock_vm := {
+		"name": "test",
+		"snapshot": {
+			"kind": "VirtualMachineSnapshot",
+			"id": "snapshot-3134",
+		},
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/sriov_device.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/sriov_device.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.vmware
 
-has_sriov_device {
-    some i
-    input.devices[i].kind == "VirtualSriovEthernetCard"
+import rego.v1
+
+has_sriov_device if {
+	some i
+	input.devices[i].kind == "VirtualSriovEthernetCard"
 }
 
-concerns[flag] {
-    has_sriov_device
-    flag := {
-        "id": "vmware.device.sriov.detected",
-        "category": "Warning",
-        "label": "SR-IOV passthrough adapter configuration detected",
-        "assessment": "SR-IOV passthrough adapter configuration is not currently supported by Migration Toolkit for Virtualization. Administrators can configure this after migration."
-    }
+concerns contains flag if {
+	has_sriov_device
+	flag := {
+		"id": "vmware.device.sriov.detected",
+		"category": "Warning",
+		"label": "SR-IOV passthrough adapter configuration detected",
+		"assessment": "SR-IOV passthrough adapter configuration is not currently supported by Migration Toolkit for Virtualization. Administrators can configure this after migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/sriov_device_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/sriov_device_test.rego
@@ -1,32 +1,30 @@
 package io.konveyor.forklift.vmware
 
-test_with_no_device {
-    mock_vm := {
-        "name": "test",
-        "devices": []
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_no_device if {
+	mock_vm := {
+		"name": "test",
+		"devices": [],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_other_yyy_device {
-    mock_vm := {
-        "name": "test",
-        "devices": [
-            { "kind": "VirtualYYYPassthrough" }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_other_yyy_device if {
+	mock_vm := {
+		"name": "test",
+		"devices": [{"kind": "VirtualYYYPassthrough"}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_sriov_nic {
-    mock_vm := {
-        "name": "test",
-        "devices": [
-            { "kind": "VirtualSriovEthernetCard" }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_sriov_nic if {
+	mock_vm := {
+		"name": "test",
+		"devices": [{"kind": "VirtualSriovEthernetCard"}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/tpm_enabled.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/tpm_enabled.rego
@@ -1,17 +1,19 @@
 package io.konveyor.forklift.vmware
 
-default has_tpm_enabled = false
+import rego.v1
 
-has_tpm_enabled = true {
-    input.tpmEnabled == true
+default has_tpm_enabled := false
+
+has_tpm_enabled if {
+	input.tpmEnabled == true
 }
 
-concerns[flag] {
-    has_tpm_enabled
-    flag := {
-        "id": "vmware.tpm.detected",
-        "category": "Warning",
-        "label": "TPM detected",
-        "assessment": "The VM is configured with a TPM device. TPM data will not be transferred during the migration."
-    }
+concerns contains flag if {
+	has_tpm_enabled
+	flag := {
+		"id": "vmware.tpm.detected",
+		"category": "Warning",
+		"label": "TPM detected",
+		"assessment": "The VM is configured with a TPM device. TPM data will not be transferred during the migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/tpm_enabled_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/tpm_enabled_test.rego
@@ -1,19 +1,21 @@
 package io.konveyor.forklift.vmware
 
-test_with_tpm_disabled {
-    mock_vm := {
-        "name": "test",
-        "tpmEnabled": false,
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_tpm_disabled if {
+	mock_vm := {
+		"name": "test",
+		"tpmEnabled": false,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_cpu_hot_add_enabled {
-    mock_vm := {
-        "name": "test",
-        "tpmEnabled": true
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_cpu_hot_add_enabled if {
+	mock_vm := {
+		"name": "test",
+		"tpmEnabled": true,
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/usb_controller.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/usb_controller.rego
@@ -1,16 +1,18 @@
 package io.konveyor.forklift.vmware
 
-has_usb_controller {
-    some i
-    input.devices[i].kind == "VirtualUSBController"
+import rego.v1
+
+has_usb_controller if {
+	some i
+	input.devices[i].kind == "VirtualUSBController"
 }
 
-concerns[flag] {
-    has_usb_controller
-    flag := {
-        "id": "vmware.usb_controller.detected",
-        "category": "Warning",
-        "label": "USB controller detected",
-        "assessment": "USB controllers are not currently supported by Migration Toolkit for Virtualization. The VM can be migrated but the devices attached to the USB controller will not be migrated. Administrators can configure this after migration."
-    }
+concerns contains flag if {
+	has_usb_controller
+	flag := {
+		"id": "vmware.usb_controller.detected",
+		"category": "Warning",
+		"label": "USB controller detected",
+		"assessment": "USB controllers are not currently supported by Migration Toolkit for Virtualization. The VM can be migrated but the devices attached to the USB controller will not be migrated. Administrators can configure this after migration.",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/usb_controller_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/usb_controller_test.rego
@@ -1,32 +1,30 @@
 package io.konveyor.forklift.vmware
 
-test_with_no_device {
-    mock_vm := {
-        "name": "test",
-        "devices": []
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+import rego.v1
+
+test_with_no_device if {
+	mock_vm := {
+		"name": "test",
+		"devices": [],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_other_xxx_device {
-    mock_vm := {
-        "name": "test",
-        "devices": [
-            { "kind": "VirtualXXXPassthrough" }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 0
+test_with_other_xxx_device if {
+	mock_vm := {
+		"name": "test",
+		"devices": [{"kind": "VirtualXXXPassthrough"}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_with_usb_controller {
-    mock_vm := {
-        "name": "test",
-        "devices": [
-            { "kind": "VirtualUSBController" }
-        ]
-    }
-    results := concerns with input as mock_vm
-    count(results) == 1
+test_with_usb_controller if {
+	mock_vm := {
+		"name": "test",
+		"devices": [{"kind": "VirtualUSBController"}],
+	}
+	results := concerns with input as mock_vm
+	count(results) == 1
 }

--- a/validation/policies/io/konveyor/forklift/vmware/validate.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/validate.rego
@@ -1,12 +1,14 @@
 package io.konveyor.forklift.vmware
 
-validate = {
-    "rules_version": RULES_VERSION,
-    "errors": errors,
-    "concerns": concerns
+import rego.v1
+
+validate := {
+	"rules_version": RULES_VERSION,
+	"errors": errors,
+	"concerns": concerns,
 }
 
-errors[message] {
-    not valid_vm
-    message := "No VM name found in input body"
+errors contains message if {
+	not valid_vm
+	message := "No VM name found in input body"
 }

--- a/validation/policies/io/konveyor/forklift/vmware/vm_os.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/vm_os.rego
@@ -1,29 +1,31 @@
 package io.konveyor.forklift.vmware
 
-default has_unsupported_os = false
+import rego.v1
+
+default has_unsupported_os := false
 
 unsupported_os_name_substrings := [
-  "red hat enterprise linux 6",
-  "vmware photon os",
+	"red hat enterprise linux 6",
+	"vmware photon os",
 ]
 
-has_unsupported_os = true {
-    lower_id := lower(input.guestId)
-    regex.match(`.*(rhel6guest|rhel6_64guest|photonguest|photon64guest).*`, lower_id)
+has_unsupported_os if {
+	lower_id := lower(input.guestId)
+	regex.match(`.*(rhel6guest|rhel6_64guest|photonguest|photon64guest).*`, lower_id)
 }
 
-has_unsupported_os {
-  lower_name := lower(input.guestNameFromVmwareTools)
-  some i
-  contains(lower_name, unsupported_os_name_substrings[i])
+has_unsupported_os if {
+	lower_name := lower(input.guestNameFromVmwareTools)
+	some i
+	contains(lower_name, unsupported_os_name_substrings[i])
 }
 
-concerns[flag] {
-    has_unsupported_os
-    flag := {
-        "id": "vmware.os.unsupported",
-        "category":   "Warning",
-        "label":      "Unsupported operating system detected",
-        "assessment": "The guest operating system is not currently supported by the Migration Toolkit for Virtualization"
-    }
+concerns contains flag if {
+	has_unsupported_os
+	flag := {
+		"id": "vmware.os.unsupported",
+		"category": "Warning",
+		"label": "Unsupported operating system detected",
+		"assessment": "The guest operating system is not currently supported by the Migration Toolkit for Virtualization",
+	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/vm_os_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/vm_os_test.rego
@@ -1,89 +1,102 @@
 package io.konveyor.forklift.vmware
- 
-test_unsupported_el6_64 {
-    mock_vm := { "name": "test",
-                 "guestId": "rhel6_64Guest"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+
+import rego.v1
+
+test_unsupported_el6_64 if {
+	mock_vm := {
+		"name": "test",
+		"guestId": "rhel6_64Guest",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_unsupported_el6_64_by_guestName {
-    mock_vm := { "name": "test",
-                 "guestNameFromVmwareTools": "Red Hat Enterprise Linux 6 (64-bit)"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_unsupported_el6_64_by_guestName if {
+	mock_vm := {
+		"name": "test",
+		"guestNameFromVmwareTools": "Red Hat Enterprise Linux 6 (64-bit)",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_unsupported_el6 {
-    mock_vm := { "name": "test",
-                 "guestId": "rhel6Guest"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_unsupported_el6 if {
+	mock_vm := {
+		"name": "test",
+		"guestId": "rhel6Guest",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_unsupported_el6_by_guestName {
-    mock_vm := { "name": "test",
-                 "guestNameFromVmwareTools": "Red Hat Enterprise Linux 6 (32-bit)"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_unsupported_el6_by_guestName if {
+	mock_vm := {
+		"name": "test",
+		"guestNameFromVmwareTools": "Red Hat Enterprise Linux 6 (32-bit)",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_unsupported_photonOS {
-    mock_vm := { "name": "test",
-                 "guestId": "photonGuest"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_unsupported_photonOS if {
+	mock_vm := {
+		"name": "test",
+		"guestId": "photonGuest",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_unsupported_photonOS_by_guestName {
-    mock_vm := { "name": "test",
-                 "guestNameFromVmwareTools": "VMware Photon OS (32-bit)"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_unsupported_photonOS_by_guestName if {
+	mock_vm := {
+		"name": "test",
+		"guestNameFromVmwareTools": "VMware Photon OS (32-bit)",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_unsupported_photonOS_64 {
-    mock_vm := { "name": "test",
-                 "guestId": "vmwarePhoton64Guest"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_unsupported_photonOS_64 if {
+	mock_vm := {
+		"name": "test",
+		"guestId": "vmwarePhoton64Guest",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_unsupported_photonOS_64_by_guestName {
-    mock_vm := { "name": "test",
-                 "guestNameFromVmwareTools": "VMware Photon OS (64-bit)"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 1
+test_unsupported_photonOS_64_by_guestName if {
+	mock_vm := {
+		"name": "test",
+		"guestNameFromVmwareTools": "VMware Photon OS (64-bit)",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 1
 }
 
-test_supported_el7 {
-    mock_vm := { "name": "test",
-                 "guestId": "rhel7_64Guest"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+test_supported_el7 if {
+	mock_vm := {
+		"name": "test",
+		"guestId": "rhel7_64Guest",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_supported_el7_by_guestName {
-    mock_vm := { "name": "test",
-                 "guestNameFromVmwareTools": "Red Hat Enterprise Linux 7 (64-bit)"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+test_supported_el7_by_guestName if {
+	mock_vm := {
+		"name": "test",
+		"guestNameFromVmwareTools": "Red Hat Enterprise Linux 7 (64-bit)",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }
 
-test_supported_windows {
-    mock_vm := { "name": "test",
-                 "guestId": "windows11_64Guest"
-                }
-    results = concerns with input as mock_vm
-    count(results) == 0
+test_supported_windows if {
+	mock_vm := {
+		"name": "test",
+		"guestId": "windows11_64Guest",
+	}
+	results = concerns with input as mock_vm
+	count(results) == 0
 }


### PR DESCRIPTION
**migrate policies to Rego v1 syntax and bump OPA to v1.8.0**

- Updated validation policies for Rego v1 syntax compatibility
- Changed OPA version in validation container to v1.8.0 (latest)

Rego v0 is deprecated, and we should use v1. Parsing in newer OPA versions requires this for compatibility.

This PR relates to [ECOPROJECT-3261](https://issues.redhat.com/browse/ECOPROJECT-3261).

The work for this PR was done using the `opa fmt` command, which is useful for this use case.

Signed-off-by: Aviel Segev <asegev@redhat.com>
