### PR TITLE
storage-offload: Fix device discovery timeout (#2712)

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
@@ -272,8 +272,8 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv 
 				context.Background(), host, []string{"storage", "core", "adapter", "rescan", "-t", "add", "-a", "1"})
 			if err != nil {
 				klog.Errorf("failed to rescan for adapters, attempt %d/%d due to: %s", i, retries, err)
-				time.Sleep(5 * time.Second)
 			}
+			time.Sleep(5 * time.Second)
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
Issue:
When the device is mapped to the ESXi host, it can take some time to get discovered by the kernel. Right now, we wait only if the rescan fails, but in cases where the scan passes, we immediately check for the device.

Fix:
Always add timeout for the next device discovery try.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->