### PR TITLE
Add hack to pin MTV version during updates

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,8 @@
+# pin-update.sh hack
+## Prerequisites
+- have installed `oc` and `jq` cli tools
+- be logged into the cluster
+- have installed older MTV operator version
+### Example scenario
+
+I have a MTV `2.9.1` operator installed. I want to update to MTV `2.9.2` but there is already a newer version available `2.9.3`. With default OLM update path, there is no way of updating to the wanted target version. So I will modify the `pin-update.sh` script to set the appropriate values in the `Defaults` section, mainly `MTV_VERSION` to the version I want to update to, e.g. `2.9.2`. Then, I can decide if I want the upgrade to be fully automatic, or I want to have additional control and approve the updated Install Plan for `2.9.2` manually. I want it to be automatic, so I will not remove the last part of the script, which approves the Install Plan. I can now execute the script by `./pin-update.sh`. The result is updated MTV operator to the target version `2.9.2` and not to the latest version `2.9.3`.

--- a/hack/pin-update.sh
+++ b/hack/pin-update.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# This script bypasses OLM upgrade path and updates MTV to a specific version
+# This should only serve as a reference, cluster admin should know what they are doing.
+
+# Prerequisites:
+#   installed "oc" and "jq" cli tools
+#   logged into the cluster
+
+# Defaults
+MTV_SUBSCRIPTION=mtv-operator
+MTV_NAMESPACE=openshift-mtv
+MTV_VERSION=2.9.2 # change to the version you want to upgrade to
+CATALOG_SOURCE=redhat-operators
+
+# Get installed CSV from current subscription
+CSV=$(oc get subscription $MTV_SUBSCRIPTION -n $MTV_NAMESPACE -o json | jq -r '.status.installedCSV')
+# Remove the current subscription
+oc delete subscription -n $MTV_NAMESPACE $MTV_SUBSCRIPTION
+# Remove the current CSV
+oc delete csv -n $MTV_NAMESPACE $CSV
+# Remove the current Operator CR
+oc delete operators -n $MTV_NAMESPACE "$MTV_SUBSCRIPTION.$MTV_NAMESPACE"
+
+# Create a new subscription with patched version
+echo """apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/$MTV_SUBSCRIPTION.$MTV_NAMESPACE: \"\"
+  name: $MTV_SUBSCRIPTION
+  namespace: $MTV_NAMESPACE
+spec:
+  channel: release-v${MTV_VERSION%.*}
+  installPlanApproval: Manual
+  name: $MTV_SUBSCRIPTION
+  source: $CATALOG_SOURCE
+  sourceNamespace: openshift-marketplace
+  startingCSV: mtv-operator.v$MTV_VERSION
+""" > new_subscription.yaml
+
+# Apply the new subscription
+oc apply -n $MTV_NAMESPACE -f new_subscription.yaml
+# Leave the file on the host for utility
+
+### Further section is optional and can be removed to disable automatic Install Plan approval 
+# Wait for OLM to create an Install Plan
+sleep 2
+ip=$(oc get -n $MTV_NAMESPACE subs -o json $MTV_SUBSCRIPTION | jq '.status.installplan.name' -r)
+# Approve the install plan
+oc -n $MTV_NAMESPACE patch installplan $ip -p '{"spec":{"approved":true}}' --type merge


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a utility to streamline upgrading the operator to a specified version with a guided manual-approval flow.
  - Automates cleanup and recreation of the operator subscription and related resources to complete the upgrade.
  - Provides sensible defaults with options for version and catalog source customization.
  - Writes a generated subscription manifest to the host for reuse and auditing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->