### PR TITLE
MTV-3111 | Add VDDK validation for RawCopyMode migrations

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1312,6 +1312,15 @@ func (r *Reconciler) validateVddkImage(plan *api.Plan) (err error) {
 			Message:  "VDDK image not set on the provider, this is required for the warm migration",
 		})
 	}
+	if plan.Spec.SkipGuestConversion && vddkImage == "" {
+		plan.Status.SetCondition(libcnd.Condition{
+			Type:     VDDKInitImageUnavailable,
+			Status:   True,
+			Reason:   NotSet,
+			Category: api.CategoryCritical,
+			Message:  "VDDK image not set on the provider, this is required for the raw copy mode migration",
+		})
+	}
 
 	return
 }


### PR DESCRIPTION
[MTV-3111] Do critical warning for rawcopymode without vddk (https://issues.redhat.com/browse/MTV-3111)

When SkipGuestConversion (RawCopyMode) is enabled, VDDK is required for VMware migrations. This adds a critical validation that blocks migration execution when VDDK image is not configured on the provider, similar to the existing warm migration validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improves status reporting for raw copy migrations when guest conversion is skipped and no VDDK image is configured. Users now see a clear “VDDK init image unavailable” condition with messaging specific to raw copy mode.
  - Maintains existing behavior and messages for warm migrations; no changes to migration flow or outcomes.
  - Enhances visibility into configuration issues, helping users quickly identify when a VDDK image is required versus when it’s intentionally omitted for raw copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->