### PR TITLE
MTV-3394 | storage-offload: fix the rescan handling

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli_test.go
@@ -1,0 +1,118 @@
+package populator
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	"go.uber.org/mock/gomock"
+
+	vmware_mocks "github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/vmware/mocks"
+)
+
+func TestRemoteEsxcli(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Remote ESXCLI Suite")
+}
+
+var _ = Describe("rescan", func() {
+	var (
+		ctrl       *gomock.Controller
+		mockClient *vmware_mocks.MockClient
+		host       *object.HostSystem
+		targetLUN  string
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockClient = vmware_mocks.NewMockClient(ctrl)
+		host = &object.HostSystem{} // A dummy host system
+		targetLUN = "naa.1234567890"
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("when the device is found on the first attempt", func() {
+		It("should return nil", func() {
+			listCmd := []string{"storage", "core", "device", "list", "-d", targetLUN}
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(listCmd)).Return(nil, nil)
+
+			err := rescan(mockClient, host, targetLUN)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when the device is found after a rescan", func() {
+		It("should return nil", func() {
+			listCmd := []string{"storage", "core", "device", "list", "-d", targetLUN}
+			rescanCmd := []string{"storage", "core", "adapter", "rescan", "-t", "add", "-a", "1"}
+
+			gomock.InOrder(
+				mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(listCmd)).Return(nil, errors.New("device not found")),
+				mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(rescanCmd)).Return(nil, nil),
+				mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(listCmd)).Return(nil, nil),
+			)
+
+			err := rescan(mockClient, host, targetLUN)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when the device is never found", func() {
+		It("should return an error", func() {
+			listCmd := []string{"storage", "core", "device", "list", "-d", targetLUN}
+			rescanCmd := []string{"storage", "core", "adapter", "rescan", "-t", "add", "-a", "1"}
+
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(listCmd)).Return(nil, errors.New("device not found")).Times(rescanRetries + 1)
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(rescanCmd)).Return(nil, nil).Times(rescanRetries)
+
+			err := rescan(mockClient, host, targetLUN)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to find device"))
+		})
+	})
+
+	Context("when rescan command always fails", func() {
+		It("should retry and eventually fail if device not found", func() {
+			listCmd := []string{"storage", "core", "device", "list", "-d", targetLUN}
+			rescanCmd := []string{"storage", "core", "adapter", "rescan", "-t", "add", "-a", "1"}
+
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(listCmd)).Return(nil, errors.New("device not found")).Times(rescanRetries + 1)
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(rescanCmd)).Return(nil, errors.New("rescan failed")).Times(rescanRetries)
+
+			err := rescan(mockClient, host, targetLUN)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to find device"))
+		})
+	})
+
+	Context("when rescan command fails", func() {
+		It("should retry and eventually succeed if device found", func() {
+			listCmd := []string{"storage", "core", "device", "list", "-d", targetLUN}
+			rescanCmd := []string{"storage", "core", "adapter", "rescan", "-t", "add", "-a", "1"}
+
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(listCmd)).Return(nil, errors.New("device not found")).Times(3)
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(listCmd)).Return(nil, nil).Times(1)
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(rescanCmd)).Return(nil, errors.New("rescan failed")).Times(2)
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(rescanCmd)).Return(nil, nil).Times(1)
+
+			err := rescan(mockClient, host, targetLUN)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should retry even when scan fails and eventually succeed if device found", func() {
+			listCmd := []string{"storage", "core", "device", "list", "-d", targetLUN}
+			rescanCmd := []string{"storage", "core", "adapter", "rescan", "-t", "add", "-a", "1"}
+
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(listCmd)).Return(nil, errors.New("device not found")).Times(3)
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(listCmd)).Return(nil, nil).Times(1)
+			mockClient.EXPECT().RunEsxCommand(gomock.Any(), host, gomock.Eq(rescanCmd)).Return(nil, errors.New("rescan failed")).Times(3)
+
+			err := rescan(mockClient, host, targetLUN)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Populator", func() {
 				storageClient.EXPECT().CurrentMappedGroups(gomock.Any(), gomock.Any()).Return([]string{}, nil)
 				storageClient.EXPECT().Map("xcopy-esxs", gomock.Any(), nil).Return(populator.LUN{NAA: "naa.616263"}, nil)
 				storageClient.EXPECT().UnMap(gomock.Any(), gomock.Any(), nil).AnyTimes()
-				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "list", "-d", "/vmfs/devices/disks/naa.616263"}).Return(nil, nil)
+				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "list", "-d", "naa.616263"}).Return(nil, nil)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(),
 					[]string{"vmkfstools", "clone", "-s", "/vmfs/volumes/my-ds/my-vm/vmdisk.vmdk", "-t", "/vmfs/devices/disks/naa.616263"}).
 					Return([]esx.Values{{"message": {`{"taskId": "1"}`}}}, nil)

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -5404,6 +5404,7 @@ spec:
                               - pureFlashArray
                               - powerflex
                               - powermax
+                              - powerstore
                               type: string
                           required:
                           - secretRef

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -5404,6 +5404,7 @@ spec:
                               - pureFlashArray
                               - powerflex
                               - powermax
+                              - powerstore
                               type: string
                           required:
                           - secretRef


### PR DESCRIPTION
Fix the rescan logic so it fails in case the rescan succeeds, but the
device is still not detected.

Also, fix the device argument to be only the naa.XYZ (or any other world
wide name) of the device, and not the /path/to/naa.XYZ as the 'esxcli
storage core device list -d XXX' doesn't handle the path.

https://issues.redhat.com/browse/MTV-3394
Blocks: https://issues.redhat.com/browse/MTV-3368

Signed-off-by: Roy Golan <rgolan@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for the PowerStore storage vendor in StorageMap configuration.

- Improvements
  - Encapsulated and improved ESXi rescan flow after volume mapping, with retries, clearer logging, and final verification to ensure devices are visible before proceeding.

- Tests
  - Added comprehensive tests covering rescan scenarios (immediate success, retries, eventual success, and failures).
  - Adjusted existing tests to reflect refined device argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->