### PR TITLE
MTV-3400 | Add NBDE clevis unlock

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -770,6 +770,14 @@ spec:
                         The VM Namespace
                         Only relevant for an openshift source.
                       type: string
+                    nbdeClevis:
+                      description: |-
+                        Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                        Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                        server is available on target network.
+                        https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                        If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                      type: boolean
                     networkNameTemplate:
                       description: |-
                         NetworkNameTemplate is a template for generating network interface names in the target virtual machine.
@@ -3035,6 +3043,14 @@ spec:
                         The VM Namespace
                         Only relevant for an openshift source.
                       type: string
+                    nbdeClevis:
+                      description: |-
+                        Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                        Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                        server is available on target network.
+                        https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                        If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                      type: boolean
                     networkNameTemplate:
                       description: |-
                         NetworkNameTemplate is a template for generating network interface names in the target virtual machine.
@@ -3578,6 +3594,14 @@ spec:
                             The VM Namespace
                             Only relevant for an openshift source.
                           type: string
+                        nbdeClevis:
+                          description: |-
+                            Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                            Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                            server is available on target network.
+                            https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                            If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                          type: boolean
                         networkNameTemplate:
                           description: |-
                             NetworkNameTemplate is a template for generating network interface names in the target virtual machine.

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -770,6 +770,14 @@ spec:
                         The VM Namespace
                         Only relevant for an openshift source.
                       type: string
+                    nbdeClevis:
+                      description: |-
+                        Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                        Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                        server is available on target network.
+                        https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                        If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                      type: boolean
                     networkNameTemplate:
                       description: |-
                         NetworkNameTemplate is a template for generating network interface names in the target virtual machine.
@@ -3035,6 +3043,14 @@ spec:
                         The VM Namespace
                         Only relevant for an openshift source.
                       type: string
+                    nbdeClevis:
+                      description: |-
+                        Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                        Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                        server is available on target network.
+                        https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                        If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                      type: boolean
                     networkNameTemplate:
                       description: |-
                         NetworkNameTemplate is a template for generating network interface names in the target virtual machine.
@@ -3578,6 +3594,14 @@ spec:
                             The VM Namespace
                             Only relevant for an openshift source.
                           type: string
+                        nbdeClevis:
+                          description: |-
+                            Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                            Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                            server is available on target network.
+                            https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                            If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                          type: boolean
                         networkNameTemplate:
                           description: |-
                             NetworkNameTemplate is a template for generating network interface names in the target virtual machine.

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -770,6 +770,14 @@ spec:
                         The VM Namespace
                         Only relevant for an openshift source.
                       type: string
+                    nbdeClevis:
+                      description: |-
+                        Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                        Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                        server is available on target network.
+                        https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                        If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                      type: boolean
                     networkNameTemplate:
                       description: |-
                         NetworkNameTemplate is a template for generating network interface names in the target virtual machine.
@@ -3035,6 +3043,14 @@ spec:
                         The VM Namespace
                         Only relevant for an openshift source.
                       type: string
+                    nbdeClevis:
+                      description: |-
+                        Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                        Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                        server is available on target network.
+                        https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                        If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                      type: boolean
                     networkNameTemplate:
                       description: |-
                         NetworkNameTemplate is a template for generating network interface names in the target virtual machine.
@@ -3578,6 +3594,14 @@ spec:
                             The VM Namespace
                             Only relevant for an openshift source.
                           type: string
+                        nbdeClevis:
+                          description: |-
+                            Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                            Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                            server is available on target network.
+                            https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                            If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                          type: boolean
                         networkNameTemplate:
                           description: |-
                             NetworkNameTemplate is a template for generating network interface names in the target virtual machine.

--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -384,6 +384,14 @@ spec:
                         The VM Namespace
                         Only relevant for an openshift source.
                       type: string
+                    nbdeClevis:
+                      description: |-
+                        Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                        Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                        server is available on target network.
+                        https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                        If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                      type: boolean
                     networkNameTemplate:
                       description: |-
                         NetworkNameTemplate is a template for generating network interface names in the target virtual machine.

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1497,6 +1497,14 @@ spec:
                         The VM Namespace
                         Only relevant for an openshift source.
                       type: string
+                    nbdeClevis:
+                      description: |-
+                        Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                        Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                        server is available on target network.
+                        https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                        If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                      type: boolean
                     networkNameTemplate:
                       description: |-
                         NetworkNameTemplate is a template for generating network interface names in the target virtual machine.
@@ -2040,6 +2048,14 @@ spec:
                             The VM Namespace
                             Only relevant for an openshift source.
                           type: string
+                        nbdeClevis:
+                          description: |-
+                            Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+                            Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+                            server is available on target network.
+                            https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+                            If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+                          type: boolean
                         networkNameTemplate:
                           description: |-
                             NetworkNameTemplate is a template for generating network interface names in the target virtual machine.

--- a/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -43,6 +43,13 @@ type VM struct {
 	// Disk decryption LUKS keys
 	// +optional
 	LUKS core.ObjectReference `json:"luks" ref:"Secret"`
+	// Attempt passphrase-less unlocking for all devices with Clevis, over the network.
+	// Conversion pod running on target cluster will attempt to connect to a TANG server, make sure TANG
+	// server is available on target network.
+	// https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening
+	// If both nbdeClevis and LUKS are configured, nbdeClevis takes precedence.
+	// +optional
+	NbdeClevis bool `json:"nbdeClevis,omitempty"`
 	// Choose the primary disk the VM boots from
 	// +optional
 	RootDisk string `json:"rootDisk,omitempty"`

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -264,6 +264,13 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 			Value: vm.HostName,
 		})
 	}
+	planVM := r.getPlanVM(vm)
+	if planVM != nil && planVM.NbdeClevis {
+		env = append(env, core.EnvVar{
+			Name:  "V2V_NBDE_CLEVIS",
+			Value: "true",
+		})
+	}
 
 	libvirtURL, fingerprint, err := r.getSourceDetails(vm, sourceSecret)
 	if err != nil {

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -26,6 +26,7 @@ const (
 	EnvLocalMigrationName         = "LOCAL_MIGRATION"
 	EnvVirtIoWinLegacyDriversName = "VIRTIO_WIN"
 	EnvHostName                   = "V2V_HOSTNAME"
+	EnvNbdeClevis                 = "V2V_NBDE_CLEVIS"
 	EnvMultipleIpsPerNicName      = "V2V_multipleIPsPerNic"
 )
 
@@ -90,6 +91,7 @@ type AppConfig struct {
 	VddkConfFile         string
 	InspectionOutputFile string
 	Luksdir              string
+	NbdeClevis           bool
 	DynamicScriptsDir    string
 	Workdir              string
 	VddkLibDir           string
@@ -100,6 +102,7 @@ func (s *AppConfig) Load() (err error) {
 	s.ExtraArgs = s.getExtraArgs()
 	flag.BoolVar(&s.IsLocalMigration, "local-migration", s.getEnvBool(EnvLocalMigrationName, true), "Migration is in local or remote cluster")
 	flag.BoolVar(&s.IsInPlace, "in-place", s.getEnvBool(EnvInPlaceName, false), "Run virt-v2v-in-place on already populated disks")
+	flag.BoolVar(&s.NbdeClevis, "nbde-clevis", s.getEnvBool(EnvNbdeClevis, false), "virt-v2v should unencrypt the disks via clevis client")
 	flag.StringVar(&s.Source, "source", os.Getenv(EnvSourceName), "Source of VM ['ova','vSphere']")
 	flag.StringVar(&s.LibvirtUrl, "libvirt-url", os.Getenv(EnvLibvirtUrlName), "Libvirt domain to the vSphere")
 	flag.StringVar(&s.Fingerprint, "fingerprint", os.Getenv(EnvFingerprintName), "Fingerprint for the vddk")

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -75,9 +75,10 @@ func (c *Conversion) addCommonArgs(cmd utils.CommandBuilder) error {
 			cmd.AddArg("--mac", mac)
 		}
 	}
-
-	// Adds LUKS keys, if they exist
-	if c.Luksdir != "" {
+	if c.NbdeClevis {
+		cmd.AddArgs("--key", "all:clevis")
+	} else if c.Luksdir != "" {
+		// Adds LUKS keys, if they exist
 		err := utils.AddLUKSKeys(c.fileSystem, cmd, c.Luksdir)
 		if err != nil {
 			return fmt.Errorf("error adding LUKS keys: %v", err)

--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -449,6 +449,10 @@ func (c *Customize) addRhelRunScripts(cmdBuilder utils.CommandBuilder) error {
 
 // addLuksKeysToCustomize appends key arguments to extraArgs
 func (c *Customize) addLuksKeysToCustomize(cmdBuilder utils.CommandBuilder) error {
+	if c.appConfig.NbdeClevis {
+		cmdBuilder.AddArgs("--key", "all:clevis")
+		return nil
+	}
 	if c.appConfig.Luksdir == "" {
 		return nil
 	}


### PR DESCRIPTION
Add a new parameter to the forklift plan to allow us to migrate VMs with [NBDE](https://access.redhat.com/articles/6987053) (Network Bound Disk Encryption).
For this, the virt-v2v uses the `--key all:clevis` that calls clevis inside the guestfs to unlock the [disks](https://github.com/libguestfs/libguestfs/blob/master/daemon/clevis-luks.c#L41). The main requirement is to have access from the guest conversion pod to the Tang server. 
This option is under `plan.spec.vm[].nbdeClevis` the option is boolean value and it takes priority over the LUKS, ut we will give warning about it.

Ref: https://issues.redhat.com/browse/MTV-3400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Clevis (NBDE) disk decryption support for VM migrations and hosts.
  * New nbdeClevis option available in VM/Plan/Migration/Host specs and configurable via env var / CLI flag.

* **Improvements**
  * Clevis now takes precedence when both LUKS and nbdeClevis are set.
  * Validation warns when both LUKS and Clevis are configured.

* **Documentation**
  * Updated CRD descriptions and precedence notes (including network name template clarifications).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->