### PR TITLE
MTV-2858 | Add UDN IP address preservation

### DIFF
--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -43,8 +43,10 @@ const (
 )
 
 const (
+	// namespaceLabelPrimaryUDN is the label key used to identify namespaces with primary user-defined networks
 	namespaceLabelPrimaryUDN = "k8s.ovn.org/primary-user-defined-network"
-	nadLabelUDN              = "k8s.ovn.org/user-defined-network"
+	// nadLabelUDN is the label key used to identify NetworkAttachmentDefinitions that are user-defined networks
+	nadLabelUDN = "k8s.ovn.org/user-defined-network"
 )
 
 // PlanSpec defines the desired state of Plan.

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -47,6 +47,10 @@ const (
 
 	// UDN L2 bridge binding, needed for KubeVirt VMs with UDN
 	UdnL2bridge = "l2bridge"
+
+	// Enhancement doc: https://github.com/openshift/enhancements/pull/1793
+	// Example: network.kubevirt.io/addresses: '{"iface1": ["192.168.0.1/24", "fd23:3214::123/64"]}'
+	AnnStaticUdnIp = "network.kubevirt.io/addresses"
 )
 
 var VolumePopulatorNotSupportedError = liberr.New("provider does not support volume populators")
@@ -157,6 +161,8 @@ type Validator interface {
 	PodNetwork(vmRef ref.Ref) (bool, error)
 	// Validate that we have information about static IPs for every virtual NIC
 	StaticIPs(vmRef ref.Ref) (bool, error)
+	// Validate if the UDN subnet matches the VM IP
+	UdnStaticIPs(vmRef ref.Ref, client client.Client) (ok bool, err error)
 	// Validate the shared disk, returns msg and category as the errors depends on the provider implementations
 	SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, msg string, category string, err error)
 	// Validate that the vm has the change tracking enabled

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -355,6 +355,11 @@ func (r *Validator) DirectStorage(vmRef ref.Ref) (bool, error) {
 }
 
 // NO-OP
+func (r *Validator) UdnStaticIPs(vmRef ref.Ref, client k8sclient.Client) (ok bool, err error) {
+	return true, nil
+}
+
+// NO-OP
 func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -67,6 +67,11 @@ func (r *Validator) MaintenanceMode(vmRef ref.Ref) (ok bool, err error) {
 	return
 }
 
+// NO-OP
+func (r *Validator) UdnStaticIPs(vmRef ref.Ref, client client.Client) (ok bool, err error) {
+	return true, nil
+}
+
 // NOOP
 func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
 	return []string{}, nil

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -38,6 +38,11 @@ func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
 	return []string{}, nil
 }
 
+// NO-OP
+func (r *Validator) UdnStaticIPs(vmRef ref.Ref, client client.Client) (ok bool, err error) {
+	return true, nil
+}
+
 func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {
 	vm := &model.VM{}
 	err := r.Source.Inventory.Find(vm, vmRef)

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -42,6 +42,11 @@ func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {
 	return invalidDisks, nil
 }
 
+// NO-OP
+func (r *Validator) UdnStaticIPs(vmRef ref.Ref, client client.Client) (ok bool, err error) {
+	return true, nil
+}
+
 func (r *Validator) MacConflicts(vmRef ref.Ref) ([]planbase.MacConflict, error) {
 	// Get source VM using common helper
 	vm, err := planbase.FindSourceVM[model.Workload](r.Source.Inventory, vmRef)

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -652,7 +653,6 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	if err != nil {
 		return
 	}
-
 	if object.Template == nil {
 		object.Template = &cnv.VirtualMachineInstanceTemplateSpec{}
 	}
@@ -676,9 +676,27 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	return
 }
 
+func isIPv4(address string) bool {
+	ip := net.ParseIP(address)
+	return ip != nil && ip.To4() != nil
+}
+
+func (r *Builder) findInterfaceIps(vm *model.VM, nic vsphere.NIC) []string {
+	var interfaceIps []string
+	for _, net := range vm.GuestNetworks {
+		if net.DeviceConfigId == nic.DeviceKey {
+			if isIPv4(net.IP) {
+				interfaceIps = append(interfaceIps, net.IP)
+			}
+		}
+	}
+	return interfaceIps
+}
+
 func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err error) {
 	var kNetworks []cnv.Network
 	var kInterfaces []cnv.Interface
+	var staticIpInterfaces = make(map[string][]string)
 
 	numNetworks := 0
 	hasUDN := r.Plan.DestinationHasUdnNetwork(r.Destination)
@@ -721,6 +739,12 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 				kInterface.Binding = &cnv.PluginBinding{
 					Name: planbase.UdnL2bridge,
 				}
+				if r.Plan.Spec.PreserveStaticIPs {
+					ips := r.findInterfaceIps(vm, nic)
+					if len(ips) > 0 {
+						staticIpInterfaces[networkName] = ips
+					}
+				}
 			} else {
 				kInterface.Masquerade = &cnv.InterfaceMasquerade{}
 			}
@@ -737,6 +761,18 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 
 	object.Template.Spec.Networks = kNetworks
 	object.Template.Spec.Domain.Devices.Interfaces = kInterfaces
+
+	if hasUDN && r.Plan.Spec.PreserveStaticIPs {
+		var staticIpInterfacesAnnotation []byte
+		staticIpInterfacesAnnotation, err = json.Marshal(staticIpInterfaces)
+		if err != nil {
+			return err
+		}
+		if object.Template.ObjectMeta.Annotations == nil {
+			object.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		object.Template.ObjectMeta.Annotations[planbase.AnnStaticUdnIp] = string(staticIpInterfacesAnnotation)
+	}
 	return
 }
 

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -852,12 +852,14 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 								dnsList = info.DnsConfig.IpAddress
 							}
 							guestNetworksList = append(guestNetworksList, model.GuestNetwork{
-								MAC:          strings.ToLower(info.MacAddress),
-								IP:           ip.IpAddress,
-								Origin:       ip.Origin,
-								PrefixLength: ip.PrefixLength,
-								DNS:          dnsList,
-								Device:       strconv.Itoa(index),
+								MAC:            strings.ToLower(info.MacAddress),
+								IP:             ip.IpAddress,
+								Origin:         ip.Origin,
+								PrefixLength:   ip.PrefixLength,
+								DNS:            dnsList,
+								Device:         strconv.Itoa(index),
+								DeviceConfigId: info.DeviceConfigId,
+								Network:        info.Network,
 							})
 						}
 					}
@@ -947,8 +949,9 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 							nicList = append(
 								nicList,
 								model.NIC{
-									MAC:   strings.ToLower(nic.MacAddress),
-									Index: nicsIndex,
+									MAC:       strings.ToLower(nic.MacAddress),
+									Index:     nicsIndex,
+									DeviceKey: nic.Key,
 									Network: model.Ref{
 										Kind: model.NetKind,
 										ID:   network,

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -366,19 +366,22 @@ type Device struct {
 
 // Virtual ethernet card.
 type NIC struct {
-	Network Ref    `json:"network"`
-	MAC     string `json:"mac"`
-	Index   int    `json:"order"`
+	Network   Ref    `json:"network"`
+	MAC       string `json:"mac"`
+	Index     int    `json:"order"`
+	DeviceKey int32  `json:"deviceKey"`
 }
 
 // Guest network.
 type GuestNetwork struct {
-	Device       string   `json:"device"`
-	MAC          string   `json:"mac"`
-	IP           string   `json:"ip"`
-	Origin       string   `json:"origin"`
-	PrefixLength int32    `json:"prefix"`
-	DNS          []string `json:"dns"`
+	Device         string   `json:"device"`
+	DeviceConfigId int32    `json:"deviceConfigId"`
+	MAC            string   `json:"mac"`
+	IP             string   `json:"ip"`
+	Origin         string   `json:"origin"`
+	PrefixLength   int32    `json:"prefix"`
+	DNS            []string `json:"dns"`
+	Network        string   `json:"network"`
 }
 
 // Guest ipStack


### PR DESCRIPTION
The UDN in the OCP 4.20.0 will have a new feature for setting IP addresses on the VMs. This will allow the forklift to specify which IP address the VM should have after migration. This way, we will be able to preserve the IP from the original provider. This requires that the IP address is from the same subnet. 
Forklift will preserve this with the `preserveStaticIPs` parameter. So, from the User Interface perspective, no configuration will change, but the flag will not only preserve static IPs but also set IP addresses in the UDNs.

Notes:
- Right now, we can not specify the default gateway, DNS,or  secondary UDNs

Ref: https://issues.redhat.com/browse/MTV-2858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Validates static IPs against User-Defined Network (UDN) subnets during plan checks and surfaces a warning when a VM’s IP doesn't match the primary UDN subnet.
  - Preserves and annotates per-interface IPv4 addresses when mapping to UDN networks with static IPs.

- Enhancements
  - Enriched vSphere VM NIC and guest-network metadata for improved network mapping and validation.
  - Added no-op UDN static-IP validation stubs across other providers to align APIs without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->