### PR TITLE
MTV-3368 | storage-offload: Pure flasharray - fix the FC host lookup and matchup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ operator/streams/**/downstream_manifests
 
 # passwords directories
 .passwords/
+
+.gemini/
+gha-creds-*.json

--- a/cmd/vsphere-xcopy-volume-populator/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/Makefile
@@ -83,12 +83,14 @@ test-copy-using-cli-pureflasharray: build
 	bin/vsphere-xcopy-volume-populator \
 		--source-vm-id="vm-67218" \
 		--source-vmdk="[eco-iscsi-pure] vm-6/vm-6.vmdk" \
-		--owner-name=test-pure-vm-6-22ab1d65 \
-		--owner-uid=test-pure-vm-6-22ab1d65 \
+		--owner-name=test-vm-6 \
+		--owner-uid=test-vm-6 \
 		--target-namespace=default \
 		--storage-vendor-product=pureFlashArray \
 		--secret-name=populator-secret \
-		--kubeconfig=$$KUBECONFIG
+		--kubeconfig=$$KUBECONFIG \
+		--esxi-clone-method=ssh
+
 
 test-copy-using-cli-powerflex: build
 	GOSCALEIO_DEBUG=1 bin/vsphere-xcopy-volume-populator \

--- a/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray.go
@@ -41,31 +41,47 @@ func NewFlashArrayClonner(hostname, username, password string, skipSSLVerificati
 	return FlashArrayClonner{client: client, clusterPrefix: clusterPrefix}, nil
 }
 
-// EnsureClonnerIgroup creates or updates an initiator group with the clonnerIqn
+// EnsureClonnerIgroup creates or updates an initiator group with the ESX adapters
 // Named hgroup in flash terminology
-func (f *FlashArrayClonner) EnsureClonnerIgroup(initiatorGroup string, clonnerIqn []string) (populator.MappingContext, error) {
+func (f *FlashArrayClonner) EnsureClonnerIgroup(initiatorGroup string, esxAdapters []string) (populator.MappingContext, error) {
 	// pure does not allow a single host to connect to 2 separae groups. Hence
 	// we must connect map the volume to the host, and not to the group
-	hostNames := []string{}
 	hosts, err := f.client.Hosts.ListHosts(nil)
 	if err != nil {
 		return nil, err
 	}
 	for _, h := range hosts {
+		klog.Infof("checking host %s, iqns: %v, wwns: %v", h.Name, h.Iqn, h.Wwn)
 		for _, iqn := range h.Iqn {
-			if slices.Contains(clonnerIqn, iqn) {
+			if slices.Contains(esxAdapters, iqn) {
 				klog.Infof("adding host to group %v", h.Name)
-				hostNames = append(hostNames, h.Name)
+				return populator.MappingContext{"hosts": []string{h.Name}}, nil
 			}
 		}
 		for _, wwn := range h.Wwn {
-			if slices.Contains(clonnerIqn, wwn) {
-				klog.Infof("adding host to group %v", h.Name)
-				hostNames = append(hostNames, h.Name)
+			for _, hostAdapter := range esxAdapters {
+				if !strings.HasPrefix(hostAdapter, "fc.") {
+					continue
+				}
+				adapterWWPN, err := fcUIDToWWPN(hostAdapter)
+				if err != nil {
+					klog.Warningf("failed to extract WWPN from adapter %s: %s", hostAdapter, err)
+					continue
+				}
+
+				// The WWN from the Pure API needs to be formatted consistently for comparison
+				formattedHostWwn := strings.ReplaceAll(strings.ToUpper(wwn), ":", "")
+				formattedAdapterWwpn := strings.ReplaceAll(adapterWWPN, ":", "")
+
+				klog.Infof("comparing ESX adapter WWPN %s with Pure host WWN %s", formattedAdapterWwpn, formattedHostWwn)
+				if formattedAdapterWwpn == formattedHostWwn {
+					klog.Infof("match found. Adding host %s to mapping context.", h.Name)
+					return populator.MappingContext{"hosts": []string{h.Name}}, nil
+				}
 			}
 		}
 	}
-	return populator.MappingContext{"hosts": hostNames}, nil
+	return nil, fmt.Errorf("no hosts found matching any of the provided IQNs/FC adapters: %v", esxAdapters)
 }
 
 // Map is responsible to mapping an initiator group to a populator.LUN
@@ -73,21 +89,24 @@ func (f *FlashArrayClonner) Map(
 	initatorGroup string,
 	targetLUN populator.LUN,
 	context populator.MappingContext) (populator.LUN, error) {
-	hosts, ok := context["hosts"]
-	if ok {
-		hs, ok := hosts.([]string)
-		if ok && len(hs) > 0 {
-			for _, host := range hs {
-				klog.Infof("connecting host %s to volume %s", host, targetLUN.Name)
-				_, err := f.client.Hosts.ConnectHost(host, targetLUN.Name, nil)
-				if err != nil {
-					if strings.Contains(err.Error(), "Connection already exists.") {
-						continue
-					}
-					return populator.LUN{}, err
-				}
+	hostsVal, ok := context["hosts"]
+	if !ok {
+		return populator.LUN{}, errors.New("hosts not found in mapping context")
+	}
 
+	hosts, ok := hostsVal.([]string)
+	if !ok || len(hosts) == 0 {
+		return populator.LUN{}, errors.New("invalid or empty hosts list in mapping context")
+	}
+
+	for _, host := range hosts {
+		klog.Infof("connecting host %s to volume %s", host, targetLUN.Name)
+		_, err := f.client.Hosts.ConnectHost(host, targetLUN.Name, nil)
+		if err != nil {
+			if strings.Contains(err.Error(), "Connection already exists.") {
+				continue
 			}
+			return populator.LUN{}, fmt.Errorf("connect host %q to volume %q: %w", host, targetLUN.Name, err)
 		}
 	}
 
@@ -128,4 +147,28 @@ func (f *FlashArrayClonner) ResolvePVToLUN(pv populator.PersistentVolume) (popul
 	klog.Infof("volume %+v\n", v)
 	l := populator.LUN{Name: v.Name, SerialNumber: v.Serial, NAA: fmt.Sprintf("naa.%s%s", FlashProviderID, strings.ToLower(v.Serial))}
 	return l, nil
+}
+
+// fcUidToWWPN extracts the WWPN (port name) from an ESXi fcUid string.
+// The expected input is of the form: 'fc.WWNN:WWPN' where the WWNN and WWPN
+// are not separated with columns every byte (2 hex chars) like 00:00:00:00:00:00:00:00
+func fcUIDToWWPN(fcUid string) (string, error) {
+	if !strings.HasPrefix(fcUid, "fc.") {
+		return "", fmt.Errorf("fcUid %q doesn't start with 'fc.'", fcUid)
+	}
+	parts := strings.Split(fcUid[3:], ":")
+	if len(parts) != 2 || len(parts[1]) == 0 {
+		return "", fmt.Errorf("fcUid %q is not in the expected fc.WWNN:WWPN format", fcUid)
+	}
+
+	wwpn := strings.ToUpper(parts[1])
+	if len(wwpn)%2 != 0 {
+		return "", fmt.Errorf("WWPN %q length isn't even", wwpn)
+	}
+
+	var formattedParts []string
+	for i := 0; i < len(wwpn); i += 2 {
+		formattedParts = append(formattedParts, wwpn[i:i+2])
+	}
+	return strings.Join(formattedParts, ":"), nil
 }

--- a/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray_test.go
@@ -1,0 +1,85 @@
+package pure
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFcUIDToWWPN(t *testing.T) {
+	testCases := []struct {
+		name          string
+		fcUid         string
+		expectedWwpn  string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:         "valid fcUid",
+			fcUid:        "fc.2020202020202020:2121212121212121",
+			expectedWwpn: "21:21:21:21:21:21:21:21",
+			expectError:  false,
+		},
+		{
+			name:          "missing WWPN",
+			fcUid:         "fc.2020202020202020",
+			expectedWwpn:  "",
+			expectError:   true,
+			errorContains: "not in the expected fc.WWNN:WWPN format",
+		},
+		{
+			name:          "invalid prefix",
+			fcUid:         "f.2020202020202020:2121212121212121",
+			expectedWwpn:  "",
+			expectError:   true,
+			errorContains: "doesn't start with 'fc.'",
+		},
+		{
+			name:          "invalid format",
+			fcUid:         "fc.2020202020202020:",
+			expectedWwpn:  "",
+			expectError:   true,
+			errorContains: "not in the expected fc.WWNN:WWPN format",
+		},
+		{
+			name:          "odd length wwpn",
+			fcUid:         "fc.2020202020202020:12345",
+			expectedWwpn:  "",
+			expectError:   true,
+			errorContains: "length isn't even",
+		},
+		{
+			name:         "lowercase input",
+			fcUid:        "fc.2020202020202020:2a2b2c2d2e2f2g2h",
+			expectedWwpn: "2A:2B:2C:2D:2E:2F:2G:2H",
+			expectError:  false,
+		},
+		{
+			name:          "empty string",
+			fcUid:         "",
+			expectedWwpn:  "",
+			expectError:   true,
+			errorContains: "doesn't start with 'fc.'",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			wwpn, err := fcUIDToWWPN(tc.fcUid)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				} else if !strings.Contains(err.Error(), tc.errorContains) {
+					t.Errorf("expected error to contain %q, but got %q", tc.errorContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if wwpn != tc.expectedWwpn {
+					t.Errorf("expected wwpn %q, but got %q", tc.expectedWwpn, wwpn)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Pure flasharray stores the wwn on the host in this form:
21:00:00:0E:1E:1E:83:D0
While the adapter on the ESX is reporting:
fc.2100000e1e1e83d0:2100000e1e1e83d2

This fix handles that difference when matching. If the matching fails
and we don't match any hosts then the Populate function returns with an
err.

https://issues.redhat.com/browse/MTV-3368

Signed-off-by: Roy Golan <rgolan@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved Fibre Channel host matching using WWPN normalization, added per-host diagnostics, stronger validation when mapping hosts, and tolerant behavior for already-existing connections.

- Tests
  - Added table-driven tests for FC UID → WWN conversion covering valid and various invalid inputs.

- Chores
  - Updated test invocation to use an SSH-based ESXi clone method and adjusted test identifiers; added new entries to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->