### PR TITLE
MTV-2771 | Avoid trying to set entry in nil map when setting plan target node sl…

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1484,6 +1484,10 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus, sortVolumesByLibvirt bool) 
 
 	// Set the target node name if specified in the plan
 	if len(r.Plan.Spec.TargetNodeSelector) > 0 {
+		// If the node selector is not set, set it to an empty map
+		if object.Spec.Template.Spec.NodeSelector == nil {
+			object.Spec.Template.Spec.NodeSelector = make(map[string]string)
+		}
 		maps.Copy(object.Spec.Template.Spec.NodeSelector, r.Plan.Spec.TargetNodeSelector)
 	}
 


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-2771

Issue:
When we set the node selector we assume it's not nil

Fix:
Check that node selector is not nil before adding new entries to it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash that could occur when setting a Target Node Selector for virtual machines. The selector is now handled safely, preventing deployment failures and improving reliability when specifying node placement.
  * No other behavior changes; this update focuses on stability when configuring node selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->