### PR TITLE
Fix: powerstore map and unmap functions

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/Makefile
@@ -120,6 +120,15 @@ test-copy-using-cli-infinibox: build
 		--secret-name=populator-secret \
 		--kubeconfig=$$KUBECONFIG
 
+test-copy-using-cli-powerstore: build
+	bin/vsphere-xcopy-volume-populator \
+		--source-vm-id="rhel9" \
+		--source-vmdk="[iscsi1] rhel9/rhel9.vmdk" \
+		--owner-name=test8-rhel9-disk-0-cf5cdf1f  \
+		--target-namespace=default \
+		--storage-vendor-product=powerstore \
+		--secret-name=powerstore-secret \
+		--kubeconfig=$$KUBECONFIG
 .PHONY: vmkfstools-wrapper
 vmkfstools-wrapper:
 	$(MAKE) -C vmkfstools-wrapper build

--- a/cmd/vsphere-xcopy-volume-populator/go.sum
+++ b/cmd/vsphere-xcopy-volume-populator/go.sum
@@ -74,6 +74,10 @@ github.com/dell/gopowerstore v1.19.0 h1:iXWqHm2ct3dbLvDnRgzHDb5aCf8Zwx1mToPV6feN
 github.com/dell/gopowerstore v1.19.0/go.mod h1:ZEF/MMMvPk/JdPeKIUGZFXd+AgQxVqCw/NePpV3QcHc=
 github.com/dell/goscaleio v1.20.0 h1:/g0zxlJiGzw5AZEqxjgwaYVc4fmv+DBoAU2PPueZxxE=
 github.com/dell/goscaleio v1.20.0/go.mod h1:XAHq2m2QNJH2l9gu47gQX2m6HjZZlzc1LIa0lrWvSkA=
+github.com/dell/gopowerstore v1.19.0 h1:iXWqHm2ct3dbLvDnRgzHDb5aCf8Zwx1mToPV6feN/H0=
+github.com/dell/gopowerstore v1.19.0/go.mod h1:ZEF/MMMvPk/JdPeKIUGZFXd+AgQxVqCw/NePpV3QcHc=
+github.com/dell/goscaleio v1.20.0 h1:/g0zxlJiGzw5AZEqxjgwaYVc4fmv+DBoAU2PPueZxxE=
+github.com/dell/goscaleio v1.20.0/go.mod h1:XAHq2m2QNJH2l9gu47gQX2m6HjZZlzc1LIa0lrWvSkA=
 github.com/devans10/pugo/flasharray v0.0.0-20241116160615-6bb8c469c9a0 h1:iywqp5xOufeydKSioTnPN8MctrbDmdLjatSHV80j/z8=
 github.com/devans10/pugo/flasharray v0.0.0-20241116160615-6bb8c469c9a0/go.mod h1:7dF4rgfqItyj4bkbwZkwp/Ul+bM4lku/CQvS9OIYF4o=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=


### PR DESCRIPTION
    Fix PowerStore mapping to use real host names instead of logical names
    
    The Map and UnMap functions were ignoring the initiatorGroup parameter
    and always operating on the ESXi host. This caused the xcopy process
    to leave volumes mapped to the ESXi host instead of the intended target,
    which is unwanted behavior.
    
    The root cause was that PowerStore initiators can only be mapped to one
    host, but the logical host name used in remote_excli (the initiator
    group name) may differ from the actual PowerStore host name used in
    production environments.
    
    Solution: we store the logical name and the real name as follows:
    - esxLogicalHostName: The initiator group name in esxi
    - esxRealHostName: The actual PowerStore host name for ESXi
    
    Now Map and UnMap resolve hosts by their real PowerStore host names
    rather than using logical names. The CurrentMappedGroups function also
    returns early if a volume is already mapped to avoid unnecessary work.
    
    Resolves: MTV-3501
    
