### PR TITLE
MTV-3120 | Initiate warm migration with storage offload

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -42,6 +42,39 @@ const (
 	// Related to https://github.com/kubevirt/containerized-data-importer/pull/3572
 	AnnVddkExtraArgs = "cdi.kubevirt.io/storage.pod.vddk.extraargs"
 
+	// CDI import backing file annotation on PVC
+	AnnImportBackingFile = "cdi.kubevirt.io/storage.import.backingFile"
+
+	// Source URL
+	AnnEndpoint = "cdi.kubevirt.io/storage.import.endpoint"
+
+	// Secret name for source credentials
+	AnnSecret = "cdi.kubevirt.io/storage.import.secretName"
+
+	// PVC UUID
+	AnnUUID = "cdi.kubevirt.io/storage.import.uuid"
+
+	// VDDK-specific thumbprint
+	AnnThumbprint = "cdi.kubevirt.io/storage.import.vddk.thumbprint"
+
+	// VDDK image
+	AnnVddkInitImageURL = "cdi.kubevirt.io/storage.pod.vddk.initimageurl"
+
+	// Importer pod progress phase
+	AnnPodPhase = "cdi.kubevirt.io/storage.pod.phase"
+
+	// True if the current checkpoint is the one taken for the cutover
+	AnnFinalCheckpoint = "cdi.kubevirt.io/storage.checkpoint.final"
+
+	// Current checkpoint reference
+	AnnCurrentCheckpoint = "cdi.kubevirt.io/storage.checkpoint.current"
+
+	// Previous checkpoint reference
+	AnnPreviousCheckpoint = "cdi.kubevirt.io/storage.checkpoint.previous"
+
+	// Not a whole annotation but a prefix, append a snapshot name to mark that the snapshot was already copied
+	AnnCheckpointsCopied = "cdi.kubevirt.io/storage.checkpoint.copied"
+
 	// Allow DataVolume to adopt a PVC
 	AnnAllowClaimAdoption = "cdi.kubevirt.io/allowClaimAdoption"
 

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -81,6 +81,9 @@ const (
 	// Inform CDI that the DataVolume is already filled up
 	AnnPrePopulated = "cdi.kubevirt.io/storage.prePopulated"
 
+	// Tell CDI which importer to use
+	AnnSource = "cdi.kubevirt.io/storage.import.source"
+
 	// In a UDN namespace we can't directly reach the virt-v2v pod unless we specify default opened ports on the pod network.
 	AnnOpenDefaultPorts = "k8s.ovn.org/open-default-ports"
 

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -42,6 +42,12 @@ const (
 	// Related to https://github.com/kubevirt/containerized-data-importer/pull/3572
 	AnnVddkExtraArgs = "cdi.kubevirt.io/storage.pod.vddk.extraargs"
 
+	// Allow DataVolume to adopt a PVC
+	AnnAllowClaimAdoption = "cdi.kubevirt.io/allowClaimAdoption"
+
+	// Inform CDI that the DataVolume is already filled up
+	AnnPrePopulated = "cdi.kubevirt.io/storage.prePopulated"
+
 	// In a UDN namespace we can't directly reach the virt-v2v pod unless we specify default opened ports on the pod network.
 	AnnOpenDefaultPorts = "k8s.ovn.org/open-default-ports"
 

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -45,46 +45,46 @@ const (
 	// CDI import backing file annotation on PVC
 	AnnImportBackingFile = "cdi.kubevirt.io/storage.import.backingFile"
 
-	// Source URL
+	// Source URL, on PVC
 	AnnEndpoint = "cdi.kubevirt.io/storage.import.endpoint"
 
-	// Secret name for source credentials
+	// Secret name for source credentials, on PVC
 	AnnSecret = "cdi.kubevirt.io/storage.import.secretName"
 
-	// PVC UUID
+	// VM UUID, on PVC
 	AnnUUID = "cdi.kubevirt.io/storage.import.uuid"
 
 	// VDDK-specific thumbprint
 	AnnThumbprint = "cdi.kubevirt.io/storage.import.vddk.thumbprint"
 
-	// VDDK image
+	// VDDK image, on PVC
 	AnnVddkInitImageURL = "cdi.kubevirt.io/storage.pod.vddk.initimageurl"
 
-	// Importer pod progress phase
+	// Importer pod progress phase, on PVC
 	AnnPodPhase = "cdi.kubevirt.io/storage.pod.phase"
 
-	// True if the current checkpoint is the one taken for the cutover
+	// True if the current checkpoint is the one taken for the cutover, on PVC
 	AnnFinalCheckpoint = "cdi.kubevirt.io/storage.checkpoint.final"
 
-	// Current checkpoint reference
+	// Current checkpoint reference, on PVC
 	AnnCurrentCheckpoint = "cdi.kubevirt.io/storage.checkpoint.current"
 
-	// Previous checkpoint reference
+	// Previous checkpoint reference, on PVC
 	AnnPreviousCheckpoint = "cdi.kubevirt.io/storage.checkpoint.previous"
 
-	// Not a whole annotation but a prefix, append a snapshot name to mark that the snapshot was already copied
+	// Not a whole annotation but a prefix, append a snapshot name to mark that the snapshot was already copied (on PVC)
 	AnnCheckpointsCopied = "cdi.kubevirt.io/storage.checkpoint.copied"
 
-	// Allow DataVolume to adopt a PVC
+	// Allow DataVolume to adopt a PVC, on DataVolume
 	AnnAllowClaimAdoption = "cdi.kubevirt.io/allowClaimAdoption"
 
-	// Inform CDI that the DataVolume is already filled up
+	// Inform CDI that the DataVolume is already filled up, on DataVolume
 	AnnPrePopulated = "cdi.kubevirt.io/storage.prePopulated"
 
-	// Tell CDI which importer to use
+	// Tell CDI which importer to use, on PVC
 	AnnSource = "cdi.kubevirt.io/storage.import.source"
 
-	// Name of the current importer pod
+	// Name of the current importer pod, on PVC
 	AnnImportPod = "cdi.kubevirt.io/storage.import.importPod"
 
 	// In a UDN namespace we can't directly reach the virt-v2v pod unless we specify default opened ports on the pod network.

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -84,6 +84,9 @@ const (
 	// Tell CDI which importer to use
 	AnnSource = "cdi.kubevirt.io/storage.import.source"
 
+	// Name of the current importer pod
+	AnnImportPod = "cdi.kubevirt.io/storage.import.importPod"
+
 	// In a UDN namespace we can't directly reach the virt-v2v pod unless we specify default opened ports on the pod network.
 	AnnOpenDefaultPorts = "k8s.ovn.org/open-default-ports"
 

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1239,7 +1239,7 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 // Check whether the specific VM supports Volume Populators by examining only the datastores used by this VM.
 // This prevents mixed configuration issues where some VMs have offload-capable datastores and others don't.
 func (r *Builder) SupportsVolumePopulators(vmRef ref.Ref) bool {
-	if !settings.Settings.Features.CopyOffload || r.Plan.Spec.Warm {
+	if !settings.Settings.Features.CopyOffload {
 		return false
 	}
 

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1410,8 +1410,8 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				} else {
 					pvc.Annotations = annotations
 				}
-				pvc.Annotations[planbase.AnnDiskSource] = baseVolume(disk.File, false)
-				pvc.Annotations["copy-offload"] = baseVolume(disk.File, false)
+				pvc.Annotations[planbase.AnnDiskSource] = baseVolume(disk.File, r.Plan.Spec.Warm)
+				pvc.Annotations["copy-offload"] = baseVolume(disk.File, r.Plan.Spec.Warm)
 
 				// Apply PVC template naming if configured, replacing the commonName
 				if err := r.setColdMigrationDefaultPVCName(&pvc.ObjectMeta, vm, diskIndex, disk); err != nil {
@@ -1442,7 +1442,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 					},
 					Spec: api.VSphereXcopyVolumePopulatorSpec{
 						VmId:                 vmRef.ID,
-						VmdkPath:             disk.File,
+						VmdkPath:             baseVolume(disk.File, r.Plan.Spec.Warm),
 						SecretName:           secretName,
 						StorageVendorProduct: string(storageVendorProduct),
 					},
@@ -1543,7 +1543,7 @@ func (r *Builder) SetPopulatorDataSourceLabels(vmRef ref.Ref, pvcs []*core.Persi
 
 func (r *Builder) GetPopulatorTaskName(pvc *core.PersistentVolumeClaim) (taskName string, err error) {
 	// copy-offload only
-	taskName = pvc.Annotations[planbase.AnnDiskSource]
+	taskName = baseVolume(pvc.Annotations[planbase.AnnDiskSource], r.Plan.Spec.Warm)
 	return
 }
 

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1499,17 +1499,17 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 						}
 						return nil, err
 					}
-				}
-
-				r.Log.Info("Ensuring a populator service account")
-				err := r.ensurePopulatorServiceAccount(namespace)
-				if err != nil {
-					return nil, err
-				}
-				r.Log.Info("Creating the populator resource", "VSphereXcopyVolumePopulator", vp)
-				err = r.Destination.Client.Create(context.TODO(), &vp, &client.CreateOptions{})
-				if err != nil {
-					return nil, err
+					// Should probably check these separately
+					r.Log.Info("Ensuring a populator service account")
+					err := r.ensurePopulatorServiceAccount(namespace)
+					if err != nil {
+						return nil, err
+					}
+					r.Log.Info("Creating the populator resource", "VSphereXcopyVolumePopulator", vp)
+					err = r.Destination.Client.Create(context.TODO(), &vp, &client.CreateOptions{})
+					if err != nil {
+						return nil, err
+					}
 				}
 
 			}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -91,12 +91,6 @@ const (
 	WindowsPrefix  = "win"
 )
 
-// Annotations
-const (
-	// CDI import backing file annotation on PVC
-	AnnImportBackingFile = "cdi.kubevirt.io/storage.import.backingFile"
-)
-
 const (
 	Shareable = "shareable"
 )
@@ -628,7 +622,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 		//       matching the disk and PVC index.
 		dv.ObjectMeta.Annotations[planbase.AnnDiskIndex] = fmt.Sprintf("%d", diskIndex)
 
-		if pvcMap != nil {
+		if pvcMap != nil && dvSource.VDDK != nil {
 			// In a warm migration with storage offload, the PVC has already been created with
 			// the name template. Copy the result to the DataVolume so it can adopt the PVC.
 			if pvc, present := pvcMap[dvSource.VDDK.BackingFile]; present && pvc != nil {
@@ -976,7 +970,7 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 		if source, ok := pvc.Annotations[planbase.AnnDiskSource]; ok {
 			pvcMap[trimBackingFileName(source)] = pvc
 		} else {
-			pvcMap[trimBackingFileName(pvc.Annotations[AnnImportBackingFile])] = pvc
+			pvcMap[trimBackingFileName(pvc.Annotations[planbase.AnnImportBackingFile])] = pvc
 		}
 	}
 
@@ -1164,7 +1158,7 @@ func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
 
 // Return a stable identifier for a PersistentDataVolume.
 func (r *Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVolumeClaim) string {
-	return baseVolume(pvc.Annotations[AnnImportBackingFile], r.Plan.Spec.Warm)
+	return baseVolume(pvc.Annotations[planbase.AnnImportBackingFile], r.Plan.Spec.Warm)
 }
 
 // Load

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1449,7 +1449,8 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 						pvc.Annotations[planbase.AnnPreviousCheckpoint] = ""
 
 						copied := fmt.Sprintf("%s.%s", planbase.AnnCheckpointsCopied, snapshot)
-						pvc.Annotations[copied] = "xcopy-initial-offload" // Any value should work here
+						pvc.Annotations[copied] = "xcopy-initial-offload"                // Any value should work here
+						pvc.Annotations[planbase.AnnImportPod] = "xcopy-initial-offload" // Should match above
 					}
 				}
 

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1439,6 +1439,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 					pvc.Annotations[planbase.AnnThumbprint] = r.Source.Provider.Status.Fingerprint
 					pvc.Annotations[planbase.AnnVddkInitImageURL] = settings.GetVDDKImage(r.Source.Provider.Spec.Settings)
 					pvc.Annotations[planbase.AnnPodPhase] = "Succeeded"
+					pvc.Annotations[planbase.AnnSource] = "vddk"
 
 					n := len(v.Warm.Precopies)
 					if n > 0 { // Should be 1 at this point
@@ -1895,8 +1896,10 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 			dst.Data["GOVMOMI_HOSTNAME"] = []byte(h.Hostname())
 		case "user":
 			dst.Data["GOVMOMI_USERNAME"] = value
+			dst.Data["accessKeyId"] = value
 		case "password":
 			dst.Data["GOVMOMI_PASSWORD"] = value
+			dst.Data["secretKey"] = value
 		case "insecureSkipVerify":
 			dst.Data["GOVMOMI_INSECURE"] = value
 		}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -520,9 +520,9 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 
 	// For storage offload warm migrations, match this DataVolume to the
 	// existing PVC via the backing file name.
-	var pvcMap map[string]*core.PersistentVolumeClaim
+	var pvcMap map[string]core.PersistentVolumeClaim
 	if r.Plan.Spec.Warm && r.SupportsVolumePopulators(vmRef) {
-		pvcMap = make(map[string]*core.PersistentVolumeClaim)
+		pvcMap = make(map[string]core.PersistentVolumeClaim)
 		pvcs := &core.PersistentVolumeClaimList{}
 		pvcLabels := map[string]string{
 			"vmID":      vmRef.ID,
@@ -544,7 +544,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 
 		for _, pvc := range pvcs.Items {
 			if copyOffload, present := pvc.Annotations["copy-offload"]; present && copyOffload != "" {
-				pvcMap[baseVolume(copyOffload, r.Plan.Spec.Warm)] = &pvc
+				pvcMap[baseVolume(copyOffload, r.Plan.Spec.Warm)] = pvc
 			}
 		}
 	}
@@ -625,7 +625,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 		if pvcMap != nil && dvSource.VDDK != nil {
 			// In a warm migration with storage offload, the PVC has already been created with
 			// the name template. Copy the result to the DataVolume so it can adopt the PVC.
-			if pvc, present := pvcMap[dvSource.VDDK.BackingFile]; present && pvc != nil {
+			if pvc, present := pvcMap[dvSource.VDDK.BackingFile]; present {
 				dv.ObjectMeta.Name = pvc.Name
 			}
 		} else {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1100,26 +1100,6 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				break
 			}
 
-			if r.builder.SupportsVolumePopulators(vm.Ref) && r.Plan.Spec.Warm {
-				pvcs, err := r.kubevirt.getPVCs(vm.Ref)
-				if err != nil {
-					break
-				}
-				for _, pvc := range pvcs {
-					n := len(vm.Warm.Precopies)
-					pvc.Annotations[base.AnnPodPhase] = "Unknown" // Signal CDI to work on this PVC
-					pvc.Annotations[base.AnnCurrentCheckpoint] = vm.Warm.Precopies[n-1].Snapshot
-					backingFile := pvc.Annotations[base.AnnImportBackingFile]
-					pvc.Annotations[base.AnnPreviousCheckpoint] = vm.Warm.Precopies[n-2].DeltaMap()[backingFile]
-					err = r.Destination.Client.Update(context.TODO(), pvc)
-					if err != nil {
-						step.AddError(err.Error())
-						err = nil
-						break
-					}
-				}
-			}
-
 			switch vm.Phase {
 			case api.PhaseAddCheckpoint:
 				vm.Phase = api.PhaseWaitForDataVolumesStatus

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -741,7 +741,8 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				return
 			}
 
-			if !r.builder.SupportsVolumePopulators(vm.Ref) {
+			if !(r.builder.SupportsVolumePopulators(vm.Ref) && !r.Plan.Spec.Warm) {
+				// Only avoid this for storage offload cold migration
 				var dataVolumes []cdi.DataVolume
 				dataVolumes, err = r.kubevirt.DataVolumes(vm)
 				if err != nil {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -802,6 +802,9 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 							r.Log.Error(err, "error getting matching DataVolume for PVC", "pvc", pvc.Name)
 							return
 						}
+						if dataVolume.Annotations == nil {
+							dataVolume.Annotations = make(map[string]string)
+						}
 
 						// Super hack alert: once the DataVolume has adopted the PVC,
 						// set the 'allowClaimAdoption' annotation to false. This gets

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1061,21 +1061,23 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				break
 			}
 
-			pvcs, err := r.kubevirt.getPVCs(vm.Ref)
-			if err != nil {
-				break
-			}
-			for _, pvc := range pvcs {
-				n := len(vm.Warm.Precopies)
-				pvc.Annotations[base.AnnPodPhase] = "Unknown" // Signal CDI to work on this PVC
-				pvc.Annotations[base.AnnCurrentCheckpoint] = vm.Warm.Precopies[n-1].Snapshot
-				backingFile := pvc.Annotations[base.AnnImportBackingFile]
-				pvc.Annotations[base.AnnPreviousCheckpoint] = vm.Warm.Precopies[n-2].DeltaMap()[backingFile]
-				err = r.Destination.Client.Update(context.TODO(), pvc)
+			if r.builder.SupportsVolumePopulators(vm.Ref) && r.Plan.Spec.Warm {
+				pvcs, err := r.kubevirt.getPVCs(vm.Ref)
 				if err != nil {
-					step.AddError(err.Error())
-					err = nil
 					break
+				}
+				for _, pvc := range pvcs {
+					n := len(vm.Warm.Precopies)
+					pvc.Annotations[base.AnnPodPhase] = "Unknown" // Signal CDI to work on this PVC
+					pvc.Annotations[base.AnnCurrentCheckpoint] = vm.Warm.Precopies[n-1].Snapshot
+					backingFile := pvc.Annotations[base.AnnImportBackingFile]
+					pvc.Annotations[base.AnnPreviousCheckpoint] = vm.Warm.Precopies[n-2].DeltaMap()[backingFile]
+					err = r.Destination.Client.Update(context.TODO(), pvc)
+					if err != nil {
+						step.AddError(err.Error())
+						err = nil
+						break
+					}
 				}
 			}
 

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -804,7 +804,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 					// CDI to allow the DataVolume to go to the Paused state, which
 					// allows forklift to reuse all the existing warm migration
 					// logic to continue after a storage offload initial copy.
-					dataVolume.Annotations["cdi.kubevirt.io/allowClaimAdoption"] = "false"
+					dataVolume.Annotations[base.AnnAllowClaimAdoption] = "false"
 					err = r.Destination.Client.Update(context.TODO(), dataVolume)
 					if err != nil {
 						r.Log.Error(err, "error updating DataVolume, retrying", "dv", dataVolume.Name)


### PR DESCRIPTION
Allow warm migration with storage offload by populating the PV with xcopy, and then applying snapshot deltas via CDI. This works by having the usual warm migration DataVolume adopt the populator PVC, adding annotations so that CDI does not try to do the initial import itself.

Reference: [MTV-3120](https://issues.redhat.com/browse/MTV-3120)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Warm-migration support with storage offload and volume populators on vSphere.
  - Added 15 new CDI/storage annotations for import endpoints, VDDK/import metadata, import source, checkpoint tracking, pre-population, and claim-adoption control.
  - Waits for DataVolume-to-PVC adoption before proceeding in warm migrations.

- **Improvements**
  - Reuse matching destination PVCs/DataVolumes during warm migrations to avoid re-creation.
  - Deterministic populator/task naming and GenerateName behavior tuned for warm flows.
  - Prefetching/duplication checks to skip creating existing PVCs and improved credential propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->