### PR TITLE
MTV-3625 | Unexpected connection error to vSphere provider.

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -35,6 +35,8 @@ const (
 	RetryDelay = time.Second * 5
 	// Max object in each update.
 	MaxObjectUpdates = 10000
+	// Connection timeout for provider operations.
+	ConnectionTimeout = 30 * time.Second
 )
 
 // Types
@@ -336,7 +338,7 @@ func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, ConnectionTimeout)
 	defer cancel()
 	client, err := r.buildClient(ctx)
 	if err != nil {
@@ -349,7 +351,7 @@ func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error
 // Test connect/logout.
 func (r *Collector) Test() (status int, err error) {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, ConnectionTimeout)
 	defer cancel()
 	status, err = r.connect(ctx)
 	if err == nil {


### PR DESCRIPTION
Issue:
vSphere provider encounters timeout issue (ConnectionTestFailed) during active warm migrations, blocking new plan creation, despite migrations continuing to run successfully.

Fix:
Increase provider connection test timeout from 10s to 30s.

Ref: https://issues.redhat.com/browse/MTV-3265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized vSphere connection timeouts to a consistent 30 seconds across operations, replacing inconsistent hard-coded values.
  * Results in more predictable connectivity, fewer intermittent timeout failures, and improved reliability for interactive and longer-running vSphere actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->