### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for ovirt-populator-2-8

### DIFF
--- a/build/ovirt-populator/Containerfile-downstream
+++ b/build/ovirt-populator/Containerfile-downstream
@@ -21,6 +21,7 @@ ARG REVISION
 
 LABEL \
     com.redhat.component="mtv-rhv-populator-container" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.8::el8" \
     name="${REGISTRY}/mtv-rhv-populator-rhel8" \
     license="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
