### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for ova-provider-server-2-8

### DIFF
--- a/build/ova-provider-server/Containerfile-downstream
+++ b/build/ova-provider-server/Containerfile-downstream
@@ -23,6 +23,7 @@ ARG REVISION
 LABEL \
     com.redhat.component="mtv-ova-provider-server-container" \
     name="${REGISTRY}/mtv-ova-provider-server-rhel9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.8::el9" \
     license="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \
     io.k8s.description="Migration Toolkit for Virtualization - OVA Provider Server" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
