### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for forklift-operator-2-8

### DIFF
--- a/build/forklift-operator/Containerfile-downstream
+++ b/build/forklift-operator/Containerfile-downstream
@@ -12,6 +12,7 @@ ARG REVISION
 
 LABEL \
     com.redhat.component="mtv-operator-container" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.8::el9" \
     name="${REGISTRY}/mtv-rhel9-operator" \
     license="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
