### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for forklift-api-dev-preview

### DIFF
--- a/build/forklift-api/Containerfile-downstream
+++ b/build/forklift-api/Containerfile-downstream
@@ -21,6 +21,7 @@ ARG REVISION
 
 LABEL \
     com.redhat.component="mtv-api-container" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
     name="${REGISTRY}/mtv-api-rhel9" \
     license="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CPE label to the downstream container image metadata.
  * Existing image labels remain unchanged.
  * No impact on application behavior or runtime functionality.
  * The new label is visible when inspecting image metadata (e.g., via standard container/image inspection tools).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->