### PR TITLE
MTV-2988 | Allow pre release versions when testing version dependent features

### DIFF
--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -19,11 +19,11 @@ const (
 // OpenShift version where the FeatureVmwareSystemSerialNumber feature is supported:
 //   - https://issues.redhat.com/browse/CNV-64582
 //   - https://issues.redhat.com/browse/MTV-2988
-const ocpMinForVmwareSystemSerial = "4.20.0"
+const ocpMinForVmwareSystemSerial = "4.20.0-0"
 
 // OpenShift version where the defined MAC address is supported in User Defined Network:
 //   - https://issues.redhat.com/browse/CNV-66820
-const ocpMinForUdnMacSupport = "4.20.0"
+const ocpMinForUdnMacSupport = "4.20.0-0"
 
 // Feature gates.
 type Features struct {

--- a/pkg/settings/features_test.go
+++ b/pkg/settings/features_test.go
@@ -39,16 +39,16 @@ func TestFeatures_Load_VmwareSystemSerialNumber(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:           "feature enabled, version with pre-release below minimum",
+			name:           "feature enabled, version with pre-release above minimum",
 			featureFlag:    "true",
 			openshiftVer:   "4.20.0-alpha.1",
-			expectedResult: false, // 4.20.0-alpha.1 < 4.20.0 per semver spec
+			expectedResult: true, // 4.20.0-alpha.1 > 4.20.0-0 per semver spec (numeric < non-numeric)
 		},
 		{
 			name:           "feature enabled, pre-release version above minimum",
 			featureFlag:    "true",
 			openshiftVer:   "4.21.0-alpha.1",
-			expectedResult: true, // 4.21.0-alpha.1 > 4.20.0
+			expectedResult: true, // 4.21.0-alpha.1 > 4.20.0-0
 		},
 
 		// V-prefixed version support


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-2988

Issue:
We want to be able to test this features in pre-release versions

Fix:
Change the minimum supported version to include pre-releases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved OpenShift version detection so 4.20.0 prerelease builds (e.g., -alpha) meet the minimum threshold, enabling VMware system serial number and UDN MAC support where applicable.

- Tests
  - Updated test cases to align with prerelease version handling and ensure correct feature gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->