### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for forklift-operator-dev-preview

### DIFF
--- a/build/forklift-operator/Containerfile-downstream
+++ b/build/forklift-operator/Containerfile-downstream
@@ -22,5 +22,6 @@ LABEL \
     vendor="Red Hat, Inc." \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
     revision="$REVISION"
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
