### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for virt-v2v-dev-preview

### DIFF
--- a/build/validation/Containerfile-downstream
+++ b/build/validation/Containerfile-downstream
@@ -35,5 +35,6 @@ LABEL \
     vendor="Red Hat, Inc." \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
-    revision="$REVISION"
+    revision="$REVISION" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9"
 

--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -89,6 +89,7 @@ LABEL \
     io.k8s.description="Migration Toolkit for Virtualization - Virt-V2V" \
     io.openshift.tags="migration,mtv,forklift" \
     summary="Migration Toolkit for Virtualization - Virt-V2V" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
     description="Migration Toolkit for Virtualization - Virt-V2V" \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
