### PR TITLE
MTV-2427 | Add preflight inspection step

### DIFF
--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -32,46 +32,55 @@ func main() {
 		os.Exit(1)
 	}
 
-	// virt-v2v or virt-v2v-in-place
-	if convert.IsInPlace {
-		err = convert.RunVirtV2vInPlace()
-	} else {
-		err = convert.RunVirtV2v()
-	}
-	if err != nil {
-		fmt.Println("Failed to execute virt-v2v command", err)
-		os.Exit(1)
-	}
-
-	// virt-v2v-inspector
-	err = convert.RunVirtV2VInspection()
-	if err != nil {
-		fmt.Println("Failed to inspect the disk", err)
-		os.Exit(1)
-	}
-	inspection, err := utils.GetInspectionV2vFromFile(convert.InspectionOutputFile)
-	if err != nil {
-		fmt.Println("Failed to get inspection file", err)
-		os.Exit(1)
-	}
-
-	// virt-customize
-	err = convert.RunCustomize(inspection.OS)
-	if err != nil {
-		fmt.Println("Failed to customize the VM", err)
-	}
-	// In the remote migrations we can not connect to the conversion pod from the controller.
-	// This connection is needed for to get the additional configuration which is gathered either form virt-v2v or
-	// virt-v2v-inspector. We expose those parameters via server in this pod and once the controller gets the config
-	// the controller sends the request to terminate the pod.
-	if convert.IsLocalMigration {
-		s := server.Server{
-			AppConfig: env,
-		}
-		err = s.Start()
+	// Check if remote inspection of VMs should run
+	if env.IsRemoteInspection {
+		err = convert.RunRemoteV2vInspection()
 		if err != nil {
-			fmt.Println("failed to run the server", err)
+			fmt.Println("Failed to execute virt-v2v-inspection command", err)
 			os.Exit(1)
+		}
+	} else {
+		// virt-v2v or virt-v2v-in-place
+		if convert.IsInPlace {
+			err = convert.RunVirtV2vInPlace()
+		} else {
+			err = convert.RunVirtV2v()
+		}
+		if err != nil {
+			fmt.Println("Failed to execute virt-v2v command", err)
+			os.Exit(1)
+		}
+
+		// virt-v2v-inspector
+		err = convert.RunVirtV2VInspection()
+		if err != nil {
+			fmt.Println("Failed to inspect the disk", err)
+			os.Exit(1)
+		}
+		inspection, err := utils.GetInspectionV2vFromFile(convert.InspectionOutputFile)
+		if err != nil {
+			fmt.Println("Failed to get inspection file", err)
+			os.Exit(1)
+		}
+
+		// virt-customize
+		err = convert.RunCustomize(inspection.OS)
+		if err != nil {
+			fmt.Println("Failed to customize the VM", err)
+		}
+		// In the remote migrations we can not connect to the conversion pod from the controller.
+		// This connection is needed for to get the additional configuration which is gathered either form virt-v2v or
+		// virt-v2v-inspector. We expose those parameters via server in this pod and once the controller gets the config
+		// the controller sends the request to terminate the pod.
+		if convert.IsLocalMigration {
+			s := server.Server{
+				AppConfig: env,
+			}
+			err = s.Start()
+			if err != nil {
+				fmt.Println("failed to run the server", err)
+				os.Exit(1)
+			}
 		}
 	}
 }

--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -36,7 +36,7 @@ func main() {
 	if env.IsRemoteInspection {
 		err = convert.RunRemoteV2vInspection()
 		if err != nil {
-			fmt.Println("Failed to execute virt-v2v-inspection command", err)
+			fmt.Println("Failed to execute virt-v2v-inspector command", err)
 			os.Exit(1)
 		}
 	} else {

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3191,9 +3191,9 @@ spec:
               runPreflightInspection:
                 default: true
                 description: |-
-                  RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
-                  - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
-                  - false: No inspection will be run before disk transfer.
+                  RunPreflightInspection controls whether an inspection step on VM base disks is performed before starting the first disk transfer. Applies only to warm migrations from VMWare.
+                  - true (default): Inspection step runs before transferring any disks and may fail if it detects the migration would fail.
+                  - false: No inspection is performed before disk transfer.
                 type: boolean
               skipGuestConversion:
                 default: false

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3188,6 +3188,13 @@ spec:
                   but will be more predictable.
                   **DANGER** When set to false, the generated PVC name may not be unique and may cause conflicts.
                 type: boolean
+              runPreflightInspection:
+                default: true
+                description: |-
+                  RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
+                  - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
+                  - false: No inspection will be run before disk transfer.
+                type: boolean
               skipGuestConversion:
                 default: false
                 description: Determines if the plan should skip the guest conversion.

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -3191,9 +3191,9 @@ spec:
               runPreflightInspection:
                 default: true
                 description: |-
-                  RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
-                  - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
-                  - false: No inspection will be run before disk transfer.
+                  RunPreflightInspection controls whether an inspection step on VM base disks is performed before starting the first disk transfer. Applies only to warm migrations from VMWare.
+                  - true (default): Inspection step runs before transferring any disks and may fail if it detects the migration would fail.
+                  - false: No inspection is performed before disk transfer.
                 type: boolean
               skipGuestConversion:
                 default: false

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -3188,6 +3188,13 @@ spec:
                   but will be more predictable.
                   **DANGER** When set to false, the generated PVC name may not be unique and may cause conflicts.
                 type: boolean
+              runPreflightInspection:
+                default: true
+                description: |-
+                  RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
+                  - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
+                  - false: No inspection will be run before disk transfer.
+                type: boolean
               skipGuestConversion:
                 default: false
                 description: Determines if the plan should skip the guest conversion.

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3191,9 +3191,9 @@ spec:
               runPreflightInspection:
                 default: true
                 description: |-
-                  RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
-                  - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
-                  - false: No inspection will be run before disk transfer.
+                  RunPreflightInspection controls whether an inspection step on VM base disks is performed before starting the first disk transfer. Applies only to warm migrations from VMWare.
+                  - true (default): Inspection step runs before transferring any disks and may fail if it detects the migration would fail.
+                  - false: No inspection is performed before disk transfer.
                 type: boolean
               skipGuestConversion:
                 default: false

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3188,6 +3188,13 @@ spec:
                   but will be more predictable.
                   **DANGER** When set to false, the generated PVC name may not be unique and may cause conflicts.
                 type: boolean
+              runPreflightInspection:
+                default: true
+                description: |-
+                  RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
+                  - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
+                  - false: No inspection will be run before disk transfer.
+                type: boolean
               skipGuestConversion:
                 default: false
                 description: Determines if the plan should skip the guest conversion.

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1290,6 +1290,13 @@ spec:
                   but will be more predictable.
                   **DANGER** When set to false, the generated PVC name may not be unique and may cause conflicts.
                 type: boolean
+              runPreflightInspection:
+                default: true
+                description: |-
+                  RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
+                  - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
+                  - false: No inspection will be run before disk transfer.
+                type: boolean
               skipGuestConversion:
                 default: false
                 description: Determines if the plan should skip the guest conversion.

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1293,9 +1293,9 @@ spec:
               runPreflightInspection:
                 default: true
                 description: |-
-                  RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
-                  - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
-                  - false: No inspection will be run before disk transfer.
+                  RunPreflightInspection controls whether an inspection step on VM base disks is performed before starting the first disk transfer. Applies only to warm migrations from VMWare.
+                  - true (default): Inspection step runs before transferring any disks and may fail if it detects the migration would fail.
+                  - false: No inspection is performed before disk transfer.
                 type: boolean
               skipGuestConversion:
                 default: false

--- a/pkg/apis/forklift/v1beta1/doc.go
+++ b/pkg/apis/forklift/v1beta1/doc.go
@@ -75,6 +75,7 @@ const (
 	PhaseCreateSnapshot                    = "CreateSnapshot"
 	PhaseCreateVM                          = "CreateVM"
 	PhaseFinalize                          = "Finalize"
+	PhasePreflightInspection               = "PreflightInspection"
 	PhasePowerOffSource                    = "PowerOffSource"
 	PhaseRemoveFinalSnapshot               = "RemoveFinalSnapshot"
 	PhaseRemovePenultimateSnapshot         = "RemovePenultimateSnapshot"

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -224,9 +224,9 @@ type PlanSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=on;off;auto
 	TargetPowerState plan.TargetPowerState `json:"targetPowerState,omitempty"`
-	// RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
-	// - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
-	// - false: No inspection will be run before disk transfer.
+	// RunPreflightInspection controls whether an inspection step on VM base disks is performed before starting the first disk transfer. Applies only to warm migrations from VMWare.
+	// - true (default): Inspection step runs before transferring any disks and may fail if it detects the migration would fail.
+	// - false: No inspection is performed before disk transfer.
 	// +kubebuilder:default:=true
 	RunPreflightInspection bool `json:"runPreflightInspection,omitempty"`
 }

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -224,6 +224,11 @@ type PlanSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=on;off;auto
 	TargetPowerState plan.TargetPowerState `json:"targetPowerState,omitempty"`
+	// RunPreflightInspection controls if an inspection step on VM base disks should be performed before starting the first disk transfer. Only applies to the warm migration type.
+	// - true (default): Inspection step will be run before transfering any disks. This step can fail if inspection finds out that migration can fail.
+	// - false: No inspection will be run before disk transfer.
+	// +kubebuilder:default:=true
+	RunPreflightInspection bool `json:"runPreflightInspection,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -100,6 +100,8 @@ const (
 	kLUKS = "isLUKS"
 	// Use
 	kUse = "use"
+	// DV secret
+	kDV = "isDV"
 )
 
 // User
@@ -123,6 +125,12 @@ const (
 
 	VddkAioBufSizeDefault  = "16"
 	VddkAioBufCountDefault = "4"
+)
+
+// VirtV2V pod types
+const (
+	VirtV2vConversionPod = 0
+	VirtV2vInspectionPod = 1
 )
 
 // Map of VirtualMachines keyed by vmID.
@@ -591,6 +599,7 @@ func (r *KubeVirt) DeleteVM(vm *plan.VMStatus) (err error) {
 
 func (r *KubeVirt) DataVolumes(vm *plan.VMStatus) (dataVolumes []cdi.DataVolume, err error) {
 	labels := r.vmLabels(vm.Ref)
+	labels[kDV] = "true"
 	secret, err := r.ensureSecret(vm.Ref, r.secretDataSetterForCDI(vm.Ref), labels)
 	if err != nil {
 		return
@@ -616,6 +625,8 @@ func (r *KubeVirt) DataVolumes(vm *plan.VMStatus) (dataVolumes []cdi.DataVolume,
 
 func (r *KubeVirt) PopulatorVolumes(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, err error) {
 	labels := r.vmLabels(vmRef)
+	// if this is added then migration fails on "RemovePenultimateSnapshot" with "no snapshots for this VM"
+	//labels[kPopulator] = "true"
 	secret, err := r.ensureSecret(vmRef, r.copyDataFromProviderSecret, labels)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -974,17 +985,20 @@ func (r *KubeVirt) getListOptionsNamespaced() (listOptions *client.ListOptions) 
 	}
 }
 
-// Ensure the guest conversion (virt-v2v) pod exists on the destination.
-func (r *KubeVirt) EnsureGuestConversionPod(vm *plan.VMStatus, vmCr *VirtualMachine, pvcs []*core.PersistentVolumeClaim) (err error) {
+// Ensure the guest conversion/inspection (virt-v2v) pod exists on the destination.
+func (r *KubeVirt) EnsureVirtV2vPod(vm *plan.VMStatus, vmCr *VirtualMachine, pvcs []*core.PersistentVolumeClaim, podType int) (err error) {
 	labels := r.vmLabels(vm.Ref)
 	v2vSecret, err := r.ensureSecret(vm.Ref, r.secretDataSetterForCDI(vm.Ref), labels)
 	if err != nil {
 		return
 	}
 
-	libvirtConfigMap, err := r.ensureLibvirtConfigMap(vm.Ref, vmCr, pvcs)
-	if err != nil {
-		return
+	var libvirtConfigMap = &core.ConfigMap{}
+	if podType == VirtV2vConversionPod {
+		libvirtConfigMap, err = r.ensureLibvirtConfigMap(vm.Ref, vmCr, pvcs)
+		if err != nil {
+			return
+		}
 	}
 
 	var vddkConfigMap *core.ConfigMap
@@ -995,12 +1009,24 @@ func (r *KubeVirt) EnsureGuestConversionPod(vm *plan.VMStatus, vmCr *VirtualMach
 		}
 	}
 
-	newPod, err := r.guestConversionPod(vm, vmCr.Spec.Template.Spec.Volumes, libvirtConfigMap, vddkConfigMap, pvcs, v2vSecret)
+	// vmVolumes is not used when creating inspection pod so it can be empty
+	vmVolumes := []cnv.Volume{}
+	if podType == VirtV2vConversionPod {
+		vmVolumes = vmCr.Spec.Template.Spec.Volumes
+	}
+	newPod, err := r.getVirtV2vPod(vm, vmVolumes, libvirtConfigMap, vddkConfigMap, pvcs, v2vSecret, podType)
 	if err != nil {
 		return
 	}
 
-	list, err := r.GetPodsWithLabels(r.conversionLabels(vm.Ref, true))
+	var podTypeLabels = map[string]string{}
+	switch podType {
+	case VirtV2vConversionPod:
+		podTypeLabels = r.conversionLabels(vm.Ref, true)
+	case VirtV2vInspectionPod:
+		podTypeLabels = r.inspectionLabels(vm.Ref)
+	}
+	list, err := r.GetPodsWithLabels(podTypeLabels)
 	if err != nil {
 		return
 	}
@@ -1912,8 +1938,8 @@ func (r *KubeVirt) getConvertorAffinity() *core.Affinity {
 	}
 }
 
-func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, libvirtConfigMap *core.ConfigMap, vddkConfigmap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, v2vSecret *core.Secret) (pod *core.Pod, err error) {
-	volumes, volumeMounts, volumeDevices, err := r.podVolumeMounts(vmVolumes, libvirtConfigMap, vddkConfigmap, pvcs, vm)
+func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, libvirtConfigMap *core.ConfigMap, vddkConfigmap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, v2vSecret *core.Secret, podType int) (pod *core.Pod, err error) {
+	volumes, volumeMounts, volumeDevices, err := r.podVolumeMounts(vmVolumes, libvirtConfigMap, vddkConfigmap, pvcs, vm, podType)
 	if err != nil {
 		return
 	}
@@ -1935,7 +1961,7 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 		err = vErr
 		return
 	}
-	if useV2vForTransfer && !r.IsCopyOffload(pvcs) {
+	if (useV2vForTransfer && !r.IsCopyOffload(pvcs)) || podType == VirtV2vInspectionPod {
 		// mount the secret for the password and CA certificate
 		volumes = append(volumes, core.Volume{
 			Name: "secret-volume",
@@ -2047,13 +2073,47 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 			Type: core.SeccompProfileTypeRuntimeDefault,
 		}
 	}
+
+	var podName string
+	var containerName string
 	// pod labels - start with user-defined labels, then system conversion labels override them
 	podLabels := make(map[string]string)
-	if r.Plan.Spec.ConvertorLabels != nil {
-		maps.Copy(podLabels, r.Plan.Spec.ConvertorLabels)
+	switch podType {
+	case VirtV2vConversionPod:
+		if r.Plan.Spec.ConvertorLabels != nil {
+			maps.Copy(podLabels, r.Plan.Spec.ConvertorLabels)
+		}
+		// System conversion labels override user labels
+		maps.Copy(podLabels, r.conversionLabels(vm.Ref, false))
+		podName = r.getGeneratedName(vm)
+		containerName = "virt-v2v"
+	case VirtV2vInspectionPod:
+		maps.Copy(podLabels, r.inspectionLabels(vm.Ref))
+		// Add inspection pod specific settings
+		podName = r.getGeneratedName(vm) + "inspection-"
+		containerName = "virt-v2v-inspection"
+		environment = append(environment,
+			core.EnvVar{
+				Name:  "V2V_remoteInspection",
+				Value: "true",
+			})
+
+		// Get VM model and data from inventory
+		virtualMachine := &model.VM{}
+		err = r.Context.Source.Inventory.Find(virtualMachine, vm.Ref)
+		if err != nil {
+			err = liberr.Wrap(err, "vm", vm.Ref.String())
+			return
+		}
+
+		// Add disks to be inspected
+		for i, disk := range virtualMachine.Disks {
+			environment = append(environment, core.EnvVar{
+				Name:  fmt.Sprintf("V2V_remoteInspectDisk_%d", i),
+				Value: fmt.Sprintf("%s", disk.ParentFile),
+			})
+		}
 	}
-	// System conversion labels override user labels
-	maps.Copy(podLabels, r.conversionLabels(vm.Ref, false))
 
 	// pod node selector
 	var podNodeSelector map[string]string
@@ -2068,7 +2128,7 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 			Namespace:    r.Plan.Spec.TargetNamespace,
 			Annotations:  annotations,
 			Labels:       podLabels,
-			GenerateName: r.getGeneratedName(vm),
+			GenerateName: podName,
 		},
 		Spec: core.PodSpec{
 			SecurityContext: &core.PodSecurityContext{
@@ -2083,7 +2143,7 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 			InitContainers: initContainers,
 			Containers: []core.Container{
 				{
-					Name:            "virt-v2v",
+					Name:            containerName,
 					Env:             environment,
 					ImagePullPolicy: core.PullAlways,
 					Resources: core.ResourceRequirements{
@@ -2135,260 +2195,7 @@ func (r *KubeVirt) guestConversionPod(vm *plan.VMStatus, vmVolumes []cnv.Volume,
 	return
 }
 
-func (r *KubeVirt) EnsureGuestInspectionPod(vm *plan.VMStatus) (pod *core.Pod, err error) {
-	var volumes []core.Volume
-	var mounts []core.VolumeMount
-
-	labels := r.vmLabels(vm.Ref)
-
-	// Create secret for virt-v2v inspection pod
-	v2vSecret, err := r.ensureSecret(vm.Ref, r.secretDataSetterForCDI(vm.Ref), labels)
-	if err != nil {
-		return
-	}
-
-	// Create vddk aio configmap if desired
-	var vddkConfigMap *core.ConfigMap
-	if r.Source.Provider.UseVddkAioOptimization() {
-		vddkConfigMap, err = r.ensureVddkConfigMap()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if vddkConfigMap != nil {
-		mounts = append(mounts,
-			core.VolumeMount{
-				Name:      VddkConf,
-				MountPath: fmt.Sprintf("/mnt/%s", VddkConf),
-			},
-		)
-		volumes = append(volumes, core.Volume{
-			Name: VddkConf,
-			VolumeSource: core.VolumeSource{
-				ConfigMap: &core.ConfigMapVolumeSource{
-					LocalObjectReference: core.LocalObjectReference{
-						Name: vddkConfigMap.Name,
-					},
-				},
-			},
-		})
-	}
-
-	// mount the secret for the password and CA certificate
-	volumes = append(volumes, core.Volume{
-		Name: "secret-volume",
-		VolumeSource: core.VolumeSource{
-			Secret: &core.SecretVolumeSource{
-				SecretName: v2vSecret.Name,
-			},
-		},
-	})
-
-	// add volume and mount for the libvirt domain xml config map.
-	// the virt-v2v pod expects to see the libvirt xml at /mnt/v2v/input.xml
-	// libvirtConfigMap, err := r.ensureLibvirtConfigMap(vm.Ref, vmCr, []*core.PersistentVolumeClaim{})
-	// if err != nil {
-	// 	return
-	// }
-
-	// volumes = append(volumes, core.Volume{
-	// 	Name: "libvirt-domain-xml",
-	// 	VolumeSource: core.VolumeSource{
-	// 		ConfigMap: &core.ConfigMapVolumeSource{
-	// 			LocalObjectReference: core.LocalObjectReference{
-	// 				Name: libvirtConfigMap.Name,
-	// 			},
-	// 		},
-	// 	},
-	// })
-
-	// Temporary space for VDDK library
-	volumes = append(volumes, core.Volume{
-		Name: VddkVolumeName,
-		VolumeSource: core.VolumeSource{
-			EmptyDir: &core.EmptyDirVolumeSource{},
-		},
-	})
-
-	mounts = append(mounts,
-		core.VolumeMount{
-			Name:      "secret-volume",
-			ReadOnly:  true,
-			MountPath: "/etc/secret",
-		},
-		// core.VolumeMount{
-		// 	Name:      "libvirt-domain-xml",
-		// 	MountPath: "/mnt/v2v",
-		// },
-		core.VolumeMount{
-			Name:      "vddk-vol-mount",
-			MountPath: "/opt",
-		},
-	)
-
-	extraConfigMapExists := len(Settings.Migration.VirtV2vExtraConfConfigMap) > 0
-	if extraConfigMapExists {
-		volumes = append(volumes, core.Volume{
-			Name: ExtraV2vConf,
-			VolumeSource: core.VolumeSource{
-				ConfigMap: &core.ConfigMapVolumeSource{
-					LocalObjectReference: core.LocalObjectReference{
-						Name: genExtraV2vConfConfigMapName(r.Plan),
-					},
-				},
-			},
-		})
-		mounts = append(mounts,
-			core.VolumeMount{
-				Name:      ExtraV2vConf,
-				MountPath: fmt.Sprintf("/mnt/%s", ExtraV2vConf),
-			},
-		)
-	}
-
-	// qemu group
-	fsGroup := qemuGroup
-	user := qemuUser
-	nonRoot := true
-	allowPrivilageEscalation := false
-
-	// VDDK image
-	var initContainers []core.Container
-
-	vddkImage := settings.GetVDDKImage(r.Source.Provider.Spec.Settings)
-	if vddkImage != "" {
-		initContainers = append(initContainers, core.Container{
-			Name:            "vddk-side-car",
-			Image:           vddkImage,
-			ImagePullPolicy: core.PullIfNotPresent,
-			VolumeMounts: []core.VolumeMount{
-				{
-					Name:      VddkVolumeName,
-					MountPath: "/opt",
-				},
-			},
-			Resources: core.ResourceRequirements{
-				Requests: core.ResourceList{
-					core.ResourceCPU:    resource.MustParse("100m"),
-					core.ResourceMemory: resource.MustParse("150Mi"),
-				},
-				Limits: core.ResourceList{
-					core.ResourceCPU:    resource.MustParse("1000m"),
-					core.ResourceMemory: resource.MustParse("500Mi"),
-				},
-			},
-			SecurityContext: &core.SecurityContext{
-				AllowPrivilegeEscalation: &allowPrivilageEscalation,
-				Capabilities: &core.Capabilities{
-					Drop: []core.Capability{"ALL"},
-				},
-			},
-		})
-	}
-
-	// seccomp profile
-	var seccompProfile core.SeccompProfile
-	if settings.Settings.OpenShift {
-		unshare := "profiles/unshare.json"
-		seccompProfile = core.SeccompProfile{
-			Type:             core.SeccompProfileTypeLocalhost,
-			LocalhostProfile: &unshare,
-		}
-	} else {
-		seccompProfile = core.SeccompProfile{
-			Type: core.SeccompProfileTypeRuntimeDefault,
-		}
-	}
-
-	// Inspection pod labels
-	podLabels := r.inspectionLabels(vm.Ref)
-
-	// pod environment
-	environment, err := r.Builder.PodEnvironment(vm.Ref, r.Source.Secret)
-	if err != nil {
-		return
-	}
-
-	// Get VM model and data from inventory
-	virtualMachine := &model.VM{}
-	err = r.Context.Source.Inventory.Find(virtualMachine, vm.Ref)
-	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
-		return
-	}
-
-	// Add disks to be inspected
-	for i, disk := range virtualMachine.Disks {
-		environment = append(environment, core.EnvVar{
-			Name:  fmt.Sprintf("V2V_remoteInspectDisk_%d", i),
-			Value: fmt.Sprintf("\"%s\"", disk.ParentFile),
-		})
-	}
-
-	pod = &core.Pod{
-		ObjectMeta: meta.ObjectMeta{
-			Namespace:    r.Plan.Spec.TargetNamespace,
-			Labels:       podLabels,
-			GenerateName: r.getGeneratedName(vm) + "inspection",
-		},
-		Spec: core.PodSpec{
-			SecurityContext: &core.PodSecurityContext{
-				FSGroup:        &fsGroup,
-				RunAsUser:      &user,
-				RunAsNonRoot:   &nonRoot,
-				SeccompProfile: &seccompProfile,
-			},
-			RestartPolicy:  core.RestartPolicyNever,
-			InitContainers: initContainers,
-			Containers: []core.Container{
-				{
-					Name:            "virt-v2v-inspection",
-					Env:             environment,
-					ImagePullPolicy: core.PullAlways,
-					Resources: core.ResourceRequirements{
-						Requests: core.ResourceList{
-							core.ResourceCPU:    resource.MustParse(Settings.Migration.VirtV2vContainerRequestsCpu),
-							core.ResourceMemory: resource.MustParse(Settings.Migration.VirtV2vContainerRequestsMemory),
-						},
-						Limits: core.ResourceList{
-							core.ResourceCPU:    resource.MustParse(Settings.Migration.VirtV2vContainerLimitsCpu),
-							core.ResourceMemory: resource.MustParse(Settings.Migration.VirtV2vContainerLimitsMemory),
-						},
-					},
-					EnvFrom: []core.EnvFromSource{
-						{
-							Prefix: "V2V_",
-							SecretRef: &core.SecretEnvSource{
-								LocalObjectReference: core.LocalObjectReference{
-									Name: v2vSecret.Name,
-								},
-							},
-						},
-					},
-					Image:        Settings.Migration.VirtV2vImage,
-					VolumeMounts: mounts,
-					SecurityContext: &core.SecurityContext{
-						AllowPrivilegeEscalation: &allowPrivilageEscalation,
-						Capabilities: &core.Capabilities{
-							Drop: []core.Capability{"ALL"},
-						},
-					},
-				},
-			},
-			Volumes: volumes,
-		},
-	}
-
-	// Request access to /dev/kvm via Kubevirt's Device Manager
-	// That is to ensure the appliance virt-v2v uses would not
-	// run in emulation mode, which is significantly slower
-	r.setKvmOnPodSpec(&pod.Spec)
-
-	return
-}
-
-func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, libvirtConfigMap *core.ConfigMap, vddkConfigmap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, vm *plan.VMStatus) (volumes []core.Volume, mounts []core.VolumeMount, devices []core.VolumeDevice, err error) {
+func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, libvirtConfigMap *core.ConfigMap, vddkConfigmap *core.ConfigMap, pvcs []*core.PersistentVolumeClaim, vm *plan.VMStatus, podType int) (volumes []core.Volume, mounts []core.VolumeMount, devices []core.VolumeDevice, err error) {
 	pvcsByName := make(map[string]*core.PersistentVolumeClaim)
 	for _, pvc := range pvcs {
 		pvcsByName[pvc.Name] = pvc
@@ -2428,18 +2235,26 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, libvirtConfigMap *cor
 		}
 	}
 
-	// add volume and mount for the libvirt domain xml config map.
-	// the virt-v2v pod expects to see the libvirt xml at /mnt/v2v/input.xml
-	volumes = append(volumes, core.Volume{
-		Name: "libvirt-domain-xml",
-		VolumeSource: core.VolumeSource{
-			ConfigMap: &core.ConfigMapVolumeSource{
-				LocalObjectReference: core.LocalObjectReference{
-					Name: libvirtConfigMap.Name,
+	if podType == VirtV2vConversionPod {
+		// add volume and mount for the libvirt domain xml config map.
+		// the virt-v2v pod expects to see the libvirt xml at /mnt/v2v/input.xml
+		volumes = append(volumes, core.Volume{
+			Name: "libvirt-domain-xml",
+			VolumeSource: core.VolumeSource{
+				ConfigMap: &core.ConfigMapVolumeSource{
+					LocalObjectReference: core.LocalObjectReference{
+						Name: libvirtConfigMap.Name,
+					},
 				},
 			},
-		},
-	})
+		})
+		mounts = append(mounts,
+			core.VolumeMount{
+				Name:      "libvirt-domain-xml",
+				MountPath: "/mnt/v2v",
+			},
+		)
+	}
 
 	extraConfigMapExists := len(Settings.Migration.VirtV2vExtraConfConfigMap) > 0
 	if extraConfigMapExists {
@@ -2492,10 +2307,6 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, libvirtConfigMap *cor
 		})
 		mounts = append(mounts,
 			core.VolumeMount{
-				Name:      "libvirt-domain-xml",
-				MountPath: "/mnt/v2v",
-			},
-			core.VolumeMount{
 				Name:      VddkVolumeName,
 				MountPath: "/opt",
 			},
@@ -2507,11 +2318,7 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, libvirtConfigMap *cor
 	case api.VSphere:
 		mounts = append(mounts,
 			core.VolumeMount{
-				Name:      "libvirt-domain-xml",
-				MountPath: "/mnt/v2v",
-			},
-			core.VolumeMount{
-				Name:      "vddk-vol-mount",
+				Name:      VddkVolumeName,
 				MountPath: "/opt",
 			},
 		)

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -102,6 +102,8 @@ const (
 	kUse = "use"
 	// DV secret
 	kDV = "isDV"
+	// Populator secret
+	kPopulator = "isPopulator"
 )
 
 // User
@@ -625,8 +627,7 @@ func (r *KubeVirt) DataVolumes(vm *plan.VMStatus) (dataVolumes []cdi.DataVolume,
 
 func (r *KubeVirt) PopulatorVolumes(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, err error) {
 	labels := r.vmLabels(vmRef)
-	// if this is added then migration fails on "RemovePenultimateSnapshot" with "no snapshots for this VM"
-	//labels[kPopulator] = "true"
+	labels[kPopulator] = "true"
 	secret, err := r.ensureSecret(vmRef, r.copyDataFromProviderSecret, labels)
 	if err != nil {
 		err = liberr.Wrap(err)

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2111,7 +2111,7 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, libv
 		for i, disk := range virtualMachine.Disks {
 			environment = append(environment, core.EnvVar{
 				Name:  fmt.Sprintf("V2V_remoteInspectDisk_%d", i),
-				Value: fmt.Sprintf("%s", disk.ParentFile),
+				Value: disk.ParentFile,
 			})
 		}
 	}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1269,6 +1269,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			}
 
 			if pod == nil {
+				r.Log.Info("Couldn't find the virt-v2v inspection pod")
 				return
 			}
 

--- a/pkg/controller/plan/migrator/base/doc.go
+++ b/pkg/controller/plan/migrator/base/doc.go
@@ -22,14 +22,15 @@ var (
 
 // Steps.
 const (
-	Initialize      = "Initialize"
-	Cutover         = "Cutover"
-	DiskAllocation  = "DiskAllocation"
-	DiskTransfer    = "DiskTransfer"
-	ImageConversion = "ImageConversion"
-	DiskTransferV2v = "DiskTransferV2v"
-	VMCreation      = "VirtualMachineCreation"
-	Unknown         = "Unknown"
+	Initialize          = "Initialize"
+	Cutover             = "Cutover"
+	DiskAllocation      = "DiskAllocation"
+	DiskTransfer        = "DiskTransfer"
+	ImageConversion     = "ImageConversion"
+	DiskTransferV2v     = "DiskTransferV2v"
+	VMCreation          = "VirtualMachineCreation"
+	PreflightInspection = "PreflightInspection"
+	Unknown             = "Unknown"
 )
 
 type Migrator interface {

--- a/pkg/controller/plan/migrator/base/doc.go
+++ b/pkg/controller/plan/migrator/base/doc.go
@@ -18,6 +18,7 @@ var (
 	VirtV2vDiskCopy         libitr.Flag = 0x10
 	OpenstackImageMigration libitr.Flag = 0x20
 	VSphere                 libitr.Flag = 0x40
+	RunInspection           libitr.Flag = 0x80
 )
 
 // Steps.

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -248,9 +248,14 @@ func (r *BaseMigrator) ExecutePhase(vm *plan.VMStatus) (ok bool, err error) {
 // Step gets the name of the pipeline step corresponding to the current VM phase.
 func (r *BaseMigrator) Step(status *plan.VMStatus) (step string) {
 	switch status.Phase {
-	case api.PhaseStarted, api.PhaseCreateInitialSnapshot, api.PhaseWaitForInitialSnapshot,
-		api.PhaseStoreInitialSnapshotDeltas, api.PhaseCreateDataVolumes:
+	case api.PhaseStarted, api.PhaseCreateInitialSnapshot, api.PhaseWaitForInitialSnapshot:
 		step = Initialize
+	case api.PhaseStoreInitialSnapshotDeltas, api.PhaseCreateDataVolumes:
+		if r.Context.Plan.Spec.RunPreflightInspection {
+			step = DiskTransfer
+		} else {
+			step = Initialize
+		}
 	case api.PhaseAllocateDisks:
 		step = DiskAllocation
 	case api.PhaseCopyDisks, api.PhaseCopyingPaused, api.PhaseRemovePreviousSnapshot, api.PhaseWaitForPreviousSnapshotRemoval,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -1136,6 +1136,9 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 						ID:   datastoreId,
 					}
 				}
+				if backing.Parent != nil {
+					md.ParentFile = backing.Parent.FileName
+				}
 				disks = append(disks, md)
 			case *types.VirtualDiskFlatVer2BackingInfo:
 				md := model.Disk{
@@ -1149,6 +1152,9 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 					Bus:            bus,
 					Serial:         backing.Uuid,
 					WinDriveLetter: winDriveLetter,
+				}
+				if backing.Parent != nil {
+					md.ParentFile = backing.Parent.FileName
 				}
 				if backing.Datastore != nil {
 					datastoreId, _ := sanitize(backing.Datastore.Value)

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -357,6 +357,7 @@ type Disk struct {
 	Serial                string `json:"serial,omitempty"`
 	WinDriveLetter        string `json:"winDriveLetter,omitempty"`
 	ChangeTrackingEnabled bool   `json:"changeTrackingEnabled"`
+	ParentFile            string `json:"parent"`
 }
 
 // Virtual Device.

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -130,7 +130,7 @@ func (s *AppConfig) Load() (err error) {
 	flag.StringVar(&s.VirtIoWinLegacyDrivers, "virtio-win-legacy-drivers", os.Getenv(EnvVirtIoWinLegacyDriversName), "Path to the virtio-win legacy drivers ISO")
 	flag.StringVar(&s.HostName, "hostname", os.Getenv(EnvHostName), "Hostname of the vm")
 	flag.StringVar(&s.MultipleIpsPerNicName, "multiple-ips-per-nic", os.Getenv(EnvMultipleIpsPerNicName), "Multiple IPs per NIC")
-	flag.BoolVar(&s.IsRemoteInspection, "remote-inspection", s.getEnvBool(EnvRemoteInspection, true), "Run virt-v2v-inspection on remote disks")
+	flag.BoolVar(&s.IsRemoteInspection, "remote-inspection", s.getEnvBool(EnvRemoteInspection, false), "Run virt-v2v-inspection on remote disks")
 	s.RemoteInspectionDisks = s.getRemoteInspectionDisks()
 	flag.Parse()
 

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
 type MountPath string
@@ -28,6 +29,8 @@ const (
 	EnvHostName                   = "V2V_HOSTNAME"
 	EnvNbdeClevis                 = "V2V_NBDE_CLEVIS"
 	EnvMultipleIpsPerNicName      = "V2V_multipleIPsPerNic"
+	EnvRemoteInspection           = "V2V_remoteInspection"
+	EnvRemoteInspectionDisk       = "V2V_remoteInspectDisk_"
 )
 
 const (
@@ -85,6 +88,11 @@ type AppConfig struct {
 	// hostname
 	HostName string
 
+	// V2V_remoteInspection
+	IsRemoteInspection bool
+	// RemoteInspectionDisks
+	RemoteInspectionDisks []string
+
 	// V2V_multipleIPsPerNic
 	MultipleIpsPerNicName string
 	// Paths
@@ -122,6 +130,8 @@ func (s *AppConfig) Load() (err error) {
 	flag.StringVar(&s.VirtIoWinLegacyDrivers, "virtio-win-legacy-drivers", os.Getenv(EnvVirtIoWinLegacyDriversName), "Path to the virtio-win legacy drivers ISO")
 	flag.StringVar(&s.HostName, "hostname", os.Getenv(EnvHostName), "Hostname of the vm")
 	flag.StringVar(&s.MultipleIpsPerNicName, "multiple-ips-per-nic", os.Getenv(EnvMultipleIpsPerNicName), "Multiple IPs per NIC")
+	flag.BoolVar(&s.IsRemoteInspection, "remote-inspection", s.getEnvBool(EnvRemoteInspection, true), "Run virt-v2v-inspection on remote disks")
+	s.RemoteInspectionDisks = s.getRemoteInspectionDisks()
 	flag.Parse()
 
 	return s.validate()
@@ -139,6 +149,20 @@ func (s *AppConfig) getExtraArgs() []string {
 		}
 	}
 	return extraArgs
+}
+
+func (s *AppConfig) getRemoteInspectionDisks() []string {
+	var disks []string
+
+	envVars := os.Environ()
+
+	for _, envVar := range envVars {
+		if strings.Contains(envVar, EnvRemoteInspectionDisk) {
+			disks = append(disks, strings.Split(envVar, "=")[1])
+		}
+	}
+
+	return disks
 }
 
 // Get boolean.

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -230,7 +230,10 @@ func (c *Conversion) RunRemoteV2vInspection() (err error) {
 		AddFlag("-v").
 		AddFlag("-x")
 
-	c.addVirtV2vRemoteInspectionArgs(v2vCmdBuilder)
+	err = c.addVirtV2vRemoteInspectionArgs(v2vCmdBuilder)
+	if err != nil {
+		return err
+	}
 
 	err = c.addVirtV2vVsphereArgs(v2vCmdBuilder)
 	if err != nil {
@@ -243,8 +246,12 @@ func (c *Conversion) RunRemoteV2vInspection() (err error) {
 	return v2vCmd.Run()
 }
 
-func (c *Conversion) addVirtV2vRemoteInspectionArgs(cmd utils.CommandBuilder) {
+func (c *Conversion) addVirtV2vRemoteInspectionArgs(cmd utils.CommandBuilder) (err error) {
+	if len(c.RemoteInspectionDisks) == 0 {
+		return fmt.Errorf("No remote disks were supplied")
+	}
 	for _, disk := range c.RemoteInspectionDisks {
 		cmd.AddArg("-io", fmt.Sprintf("vddk-file=%s", disk))
 	}
+	return
 }

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -224,3 +224,27 @@ func (c *Conversion) RunCustomize(osinfo utils.InspectionOS) error {
 	custom := customize.NewCustomize(c.AppConfig, disks, osinfo)
 	return custom.Run()
 }
+
+func (c *Conversion) RunRemoteV2vInspection() (err error) {
+	v2vCmdBuilder := c.CommandBuilder.New("virt-v2v-inspector").
+		AddFlag("-v").
+		AddFlag("-x")
+
+	c.addVirtV2vRemoteInspectionArgs(v2vCmdBuilder)
+
+	err = c.addVirtV2vVsphereArgs(v2vCmdBuilder)
+	if err != nil {
+		return err
+	}
+
+	v2vCmd := v2vCmdBuilder.Build()
+	v2vCmd.SetStdout(os.Stdout)
+	v2vCmd.SetStderr(os.Stderr)
+	return v2vCmd.Run()
+}
+
+func (c *Conversion) addVirtV2vRemoteInspectionArgs(cmd utils.CommandBuilder) {
+	for _, disk := range c.RemoteInspectionDisks {
+		cmd.AddArg("-io", fmt.Sprintf("vddk-file=%s", disk))
+	}
+}

--- a/pkg/virt-v2v/utils/command.go
+++ b/pkg/virt-v2v/utils/command.go
@@ -111,6 +111,6 @@ func (cb *CommandBuilderImpl) AddExtraArgs(values ...string) CommandBuilder {
 }
 
 func (cb *CommandBuilderImpl) Build() CommandExecutor {
-	fmt.Print("Building command:", cb.BaseCommand, cb.Args)
+	fmt.Println("Building command:", cb.BaseCommand, cb.Args)
 	return &Command{cmd: exec.Command(cb.BaseCommand, cb.Args...)}
 }


### PR DESCRIPTION
Adds a step to the warm migration pipeline so it fails early instead of only after the disk transfer.

Resolves: MTV-2427

Ref: https://issues.redhat.com/browse/MTV-2427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional preflight inspection before the first disk transfer for warm migrations (Plan toggle, default: true).
  * Remote disk inspection mode via CLI flag / environment variables to inspect remote VM disks before migration.
  * New migration phase and pod workflow to run and report preflight inspections prior to conversion/customization.

* **Improvements**
  * vSphere disk metadata now includes parent-file information for clearer disk lineage.
  * VM customization now runs after inspection data is obtained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->