### PR TITLE
chore: Align upstream with downstream by adding root user

### DIFF
--- a/build/forklift-api/Containerfile
+++ b/build/forklift-api/Containerfile
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"

--- a/build/forklift-controller/Containerfile
+++ b/build/forklift-controller/Containerfile
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"

--- a/build/openstack-populator/Containerfile
+++ b/build/openstack-populator/Containerfile
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"

--- a/build/ova-provider-server/Containerfile
+++ b/build/ova-provider-server/Containerfile
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"

--- a/build/populator-controller/Containerfile
+++ b/build/populator-controller/Containerfile
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"

--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -19,6 +19,7 @@ RUN mkdir -p /usr/local/lib/guestfs/appliance && \
     mv -vf root.qcow2 root
 
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"

--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -1,5 +1,6 @@
 # Build virt-v2v binary
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"

--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -1,5 +1,6 @@
 # Build virt-v2v binary
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"

--- a/build/virt-v2v/Containerfile-upstream-fssupport
+++ b/build/virt-v2v/Containerfile-upstream-fssupport
@@ -1,5 +1,6 @@
 # Build virt-v2v binary
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS "-mod=vendor -tags=strictfipsruntime"


### PR DESCRIPTION
Issue:
In our upstream builds we use regular users for the builder image, in cases the builder require to create a dir, the build will fail.

Fix:
Align with downstream build and use root user when building the builder image.

Note:
Downstream builds already use root user for builder image.
https://github.com/kubev2v/forklift/blob/main/build/forklift-controller/Containerfile-downstream#L3

Note II:
Known issue with permission denied issue in podman

Example:
regular user:
```bash
[1/2] STEP 7/7: RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o forklift-api github.com/kubev2v/forklift/cmd/forklift-api
failed to initialize build cache at /go-build/cache: mkdir /go-build/cache: permission denied
Error: building at STEP "RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o forklift-api github.com/kubev2v/forklift/cmd/forklift-api": while running runtime: exit status 1
make: *** [Makefile:266: build-api-image] Error 1
```

root user:
```bash
[1/2] STEP 6/8: ENV GOEXPERIMENT=strictfipsruntime
--> 29694963b0a8
[1/2] STEP 7/8: ENV GOCACHE=/go-build/cache
--> 52562222029f
[1/2] STEP 8/8: RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o forklift-api github.com/kubev2v/forklift/cmd/forklift-api
--> 0e56bb4f9285
...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized container build process across components to run builder stages with elevated permissions, improving consistency and resolving permission issues during image builds.
  - Ensures reliable file ownership handling during builds without altering runtime behavior.
  - No changes to application features or runtime images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->