### PR TITLE
MTV-3259 | OCP > OCP migrate VM failed on failed to verify certificate: x509 with prehook.

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2534,6 +2534,12 @@ func (r *KubeVirt) ensureConfigMap(vmRef ref.Ref) (configMap *core.ConfigMap, er
 	}
 	if len(list.Items) > 0 {
 		configMap = &list.Items[0]
+		// If a ConfigMap already exists (e.g. from a hook), merge in any missing
+		// provider-specific data required for the migration.
+		err = r.updateConfigMap(vmRef, configMap)
+		if err != nil {
+			return
+		}
 	} else {
 		configMap, err = r.configMap(vmRef)
 		if err != nil {
@@ -2546,6 +2552,56 @@ func (r *KubeVirt) ensureConfigMap(vmRef ref.Ref) (configMap *core.ConfigMap, er
 		}
 		r.Log.V(1).Info(
 			"ConfigMap created.",
+			"configMap",
+			path.Join(
+				configMap.Namespace,
+				configMap.Name),
+			"vm",
+			vmRef.String())
+	}
+
+	return
+}
+
+// updateConfigMap merges provider-specific data (e.g., certificates)
+// into an existing ConfigMap without overwriting existing keys.
+func (r *KubeVirt) updateConfigMap(vmRef ref.Ref, configMap *core.ConfigMap) (err error) {
+	// Create a temporary ConfigMap to get the provider data from the builder.
+	tempConfigMap := &core.ConfigMap{
+		Data: make(map[string]string),
+	}
+
+	err = r.Builder.ConfigMap(vmRef, r.Source.Secret, tempConfigMap)
+	if err != nil {
+		return
+	}
+
+	if configMap.Data == nil {
+		configMap.Data = make(map[string]string)
+	}
+
+	needsUpdate := false
+	for key, value := range tempConfigMap.Data {
+		if _, exists := configMap.Data[key]; !exists {
+			r.Log.Info(
+				"Updating ConfigMap with missing data.",
+				"key",
+				key,
+				"configMap",
+				configMap.Name)
+			configMap.Data[key] = value
+			needsUpdate = true
+		}
+	}
+
+	if needsUpdate {
+		err = r.Destination.Client.Update(context.TODO(), configMap)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		r.Log.V(1).Info(
+			"ConfigMap updated with provider data.",
 			"configMap",
 			path.Join(
 				configMap.Namespace,

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -2,17 +2,109 @@
 package plan
 
 import (
+	"fmt"
+
 	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web"
+	webbase "github.com/kubev2v/forklift/pkg/controller/provider/web/base"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	cnv "kubevirt.io/api/core/v1"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+// Mock inventory for testing - implements web.Client interface.
+// Only VM() is actually called by ensureConfigMap, but all methods are required to satisfy the interface.
+type mockInventory struct{}
+
+func (m *mockInventory) VM(_ *ref.Ref) (interface{}, error)       { return struct{}{}, nil } // Used by ensureConfigMap
+func (m *mockInventory) Find(_ interface{}, _ ref.Ref) error      { return nil }
+func (m *mockInventory) Finder() web.Finder                       { return nil }
+func (m *mockInventory) Get(_ interface{}, _ string) error        { return nil }
+func (m *mockInventory) Host(_ *ref.Ref) (interface{}, error)     { return struct{}{}, nil }
+func (m *mockInventory) List(_ interface{}, _ ...web.Param) error { return nil }
+func (m *mockInventory) Network(_ *ref.Ref) (interface{}, error)  { return struct{}{}, nil }
+func (m *mockInventory) Storage(_ *ref.Ref) (interface{}, error)  { return struct{}{}, nil }
+func (m *mockInventory) Watch(_ interface{}, _ webbase.EventHandler) (*webbase.Watch, error) {
+	return &webbase.Watch{}, nil
+}
+func (m *mockInventory) Workload(_ *ref.Ref) (interface{}, error) { return struct{}{}, nil }
+
+// Mock builder for testing - implements adapter.Builder interface.
+// Only ConfigMap() is actually called by ensureConfigMap, but all methods are required to satisfy the interface.
+type mockBuilder struct{}
+
+func (m *mockBuilder) ConfigMap(_ ref.Ref, _ *v1.Secret, cm *v1.ConfigMap) error { // Used by ensureConfigMap
+	cm.Data = map[string]string{"ca.pem": "test-cert-data"}
+	return nil
+}
+
+// Error mocks for testing error scenarios
+type errorBuilder struct {
+	mockBuilder
+	errorMsg string
+}
+
+func (m *errorBuilder) ConfigMap(_ ref.Ref, _ *v1.Secret, _ *v1.ConfigMap) error {
+	return fmt.Errorf("%s", m.errorMsg)
+}
+
+type errorInventory struct {
+	mockInventory
+	errorMsg string
+}
+
+func (m *errorInventory) VM(_ *ref.Ref) (interface{}, error) {
+	return nil, fmt.Errorf("%s", m.errorMsg)
+}
+func (m *mockBuilder) Secret(_ ref.Ref, _, _ *v1.Secret) error { return nil }
+func (m *mockBuilder) VirtualMachine(_ ref.Ref, _ *cnv.VirtualMachineSpec, _ []*v1.PersistentVolumeClaim, _ bool, _ bool) error {
+	return nil
+}
+func (m *mockBuilder) DataVolumes(_ ref.Ref, _ *v1.Secret, _ *v1.ConfigMap, _ *cdi.DataVolume, _ *v1.ConfigMap) ([]cdi.DataVolume, error) {
+	return []cdi.DataVolume{}, nil
+}
+func (m *mockBuilder) Tasks(_ ref.Ref) ([]*planapi.Task, error) { return []*planapi.Task{}, nil }
+func (m *mockBuilder) TemplateLabels(_ ref.Ref) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (m *mockBuilder) ResolveDataVolumeIdentifier(_ *cdi.DataVolume) string { return "" }
+func (m *mockBuilder) ResolvePersistentVolumeClaimIdentifier(_ *v1.PersistentVolumeClaim) string {
+	return ""
+}
+func (m *mockBuilder) PodEnvironment(_ ref.Ref, _ *v1.Secret) ([]v1.EnvVar, error) {
+	return []v1.EnvVar{}, nil
+}
+func (m *mockBuilder) LunPersistentVolumes(_ ref.Ref) ([]v1.PersistentVolume, error) {
+	return []v1.PersistentVolume{}, nil
+}
+func (m *mockBuilder) LunPersistentVolumeClaims(_ ref.Ref) ([]v1.PersistentVolumeClaim, error) {
+	return []v1.PersistentVolumeClaim{}, nil
+}
+func (m *mockBuilder) SupportsVolumePopulators(_ ref.Ref) bool { return false }
+func (m *mockBuilder) PopulatorVolumes(_ ref.Ref, _ map[string]string, _ string) ([]*v1.PersistentVolumeClaim, error) {
+	return []*v1.PersistentVolumeClaim{}, nil
+}
+func (m *mockBuilder) PopulatorTransferredBytes(_ *v1.PersistentVolumeClaim) (int64, error) {
+	return 0, nil
+}
+func (m *mockBuilder) SetPopulatorDataSourceLabels(_ ref.Ref, _ []*v1.PersistentVolumeClaim) error {
+	return nil
+}
+func (m *mockBuilder) GetPopulatorTaskName(_ *v1.PersistentVolumeClaim) (string, error) {
+	return "", nil
+}
+func (m *mockBuilder) PreferenceName(_ ref.Ref, _ *v1.ConfigMap) (string, error) {
+	return "", nil
+}
 
 var KubeVirtLog = logging.WithName("kubevirt-test")
 
@@ -34,6 +126,92 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			pvcs, err := kubevirt.getPVCs(ref.Ref{ID: "test"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvcs).To(HaveLen(1))
+		})
+	})
+
+	ginkgo.Describe("ensureConfigMap", func() {
+		ginkgo.It("merges provider data into existing hook ConfigMap", func() {
+			hookConfigMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hook-cm",
+					Namespace: "test",
+					Labels:    map[string]string{"migration": "test", "plan": "", "vmID": "test"},
+				},
+				Data: map[string]string{"plan.yml": "hook-data"},
+			}
+			kubevirt := createKubeVirtWithBuilder(hookConfigMap)
+			vmRef := ref.Ref{ID: "test", Name: "test", Namespace: "test"}
+
+			cm, err := kubevirt.ensureConfigMap(vmRef)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cm.Data).To(HaveKey("plan.yml"))
+			Expect(cm.Data).To(HaveKey("ca.pem"))
+			Expect(cm.Data["plan.yml"]).To(Equal("hook-data"))
+			Expect(cm.Data["ca.pem"]).To(Equal("test-cert-data"))
+		})
+
+		ginkgo.It("creates new ConfigMap when none exists", func() {
+			kubevirt := createKubeVirtWithBuilder()
+			vmRef := ref.Ref{ID: "test", Name: "test", Namespace: "test"}
+
+			cm, err := kubevirt.ensureConfigMap(vmRef)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cm).ToNot(BeNil())
+			Expect(cm.Data).To(HaveKey("ca.pem"))
+		})
+
+		ginkgo.It("does not duplicate keys on repeated calls", func() {
+			hookConfigMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hook-cm",
+					Namespace: "test",
+					Labels:    map[string]string{"migration": "test", "plan": "", "vmID": "test"},
+				},
+				Data: map[string]string{"plan.yml": "hook-data"},
+			}
+			kubevirt := createKubeVirtWithBuilder(hookConfigMap)
+			vmRef := ref.Ref{ID: "test", Name: "test", Namespace: "test"}
+
+			cm1, err1 := kubevirt.ensureConfigMap(vmRef)
+			Expect(err1).ToNot(HaveOccurred())
+			Expect(cm1.Data).To(HaveLen(2))
+
+			cm2, err2 := kubevirt.ensureConfigMap(vmRef)
+			Expect(err2).ToNot(HaveOccurred())
+			Expect(cm2.Data).To(HaveLen(2))
+			Expect(cm2.Data["ca.pem"]).To(Equal("test-cert-data"))
+		})
+
+		ginkgo.It("handles Builder.ConfigMap error gracefully", func() {
+			hookConfigMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hook-cm",
+					Namespace: "test",
+					Labels:    map[string]string{"migration": "test", "plan": "", "vmID": "test"},
+				},
+				Data: map[string]string{"plan.yml": "hook-data"},
+			}
+			// Use a builder that returns an error
+			kubevirt := createKubeVirtWithErrorBuilder(hookConfigMap, "builder error")
+			vmRef := ref.Ref{ID: "test", Name: "test", Namespace: "test"}
+
+			_, err := kubevirt.ensureConfigMap(vmRef)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("builder error"))
+		})
+
+		ginkgo.It("handles Inventory.VM error gracefully", func() {
+			// Use an inventory that returns an error
+			kubevirt := createKubeVirtWithErrorInventory("inventory error")
+			vmRef := ref.Ref{ID: "test", Name: "test", Namespace: "test"}
+
+			_, err := kubevirt.ensureConfigMap(vmRef)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("inventory error"))
 		})
 	})
 
@@ -73,7 +251,100 @@ func createPlanKubevirt() *v1beta1.Plan {
 	return &v1beta1.Plan{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: v1beta1.PlanSpec{
-			Type: "cold",
+			Type:            "cold",
+			TargetNamespace: "test",
 		},
+	}
+}
+
+func createKubeVirtWithBuilder(objs ...runtime.Object) *KubeVirt {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	v1beta1.SchemeBuilder.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objs...).
+		Build()
+
+	inventory := &mockInventory{}
+	builder := &mockBuilder{}
+
+	return &KubeVirt{
+		Context: &plancontext.Context{
+			Destination: plancontext.Destination{
+				Client: client,
+			},
+			Source: plancontext.Source{
+				Inventory: inventory,
+				Secret:    &v1.Secret{},
+			},
+			Log:       KubeVirtLog,
+			Migration: createMigration(),
+			Plan:      createPlanKubevirt(),
+			Client:    client,
+		},
+		Builder: builder,
+	}
+}
+
+func createKubeVirtWithErrorBuilder(objs runtime.Object, errorMsg string) *KubeVirt {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	v1beta1.SchemeBuilder.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objs).
+		Build()
+
+	inventory := &mockInventory{}
+	builder := &errorBuilder{errorMsg: errorMsg}
+
+	return &KubeVirt{
+		Context: &plancontext.Context{
+			Destination: plancontext.Destination{
+				Client: client,
+			},
+			Source: plancontext.Source{
+				Inventory: inventory,
+				Secret:    &v1.Secret{},
+			},
+			Log:       KubeVirtLog,
+			Migration: createMigration(),
+			Plan:      createPlanKubevirt(),
+			Client:    client,
+		},
+		Builder: builder,
+	}
+}
+
+func createKubeVirtWithErrorInventory(errorMsg string) *KubeVirt {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	v1beta1.SchemeBuilder.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	inventory := &errorInventory{errorMsg: errorMsg}
+	builder := &mockBuilder{}
+
+	return &KubeVirt{
+		Context: &plancontext.Context{
+			Destination: plancontext.Destination{
+				Client: client,
+			},
+			Source: plancontext.Source{
+				Inventory: inventory,
+				Secret:    &v1.Secret{},
+			},
+			Log:       KubeVirtLog,
+			Migration: createMigration(),
+			Plan:      createPlanKubevirt(),
+			Client:    client,
+		},
+		Builder: builder,
 	}
 }


### PR DESCRIPTION
Issue:
Pre-hooks create ConfigMaps with hook data (plan.yml, playbook.yml, workload.yml).
Later when ensureConfigMap() is called to prepare for DataVolume creation,
it finds this existing hook ConfigMap and reuses it as the certConfigMap for
CDI importer (avoiding duplicate ConfigMaps for the same VM),
causing TLS verification failures: "x509: certificate signed by unknown authority"

Fix:
Modified ensureConfigMap() to merge provider-specific data
(e.g., ca.pem) into existing ConfigMaps before DataVolume creation.

Ref: https://issues.redhat.com/browse/MTV-3259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Existing Kubernetes configuration maps are now supplemented with missing provider data without overwriting existing keys.
  - Idempotent behavior: repeated runs no longer create duplicate entries.
  - Clearer error propagation when provider or VM data retrieval fails, improving reliability.

- Tests
  - Added comprehensive unit tests covering creation vs. merge behavior, idempotency, and failure scenarios to ensure robust handling across success and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->