### PR TITLE
Remove obsolete GetRuntimeErrors method from Collector interface

### DIFF
--- a/pkg/controller/provider/container/openstack/collector.go
+++ b/pkg/controller/provider/container/openstack/collector.go
@@ -119,11 +119,6 @@ func (r *Collector) Version() (_, _, _, _ string, err error) {
 	return
 }
 
-// returns runtime errors - not supported by openstack collector
-func (r *Collector) GetRuntimeErrors() map[string]error {
-	return nil
-}
-
 // Follow link
 func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error {
 	return fmt.Errorf("not implemented")

--- a/pkg/controller/provider/container/ova/collector.go
+++ b/pkg/controller/provider/container/ova/collector.go
@@ -123,11 +123,6 @@ func (r *Collector) Version() (_, _, _, _ string, err error) {
 	return
 }
 
-// returns runtime errors - not supported by ova collector
-func (r *Collector) GetRuntimeErrors() map[string]error {
-	return nil
-}
-
 // Follow link
 func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error {
 	return fmt.Errorf("not implemented")

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -152,11 +152,6 @@ func (r *Collector) Version() (major, minor, build, revision string, err error) 
 	return
 }
 
-// returns runtime errors - not supported by ovirt collector
-func (r *Collector) GetRuntimeErrors() map[string]error {
-	return nil
-}
-
 func parseVersion(fullVersion string) (major, minor, build, revision string) {
 	version := strings.Split(fullVersion, ".")
 	major = version[0]

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -366,11 +366,6 @@ func (r *Collector) Version() (_, _, _, _ string, err error) {
 	return
 }
 
-// returns runtime errors - not supported by vsphere collector
-func (r *Collector) GetRuntimeErrors() map[string]error {
-	return nil
-}
-
 // Start the collector.
 func (r *Collector) Start() error {
 	ctx := context.Background()

--- a/pkg/lib/cmd/inventory/main.go
+++ b/pkg/lib/cmd/inventory/main.go
@@ -176,10 +176,6 @@ func (*Collector) Version() (string, string, string, string, error) {
 	return "", "", "", "", nil
 }
 
-func (*Collector) GetRuntimeErrors() map[string]error {
-	return nil
-}
-
 func (r *Collector) Name() string {
 	return "tester"
 }

--- a/pkg/lib/inventory/container/container.go
+++ b/pkg/lib/inventory/container/container.go
@@ -152,6 +152,4 @@ type Collector interface {
 	Reset()
 	// Get the system version - currently, ovirt-only
 	Version() (string, string, string, string, error)
-	// Get runtime errors - returns map of resource kind to error
-	GetRuntimeErrors() map[string]error
 }

--- a/pkg/lib/inventory/container/ocp/collector.go
+++ b/pkg/lib/inventory/container/ocp/collector.go
@@ -234,12 +234,3 @@ func (r *Collector) ClearError(kind string) {
 func (r *Collector) SetError(kind string, err error) {
 	r.errors[kind] = err
 }
-
-// returns a copy of all current errors that were encountered while querying the inventory
-func (r *Collector) GetRuntimeErrors() map[string]error {
-	errors := make(map[string]error)
-	for k, v := range r.errors {
-		errors[k] = v
-	}
-	return errors
-}


### PR DESCRIPTION
Commit 9f2912e7 made this interface method obsolete so it is no longer
used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined inventory collectors across multiple providers by removing unused runtime error reporting paths. Standard collection and versioning behavior remains unchanged for typical workflows.
- Chores
  - Aligned public interfaces to reflect the removal of unused error reporting, ensuring consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->