### PR TITLE
Add feature flag for StaticUdnIpAddresses

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -156,6 +156,12 @@ spec:
                 description: 'Snapshot status check rate in seconds (default: 10)'
                 pattern: ^[1-9][0-9]*$
                 type: string
+              controller_static_udn_ip_addresses:
+                description: 'Enable static udn IP addresses feature (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               controller_tls_connection_timeout_sec:
                 description: 'TLS connection timeout seconds (default: 5)'
                 pattern: ^[1-9][0-9]*$

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -156,6 +156,12 @@ spec:
                 description: 'Snapshot status check rate in seconds (default: 10)'
                 pattern: ^[1-9][0-9]*$
                 type: string
+              controller_static_udn_ip_addresses:
+                description: 'Enable static udn IP addresses feature (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               controller_tls_connection_timeout_sec:
                 description: 'TLS connection timeout seconds (default: 5)'
                 pattern: ^[1-9][0-9]*$

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -156,6 +156,12 @@ spec:
                 description: 'Snapshot status check rate in seconds (default: 10)'
                 pattern: ^[1-9][0-9]*$
                 type: string
+              controller_static_udn_ip_addresses:
+                description: 'Enable static udn IP addresses feature (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               controller_tls_connection_timeout_sec:
                 description: 'TLS connection timeout seconds (default: 5)'
                 pattern: ^[1-9][0-9]*$

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -297,6 +297,10 @@ spec:
                 type: string
                 enum: ["true", "false"]
                 description: "Retain precopy pods (default: false)"
+              controller_static_udn_ip_addresses:
+                type: string
+                enum: ["true", "false"]
+                description: "Enable static udn IP addresses feature (default: false)"
 
               # Storage & Performance Settings
               controller_filesystem_overhead:

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -43,6 +43,7 @@ controller_snapshot_removal_check_retries: 20
 controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_retain_precopy_importer_pods: false
+controller_static_udn_ip_addresses: false
 controller_max_vm_inflight: 20
 controller_filesystem_overhead: 10
 controller_block_overhead: 0

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -132,6 +132,10 @@ spec:
         - name: FEATURE_OVIRT_WARM_MIGRATION
           value: "true"
 {% endif %}
+{% if controller_static_udn_ip_addresses|bool %}
+        - name: FEATURE_STATIC_UDN_IP_ADDRESSES
+          value: "true"
+{% endif %}
 {% if controller_retain_precopy_importer_pods|bool %}
         - name: FEATURE_RETAIN_PRECOPY_IMPORTER_PODS
           value: "true"

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -802,7 +802,7 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 	object.Template.Spec.Networks = kNetworks
 	object.Template.Spec.Domain.Devices.Interfaces = kInterfaces
 
-	if hasUDN && r.Plan.Spec.PreserveStaticIPs && len(staticIpInterfaces) > 0 {
+	if settings.Settings.StaticUdnIpAddresses && hasUDN && r.Plan.Spec.PreserveStaticIPs && len(staticIpInterfaces) > 0 {
 		var staticIpInterfacesAnnotation []byte
 		staticIpInterfacesAnnotation, err = json.Marshal(staticIpInterfaces)
 		if err != nil {

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -979,13 +979,14 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 			sharedDisks.Type = fmt.Sprintf("%s-%s", sharedDisks.Type, ref.ID)
 			sharedDisksConditions = append(sharedDisksConditions, sharedDisks)
 		}
-
-		ok, err = validator.UdnStaticIPs(*ref, ctx.Destination.Client)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			vmIpDoesNotMatchUdnSubnet.Items = append(vmIpDoesNotMatchUdnSubnet.Items, ref.String())
+		if settings.Settings.StaticUdnIpAddresses && plan.Spec.PreserveStaticIPs && plan.DestinationHasUdnNetwork(r.Client) {
+			ok, err = validator.UdnStaticIPs(*ref, ctx.Destination.Client)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				vmIpDoesNotMatchUdnSubnet.Items = append(vmIpDoesNotMatchUdnSubnet.Items, ref.String())
+			}
 		}
 		// Destination.
 		provider = plan.Referenced.Provider.Destination

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -10,6 +10,7 @@ import (
 const (
 	FeatureOvirtWarmMigration        = "FEATURE_OVIRT_WARM_MIGRATION"
 	FeatureRetainPrecopyImporterPods = "FEATURE_RETAIN_PRECOPY_IMPORTER_PODS"
+	FeatureStaticUdnIpAddresses      = "FEATURE_STATIC_UDN_IP_ADDRESSES"
 	FeatureVsphereIncrementalBackup  = "FEATURE_VSPHERE_INCREMENTAL_BACKUP"
 	FeatureCopyOffload               = "FEATURE_COPY_OFFLOAD"
 	FeatureOCPLiveMigration          = "FEATURE_OCP_LIVE_MIGRATION"
@@ -42,6 +43,8 @@ type Features struct {
 	VmwareSystemSerialNumber bool
 	// Whether to create VMs with MAC address with the User Defined Network
 	UdnSupportsMac bool
+	// Whether to create VMs with MAC address with the User Defined Network
+	StaticUdnIpAddresses bool
 }
 
 // isOpenShiftVersionAboveMinimum checks if OpenShift version is above or equal to minimum version using semantic versioning
@@ -70,6 +73,7 @@ func (r *Features) isOpenShiftVersionAboveMinimum(minimumVersion string) bool {
 func (r *Features) Load() (err error) {
 	r.OvirtWarmMigration = getEnvBool(FeatureOvirtWarmMigration, false)
 	r.RetainPrecopyImporterPods = getEnvBool(FeatureRetainPrecopyImporterPods, false)
+	r.StaticUdnIpAddresses = getEnvBool(FeatureStaticUdnIpAddresses, false)
 	r.VsphereIncrementalBackup = getEnvBool(FeatureVsphereIncrementalBackup, false)
 	r.CopyOffload = getEnvBool(FeatureCopyOffload, false)
 	r.OCPLiveMigration = getEnvBool(FeatureOCPLiveMigration, false)


### PR DESCRIPTION
Add feature flag for StaticUdnIpAddresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a configurable option to enable static UDN IP addresses for migrations. Disabled by default.
  - Added a new field in the ForkliftController configuration to toggle this feature (“true”/“false”). When enabled, the controller applies static IP annotations and performs UDN subnet validation during plan execution.
  - The operator exposes a corresponding environment-based toggle to align runtime behavior with the configured setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->