### PR TITLE
MTV-1381 | Preserve static IPs default

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3057,6 +3057,7 @@ spec:
                   its oVirt cluster.
                 type: boolean
               preserveStaticIPs:
+                default: true
                 description: Preserve static IPs of VMs in vSphere
                 type: boolean
               provider:

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -3057,6 +3057,7 @@ spec:
                   its oVirt cluster.
                 type: boolean
               preserveStaticIPs:
+                default: true
                 description: Preserve static IPs of VMs in vSphere
                 type: boolean
               provider:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3057,6 +3057,7 @@ spec:
                   its oVirt cluster.
                 type: boolean
               preserveStaticIPs:
+                default: true
                 description: Preserve static IPs of VMs in vSphere
                 type: boolean
               provider:

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1165,6 +1165,7 @@ spec:
                   its oVirt cluster.
                 type: boolean
               preserveStaticIPs:
+                default: true
                 description: Preserve static IPs of VMs in vSphere
                 type: boolean
               provider:

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -110,6 +110,7 @@ type PlanSpec struct {
 	// Preserve the CPU model and flags the VM runs with in its oVirt cluster.
 	PreserveClusterCPUModel bool `json:"preserveClusterCpuModel,omitempty"`
 	// Preserve static IPs of VMs in vSphere
+	// +kubebuilder:default:=true
 	PreserveStaticIPs bool `json:"preserveStaticIPs,omitempty"`
 	// Deprecated: this field will be deprecated in 2.8.
 	DiskBus cnv.DiskBus `json:"diskBus,omitempty"`


### PR DESCRIPTION
MTV-1381 | Preserve static IPs default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration plans now preserve static IPs by default when the option is not specified, reducing setup steps and ensuring consistent network behavior out of the box. Existing plans that explicitly disable this remain unchanged.

* **Chores**
  * Updated operator manifests and CRD definitions to reflect the new default for the preserveStaticIPs field, ensuring consistent behavior across environments and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->