### PR TITLE
[CCLM] Ignore LiveMigratable condition on OCP VMs

### DIFF
--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -73,7 +73,7 @@ func (r *Validator) VMMigrationType(vmRef ref.Ref) (ok bool, err error) {
 			return
 		}
 		for _, cnd := range vm.Status.Conditions {
-			if cnd.Type == ConditionStorageLiveMigratable || cnd.Type == ConditionLiveMigratable {
+			if cnd.Type == ConditionStorageLiveMigratable {
 				if cnd.Status != True {
 					ok = false
 					return


### PR DESCRIPTION
KubeVirt tolerates doing cross-cluster live migration of a VM with a false LiveMigratable condition as long as StorageLiveMigratable is true.

Fixes [MTV-3478](https://issues.redhat.com/browse/MTV-3478)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected VM migration readiness validation to consider only storage live-migration status, preventing false negatives when general live-migration is unavailable.
  * Reduces erroneous “not migratable” results and allows migrations to proceed when storage-backed live migration is supported.
  * Improves reliability of migration planning and reduces unexpected validation failures for certain VM states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->