### PR TITLE
Only attempt to update Plan status once per reconcile

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -111,6 +111,18 @@ func (r *Migration) Run() (reQ time.Duration, err error) {
 		var vm *plan.VMStatus
 		vm, hasNext, err = r.scheduler.Next()
 		if err != nil {
+			if errors.As(err, &web.NotFoundError{}) {
+				vm.SetCondition(libcnd.Condition{
+					Type:     api.ConditionCanceled,
+					Status:   libcnd.True,
+					Category: api.CategoryAdvisory,
+					Reason:   NotFound,
+					Message:  "VM was not found in inventory.",
+					Durable:  true,
+				})
+				err = nil
+				continue
+			}
 			return
 		}
 		if hasNext {

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -10,7 +10,6 @@ import (
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
-	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 )
 
@@ -124,16 +123,6 @@ func (r *Scheduler) buildInFlight() (err error) {
 		vm := &model.VM{}
 		err = r.Source.Inventory.Find(vm, vmStatus.Ref)
 		if err != nil {
-			if errors.As(err, &web.NotFoundError{}) {
-				vmStatus.SetCondition(libcnd.Condition{
-					Type:     api.ConditionCanceled,
-					Status:   libcnd.True,
-					Category: api.CategoryAdvisory,
-					Reason:   NotFound,
-					Message:  "VM was not found in inventory.",
-					Durable:  true,
-				})
-			}
 			return
 		}
 		if vmStatus.Running() {


### PR DESCRIPTION
The Plan status was getting updated before the call to `execute()`, and then once during or after `execute()` as well. This frequently results in conflicts during the second attempt to update the status, and updating the status after `execute()` returns with error can result in the Plan entering an inconsistent state. (for instance, if the migration runner returned with an error after the `Executing` condition had been set, but before `begin()` had completed successfully.)

The check for VMs that have been deleted from the inventory while the plan is being processed should occur outside of the scheduler so that the scheduler implementations don't need to be responsible for setting the `Canceled` condition on the VM.

This also fixes a bug where the `Canceled` condition was being set on the missing VM's status, but the `NotFound` error from the inventory was still being passed to the caller, causing the reconcile to fail. The `NotFound` error should be set to `nil` after the VM's status is set so that plan execution can continue. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * None

* Bug Fixes
  * Migrations no longer abort when a VM is missing; the VM is marked as canceled with an advisory message (“VM was not found in inventory.”), allowing the run to continue.

* Refactor
  * Streamlined plan status updates to occur once upon successful completion, reducing redundant updates and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->