### PR TITLE
MTV-2666 | VM migration with single interface from OSP fails with "more than one interface is connected to a pod network in spec.template.spec.interfaces"

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -540,7 +540,9 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 	numNetworks := 0
 	for vmNetworkName, vmAddresses := range vm.Addresses {
 		if nics, ok := vmAddresses.([]interface{}); ok {
-			for _, nic := range nics {
+			// Use only first NIC in order to avoid duplicates in case of multiple NICs per interface
+			if len(nics) > 0 {
+				nic := nics[0]
 				// Look for the network map for the source network
 				var vmNetworkID string
 				for _, vmNetwork := range vm.Networks {


### PR DESCRIPTION
Issue:
When migrating an OpenStack VM that has a single interface but multiple NICs attached to it, the migration fails with an error saying there are multiple interfaces connected to the same pod.

Fix:
During destination VM creation in the mapping network phase, use only the first NIC per interface to avoid the duplication.

Ref: https://issues.redhat.com/browse/MTV-2666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate network interface mappings during OpenStack VM planning by using only the primary NIC per interface.
  * Ensures safer handling when interfaces have no NICs, avoiding errors during plan generation.
  * Improves consistency of network assignments, resulting in more predictable provisioning outcomes and cleaner plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->