### PR TITLE
offload: implement proper cleanup for tmp resources

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/destinationclient.go
+++ b/pkg/controller/plan/adapter/vsphere/destinationclient.go
@@ -1,8 +1,18 @@
 package vsphere
 
 import (
+	"context"
+	"path"
+
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	core "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type DestinationClient struct {
@@ -10,11 +20,161 @@ type DestinationClient struct {
 }
 
 func (d *DestinationClient) DeletePopulatorDataSource(vm *plan.VMStatus) error {
-	// not supported - do nothing
+	d.Log.Info("Starting DeletePopulatorDataSource", "vm", vm.String())
+
+	populatorCrList, err := d.getPopulatorCrList()
+	if err != nil {
+		d.Log.Error(err, "Failed to get populator CR list")
+		return liberr.Wrap(err)
+	}
+
+	d.Log.Info("Found populator CRs to delete", "count", len(populatorCrList.Items))
+
+	for i, populatorCr := range populatorCrList.Items {
+		d.Log.Info("Deleting populator CR",
+			"index", i+1,
+			"total", len(populatorCrList.Items),
+			"name", populatorCr.Name,
+			"namespace", populatorCr.Namespace,
+			"vmdkPath", populatorCr.Spec.VmdkPath)
+
+		err = d.DeleteObject(&populatorCr, vm, "Deleted VSphereXcopyPopulator CR.", "VSphereXcopyVolumePopulator")
+		if err != nil {
+			d.Log.Error(err, "Failed to delete populator CR", "name", populatorCr.Name)
+			return liberr.Wrap(err)
+		}
+
+		d.Log.Info("Successfully deleted populator CR", "name", populatorCr.Name)
+	}
+
+	d.Log.Info("Completed DeletePopulatorDataSource", "vm", vm.String())
 	return nil
 }
 
 func (r *DestinationClient) SetPopulatorCrOwnership() (err error) {
-	// not supported - do nothing
-	return
+	// Owner references are already set during populator CR creation in builder.go
+	// This method is kept for interface compatibility but is a no-op for vSphere
+	r.Log.V(2).Info("Owner references already set during populator CR creation - no action needed")
+	return nil
+}
+
+// Get the VSphereXcopyVolumePopulator CustomResource List.
+func (r *DestinationClient) getPopulatorCrList() (populatorCrList v1beta1.VSphereXcopyVolumePopulatorList, err error) {
+	snap := r.Plan.Status.Migration.ActiveSnapshot()
+	if snap.Migration.UID == "" {
+		err = liberr.New("no active migration snapshot", "plan", r.Plan.Name)
+		r.Log.Error(err, "Cannot list populator CRs")
+		return v1beta1.VSphereXcopyVolumePopulatorList{}, err
+	}
+	migUID := string(snap.Migration.UID)
+	r.Log.Info("Getting populator CR list",
+		"namespace", r.Plan.Spec.TargetNamespace,
+		"migrationUID", migUID)
+
+	populatorCrList = v1beta1.VSphereXcopyVolumePopulatorList{}
+	err = r.Destination.Client.List(
+		context.TODO(),
+		&populatorCrList,
+		&client.ListOptions{
+			Namespace:     r.Plan.Spec.TargetNamespace,
+			LabelSelector: labels.SelectorFromSet(map[string]string{"migration": migUID}),
+		})
+
+	if err != nil {
+		r.Log.Error(err, "Failed to list populator CRs")
+	} else {
+		r.Log.Info("Successfully listed populator CRs", "count", len(populatorCrList.Items))
+	}
+
+	return populatorCrList, err
+}
+
+// Deletes an object from destination cluster associated with the VM.
+func (r *DestinationClient) DeleteObject(object client.Object, vm *plan.VMStatus, message, objType string) (err error) {
+	r.Log.Info("Deleting object",
+		"type", objType,
+		"name", object.GetName(),
+		"namespace", object.GetNamespace(),
+		"vm", vm.String())
+
+	err = r.Destination.Client.Delete(context.TODO(), object)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			r.Log.Info("Object not found, already deleted",
+				"type", objType,
+				"name", object.GetName())
+			err = nil
+		} else {
+			r.Log.Error(err, "Failed to delete object",
+				"type", objType,
+				"name", object.GetName())
+			return liberr.Wrap(err)
+		}
+	} else {
+		r.Log.Info(message,
+			objType,
+			path.Join(object.GetNamespace(), object.GetName()),
+			"vm", vm.String())
+	}
+	return err
+}
+
+func (r *DestinationClient) findPVCByCR(cr *v1beta1.VSphereXcopyVolumePopulator) (pvc *core.PersistentVolumeClaim, err error) {
+	snap := r.Plan.Status.Migration.ActiveSnapshot()
+	if snap.Migration.UID == "" {
+		err = liberr.New("no active migration snapshot", "plan", r.Plan.Name)
+		r.Log.Error(err, "Cannot find PVC for populator CR")
+		return nil, err
+	}
+	migUID := string(snap.Migration.UID)
+	r.Log.Info("Finding PVC for populator CR",
+		"populatorName", cr.Name,
+		"vmdkPath", cr.Spec.VmdkPath,
+		"namespace", r.Plan.Spec.TargetNamespace,
+		"migrationUID", migUID)
+
+	pvcList := core.PersistentVolumeClaimList{}
+	err = r.Destination.Client.List(
+		context.TODO(),
+		&pvcList,
+		&client.ListOptions{
+			Namespace: r.Plan.Spec.TargetNamespace,
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				"migration": migUID,
+			}),
+			FieldSelector: fields.SelectorFromSet(map[string]string{
+				"metadata.annotations.copy-offload": cr.Spec.VmdkPath,
+			}),
+		})
+
+	if err != nil {
+		r.Log.Error(err, "Failed to list PVCs for populator CR", "populatorName", cr.Name)
+		err = liberr.Wrap(err)
+		return nil, err
+	}
+
+	r.Log.Info("Found PVCs matching populator CR",
+		"populatorName", cr.Name,
+		"count", len(pvcList.Items))
+
+	if len(pvcList.Items) == 0 {
+		err = liberr.New("PVC not found", "vmdkPath", cr.Spec.VmdkPath)
+		r.Log.Error(err, "No PVC found for populator CR", "populatorName", cr.Name)
+		return nil, err
+	}
+
+	if len(pvcList.Items) > 1 {
+		err = liberr.New("Multiple PVCs found", "vmdkPath", cr.Spec.VmdkPath)
+		r.Log.Error(err, "Multiple PVCs found for populator CR",
+			"populatorName", cr.Name,
+			"count", len(pvcList.Items))
+		return nil, err
+	}
+
+	pvc = &pvcList.Items[0]
+	r.Log.Info("Successfully found matching PVC",
+		"populatorName", cr.Name,
+		"pvcName", pvc.Name)
+
+	return pvc, nil
 }

--- a/pkg/controller/plan/adapter/vsphere/destinationclient_test.go
+++ b/pkg/controller/plan/adapter/vsphere/destinationclient_test.go
@@ -1,0 +1,474 @@
+package vsphere
+
+import (
+	"context"
+
+	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var destClientLog = logging.WithName("destination-client-test")
+
+var _ = Describe("DestinationClient", func() {
+	Describe("DeletePopulatorDataSource", func() {
+		It("should delete all populator CRs successfully", func() {
+			// Setup
+			populator1 := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "populator-1",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/path1.vmdk",
+				},
+			}
+			populator2 := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "populator-2",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/path2.vmdk",
+				},
+			}
+
+			destClient := createDestinationClient(populator1, populator2)
+			vmStatus := &planapi.VMStatus{
+				NewName: "test-vm",
+			}
+
+			// Execute
+			err := destClient.DeletePopulatorDataSource(vmStatus)
+
+			// Assert
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify all populators are deleted
+			populatorList := &v1beta1.VSphereXcopyVolumePopulatorList{}
+			err = destClient.Destination.Client.List(context.TODO(), populatorList, client.InNamespace("test"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(populatorList.Items).To(BeEmpty())
+		})
+
+		It("should succeed when no populator CRs exist", func() {
+			// Setup
+			destClient := createDestinationClient()
+			vmStatus := &planapi.VMStatus{
+				NewName: "test-vm",
+			}
+
+			// Execute
+			err := destClient.DeletePopulatorDataSource(vmStatus)
+
+			// Assert
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("getPopulatorCrList", func() {
+		It("should return only CRs matching the migration UID", func() {
+			// Setup
+			populator1 := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "populator-match-1",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/path1.vmdk",
+				},
+			}
+			populator2 := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "populator-match-2",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/path2.vmdk",
+				},
+			}
+			populatorDifferent := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "populator-different-migration",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "different-uid",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/path3.vmdk",
+				},
+			}
+
+			destClient := createDestinationClient(populator1, populator2, populatorDifferent)
+
+			// Execute
+			populatorList, err := destClient.getPopulatorCrList()
+
+			// Assert
+			Expect(err).NotTo(HaveOccurred())
+			Expect(populatorList.Items).To(HaveLen(2))
+			for _, pop := range populatorList.Items {
+				Expect(pop.Labels["migration"]).To(Equal("123"))
+			}
+		})
+
+		It("should return empty list when no populator CRs exist", func() {
+			// Setup
+			destClient := createDestinationClient()
+
+			// Execute
+			populatorList, err := destClient.getPopulatorCrList()
+
+			// Assert
+			Expect(err).NotTo(HaveOccurred())
+			Expect(populatorList.Items).To(BeEmpty())
+		})
+	})
+
+	Describe("DeleteObject", func() {
+		It("should delete the object successfully", func() {
+			// Setup
+			populator := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-populator",
+					Namespace: "test",
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/test.vmdk",
+				},
+			}
+
+			destClient := createDestinationClient(populator)
+			vmStatus := &planapi.VMStatus{
+				NewName: "test-vm",
+			}
+
+			// Execute
+			err := destClient.DeleteObject(populator, vmStatus, "Deleted test object", "VSphereXcopyVolumePopulator")
+
+			// Assert
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify object is deleted
+			deletedPop := &v1beta1.VSphereXcopyVolumePopulator{}
+			err = destClient.Destination.Client.Get(context.TODO(), client.ObjectKey{
+				Name:      "test-populator",
+				Namespace: "test",
+			}, deletedPop)
+			Expect(k8serr.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should succeed without error when object does not exist", func() {
+			// Setup
+			destClient := createDestinationClient()
+			populator := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "nonexistent-populator",
+					Namespace: "test",
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/test.vmdk",
+				},
+			}
+			vmStatus := &planapi.VMStatus{
+				NewName: "test-vm",
+			}
+
+			// Execute
+			err := destClient.DeleteObject(populator, vmStatus, "Deleted test object", "VSphereXcopyVolumePopulator")
+
+			// Assert
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("findPVCByCR", func() {
+		It("should return the matching PVC", func() {
+			// Setup
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmdkKey":   "disk-1",
+					},
+					Annotations: map[string]string{
+						"copy-offload": "/vmdk/test.vmdk",
+					},
+				},
+				Spec: core.PersistentVolumeClaimSpec{
+					AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+				},
+			}
+			populator := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-populator",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmdkKey":   "disk-1",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/test.vmdk",
+				},
+			}
+
+			destClient := createDestinationClient(pvc, populator)
+
+			// Execute
+			foundPVC, err := destClient.findPVCByCR(populator)
+
+			// Assert
+			Expect(err).NotTo(HaveOccurred())
+			Expect(foundPVC).NotTo(BeNil())
+			Expect(foundPVC.Name).To(Equal("test-pvc"))
+			Expect(foundPVC.Labels["vmdkKey"]).To(Equal("disk-1"))
+		})
+
+		It("should return an error when no matching PVC exists", func() {
+			// Setup
+			populator := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-populator",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmdkKey":   "disk-1",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/test.vmdk",
+				},
+			}
+
+			destClient := createDestinationClient(populator)
+
+			// Execute
+			foundPVC, err := destClient.findPVCByCR(populator)
+
+			// Assert
+			Expect(err).To(HaveOccurred())
+			Expect(foundPVC).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("PVC not found"))
+		})
+
+		It("should return an error when multiple matching PVCs exist", func() {
+			// Setup
+			pvc1 := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-pvc-1",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmdkKey":   "disk-1",
+					},
+					Annotations: map[string]string{
+						"copy-offload": "/vmdk/test.vmdk",
+					},
+				},
+				Spec: core.PersistentVolumeClaimSpec{
+					AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+				},
+			}
+			pvc2 := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-pvc-2",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmdkKey":   "disk-1",
+					},
+					Annotations: map[string]string{
+						"copy-offload": "/vmdk/test.vmdk",
+					},
+				},
+				Spec: core.PersistentVolumeClaimSpec{
+					AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+				},
+			}
+			populator := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-populator",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmdkKey":   "disk-1",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/test.vmdk",
+				},
+			}
+
+			destClient := createDestinationClient(pvc1, pvc2, populator)
+
+			// Execute
+			foundPVC, err := destClient.findPVCByCR(populator)
+
+			// Assert
+			Expect(err).To(HaveOccurred())
+			Expect(foundPVC).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("Multiple PVCs found"))
+		})
+
+		It("should not find PVC with different migration UID", func() {
+			// Setup
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-pvc-different",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "different-migration-uid",
+						"vmdkKey":   "disk-1",
+					},
+				},
+				Spec: core.PersistentVolumeClaimSpec{
+					AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+				},
+			}
+			populator := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-populator",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmdkKey":   "disk-1",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/test.vmdk",
+				},
+			}
+
+			destClient := createDestinationClient(pvc, populator)
+
+			// Execute
+			foundPVC, err := destClient.findPVCByCR(populator)
+
+			// Assert
+			Expect(err).To(HaveOccurred())
+			Expect(foundPVC).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("PVC not found"))
+		})
+
+		It("should not find PVC with different vmdkKey", func() {
+			// Setup
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-pvc-different-key",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmdkKey":   "disk-2",
+					},
+				},
+				Spec: core.PersistentVolumeClaimSpec{
+					AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+				},
+			}
+			populator := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-populator",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmdkKey":   "disk-1",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/test.vmdk",
+				},
+			}
+
+			destClient := createDestinationClient(pvc, populator)
+
+			// Execute
+			foundPVC, err := destClient.findPVCByCR(populator)
+
+			// Assert
+			Expect(err).To(HaveOccurred())
+			Expect(foundPVC).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("PVC not found"))
+		})
+	})
+})
+
+//nolint:errcheck
+func createDestinationClient(objs ...runtime.Object) *DestinationClient {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	_ = core.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+	v1beta1.SchemeBuilder.AddToScheme(scheme)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objs...).
+		WithIndex(&core.PersistentVolumeClaim{}, "metadata.annotations.copy-offload", func(obj client.Object) []string {
+			pvc := obj.(*core.PersistentVolumeClaim)
+			if pvc.Annotations != nil {
+				if val, ok := pvc.Annotations["copy-offload"]; ok {
+					return []string{val}
+				}
+			}
+			return []string{}
+		}).
+		Build()
+
+	plan := createPlan()
+	migrationUID := k8stypes.UID("123")
+
+	// Set up the migration status with proper snapshot
+	migration := &v1beta1.Migration{
+		ObjectMeta: meta.ObjectMeta{
+			UID: migrationUID,
+		},
+	}
+
+	// Add migration snapshot to plan status
+	plan.Status.Migration.History = []planapi.Snapshot{
+		{
+			Migration: planapi.SnapshotRef{
+				UID: migrationUID,
+			},
+		},
+	}
+
+	return &DestinationClient{
+		Context: &plancontext.Context{
+			Destination: plancontext.Destination{
+				Client: client,
+			},
+			Plan:      plan,
+			Migration: migration,
+			Log:       destClientLog,
+			Client:    client,
+		},
+	}
+}


### PR DESCRIPTION
### feat(vsphere): implement comprehensive cleanup for VSphere xcopy volume populator resources

Implement proper resource lifecycle management for VSphereXcopyVolumePopulator CRs
to prevent resource leakage during migration cleanup operations.

Key changes:
- Add owner references from VSphereXcopyVolumePopulator CRs to PVCs for automatic
  garbage collection when PVCs are deleted
- Implement DeletePopulatorDataSource() to properly clean up populator CRs during
  migration cancel/archive operations
- Add comprehensive logging and error handling for cleanup operations
- Fetch PVC UID after creation to ensure accurate owner reference setup

This addresses temporary resource leakage issues where populator pods, PVCs, and
related resources were left orphaned after migration completion, particularly
during migration cancellation or archival.

Related to: https://github.com/kubev2v/forklift/pull/223