### PR TITLE
[CCLM] Case-insensitive comparison of InstanceType

### DIFF
--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -1503,7 +1503,7 @@ func (r *Builder) LocalInstanceType(vm *planapi.VMStatus) (target *instancetype.
 		return
 	}
 
-	if virtualMachine.Object.Spec.Instancetype == nil || virtualMachine.Object.Spec.Instancetype.Kind == kubevirtapi.ClusterSingularResourceName {
+	if virtualMachine.Object.Spec.Instancetype == nil || strings.EqualFold(virtualMachine.Object.Spec.Instancetype.Kind, kubevirtapi.ClusterSingularResourceName) {
 		err = liberr.New("VM does not have a reference to a local InstanceType.")
 		return
 	}
@@ -1532,7 +1532,7 @@ func (r *Builder) LocalPreference(vm *planapi.VMStatus) (target *instancetype.Vi
 		return
 	}
 
-	if virtualMachine.Object.Spec.Preference == nil || virtualMachine.Object.Spec.Preference.Kind == kubevirtapi.ClusterSingularPreferenceResourceName {
+	if virtualMachine.Object.Spec.Preference == nil || strings.EqualFold(virtualMachine.Object.Spec.Preference.Kind, kubevirtapi.ClusterSingularPreferenceResourceName) {
 		err = liberr.New("VM does not have a reference to a local Preference.")
 		return
 	}

--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -711,8 +711,7 @@ func (r *LiveMigrator) RequiresLocalPreference(vm *planapi.VMStatus) (required b
 		return
 	}
 	required = virtualMachine.Object.Spec.Preference != nil &&
-		virtualMachine.Object.Spec.Preference.Kind != kubevirtapi.ClusterSingularPreferenceResourceName
-
+		!strings.EqualFold(virtualMachine.Object.Spec.Preference.Kind, kubevirtapi.ClusterSingularPreferenceResourceName)
 	return
 }
 
@@ -726,7 +725,7 @@ func (r *LiveMigrator) RequiresClusterPreference(vm *planapi.VMStatus) (required
 		return
 	}
 	required = virtualMachine.Object.Spec.Preference != nil &&
-		virtualMachine.Object.Spec.Preference.Kind == kubevirtapi.ClusterSingularPreferenceResourceName
+		strings.EqualFold(virtualMachine.Object.Spec.Preference.Kind, kubevirtapi.ClusterSingularPreferenceResourceName)
 	return
 }
 
@@ -740,7 +739,7 @@ func (r *LiveMigrator) RequiresLocalInstanceType(vm *planapi.VMStatus) (required
 		return
 	}
 	required = virtualMachine.Object.Spec.Instancetype != nil &&
-		virtualMachine.Object.Spec.Instancetype.Kind != kubevirtapi.ClusterSingularResourceName
+		!strings.EqualFold(virtualMachine.Object.Spec.Instancetype.Kind, kubevirtapi.ClusterSingularResourceName)
 	return
 }
 
@@ -754,7 +753,7 @@ func (r *LiveMigrator) RequiresClusterInstanceType(vm *planapi.VMStatus) (requir
 		return
 	}
 	required = virtualMachine.Object.Spec.Instancetype != nil &&
-		virtualMachine.Object.Spec.Instancetype.Kind == kubevirtapi.ClusterSingularResourceName
+		strings.EqualFold(virtualMachine.Object.Spec.Instancetype.Kind, kubevirtapi.ClusterSingularResourceName)
 	return
 }
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MTV-3417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Comparisons of resource type names are now case-insensitive, reducing misidentification of local vs. cluster preferences or instance types.
  * Improves reliability of plan migration when encountering mixed-case resource kinds.
  * No control-flow or error-handling changes; behavior is preserved apart from comparison semantics.
  * No user action required; existing configurations continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->