### PR TITLE
MTV-3495 | type warm migration doesn't work properly

### DIFF
--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -278,6 +278,13 @@ type Plan struct {
 	Referenced `json:"-"`
 }
 
+// IsWarm returns true if the plan is a warm migration.
+// Supports both the deprecated 'warm: true' field (for backward compatibility)
+// and the current 'type: warm' field.
+func (p *Plan) IsWarm() bool {
+	return p.Spec.Warm || p.Spec.Type == MigrationWarm
+}
+
 // If the plan calls for the vm to be cold migrated to the local cluster, we can
 // just use virt-v2v directly to convert the vm while copying data over. In other
 // cases, we use CDI to transfer disks to the destination cluster and then use
@@ -296,7 +303,7 @@ func (p *Plan) ShouldUseV2vForTransfer() (bool, error) {
 	case VSphere:
 		// The virt-v2v transferes all disks attached to the VM. If we want to skip the shared disks so we don't transfer
 		// them multiple times we need to manage the transfer using KubeVirt CDI DataVolumes and v2v-in-place.
-		return !p.Spec.Warm && // The Warm Migraiton needs to use CDI to manage the snapshot delta
+		return !p.IsWarm() && // The Warm Migraiton needs to use CDI to manage the snapshot delta
 				destination.IsHost() && // We can't monitor progress from the guest converison pod on the remote clusters
 				p.Spec.MigrateSharedDisks && // virt-v2v migrates all disks, to skip shared we need to control the disk selection
 				!p.Spec.SkipGuestConversion && // virt-v2v always converts the guest, to perform RawCopyMode we need to copy just disks via CDI
@@ -366,9 +373,8 @@ func (r *Plan) IsSourceProviderOCP() bool {
 func (r *Plan) IsSourceProviderVSphere() bool { return r.Provider.Source.Type() == VSphere }
 
 func (r *Plan) ShouldRunPreflightInspection() bool {
-	isWarm := r.Spec.Type == MigrationWarm || r.Spec.Warm
 	return r.IsSourceProviderVSphere() &&
-		isWarm &&
+		r.IsWarm() &&
 		!r.Spec.SkipGuestConversion &&
 		r.Spec.RunPreflightInspection
 }

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -669,7 +669,7 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 }
 
 func (r *Builder) SupportsVolumePopulators(vmRef ref.Ref) bool {
-	return !r.Context.Plan.Spec.Warm && r.Context.Plan.Provider.Destination.IsHost()
+	return !r.Context.Plan.IsWarm() && r.Context.Plan.Provider.Destination.IsHost()
 }
 
 func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string, secretName string) (pvcs []*core.PersistentVolumeClaim, err error) {

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -424,7 +424,7 @@ func (r Client) Finalize(vms []*planapi.VMStatus, planName string) {
 		}
 	}()
 
-	if !r.Plan.Spec.Warm {
+	if !r.Plan.IsWarm() {
 		r.Log.Info("Skipping precopy removal for cold migration")
 		return
 	}

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -362,7 +362,7 @@ func (r *Validator) SharedDisks(vmRef ref.Ref, client client.Client) (ok bool, m
 		return false, msg, "", liberr.Wrap(err, "vm", vmRef)
 	}
 	// Warm migration
-	if vm.HasSharedDisk() && r.Plan.Spec.Warm {
+	if vm.HasSharedDisk() && r.Plan.IsWarm() {
 		return false, "The shared disks cannot be used with warm migration", "", nil
 	}
 
@@ -599,9 +599,8 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 
 // Validate that the vm has the change tracking enabled
 func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) {
-	// Check if this is a warm migration using both old and new fields for backward compatibility
-	isWarmMigration := r.Plan.Spec.Warm || r.Plan.Spec.Type == api.MigrationWarm
-	if !isWarmMigration {
+	// Check if this is a warm migration
+	if !r.Plan.IsWarm() {
 		return true, nil
 	}
 	vm := &model.Workload{}
@@ -639,9 +638,8 @@ func (r *Validator) getPlanVMTargetName(vm *model.VM) string {
 
 // Validate that VM has no pre-existing snapshots for warm migration
 func (r *Validator) HasSnapshot(vmRef ref.Ref) (ok bool, msg string, category string, err error) {
-	// Check if this is a warm migration using both old and new fields for backward compatibility
-	isWarmMigration := r.Plan.Spec.Warm || r.Plan.Spec.Type == api.MigrationWarm
-	if !isWarmMigration {
+	// Check if this is a warm migration
+	if !r.Plan.IsWarm() {
 		return true, "", "", nil
 	}
 	vm := &model.VM{}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1421,13 +1421,13 @@ func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap
 		}
 	}
 
-	if r.Plan.Spec.Warm || !r.Destination.Provider.IsHost() || r.Plan.IsSourceProviderOCP() {
+	if r.Plan.IsWarm() || !r.Destination.Provider.IsHost() || r.Plan.IsSourceProviderOCP() {
 		// Set annotation for WFFC storage classes. Note that we create data volumes while
 		// running a cold migration to the local cluster only when the source is either OpenShift
 		// or vSphere, and in the latter case the conversion pod acts as the first-consumer
 		annotations[planbase.AnnBindImmediate] = "true"
 	}
-	if r.Plan.Spec.Warm && r.Builder.SupportsVolumePopulators(vm.Ref) {
+	if r.Plan.IsWarm() && r.Builder.SupportsVolumePopulators(vm.Ref) {
 		// For storage offload, tie DataVolume to pre-imported PVC
 		annotations[planbase.AnnAllowClaimAdoption] = "true"
 		annotations[planbase.AnnPrePopulated] = "true"
@@ -1441,7 +1441,7 @@ func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap
 			Annotations: annotations,
 		},
 	}
-	if !(r.Builder.SupportsVolumePopulators(vm.Ref) && r.Plan.Spec.Warm) {
+	if !(r.Builder.SupportsVolumePopulators(vm.Ref) && r.Plan.IsWarm()) {
 		// For storage offload warm migrations, the template should have already
 		// been applied to the PVC that will be adopted by this DataVolume, so
 		// only add generateName for other migration types.

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -754,7 +754,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			}
 
 			// Create DataVolumes unless this is a cold migration using storage offload
-			if r.Plan.Spec.Warm || !r.builder.SupportsVolumePopulators(vm.Ref) {
+			if r.Plan.IsWarm() || !r.builder.SupportsVolumePopulators(vm.Ref) {
 				var dataVolumes []cdi.DataVolume
 				dataVolumes, err = r.kubevirt.DataVolumes(vm)
 				if err != nil {
@@ -788,7 +788,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			}
 
 			// Wait for the DataVolume to adopt the PVC before proceeding
-			if r.builder.SupportsVolumePopulators(vm.Ref) && r.Plan.Spec.Warm {
+			if r.builder.SupportsVolumePopulators(vm.Ref) && r.Plan.IsWarm() {
 				var pvcs []*core.PersistentVolumeClaim
 				pvcs, err = r.kubevirt.getPVCs(vm.Ref)
 				if err != nil {
@@ -905,7 +905,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				break
 			}
 			if step.MarkedCompleted() && !step.HasError() {
-				if r.Plan.Spec.Warm {
+				if r.Plan.IsWarm() {
 					now := meta.Now()
 					next := meta.NewTime(now.Add(time.Duration(Settings.PrecopyInterval) * time.Minute))
 					n := len(vm.Warm.Precopies)
@@ -1666,7 +1666,7 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 					continue
 				}
 
-				if r.Plan.Spec.Warm && len(importer.Status.ContainerStatuses) > 0 {
+				if r.Plan.IsWarm() && len(importer.Status.ContainerStatuses) > 0 {
 					vm.Warm.Failures = int(importer.Status.ContainerStatuses[0].RestartCount)
 				}
 				if restartLimitExceeded(importer) {

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -43,7 +43,7 @@ func (r *BaseMigrator) Complete(vm *plan.VMStatus) {
 func (r *BaseMigrator) Status(vm plan.VM) (status *plan.VMStatus) {
 	if current, found := r.Context.Plan.Status.Migration.FindVM(vm.Ref); !found {
 		status = &plan.VMStatus{VM: vm}
-		if r.Context.Plan.Spec.Warm {
+		if r.Context.Plan.IsWarm() {
 			status.Warm = &plan.Warm{}
 		}
 	} else {
@@ -60,7 +60,7 @@ func (r *BaseMigrator) Reset(vm *plan.VMStatus, pipeline []*plan.Step) {
 	vm.Phase = step.Name
 	vm.Pipeline = pipeline
 	vm.Error = nil
-	if r.Context.Plan.Spec.Warm {
+	if r.Context.Plan.IsWarm() {
 		vm.Warm = &plan.Warm{}
 	}
 }
@@ -230,7 +230,7 @@ func (r *BaseMigrator) Itinerary(vm plan.VM) (itinerary *libitr.Itinerary) {
 	// Plan.Spec.Type supersedes the deprecated Warm boolean.
 	if r.Context.Plan.Spec.Type == api.MigrationOnlyConversion {
 		itinerary = r.onlyConversionItinerary()
-	} else if r.Context.Plan.Spec.Warm {
+	} else if r.Context.Plan.IsWarm() {
 		itinerary = r.warmItinerary()
 	} else {
 		itinerary = r.coldItinerary()
@@ -277,7 +277,7 @@ func (r *BaseMigrator) Step(status *plan.VMStatus) (step string) {
 	case api.PhasePreHook, api.PhasePostHook:
 		step = status.Phase
 	case api.PhaseStorePowerState, api.PhasePowerOffSource, api.PhaseWaitForPowerOff:
-		if r.Context.Plan.Spec.Warm {
+		if r.Context.Plan.IsWarm() {
 			step = Cutover
 		} else {
 			step = Initialize

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -307,7 +307,7 @@ func (r *Reconciler) ensureSecretForProvider(plan *api.Plan) error {
 
 // Validate that warm migration is supported from the source provider.
 func (r *Reconciler) validateWarmMigration(ctx *plancontext.Context) (err error) {
-	if !ctx.Plan.Spec.Warm {
+	if !ctx.Plan.IsWarm() {
 		return
 	}
 	provider := ctx.Plan.Referenced.Provider.Source
@@ -1021,8 +1021,7 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 			}
 		}
 		// Warm migration.
-		isWarmMigration := plan.Spec.Warm || plan.Spec.Type == api.MigrationWarm
-		if isWarmMigration {
+		if plan.IsWarm() {
 			enabled, err := validator.ChangeTrackingEnabled(*ref)
 			if err != nil {
 				return err
@@ -1366,7 +1365,7 @@ func (r *Reconciler) validateVddkImage(plan *api.Plan) (err error) {
 		}
 		err = r.validateVddkImageJob(job, plan)
 	}
-	if plan.Spec.Warm && vddkImage == "" {
+	if plan.IsWarm() && vddkImage == "" {
 		plan.Status.SetCondition(libcnd.Condition{
 			Type:     VDDKInitImageUnavailable,
 			Status:   True,

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
@@ -26,7 +26,7 @@ type PlanAdmitter struct {
 
 func (admitter *PlanAdmitter) validateStorage() error {
 
-	if admitter.plan.Spec.Warm {
+	if admitter.plan.IsWarm() {
 		log.Info("Warm migration supports all storages, passing")
 		return nil
 	}
@@ -82,8 +82,7 @@ func (admitter *PlanAdmitter) validateStorage() error {
 
 func (admitter *PlanAdmitter) validateWarmMigrations() error {
 	providerType := admitter.sourceProvider.Type()
-	isWarmMigration := admitter.plan.Spec.Warm
-	if providerType == api.OpenStack && isWarmMigration {
+	if providerType == api.OpenStack && admitter.plan.IsWarm() {
 		err := liberr.New("warm migration is not supported by the provider")
 		log.Error(err, "provider", providerType)
 		return err

--- a/pkg/monitoring/metrics/forklift-controller/migration_metrics.go
+++ b/pkg/monitoring/metrics/forklift-controller/migration_metrics.go
@@ -52,7 +52,6 @@ func RecordMigrationMetrics(c client.Client) {
 				}
 
 				isLocal := destProvider.Spec.URL == ""
-				isWarm := plan.Spec.Warm
 
 				var target, mode string
 				if isLocal {
@@ -60,7 +59,7 @@ func RecordMigrationMetrics(c client.Client) {
 				} else {
 					target = Remote
 				}
-				if isWarm {
+				if plan.IsWarm() {
 					mode = Warm
 				} else {
 					mode = Cold

--- a/pkg/monitoring/metrics/forklift-controller/plan_metrics.go
+++ b/pkg/monitoring/metrics/forklift-controller/plan_metrics.go
@@ -44,7 +44,6 @@ func RecordPlanMetrics(c client.Client) {
 				}
 
 				isLocal := destProvider.Spec.URL == ""
-				isWarm := m.Spec.Warm
 
 				var target, mode, key string
 				if isLocal {
@@ -52,7 +51,7 @@ func RecordPlanMetrics(c client.Client) {
 				} else {
 					target = Remote
 				}
-				if isWarm {
+				if m.IsWarm() {
 					mode = Warm
 				} else {
 					mode = Cold


### PR DESCRIPTION
Issue:
When using "type: warm" in the Plan YAML without setting "warm: true", the migration behaves unexpectedly and no cutover occurs.

Fix:
Added a new function IsWarm() that Supports both the deprecated 'warm: true' field (for backward compatibility)
and the current 'type: warm' field..

Ref: https://issues.redhat.com/browse/MTV-3495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Unified warm-migration detection behind a single method across migration flow, providers, validators, webhooks, and controllers. Improves consistency for warm vs. cold logic, volume populators, annotations, pre-copy handling, and template naming.
- Bug Fixes
  - Resolves inconsistencies in warm-migration gating, snapshot/change-tracking checks, and preflight inspection, reducing unexpected migration issues across providers.
- Metrics
  - Standardizes warm/cold mode determination in migration and plan metrics for more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->