### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for vsphere-xcopy-volume-populator-2-9

### DIFF
--- a/build/vsphere-xcopy-volume-populator/Containerfile-downstream
+++ b/build/vsphere-xcopy-volume-populator/Containerfile-downstream
@@ -45,4 +45,5 @@ LABEL \
     vendor="Red Hat, Inc." \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
-    revision="$REVISION"
+    revision="$REVISION" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
