### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for validation-2-9

### DIFF
--- a/build/validation/Containerfile-downstream
+++ b/build/validation/Containerfile-downstream
@@ -25,6 +25,7 @@ ARG REVISION
 
 LABEL \
     com.redhat.component="mtv-validation-container" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
     name="${REGISTRY}/mtv-validation-rhel9" \
     license="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
