### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for openstack-populator-2-9

### DIFF
--- a/build/openstack-populator/Containerfile-downstream
+++ b/build/openstack-populator/Containerfile-downstream
@@ -20,6 +20,7 @@ ARG REGISTRY
 ARG REVISION
 
 LABEL \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
     com.redhat.component="mtv-openstack-populator-container" \
     name="${REGISTRY}/mtv-openstack-populator-rhel9" \
     license="Apache License 2.0" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
