### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for forklift-api-2-9

### DIFF
--- a/build/forklift-api/Containerfile-downstream
+++ b/build/forklift-api/Containerfile-downstream
@@ -22,6 +22,7 @@ ARG REVISION
 LABEL \
     com.redhat.component="mtv-api-container" \
     name="${REGISTRY}/mtv-api-rhel9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
     license="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \
     io.k8s.description="Migration Toolkit for Virtualization - API" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
