### PR TITLE
NO JIRA | Move CPE setting to a template (#3045)

### DIFF
--- a/build/forklift-api/Containerfile-downstream
+++ b/build/forklift-api/Containerfile-downstream
@@ -18,10 +18,11 @@ ENTRYPOINT ["/usr/local/bin/forklift-api"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-api-container" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9" \
     name="${REGISTRY}/mtv-api-rhel9" \
     license="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \

--- a/build/forklift-cli-download/Containerfile-downstream
+++ b/build/forklift-cli-download/Containerfile-downstream
@@ -7,10 +7,11 @@ CMD ["nginx", "-g", "daemon off;"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-cli-download-container" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9" \
     name="${REGISTRY}/mtv-cli-download-rhel9" \
     license="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \

--- a/build/forklift-controller/Containerfile-downstream
+++ b/build/forklift-controller/Containerfile-downstream
@@ -22,6 +22,7 @@ ENTRYPOINT ["/usr/local/bin/forklift-controller"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-controller-container" \
@@ -35,5 +36,5 @@ LABEL \
     vendor="Red Hat, Inc." \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9" \
     revision="$REVISION"

--- a/build/forklift-operator-bundle/Containerfile-downstream
+++ b/build/forklift-operator-bundle/Containerfile-downstream
@@ -70,6 +70,7 @@ ARG DEFAULT_CHANNEL
 ARG REGISTRY
 ARG OCP_VERSIONS
 ARG REVISION
+ARG CPE
 
 COPY --from=builder /repo/build/manifests /manifests/
 COPY --from=builder /repo/build/metadata /metadata/
@@ -107,11 +108,10 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 # Main labels
 LABEL \
     com.redhat.component="mtv-operator-bundle-container" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9" \
     name="${REGISTRY}/mtv-operator-bundle" \
     License="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \
-
     io.openshift.tags="migration" \
     io.k8s.description="Migration Toolkit for Virtualization - Operator Bundle" \
     summary="Migration Toolkit for Virtualization - Operator Bundle" \

--- a/build/forklift-operator/Containerfile-downstream
+++ b/build/forklift-operator/Containerfile-downstream
@@ -9,6 +9,7 @@ ARG VERSION
 ARG RELEASE
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-operator-container" \
@@ -22,6 +23,6 @@ LABEL \
     vendor="Red Hat, Inc." \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9" \
     revision="$REVISION"
 

--- a/build/openstack-populator/Containerfile-downstream
+++ b/build/openstack-populator/Containerfile-downstream
@@ -18,6 +18,7 @@ ENTRYPOINT ["/usr/local/bin/openstack-populator"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-openstack-populator-container" \
@@ -32,4 +33,4 @@ LABEL \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
     revision="$REVISION" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9"
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9"

--- a/build/ova-provider-server/Containerfile-downstream
+++ b/build/ova-provider-server/Containerfile-downstream
@@ -19,10 +19,11 @@ ENTRYPOINT ["/usr/local/bin/ova-provider-server"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-ova-provider-server-container" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9" \
     name="${REGISTRY}/mtv-ova-provider-server-rhel9" \
     license="Apache License 2.0" \
     io.k8s.display-name="Migration Toolkit for Virtualization" \

--- a/build/ovirt-populator/Containerfile-downstream
+++ b/build/ovirt-populator/Containerfile-downstream
@@ -18,6 +18,7 @@ ENTRYPOINT ["/usr/local/bin/ovirt-populator"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-rhv-populator-container" \
@@ -32,5 +33,5 @@ LABEL \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
     revision="$REVISION" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el8"
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el8"
 

--- a/build/populator-controller/Containerfile-downstream
+++ b/build/populator-controller/Containerfile-downstream
@@ -19,6 +19,7 @@ ENTRYPOINT ["/usr/local/bin/populator-controller"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-populator-controller-container" \
@@ -33,4 +34,4 @@ LABEL \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
     revision="$REVISION" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9"
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9"

--- a/build/release.conf
+++ b/build/release.conf
@@ -4,6 +4,9 @@ VERSION=2.10.0
 # Release version, format "vX.Y"
 RELEASE=v2.10
 
+# This setting must mirror the Y stream version specified above, e.g. if RELEASE == v2.10 then CPE == 2.10 (without the "v")
+CPE=2.10
+
 # Operator channel where the version will be deployed, e.g. dev-preview, release-v2.9 ...
 CHANNEL=release-v2.10
 

--- a/build/validation/Containerfile-downstream
+++ b/build/validation/Containerfile-downstream
@@ -22,6 +22,7 @@ ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-validation-container" \
@@ -36,5 +37,5 @@ LABEL \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
     revision="$REVISION" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9"
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9"
 

--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -81,6 +81,7 @@ ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-virt-v2v-container" \
@@ -90,7 +91,7 @@ LABEL \
     io.k8s.description="Migration Toolkit for Virtualization - Virt-V2V" \
     io.openshift.tags="migration,mtv,forklift" \
     summary="Migration Toolkit for Virtualization - Virt-V2V" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9" \
     description="Migration Toolkit for Virtualization - Virt-V2V" \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \

--- a/build/vsphere-xcopy-volume-populator/Containerfile-downstream
+++ b/build/vsphere-xcopy-volume-populator/Containerfile-downstream
@@ -32,6 +32,7 @@ ENTRYPOINT ["/bin/vsphere-xcopy-volume-populator"]
 ARG VERSION
 ARG REGISTRY
 ARG REVISION
+ARG CPE
 
 LABEL \
     com.redhat.component="mtv-vsphere-xcopy-volume-populator-container" \
@@ -45,5 +46,5 @@ LABEL \
     vendor="Red Hat, Inc." \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
     version="$VERSION" \
-    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:${CPE}::el9" \
     revision="$REVISION"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
- Standardized container image metadata by parameterizing the CPE value across downstream images.
- Introduced a configurable CPE version in release configuration to align with the current release stream.
- Replaced hard-coded CPE versions with build-time configuration, improving consistency and maintainability.
  - No runtime behavior changes; impact limited to image metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->