### PR TITLE
backport: MTV-3415 | Add kubevirt template workload annotations (#2984)

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1497,6 +1497,21 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus, sortVolumesByLibvirt bool) 
 	object.Spec.RunStrategy = &runStrategy
 	object.Spec.Running = nil // Ensure running is not set
 
+	// Add kubevirt template annotations if they are missing
+	kubevirtWorkloadAnn := []string{
+		"vm.kubevirt.io/flavor",
+		"vm.kubevirt.io/os",
+		"vm.kubevirt.io/workload",
+	}
+	if object.Spec.Template.ObjectMeta.Annotations == nil {
+		object.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	for _, ann := range kubevirtWorkloadAnn {
+		if _, ok := object.Spec.Template.ObjectMeta.Annotations[ann]; !ok {
+			object.Spec.Template.ObjectMeta.Annotations[ann] = ""
+		}
+	}
+
 	err = r.Builder.VirtualMachine(vm.Ref, &object.Spec, pvcs, vm.InstanceType != "", sortVolumesByLibvirt)
 	if err != nil {
 		return


### PR DESCRIPTION
Issue: Missing kubevirt workload annotations in migrated VM template cause issues when trying to set the workload type through UI.

Fix: Add the annotations to the template.

Ref: https://issues.redhat.com/browse/MTV-3415

Resolves: MTV-3415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

* **Bug Fixes**
* Generated VirtualMachine templates now always include standard KubeVirt annotations (flavor, OS, workload), inserting empty values if missing.
* Initializes template annotations when absent to prevent missing metadata.
* Improves compatibility with dashboards, policies, and automation that depend on these annotations.
  * No changes to VM spec behavior; only template metadata is affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->