### PR TITLE
BTRFS filesystem concern ID shouldn't include btrfs_disks list index

### DIFF
--- a/validation/policies/io/konveyor/forklift/vmware/btrfs_filesystem.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/btrfs_filesystem.rego
@@ -16,7 +16,7 @@ concerns contains flag if {
 	btrfs_disks[idx]
 	disk := input.guestDisks[idx]
 	flag := {
-		"id": sprintf("vmware.guestDisks.btrfs.unsupported.%v", [idx]),
+		"id": "vmware.guestDisks.btrfs.unsupported",
 		"category": "Warning",
 		"label": "BTRFS filesystem detected on disk",
 		"assessment": "BTRFS filesystem is not supported and may cause issues during guest conversion",

--- a/validation/policies/io/konveyor/forklift/vmware/btrfs_filesystem_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/btrfs_filesystem_test.rego
@@ -38,7 +38,7 @@ test_vm_with_btrfs_creates_concern if {
 
 # Test: Case insensitive BTRFS detection
 test_btrfs_case_insensitive if {
-	count(concerns) == 3 with input as {
+	count(concerns) == 1 with input as {
 		"guestId": "ubuntu64Guest",
 		"guestDisks": [
 			{
@@ -65,7 +65,7 @@ test_btrfs_case_insensitive if {
 
 # Test: Mixed filesystem types should only flag BTRFS disks
 test_mixed_filesystems_partial_concerns if {
-	count(concerns) == 2 with input as {
+	count(concerns) == 1 with input as {
 		"guestId": "ubuntu64Guest",
 		"guestDisks": [
 			{


### PR DESCRIPTION
The concern ID should be the same for all the concerns of this type Align to the way its done in other concerns

Resolves: ECOPROJECT-3359