### PR TITLE
NO JIRA | Add missing OCP version

### DIFF
--- a/build/release.conf
+++ b/build/release.conf
@@ -17,4 +17,4 @@ DEFAULT_CHANNEL=release-v2.11
 REGISTRY=mtv-candidate
 
 # Which OCP versions are supported by this release
-OCP_VERSIONS=v4.19-v4.20
+OCP_VERSIONS=v4.19-v4.21


### PR DESCRIPTION
Issue: upper OCP version was missing but now it's available

Fix: Add it

Resolution: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded declared platform compatibility to include OpenShift Container Platform v4.21 by raising the supported upper bound.
  * Updated release configuration to reflect the new supported version range.
  * Installations and upgrades on OCP 4.21 are now recognized as supported.
  * No functional changes or user-facing behavior updates; existing workflows and APIs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->