### PR TITLE
chore | Bump upstream ovirt populator go version

### DIFF
--- a/build/forklift-operator-index/Containerfile
+++ b/build/forklift-operator-index/Containerfile
@@ -15,6 +15,11 @@ COPY --from=opm /bin/opm /bin/opm
 COPY operator /app
 WORKDIR /app
 
+# Add a configure container policy to allow pulling from insecure registries
+# Ref: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md
+RUN mkdir -p /etc/containers && \
+    echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json
+
 RUN cat catalog/operator.yml | envsubst > operator.yaml
 RUN opm render ${OPERATOR_BUNDLE_IMAGE} ${OPM_OPTS} -o yaml >> operator.yaml
 

--- a/build/ovirt-populator/Containerfile
+++ b/build/ovirt-populator/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.23.6-2.1747189110 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.24.6-1760518714 AS builder
 ENV GOPATH=$APP_ROOT
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/ovirt-populator/Containerfile-upstream
+++ b/build/ovirt-populator/Containerfile-upstream
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.23.6-2.1747189110 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.24.6-1760518714 AS builder
 ENV GOPATH=$APP_ROOT
 WORKDIR /app
 COPY --chown=1001:0 ./ ./


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift/pull/2276 - bump downstream go version

Bump upstream ovirt populator go version

  - [x] bump upstream ovirt populator builder go version from 1.23 to 1.24
  - [x] add an upstream operator index containerfile, to allow building operator index using insecure sources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for pulling from insecure container registries during operator index builds, improving compatibility in restricted or air‑gapped environments.

* **Chores**
  * Upgraded the builder base image (Go toolset) to a newer version to modernize the build environment; no user-facing behavior changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->