### PR TITLE
MTV-3259 | | OCP > OCP migrate VM failed on failed to verify certificate: x509 with prehook.

### DIFF
--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -26,6 +26,13 @@ import (
 const (
 	// VM step label
 	kStep = "step"
+	// Hook ID label
+	kHook = "hook"
+)
+
+// Resource label
+const (
+	ResourceHookConfig = "hook-config"
 )
 
 // Hook runner.
@@ -362,5 +369,7 @@ func (r *HookRunner) labels() map[string]string {
 		kMigration: string(r.Migration.UID),
 		kVM:        r.vm.ID,
 		kStep:      r.vm.Phase,
+		kHook:      string(r.hook.UID),
+		kResource:  ResourceHookConfig,
 	}
 }

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -103,6 +103,14 @@ const (
 	kDV = "isDV"
 	// Populator secret
 	kPopulator = "isPopulator"
+	// Resource label
+	kResource = "resource"
+)
+
+// Resource labels
+const (
+	ResourceVMConfig   = "vm-config"
+	ResourceVDDKConfig = "vddk-config"
 )
 
 // User
@@ -2425,6 +2433,7 @@ func (r *KubeVirt) ensureConfigMap(vmRef ref.Ref) (configMap *core.ConfigMap, er
 	if err != nil {
 		return
 	}
+
 	list := &core.ConfigMapList{}
 	err = r.Destination.Client.List(
 		context.TODO(),
@@ -2624,6 +2633,7 @@ func (r *KubeVirt) inspectionLabels(vmRef ref.Ref) (labels map[string]string) {
 func (r *KubeVirt) vmLabels(vmRef ref.Ref) (labels map[string]string) {
 	labels = r.planLabels()
 	labels[kVM] = vmRef.ID
+	labels[kResource] = ResourceVMConfig
 	return
 }
 
@@ -2632,6 +2642,7 @@ func (r *KubeVirt) vmLabels(vmRef ref.Ref) (labels map[string]string) {
 func (r *KubeVirt) vddkLabels() (labels map[string]string) {
 	labels = r.planLabels()
 	labels[kUse] = VddkConf
+	labels[kResource] = ResourceVDDKConfig
 	return
 }
 


### PR DESCRIPTION
Issue:    
Pre-hooks create ConfigMaps with hook data (plan.yml, playbook.yml, workload.yml).
Later when ensureConfigMap() is called to prepare for DataVolume creation,
it finds this existing hook ConfigMap and reuses it as the certConfigMap for
CDI importer (avoiding duplicate ConfigMaps for the same VM),
causing TLS verification failures: "x509: certificate signed by unknown authority"

Fix:
Adding a new "resource" label to the configMaps to distinguish between the hook and the vm configMaps.

Ref: https://issues.redhat.com/browse/MTV-3259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource filtering to only include VM-related items that are not already marked with a step, preventing duplicate or unintended processing.
  * Enhances reliability of plan execution and reduces noise in logs and UI listings by excluding already-handled resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->