### PR TITLE
MTV-3552 | Correct MTV operator compatibility

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -6797,9 +6797,9 @@ spec:
 
     ### Compatibility
 
-    Migration Toolkit for Virtualization 2.7 is supported on OpenShift 4.15, 4.16 and 4.17
+    Migration Toolkit for Virtualization 2.10 is supported on OpenShift 4.18, 4.19 and 4.20
 
-    Migration Toolkit for Virtualization 2.8 is supported on OpenShift 4.16, 4.17 and 4.18
+    Migration Toolkit for Virtualization 2.11 is supported on OpenShift 4.19, 4.20 and 4.21
 
     More information on compatibility in the [MTV Lifecycle document](https://access.redhat.com/support/policy/updates/migration-toolkit-for-virtualization).
 

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -58,9 +58,9 @@ spec:
 
     ### Compatibility
 
-    Migration Toolkit for Virtualization 2.7 is supported on OpenShift 4.15, 4.16 and 4.17
+    Migration Toolkit for Virtualization 2.10 is supported on OpenShift 4.18, 4.19 and 4.20
 
-    Migration Toolkit for Virtualization 2.8 is supported on OpenShift 4.16, 4.17 and 4.18
+    Migration Toolkit for Virtualization 2.11 is supported on OpenShift 4.19, 4.20 and 4.21
 
     More information on compatibility in the [MTV Lifecycle document](https://access.redhat.com/support/policy/updates/migration-toolkit-for-virtualization).
 


### PR DESCRIPTION
Resolves: MTV-3552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated compatibility information for Migration Toolkit for Virtualization:
    - Version 2.10 is now documented as compatible with OpenShift 4.18–4.20 (replacing 2.7 on 4.15–4.17).
    - Version 2.11 is now documented as compatible with OpenShift 4.19–4.21 (replacing 2.8 on 4.16–4.18).
  - No functional behavior changes; this update clarifies supported platform versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->