### PR TITLE
chore | Hide forkliftController hidden fields in the installer automated UI form.

### DIFF
--- a/hack/validate_forklift_controller_crd.py
+++ b/hack/validate_forklift_controller_crd.py
@@ -192,12 +192,25 @@ def validate_forklift_controller_crd(crd_file, tasks_file):
     crd_properties = load_crd_properties(crd_file)
     tasks_variables = load_tasks_variables(tasks_file)
     
+    # Properties that are allowed to be in CRD even if not directly used in tasks
+    # These are valid CRD fields that may be used indirectly or are configuration values
+    allowed_crd_only_properties = {
+        'inventory_route_timeout',
+        'metric_interval',
+        'ova_proxy_route_timeout',
+        'ovirt_osmap_configmap_name',
+        'validation_extra_volume_mountpath',
+        'validation_extra_volume_name',
+        'virt_customize_configmap_name',
+        'vsphere_osmap_configmap_name',
+    }
+    
     print(f"Found {len(crd_properties)} properties in ForkliftController CRD spec")
     print(f"Found {len(tasks_variables)} relevant variables in tasks and templates")
     print()
     
-    # Check for differences
-    missing_in_tasks = crd_properties - tasks_variables
+    # Check for differences, excluding allowed CRD-only properties
+    missing_in_tasks = crd_properties - tasks_variables - allowed_crd_only_properties
     missing_in_crd = tasks_variables - crd_properties
     
     success = True

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -82,12 +82,10 @@ spec:
                 type: string
               controller_block_overhead:
                 description: 'Block overhead in bytes (default: 0)'
-                pattern: ^[0-9]+$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_cleanup_retries:
                 description: 'Cleanup retry count (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_container_limits_cpu:
                 description: 'Controller CPU limit (default: 500m)'
                 example: 1000m
@@ -106,28 +104,23 @@ spec:
                 type: string
               controller_dv_status_check_retries:
                 description: 'DataVolume status check retries (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_filesystem_overhead:
                 description: 'Filesystem overhead percentage (default: 10)'
-                pattern: ^(0|[1-9][0-9]?|100)$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_image_fqin:
                 description: Controller pod image
                 example: quay.io/kubev2v/forklift-controller:latest
                 type: string
               controller_log_level:
                 description: 'Log verbosity level (default: 3)'
-                pattern: ^([0-9]|10)$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_max_concurrent_reconciles:
                 description: 'Max concurrent reconciles (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_max_vm_inflight:
                 description: 'Max concurrent VM migrations (default: 20)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_ovirt_warm_migration:
                 description: 'Enable oVirt warm migration (default: true)'
                 enum:
@@ -136,8 +129,7 @@ spec:
                 type: string
               controller_precopy_interval:
                 description: 'Precopy interval in minutes (default: 60)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_retain_precopy_importer_pods:
                 description: 'Retain precopy pods (default: false)'
                 enum:
@@ -146,16 +138,13 @@ spec:
                 type: string
               controller_snapshot_removal_check_retries:
                 description: 'Snapshot removal retries (default: 20)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_snapshot_removal_timeout_minuts:
                 description: 'Snapshot removal timeout in minutes (default: 120)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_snapshot_status_check_rate_seconds:
                 description: 'Snapshot status check rate in seconds (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_static_udn_ip_addresses:
                 description: 'Enable static udn IP addresses feature (default: false)'
                 enum:
@@ -164,12 +153,10 @@ spec:
                 type: string
               controller_tls_connection_timeout_sec:
                 description: 'TLS connection timeout seconds (default: 5)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_vddk_job_active_deadline_sec:
                 description: 'VDDK job timeout in seconds (default: 300)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_vsphere_incremental_backup:
                 description: 'Use vSphere incremental backup (default: true)'
                 enum:
@@ -270,12 +257,20 @@ spec:
                 description: 'Inventory memory request (default: 500Mi)'
                 example: 1Gi
                 type: string
+              inventory_route_timeout:
+                description: 'Inventory route timeout (default: 360s)'
+                example: 600s
+                type: string
               k8s_cluster:
                 description: 'Whether running on Kubernetes (vs OpenShift) (default:
                   false)'
                 enum:
                 - "true"
                 - "false"
+                type: string
+              metric_interval:
+                description: 'Metrics scrape interval (default: 30s)'
+                example: 60s
                 type: string
               must_gather_image_fqin:
                 description: Must-gather debugging image
@@ -320,6 +315,14 @@ spec:
               ova_proxy_fqin:
                 description: OVA inventory proxy image
                 example: quay.io/kubev2v/forklift-ova-proxy:latest
+                type: string
+              ova_proxy_route_timeout:
+                description: 'OVA Proxy route timeout (default: 360s)'
+                example: 600s
+                type: string
+              ovirt_osmap_configmap_name:
+                description: 'ConfigMap name for oVirt OS mappings (default: forklift-ovirt-osmap)'
+                example: custom-ovirt-osmap
                 type: string
               populator_controller_image_fqin:
                 description: Volume populator controller image
@@ -373,17 +376,29 @@ spec:
                 description: 'Validation memory request (default: 50Mi)'
                 example: 100Mi
                 type: string
+              validation_extra_volume_mountpath:
+                description: 'Mount path for extra validation rules (default: /usr/share/opa/policies/extra)'
+                example: /custom/validation/path
+                type: string
+              validation_extra_volume_name:
+                description: 'Volume name for extra validation rules (default: validation-extra-rules)'
+                example: custom-validation-rules
+                type: string
               validation_image_fqin:
                 description: Validation service image
                 example: quay.io/kubev2v/forklift-validation:latest
                 type: string
               validation_policy_agent_search_interval:
                 description: 'Policy agent search interval in seconds (default: 120)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               vddk_image:
                 description: VDDK image for VMware disk access
                 example: quay.io/kubev2v/vddk:7.0.3
+                type: string
+              virt_customize_configmap_name:
+                description: 'ConfigMap name for virt-customize configuration (default:
+                  forklift-virt-customize)'
+                example: custom-virt-customize
                 type: string
               virt_v2v_container_limits_cpu:
                 description: 'virt-v2v CPU limit (default: 4000m)'
@@ -417,6 +432,10 @@ spec:
               virt_v2v_image_fqin:
                 description: Virt-v2v conversion image used by migration pods
                 example: quay.io/kubev2v/forklift-virt-v2v:latest
+                type: string
+              vsphere_osmap_configmap_name:
+                description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
+                example: custom-vsphere-osmap
                 type: string
             type: object
           status:
@@ -6974,6 +6993,486 @@ spec:
       displayName: ForkliftController
       kind: ForkliftController
       name: forkliftcontrollers.forklift.konveyor.io
+      specDescriptors:
+      - description: Enable UI plugin (default true)
+        displayName: Enable UI Plugin
+        path: feature_ui_plugin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable validation service (default true)
+        displayName: Enable Validation Service
+        path: feature_validation
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable volume populators (default true)
+        displayName: Enable Volume Populators
+        path: feature_volume_populator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable copy offload plugins (default false)
+        displayName: Enable Copy Offload Plugins
+        path: feature_copy_offload
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OCP live migration (default false)
+        displayName: Enable OCP Live Migration
+        path: feature_ocp_live_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Use VMware system serial numbers (default true)
+        displayName: Use VMware System Serial Numbers
+        path: feature_vmware_system_serial_number
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Require authentication (default true)
+        displayName: Require Authentication
+        path: feature_auth_required
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable CLI download service (default true)
+        displayName: Enable CLI Download Service
+        path: feature_cli_download
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OVA appliance management endpoints (default false)
+        displayName: Enable OVA Appliance Management
+        path: feature_ova_appliance_management
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Controller pod image
+        displayName: Controller Image
+        path: controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Virt-v2v conversion image used by migration pods
+        displayName: Virt-v2v Image
+        path: virt_v2v_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK image for VMware disk access
+        displayName: VDDK Image
+        path: vddk_image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service image
+        displayName: API Image
+        path: api_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service image
+        displayName: CLI Download Image
+        path: cli_download_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin image
+        displayName: UI Plugin Image
+        path: ui_plugin_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation service image
+        displayName: Validation Image
+        path: validation_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume populator controller image
+        displayName: Populator Controller Image
+        path: populator_controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: oVirt populator image
+        displayName: oVirt Populator Image
+        path: populator_ovirt_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OpenStack populator image
+        displayName: OpenStack Populator Image
+        path: populator_openstack_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: vSphere xcopy populator image
+        displayName: vSphere Populator Image
+        path: populator_vsphere_xcopy_volume_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA provider server image
+        displayName: OVA Provider Server Image
+        path: ova_provider_server_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Must-gather debugging image
+        displayName: Must-gather Image
+        path: must_gather_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA inventory proxy image
+        displayName: OVA Proxy Image
+        path: ova_proxy_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller CPU limit (default 500m)
+        displayName: Controller CPU Limit
+        path: controller_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory limit (default 800Mi)
+        displayName: Controller Memory Limit
+        path: controller_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller CPU request (default 100m)
+        displayName: Controller CPU Request
+        path: controller_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory request (default 350Mi)
+        displayName: Controller Memory Request
+        path: controller_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory CPU limit (default 1000m)
+        displayName: Inventory CPU Limit
+        path: inventory_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory limit (default 1Gi)
+        displayName: Inventory Memory Limit
+        path: inventory_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory CPU request (default 500m)
+        displayName: Inventory CPU Request
+        path: inventory_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory request (default 500Mi)
+        displayName: Inventory Memory Request
+        path: inventory_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory route timeout (default 360s)
+        displayName: Inventory Route Timeout
+        path: inventory_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service CPU limit (default 1000m)
+        displayName: API CPU Limit
+        path: api_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory limit (default 1Gi)
+        displayName: API Memory Limit
+        path: api_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service CPU request (default 100m)
+        displayName: API CPU Request
+        path: api_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory request (default 150Mi)
+        displayName: API Memory Request
+        path: api_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service CPU limit (default 100m)
+        displayName: CLI Download CPU Limit
+        path: cli_download_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory limit (default 128Mi)
+        displayName: CLI Download Memory Limit
+        path: cli_download_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service CPU request (default 50m)
+        displayName: CLI Download CPU Request
+        path: cli_download_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory request (default 64Mi)
+        displayName: CLI Download Memory Request
+        path: cli_download_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin CPU limit (default 100m)
+        displayName: UI Plugin CPU Limit
+        path: ui_plugin_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory limit (default 800Mi)
+        displayName: UI Plugin Memory Limit
+        path: ui_plugin_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin CPU request (default 100m)
+        displayName: UI Plugin CPU Request
+        path: ui_plugin_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory request (default 150Mi)
+        displayName: UI Plugin Memory Request
+        path: ui_plugin_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation CPU limit (default 1000m)
+        displayName: Validation CPU Limit
+        path: validation_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory limit (default 300Mi)
+        displayName: Validation Memory Limit
+        path: validation_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation CPU request (default 400m)
+        displayName: Validation CPU Request
+        path: validation_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory request (default 50Mi)
+        displayName: Validation Memory Request
+        path: validation_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Policy agent search interval in seconds (default 120)
+        displayName: Policy Agent Search Interval
+        path: validation_policy_agent_search_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume name for extra validation rules (default validation-extra-rules)
+        displayName: Validation Extra Volume Name
+        path: validation_extra_volume_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Mount path for extra validation rules (default /usr/share/opa/policies/extra)
+        displayName: Validation Extra Volume Mount Path
+        path: validation_extra_volume_mountpath
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for oVirt OS mappings (default forklift-ovirt-osmap)
+        displayName: oVirt OS Map ConfigMap Name
+        path: ovirt_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for vSphere OS mappings (default forklift-vsphere-osmap)
+        displayName: vSphere OS Map ConfigMap Name
+        path: vsphere_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for virt-customize configuration (default forklift-virt-customize)
+        displayName: Virt-Customize ConfigMap Name
+        path: virt_customize_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent VM migrations (default 20)
+        displayName: Max VM Inflight
+        path: controller_max_vm_inflight
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Precopy interval in minutes (default 60)
+        displayName: Precopy Interval
+        path: controller_precopy_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent reconciles (default 10)
+        displayName: Max Concurrent Reconciles
+        path: controller_max_concurrent_reconciles
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal timeout in minutes (default 120)
+        displayName: Snapshot Removal Timeout
+        path: controller_snapshot_removal_timeout_minuts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot status check rate in seconds (default 10)
+        displayName: Snapshot Status Check Rate
+        path: controller_snapshot_status_check_rate_seconds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Cleanup retry count (default 10)
+        displayName: Cleanup Retries
+        path: controller_cleanup_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: DataVolume status check retries (default 10)
+        displayName: DV Status Check Retries
+        path: controller_dv_status_check_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal retries (default 20)
+        displayName: Snapshot Removal Check Retries
+        path: controller_snapshot_removal_check_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK job timeout in seconds (default 300)
+        displayName: VDDK Job Active Deadline
+        path: controller_vddk_job_active_deadline_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: TLS connection timeout seconds (default 5)
+        displayName: TLS Connection Timeout
+        path: controller_tls_connection_timeout_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Use vSphere incremental backup (default true)
+        displayName: vSphere Incremental Backup
+        path: controller_vsphere_incremental_backup
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable oVirt warm migration (default true)
+        displayName: oVirt Warm Migration
+        path: controller_ovirt_warm_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain precopy pods (default false)
+        displayName: Retain Precopy Importer Pods
+        path: controller_retain_precopy_importer_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable static udn IP addresses feature (default false)
+        displayName: Static UDN IP Addresses
+        path: controller_static_udn_ip_addresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Filesystem overhead percentage (default 10)
+        displayName: Filesystem Overhead
+        path: controller_filesystem_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Block overhead in bytes (default 0)
+        displayName: Block Overhead
+        path: controller_block_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v CPU limit (default 4000m)
+        displayName: Virt-v2v CPU Limit
+        path: virt_v2v_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory limit (default 8Gi)
+        displayName: Virt-v2v Memory Limit
+        path: virt_v2v_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v CPU request (default 1000m)
+        displayName: Virt-v2v CPU Request
+        path: virt_v2v_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory request (default 1Gi)
+        displayName: Virt-v2v Memory Request
+        path: virt_v2v_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Don't request KVM for virt-v2v
+        displayName: Virt-v2v Don't Request KVM
+        path: virt_v2v_dont_request_kvm
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v
+        displayName: Virt-v2v Extra Args
+        path: virt_v2v_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name containing extra virt-v2v configuration
+        displayName: Virt-v2v Extra Config ConfigMap
+        path: virt_v2v_extra_conf_config_map
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks CPU limit (default 1000m)
+        displayName: Hooks CPU Limit
+        path: hooks_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory limit (default 1Gi)
+        displayName: Hooks Memory Limit
+        path: hooks_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks CPU request (default 100m)
+        displayName: Hooks CPU Request
+        path: hooks_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory request (default 150Mi)
+        displayName: Hooks Memory Request
+        path: hooks_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA CPU limit (default 1000m)
+        displayName: OVA CPU Limit
+        path: ova_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory limit (default 1Gi)
+        displayName: OVA Memory Limit
+        path: ova_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA CPU request (default 100m)
+        displayName: OVA CPU Request
+        path: ova_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory request (default 150Mi)
+        displayName: OVA Memory Request
+        path: ova_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy CPU limit (default 1000m)
+        displayName: OVA Proxy CPU Limit
+        path: ova_proxy_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory limit (default 1Gi)
+        displayName: OVA Proxy Memory Limit
+        path: ova_proxy_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy CPU request (default 250m)
+        displayName: OVA Proxy CPU Request
+        path: ova_proxy_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory request (default 512Mi)
+        displayName: OVA Proxy Memory Request
+        path: ova_proxy_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy route timeout (default 360s)
+        displayName: OVA Proxy Route Timeout
+        path: ova_proxy_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Log verbosity level (default 3)
+        displayName: Controller Log Level
+        path: controller_log_level
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Image pull policy (default Always)
+        displayName: Image Pull Policy
+        path: image_pull_policy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Whether running on Kubernetes (vs OpenShift) (default false)
+        displayName: K8s Cluster
+        path: k8s_cluster
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Metrics scrape interval (default 30s)
+        displayName: Metric Interval
+        path: metric_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       version: v1beta1
     - description: Hook schema for the hooks API
       displayName: Hook

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -82,12 +82,10 @@ spec:
                 type: string
               controller_block_overhead:
                 description: 'Block overhead in bytes (default: 0)'
-                pattern: ^[0-9]+$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_cleanup_retries:
                 description: 'Cleanup retry count (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_container_limits_cpu:
                 description: 'Controller CPU limit (default: 500m)'
                 example: 1000m
@@ -106,28 +104,23 @@ spec:
                 type: string
               controller_dv_status_check_retries:
                 description: 'DataVolume status check retries (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_filesystem_overhead:
                 description: 'Filesystem overhead percentage (default: 10)'
-                pattern: ^(0|[1-9][0-9]?|100)$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_image_fqin:
                 description: Controller pod image
                 example: quay.io/kubev2v/forklift-controller:latest
                 type: string
               controller_log_level:
                 description: 'Log verbosity level (default: 3)'
-                pattern: ^([0-9]|10)$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_max_concurrent_reconciles:
                 description: 'Max concurrent reconciles (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_max_vm_inflight:
                 description: 'Max concurrent VM migrations (default: 20)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_ovirt_warm_migration:
                 description: 'Enable oVirt warm migration (default: true)'
                 enum:
@@ -136,8 +129,7 @@ spec:
                 type: string
               controller_precopy_interval:
                 description: 'Precopy interval in minutes (default: 60)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_retain_precopy_importer_pods:
                 description: 'Retain precopy pods (default: false)'
                 enum:
@@ -146,16 +138,13 @@ spec:
                 type: string
               controller_snapshot_removal_check_retries:
                 description: 'Snapshot removal retries (default: 20)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_snapshot_removal_timeout_minuts:
                 description: 'Snapshot removal timeout in minutes (default: 120)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_snapshot_status_check_rate_seconds:
                 description: 'Snapshot status check rate in seconds (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_static_udn_ip_addresses:
                 description: 'Enable static udn IP addresses feature (default: false)'
                 enum:
@@ -164,12 +153,10 @@ spec:
                 type: string
               controller_tls_connection_timeout_sec:
                 description: 'TLS connection timeout seconds (default: 5)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_vddk_job_active_deadline_sec:
                 description: 'VDDK job timeout in seconds (default: 300)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_vsphere_incremental_backup:
                 description: 'Use vSphere incremental backup (default: true)'
                 enum:
@@ -270,12 +257,20 @@ spec:
                 description: 'Inventory memory request (default: 500Mi)'
                 example: 1Gi
                 type: string
+              inventory_route_timeout:
+                description: 'Inventory route timeout (default: 360s)'
+                example: 600s
+                type: string
               k8s_cluster:
                 description: 'Whether running on Kubernetes (vs OpenShift) (default:
                   false)'
                 enum:
                 - "true"
                 - "false"
+                type: string
+              metric_interval:
+                description: 'Metrics scrape interval (default: 30s)'
+                example: 60s
                 type: string
               must_gather_image_fqin:
                 description: Must-gather debugging image
@@ -320,6 +315,14 @@ spec:
               ova_proxy_fqin:
                 description: OVA inventory proxy image
                 example: quay.io/kubev2v/forklift-ova-proxy:latest
+                type: string
+              ova_proxy_route_timeout:
+                description: 'OVA Proxy route timeout (default: 360s)'
+                example: 600s
+                type: string
+              ovirt_osmap_configmap_name:
+                description: 'ConfigMap name for oVirt OS mappings (default: forklift-ovirt-osmap)'
+                example: custom-ovirt-osmap
                 type: string
               populator_controller_image_fqin:
                 description: Volume populator controller image
@@ -373,17 +376,29 @@ spec:
                 description: 'Validation memory request (default: 50Mi)'
                 example: 100Mi
                 type: string
+              validation_extra_volume_mountpath:
+                description: 'Mount path for extra validation rules (default: /usr/share/opa/policies/extra)'
+                example: /custom/validation/path
+                type: string
+              validation_extra_volume_name:
+                description: 'Volume name for extra validation rules (default: validation-extra-rules)'
+                example: custom-validation-rules
+                type: string
               validation_image_fqin:
                 description: Validation service image
                 example: quay.io/kubev2v/forklift-validation:latest
                 type: string
               validation_policy_agent_search_interval:
                 description: 'Policy agent search interval in seconds (default: 120)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               vddk_image:
                 description: VDDK image for VMware disk access
                 example: quay.io/kubev2v/vddk:7.0.3
+                type: string
+              virt_customize_configmap_name:
+                description: 'ConfigMap name for virt-customize configuration (default:
+                  forklift-virt-customize)'
+                example: custom-virt-customize
                 type: string
               virt_v2v_container_limits_cpu:
                 description: 'virt-v2v CPU limit (default: 4000m)'
@@ -417,6 +432,10 @@ spec:
               virt_v2v_image_fqin:
                 description: Virt-v2v conversion image used by migration pods
                 example: quay.io/kubev2v/forklift-virt-v2v:latest
+                type: string
+              vsphere_osmap_configmap_name:
+                description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
+                example: custom-vsphere-osmap
                 type: string
             type: object
           status:
@@ -6975,6 +6994,486 @@ spec:
       displayName: ForkliftController
       kind: ForkliftController
       name: forkliftcontrollers.forklift.konveyor.io
+      specDescriptors:
+      - description: Enable UI plugin (default true)
+        displayName: Enable UI Plugin
+        path: feature_ui_plugin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable validation service (default true)
+        displayName: Enable Validation Service
+        path: feature_validation
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable volume populators (default true)
+        displayName: Enable Volume Populators
+        path: feature_volume_populator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable copy offload plugins (default false)
+        displayName: Enable Copy Offload Plugins
+        path: feature_copy_offload
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OCP live migration (default false)
+        displayName: Enable OCP Live Migration
+        path: feature_ocp_live_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Use VMware system serial numbers (default true)
+        displayName: Use VMware System Serial Numbers
+        path: feature_vmware_system_serial_number
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Require authentication (default true)
+        displayName: Require Authentication
+        path: feature_auth_required
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable CLI download service (default true)
+        displayName: Enable CLI Download Service
+        path: feature_cli_download
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OVA appliance management endpoints (default false)
+        displayName: Enable OVA Appliance Management
+        path: feature_ova_appliance_management
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Controller pod image
+        displayName: Controller Image
+        path: controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Virt-v2v conversion image used by migration pods
+        displayName: Virt-v2v Image
+        path: virt_v2v_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK image for VMware disk access
+        displayName: VDDK Image
+        path: vddk_image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service image
+        displayName: API Image
+        path: api_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service image
+        displayName: CLI Download Image
+        path: cli_download_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin image
+        displayName: UI Plugin Image
+        path: ui_plugin_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation service image
+        displayName: Validation Image
+        path: validation_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume populator controller image
+        displayName: Populator Controller Image
+        path: populator_controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: oVirt populator image
+        displayName: oVirt Populator Image
+        path: populator_ovirt_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OpenStack populator image
+        displayName: OpenStack Populator Image
+        path: populator_openstack_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: vSphere xcopy populator image
+        displayName: vSphere Populator Image
+        path: populator_vsphere_xcopy_volume_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA provider server image
+        displayName: OVA Provider Server Image
+        path: ova_provider_server_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Must-gather debugging image
+        displayName: Must-gather Image
+        path: must_gather_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA inventory proxy image
+        displayName: OVA Proxy Image
+        path: ova_proxy_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller CPU limit (default 500m)
+        displayName: Controller CPU Limit
+        path: controller_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory limit (default 800Mi)
+        displayName: Controller Memory Limit
+        path: controller_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller CPU request (default 100m)
+        displayName: Controller CPU Request
+        path: controller_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory request (default 350Mi)
+        displayName: Controller Memory Request
+        path: controller_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory CPU limit (default 1000m)
+        displayName: Inventory CPU Limit
+        path: inventory_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory limit (default 1Gi)
+        displayName: Inventory Memory Limit
+        path: inventory_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory CPU request (default 500m)
+        displayName: Inventory CPU Request
+        path: inventory_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory request (default 500Mi)
+        displayName: Inventory Memory Request
+        path: inventory_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory route timeout (default 360s)
+        displayName: Inventory Route Timeout
+        path: inventory_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service CPU limit (default 1000m)
+        displayName: API CPU Limit
+        path: api_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory limit (default 1Gi)
+        displayName: API Memory Limit
+        path: api_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service CPU request (default 100m)
+        displayName: API CPU Request
+        path: api_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory request (default 150Mi)
+        displayName: API Memory Request
+        path: api_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service CPU limit (default 100m)
+        displayName: CLI Download CPU Limit
+        path: cli_download_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory limit (default 128Mi)
+        displayName: CLI Download Memory Limit
+        path: cli_download_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service CPU request (default 50m)
+        displayName: CLI Download CPU Request
+        path: cli_download_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory request (default 64Mi)
+        displayName: CLI Download Memory Request
+        path: cli_download_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin CPU limit (default 100m)
+        displayName: UI Plugin CPU Limit
+        path: ui_plugin_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory limit (default 800Mi)
+        displayName: UI Plugin Memory Limit
+        path: ui_plugin_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin CPU request (default 100m)
+        displayName: UI Plugin CPU Request
+        path: ui_plugin_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory request (default 150Mi)
+        displayName: UI Plugin Memory Request
+        path: ui_plugin_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation CPU limit (default 1000m)
+        displayName: Validation CPU Limit
+        path: validation_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory limit (default 300Mi)
+        displayName: Validation Memory Limit
+        path: validation_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation CPU request (default 400m)
+        displayName: Validation CPU Request
+        path: validation_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory request (default 50Mi)
+        displayName: Validation Memory Request
+        path: validation_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Policy agent search interval in seconds (default 120)
+        displayName: Policy Agent Search Interval
+        path: validation_policy_agent_search_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume name for extra validation rules (default validation-extra-rules)
+        displayName: Validation Extra Volume Name
+        path: validation_extra_volume_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Mount path for extra validation rules (default /usr/share/opa/policies/extra)
+        displayName: Validation Extra Volume Mount Path
+        path: validation_extra_volume_mountpath
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for oVirt OS mappings (default forklift-ovirt-osmap)
+        displayName: oVirt OS Map ConfigMap Name
+        path: ovirt_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for vSphere OS mappings (default forklift-vsphere-osmap)
+        displayName: vSphere OS Map ConfigMap Name
+        path: vsphere_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for virt-customize configuration (default forklift-virt-customize)
+        displayName: Virt-Customize ConfigMap Name
+        path: virt_customize_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent VM migrations (default 20)
+        displayName: Max VM Inflight
+        path: controller_max_vm_inflight
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Precopy interval in minutes (default 60)
+        displayName: Precopy Interval
+        path: controller_precopy_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent reconciles (default 10)
+        displayName: Max Concurrent Reconciles
+        path: controller_max_concurrent_reconciles
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal timeout in minutes (default 120)
+        displayName: Snapshot Removal Timeout
+        path: controller_snapshot_removal_timeout_minuts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot status check rate in seconds (default 10)
+        displayName: Snapshot Status Check Rate
+        path: controller_snapshot_status_check_rate_seconds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Cleanup retry count (default 10)
+        displayName: Cleanup Retries
+        path: controller_cleanup_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: DataVolume status check retries (default 10)
+        displayName: DV Status Check Retries
+        path: controller_dv_status_check_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal retries (default 20)
+        displayName: Snapshot Removal Check Retries
+        path: controller_snapshot_removal_check_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK job timeout in seconds (default 300)
+        displayName: VDDK Job Active Deadline
+        path: controller_vddk_job_active_deadline_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: TLS connection timeout seconds (default 5)
+        displayName: TLS Connection Timeout
+        path: controller_tls_connection_timeout_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Use vSphere incremental backup (default true)
+        displayName: vSphere Incremental Backup
+        path: controller_vsphere_incremental_backup
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable oVirt warm migration (default true)
+        displayName: oVirt Warm Migration
+        path: controller_ovirt_warm_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain precopy pods (default false)
+        displayName: Retain Precopy Importer Pods
+        path: controller_retain_precopy_importer_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable static udn IP addresses feature (default false)
+        displayName: Static UDN IP Addresses
+        path: controller_static_udn_ip_addresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Filesystem overhead percentage (default 10)
+        displayName: Filesystem Overhead
+        path: controller_filesystem_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Block overhead in bytes (default 0)
+        displayName: Block Overhead
+        path: controller_block_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v CPU limit (default 4000m)
+        displayName: Virt-v2v CPU Limit
+        path: virt_v2v_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory limit (default 8Gi)
+        displayName: Virt-v2v Memory Limit
+        path: virt_v2v_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v CPU request (default 1000m)
+        displayName: Virt-v2v CPU Request
+        path: virt_v2v_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory request (default 1Gi)
+        displayName: Virt-v2v Memory Request
+        path: virt_v2v_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Don't request KVM for virt-v2v
+        displayName: Virt-v2v Don't Request KVM
+        path: virt_v2v_dont_request_kvm
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v
+        displayName: Virt-v2v Extra Args
+        path: virt_v2v_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name containing extra virt-v2v configuration
+        displayName: Virt-v2v Extra Config ConfigMap
+        path: virt_v2v_extra_conf_config_map
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks CPU limit (default 1000m)
+        displayName: Hooks CPU Limit
+        path: hooks_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory limit (default 1Gi)
+        displayName: Hooks Memory Limit
+        path: hooks_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks CPU request (default 100m)
+        displayName: Hooks CPU Request
+        path: hooks_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory request (default 150Mi)
+        displayName: Hooks Memory Request
+        path: hooks_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA CPU limit (default 1000m)
+        displayName: OVA CPU Limit
+        path: ova_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory limit (default 1Gi)
+        displayName: OVA Memory Limit
+        path: ova_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA CPU request (default 100m)
+        displayName: OVA CPU Request
+        path: ova_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory request (default 150Mi)
+        displayName: OVA Memory Request
+        path: ova_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy CPU limit (default 1000m)
+        displayName: OVA Proxy CPU Limit
+        path: ova_proxy_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory limit (default 1Gi)
+        displayName: OVA Proxy Memory Limit
+        path: ova_proxy_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy CPU request (default 250m)
+        displayName: OVA Proxy CPU Request
+        path: ova_proxy_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory request (default 512Mi)
+        displayName: OVA Proxy Memory Request
+        path: ova_proxy_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy route timeout (default 360s)
+        displayName: OVA Proxy Route Timeout
+        path: ova_proxy_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Log verbosity level (default 3)
+        displayName: Controller Log Level
+        path: controller_log_level
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Image pull policy (default Always)
+        displayName: Image Pull Policy
+        path: image_pull_policy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Whether running on Kubernetes (vs OpenShift) (default false)
+        displayName: K8s Cluster
+        path: k8s_cluster
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Metrics scrape interval (default 30s)
+        displayName: Metric Interval
+        path: metric_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       version: v1beta1
     - description: VM migration
       displayName: Migration

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -82,12 +82,10 @@ spec:
                 type: string
               controller_block_overhead:
                 description: 'Block overhead in bytes (default: 0)'
-                pattern: ^[0-9]+$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_cleanup_retries:
                 description: 'Cleanup retry count (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_container_limits_cpu:
                 description: 'Controller CPU limit (default: 500m)'
                 example: 1000m
@@ -106,28 +104,23 @@ spec:
                 type: string
               controller_dv_status_check_retries:
                 description: 'DataVolume status check retries (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_filesystem_overhead:
                 description: 'Filesystem overhead percentage (default: 10)'
-                pattern: ^(0|[1-9][0-9]?|100)$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_image_fqin:
                 description: Controller pod image
                 example: quay.io/kubev2v/forklift-controller:latest
                 type: string
               controller_log_level:
                 description: 'Log verbosity level (default: 3)'
-                pattern: ^([0-9]|10)$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_max_concurrent_reconciles:
                 description: 'Max concurrent reconciles (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_max_vm_inflight:
                 description: 'Max concurrent VM migrations (default: 20)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_ovirt_warm_migration:
                 description: 'Enable oVirt warm migration (default: true)'
                 enum:
@@ -136,8 +129,7 @@ spec:
                 type: string
               controller_precopy_interval:
                 description: 'Precopy interval in minutes (default: 60)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_retain_precopy_importer_pods:
                 description: 'Retain precopy pods (default: false)'
                 enum:
@@ -146,16 +138,13 @@ spec:
                 type: string
               controller_snapshot_removal_check_retries:
                 description: 'Snapshot removal retries (default: 20)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_snapshot_removal_timeout_minuts:
                 description: 'Snapshot removal timeout in minutes (default: 120)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_snapshot_status_check_rate_seconds:
                 description: 'Snapshot status check rate in seconds (default: 10)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_static_udn_ip_addresses:
                 description: 'Enable static udn IP addresses feature (default: false)'
                 enum:
@@ -164,12 +153,10 @@ spec:
                 type: string
               controller_tls_connection_timeout_sec:
                 description: 'TLS connection timeout seconds (default: 5)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_vddk_job_active_deadline_sec:
                 description: 'VDDK job timeout in seconds (default: 300)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               controller_vsphere_incremental_backup:
                 description: 'Use vSphere incremental backup (default: true)'
                 enum:
@@ -270,12 +257,20 @@ spec:
                 description: 'Inventory memory request (default: 500Mi)'
                 example: 1Gi
                 type: string
+              inventory_route_timeout:
+                description: 'Inventory route timeout (default: 360s)'
+                example: 600s
+                type: string
               k8s_cluster:
                 description: 'Whether running on Kubernetes (vs OpenShift) (default:
                   false)'
                 enum:
                 - "true"
                 - "false"
+                type: string
+              metric_interval:
+                description: 'Metrics scrape interval (default: 30s)'
+                example: 60s
                 type: string
               must_gather_image_fqin:
                 description: Must-gather debugging image
@@ -320,6 +315,14 @@ spec:
               ova_proxy_fqin:
                 description: OVA inventory proxy image
                 example: quay.io/kubev2v/forklift-ova-proxy:latest
+                type: string
+              ova_proxy_route_timeout:
+                description: 'OVA Proxy route timeout (default: 360s)'
+                example: 600s
+                type: string
+              ovirt_osmap_configmap_name:
+                description: 'ConfigMap name for oVirt OS mappings (default: forklift-ovirt-osmap)'
+                example: custom-ovirt-osmap
                 type: string
               populator_controller_image_fqin:
                 description: Volume populator controller image
@@ -373,17 +376,29 @@ spec:
                 description: 'Validation memory request (default: 50Mi)'
                 example: 100Mi
                 type: string
+              validation_extra_volume_mountpath:
+                description: 'Mount path for extra validation rules (default: /usr/share/opa/policies/extra)'
+                example: /custom/validation/path
+                type: string
+              validation_extra_volume_name:
+                description: 'Volume name for extra validation rules (default: validation-extra-rules)'
+                example: custom-validation-rules
+                type: string
               validation_image_fqin:
                 description: Validation service image
                 example: quay.io/kubev2v/forklift-validation:latest
                 type: string
               validation_policy_agent_search_interval:
                 description: 'Policy agent search interval in seconds (default: 120)'
-                pattern: ^[1-9][0-9]*$
-                type: string
+                x-kubernetes-int-or-string: true
               vddk_image:
                 description: VDDK image for VMware disk access
                 example: quay.io/kubev2v/vddk:7.0.3
+                type: string
+              virt_customize_configmap_name:
+                description: 'ConfigMap name for virt-customize configuration (default:
+                  forklift-virt-customize)'
+                example: custom-virt-customize
                 type: string
               virt_v2v_container_limits_cpu:
                 description: 'virt-v2v CPU limit (default: 4000m)'
@@ -417,6 +432,10 @@ spec:
               virt_v2v_image_fqin:
                 description: Virt-v2v conversion image used by migration pods
                 example: quay.io/kubev2v/forklift-virt-v2v:latest
+                type: string
+              vsphere_osmap_configmap_name:
+                description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
+                example: custom-vsphere-osmap
                 type: string
             type: object
           status:
@@ -6974,6 +6993,486 @@ spec:
       displayName: ForkliftController
       kind: ForkliftController
       name: forkliftcontrollers.forklift.konveyor.io
+      specDescriptors:
+      - description: Enable UI plugin (default true)
+        displayName: Enable UI Plugin
+        path: feature_ui_plugin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable validation service (default true)
+        displayName: Enable Validation Service
+        path: feature_validation
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable volume populators (default true)
+        displayName: Enable Volume Populators
+        path: feature_volume_populator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable copy offload plugins (default false)
+        displayName: Enable Copy Offload Plugins
+        path: feature_copy_offload
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OCP live migration (default false)
+        displayName: Enable OCP Live Migration
+        path: feature_ocp_live_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Use VMware system serial numbers (default true)
+        displayName: Use VMware System Serial Numbers
+        path: feature_vmware_system_serial_number
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Require authentication (default true)
+        displayName: Require Authentication
+        path: feature_auth_required
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable CLI download service (default true)
+        displayName: Enable CLI Download Service
+        path: feature_cli_download
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OVA appliance management endpoints (default false)
+        displayName: Enable OVA Appliance Management
+        path: feature_ova_appliance_management
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Controller pod image
+        displayName: Controller Image
+        path: controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Virt-v2v conversion image used by migration pods
+        displayName: Virt-v2v Image
+        path: virt_v2v_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK image for VMware disk access
+        displayName: VDDK Image
+        path: vddk_image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service image
+        displayName: API Image
+        path: api_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service image
+        displayName: CLI Download Image
+        path: cli_download_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin image
+        displayName: UI Plugin Image
+        path: ui_plugin_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation service image
+        displayName: Validation Image
+        path: validation_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume populator controller image
+        displayName: Populator Controller Image
+        path: populator_controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: oVirt populator image
+        displayName: oVirt Populator Image
+        path: populator_ovirt_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OpenStack populator image
+        displayName: OpenStack Populator Image
+        path: populator_openstack_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: vSphere xcopy populator image
+        displayName: vSphere Populator Image
+        path: populator_vsphere_xcopy_volume_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA provider server image
+        displayName: OVA Provider Server Image
+        path: ova_provider_server_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Must-gather debugging image
+        displayName: Must-gather Image
+        path: must_gather_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA inventory proxy image
+        displayName: OVA Proxy Image
+        path: ova_proxy_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller CPU limit (default 500m)
+        displayName: Controller CPU Limit
+        path: controller_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory limit (default 800Mi)
+        displayName: Controller Memory Limit
+        path: controller_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller CPU request (default 100m)
+        displayName: Controller CPU Request
+        path: controller_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory request (default 350Mi)
+        displayName: Controller Memory Request
+        path: controller_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory CPU limit (default 1000m)
+        displayName: Inventory CPU Limit
+        path: inventory_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory limit (default 1Gi)
+        displayName: Inventory Memory Limit
+        path: inventory_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory CPU request (default 500m)
+        displayName: Inventory CPU Request
+        path: inventory_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory request (default 500Mi)
+        displayName: Inventory Memory Request
+        path: inventory_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory route timeout (default 360s)
+        displayName: Inventory Route Timeout
+        path: inventory_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service CPU limit (default 1000m)
+        displayName: API CPU Limit
+        path: api_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory limit (default 1Gi)
+        displayName: API Memory Limit
+        path: api_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service CPU request (default 100m)
+        displayName: API CPU Request
+        path: api_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory request (default 150Mi)
+        displayName: API Memory Request
+        path: api_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service CPU limit (default 100m)
+        displayName: CLI Download CPU Limit
+        path: cli_download_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory limit (default 128Mi)
+        displayName: CLI Download Memory Limit
+        path: cli_download_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service CPU request (default 50m)
+        displayName: CLI Download CPU Request
+        path: cli_download_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory request (default 64Mi)
+        displayName: CLI Download Memory Request
+        path: cli_download_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin CPU limit (default 100m)
+        displayName: UI Plugin CPU Limit
+        path: ui_plugin_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory limit (default 800Mi)
+        displayName: UI Plugin Memory Limit
+        path: ui_plugin_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin CPU request (default 100m)
+        displayName: UI Plugin CPU Request
+        path: ui_plugin_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory request (default 150Mi)
+        displayName: UI Plugin Memory Request
+        path: ui_plugin_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation CPU limit (default 1000m)
+        displayName: Validation CPU Limit
+        path: validation_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory limit (default 300Mi)
+        displayName: Validation Memory Limit
+        path: validation_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation CPU request (default 400m)
+        displayName: Validation CPU Request
+        path: validation_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory request (default 50Mi)
+        displayName: Validation Memory Request
+        path: validation_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Policy agent search interval in seconds (default 120)
+        displayName: Policy Agent Search Interval
+        path: validation_policy_agent_search_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume name for extra validation rules (default validation-extra-rules)
+        displayName: Validation Extra Volume Name
+        path: validation_extra_volume_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Mount path for extra validation rules (default /usr/share/opa/policies/extra)
+        displayName: Validation Extra Volume Mount Path
+        path: validation_extra_volume_mountpath
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for oVirt OS mappings (default forklift-ovirt-osmap)
+        displayName: oVirt OS Map ConfigMap Name
+        path: ovirt_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for vSphere OS mappings (default forklift-vsphere-osmap)
+        displayName: vSphere OS Map ConfigMap Name
+        path: vsphere_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for virt-customize configuration (default forklift-virt-customize)
+        displayName: Virt-Customize ConfigMap Name
+        path: virt_customize_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent VM migrations (default 20)
+        displayName: Max VM Inflight
+        path: controller_max_vm_inflight
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Precopy interval in minutes (default 60)
+        displayName: Precopy Interval
+        path: controller_precopy_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent reconciles (default 10)
+        displayName: Max Concurrent Reconciles
+        path: controller_max_concurrent_reconciles
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal timeout in minutes (default 120)
+        displayName: Snapshot Removal Timeout
+        path: controller_snapshot_removal_timeout_minuts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot status check rate in seconds (default 10)
+        displayName: Snapshot Status Check Rate
+        path: controller_snapshot_status_check_rate_seconds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Cleanup retry count (default 10)
+        displayName: Cleanup Retries
+        path: controller_cleanup_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: DataVolume status check retries (default 10)
+        displayName: DV Status Check Retries
+        path: controller_dv_status_check_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal retries (default 20)
+        displayName: Snapshot Removal Check Retries
+        path: controller_snapshot_removal_check_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK job timeout in seconds (default 300)
+        displayName: VDDK Job Active Deadline
+        path: controller_vddk_job_active_deadline_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: TLS connection timeout seconds (default 5)
+        displayName: TLS Connection Timeout
+        path: controller_tls_connection_timeout_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Use vSphere incremental backup (default true)
+        displayName: vSphere Incremental Backup
+        path: controller_vsphere_incremental_backup
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable oVirt warm migration (default true)
+        displayName: oVirt Warm Migration
+        path: controller_ovirt_warm_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain precopy pods (default false)
+        displayName: Retain Precopy Importer Pods
+        path: controller_retain_precopy_importer_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable static udn IP addresses feature (default false)
+        displayName: Static UDN IP Addresses
+        path: controller_static_udn_ip_addresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Filesystem overhead percentage (default 10)
+        displayName: Filesystem Overhead
+        path: controller_filesystem_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Block overhead in bytes (default 0)
+        displayName: Block Overhead
+        path: controller_block_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v CPU limit (default 4000m)
+        displayName: Virt-v2v CPU Limit
+        path: virt_v2v_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory limit (default 8Gi)
+        displayName: Virt-v2v Memory Limit
+        path: virt_v2v_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v CPU request (default 1000m)
+        displayName: Virt-v2v CPU Request
+        path: virt_v2v_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory request (default 1Gi)
+        displayName: Virt-v2v Memory Request
+        path: virt_v2v_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Don't request KVM for virt-v2v
+        displayName: Virt-v2v Don't Request KVM
+        path: virt_v2v_dont_request_kvm
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v
+        displayName: Virt-v2v Extra Args
+        path: virt_v2v_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name containing extra virt-v2v configuration
+        displayName: Virt-v2v Extra Config ConfigMap
+        path: virt_v2v_extra_conf_config_map
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks CPU limit (default 1000m)
+        displayName: Hooks CPU Limit
+        path: hooks_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory limit (default 1Gi)
+        displayName: Hooks Memory Limit
+        path: hooks_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks CPU request (default 100m)
+        displayName: Hooks CPU Request
+        path: hooks_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory request (default 150Mi)
+        displayName: Hooks Memory Request
+        path: hooks_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA CPU limit (default 1000m)
+        displayName: OVA CPU Limit
+        path: ova_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory limit (default 1Gi)
+        displayName: OVA Memory Limit
+        path: ova_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA CPU request (default 100m)
+        displayName: OVA CPU Request
+        path: ova_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory request (default 150Mi)
+        displayName: OVA Memory Request
+        path: ova_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy CPU limit (default 1000m)
+        displayName: OVA Proxy CPU Limit
+        path: ova_proxy_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory limit (default 1Gi)
+        displayName: OVA Proxy Memory Limit
+        path: ova_proxy_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy CPU request (default 250m)
+        displayName: OVA Proxy CPU Request
+        path: ova_proxy_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory request (default 512Mi)
+        displayName: OVA Proxy Memory Request
+        path: ova_proxy_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy route timeout (default 360s)
+        displayName: OVA Proxy Route Timeout
+        path: ova_proxy_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Log verbosity level (default 3)
+        displayName: Controller Log Level
+        path: controller_log_level
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Image pull policy (default Always)
+        displayName: Image Pull Policy
+        path: image_pull_policy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Whether running on Kubernetes (vs OpenShift) (default false)
+        displayName: K8s Cluster
+        path: k8s_cluster
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Metrics scrape interval (default 30s)
+        displayName: Metric Interval
+        path: metric_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       version: v1beta1
     - description: Hook schema for the hooks API
       displayName: Hook

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -173,6 +173,10 @@ spec:
                 type: string
                 description: "Inventory memory request (default: 500Mi)"
                 example: "1Gi"
+              inventory_route_timeout:
+                type: string
+                description: "Inventory route timeout (default: 360s)"
+                example: "600s"
 
               # API Resource Configuration
               api_container_limits_cpu:
@@ -246,51 +250,62 @@ spec:
                 description: "Validation memory request (default: 50Mi)"
                 example: "100Mi"
               validation_policy_agent_search_interval:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Policy agent search interval in seconds (default: 120)"
-                pattern: "^[1-9][0-9]*$"
+              validation_extra_volume_name:
+                type: string
+                description: "Volume name for extra validation rules (default: validation-extra-rules)"
+                example: "custom-validation-rules"
+              validation_extra_volume_mountpath:
+                type: string
+                description: "Mount path for extra validation rules (default: /usr/share/opa/policies/extra)"
+                example: "/custom/validation/path"
+
+              # ConfigMap Names
+              ovirt_osmap_configmap_name:
+                type: string
+                description: "ConfigMap name for oVirt OS mappings (default: forklift-ovirt-osmap)"
+                example: "custom-ovirt-osmap"
+              vsphere_osmap_configmap_name:
+                type: string
+                description: "ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)"
+                example: "custom-vsphere-osmap"
+              virt_customize_configmap_name:
+                type: string
+                description: "ConfigMap name for virt-customize configuration (default: forklift-virt-customize)"
+                example: "custom-virt-customize"
 
               # Migration Settings & Timeouts
               controller_max_vm_inflight:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Max concurrent VM migrations (default: 20)"
-                pattern: "^[1-9][0-9]*$"
               controller_precopy_interval:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Precopy interval in minutes (default: 60)"
-                pattern: "^[1-9][0-9]*$"
               controller_max_concurrent_reconciles:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Max concurrent reconciles (default: 10)"
-                pattern: "^[1-9][0-9]*$"
               controller_snapshot_removal_timeout_minuts:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Snapshot removal timeout in minutes (default: 120)"
-                pattern: "^[1-9][0-9]*$"
               controller_snapshot_status_check_rate_seconds:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Snapshot status check rate in seconds (default: 10)"
-                pattern: "^[1-9][0-9]*$"
               controller_cleanup_retries:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Cleanup retry count (default: 10)"
-                pattern: "^[1-9][0-9]*$"
               controller_dv_status_check_retries:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "DataVolume status check retries (default: 10)"
-                pattern: "^[1-9][0-9]*$"
               controller_snapshot_removal_check_retries:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Snapshot removal retries (default: 20)"
-                pattern: "^[1-9][0-9]*$"
               controller_vddk_job_active_deadline_sec:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "VDDK job timeout in seconds (default: 300)"
-                pattern: "^[1-9][0-9]*$"
               controller_tls_connection_timeout_sec:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "TLS connection timeout seconds (default: 5)"
-                pattern: "^[1-9][0-9]*$"
 
               # Migration Feature-Specific Settings
               controller_vsphere_incremental_backup:
@@ -312,13 +327,11 @@ spec:
 
               # Storage & Performance Settings
               controller_filesystem_overhead:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Filesystem overhead percentage (default: 10)"
-                pattern: "^(0|[1-9][0-9]?|100)$"
               controller_block_overhead:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Block overhead in bytes (default: 0)"
-                pattern: "^[0-9]+$"
 
               # Virt-v2v Settings
               virt_v2v_container_limits_cpu:
@@ -402,12 +415,15 @@ spec:
                 type: string
                 description: "OVA Proxy memory request (default: 512Mi)"
                 example: "300Mi"
+              ova_proxy_route_timeout:
+                type: string
+                description: "OVA Proxy route timeout (default: 360s)"
+                example: "600s"
 
               # Logging & General Settings
               controller_log_level:
-                type: string
+                x-kubernetes-int-or-string: true
                 description: "Log verbosity level (default: 3)"
-                pattern: "^([0-9]|10)$"
               image_pull_policy:
                 type: string
                 enum: ["Always", "IfNotPresent", "Never"]
@@ -416,6 +432,12 @@ spec:
                 type: string
                 enum: ["true", "false"]
                 description: "Whether running on Kubernetes (vs OpenShift) (default: false)"
+              
+              # Metrics Settings
+              metric_interval:
+                type: string
+                description: "Metrics scrape interval (default: 30s)"
+                example: "60s"
               
             additionalProperties: true
           status:

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -49,6 +49,504 @@ spec:
       kind: ForkliftController
       name: forkliftcontrollers.forklift.konveyor.io
       version: v1beta1
+      specDescriptors:
+      # Feature Gates
+      - description: Enable UI plugin (default true)
+        displayName: Enable UI Plugin
+        path: feature_ui_plugin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable validation service (default true)
+        displayName: Enable Validation Service
+        path: feature_validation
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable volume populators (default true)
+        displayName: Enable Volume Populators
+        path: feature_volume_populator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable copy offload plugins (default false)
+        displayName: Enable Copy Offload Plugins
+        path: feature_copy_offload
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OCP live migration (default false)
+        displayName: Enable OCP Live Migration
+        path: feature_ocp_live_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Use VMware system serial numbers (default true)
+        displayName: Use VMware System Serial Numbers
+        path: feature_vmware_system_serial_number
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Require authentication (default true)
+        displayName: Require Authentication
+        path: feature_auth_required
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable CLI download service (default true)
+        displayName: Enable CLI Download Service
+        path: feature_cli_download
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OVA appliance management endpoints (default false)
+        displayName: Enable OVA Appliance Management
+        path: feature_ova_appliance_management
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      # Container Images
+      - description: Controller pod image
+        displayName: Controller Image
+        path: controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Virt-v2v conversion image used by migration pods
+        displayName: Virt-v2v Image
+        path: virt_v2v_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK image for VMware disk access
+        displayName: VDDK Image
+        path: vddk_image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service image
+        displayName: API Image
+        path: api_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service image
+        displayName: CLI Download Image
+        path: cli_download_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin image
+        displayName: UI Plugin Image
+        path: ui_plugin_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation service image
+        displayName: Validation Image
+        path: validation_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume populator controller image
+        displayName: Populator Controller Image
+        path: populator_controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: oVirt populator image
+        displayName: oVirt Populator Image
+        path: populator_ovirt_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OpenStack populator image
+        displayName: OpenStack Populator Image
+        path: populator_openstack_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: vSphere xcopy populator image
+        displayName: vSphere Populator Image
+        path: populator_vsphere_xcopy_volume_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA provider server image
+        displayName: OVA Provider Server Image
+        path: ova_provider_server_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Must-gather debugging image
+        displayName: Must-gather Image
+        path: must_gather_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA inventory proxy image
+        displayName: OVA Proxy Image
+        path: ova_proxy_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Controller Resource Configuration
+      - description: Controller CPU limit (default 500m)
+        displayName: Controller CPU Limit
+        path: controller_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory limit (default 800Mi)
+        displayName: Controller Memory Limit
+        path: controller_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller CPU request (default 100m)
+        displayName: Controller CPU Request
+        path: controller_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory request (default 350Mi)
+        displayName: Controller Memory Request
+        path: controller_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Inventory Resource Configuration
+      - description: Inventory CPU limit (default 1000m)
+        displayName: Inventory CPU Limit
+        path: inventory_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory limit (default 1Gi)
+        displayName: Inventory Memory Limit
+        path: inventory_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory CPU request (default 500m)
+        displayName: Inventory CPU Request
+        path: inventory_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory request (default 500Mi)
+        displayName: Inventory Memory Request
+        path: inventory_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory route timeout (default 360s)
+        displayName: Inventory Route Timeout
+        path: inventory_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # API Resource Configuration
+      - description: API service CPU limit (default 1000m)
+        displayName: API CPU Limit
+        path: api_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory limit (default 1Gi)
+        displayName: API Memory Limit
+        path: api_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service CPU request (default 100m)
+        displayName: API CPU Request
+        path: api_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory request (default 150Mi)
+        displayName: API Memory Request
+        path: api_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # CLI Download Resource Configuration
+      - description: CLI download service CPU limit (default 100m)
+        displayName: CLI Download CPU Limit
+        path: cli_download_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory limit (default 128Mi)
+        displayName: CLI Download Memory Limit
+        path: cli_download_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service CPU request (default 50m)
+        displayName: CLI Download CPU Request
+        path: cli_download_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory request (default 64Mi)
+        displayName: CLI Download Memory Request
+        path: cli_download_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # UI Plugin Resource Configuration
+      - description: UI plugin CPU limit (default 100m)
+        displayName: UI Plugin CPU Limit
+        path: ui_plugin_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory limit (default 800Mi)
+        displayName: UI Plugin Memory Limit
+        path: ui_plugin_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin CPU request (default 100m)
+        displayName: UI Plugin CPU Request
+        path: ui_plugin_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory request (default 150Mi)
+        displayName: UI Plugin Memory Request
+        path: ui_plugin_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Validation Resource Configuration
+      - description: Validation CPU limit (default 1000m)
+        displayName: Validation CPU Limit
+        path: validation_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory limit (default 300Mi)
+        displayName: Validation Memory Limit
+        path: validation_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation CPU request (default 400m)
+        displayName: Validation CPU Request
+        path: validation_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory request (default 50Mi)
+        displayName: Validation Memory Request
+        path: validation_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Policy agent search interval in seconds (default 120)
+        displayName: Policy Agent Search Interval
+        path: validation_policy_agent_search_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume name for extra validation rules (default validation-extra-rules)
+        displayName: Validation Extra Volume Name
+        path: validation_extra_volume_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Mount path for extra validation rules (default /usr/share/opa/policies/extra)
+        displayName: Validation Extra Volume Mount Path
+        path: validation_extra_volume_mountpath
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # ConfigMap Names
+      - description: ConfigMap name for oVirt OS mappings (default forklift-ovirt-osmap)
+        displayName: oVirt OS Map ConfigMap Name
+        path: ovirt_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for vSphere OS mappings (default forklift-vsphere-osmap)
+        displayName: vSphere OS Map ConfigMap Name
+        path: vsphere_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for virt-customize configuration (default forklift-virt-customize)
+        displayName: Virt-Customize ConfigMap Name
+        path: virt_customize_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Migration Settings & Timeouts
+      - description: Max concurrent VM migrations (default 20)
+        displayName: Max VM Inflight
+        path: controller_max_vm_inflight
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Precopy interval in minutes (default 60)
+        displayName: Precopy Interval
+        path: controller_precopy_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent reconciles (default 10)
+        displayName: Max Concurrent Reconciles
+        path: controller_max_concurrent_reconciles
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal timeout in minutes (default 120)
+        displayName: Snapshot Removal Timeout
+        path: controller_snapshot_removal_timeout_minuts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot status check rate in seconds (default 10)
+        displayName: Snapshot Status Check Rate
+        path: controller_snapshot_status_check_rate_seconds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Cleanup retry count (default 10)
+        displayName: Cleanup Retries
+        path: controller_cleanup_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: DataVolume status check retries (default 10)
+        displayName: DV Status Check Retries
+        path: controller_dv_status_check_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal retries (default 20)
+        displayName: Snapshot Removal Check Retries
+        path: controller_snapshot_removal_check_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK job timeout in seconds (default 300)
+        displayName: VDDK Job Active Deadline
+        path: controller_vddk_job_active_deadline_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: TLS connection timeout seconds (default 5)
+        displayName: TLS Connection Timeout
+        path: controller_tls_connection_timeout_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Migration Feature-Specific Settings
+      - description: Use vSphere incremental backup (default true)
+        displayName: vSphere Incremental Backup
+        path: controller_vsphere_incremental_backup
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable oVirt warm migration (default true)
+        displayName: oVirt Warm Migration
+        path: controller_ovirt_warm_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain precopy pods (default false)
+        displayName: Retain Precopy Importer Pods
+        path: controller_retain_precopy_importer_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable static udn IP addresses feature (default false)
+        displayName: Static UDN IP Addresses
+        path: controller_static_udn_ip_addresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Storage & Performance Settings
+      - description: Filesystem overhead percentage (default 10)
+        displayName: Filesystem Overhead
+        path: controller_filesystem_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Block overhead in bytes (default 0)
+        displayName: Block Overhead
+        path: controller_block_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Virt-v2v Settings
+      - description: virt-v2v CPU limit (default 4000m)
+        displayName: Virt-v2v CPU Limit
+        path: virt_v2v_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory limit (default 8Gi)
+        displayName: Virt-v2v Memory Limit
+        path: virt_v2v_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v CPU request (default 1000m)
+        displayName: Virt-v2v CPU Request
+        path: virt_v2v_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory request (default 1Gi)
+        displayName: Virt-v2v Memory Request
+        path: virt_v2v_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Don't request KVM for virt-v2v
+        displayName: Virt-v2v Don't Request KVM
+        path: virt_v2v_dont_request_kvm
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v
+        displayName: Virt-v2v Extra Args
+        path: virt_v2v_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name containing extra virt-v2v configuration
+        displayName: Virt-v2v Extra Config ConfigMap
+        path: virt_v2v_extra_conf_config_map
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Hooks Settings
+      - description: Hooks CPU limit (default 1000m)
+        displayName: Hooks CPU Limit
+        path: hooks_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory limit (default 1Gi)
+        displayName: Hooks Memory Limit
+        path: hooks_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks CPU request (default 100m)
+        displayName: Hooks CPU Request
+        path: hooks_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory request (default 150Mi)
+        displayName: Hooks Memory Request
+        path: hooks_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # OVA Settings
+      - description: OVA CPU limit (default 1000m)
+        displayName: OVA CPU Limit
+        path: ova_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory limit (default 1Gi)
+        displayName: OVA Memory Limit
+        path: ova_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA CPU request (default 100m)
+        displayName: OVA CPU Request
+        path: ova_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory request (default 150Mi)
+        displayName: OVA Memory Request
+        path: ova_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # OVA Proxy Settings
+      - description: OVA Proxy CPU limit (default 1000m)
+        displayName: OVA Proxy CPU Limit
+        path: ova_proxy_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory limit (default 1Gi)
+        displayName: OVA Proxy Memory Limit
+        path: ova_proxy_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy CPU request (default 250m)
+        displayName: OVA Proxy CPU Request
+        path: ova_proxy_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory request (default 512Mi)
+        displayName: OVA Proxy Memory Request
+        path: ova_proxy_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy route timeout (default 360s)
+        displayName: OVA Proxy Route Timeout
+        path: ova_proxy_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Logging & General Settings
+      - description: Log verbosity level (default 3)
+        displayName: Controller Log Level
+        path: controller_log_level
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Image pull policy (default Always)
+        displayName: Image Pull Policy
+        path: image_pull_policy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Whether running on Kubernetes (vs OpenShift) (default false)
+        displayName: K8s Cluster
+        path: k8s_cluster
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Metrics Settings
+      - description: Metrics scrape interval (default 30s)
+        displayName: Metric Interval
+        path: metric_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
     - description: VM migration
       displayName: Migration
       kind: Migration

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -115,6 +115,504 @@ spec:
         kind: ForkliftController
         name: forkliftcontrollers.forklift.konveyor.io
         version: v1beta1
+        specDescriptors:
+        # Feature Gates
+        - description: Enable UI plugin (default true)
+          displayName: Enable UI Plugin
+          path: feature_ui_plugin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable validation service (default true)
+          displayName: Enable Validation Service
+          path: feature_validation
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable volume populators (default true)
+          displayName: Enable Volume Populators
+          path: feature_volume_populator
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable copy offload plugins (default false)
+          displayName: Enable Copy Offload Plugins
+          path: feature_copy_offload
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable OCP live migration (default false)
+          displayName: Enable OCP Live Migration
+          path: feature_ocp_live_migration
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Use VMware system serial numbers (default true)
+          displayName: Use VMware System Serial Numbers
+          path: feature_vmware_system_serial_number
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Require authentication (default true)
+          displayName: Require Authentication
+          path: feature_auth_required
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable CLI download service (default true)
+          displayName: Enable CLI Download Service
+          path: feature_cli_download
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable OVA appliance management endpoints (default false)
+          displayName: Enable OVA Appliance Management
+          path: feature_ova_appliance_management
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        # Container Images
+        - description: Controller pod image
+          displayName: Controller Image
+          path: controller_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Virt-v2v conversion image used by migration pods
+          displayName: Virt-v2v Image
+          path: virt_v2v_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: VDDK image for VMware disk access
+          displayName: VDDK Image
+          path: vddk_image
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: API service image
+          displayName: API Image
+          path: api_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: CLI download service image
+          displayName: CLI Download Image
+          path: cli_download_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: UI plugin image
+          displayName: UI Plugin Image
+          path: ui_plugin_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Validation service image
+          displayName: Validation Image
+          path: validation_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume populator controller image
+          displayName: Populator Controller Image
+          path: populator_controller_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: oVirt populator image
+          displayName: oVirt Populator Image
+          path: populator_ovirt_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OpenStack populator image
+          displayName: OpenStack Populator Image
+          path: populator_openstack_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: vSphere xcopy populator image
+          displayName: vSphere Populator Image
+          path: populator_vsphere_xcopy_volume_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA provider server image
+          displayName: OVA Provider Server Image
+          path: ova_provider_server_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Must-gather debugging image
+          displayName: Must-gather Image
+          path: must_gather_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA inventory proxy image
+          displayName: OVA Proxy Image
+          path: ova_proxy_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Controller Resource Configuration
+        - description: Controller CPU limit (default 500m)
+          displayName: Controller CPU Limit
+          path: controller_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Controller memory limit (default 800Mi)
+          displayName: Controller Memory Limit
+          path: controller_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Controller CPU request (default 100m)
+          displayName: Controller CPU Request
+          path: controller_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Controller memory request (default 350Mi)
+          displayName: Controller Memory Request
+          path: controller_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Inventory Resource Configuration
+        - description: Inventory CPU limit (default 1000m)
+          displayName: Inventory CPU Limit
+          path: inventory_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Inventory memory limit (default 1Gi)
+          displayName: Inventory Memory Limit
+          path: inventory_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Inventory CPU request (default 500m)
+          displayName: Inventory CPU Request
+          path: inventory_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Inventory memory request (default 500Mi)
+          displayName: Inventory Memory Request
+          path: inventory_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Inventory route timeout (default 360s)
+          displayName: Inventory Route Timeout
+          path: inventory_route_timeout
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # API Resource Configuration
+        - description: API service CPU limit (default 1000m)
+          displayName: API CPU Limit
+          path: api_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: API service memory limit (default 1Gi)
+          displayName: API Memory Limit
+          path: api_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: API service CPU request (default 100m)
+          displayName: API CPU Request
+          path: api_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: API service memory request (default 150Mi)
+          displayName: API Memory Request
+          path: api_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # CLI Download Resource Configuration
+        - description: CLI download service CPU limit (default 100m)
+          displayName: CLI Download CPU Limit
+          path: cli_download_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: CLI download service memory limit (default 128Mi)
+          displayName: CLI Download Memory Limit
+          path: cli_download_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: CLI download service CPU request (default 50m)
+          displayName: CLI Download CPU Request
+          path: cli_download_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: CLI download service memory request (default 64Mi)
+          displayName: CLI Download Memory Request
+          path: cli_download_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # UI Plugin Resource Configuration
+        - description: UI plugin CPU limit (default 100m)
+          displayName: UI Plugin CPU Limit
+          path: ui_plugin_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: UI plugin memory limit (default 800Mi)
+          displayName: UI Plugin Memory Limit
+          path: ui_plugin_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: UI plugin CPU request (default 100m)
+          displayName: UI Plugin CPU Request
+          path: ui_plugin_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: UI plugin memory request (default 150Mi)
+          displayName: UI Plugin Memory Request
+          path: ui_plugin_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Validation Resource Configuration
+        - description: Validation CPU limit (default 1000m)
+          displayName: Validation CPU Limit
+          path: validation_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Validation memory limit (default 300Mi)
+          displayName: Validation Memory Limit
+          path: validation_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Validation CPU request (default 400m)
+          displayName: Validation CPU Request
+          path: validation_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Validation memory request (default 50Mi)
+          displayName: Validation Memory Request
+          path: validation_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Policy agent search interval in seconds (default 120)
+          displayName: Policy Agent Search Interval
+          path: validation_policy_agent_search_interval
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume name for extra validation rules (default validation-extra-rules)
+          displayName: Validation Extra Volume Name
+          path: validation_extra_volume_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Mount path for extra validation rules (default /usr/share/opa/policies/extra)
+          displayName: Validation Extra Volume Mount Path
+          path: validation_extra_volume_mountpath
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # ConfigMap Names
+        - description: ConfigMap name for oVirt OS mappings (default forklift-ovirt-osmap)
+          displayName: oVirt OS Map ConfigMap Name
+          path: ovirt_osmap_configmap_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: ConfigMap name for vSphere OS mappings (default forklift-vsphere-osmap)
+          displayName: vSphere OS Map ConfigMap Name
+          path: vsphere_osmap_configmap_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: ConfigMap name for virt-customize configuration (default forklift-virt-customize)
+          displayName: Virt-Customize ConfigMap Name
+          path: virt_customize_configmap_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Migration Settings & Timeouts
+        - description: Max concurrent VM migrations (default 20)
+          displayName: Max VM Inflight
+          path: controller_max_vm_inflight
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Precopy interval in minutes (default 60)
+          displayName: Precopy Interval
+          path: controller_precopy_interval
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Max concurrent reconciles (default 10)
+          displayName: Max Concurrent Reconciles
+          path: controller_max_concurrent_reconciles
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Snapshot removal timeout in minutes (default 120)
+          displayName: Snapshot Removal Timeout
+          path: controller_snapshot_removal_timeout_minuts
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Snapshot status check rate in seconds (default 10)
+          displayName: Snapshot Status Check Rate
+          path: controller_snapshot_status_check_rate_seconds
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Cleanup retry count (default 10)
+          displayName: Cleanup Retries
+          path: controller_cleanup_retries
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: DataVolume status check retries (default 10)
+          displayName: DV Status Check Retries
+          path: controller_dv_status_check_retries
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Snapshot removal retries (default 20)
+          displayName: Snapshot Removal Check Retries
+          path: controller_snapshot_removal_check_retries
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: VDDK job timeout in seconds (default 300)
+          displayName: VDDK Job Active Deadline
+          path: controller_vddk_job_active_deadline_sec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: TLS connection timeout seconds (default 5)
+          displayName: TLS Connection Timeout
+          path: controller_tls_connection_timeout_sec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Migration Feature-Specific Settings
+        - description: Use vSphere incremental backup (default true)
+          displayName: vSphere Incremental Backup
+          path: controller_vsphere_incremental_backup
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Enable oVirt warm migration (default true)
+          displayName: oVirt Warm Migration
+          path: controller_ovirt_warm_migration
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Retain precopy pods (default false)
+          displayName: Retain Precopy Importer Pods
+          path: controller_retain_precopy_importer_pods
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Enable static udn IP addresses feature (default false)
+          displayName: Static UDN IP Addresses
+          path: controller_static_udn_ip_addresses
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Storage & Performance Settings
+        - description: Filesystem overhead percentage (default 10)
+          displayName: Filesystem Overhead
+          path: controller_filesystem_overhead
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Block overhead in bytes (default 0)
+          displayName: Block Overhead
+          path: controller_block_overhead
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Virt-v2v Settings
+        - description: virt-v2v CPU limit (default 4000m)
+          displayName: Virt-v2v CPU Limit
+          path: virt_v2v_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: virt-v2v memory limit (default 8Gi)
+          displayName: Virt-v2v Memory Limit
+          path: virt_v2v_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: virt-v2v CPU request (default 1000m)
+          displayName: Virt-v2v CPU Request
+          path: virt_v2v_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: virt-v2v memory request (default 1Gi)
+          displayName: Virt-v2v Memory Request
+          path: virt_v2v_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Don't request KVM for virt-v2v
+          displayName: Virt-v2v Don't Request KVM
+          path: virt_v2v_dont_request_kvm
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Additional arguments for virt-v2v
+          displayName: Virt-v2v Extra Args
+          path: virt_v2v_extra_args
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: ConfigMap name containing extra virt-v2v configuration
+          displayName: Virt-v2v Extra Config ConfigMap
+          path: virt_v2v_extra_conf_config_map
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Hooks Settings
+        - description: Hooks CPU limit (default 1000m)
+          displayName: Hooks CPU Limit
+          path: hooks_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Hooks memory limit (default 1Gi)
+          displayName: Hooks Memory Limit
+          path: hooks_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Hooks CPU request (default 100m)
+          displayName: Hooks CPU Request
+          path: hooks_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Hooks memory request (default 150Mi)
+          displayName: Hooks Memory Request
+          path: hooks_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # OVA Settings
+        - description: OVA CPU limit (default 1000m)
+          displayName: OVA CPU Limit
+          path: ova_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA memory limit (default 1Gi)
+          displayName: OVA Memory Limit
+          path: ova_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA CPU request (default 100m)
+          displayName: OVA CPU Request
+          path: ova_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA memory request (default 150Mi)
+          displayName: OVA Memory Request
+          path: ova_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # OVA Proxy Settings
+        - description: OVA Proxy CPU limit (default 1000m)
+          displayName: OVA Proxy CPU Limit
+          path: ova_proxy_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA Proxy memory limit (default 1Gi)
+          displayName: OVA Proxy Memory Limit
+          path: ova_proxy_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA Proxy CPU request (default 250m)
+          displayName: OVA Proxy CPU Request
+          path: ova_proxy_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA Proxy memory request (default 512Mi)
+          displayName: OVA Proxy Memory Request
+          path: ova_proxy_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA Proxy route timeout (default 360s)
+          displayName: OVA Proxy Route Timeout
+          path: ova_proxy_route_timeout
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Logging & General Settings
+        - description: Log verbosity level (default 3)
+          displayName: Controller Log Level
+          path: controller_log_level
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Image pull policy (default Always)
+          displayName: Image Pull Policy
+          path: image_pull_policy
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Whether running on Kubernetes (vs OpenShift) (default false)
+          displayName: K8s Cluster
+          path: k8s_cluster
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Metrics Settings
+        - description: Metrics scrape interval (default 30s)
+          displayName: Metric Interval
+          path: metric_interval
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Hook schema for the hooks API
         displayName: Hook
         kind: Hook

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -119,6 +119,504 @@ spec:
         kind: ForkliftController
         name: forkliftcontrollers.forklift.konveyor.io
         version: v1beta1
+        specDescriptors:
+        # Feature Gates
+        - description: Enable UI plugin (default true)
+          displayName: Enable UI Plugin
+          path: feature_ui_plugin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable validation service (default true)
+          displayName: Enable Validation Service
+          path: feature_validation
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable volume populators (default true)
+          displayName: Enable Volume Populators
+          path: feature_volume_populator
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable copy offload plugins (default false)
+          displayName: Enable Copy Offload Plugins
+          path: feature_copy_offload
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable OCP live migration (default false)
+          displayName: Enable OCP Live Migration
+          path: feature_ocp_live_migration
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Use VMware system serial numbers (default true)
+          displayName: Use VMware System Serial Numbers
+          path: feature_vmware_system_serial_number
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Require authentication (default true)
+          displayName: Require Authentication
+          path: feature_auth_required
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable CLI download service (default true)
+          displayName: Enable CLI Download Service
+          path: feature_cli_download
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Enable OVA appliance management endpoints (default false)
+          displayName: Enable OVA Appliance Management
+          path: feature_ova_appliance_management
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
+        # Container Images
+        - description: Controller pod image
+          displayName: Controller Image
+          path: controller_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Virt-v2v conversion image used by migration pods
+          displayName: Virt-v2v Image
+          path: virt_v2v_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: VDDK image for VMware disk access
+          displayName: VDDK Image
+          path: vddk_image
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: API service image
+          displayName: API Image
+          path: api_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: CLI download service image
+          displayName: CLI Download Image
+          path: cli_download_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: UI plugin image
+          displayName: UI Plugin Image
+          path: ui_plugin_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Validation service image
+          displayName: Validation Image
+          path: validation_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume populator controller image
+          displayName: Populator Controller Image
+          path: populator_controller_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: oVirt populator image
+          displayName: oVirt Populator Image
+          path: populator_ovirt_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OpenStack populator image
+          displayName: OpenStack Populator Image
+          path: populator_openstack_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: vSphere xcopy populator image
+          displayName: vSphere Populator Image
+          path: populator_vsphere_xcopy_volume_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA provider server image
+          displayName: OVA Provider Server Image
+          path: ova_provider_server_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Must-gather debugging image
+          displayName: Must-gather Image
+          path: must_gather_image_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA inventory proxy image
+          displayName: OVA Proxy Image
+          path: ova_proxy_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Controller Resource Configuration
+        - description: Controller CPU limit (default 500m)
+          displayName: Controller CPU Limit
+          path: controller_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Controller memory limit (default 800Mi)
+          displayName: Controller Memory Limit
+          path: controller_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Controller CPU request (default 100m)
+          displayName: Controller CPU Request
+          path: controller_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Controller memory request (default 350Mi)
+          displayName: Controller Memory Request
+          path: controller_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Inventory Resource Configuration
+        - description: Inventory CPU limit (default 1000m)
+          displayName: Inventory CPU Limit
+          path: inventory_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Inventory memory limit (default 1Gi)
+          displayName: Inventory Memory Limit
+          path: inventory_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Inventory CPU request (default 500m)
+          displayName: Inventory CPU Request
+          path: inventory_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Inventory memory request (default 500Mi)
+          displayName: Inventory Memory Request
+          path: inventory_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Inventory route timeout (default 360s)
+          displayName: Inventory Route Timeout
+          path: inventory_route_timeout
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # API Resource Configuration
+        - description: API service CPU limit (default 1000m)
+          displayName: API CPU Limit
+          path: api_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: API service memory limit (default 1Gi)
+          displayName: API Memory Limit
+          path: api_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: API service CPU request (default 100m)
+          displayName: API CPU Request
+          path: api_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: API service memory request (default 150Mi)
+          displayName: API Memory Request
+          path: api_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # CLI Download Resource Configuration
+        - description: CLI download service CPU limit (default 100m)
+          displayName: CLI Download CPU Limit
+          path: cli_download_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: CLI download service memory limit (default 128Mi)
+          displayName: CLI Download Memory Limit
+          path: cli_download_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: CLI download service CPU request (default 50m)
+          displayName: CLI Download CPU Request
+          path: cli_download_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: CLI download service memory request (default 64Mi)
+          displayName: CLI Download Memory Request
+          path: cli_download_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # UI Plugin Resource Configuration
+        - description: UI plugin CPU limit (default 100m)
+          displayName: UI Plugin CPU Limit
+          path: ui_plugin_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: UI plugin memory limit (default 800Mi)
+          displayName: UI Plugin Memory Limit
+          path: ui_plugin_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: UI plugin CPU request (default 100m)
+          displayName: UI Plugin CPU Request
+          path: ui_plugin_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: UI plugin memory request (default 150Mi)
+          displayName: UI Plugin Memory Request
+          path: ui_plugin_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Validation Resource Configuration
+        - description: Validation CPU limit (default 1000m)
+          displayName: Validation CPU Limit
+          path: validation_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Validation memory limit (default 300Mi)
+          displayName: Validation Memory Limit
+          path: validation_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Validation CPU request (default 400m)
+          displayName: Validation CPU Request
+          path: validation_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Validation memory request (default 50Mi)
+          displayName: Validation Memory Request
+          path: validation_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Policy agent search interval in seconds (default 120)
+          displayName: Policy Agent Search Interval
+          path: validation_policy_agent_search_interval
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume name for extra validation rules (default validation-extra-rules)
+          displayName: Validation Extra Volume Name
+          path: validation_extra_volume_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Mount path for extra validation rules (default /usr/share/opa/policies/extra)
+          displayName: Validation Extra Volume Mount Path
+          path: validation_extra_volume_mountpath
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # ConfigMap Names
+        - description: ConfigMap name for oVirt OS mappings (default forklift-ovirt-osmap)
+          displayName: oVirt OS Map ConfigMap Name
+          path: ovirt_osmap_configmap_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: ConfigMap name for vSphere OS mappings (default forklift-vsphere-osmap)
+          displayName: vSphere OS Map ConfigMap Name
+          path: vsphere_osmap_configmap_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: ConfigMap name for virt-customize configuration (default forklift-virt-customize)
+          displayName: Virt-Customize ConfigMap Name
+          path: virt_customize_configmap_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Migration Settings & Timeouts
+        - description: Max concurrent VM migrations (default 20)
+          displayName: Max VM Inflight
+          path: controller_max_vm_inflight
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Precopy interval in minutes (default 60)
+          displayName: Precopy Interval
+          path: controller_precopy_interval
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Max concurrent reconciles (default 10)
+          displayName: Max Concurrent Reconciles
+          path: controller_max_concurrent_reconciles
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Snapshot removal timeout in minutes (default 120)
+          displayName: Snapshot Removal Timeout
+          path: controller_snapshot_removal_timeout_minuts
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Snapshot status check rate in seconds (default 10)
+          displayName: Snapshot Status Check Rate
+          path: controller_snapshot_status_check_rate_seconds
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Cleanup retry count (default 10)
+          displayName: Cleanup Retries
+          path: controller_cleanup_retries
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: DataVolume status check retries (default 10)
+          displayName: DV Status Check Retries
+          path: controller_dv_status_check_retries
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Snapshot removal retries (default 20)
+          displayName: Snapshot Removal Check Retries
+          path: controller_snapshot_removal_check_retries
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: VDDK job timeout in seconds (default 300)
+          displayName: VDDK Job Active Deadline
+          path: controller_vddk_job_active_deadline_sec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: TLS connection timeout seconds (default 5)
+          displayName: TLS Connection Timeout
+          path: controller_tls_connection_timeout_sec
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Migration Feature-Specific Settings
+        - description: Use vSphere incremental backup (default true)
+          displayName: vSphere Incremental Backup
+          path: controller_vsphere_incremental_backup
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Enable oVirt warm migration (default true)
+          displayName: oVirt Warm Migration
+          path: controller_ovirt_warm_migration
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Retain precopy pods (default false)
+          displayName: Retain Precopy Importer Pods
+          path: controller_retain_precopy_importer_pods
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Enable static udn IP addresses feature (default false)
+          displayName: Static UDN IP Addresses
+          path: controller_static_udn_ip_addresses
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Storage & Performance Settings
+        - description: Filesystem overhead percentage (default 10)
+          displayName: Filesystem Overhead
+          path: controller_filesystem_overhead
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Block overhead in bytes (default 0)
+          displayName: Block Overhead
+          path: controller_block_overhead
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Virt-v2v Settings
+        - description: virt-v2v CPU limit (default 4000m)
+          displayName: Virt-v2v CPU Limit
+          path: virt_v2v_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: virt-v2v memory limit (default 8Gi)
+          displayName: Virt-v2v Memory Limit
+          path: virt_v2v_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: virt-v2v CPU request (default 1000m)
+          displayName: Virt-v2v CPU Request
+          path: virt_v2v_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: virt-v2v memory request (default 1Gi)
+          displayName: Virt-v2v Memory Request
+          path: virt_v2v_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Don't request KVM for virt-v2v
+          displayName: Virt-v2v Don't Request KVM
+          path: virt_v2v_dont_request_kvm
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Additional arguments for virt-v2v
+          displayName: Virt-v2v Extra Args
+          path: virt_v2v_extra_args
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: ConfigMap name containing extra virt-v2v configuration
+          displayName: Virt-v2v Extra Config ConfigMap
+          path: virt_v2v_extra_conf_config_map
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Hooks Settings
+        - description: Hooks CPU limit (default 1000m)
+          displayName: Hooks CPU Limit
+          path: hooks_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Hooks memory limit (default 1Gi)
+          displayName: Hooks Memory Limit
+          path: hooks_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Hooks CPU request (default 100m)
+          displayName: Hooks CPU Request
+          path: hooks_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Hooks memory request (default 150Mi)
+          displayName: Hooks Memory Request
+          path: hooks_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # OVA Settings
+        - description: OVA CPU limit (default 1000m)
+          displayName: OVA CPU Limit
+          path: ova_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA memory limit (default 1Gi)
+          displayName: OVA Memory Limit
+          path: ova_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA CPU request (default 100m)
+          displayName: OVA CPU Request
+          path: ova_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA memory request (default 150Mi)
+          displayName: OVA Memory Request
+          path: ova_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # OVA Proxy Settings
+        - description: OVA Proxy CPU limit (default 1000m)
+          displayName: OVA Proxy CPU Limit
+          path: ova_proxy_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA Proxy memory limit (default 1Gi)
+          displayName: OVA Proxy Memory Limit
+          path: ova_proxy_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA Proxy CPU request (default 250m)
+          displayName: OVA Proxy CPU Request
+          path: ova_proxy_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA Proxy memory request (default 512Mi)
+          displayName: OVA Proxy Memory Request
+          path: ova_proxy_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: OVA Proxy route timeout (default 360s)
+          displayName: OVA Proxy Route Timeout
+          path: ova_proxy_route_timeout
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Logging & General Settings
+        - description: Log verbosity level (default 3)
+          displayName: Controller Log Level
+          path: controller_log_level
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Image pull policy (default Always)
+          displayName: Image Pull Policy
+          path: image_pull_policy
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Whether running on Kubernetes (vs OpenShift) (default false)
+          displayName: K8s Cluster
+          path: k8s_cluster
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Metrics Settings
+        - description: Metrics scrape interval (default 30s)
+          displayName: Metric Interval
+          path: metric_interval
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Hook schema for the hooks API
         displayName: Hook
         kind: Hook


### PR DESCRIPTION
Issue:
After setting up an strict API, where feature flags are strings, the automated UI form got very big and included some fields we did not want to expose to the UI.

Fix:
Continue with relaxed type settings, 

 - [x] Adding new fields to the forklift controller CRD
 - [x] Hide all fields except the feature flags from the UI form

Notes:
  - YAML help include all fields
  - Since CRD and UI require deterministic types, we will only accept strings for boolean fields.

Screenshots:

Automated UI:
<img width="1675" height="1172" alt="forkliftcontroller-form" src="https://github.com/user-attachments/assets/4e51a86d-ac3b-4d7c-bf83-960747fa7600" />

YAML form:
<img width="1675" height="1172" alt="forkliftcontroller-yaml" src="https://github.com/user-attachments/assets/9d2670e9-1833-4d30-8c82-05fae5278fbb" />

