### PR TITLE
MTV-3477 | storage-offload: Use --version to verify the wrapper script version

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
@@ -31,11 +31,14 @@ func ensureVib(client vmware.Client, esx *object.HostSystem, datastore string, d
 		return fmt.Errorf("failed to get the VIB version from ESXi %s: %w", esx.Name(), err)
 	}
 
-	klog.Infof("current vib version on ESXi %s: %s", esx.Name(), version)
 	if version == desiredVibVersion {
+		klog.Infof("vib version on ESXi %s is at the expected version: %s", esx.Name(), version)
+		klog.Infof("validating esxcli vmkfstools is active")
+		version, err := client.RunEsxCommand(context.Background(), esx, []string{"version"})
 		return nil
 	}
 
+	klog.Infof("vib version on ESXi %s is %s - installing the expected version", esx.Name(), version)
 	dc, err := getHostDC(esx)
 	if err != nil {
 		return err
@@ -50,7 +53,8 @@ func ensureVib(client vmware.Client, esx *object.HostSystem, datastore string, d
 	if err != nil {
 		return fmt.Errorf("failed to install the VIB on ESXi %s: %w", esx.Name(), err)
 	}
-	klog.Infof("installed vib on ESXi %s version %s", esx.Name(), VibVersion)
+	klog.Infof("installed vib on ESXi %s version %s.", esx.Name(), VibVersion)
+	klog.Infof("ATTENTION - please restart hostd to make the vmkfstools esxcli plugin active by running '/etc/init.d/hostd restart'")
 	return nil
 }
 

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/Makefile
@@ -6,6 +6,7 @@ test:
 	python vmkfstools_wrapper_test.py
 
 build: test
+	sed "s/__VERSION__/$(VIB_VERSION)/g" vmkfstools_wrapper.py > vmkfstools_wrapper.py.versioned
 	VIB_VERSION=${VIB_VERSION} ./create-vib.sh 
 
 install: build

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/create-vib.sh
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/create-vib.sh
@@ -37,7 +37,7 @@ mkdir -p ${ESXCLI_PLUGINS_DIR}
 # in esxcli-vmkfstools.xml, but this is left just to prove we can use it.
 # Should be removed if we find it useless.
 cp -v esxcli-vmkfstools.xml ${ESXCLI_PLUGINS_DIR}
-cp -v vmkfstools_wrapper.py ${CUSTOM_VIB_BIN_DIR}/vmkfstools-wrapper
+cp -v vmkfstools_wrapper.py.versioned ${CUSTOM_VIB_BIN_DIR}/vmkfstools-wrapper
 chmod +x ${CUSTOM_VIB_BIN_DIR}/vmkfstools-wrapper
 
 # Create tgz with payload

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/esxcli-vmkfstools.xml
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/esxcli-vmkfstools.xml
@@ -9,6 +9,20 @@
    </namespaces>
 
    <commands>
+      <command path="vmkfstools.version">
+         <description>vmkfstools version</description>
+         <output-spec>
+            <structure typeName="result">
+               <field name="status"> <string/></field>
+               <field name="message"> <string/></field>
+            </structure>
+         </output-spec>
+         <format-parameters>
+            <formatter>simple</formatter>
+         </format-parameters>
+         <execute>/opt/redhat/vmkfstools-wrapper --version</execute>
+      </command>
+
       <command path="vmkfstools.clone">
          <description>Clone VMDK to RDM</description>
          <input-spec>

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/version.mk
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/version.mk
@@ -1,1 +1,1 @@
-VIB_VERSION := 0.1.1
+VIB_VERSION := 0.1.2

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vmkfstools_wrapper.py
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vmkfstools_wrapper.py
@@ -8,6 +8,7 @@ import subprocess
 import uuid
 import re
 
+VERSION = "__VERSION__"
 TMP_PREFIX = "/tmp/vmkfstools-wrapper-{}"
 
 XML = """<?xml version="1.0" ?>
@@ -62,6 +63,9 @@ def clone(args):
         stdout_file.close()
         stderr_file.close()
 
+def version():
+        result = {"version": VERSION}
+        print(XML.format("0", json.dumps(result)))
 
 def taskGet(args):
     tmp_dir = TMP_PREFIX.format(args.task_id[0])
@@ -146,6 +150,8 @@ def main():
     parser.add_argument("-i", "--task-id", type=str, nargs=1,
                         metavar="task_id", default=None,
                         help="id of task to get")
+    parser.add_argument("--version", action="store_true",
+                        help="get the version")
     args = parser.parse_args()
     logging.basicConfig(filename='/var/log/vmkfstools-wrapper.log',
                         level=logging.INFO,

--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vmkfstools_wrapper_test.py
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/vmkfstools_wrapper_test.py
@@ -23,7 +23,8 @@ class TestVmkfstoolsWrapper(unittest.TestCase):
             main()
             mocked_clone.assert_called_once_with(
                 Namespace(clone=True, source_vmdk="foo", target_lun="bar",
-                          task_get=False, task_clean=False, task_id=None))
+                          task_get=False, task_clean=False, task_id=None,
+                          version=False))
 
     @patch('sys.argv', ['vmkfstools_wrapper', '--task-get', '-i', 'foo'])
     def test_task_get(self):
@@ -33,7 +34,8 @@ class TestVmkfstoolsWrapper(unittest.TestCase):
             main()
             mocked_get.assert_called_once_with(
                 Namespace(clone=False, source_vmdk=None, target_lun=None,
-                          task_get=True, task_clean=False, task_id=['foo']))
+                          task_get=True, task_clean=False, task_id=['foo'],
+                          version=False))
 
     @patch('sys.argv', ['vmkfstools_wrapper', '--task-clean', '-i', 'foo'])
     def test_task_clean(self):
@@ -43,7 +45,8 @@ class TestVmkfstoolsWrapper(unittest.TestCase):
             main()
             mocked_task_clean.assert_called_once_with(
                 Namespace(clone=False, source_vmdk=None, target_lun=None,
-                          task_get=False, task_clean=True, task_id=['foo']))
+                          task_get=False, task_clean=True, task_id=['foo'],
+                          version=False))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add --version to vmkfstools-wrapper and use it to verify the installation status

https://issues.redhat.com/browse/MTV-3477

Signed-off-by: Roy Golan <rgolan@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added vmkfstools version command to retrieve wrapper version information.

* **Improvements**
  * Enhanced logging during VIB validation and installation with clearer status messages.
  * Added notice recommending hostd service restart after VIB installation to activate the vmkfstools plugin.

* **Chores**
  * Bumped version from 0.1.1 to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->