### PR TITLE
Propagate ApplianceManagement condition to Provider

### DIFF
--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -204,6 +204,10 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		}
 	}
 
+	// Begin staging conditions.
+	provider.Status.Phase = Staging
+	provider.Status.BeginStagingConditions()
+
 	if provider.Type() == api.Ova && provider.DeletionTimestamp == nil {
 		if !provider.HasReconciled() {
 			// the provider has changed, so delete the old
@@ -238,10 +242,6 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 			return
 		}
 	}
-
-	// Begin staging conditions.
-	provider.Status.Phase = Staging
-	provider.Status.BeginStagingConditions()
 
 	// Validations.
 	err = r.validate(provider)

--- a/pkg/controller/provider/ova-setup.go
+++ b/pkg/controller/provider/ova-setup.go
@@ -22,6 +22,10 @@ func (r Reconciler) EnsureOVAProviderServer(ctx context.Context, provider *api.P
 		return
 	}
 	provider.Status.Service = server.Status.Service
+	cnd := server.Status.FindCondition(ova.ApplianceManagementEnabled)
+	if cnd != nil {
+		provider.Status.SetCondition(*cnd)
+	}
 	return
 }
 


### PR DESCRIPTION
This propagates the ApplianceManagementEnabled condition from the OVAProviderServer CR to the Provider CR. This will enable the UI to determine whether to show the upload form without having to lookup the OVAProviderServer, and it makes it easy to see whether the feature is enabled.

<img width="2149" height="529" alt="image" src="https://github.com/user-attachments/assets/3618c360-760c-4d4d-8318-b6a50f3c4e3f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed staging status initialization to execute once and at the appropriate time during the reconciliation process, improving overall state management reliability.
  * Enhanced appliance management enabled condition propagation to ensure accurate and complete status tracking across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->