### PR TITLE
Fix PreserveStaticIps validation for all non vSphere providers

### DIFF
--- a/pkg/apis/forklift/v1beta1/provider.go
+++ b/pkg/apis/forklift/v1beta1/provider.go
@@ -146,6 +146,10 @@ func (p *Provider) Type() ProviderType {
 	return Undefined
 }
 
+func (p *Provider) SupportsPreserveStaticIps() bool {
+	return p.Type() == VSphere
+}
+
 // This provider is the `host` cluster.
 func (p *Provider) IsHost() bool {
 	return p.Type() == OpenShift && p.Spec.URL == ""

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -464,7 +464,7 @@ func (r *Reconciler) validateNetworkMap(plan *api.Plan) (err error) {
 	}
 	// Check if we are preserving static IPs and give warning if we are mapping to Pod Network.
 	// The Pod network has different subnet than the source provider so the VMs might not be accessible.
-	if plan.Spec.PreserveStaticIPs {
+	if plan.Referenced.Provider.Source.SupportsPreserveStaticIps() && plan.Spec.PreserveStaticIPs {
 		var hasMappingToPodNetwork bool
 		for _, networkMap := range mp.Spec.Map {
 			if networkMap.Destination.Type == Pod {


### PR DESCRIPTION
Issue: As the PreserveStaticIps became a default to true for providers. The validation started showing error when mapping the pod networking for example between two ocp clusters.

Fix: Add check for the validation to report status only to the providers that support PreserveStaticIps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider-specific compatibility check added so static IP preservation is only considered when the chosen provider supports it.

* **Bug Fixes**
  * Validation tightened to skip static-IP-preservation advisory for providers that don’t support it, preventing invalid plan configurations and reducing migration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->