### PR TITLE
Add sysprep to live migraiton

### DIFF
--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -1578,6 +1578,11 @@ func (r *Builder) ConfigMaps(vm *planapi.VMStatus) (list []core.ConfigMap, err e
 		case vol.ConfigMap != nil:
 			key := types.NamespacedName{Namespace: virtualMachine.Namespace, Name: vol.ConfigMap.Name}
 			sources = append(sources, key)
+		case vol.Sysprep != nil:
+			if vol.Sysprep.ConfigMap != nil {
+				key := types.NamespacedName{Namespace: virtualMachine.Namespace, Name: vol.Sysprep.ConfigMap.Name}
+				sources = append(sources, key)
+			}
 		default:
 			continue
 		}
@@ -1650,6 +1655,11 @@ func (r *Builder) Secrets(vm *planapi.VMStatus) (list []core.Secret, err error) 
 			}
 			if vol.CloudInitConfigDrive.NetworkDataSecretRef != nil {
 				key := types.NamespacedName{Namespace: virtualMachine.Namespace, Name: vol.CloudInitConfigDrive.NetworkDataSecretRef.Name}
+				sources = append(sources, key)
+			}
+		case vol.Sysprep != nil:
+			if vol.Sysprep.Secret != nil {
+				key := types.NamespacedName{Namespace: virtualMachine.Namespace, Name: vol.Sysprep.Secret.Name}
 				sources = append(sources, key)
 			}
 		default:


### PR DESCRIPTION
While workign on https://github.com/kubev2v/forklift/pull/3218 I found that the sysprep is missing in the live migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Sysprep-related configuration and secrets during migration to ensure these resources are properly included in the migration process alongside other configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->