### PR TITLE
Migrate ContainerDisk image pull secrets

### DIFF
--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -1680,6 +1680,11 @@ func (r *Builder) Secrets(vm *planapi.VMStatus) (list []core.Secret, err error) 
 				key := types.NamespacedName{Namespace: virtualMachine.Namespace, Name: vol.Sysprep.Secret.Name}
 				sources = append(sources, key)
 			}
+		case vol.ContainerDisk != nil:
+			if vol.ContainerDisk.ImagePullSecret != "" {
+				key := types.NamespacedName{Namespace: virtualMachine.Namespace, Name: vol.ContainerDisk.ImagePullSecret}
+				sources = append(sources, key)
+			}
 		default:
 			continue
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure image-pull secrets referenced by container disk VM volumes are included during secret migration, so all required secrets are migrated alongside associated VM volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->