### PR TITLE
Ignore successful VMs when validating plans

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -815,6 +815,16 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 				setOfTargetName[vm.TargetName] = true
 			}
 		}
+
+		// We don't need to revalidate a VM that was already successfully
+		// migrated by this plan, but we still want to consider it for
+		// name and ID uniqueness checks.
+		if status, found := plan.Status.Migration.FindVM(*ref); found {
+			if status.HasCondition(api.ConditionSucceeded) {
+				continue
+			}
+		}
+
 		// check for supported OVA source
 		if ova, ok := v.(*ova.VM); ok {
 			for _, concern := range ova.Concerns {


### PR DESCRIPTION
VMs that have been successfully migrated and have the Succeeded status were still validated as though they need to be migrated, which can result in conditions on the Plan that cause it to not become Ready. This means that there are scenarios where a Plan that partly succeeded and partly failed couldn't be re-run, because the successful VMs are now causing incorrect blocker conditions.

We can skip validating VMs that the Plan considers to have been successfully migrated, because they won't be remigrated by the plan and can't affect its success. (any interference that VM would cause for another incomplete VM on the plan would still be picked up by the other VM's validation)

Resolves: [MTV-3281](https://issues.redhat.com/browse/MTV-3281) | [CCLM] "VMPowerStateUnsupported" and "MAC address conflicts" error after migration succeeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plan validation now skips re-checking VMs that were already migrated successfully by the same plan, reducing validation time and avoiding redundant checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->