### PR TITLE
Add quats for namespace string var inside json

### DIFF
--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -6970,7 +6970,7 @@ metadata:
         "kind": "ForkliftController",
         "metadata": {
           "name": "forklift-controller",
-          "namespace": konveyor-forklift
+          "namespace": "konveyor-forklift"
         },
         "spec": {
           "feature_ui_plugin": "true",

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
         "kind": "ForkliftController",
         "metadata": {
           "name": "forklift-controller",
-          "namespace": ${NAMESPACE}
+          "namespace": "${NAMESPACE}"
         },
         "spec": {
           "feature_ui_plugin": "true",


### PR DESCRIPTION
Add quats for namespace string var inside json

Fixes: https://github.com/kubev2v/forklift/issues/3209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated namespace value formatting in operator manifests to ensure namespace parameters are properly quoted and treated as strings for consistent initialization and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->