### PR TITLE
MTV-2620 | Warm migration left snapshot on vCenter when migration hit error

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1360,6 +1360,13 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 
 	} else if vm.Error != nil {
 		vm.Phase = api.PhaseCompleted
+
+		// Failed warm migration can't follow its planned itinerary to snapshot removal phase
+		// so we remove the snapshot here to prevent an orphaned snapshot.
+		if r.Plan.IsWarm() && !vm.HasCondition(api.ConditionFailed) {
+			r.removeLastWarmSnapshot(vm)
+		}
+
 		vm.SetCondition(
 			libcnd.Condition{
 				Type:     api.ConditionFailed,


### PR DESCRIPTION
Issue:
Migration can fail in various phases and  in warm migration it can lead  to an orphaned snapshot cause we don't reach the snapshot removal phase.

Fix:
Add snapshot removal at the point of failure detection in execute() to ensure immediate cleanup when the migration can no longer follow its planned itinerary.

Ref: https://issues.redhat.com/browse/MTV-2620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration error handling: when a VM migration fails, leftover warm snapshots are removed to prevent orphaned snapshots and keep VM state consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->