### PR TITLE
MTV-3486 | Inventory is not updated after configuration changes on vmware.

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -1049,7 +1049,7 @@ func (r Collector) applyLeave(tx *libmodel.Tx, u types.ObjectUpdate) error {
 				ID: u.Obj.Value,
 			},
 		}
-	case Network:
+	case Network, OpaqueNetwork, DVPortGroup, DVSwitch:
 		deleted = &model.Network{
 			Base: model.Base{
 				ID: u.Obj.Value,


### PR DESCRIPTION
Issue:
Network objects remain in the inventory after deletion from VMware.

Fix:
Add missing network types to applyLeave() to properly remove those network types from inventory when deleted from VMware.

Ref:https://issues.redhat.com/browse/MTV-3486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved network resource cleanup by extending deletion handling to additional network object types in vSphere environments, ensuring more comprehensive resource management during object removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->