### PR TITLE
Handle vms that have vmexport phase of `Skipped`

### DIFF
--- a/pkg/controller/plan/adapter/ocp/client.go
+++ b/pkg/controller/plan/adapter/ocp/client.go
@@ -209,6 +209,10 @@ func (r *Client) PreTransferActions(vmRef ref.Ref) (ready bool, err error) {
 		r.Log.Info("VM-export is ready.", "vm", vmRef.Name)
 		return true, nil
 	}
+	if vmExport.Status != nil && vmExport.Status.Phase == export.Skipped {
+		r.Log.Info("VM-export is skipped (no exportable volumes), will migrate VM definition only.", "vm", vmRef.Name)
+		return true, nil
+	}
 
 	r.Log.Info("Waiting for VM-export to be ready...", "vm", vmRef.Name)
 	return false, nil


### PR DESCRIPTION
When a vm does not contain any volumes that need to be exported (for
example, a vm with only ContainerDisk disks) the vmexport object will
have a phase of `Skipped`. We don't currently handle this, so MTV will
simply wait for the vmexport object to eventually reach a stage of
`Ready`, which never happens. Since we want to be able to migrate these
vms, add explicit handling for this situation.

Resolves: https://issues.redhat.com/projects/MTV/issues/MTV-3516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of skipped VM exports: migrations now treat a skipped export as ready and retrieve VM definitions directly from the source, preventing unnecessary export manifest processing.
* **Refactor**
  * Simplified VM source retrieval and updated flows to use the unified retrieval path, with clearer logging for skipped-export scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->