### PR TITLE
MTV-3745 | Hit unexpected MacConflicts error.

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -198,6 +198,14 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		return
 	}
 
+	// Don't reconcile succeeded plans unless they need archiving.
+	if plan.Status.HasCondition(Succeeded) && !plan.Spec.Archived {
+		r.Log.V(1).Info("Skipping reconcile of succeeded plan.", "plan", plan.Name)
+		result.RequeueAfter = 0
+		err = nil
+		return
+	}
+
 	// Postpone as needed.
 	postpone, err := r.postpone()
 	if err != nil {


### PR DESCRIPTION
Issue:
Completed migration plans continue to be re-validated (before the refactoring the
 mac address conflicts were handled in the provider builder).
If the destination VM is deleted and the same source VM is migrated again, the old completed plan may incorrectly flag MAC address conflicts with the new destination VM, leading to false validation errors.

Fix:
Skip all validation upon succeeded plans.
This avoids unnecessary reconciliation work and prevents false positives, such as MAC address conflicts from completed plans interfering with new migrations.

Ref: https://issues.redhat.com/browse/MTV-3475