### PR TITLE
No jira | Archive inspection pod alongside other resources

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1216,6 +1216,21 @@ func (r *KubeVirt) DeletePVCConsumerPod(vm *plan.VMStatus) (err error) {
 	return
 }
 
+// Delete the inspection pod.
+func (r *KubeVirt) DeletePreflightInspectionPod(vm *plan.VMStatus) (err error) {
+	list, err := r.GetPodsWithLabels(r.inspectionLabels(vm.Ref))
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	for _, object := range list.Items {
+		err := r.DeleteObject(&object, vm, "Deleted preflight inspection pod.", "pod")
+		if err != nil {
+			return err
+		}
+	}
+	return
+}
+
 // Delete the guest conversion pod on the destination cluster.
 func (r *KubeVirt) DeleteGuestConversionPod(vm *plan.VMStatus) (err error) {
 	list, err := r.GetPodsWithLabels(r.conversionLabels(vm.Ref, true))

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -427,6 +427,9 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool) error
 	if err := r.kubevirt.DeleteGuestConversionPod(vm); failOnErr(err) {
 		return err
 	}
+	if err := r.kubevirt.DeletePreflightInspectionPod(vm); failOnErr(err) {
+		return err
+	}
 	if err := r.kubevirt.DeleteSecret(vm); failOnErr(err) {
 		return err
 	}


### PR DESCRIPTION
Issue: When user archive plan, the preflight inspection pod was left on the cluster.

Fix: Add preflight inspection pod deletion to archiving

Resolves: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the migration cleanup process to properly remove temporary inspection pods after preflight checks, ensuring improved resource cleanup and preventing orphaned resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->