### PR TITLE
MTV-1904 | Warm migration failed when mtv is installed on normal namespace

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -2003,27 +2003,6 @@ func (r *Reconciler) validatePodSecurity(plan *api.Plan) error {
 			"plan", plan.Name)
 	}
 
-	// For OpenShift, also check if restricted-v2 SCC is indicated
-	// The restricted-v2 SCC typically sets specific annotations on the namespace
-	if settings.Settings.OpenShift && !isRestricted {
-		// Check for restricted-v2 SCC indicator
-		// When restricted-v2 SCC is used, the namespace may have specific annotations
-		// or the enforce label may be set to restricted
-		if ns.Annotations["openshift.io/sa.scc.uid-range"] != "" {
-			// Check if the UID range indicates restricted (restricted-v2 uses specific ranges)
-			// restricted-v2 typically uses UID ranges like 1000790000-1000799999
-			uidRange := ns.Annotations["openshift.io/sa.scc.uid-range"]
-			if strings.Contains(uidRange, "100079") {
-				// This looks like restricted-v2 SCC range
-				isRestricted = true
-				r.Log.Info("Detected restricted-v2 SCC from namespace annotation",
-					"namespace", controllerNamespace,
-					"uidRange", uidRange,
-					"plan", plan.Name)
-			}
-		}
-	}
-
 	// If restricted policies detected, add a warning condition (non-blocking)
 	if isRestricted {
 		restrictedPodSecurity := libcnd.Condition{


### PR DESCRIPTION
Resolves: MTV-1904

@https://issues.redhat.com/browse/MTV-1904

Summary
When MTV is installed in a namespace with restrictive Pod Security Standards (e.g. pod-security.kubernetes.io/enforce=restricted) or OpenShift restricted-v2 SCC, warm migration can fail because conversion pods need security context settings that violate those policies. This change does not modify conversion pod security context; it adds detection and a non-blocking warning so users are informed before running a migration.
Changes

Detection: During plan validation, check the controller namespace (from POD_NAMESPACE) for the pod-security.kubernetes.io/enforce=restricted label.

Warning: If restricted policy is detected, add a non-blocking warning condition to the plan status. The warning does not block migration but tells users they may need to disable SCC label synchronization and apply the privileged label.

Scope: Only pkg/controller/plan/validation.go is modified. No changes to conversion pod creation or security context.

User impact: Users see a warning on the migration plan when the MTV controller runs in a restricted namespace.

Warning message: "Namespace 'X' where MTV is installed may be restricted, causing migration to fail. Disable SCC label synchronization and apply the privileged label."
Migrations are not blocked; the warning is advisory so users can adjust the namespace policy before running a migration if needed.