### PR TITLE
chore(Mac build): fix virt-v2v upstream image build on mac

### DIFF
--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -49,7 +49,8 @@ RUN mkdir -p /usr/lib64/guestfs/appliance && \
 # This prevents libvirt from attempting to create files in the root directory,
 # which would lead to permission errors.
 # Refer to: https://issues.redhat.com/browse/RHEL-105490
-RUN mkdir /home/qemu && chown qemu:qemu /home/qemu
+RUN mkdir -p /home/qemu/.cache/libvirt && \
+    chown -R qemu:qemu /home/qemu
 ENV HOME=/home/qemu
 
 # The libvirt can hang when destroying libguestfs domains due to the

--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -46,7 +46,8 @@ RUN mkdir -p /usr/lib64/guestfs/appliance && \
 # This prevents libvirt from attempting to create files in the root directory,
 # which would lead to permission errors.
 # Refer to: https://issues.redhat.com/browse/RHEL-105490
-RUN mkdir /home/qemu && chown qemu:qemu /home/qemu
+RUN mkdir -p /home/qemu/.cache/libvirt && \
+    chown -R qemu:qemu /home/qemu
 ENV HOME=/home/qemu
 
 # The 'virt-v2v' tool can hang when destroying libguestfs domains due to the

--- a/build/virt-v2v/Containerfile-upstream-fssupport
+++ b/build/virt-v2v/Containerfile-upstream-fssupport
@@ -58,7 +58,8 @@ RUN mkdir -p /usr/lib64/guestfs/appliance && \
 # This prevents libvirt from attempting to create files in the root directory,
 # which would lead to permission errors.
 # Refer to: https://issues.redhat.com/browse/RHEL-105490
-RUN mkdir /home/qemu && chown qemu:qemu /home/qemu
+RUN mkdir -p /home/qemu/.cache/libvirt && \
+    chown -R qemu:qemu /home/qemu
 ENV HOME=/home/qemu
 
 # The libvirt can hang when destroying libguestfs domains due to the


### PR DESCRIPTION
Issue:
When building on mac, libvirt can't build the missing subdir after the build is done

FIx:
Explicitly create all libvirt subdirs in the Containerfile during build time, so we will not hit an error during running time

Note:
changes are only to the upstream builds, no change downstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process robustness with improved directory initialization and permission handling across multiple build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->