### PR TITLE
MTV-3625 | Set predictable default pvc name template

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1655,7 +1655,7 @@ func (r *Builder) setObjectNameFromTemplate(objectMeta *metav1.ObjectMeta, templ
 func (r *Builder) setColdMigrationDefaultPVCName(objectMeta *metav1.ObjectMeta, vm *model.VM, diskIndex int, disk vsphere.Disk) error {
 	pvcNameTemplate := r.getPVCNameTemplate(vm)
 	if pvcNameTemplate == "" {
-		pvcNameTemplate = "{{.PlanName}}-{{.VmName}}-disk-{{.DiskIndex}}"
+		pvcNameTemplate = "{{trunc 4 .PlanName}}-{{trunc 4 .VmName}}-disk-{{.DiskIndex}}"
 	}
 
 	planVM := r.getPlanVM(vm)

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -209,11 +209,11 @@ var _ = Describe("vSphere builder", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pvcs).To(HaveLen(1))
 			pvc := pvcs[0]
-			Expect(pvc.Name).Should(HavePrefix(fmt.Sprintf("%s-%s-disk-", builder.Plan.Name, vm.Name)))
+			// The default template now uses trunc 4 for both plan and VM names
+			Expect(pvc.Name).Should(HavePrefix(fmt.Sprintf("%.4s-%.4s-disk-", builder.Plan.Name, vm.Name)))
 			Expect(pvc.Spec.DataSourceRef.Kind).To(Equal(v1beta1.VSphereXcopyVolumePopulatorKind))
 			Expect(pvc.Spec.DataSourceRef.APIGroup).To(Equal(&v1beta1.SchemeGroupVersion.Group))
 			Expect(pvc.Spec.DataSourceRef.Name).To(Equal(pvc.Name))
-
 		})
 
 		It("should honor explicit AccessMode StorageMap and ignore VolumeMode from StorageMap", func() {


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-3625

Issue:
In xcopy scenario we force default PVC name template the include the plan name, vm name and the disk index, this template may result in a long PVC name that we will fail because we use this name both as name and label.

Fix:
Default to a shorter predictable PVC name, in case no PVC name template is provided by the user.

Example:
Plan using the new default xcopy template (setting the new default value explicitly)
```bash
❯ oc mtv create plan test1 -S chho --vms yzamir-func-win2019,yzamir-func-win2025 --pvc-name-template "{{trunc 4 .PlanName}}-{{trunc 4 .VmName}}-disk-{{.DiskIndex}}"
No target provider specified, using default OpenShift provider: host
No target namespace specified, using plan namespace: test
plan/test1 created

❯ oc get pvc
No resources found in test namespace.

❯ oc mtv start plan test1
Migration started for plan 'test1' in namespace 'test'

❯ oc mtv get plan
NAME        SOURCE      TARGET      VMS                READY       STATUS      PROGRESS        CUTOVER     ARCHIVED    CREATED
test1       chho        host        0/2 (S:0/F:0/C:0)  true        Executing   0.0% (0/50 GB)  cold        false       2025-10-30 10:35:38
❯ oc get pvc
NAME                                         STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                                 VOLUMEATTRIBUTESCLASS   AGE
prime-157eaa90-89ba-4f2f-8a86-6a574732fd4a   Bound     pvc-88fcee18-99c4-4765-bd6d-38950453303a   12Gi       RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 15s
prime-383d79fd-f424-474f-b583-d8223434fbff   Bound     pvc-6dfd8085-bf9c-4d8f-bee6-4e1fe42366fc   4Gi        RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 13s
prime-5f1fb557-0063-4771-a7ed-a76d04bdee37   Bound     pvc-3edc9022-e7e5-4f1f-86aa-3f1c1effb54e   3Gi        RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 14s
prime-62729a08-6f2a-46f6-8c48-bf1acb585b3a   Bound     pvc-bbf1a6cd-675b-4e28-b77d-aa83a145ad02   2Gi        RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 15s
prime-80df458e-4970-4b9d-9425-e821d4f3f801   Bound     pvc-3cf6faa0-5313-4c63-b077-bc148e7af645   1Gi        RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 15s
prime-a591ce81-3aed-47c0-a709-c12ac886da76   Bound     pvc-9deed8ae-64c1-4c92-afd4-85f86b1741d9   20Gi       RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 14s
prime-ab326934-0e41-41ed-8e2d-867724b5df63   Bound     pvc-a11cc053-6cf8-4e55-acb0-8d62b7a35dcd   2Gi        RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 14s
prime-ed7c2cd4-d5a9-4e86-9e71-c4515debdceb   Bound     pvc-ce22052d-ecb7-4d53-b55d-799113f89f58   6Gi        RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 13s
test-yzam-disk-0-m6mxn                       Bound     pvc-9deed8ae-64c1-4c92-afd4-85f86b1741d9   20Gi       RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 14s
test-yzam-disk-0-sbc84                       Bound     pvc-88fcee18-99c4-4765-bd6d-38950453303a   12Gi       RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 15s
test-yzam-disk-1-4v96n                       Bound     pvc-3cf6faa0-5313-4c63-b077-bc148e7af645   1Gi        RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 15s
test-yzam-disk-1-tcc8v                       Pending                                                                        ocs-storagecluster-ceph-rbd-virtualization   <unset>                 14s
test-yzam-disk-2-dwx6g                       Bound     pvc-bbf1a6cd-675b-4e28-b77d-aa83a145ad02   2Gi        RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 15s
test-yzam-disk-2-zfwkp                       Pending                                                                        ocs-storagecluster-ceph-rbd-virtualization   <unset>                 14s
test-yzam-disk-3-r6z5g                       Bound     pvc-3edc9022-e7e5-4f1f-86aa-3f1c1effb54e   3Gi        RWX            ocs-storagecluster-ceph-rbd-virtualization   <unset>                 15s
test-yzam-disk-3-tp95x                       Pending
```