### PR TITLE
MTV-2892 | No UEFI detection concern in OVA inventory.

### DIFF
--- a/cmd/ova-provider-server/ova/vm.go
+++ b/cmd/ova-provider-server/ova/vm.go
@@ -12,6 +12,7 @@ type VM struct {
 	PolicyVersion         int
 	UUID                  string
 	Firmware              string
+	SecureBoot            bool
 	CpuAffinity           []int32
 	CpuHotAddEnabled      bool
 	CpuHotRemoveEnabled   bool
@@ -49,6 +50,11 @@ func (r *VM) apply(key string, value string) {
 	switch key {
 	case "firmware":
 		r.Firmware = value
+	case "bootOptions.efiSecureBootEnabled":
+		r.SecureBoot, _ = strconv.ParseBool(value)
+	case "uefi.secureBoot.enabled":
+		// Legacy key used in some vSphere and Workstation/Fusion OVAs
+		r.SecureBoot, _ = strconv.ParseBool(value)
 	case "memoryHotAddEnabled":
 		r.MemoryHotAddEnabled, _ = strconv.ParseBool(value)
 	case "cpuHotAddEnabled":

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gophercloud/gophercloud v1.14.1
 	github.com/gophercloud/utils v0.0.0-20230418172808-6eab72e966e1
@@ -83,7 +84,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/pkg/controller/plan/adapter/ova/ova_firmware_test.go
+++ b/pkg/controller/plan/adapter/ova/ova_firmware_test.go
@@ -1,0 +1,168 @@
+package ova
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ova"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	cnv "kubevirt.io/api/core/v1"
+)
+
+func TestMapFirmware(t *testing.T) {
+	tests := []struct {
+		name               string
+		firmware           string
+		secureBoot         bool
+		expectedBootloader *cnv.Bootloader
+		expectedSMM        *cnv.FeatureState
+		migrationVMs       []*plan.VMStatus
+	}{
+		{
+			name:       "UEFI with SecureBoot enabled",
+			firmware:   "efi",
+			secureBoot: true,
+			expectedBootloader: &cnv.Bootloader{
+				EFI: &cnv.EFI{
+					SecureBoot: boolPtr(true),
+				},
+			},
+			expectedSMM: &cnv.FeatureState{
+				Enabled: boolPtr(true),
+			},
+		},
+		{
+			name:       "UEFI with SecureBoot disabled",
+			firmware:   "efi",
+			secureBoot: false,
+			expectedBootloader: &cnv.Bootloader{
+				EFI: &cnv.EFI{
+					SecureBoot: boolPtr(false),
+				},
+			},
+			expectedSMM: nil, // SMM should not be set when SecureBoot is disabled
+		},
+		{
+			name:       "BIOS firmware ignores SecureBoot",
+			firmware:   "bios",
+			secureBoot: true, // This should be ignored for BIOS
+			expectedBootloader: &cnv.Bootloader{
+				BIOS: &cnv.BIOS{},
+			},
+			expectedSMM: nil, // SMM should not be set for BIOS
+		},
+		{
+			name:       "Empty firmware defaults to UEFI without SecureBoot",
+			firmware:   "",
+			secureBoot: false,
+			expectedBootloader: &cnv.Bootloader{
+				EFI: &cnv.EFI{
+					SecureBoot: boolPtr(false),
+				},
+			},
+			expectedSMM:  nil,
+			migrationVMs: nil,
+		},
+		{
+			name:       "Empty firmware falls back to Migration.Status.VMs with SecureBoot",
+			firmware:   "",
+			secureBoot: true,
+			expectedBootloader: &cnv.Bootloader{
+				EFI: &cnv.EFI{
+					SecureBoot: boolPtr(true),
+				},
+			},
+			expectedSMM: &cnv.FeatureState{
+				Enabled: boolPtr(true),
+			},
+			migrationVMs: []*plan.VMStatus{
+				{
+					VM: plan.VM{
+						Ref: ref.Ref{
+							ID: "test-vm-id",
+						},
+					},
+					Firmware: "efi",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create migration VMs list (use test-specific or empty)
+			migrationVMs := tt.migrationVMs
+			if migrationVMs == nil {
+				migrationVMs = []*plan.VMStatus{}
+			}
+
+			// Create a builder with minimal context
+			builder := &Builder{
+				Context: &plancontext.Context{
+					Log: logging.WithName("test"),
+					Migration: &api.Migration{
+						Status: api.MigrationStatus{
+							VMs: migrationVMs,
+						},
+					},
+				},
+			}
+
+			// Create test VM
+			vm := &model.VM{
+				Firmware:   tt.firmware,
+				SecureBoot: tt.secureBoot,
+			}
+
+			// Create test VM reference
+			vmRef := ref.Ref{
+				ID: "test-vm-id",
+			}
+
+			// Create empty VM spec
+			vmSpec := &cnv.VirtualMachineSpec{
+				Template: &cnv.VirtualMachineInstanceTemplateSpec{
+					Spec: cnv.VirtualMachineInstanceSpec{
+						Domain: cnv.DomainSpec{},
+					},
+				},
+			}
+
+			// Call mapFirmware
+			builder.mapFirmware(vm, vmRef, vmSpec)
+
+			// Verify bootloader
+			if vmSpec.Template.Spec.Domain.Firmware == nil {
+				t.Fatal("Firmware should be set but is nil")
+			}
+
+			bootloader := vmSpec.Template.Spec.Domain.Firmware.Bootloader
+			if bootloader == nil {
+				t.Fatal("Bootloader should be set but is nil")
+			}
+
+			// Check bootloader configuration
+			if diff := cmp.Diff(tt.expectedBootloader, bootloader); diff != "" {
+				t.Errorf("Bootloader mismatch (-want +got):\n%s", diff)
+			}
+
+			// Check SMM feature
+			var actualSMM *cnv.FeatureState
+			if vmSpec.Template.Spec.Domain.Features != nil {
+				actualSMM = vmSpec.Template.Spec.Domain.Features.SMM
+			}
+			if diff := cmp.Diff(tt.expectedSMM, actualSMM); diff != "" {
+				t.Errorf("SMM mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// Helper function
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/pkg/controller/provider/container/ova/resource.go
+++ b/pkg/controller/provider/container/ova/resource.go
@@ -19,6 +19,7 @@ type VM struct {
 	PolicyVersion         int      `json:"PolicyVersion"`
 	UUID                  string   `json:"UUID"`
 	Firmware              string   `json:"Firmware"`
+	SecureBoot            bool     `json:"SecureBoot"`
 	CpuAffinity           []int32  `json:"CpuAffinity"`
 	CpuHotAddEnabled      bool     `json:"CpuHotAddEnabled"`
 	CpuHotRemoveEnabled   bool     `json:"CpuHotRemoveEnabled"`
@@ -74,6 +75,7 @@ func (r *VM) ApplyTo(m *model.VM) {
 	m.PolicyVersion = r.PolicyVersion
 	m.UUID = r.UUID
 	m.Firmware = r.Firmware
+	m.SecureBoot = r.SecureBoot
 	m.CpuAffinity = r.CpuAffinity
 	m.CpuHotAddEnabled = r.CpuHotAddEnabled
 	m.CpuHotRemoveEnabled = r.CpuHotRemoveEnabled

--- a/pkg/controller/provider/model/ova/model.go
+++ b/pkg/controller/provider/model/ova/model.go
@@ -74,6 +74,7 @@ type VM struct {
 	PolicyVersion         int       `sql:"d0,index(policyVersion)"`
 	UUID                  string    `sql:""`
 	Firmware              string    `sql:""`
+	SecureBoot            bool      `sql:""`
 	CpuAffinity           []int32   `sql:""`
 	CpuHotAddEnabled      bool      `sql:""`
 	CpuHotRemoveEnabled   bool      `sql:""`

--- a/pkg/controller/provider/web/ova/vm.go
+++ b/pkg/controller/provider/web/ova/vm.go
@@ -209,6 +209,7 @@ type VM struct {
 	PolicyVersion         int             `json:"policyVersion"`
 	UUID                  string          `json:"uuid"`
 	Firmware              string          `json:"firmware"`
+	SecureBoot            bool            `json:"secureBoot"`
 	CpuAffinity           []int32         `json:"cpuAffinity"`
 	CpuHotAddEnabled      bool            `json:"cpuHotAddEnabled"`
 	CpuHotRemoveEnabled   bool            `json:"cpuHotRemoveEnabled"`
@@ -236,6 +237,7 @@ func (r *VM) With(m *model.VM) {
 	r.PolicyVersion = m.PolicyVersion
 	r.UUID = m.UUID
 	r.Firmware = m.Firmware
+	r.SecureBoot = m.SecureBoot
 	r.ChangeTrackingEnabled = m.ChangeTrackingEnabled
 	r.CpuAffinity = m.CpuAffinity
 	r.CpuHotAddEnabled = m.CpuHotAddEnabled


### PR DESCRIPTION
Issue:
OVA VMs using UEFI with SecureBoot were incorrectly flagged as not supporting SecureBoot, even when the source OVF had SecureBoot enabled. While UEFI support existed, the OVA metadata lacked  SecureBoot configuration, causing it to be ignored.

Fix:
Add detection of SecureBoot flags and apply the corresponding SecureBoot and SMM configuration for OVA-based UEFI VMs.

Ref: https://issues.redhat.com/browse/MTV-2892