### PR TITLE
MTV-3558 | Append relatedImages during bundle CSV build

### DIFF
--- a/build/forklift-operator-bundle/Containerfile-downstream
+++ b/build/forklift-operator-bundle/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24.4-1752083840 AS envsubst
+FROM quay.io/konflux-ci/yq AS tools
 
 FROM registry.redhat.io/openshift4/ose-operator-sdk-rhel9@sha256:2e8ded84e20ba61e6dd10c99b95d1831f9852d87f47badb9535ee3ced22506a7 AS builder
 
@@ -41,7 +41,8 @@ ARG VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE="registry.redhat.io/mtv-candidate/mtv-v
 
 USER root
 
-COPY --from=envsubst /usr/bin/envsubst /usr/bin/envsubst
+COPY --from=tools /usr/bin/envsubst /usr/bin/envsubst
+COPY --from=tools /usr/bin/yq /usr/bin/yq
 
 COPY ./operator /repo
 COPY ./build/forklift-operator-bundle/images.conf /repo/images.conf
@@ -61,6 +62,11 @@ RUN source ./images.conf && \
     --default-channel $DEFAULT_CHANNEL \
     --output-dir build
 
+# CSV from operator-sdk does not contain `relatedImages` which causes issues in diconnected environments.
+# Load relatedImages object from "operator/related_images.yaml", append it to generated CSV spec and envsubst the ENV variables for specific images
+# MTV-3558
+RUN yq eval -i 'load("related_images.yaml").relatedImages as $images | .spec.relatedImages = $images' build/manifests/mtv-operator.clusterserviceversion.yaml
+RUN envsubst < build/manifests/mtv-operator.clusterserviceversion.yaml > temp.yaml && cp temp.yaml build/manifests/mtv-operator.clusterserviceversion.yaml
 USER 1001
 
 FROM scratch

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -7600,33 +7600,6 @@ spec:
   minKubeVersion: 1.27.0
   provider:
     name: Red Hat
-  relatedImages:
-  - image: ${OPERATOR_IMAGE}
-    name: forklift-operator
-  - image: ${CONTROLLER_IMAGE}
-    name: controller
-  - image: ${MUST_GATHER_IMAGE}
-    name: must_gather
-  - image: ${VALIDATION_IMAGE}
-    name: validation
-  - image: ${API_IMAGE}
-    name: api
-  - image: ${POPULATOR_CONTROLLER_IMAGE}
-    name: populator_controller
-  - image: ${OVIRT_POPULATOR_IMAGE}
-    name: rhv_populator
-  - image: ${VIRT_V2V_IMAGE}
-    name: virt_v2v
-  - image: ${OPENSTACK_POPULATOR_IMAGE}
-    name: openstack_populator
-  - image: ${UI_PLUGIN_IMAGE}
-    name: ui_plugin
-  - image: ${OVA_PROVIDER_SERVER_IMAGE}
-    name: ova_provider_server
-  - image: ${OVA_PROXY_IMAGE}
-    name: ova_proxy
-  - image: ${VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE}
-    name: vsphere_xcopy_volume_populator
   version: ${MTV_VERSION}
 ---
 apiVersion: scorecard.operatorframework.io/v1alpha3

--- a/operator/related_images.yaml
+++ b/operator/related_images.yaml
@@ -1,0 +1,29 @@
+relatedImages:
+  - name: forklift-operator
+    image: ${OPERATOR_IMAGE}
+  - name: controller
+    image: ${CONTROLLER_IMAGE}
+  - name: must_gather
+    image: ${MUST_GATHER_IMAGE}
+  - name: validation
+    image: ${VALIDATION_IMAGE}
+  - name: api
+    image: ${API_IMAGE}
+  - name: populator_controller
+    image: ${POPULATOR_CONTROLLER_IMAGE}
+  - name: rhv_populator
+    image: ${OVIRT_POPULATOR_IMAGE}
+  - name: virt_v2v
+    image: ${VIRT_V2V_IMAGE}
+  - name: openstack_populator
+    image: ${OPENSTACK_POPULATOR_IMAGE}
+  - name: ui_plugin
+    image: ${UI_PLUGIN_IMAGE}
+  - name: ova_provider_server
+    image: ${OVA_PROVIDER_SERVER_IMAGE}
+  - name: ova_proxy
+    image: ${OVA_PROXY_IMAGE}
+  - name: vsphere_xcopy_volume_populator
+    image: ${VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE}
+  - name: cli_download
+    image: ${CLI_DOWNLOAD_IMAGE}

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -668,30 +668,3 @@ spec:
         kind: VSphereXcopyVolumePopulator
         name: vspherexcopyvolumepopulators.forklift.konveyor.io
         version: v1beta1
-  relatedImages:
-    - name: forklift-operator
-      image: "${OPERATOR_IMAGE}"
-    - name: controller
-      image: "${CONTROLLER_IMAGE}"
-    - name: must_gather
-      image: "${MUST_GATHER_IMAGE}"
-    - name: validation
-      image: "${VALIDATION_IMAGE}"
-    - name: api
-      image: "${API_IMAGE}"
-    - name: populator_controller
-      image: "${POPULATOR_CONTROLLER_IMAGE}"
-    - name: rhv_populator
-      image: "${OVIRT_POPULATOR_IMAGE}"
-    - name: virt_v2v
-      image: "${VIRT_V2V_IMAGE}"
-    - name: openstack_populator
-      image: "${OPENSTACK_POPULATOR_IMAGE}"
-    - name: ui_plugin
-      image: "${UI_PLUGIN_IMAGE}"
-    - name: ova_provider_server
-      image: "${OVA_PROVIDER_SERVER_IMAGE}"
-    - name: ova_proxy
-      image: "${OVA_PROXY_IMAGE}"
-    - name: vsphere_xcopy_volume_populator
-      image: "${VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE}"


### PR DESCRIPTION
Issue: There is a bug in operator-sdk and it ignores "relatedImages" field in CSV base during bundle build.

Fix: Always append the relatedImages to the spec of already generated CSV

Resolves: MTV-3558