### PR TITLE
MTV-1324 | Warn on NADs with missing default route

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -45,6 +45,7 @@ const (
 	MigrationTypeNotValid           = "MigrationTypeNotValid"
 	NamespaceNotValid               = "NamespaceNotValid"
 	TransferNetNotValid             = "TransferNetworkNotValid"
+	TransferNetMissingDefaultRoute  = "TransferNetworkMissingDefaultRoute"
 	NetRefNotValid                  = "NetworkMapRefNotValid"
 	NetMapNotReady                  = "NetworkMapNotReady"
 	NetMapPreservingIPsOnPodNetwork = "NetMapPreservingIPsOnPodNetwork"
@@ -1233,6 +1234,13 @@ func (r *Reconciler) validateTransferNetwork(plan *api.Plan) (err error) {
 		Reason:   NotValid,
 		Message:  "Transfer network default route annotation is not a valid IP address.",
 	}
+	missingDefaultRoute := libcnd.Condition{
+		Type:     TransferNetMissingDefaultRoute,
+		Status:   True,
+		Category: api.CategoryWarn,
+		Reason:   NotValid,
+		Message:  "Transfer network missing default route annotation.",
+	}
 	key := client.ObjectKey{
 		Namespace: plan.Spec.TransferNetwork.Namespace,
 		Name:      plan.Spec.TransferNetwork.Name,
@@ -1250,6 +1258,7 @@ func (r *Reconciler) validateTransferNetwork(plan *api.Plan) (err error) {
 	}
 	route, found := netAttachDef.Annotations[AnnForkliftNetworkRoute]
 	if !found {
+		plan.Status.SetCondition(missingDefaultRoute)
 		return
 	}
 	ip := net.ParseIP(route)


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-1324

Issue:
in https://github.com/kubev2v/forklift/pull/1244 we implemented a mechanism for using `forklift.konveyor.io/route` annotation on NADs to specify the gateway ip, without this annotation the transfer network may point to the wrong route.

Fix:
Add a warning to the Plan status that will alert users that they are using a transfer network without a default route.

Warning item:
```
 message: Transfer network missing default route annotation.
 type: TransferNetworkMissingDefaultRoute
```

Example:
```bash
❯ oc mtv get plans -o yaml | yq

- archived: "false"
  created: "2025-11-04 14:53:35"
  ...
    status:
      conditions:
        - category: Warn
          items:
          ...
        - category: Warn
          lastTransitionTime: "2025-11-04T12:55:29Z"
          message: Transfer network missing default route annotation.
          reason: NotValid
          status: "True"
          type: TransferNetworkMissingDefaultRoute
      migration: {}
      observedGeneration: 1
```