### PR TITLE
MTV-3700 | Look for default reoute in the NAD config

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -154,6 +154,23 @@ type KubeVirt struct {
 	Ensurer adapter.Ensurer
 }
 
+// CNINetworkConfig represents a CNI network configuration parsed from a NetworkAttachmentDefinition.
+// This includes the IPAM configuration with routes for determining default gateway.
+type CNINetworkConfig struct {
+	IPAM CNIIPAMConfig `json:"ipam"`
+}
+
+// CNIIPAMConfig represents the IPAM section of a CNI network configuration.
+type CNIIPAMConfig struct {
+	Routes []CNIRoute `json:"routes"`
+}
+
+// CNIRoute represents a single route entry in the CNI IPAM configuration.
+type CNIRoute struct {
+	Dst string `json:"dst"` // Destination network in CIDR notation (e.g., "0.0.0.0/0" for default route)
+	GW  string `json:"gw"`  // Gateway IP address
+}
+
 // Build a VirtualMachineMap.
 func (r *KubeVirt) VirtualMachineMap() (mp VirtualMachineMap, err error) {
 	list, err := r.ListVMs()
@@ -2668,11 +2685,56 @@ func (r *KubeVirt) vmAllButMigrationLabels(vmRef ref.Ref) (labels map[string]str
 	return
 }
 
-// setTransferNetwork sets the transfer network annotation on the DataVolume so
-// that it can be used by the importer pod. If the `forklift.konveyor.io/route` annotation
-// is present on the referenced NAD, then it will be used with the `k8s.v1.cni.cncf.io/networks` annotation
-// to set the default route. If not, this will fall back to setting the `v1.multus-cni.io/default-network` annotation
-// with the namespaced name of the NAD.
+// guessTransferNetworkDefaultRoute determines the default gateway IP address for the transfer network
+// by checking the NetworkAttachmentDefinition in the following priority order:
+//
+//  1. Checks the AnnForkliftNetworkRoute annotation on the NAD
+//  2. Parses the NAD's spec.config JSON and looks for the default route (0.0.0.0/0 or ::/0)
+//     in the ipam.routes array, extracting the gateway IP from the matching route entry
+//
+// Returns:
+//   - route: The gateway IP address as a string (e.g., "192.168.1.1")
+//   - found: true if a route was found, false otherwise
+func (r *KubeVirt) guessTransferNetworkDefaultRoute(netAttachDef *k8snet.NetworkAttachmentDefinition) (route string, found bool) {
+	// First, try to get the default route from the annotation.
+	route, found = netAttachDef.Annotations[AnnForkliftNetworkRoute]
+	if found {
+		return route, true
+	}
+
+	// If the route annotation is not set, try to get the default route from the gw config value.
+	// Parse the Config string which is a JSON string containing network configuration.
+	if netAttachDef.Spec.Config != "" {
+		var config CNINetworkConfig
+		err := json.Unmarshal([]byte(netAttachDef.Spec.Config), &config)
+		if err != nil {
+			// If we can't parse the config, just return not found
+			return "", false
+		}
+
+		// Look for the default route (0.0.0.0/0 or ::/0) in the routes
+		for _, r := range config.IPAM.Routes {
+			if r.Dst == "0.0.0.0/0" || r.Dst == "::/0" {
+				return r.GW, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// setTransferNetwork configures the transfer network for the DataVolume's importer pod
+// by setting appropriate annotations based on whether a default gateway route can be determined.
+//
+// Behavior:
+//   - If a default gateway is found (via annotation or NAD config): Sets the
+//     k8s.v1.cni.cncf.io/networks annotation with the gateway to configure routing
+//   - If no default gateway is found: Falls back to setting the legacy
+//     v1.multus-cni.io/default-network annotation with the NAD's namespaced name
+//
+// The default gateway is discovered by checking the NAD annotation and IPAM config
+// (see guessTransferNetworkDefaultRoute for details).
+//
 // FIXME: the codepath using the multus annotation should be phased out.
 func (r *KubeVirt) setTransferNetwork(annotations map[string]string) (err error) {
 	key := client.ObjectKey{
@@ -2686,7 +2748,7 @@ func (r *KubeVirt) setTransferNetwork(annotations map[string]string) (err error)
 		return
 	}
 
-	route, found := netAttachDef.Annotations[AnnForkliftNetworkRoute]
+	route, found := r.guessTransferNetworkDefaultRoute(netAttachDef)
 	if found {
 		nse := k8snet.NetworkSelectionElement{
 			Namespace: key.Namespace,
@@ -2697,7 +2759,7 @@ func (r *KubeVirt) setTransferNetwork(annotations map[string]string) (err error)
 			nse.GatewayRequest = []net.IP{ip}
 		} else {
 			err = liberr.New(
-				"Transfer network default route annotation is not a valid IP address.",
+				"Transfer network default route is not a valid IP address.",
 				"route", route)
 			return
 		}


### PR DESCRIPTION
Ref: 
https://issues.redhat.com/browse/MTV-3700

Issue:
Today MTV get the transfer network default route only using the NADs `forklift.konveyor.io/route` annotation, if users forget to set the default route explicitly, migration may fail silently.

Fix:
In case the explicit default route is not set via the annotation, MTV will try to fetch the default gateway via the NADs configuration.

Note:
A warning the route is not set explicitly will still be available to users even if we can get the route implicitly - https://github.com/kubev2v/forklift/pull/3453
