### PR TITLE
MTV-3078 | Fix false VMware Tools warning

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -688,9 +688,9 @@ func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
 
 	// Only check VMware Tools status if VM is powered on
 	if vm.PowerState == string(types.VirtualMachinePowerStatePoweredOn) {
-		// Check all VMware Tools issues: unknown status, not installed, not running, or unmanaged
+		// Check critical VMware Tools issues: unknown status, not installed, or not running
 		if isUnknownToolsStatus(vm.ToolsStatus) || vm.ToolsStatus == ToolsNotInstalled ||
-			vm.ToolsRunningStatus == GuestToolsNotRunning || vm.ToolsVersionStatus == GuestToolsUnmanaged {
+			vm.ToolsRunningStatus == GuestToolsNotRunning {
 			return false, nil
 		}
 	}

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -363,7 +363,9 @@ var _ = Describe("vsphere validation tests", func() {
 			// Critical cases - powered on VMs with tools issues
 			Entry("when VMware Tools are not installed", "tools_not_installed", false, false),
 			Entry("when VMware Tools are not running", "tools_not_running", false, false),
-			Entry("when VMware Tools are unmanaged", "tools_unmanaged", false, false),
+
+			// Unmanaged tools (open-vm-tools) should pass validation
+			Entry("when VMware Tools are unmanaged (open-vm-tools)", "tools_unmanaged", true, false),
 
 			// Encrypted/unknown tools status must block when VM is powered on
 			Entry("when VMware Tools status is empty (encrypted VM) -> block", "tools_status_unknown", false, false),


### PR DESCRIPTION
 Issue:
    VMs were incorrectly flagged
    with 'VMware Tools issues detected' warning. The validator treated these
    as a critical issues.
    
Fix:
  - Remove GuestToolsUnmanaged check from validator
  - Update test to expect validation success for unmanaged tools
    
Ref :https://issues.redhat.com/browse/MTV-3078