### PR TITLE
MTV-3816 | OsType field missing from inventory API response

### DIFF
--- a/pkg/controller/provider/container/ova/resource.go
+++ b/pkg/controller/provider/container/ova/resource.go
@@ -15,6 +15,7 @@ type VM struct {
 	Name                  string   `json:"Name"`
 	OvaPath               string   `json:"OvaPath"`
 	OvaSource             string   `json:"OvaSource"`
+	OsType                string   `json:"OsType"`
 	RevisionValidated     int64    `json:"RevisionValidated"`
 	PolicyVersion         int      `json:"PolicyVersion"`
 	UUID                  string   `json:"UUID"`
@@ -71,6 +72,7 @@ func (r *VM) ApplyTo(m *model.VM) {
 	m.ID = r.UUID
 	m.OvaPath = r.OvaPath
 	m.OvaSource = r.OvaSource
+	m.OsType = r.OsType
 	m.RevisionValidated = r.RevisionValidated
 	m.PolicyVersion = r.PolicyVersion
 	m.UUID = r.UUID

--- a/pkg/controller/provider/model/ova/model.go
+++ b/pkg/controller/provider/model/ova/model.go
@@ -70,6 +70,7 @@ type VM struct {
 	Base
 	OvaPath               string    `sql:""`
 	OvaSource             string    `sql:""`
+	OsType                string    `sql:""`
 	RevisionValidated     int64     `sql:"d0,index(revisionValidated)"`
 	PolicyVersion         int       `sql:"d0,index(policyVersion)"`
 	UUID                  string    `sql:""`

--- a/pkg/controller/provider/web/ova/vm.go
+++ b/pkg/controller/provider/web/ova/vm.go
@@ -205,6 +205,7 @@ type VM struct {
 	VM1
 	OvaPath               string          `json:"ovaPath"`
 	OvaSource             string          `json:"ovaSource"`
+	OsType                string          `json:"osType"`
 	RevisionValidated     int64           `json:"revisionValidated"`
 	PolicyVersion         int             `json:"policyVersion"`
 	UUID                  string          `json:"uuid"`
@@ -257,6 +258,7 @@ func (r *VM) With(m *model.VM) {
 	r.NICs = m.NICs
 	r.OvaPath = m.OvaPath
 	r.OvaSource = m.OvaSource
+	r.OsType = m.OsType
 	r.Disks = m.Disks
 	r.Networks = m.Networks
 }


### PR DESCRIPTION
Issue:
OsType was parsed from OVF files but not exposed in the inventory API response,
even though the OVA provider server was correctly extracting it from the OVF XML.

Fix:
Added OsType field throughout the OVA provider stack

Ref: https://issues.redhat.com/browse/MTV-3816