### PR TITLE
Propagate customization errors up to controller as warnings

### DIFF
--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -81,7 +81,12 @@ func main() {
 		// virt-customize
 		err = convert.RunCustomize(inspection.OS)
 		if err != nil {
-			fmt.Println("Failed to customize the VM", err)
+			warningMsg := fmt.Sprintf("VM customization failed: %v. Migration will proceed but customization was not applied successfully.", err)
+			fmt.Println("WARNING:", warningMsg)
+			server.AddWarning(server.Warning{
+				Reason:  "CustomizationFailed",
+				Message: warningMsg,
+			})
 		}
 		// In the remote migrations we can not connect to the conversion pod from the controller.
 		// This connection is needed for to get the additional configuration which is gathered either form virt-v2v or

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1209,6 +1209,42 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 		r.Log.Info("Setting the vm OS ", vm.OperatingSystem, "vmId", vm.ID)
 	}
 
+	// Fetch warnings before shutting down
+	warningsURL := fmt.Sprintf("http://%s:8080/warnings", pod.Status.PodIP)
+	if resp, err = http.Get(warningsURL); err == nil {
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			var body []byte
+			if resp.Body != nil {
+				if data, err := io.ReadAll(resp.Body); err == nil {
+					body = data
+				}
+			}
+
+			contentType := resp.Header.Get("Content-Type")
+			if contentType != "application/json" {
+				r.Log.Info("contentType=%s, expect application/json", contentType)
+			}
+
+			var warnings []struct {
+				Reason  string `json:"reason"`
+				Message string `json:"message"`
+			}
+			if err = json.Unmarshal(body, &warnings); err == nil {
+				for _, warning := range warnings {
+					vm.SetCondition(libcnd.Condition{
+						Type:     ConversionHasWarnings,
+						Status:   True,
+						Category: "Warning",
+						Reason:   warning.Reason,
+						Message:  warning.Message,
+					})
+					r.Log.Info("Conversion warning detected", "reason", warning.Reason, "vmId", vm.ID)
+				}
+			}
+		}
+	}
+
 	shutdownURL := fmt.Sprintf("http://%s:8080/shutdown", pod.Status.PodIP)
 	resp, err = http.Post(shutdownURL, "application/json", nil)
 	if err == nil {

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -74,6 +74,7 @@ const (
 	Succeeded                       = "Succeeded"
 	Failed                          = "Failed"
 	Canceled                        = "Canceled"
+	ConversionHasWarnings           = "ConversionHasWarnings"
 	Deleted                         = "Deleted"
 	Paused                          = "Paused"
 	Archived                        = "Archived"


### PR DESCRIPTION
The virt-v2v container exposes a new '/warnings' endpoint and when
requested, it returns a json-encoded list of warnings that have occured:
`[ { reason: "MyWarningReason", message: "detailed description of the warning"}]`

After conversion and before issuing the `/shutdown` request, the
controller queries `/warnings` and uses the response to set conditions
on the Migration vm statuses.
