### PR TITLE
Add support for "none" keyword in transfer network route annotation

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1261,9 +1261,12 @@ func (r *Reconciler) validateTransferNetwork(plan *api.Plan) (err error) {
 		plan.Status.SetCondition(missingDefaultRoute)
 		return
 	}
-	ip := net.ParseIP(route)
-	if ip == nil {
-		plan.Status.SetCondition(notValid)
+	// Handle case where user explicitly requested not to have a default route
+	if route != AnnForkliftRouteValueNone {
+		ip := net.ParseIP(route)
+		if ip == nil {
+			plan.Status.SetCondition(notValid)
+		}
 	}
 
 	return


### PR DESCRIPTION
Allows to explicitly specify no gateway for transfer networks by setting forklift.konveyor.io/route to "none". This enables use of OVN-Kubernetes localnet topologies where the transfer network has no gateway but direct layer 2 connectivity to ESXi hosts is available and vCenter is not reachable from within the transfer network.

Resolves: None