### PR TITLE
MTV-3837 | add resources requests and limit to populator containers 

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -440,6 +440,22 @@ spec:
                 description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
                 example: custom-vsphere-osmap
                 type: string
+              populator_container_limits_cpu:
+                description: 'Populator CPU limit (default: 1000m)'
+                example: 2000m
+                type: string
+              populator_container_limits_memory:
+                description: 'Populator memory limit (default: 1Gi)'
+                example: 2Gi
+                type: string
+              populator_container_requests_cpu:
+                description: 'Populator CPU request (default: 100m)'
+                example: 200m
+                type: string
+              populator_container_requests_memory:
+                description: 'Populator memory request (default: 512Mi)'
+                example: 300Mi
+                type: string
             type: object
           status:
             description: Status defines the observed state of ForkliftController
@@ -7456,6 +7472,26 @@ spec:
       - description: OVA Proxy route timeout (default 360s)
         displayName: OVA Proxy Route Timeout
         path: ova_proxy_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Populator CPU limit (default 1000m)
+        displayName: Populator CPU Limit
+        path: populator_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Populator memory limit (default 1Gi)
+        displayName: Populator Memory Limit
+        path: populator_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Populator CPU request (default 100m)
+        displayName: Populator CPU Request
+        path: populator_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Populator memory request (default 512Mi)
+        displayName: Populator Memory Request
+        path: populator_container_requests_memory
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Log verbosity level (default 3)

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -118,6 +118,9 @@ spec:
               controller_max_concurrent_reconciles:
                 description: 'Max concurrent reconciles (default: 10)'
                 x-kubernetes-int-or-string: true
+              controller_max_parent_backing_retries:
+                description: 'Max retries when getting parent disks (default: 10)'
+                x-kubernetes-int-or-string: true
               controller_max_vm_inflight:
                 description: 'Max concurrent VM migrations (default: 20)'
                 x-kubernetes-int-or-string: true
@@ -323,6 +326,22 @@ spec:
               ovirt_osmap_configmap_name:
                 description: 'ConfigMap name for oVirt OS mappings (default: forklift-ovirt-osmap)'
                 example: custom-ovirt-osmap
+                type: string
+              populator_container_limits_cpu:
+                description: 'Volume Populator CPU limit (default: 1000m)'
+                example: 2000m
+                type: string
+              populator_container_limits_memory:
+                description: 'Volume Populator memory limit (default: 1Gi)'
+                example: 2Gi
+                type: string
+              populator_container_requests_cpu:
+                description: 'Volume Populator CPU request (default: 100m)'
+                example: 200m
+                type: string
+              populator_container_requests_memory:
+                description: 'Volume Populator memory request (default: 512Mi)'
+                example: 300Mi
                 type: string
               populator_controller_image_fqin:
                 description: Volume populator controller image
@@ -7456,6 +7475,26 @@ spec:
         path: ova_proxy_route_timeout
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator CPU limit (default 1000m)
+          displayName: Volume Populator CPU Limit
+          path: populator_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator memory limit (default 1Gi)
+          displayName: Volume Populator Memory Limit
+          path: populator_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator CPU request (default 100m)
+          displayName: Volume Populator CPU Request
+          path: populator_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator memory request (default 512Mi)
+          displayName: Volume Populator Memory Request
+          path: populator_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Log verbosity level (default 3)
         displayName: Controller Log Level
         path: controller_log_level

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -440,6 +440,22 @@ spec:
                 description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
                 example: custom-vsphere-osmap
                 type: string
+              populator_container_limits_cpu:
+                description: 'Populator CPU limit (default: 1000m)'
+                example: 2000m
+                type: string
+              populator_container_limits_memory:
+                description: 'Populator memory limit (default: 1Gi)'
+                example: 2Gi
+                type: string
+              populator_container_requests_cpu:
+                description: 'Populator CPU request (default: 100m)'
+                example: 200m
+                type: string
+              populator_container_requests_memory:
+                description: 'Populator memory request (default: 512Mi)'
+                example: 300Mi
+                type: string
             type: object
           status:
             description: Status defines the observed state of ForkliftController
@@ -7456,6 +7472,26 @@ spec:
       - description: OVA Proxy route timeout (default 360s)
         displayName: OVA Proxy Route Timeout
         path: ova_proxy_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Populator CPU limit (default 1000m)
+        displayName: Populator CPU Limit
+        path: populator_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Populator memory limit (default 1Gi)
+        displayName: Populator Memory Limit
+        path: populator_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Populator CPU request (default 100m)
+        displayName: Populator CPU Request
+        path: populator_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Populator memory request (default 512Mi)
+        displayName: Populator Memory Request
+        path: populator_container_requests_memory
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Log verbosity level (default 3)

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -422,6 +422,25 @@ spec:
                 type: string
                 description: "OVA Proxy route timeout (default: 360s)"
                 example: "600s"
+              
+              # Volume Populator Settings
+              populator_container_limits_cpu:
+                type: string
+                description: "Volume Populator CPU limit (default: 1000m)"
+                example: "2000m"
+              populator_container_limits_memory:
+                type: string
+                description: "Volume Populator memory limit (default: 1Gi)"
+                example: "2Gi"
+              populator_container_requests_cpu:
+                type: string
+                description: "Volume Populator CPU request (default: 100m)"
+                example: "200m"
+              populator_container_requests_memory:
+                type: string
+                description: "Volume Populator memory request (default: 512Mi)"
+                example: "300Mi"
+
 
               # Logging & General Settings
               controller_log_level:

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -525,6 +525,27 @@ spec:
         path: ova_proxy_route_timeout
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      # Volume Populator Settings
+        - description: Volume Populator CPU limit (default 1000m)
+          displayName: Volume Populator CPU Limit
+          path: populator_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator memory limit (default 1Gi)
+          displayName: Volume Populator Memory Limit
+          path: populator_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator CPU request (default 100m)
+          displayName: Volume Populator CPU Request
+          path: populator_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator memory request (default 512Mi)
+          displayName: Volume Populator Memory Request
+          path: populator_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
       # Logging & General Settings
       - description: Log verbosity level (default 3)
         displayName: Controller Log Level

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -158,6 +158,11 @@ ova_container_limits_memory: "1Gi"
 ova_container_requests_cpu: "100m"
 ova_container_requests_memory: "512Mi"
 
+populator_container_limits_cpu: "1000m"
+populator_container_limits_memory: "1Gi"
+populator_container_requests_cpu: "100m"
+populator_container_requests_memory: "512Mi"
+
 ova_proxy_fqin: "{{ lookup( 'env', 'OVA_PROXY_IMAGE') or lookup( 'env', 'RELATED_IMAGE_OVA_PROXY') }}"
 ova_proxy_container_name: "{{ app_name }}-ova-proxy"
 ova_proxy_service_name: "{{ app_name }}-ova-proxy"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -204,6 +204,14 @@ spec:
           value: "{{ ova_container_requests_cpu }}"
         - name: OVA_CONTAINER_REQUESTS_MEMORY
           value: "{{ ova_container_requests_memory }}"
+        - name: POPULATOR_CONTAINER_LIMITS_CPU
+          value: "{{ populator_container_limits_cpu }}"
+        - name: POPULATOR_CONTAINER_LIMITS_MEMORY
+          value: "{{ populator_container_limits_memory }}"
+        - name: POPULATOR_CONTAINER_REQUESTS_CPU
+          value: "{{ populator_container_requests_cpu }}"
+        - name: POPULATOR_CONTAINER_REQUESTS_MEMORY
+          value: "{{ populator_container_requests_memory }}"
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}

--- a/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
@@ -32,6 +32,14 @@ spec:
           - name: VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE
             value: {{ populator_vsphere_xcopy_volume_image_fqin }}
 {% endif %}
+          - name: POPULATOR_CONTAINER_LIMITS_CPU
+            value: "{{ populator_container_limits_cpu }}"
+          - name: POPULATOR_CONTAINER_LIMITS_MEMORY
+            value: "{{ populator_container_limits_memory }}"
+          - name: POPULATOR_CONTAINER_REQUESTS_CPU
+            value: "{{ populator_container_requests_cpu }}"
+          - name: POPULATOR_CONTAINER_REQUESTS_MEMORY
+            value: "{{ populator_container_requests_memory }}"
           ports:
             - containerPort: 8080
               name: http-endpoint

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -591,6 +591,27 @@ spec:
           path: ova_proxy_route_timeout
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Volume Populator Settings
+        - description: Volume Populator CPU limit (default 1000m)
+          displayName: Volume Populator CPU Limit
+          path: populator_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator memory limit (default 1Gi)
+          displayName: Volume Populator Memory Limit
+          path: populator_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator CPU request (default 100m)
+          displayName: Volume Populator CPU Request
+          path: populator_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator memory request (default 512Mi)
+          displayName: Volume Populator Memory Request
+          path: populator_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         # Logging & General Settings
         - description: Log verbosity level (default 3)
           displayName: Controller Log Level

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -595,6 +595,27 @@ spec:
           path: ova_proxy_route_timeout
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        # Volume Populator Settings
+        - description: Volume Populator CPU limit (default 1000m)
+          displayName: Volume Populator CPU Limit
+          path: populator_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator memory limit (default 1Gi)
+          displayName: Volume Populator Memory Limit
+          path: populator_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator CPU request (default 100m)
+          displayName: Volume Populator CPU Request
+          path: populator_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Volume Populator memory request (default 512Mi)
+          displayName: Volume Populator Memory Request
+          path: populator_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         # Logging & General Settings
         - description: Log verbosity level (default 3)
           displayName: Controller Log Level

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -12,42 +12,54 @@ import (
 
 // Environment variables.
 const (
-	MaxVmInFlight                  = "MAX_VM_INFLIGHT"
-	HookRetry                      = "HOOK_RETRY"
-	ImporterRetry                  = "IMPORTER_RETRY"
-	VirtV2vImage                   = "VIRT_V2V_IMAGE"
-	vddkImage                      = "VDDK_IMAGE"
-	PrecopyInterval                = "PRECOPY_INTERVAL"
-	VirtV2vDontRequestKVM          = "VIRT_V2V_DONT_REQUEST_KVM"
-	SnapshotRemovalTimeout         = "SNAPSHOT_REMOVAL_TIMEOUT"
-	SnapshotStatusCheckRate        = "SNAPSHOT_STATUS_CHECK_RATE"
-	CDIExportTokenTTL              = "CDI_EXPORT_TOKEN_TTL"
-	FileSystemOverhead             = "FILESYSTEM_OVERHEAD"
-	BlockOverhead                  = "BLOCK_OVERHEAD"
-	CleanupRetries                 = "CLEANUP_RETRIES"
-	DvStatusCheckRetries           = "DV_STATUS_CHECK_RETRIES"
-	SnapshotRemovalCheckRetries    = "SNAPSHOT_REMOVAL_CHECK_RETRIES"
-	OvirtOsConfigMap               = "OVIRT_OS_MAP"
-	VsphereOsConfigMap             = "VSPHERE_OS_MAP"
-	VirtCustomizeConfigMap         = "VIRT_CUSTOMIZE_MAP"
-	VddkJobActiveDeadline          = "VDDK_JOB_ACTIVE_DEADLINE"
-	VirtV2vExtraArgs               = "VIRT_V2V_EXTRA_ARGS"
-	VirtV2vExtraConfConfigMap      = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
-	VirtV2vContainerLimitsCpu      = "VIRT_V2V_CONTAINER_LIMITS_CPU"
-	VirtV2vContainerLimitsMemory   = "VIRT_V2V_CONTAINER_LIMITS_MEMORY"
-	VirtV2vContainerRequestsCpu    = "VIRT_V2V_CONTAINER_REQUESTS_CPU"
-	VirtV2vContainerRequestsMemory = "VIRT_V2V_CONTAINER_REQUESTS_MEMORY"
-	HooksContainerLimitsCpu        = "HOOKS_CONTAINER_LIMITS_CPU"
-	HooksContainerLimitsMemory     = "HOOKS_CONTAINER_LIMITS_MEMORY"
-	HooksContainerRequestsCpu      = "HOOKS_CONTAINER_REQUESTS_CPU"
-	HooksContainerRequestsMemory   = "HOOKS_CONTAINER_REQUESTS_MEMORY"
-	OvaContainerLimitsCpu          = "OVA_CONTAINER_LIMITS_CPU"
-	OvaContainerLimitsMemory       = "OVA_CONTAINER_LIMITS_MEMORY"
-	OvaContainerRequestsCpu        = "OVA_CONTAINER_REQUESTS_CPU"
-	OvaContainerRequestsMemory     = "OVA_CONTAINER_REQUESTS_MEMORY"
-	TlsConnectionTimeout           = "TLS_CONNECTION_TIMEOUT"
-	MaxConcurrentReconciles        = "MAX_CONCURRENT_RECONCILES"
-	MaxParentBackingRetries        = "MAX_PARENT_BACKING_RETRIES"
+	MaxVmInFlight                    = "MAX_VM_INFLIGHT"
+	HookRetry                        = "HOOK_RETRY"
+	ImporterRetry                    = "IMPORTER_RETRY"
+	VirtV2vImage                     = "VIRT_V2V_IMAGE"
+	vddkImage                        = "VDDK_IMAGE"
+	PrecopyInterval                  = "PRECOPY_INTERVAL"
+	VirtV2vDontRequestKVM            = "VIRT_V2V_DONT_REQUEST_KVM"
+	SnapshotRemovalTimeout           = "SNAPSHOT_REMOVAL_TIMEOUT"
+	SnapshotStatusCheckRate          = "SNAPSHOT_STATUS_CHECK_RATE"
+	CDIExportTokenTTL                = "CDI_EXPORT_TOKEN_TTL"
+	FileSystemOverhead               = "FILESYSTEM_OVERHEAD"
+	BlockOverhead                    = "BLOCK_OVERHEAD"
+	CleanupRetries                   = "CLEANUP_RETRIES"
+	DvStatusCheckRetries             = "DV_STATUS_CHECK_RETRIES"
+	SnapshotRemovalCheckRetries      = "SNAPSHOT_REMOVAL_CHECK_RETRIES"
+	OvirtOsConfigMap                 = "OVIRT_OS_MAP"
+	VsphereOsConfigMap               = "VSPHERE_OS_MAP"
+	VirtCustomizeConfigMap           = "VIRT_CUSTOMIZE_MAP"
+	VddkJobActiveDeadline            = "VDDK_JOB_ACTIVE_DEADLINE"
+	VirtV2vExtraArgs                 = "VIRT_V2V_EXTRA_ARGS"
+	VirtV2vExtraConfConfigMap        = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
+	VirtV2vContainerLimitsCpu        = "VIRT_V2V_CONTAINER_LIMITS_CPU"
+	VirtV2vContainerLimitsMemory     = "VIRT_V2V_CONTAINER_LIMITS_MEMORY"
+	VirtV2vContainerRequestsCpu      = "VIRT_V2V_CONTAINER_REQUESTS_CPU"
+	VirtV2vContainerRequestsMemory   = "VIRT_V2V_CONTAINER_REQUESTS_MEMORY"
+	HooksContainerLimitsCpu          = "HOOKS_CONTAINER_LIMITS_CPU"
+	HooksContainerLimitsMemory       = "HOOKS_CONTAINER_LIMITS_MEMORY"
+	HooksContainerRequestsCpu        = "HOOKS_CONTAINER_REQUESTS_CPU"
+	HooksContainerRequestsMemory     = "HOOKS_CONTAINER_REQUESTS_MEMORY"
+	OvaContainerLimitsCpu            = "OVA_CONTAINER_LIMITS_CPU"
+	OvaContainerLimitsMemory         = "OVA_CONTAINER_LIMITS_MEMORY"
+	OvaContainerRequestsCpu          = "OVA_CONTAINER_REQUESTS_CPU"
+	OvaContainerRequestsMemory       = "OVA_CONTAINER_REQUESTS_MEMORY"
+	PopulatorContainerLimitsCpu      = "POPULATOR_CONTAINER_LIMITS_CPU"
+	PopulatorContainerLimitsMemory   = "POPULATOR_CONTAINER_LIMITS_MEMORY"
+	PopulatorContainerRequestsCpu    = "POPULATOR_CONTAINER_REQUESTS_CPU"
+	PopulatorContainerRequestsMemory = "POPULATOR_CONTAINER_REQUESTS_MEMORY"
+	TlsConnectionTimeout             = "TLS_CONNECTION_TIMEOUT"
+	MaxConcurrentReconciles          = "MAX_CONCURRENT_RECONCILES"
+	MaxParentBackingRetries          = "MAX_PARENT_BACKING_RETRIES"
+)
+
+// Default values for populator container resources
+var (
+	DefaultPopulatorContainerLimitsCpu      = resource.NewQuantity(1000, resource.DecimalSI)
+	DefaultPopulatorContainerLimitsMemory   = resource.NewQuantity(1024, resource.BinarySI)
+	DefaultPopulatorContainerRequestsCpu    = resource.NewQuantity(100, resource.DecimalSI)
+	DefaultPopulatorContainerRequestsMemory = resource.NewQuantity(512, resource.BinarySI)
 )
 
 // Migration settings
@@ -91,19 +103,23 @@ type Migration struct {
 	// Additional arguments for virt-v2v
 	VirtV2vExtraArgs string
 	// Additional configuration for virt-v2v
-	VirtV2vExtraConfConfigMap      string
-	VirtV2vContainerLimitsCpu      string
-	VirtV2vContainerLimitsMemory   string
-	VirtV2vContainerRequestsCpu    string
-	VirtV2vContainerRequestsMemory string
-	HooksContainerLimitsCpu        string
-	HooksContainerLimitsMemory     string
-	HooksContainerRequestsCpu      string
-	HooksContainerRequestsMemory   string
-	OvaContainerLimitsCpu          string
-	OvaContainerLimitsMemory       string
-	OvaContainerRequestsCpu        string
-	OvaContainerRequestsMemory     string
+	VirtV2vExtraConfConfigMap        string
+	VirtV2vContainerLimitsCpu        string
+	VirtV2vContainerLimitsMemory     string
+	VirtV2vContainerRequestsCpu      string
+	VirtV2vContainerRequestsMemory   string
+	HooksContainerLimitsCpu          string
+	HooksContainerLimitsMemory       string
+	HooksContainerRequestsCpu        string
+	HooksContainerRequestsMemory     string
+	OvaContainerLimitsCpu            string
+	OvaContainerLimitsMemory         string
+	OvaContainerRequestsCpu          string
+	OvaContainerRequestsMemory       string
+	PopulatorContainerLimitsCpu      resource.Quantity
+	PopulatorContainerLimitsMemory   resource.Quantity
+	PopulatorContainerRequestsCpu    resource.Quantity
+	PopulatorContainerRequestsMemory resource.Quantity
 	// VDDK image for guest conversion
 	VddkImage string
 	// TlsConnectionTimeout is the timeout for TLS connections in seconds
@@ -261,6 +277,38 @@ func (r *Migration) Load() (err error) {
 		r.OvaContainerRequestsMemory = val
 	} else {
 		r.OvaContainerRequestsMemory = "512Mi"
+	}
+	if val, found := os.LookupEnv(PopulatorContainerLimitsCpu); found {
+		r.PopulatorContainerLimitsCpu, err = resource.ParseQuantity(val)
+		if err != nil {
+			return fmt.Errorf("invalid Populator CPU limit %q: %w", val, err)
+		}
+	} else {
+		r.PopulatorContainerLimitsCpu = *DefaultPopulatorContainerLimitsCpu
+	}
+	if val, found := os.LookupEnv(PopulatorContainerLimitsMemory); found {
+		r.PopulatorContainerLimitsMemory, err = resource.ParseQuantity(val)
+		if err != nil {
+			return fmt.Errorf("invalid Populator memory limit %q: %w", val, err)
+		}
+	} else {
+		r.PopulatorContainerLimitsMemory = *DefaultPopulatorContainerLimitsMemory
+	}
+	if val, found := os.LookupEnv(PopulatorContainerRequestsCpu); found {
+		r.PopulatorContainerRequestsCpu, err = resource.ParseQuantity(val)
+		if err != nil {
+			return fmt.Errorf("invalid Populator CPU request %q: %w", val, err)
+		}
+	} else {
+		r.PopulatorContainerRequestsCpu = *DefaultPopulatorContainerRequestsCpu
+	}
+	if val, found := os.LookupEnv(PopulatorContainerRequestsMemory); found {
+		r.PopulatorContainerRequestsMemory, err = resource.ParseQuantity(val)
+		if err != nil {
+			return fmt.Errorf("invalid Populator memory request %q: %w", val, err)
+		}
+	} else {
+		r.PopulatorContainerRequestsMemory = *DefaultPopulatorContainerRequestsMemory
 	}
 	r.MaxConcurrentReconciles, err = getPositiveEnvLimit(MaxConcurrentReconciles, 10)
 	if err != nil {


### PR DESCRIPTION
Currently, the populator container created during the DiskAllocation phase is spun up without any Kubernetes resource requests or limits.

This poses two main problems:

Cluster Instability (Noisy Neighbor): An unbounded populator container can consume an excessive amount of CPU or memory, potentially starving other critical workloads on the same node and leading to instability.

No Quality of Service (QoS): Without requests, the populator pod gets a BestEffort QoS class, making it the first to be evicted under resource pressure. This can interrupt and delay disk operations (like VM migrations) unexpectedly.




Proposed Solution
Modify the populator container specification to include configurable resources definitions. This involves adding:

resources.requests (e.g., CPU, memory): To guarantee a minimum amount of resources for the populator to function reliably. This will likely move its QoS class to Burstable.

resources.limits (e.g., CPU, memory): To cap the maximum resources the populator can consume, preventing it from impacting other services.

These values should be made configurable to allow cluster administrators to tune them based on their specific node sizes and workloads.

Resolve: MTV-3837