### PR TITLE
MTV-3796 | Include VirtualPCNet32 NICs in inventory.

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -925,6 +925,8 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 							nic = &device.VirtualEthernetCard
 						case *types.VirtualVmxnet3:
 							nic = &device.VirtualEthernetCard
+						case *types.VirtualPCNet32:
+							nic = &device.VirtualEthernetCard
 						}
 
 						if nic != nil && nic.Backing != nil {


### PR DESCRIPTION
Issue: [MTV-3796](https://issues.redhat.com/browse/MTV-3796) VMware provider inventory does not include VirtualPCNet32 NICs that might be seen on older VMs.

Fix: Include VirtualPCNet32 NICs in the list of detected virtual network hardware.