### PR TITLE
MTV-3709 | Provide an option to customize the ephemeral storage used …

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -57,6 +57,28 @@ spec:
               archived:
                 description: Whether this plan should be archived.
                 type: boolean
+              conversionTempStorageClass:
+                description: |-
+                  ConversionTempStorageClass specifies the storage class to use for temporary conversion storage.
+                  When specified, virt-v2v conversion pods will use a temporary PVC from this storage class
+                  instead of using the node's ephemeral storage for the conversion scratch space.
+                  This is useful for:
+                    - Large VM migrations (10+ TB disks) where fstrim operations create large overlays
+                    - OVA imports that require full uncompressed disk copies in temporary storage
+                    - Nodes with limited ephemeral storage that may cause pod eviction due to storage pressure
+                  The temporary PVC is automatically created and deleted with the conversion pod.
+                type: string
+              conversionTempStorageSize:
+                description: |-
+                  ConversionTempStorageSize specifies the size of the temporary conversion storage PVC.
+                  Only used when ConversionTempStorageClass is specified.
+                  User specification allows for buffer space beyond the largest disk size to accommodate:
+                    - Temporary files during conversion
+                    - Multiple concurrent conversions
+                    - OVA imports requiring full uncompressed copies
+                  Recommended minimum: size of the largest VM disk being migrated.
+                  Format: standard Kubernetes resource quantity (e.g., "30Gi", "1Ti")
+                type: string
               convertorAffinity:
                 description: |-
                   ConvertorAffinity allows specifying hard- and soft-affinity for virt-v2v convertor pods.
@@ -1005,25 +1027,6 @@ spec:
                   See Pod NodeSelector documentation for more details,
                   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
                 type: object
-              convertorTempStorageClass:
-                description: |-
-                  ConvertorTempStorageClass specifies the storage class to use for temporary conversion storage.
-                  When specified, virt-v2v convertor pods will use a temporary PVC from this storage class
-                  instead of using the node's ephemeral storage for the conversion scratch space.
-                  This is useful for:
-                    - Large VM migrations (10+ TB disks) where fstrim operations create large overlays
-                    - OVA imports that require full uncompressed disk copies in temporary storage
-                    - Nodes with limited ephemeral storage that may cause pod eviction due to storage pressure
-                  The temporary PVC is automatically created and deleted with the convertor pod.
-                type: string
-              convertorTempStorageSize:
-                description: |-
-                  ConvertorTempStorageSize specifies the size of the temporary conversion storage PVC.
-                  Only used when ConvertorTempStorageClass is specified.
-                  Should be sized according to the largest disk in the migration plan.
-                  Recommended minimum: size of the largest VM disk being migrated.
-                  Format: standard Kubernetes resource quantity (e.g., "30Gi", "1Ti")
-                type: string
               deleteGuestConversionPod:
                 description: |-
                   DeleteGuestConversionPod determines if the guest conversion pod should be deleted after successful migration.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -94,23 +94,26 @@ type PlanSpec struct {
 	// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 	// +structType=atomic
 	ConvertorAffinity *core.Affinity `json:"convertorAffinity,omitempty"`
-	// ConvertorTempStorageClass specifies the storage class to use for temporary conversion storage.
-	// When specified, virt-v2v convertor pods will use a temporary PVC from this storage class
+	// ConversionTempStorageClass specifies the storage class to use for temporary conversion storage.
+	// When specified, virt-v2v conversion pods will use a temporary PVC from this storage class
 	// instead of using the node's ephemeral storage for the conversion scratch space.
 	// This is useful for:
 	//   - Large VM migrations (10+ TB disks) where fstrim operations create large overlays
 	//   - OVA imports that require full uncompressed disk copies in temporary storage
 	//   - Nodes with limited ephemeral storage that may cause pod eviction due to storage pressure
-	// The temporary PVC is automatically created and deleted with the convertor pod.
+	// The temporary PVC is automatically created and deleted with the conversion pod.
 	// +optional
-	ConvertorTempStorageClass string `json:"convertorTempStorageClass,omitempty"`
-	// ConvertorTempStorageSize specifies the size of the temporary conversion storage PVC.
-	// Only used when ConvertorTempStorageClass is specified.
-	// Should be sized according to the largest disk in the migration plan.
+	ConversionTempStorageClass string `json:"conversionTempStorageClass,omitempty"`
+	// ConversionTempStorageSize specifies the size of the temporary conversion storage PVC.
+	// Only used when ConversionTempStorageClass is specified.
+	// User specification allows for buffer space beyond the largest disk size to accommodate:
+	//   - Temporary files during conversion
+	//   - Multiple concurrent conversions
+	//   - OVA imports requiring full uncompressed copies
 	// Recommended minimum: size of the largest VM disk being migrated.
 	// Format: standard Kubernetes resource quantity (e.g., "30Gi", "1Ti")
 	// +optional
-	ConvertorTempStorageSize string `json:"convertorTempStorageSize,omitempty"`
+	ConversionTempStorageSize string `json:"conversionTempStorageSize,omitempty"`
 	// Providers.
 	Provider provider.Pair `json:"provider"`
 	// Resource mapping.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2099,10 +2099,12 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, vddk
 	})
 
 	// Add temporary conversion storage if configured
-	if r.Plan.Spec.ConvertorTempStorageClass != "" && r.Plan.Spec.ConvertorTempStorageSize != "" {
+	if r.Plan.Spec.ConversionTempStorageClass != "" && r.Plan.Spec.ConversionTempStorageSize != "" {
 		// Use Generic Ephemeral Volume for temporary conversion storage
 		// This creates a temporary PVC that is automatically deleted with the pod
-		storageClass := r.Plan.Spec.ConvertorTempStorageClass
+		storageClass := r.Plan.Spec.ConversionTempStorageClass
+		// VolumeMode must be Filesystem since we mount it at /var/tmp/virt-v2v for use as a filesystem.
+		// Without this, Kubernetes may default to block mode which cannot be mounted as a filesystem.
 		volumeMode := core.PersistentVolumeFilesystem
 		volumes = append(volumes, core.Volume{
 			Name: "conversion-temp-storage",
@@ -2117,7 +2119,7 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, vddk
 							VolumeMode:       &volumeMode,
 							Resources: core.VolumeResourceRequirements{
 								Requests: core.ResourceList{
-									core.ResourceStorage: resource.MustParse(r.Plan.Spec.ConvertorTempStorageSize),
+									core.ResourceStorage: resource.MustParse(r.Plan.Spec.ConversionTempStorageSize),
 								},
 							},
 						},

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -224,29 +224,29 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 		})
 	})
 
-	ginkgo.Describe("ConvertorTempStorage plan spec", func() {
-		ginkgo.It("should read ConvertorTempStorageClass and ConvertorTempStorageSize from plan spec", func() {
+	ginkgo.Describe("ConversionTempStorage plan spec", func() {
+		ginkgo.It("should read ConversionTempStorageClass and ConversionTempStorageSize from plan spec", func() {
 			plan := createPlanKubevirt(nil)
-			plan.Spec.ConvertorTempStorageClass = "fast-ssd"
-			plan.Spec.ConvertorTempStorageSize = "100Gi"
+			plan.Spec.ConversionTempStorageClass = "fast-ssd"
+			plan.Spec.ConversionTempStorageSize = "100Gi"
 
 			kubevirt := createKubeVirt()
 			kubevirt.Plan = plan
 
-			Expect(kubevirt.Plan.Spec.ConvertorTempStorageClass).To(Equal("fast-ssd"))
-			Expect(kubevirt.Plan.Spec.ConvertorTempStorageSize).To(Equal("100Gi"))
+			Expect(kubevirt.Plan.Spec.ConversionTempStorageClass).To(Equal("fast-ssd"))
+			Expect(kubevirt.Plan.Spec.ConversionTempStorageSize).To(Equal("100Gi"))
 		})
 
-		ginkgo.It("should handle empty ConvertorTempStorage fields", func() {
+		ginkgo.It("should handle empty ConversionTempStorage fields", func() {
 			plan := createPlanKubevirt(nil)
-			plan.Spec.ConvertorTempStorageClass = ""
-			plan.Spec.ConvertorTempStorageSize = ""
+			plan.Spec.ConversionTempStorageClass = ""
+			plan.Spec.ConversionTempStorageSize = ""
 
 			kubevirt := createKubeVirt()
 			kubevirt.Plan = plan
 
-			Expect(kubevirt.Plan.Spec.ConvertorTempStorageClass).To(Equal(""))
-			Expect(kubevirt.Plan.Spec.ConvertorTempStorageSize).To(Equal(""))
+			Expect(kubevirt.Plan.Spec.ConversionTempStorageClass).To(Equal(""))
+			Expect(kubevirt.Plan.Spec.ConversionTempStorageSize).To(Equal(""))
 		})
 	})
 

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -224,8 +224,8 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 		return err
 	}
 
-	// Validate convertor temp storage configuration
-	if err = r.validateConvertorTempStorage(plan); err != nil {
+	// Validate conversion temp storage configuration
+	if err = r.validateConversionTempStorage(plan); err != nil {
 		return err
 	}
 
@@ -1857,9 +1857,9 @@ func (r *Reconciler) IsValidTargetName(targetName string) error {
 	return nil
 }
 
-func (r *Reconciler) validateConvertorTempStorage(plan *api.Plan) error {
-	storageClass := plan.Spec.ConvertorTempStorageClass
-	storageSize := plan.Spec.ConvertorTempStorageSize
+func (r *Reconciler) validateConversionTempStorage(plan *api.Plan) error {
+	storageClass := plan.Spec.ConversionTempStorageClass
+	storageSize := plan.Spec.ConversionTempStorageSize
 
 	// If neither is set, that's fine
 	if storageClass == "" && storageSize == "" {
@@ -1868,29 +1868,29 @@ func (r *Reconciler) validateConvertorTempStorage(plan *api.Plan) error {
 
 	// If only one is set, that's an error
 	if storageClass == "" || storageSize == "" {
-		convertorTempStorageIncomplete := libcnd.Condition{
+		conversionTempStorageIncomplete := libcnd.Condition{
 			Type:     NotValid,
 			Status:   True,
 			Category: api.CategoryCritical,
-			Message:  "Both ConvertorTempStorageClass and ConvertorTempStorageSize must be specified together.",
+			Message:  "Both ConversionTempStorageClass and ConversionTempStorageSize must be specified together.",
 			Items:    []string{},
 		}
-		plan.Status.SetCondition(convertorTempStorageIncomplete)
+		plan.Status.SetCondition(conversionTempStorageIncomplete)
 		return nil
 	}
 
 	// Validate that storageSize is a valid Kubernetes resource quantity
 	_, err := resource.ParseQuantity(storageSize)
 	if err != nil {
-		convertorTempStorageSizeInvalid := libcnd.Condition{
+		conversionTempStorageSizeInvalid := libcnd.Condition{
 			Type:     NotValid,
 			Status:   True,
 			Category: api.CategoryCritical,
-			Message:  fmt.Sprintf("ConvertorTempStorageSize '%s' is not a valid Kubernetes resource quantity: %v", storageSize, err),
+			Message:  fmt.Sprintf("ConversionTempStorageSize '%s' is not a valid Kubernetes resource quantity: %v", storageSize, err),
 			Items:    []string{},
 		}
-		plan.Status.SetCondition(convertorTempStorageSizeInvalid)
-		r.Log.Info("Convertor temp storage size is invalid", "error", err.Error(), "size", storageSize, "plan", plan.Name, "namespace", plan.Namespace)
+		plan.Status.SetCondition(conversionTempStorageSizeInvalid)
+		r.Log.Info("Conversion temp storage size is invalid", "error", err.Error(), "size", storageSize, "plan", plan.Name, "namespace", plan.Namespace)
 		return nil
 	}
 

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -348,19 +348,19 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 		})
 	})
 
-	ginkgo.Describe("validateConvertorTempStorage", func() {
+	ginkgo.Describe("validateConversionTempStorage", func() {
 		ginkgo.It("should pass when both fields are set", func() {
 			secret := createSecret(sourceSecretName, sourceNamespace, false)
 			source := createProvider(sourceName, sourceNamespace, "https://source", api.OpenShift, &core.ObjectReference{Name: sourceSecretName, Namespace: sourceNamespace})
 			destination := createProvider(destName, destNamespace, "", api.OpenShift, &core.ObjectReference{})
 			plan := createPlan(testPlanName, testNamespace, source, destination)
-			plan.Spec.ConvertorTempStorageClass = "fast-ssd"
-			plan.Spec.ConvertorTempStorageSize = "50Gi"
+			plan.Spec.ConversionTempStorageClass = "fast-ssd"
+			plan.Spec.ConversionTempStorageSize = "50Gi"
 			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
-			err := reconciler.validateConvertorTempStorage(plan)
+			err := reconciler.validateConversionTempStorage(plan)
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(plan.Status.HasCondition(NotValid)).To(gomega.BeFalse())
@@ -375,7 +375,7 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
-			err := reconciler.validateConvertorTempStorage(plan)
+			err := reconciler.validateConversionTempStorage(plan)
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(plan.Status.HasCondition(NotValid)).To(gomega.BeFalse())
@@ -386,19 +386,19 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			source := createProvider(sourceName, sourceNamespace, "https://source", api.OpenShift, &core.ObjectReference{Name: sourceSecretName, Namespace: sourceNamespace})
 			destination := createProvider(destName, destNamespace, "", api.OpenShift, &core.ObjectReference{})
 			plan := createPlan(testPlanName, testNamespace, source, destination)
-			plan.Spec.ConvertorTempStorageClass = "fast-ssd"
-			plan.Spec.ConvertorTempStorageSize = ""
+			plan.Spec.ConversionTempStorageClass = "fast-ssd"
+			plan.Spec.ConversionTempStorageSize = ""
 			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
-			err := reconciler.validateConvertorTempStorage(plan)
+			err := reconciler.validateConversionTempStorage(plan)
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(plan.Status.HasCondition(NotValid)).To(gomega.BeTrue())
 			condition := plan.Status.FindCondition(NotValid)
 			gomega.Expect(condition).NotTo(gomega.BeNil())
-			gomega.Expect(condition.Message).To(gomega.ContainSubstring("Both ConvertorTempStorageClass and ConvertorTempStorageSize must be specified together"))
+			gomega.Expect(condition.Message).To(gomega.ContainSubstring("Both ConversionTempStorageClass and ConversionTempStorageSize must be specified together"))
 		})
 
 		ginkgo.It("should fail when only storage size is set", func() {
@@ -406,19 +406,19 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			source := createProvider(sourceName, sourceNamespace, "https://source", api.OpenShift, &core.ObjectReference{Name: sourceSecretName, Namespace: sourceNamespace})
 			destination := createProvider(destName, destNamespace, "", api.OpenShift, &core.ObjectReference{})
 			plan := createPlan(testPlanName, testNamespace, source, destination)
-			plan.Spec.ConvertorTempStorageClass = ""
-			plan.Spec.ConvertorTempStorageSize = "50Gi"
+			plan.Spec.ConversionTempStorageClass = ""
+			plan.Spec.ConversionTempStorageSize = "50Gi"
 			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
-			err := reconciler.validateConvertorTempStorage(plan)
+			err := reconciler.validateConversionTempStorage(plan)
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(plan.Status.HasCondition(NotValid)).To(gomega.BeTrue())
 			condition := plan.Status.FindCondition(NotValid)
 			gomega.Expect(condition).NotTo(gomega.BeNil())
-			gomega.Expect(condition.Message).To(gomega.ContainSubstring("Both ConvertorTempStorageClass and ConvertorTempStorageSize must be specified together"))
+			gomega.Expect(condition.Message).To(gomega.ContainSubstring("Both ConversionTempStorageClass and ConversionTempStorageSize must be specified together"))
 		})
 
 		ginkgo.It("should fail when storage size is invalid", func() {
@@ -426,13 +426,13 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			source := createProvider(sourceName, sourceNamespace, "https://source", api.OpenShift, &core.ObjectReference{Name: sourceSecretName, Namespace: sourceNamespace})
 			destination := createProvider(destName, destNamespace, "", api.OpenShift, &core.ObjectReference{})
 			plan := createPlan(testPlanName, testNamespace, source, destination)
-			plan.Spec.ConvertorTempStorageClass = "fast-ssd"
-			plan.Spec.ConvertorTempStorageSize = "invalid-size"
+			plan.Spec.ConversionTempStorageClass = "fast-ssd"
+			plan.Spec.ConversionTempStorageSize = "invalid-size"
 			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
-			err := reconciler.validateConvertorTempStorage(plan)
+			err := reconciler.validateConversionTempStorage(plan)
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(plan.Status.HasCondition(NotValid)).To(gomega.BeTrue())
@@ -451,11 +451,11 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			validSizes := []string{"50Gi", "1Ti", "100Mi", "500G", "2T"}
 			for _, size := range validSizes {
 				plan := createPlan(testPlanName, testNamespace, source, destination)
-				plan.Spec.ConvertorTempStorageClass = "fast-ssd"
-				plan.Spec.ConvertorTempStorageSize = size
+				plan.Spec.ConversionTempStorageClass = "fast-ssd"
+				plan.Spec.ConversionTempStorageSize = size
 
 				reconciler = createFakeReconciler(secret, plan, source, destination)
-				err := reconciler.validateConvertorTempStorage(plan)
+				err := reconciler.validateConversionTempStorage(plan)
 
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Size %s should be valid", size)
 				gomega.Expect(plan.Status.HasCondition(NotValid)).To(gomega.BeFalse(), "Size %s should not cause validation error", size)


### PR DESCRIPTION
https://issues.redhat.com/browse/MTV-3709

This commit adds support for configuring custom ephemeral storage for virt-v2v conversion pods, preventing pod eviction due to storage pressure on nodes with limited ephemeral storage.

Changes:
- Added ConvertorTempStorageClass field to PlanSpec for specifying the storage class to use for temporary conversion storage
- Added ConvertorTempStorageSize field to PlanSpec for specifying the size of the temporary storage PVC (e.g., "30Gi", "1Ti")
- Implemented Generic Ephemeral Volume support in virt-v2v pod creation that automatically provisions and cleans up temporary PVCs
- Added volume mount at /var/tmp/virt-v2v for the temporary storage
- Set TMPDIR environment variable to direct virt-v2v to use the custom scratch directory
- Added validation to ensure both ConvertorTempStorageClass and ConvertorTempStorageSize are specified together
- Added validation to ensure ConvertorTempStorageSize is a valid Kubernetes resource quantity
- Added proper error messages via Plan conditions when validation fails

Use Cases:
- Large VM migrations (10+ TB disks) where fstrim operations create large overlays
- OVA imports that require full uncompressed disk copies in temporary storage
- Nodes with limited ephemeral storage that may cause pod eviction

Implementation Details:
- Uses Kubernetes Generic Ephemeral Volumes for automatic PVC lifecycle management
- Temporary PVC is created when the conversion pod starts and deleted when it completes
- Backward compatible: existing plans without these fields continue to use node ephemeral storage
- Follows existing convertor configuration patterns (ConvertorLabels, ConvertorNodeSelector, ConvertorAffinity)

Resolves: MTV-3709