### PR TITLE
MTV-3654 | OVA: Use ResourceType to identify devices

### DIFF
--- a/cmd/ova-provider-server/ova/ova.go
+++ b/cmd/ova-provider-server/ova/ova.go
@@ -111,7 +111,7 @@ type Item struct {
 	Description     string          `xml:"Description,omitempty"`
 	ElementName     string          `xml:"ElementName"`
 	InstanceID      string          `xml:"InstanceID"`
-	ResourceType    string          `xml:"ResourceType"`
+	ResourceType    int             `xml:"ResourceType"`
 	VirtualQuantity int32           `xml:"VirtualQuantity"`
 	Address         string          `xml:"Address,omitempty"`
 	ResourceSubType string          `xml:"ResourceSubType,omitempty"`


### PR DESCRIPTION
The OVA scanner was looking at the display name of devices in order to identify NICs and other device types. This is incorrect and fragile, since there's no guarantee that devices have a regular or meaningful display name.

The OVF specification provides for devices to have a resource type which is used to identify the kind of device and its parameters. This change set uses the resource type to identify devices instead of display name.

Resolves: MTV-3654 | No interface related settings in VM yaml file after migrating VM from ova file to OCP cluster
Ref: https://issues.redhat.com/browse/MTV-3654