### PR TITLE
Enable descheduler evictions for migrated VMs

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1028,6 +1028,18 @@ spec:
               diskBus:
                 description: 'Deprecated: this field will be deprecated in 2.8.'
                 type: string
+              enableDescheduler:
+                description: |-
+                  EnableDescheduler controls whether to enable the descheduler for migrated VMs.
+                  When enabled, the descheduler.alpha.kubernetes.io/evict annotation is added to the VirtualMachine,
+                  allowing the OpenShift descheduler to rebalance VM workloads across the cluster.
+                  This is similar to VMware DRS (Distributed Resource Scheduler) functionality.
+                  For VMware source VMs:
+                    - If the source VM had DRS enabled in VMware, this will be automatically set to true
+                    - Otherwise it will be set to false unless explicitly overridden in the Plan
+                  For other source providers:
+                    - Defaults to false unless explicitly set to true in the Plan
+                type: boolean
               installLegacyDrivers:
                 description: |-
                   InstallLegacyDrivers determines whether to install legacy windows drivers in the VM.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -233,6 +233,17 @@ type PlanSpec struct {
 	// - false: No inspection is performed before disk transfer.
 	// +kubebuilder:default:=true
 	RunPreflightInspection bool `json:"runPreflightInspection,omitempty"`
+	// EnableDescheduler controls whether to enable the descheduler for migrated VMs.
+	// When enabled, the descheduler.alpha.kubernetes.io/evict annotation is added to the VirtualMachine,
+	// allowing the OpenShift descheduler to rebalance VM workloads across the cluster.
+	// This is similar to VMware DRS (Distributed Resource Scheduler) functionality.
+	// For VMware source VMs:
+	//   - If the source VM had DRS enabled in VMware, this will be automatically set to true
+	//   - Otherwise it will be set to false unless explicitly overridden in the Plan
+	// For other source providers:
+	//   - Defaults to false unless explicitly set to true in the Plan
+	// +optional
+	EnableDescheduler bool `json:"enableDescheduler,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -151,6 +151,7 @@ const (
 	fToolsRunningStatus = "guest.toolsRunningStatus"
 	// fToolsVersionStatus is deprecated since vSphere API 5.1; use fToolsVersionStatus2 for more detailed status
 	fToolsVersionStatus = "guest.toolsVersionStatus2"
+	fDRSBehavior        = "config.drsConfig.defaultVmBehavior"
 )
 
 // Selections
@@ -850,6 +851,7 @@ func (r *Collector) vmPathSet() []string {
 		fToolsStatus,
 		fToolsRunningStatus,
 		fToolsVersionStatus,
+		fDRSBehavior,
 	}
 
 	apiVer := strings.Split(r.client.ServiceContent.About.ApiVersion, ".")

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -815,6 +815,12 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if b, cast := p.Val.(bool); cast {
 					v.model.NestedHVEnabled = b
 				}
+			case fDRSBehavior:
+				// DRS defaultVmBehavior can be: manual, partiallyAutomated, fullyAutomated
+				// We consider DRS enabled if it's partiallyAutomated or fullyAutomated
+				if s, cast := p.Val.(string); cast {
+					v.model.DRSEnabled = (s == "partiallyAutomated" || s == "fullyAutomated")
+				}
 			case fGuestDisk:
 				if disks, cast := p.Val.(types.ArrayOfGuestDiskInfo); cast {
 					var diskMountPoints []model.DiskMountPoint

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -331,6 +331,7 @@ type VM struct {
 	ToolsVersionStatus       string           `sql:""`
 	DiskEnableUuid           bool             `sql:""`
 	NestedHVEnabled          bool             `sql:""`
+	DRSEnabled               bool             `sql:""`
 }
 
 // Determine if current revision has been validated.

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -256,6 +256,7 @@ type VM struct {
 	ToolsVersionStatus string `json:"toolsVersionStatus2"`
 	DiskEnableUuid     bool   `json:"diskEnableUuid"`
 	NestedHVEnabled    bool   `json:"nestedHVEnabled"`
+	DRSEnabled         bool   `json:"drsEnabled"`
 }
 
 // Build the resource using the model.
@@ -295,6 +296,7 @@ func (r *VM) With(m *model.VM) {
 	r.ToolsVersionStatus = m.ToolsVersionStatus
 	r.DiskEnableUuid = m.DiskEnableUuid
 	r.NestedHVEnabled = m.NestedHVEnabled
+	r.DRSEnabled = m.DRSEnabled
 }
 
 // Build self link (URI).


### PR DESCRIPTION
Add support for enabling OpenShift descheduler for migrated VMs, providing similar functionality to VMware DRS (Distributed Resource Scheduler).

Changes:
- Added EnableDescheduler field to PlanSpec to control descheduler annotation
- Added DRSEnabled field to VMware VM model to track source DRS status
- Added fDRSBehavior property collection to VMware inventory collector
- Added logic to detect DRS status (partiallyAutomated or fullyAutomated) during inventory collection
- Added descheduler.alpha.kubernetes.io/evict annotation to VirtualMachine spec when enabled
- Automatically enable descheduler for VMware VMs that had DRS enabled in the source

Behavior:
- For VMware source VMs: automatically enable if DRS was enabled in VMware
- For other providers or manual override: use Plan.Spec.EnableDescheduler setting
- When enabled, adds descheduler.alpha.kubernetes.io/evict: "true" annotation to allow VM rebalancing

Benefits:
- Seamless transition from VMware DRS to OpenShift descheduler
- Enables workload rebalancing across OpenShift cluster
- Familiar DRS-like functionality for customers migrating from VMware