### PR TITLE
MTV-3659 | OVA: Use build/ensure pattern for virt-v2v NFS mounts

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -3044,7 +3044,7 @@ func GetOvaPvcListNfs(dClient client.Client, planID string, planNamespace string
 
 func (r *KubeVirt) EnsurePVForNFS(pv *core.PersistentVolume) (out *core.PersistentVolume, err error) {
 	list := &core.PersistentVolumeList{}
-	err = r.Destination.List(
+	err = r.Destination.Client.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -3058,7 +3058,7 @@ func (r *KubeVirt) EnsurePVForNFS(pv *core.PersistentVolume) (out *core.Persiste
 	if len(list.Items) > 0 {
 		out = &list.Items[0]
 	} else {
-		err = r.Destination.Create(context.TODO(), pv)
+		err = r.Destination.Client.Create(context.TODO(), pv)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -3101,11 +3101,12 @@ func (r *KubeVirt) BuildPVForNFS(vm *plan.VMStatus) (pv *core.PersistentVolume) 
 
 func (r *KubeVirt) EnsurePVCForNFS(pvc *core.PersistentVolumeClaim) (out *core.PersistentVolumeClaim, err error) {
 	list := &core.PersistentVolumeClaimList{}
-	err = r.Destination.List(
+	err = r.Destination.Client.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(pvc.Labels),
+			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
 	if err != nil {
@@ -3115,7 +3116,7 @@ func (r *KubeVirt) EnsurePVCForNFS(pvc *core.PersistentVolumeClaim) (out *core.P
 	if len(list.Items) > 0 {
 		out = &list.Items[0]
 	} else {
-		err = r.Destination.Create(context.TODO(), pvc)
+		err = r.Destination.Client.Create(context.TODO(), pvc)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return


### PR DESCRIPTION
The code that creates the NFS volumes for virt-v2v pods for OVA imports was not checking whether or not the volumes already existed before creating them. This was causing dozens of "ova-store-*" PVs and PVCs to be created for migrations. This changeset fixes the immediate problem by using the build/ensure pattern (with corrected labels) to only create the resources once.

As an aside, the code that creates the NFS mounts for the virt-v2v pods for OVA imports is buried in `podVolumeMounts` which is called from `getVirtV2vPod`. It is surprising for a function that should just be building a pod spec to have side effects on the cluster. This should be factored out when the opportunity arises.

Resolves: MTV-3659 | To many bounded "ova-store-pvc-*" PVCs left after migrating VM from ova file to OCP cluster
Ref: https://issues.redhat.com/browse/MTV-3659