### PR TITLE
MTV-3634 | OVA: Check for write perm before starting to read

### DIFF
--- a/cmd/ova-provider-server/api/base.go
+++ b/cmd/ova-provider-server/api/base.go
@@ -30,11 +30,13 @@ func ErrorHandler() gin.HandlerFunc {
 			return
 		}
 		err := ctx.Errors.Last()
-		if errors.Is(err.Err, &BadRequestError{}) {
+		badRequest := &BadRequestError{}
+		if errors.As(err, &badRequest) {
 			ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		if errors.Is(err.Err, &ConflictError{}) {
+		conflict := &ConflictError{}
+		if errors.As(err, &conflict) {
 			ctx.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 			return
 		}


### PR DESCRIPTION
Check to see if the destination is writable before beginning to read the request body so that this
class of errors can be caught quickly.

Also fixes error type comparisons in the error handler.

Resolves: MTV-3634 | Check the write permission earlier when upload local ova file to ova provider
Ref: https://issues.redhat.com/browse/MTV-3634