### PR TITLE
MTV-3834 | ARM64: Support multi arch OPA downloads, upstream only

### DIFF
--- a/build/validation/Containerfile
+++ b/build/validation/Containerfile
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
-RUN curl -L https://github.com/open-policy-agent/opa/releases/download/v1.8.0/opa_linux_amd64 > /usr/bin/opa
+ARG TARGETARCH=amd64
+RUN curl -L https://github.com/open-policy-agent/opa/releases/download/v1.8.0/opa_linux_${TARGETARCH}_static > /usr/bin/opa
 RUN chmod +x /usr/bin/opa
 COPY validation/policies /usr/share/opa/policies/
 COPY validation/entrypoint.sh /usr/bin/


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-3834

Issue:
Upstream build of validation container image download pre build binaries, hardcoded to amd64

Fix:
Use env var to control the OPA download image, default to amd64 in case no var is used