### PR TITLE
MTV-3624 | Improve authentication error logging for Ontap and PowerStore

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/ontap/ontap.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/ontap/ontap.go
@@ -69,7 +69,7 @@ func NewNetappClonner(hostname, username, password string) (NetappClonner, error
 	client, err := api.NewRestClientFromOntapConfig(context.TODO(), &config)
 	if err != nil {
 		klog.V(2).Infof("ONTAP client initialization error details: %v", err)
-		return NetappClonner{}, fmt.Errorf("please recheck storage password or SVM name in the storage secret.")
+		return NetappClonner{}, fmt.Errorf("failed to initialize ONTAP client (common causes: incorrect password, invalid SVM name, network connectivity): %w", err)
 	}
 
 	nc := NetappClonner{api: client}

--- a/cmd/vsphere-xcopy-volume-populator/internal/powerstore/powerstore.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/powerstore/powerstore.go
@@ -329,5 +329,11 @@ func NewPowerstoreClonner(hostname, username, password string, sslSkipVerify boo
 		return PowerstoreClonner{}, fmt.Errorf("failed to create PowerStore client: %w", err)
 	}
 
+	ctx := context.Background()
+	_, err = client.GetCluster(ctx)
+	if err != nil {
+		return PowerstoreClonner{}, fmt.Errorf("failed to authenticate with PowerStore backend %s: %w", hostname, err)
+	}
+
 	return PowerstoreClonner{Client: client}, nil
 }


### PR DESCRIPTION
## Description
This PR improves the error handling logic for Ontap and PowerStore integrations.

## Motivation
Previously, if a user provided an incorrect SVM or invalid credentials in the backend secret, the resulting error message was generic or misleading. This made it difficult to identify the root cause (authentication vs. network vs. other issues).


The logs will now clearly indicate if the failure is due to authentication/configuration issues.

Resolves: MTV-3624