### PR TITLE
chore(deps): Update CDI version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	kubevirt.io/api v1.6.0-beta.0.0.20250702170314-dd941825f5d3
-	kubevirt.io/containerized-data-importer-api v1.60.3-0.20241105012228-50fbed985de9
+	kubevirt.io/containerized-data-importer-api v1.63.1-0.20251115214221-0b4e9b5c9c59
 	libvirt.org/go/libvirt v1.10009.1
 	libvirt.org/go/libvirtxml v1.11009.0
 	modernc.org/sqlite v1.39.1

--- a/go.sum
+++ b/go.sum
@@ -856,8 +856,8 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 kubevirt.io/api v1.6.0-beta.0.0.20250702170314-dd941825f5d3 h1:7DeToiNAgDlkShV0XOVUSTW+yc5FHfumuE9qSXN6Luk=
 kubevirt.io/api v1.6.0-beta.0.0.20250702170314-dd941825f5d3/go.mod h1:NU90RB72PMMTfN6jN5ca1HLyBqW7aj6RypJlF9QYNhc=
-kubevirt.io/containerized-data-importer-api v1.60.3-0.20241105012228-50fbed985de9 h1:KTb8wO1Lxj220DX7d2Rdo9xovvlyWWNo3AVm2ua+1nY=
-kubevirt.io/containerized-data-importer-api v1.60.3-0.20241105012228-50fbed985de9/go.mod h1:SDJjLGhbPyayDqAqawcGmVNapBp0KodOQvhKPLVGCQU=
+kubevirt.io/containerized-data-importer-api v1.63.1-0.20251115214221-0b4e9b5c9c59 h1:dEVxWfRRNzrUzQKYjKQ9Olv2zAdnD+8hz5Y11vKvq88=
+kubevirt.io/containerized-data-importer-api v1.63.1-0.20251115214221-0b4e9b5c9c59/go.mod h1:VGp35wxpLXU18b7cnEpmcThI3AjcZUSfg/Zfql44U4o=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 h1:QMrd0nKP0BGbnxTqakhDZAUhGKxPiPiN5gSDqKUmGGc=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 libvirt.org/go/libvirt v1.10009.1 h1:Z79EnxEVE190MeULGoq1GY0tb+O18FpYzUNYDHgkrN8=

--- a/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/register.go
+++ b/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/register.go
@@ -8,8 +8,11 @@ import (
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core"
 )
 
-// SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: core.GroupName, Version: "v1beta1"}
+// SchemeGroupVersion and GroupVersion is group version used to register these objects
+var (
+	SchemeGroupVersion = schema.GroupVersion{Group: core.GroupName, Version: "v1beta1"}
+	GroupVersion       = schema.GroupVersion{Group: core.GroupName, Version: "v1beta1"}
+)
 
 // CDIGroupVersionKind group version kind
 var CDIGroupVersionKind = schema.GroupVersionKind{Group: SchemeGroupVersion.Group, Version: SchemeGroupVersion.Version, Kind: "CDI"}

--- a/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -596,6 +596,10 @@ type DataImportCronSpec struct {
 	// RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RatainAll.
 	// +optional
 	RetentionPolicy *DataImportCronRetentionPolicy `json:"retentionPolicy,omitempty"`
+	// CreatedBy is the JSON-marshaled UserInfo of the user who created this DataImportCron.
+	// This field is set by the mutating webhook and cannot be set by users.
+	// +optional
+	CreatedBy *string `json:"createdBy,omitempty"`
 }
 
 // DataImportCronGarbageCollect represents the DataImportCron garbage collection mode

--- a/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -295,6 +295,7 @@ func (DataImportCronSpec) SwaggerDoc() map[string]string {
 		"importsToKeep":     "Number of import PVCs to keep when garbage collecting. Default is 3.\n+optional",
 		"managedDataSource": "ManagedDataSource specifies the name of the corresponding DataSource this cron will manage.\nDataSource has to be in the same namespace.",
 		"retentionPolicy":   "RetentionPolicy specifies whether the created DataVolumes and DataSources are retained when their DataImportCron is deleted. Default is RatainAll.\n+optional",
+		"createdBy":         "CreatedBy is the JSON-marshaled UserInfo of the user who created this DataImportCron.\nThis field is set by the mutating webhook and cannot be set by users.\n+optional",
 	}
 }
 

--- a/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -621,6 +621,11 @@ func (in *DataImportCronSpec) DeepCopyInto(out *DataImportCronSpec) {
 		*out = new(DataImportCronRetentionPolicy)
 		**out = **in
 	}
+	if in.CreatedBy != nil {
+		in, out := &in.CreatedBy, &out.CreatedBy
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1180,8 +1180,8 @@ kubevirt.io/api/export
 kubevirt.io/api/export/v1alpha1
 kubevirt.io/api/instancetype
 kubevirt.io/api/instancetype/v1beta1
-# kubevirt.io/containerized-data-importer-api v1.60.3-0.20241105012228-50fbed985de9
-## explicit; go 1.22.0
+# kubevirt.io/containerized-data-importer-api v1.63.1-0.20251115214221-0b4e9b5c9c59
+## explicit; go 1.23.0
 kubevirt.io/containerized-data-importer-api/pkg/apis/core
 kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1
 # kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90


### PR DESCRIPTION
Issue:
in ovirt builder
https://github.com/yaacov/forklift/blob/main/pkg/controller/plan/adapter/ovirt/builder.go#L226

we use a field `imageioSource.InsecureSkipVerify` only available on `kubevirt.io/containerized-data-importer-api v1.63.1`
but we forgot to update the go.mod file

Fix:
update the go.mod file to use the matching version.

Ref:
https://github.com/kubev2v/forklift/pull/3489