### PR TITLE
MTV-3834 | ARM64: fix makefile target opa-bin for none x86 machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -616,13 +616,8 @@ mockgen-install:
 
 opa-bin:
 ifeq (, $(shell command -v opa))
-	@{ \
-	set -e ;\
-	mkdir -p ${HOME}/.local/bin ; \
-	curl -sL -o ${HOME}/.local/bin/opa https://openpolicyagent.org/downloads/v0.65.0/opa_linux_amd64_static ; \
-	chmod 755 ${HOME}/.local/bin/opa ;\
-	}
-OPA=${HOME}/.local/bin/opa
+	GOBIN=$(GOBIN) go install github.com/open-policy-agent/opa@v1.8.0
+OPA=$(GOBIN)/opa
 else
 OPA=$(shell which opa)
 endif


### PR DESCRIPTION
Issue:
Running `make opa-bin` on none x86 machine will install the wrong binaries.

Fix:
  - Use go lang automatic platform detection to install the correct binaries on any platform.
  - Update OPA version from v0.65.0 to v1.8.0 to match build version