### PR TITLE
MTV-3645 | RFE: Allow setting transfer network to the forklift controller pod

### DIFF
--- a/hack/validate_forklift_controller_crd.py
+++ b/hack/validate_forklift_controller_crd.py
@@ -195,6 +195,7 @@ def validate_forklift_controller_crd(crd_file, tasks_file):
     # Properties that are allowed to be in CRD even if not directly used in tasks
     # These are valid CRD fields that may be used indirectly or are configuration values
     allowed_crd_only_properties = {
+        'controller_transfer_network',
         'inventory_route_timeout',
         'metric_interval',
         'ova_proxy_route_timeout',

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -155,6 +155,10 @@ spec:
                 type: string
                 description: "Controller memory request (default: 350Mi)"
                 example: "500Mi"
+              controller_transfer_network:
+                type: string
+                description: "Optional NAD name for controller pod transfer network (format: 'namespace/network-name')"
+                example: "openshift-mtv/transfer-network"
 
               # Inventory Resource Configuration
               inventory_container_limits_cpu:

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -24,6 +24,11 @@ spec:
         prometheus.forklift.konveyor.io: "true" 
       annotations:
         configHash: "{{ (inventory_volume_path | string) }}"
+{% if controller_transfer_network is defined %}
+        k8s.v1.cni.cncf.io/networks: "{{ controller_transfer_network }}"
+{% else %}
+        k8s.v1.cni.cncf.io/networks: null
+{% endif %}
     spec:
       serviceAccountName: {{ controller_service_name }}
       containers:


### PR DESCRIPTION
Issue:
Currently, MTV allows setting transfer network in the provider and plan, which adds secondary network to importer and populator pods using the k8s.v1.cni.cncf.io/networks annotation. However, when the OCP default node network lacks connectivity to VMware/RHV providers, customers cannot add providers directly since the forklift controller cannot contact them. The current workaround requires cluster-wide changes (IP on second interface + routingViaHost), which is not ideal.

Fix:
Add controller_transfer_network field to ForkliftController CRD to allow customers to assign a secondary network to the forklift controller pod, similar to how it's assigned to importer/populator pods. This enables connectivity to providers via transfer network without cluster-wide changes.

Ref: https://issues.redhat.com/browse/MTV-3645