### PR TITLE
[release-2.10] MTV-3613 | Add Req for provider validation

### DIFF
--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -267,6 +267,8 @@ func (r *Reconciler) validateSecret(provider *api.Provider) (secret *core.Secret
 				Category: Critical,
 				Message:  err.Error(),
 			})
+			err = nil
+			//nolint:nilerr
 			return
 		}
 		provider.Status.Fingerprint = util.Fingerprint(crt)


### PR DESCRIPTION
Resolves: MTV-3613

Issue: When the validation fails we don't req. Additionally I noticed that we have update of the CR at two places so I moved it to one defer same as we have in plan controller.