### PR TITLE
MTV-1370 | Fix recording rule name for telemetry

### DIFF
--- a/operator/roles/forkliftcontroller/templates/monitor/recordingrole-migrations.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/monitor/recordingrole-migrations.yml.j2
@@ -8,7 +8,7 @@ spec:
   groups:
   - name: mtv-migrations
     rules:
-    - record: cluster:mtv_migrations_status_total:max
+    - record: cluster:mtv_migrations_status_total:sum
       expr: max by(status, provider, mode, target) (mtv_migrations_status_total)
       labels:
         app: {{ app_name }}


### PR DESCRIPTION
We had to rename the exposed metric because of possible confusion naming in CMO.