### PR TITLE
MTV-3935 | copy-offload: Refactor device detachment

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/Makefile
@@ -54,7 +54,7 @@ install-mockgen:
 test-copy-using-cli: build
 	bin/vsphere-xcopy-volume-populator \
 		--source-vm-id=vm-100838 \
-		--source-vmdk="[eco-iscsi-ds3] vm-1-1-test-rename/vm-1-1-test-rename_2.vmdk" \
+		--source-vmdk="[eco-iscsi-ds2] rgolan-vm-1/rgolan-vm-1.vmdk" \
 		--owner-name=test-cli \
 		--target-namespace=default \
 		--storage-vendor-product=ontap \

--- a/cmd/vsphere-xcopy-volume-populator/internal/fcutil/fcutil.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/fcutil/fcutil.go
@@ -10,8 +10,9 @@ import (
 // and returns the WWNN and WWPN separately (unformatted hex strings).
 //
 // Example:
-//   input: "fc.2000000000000001:2100000000000001"
-//   output: wwnn="2000000000000001", wwpn="2100000000000001", err=nil
+//
+//	input: "fc.2000000000000001:2100000000000001"
+//	output: wwnn="2000000000000001", wwpn="2100000000000001", err=nil
 //
 // The returned WWNN and WWPN are uppercase hex strings without formatting.
 func ParseFCAdapter(fcID string) (wwnn, wwpn string, err error) {
@@ -55,8 +56,9 @@ func ParseFCAdapter(fcID string) (wwnn, wwpn string, err error) {
 // FormatWWNWithColons formats a WWN hex string by inserting colons every 2 characters.
 //
 // Example:
-//   input: "2100000000000001"
-//   output: "21:00:00:00:00:00:00:01"
+//
+//	input: "2100000000000001"
+//	output: "21:00:00:00:00:00:00:01"
 //
 // The input should be an uppercase hex string with even length.
 // If the input has odd length, the last character will be in its own segment.
@@ -80,12 +82,14 @@ func FormatWWNWithColons(wwn string) string {
 // This is useful for comparing WWNs from different sources that may use different formatting.
 //
 // Example:
-//   input: "21:00:00:00:00:00:00:01"
-//   output: "2100000000000001"
+//
+//	input: "21:00:00:00:00:00:00:01"
+//	output: "2100000000000001"
 //
 // Example:
-//   input: "21-00-00-00-00-00-00-01"
-//   output: "2100000000000001"
+//
+//	input: "21-00-00-00-00-00-00-01"
+//	output: "2100000000000001"
 func NormalizeWWN(wwn string) string {
 	cleaned := strings.ReplaceAll(wwn, ":", "")
 	cleaned = strings.ReplaceAll(cleaned, "-", "")
@@ -99,8 +103,9 @@ func NormalizeWWN(wwn string) string {
 // This is the most common operation needed by storage backends.
 //
 // Example:
-//   input: "fc.2000000000000001:2100000000000001"
-//   output: "21:00:00:00:00:00:00:01"
+//
+//	input: "fc.2000000000000001:2100000000000001"
+//	output: "21:00:00:00:00:00:00:01"
 func ExtractAndFormatWWPN(fcID string) (string, error) {
 	_, wwpn, err := ParseFCAdapter(fcID)
 	if err != nil {
@@ -112,8 +117,9 @@ func ExtractAndFormatWWPN(fcID string) (string, error) {
 // ExtractWWPN extracts the WWPN from an ESX FC adapter ID without formatting.
 //
 // Example:
-//   input: "fc.2000000000000001:2100000000000001"
-//   output: "2100000000000001"
+//
+//	input: "fc.2000000000000001:2100000000000001"
+//	output: "2100000000000001"
 func ExtractWWPN(fcID string) (string, error) {
 	_, wwpn, err := ParseFCAdapter(fcID)
 	return wwpn, err
@@ -123,8 +129,9 @@ func ExtractWWPN(fcID string) (string, error) {
 // Returns true if the WWNs are equivalent.
 //
 // Example:
-//   CompareWWNs("21:00:00:00:00:00:00:01", "2100000000000001") // returns true
-//   CompareWWNs("21-00-00-00-00-00-00-01", "21:00:00:00:00:00:00:01") // returns true
+//
+//	CompareWWNs("21:00:00:00:00:00:00:01", "2100000000000001") // returns true
+//	CompareWWNs("21-00-00-00-00-00-00-01", "21:00:00:00:00:00:00:01") // returns true
 func CompareWWNs(wwn1, wwn2 string) bool {
 	return NormalizeWWN(wwn1) == NormalizeWWN(wwn2)
 }

--- a/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
@@ -141,6 +141,9 @@ var _ = Describe("Populator", func() {
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"vmkfstools", "taskGet", "-i", "1"}).
 					Return([]esx.Values{{"message": {`{"exitCode": "0"}`}}}, nil)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"vmkfstools", "taskClean", "-i", "1"}).Return(nil, nil)
+				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "set", "--state", "off", "-d", "naa.616263"}).Return(nil, nil)
+				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "list", "-d", "naa.616263"}).Return([]esx.Values{map[string][]string{"Status": []string{"off"}}}, nil)
+				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "detached", "remove", "-d", "naa.616263"}).Return(nil, nil)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "adapter", "rescan", "-t", "delete", "-A", "vmhbatest"}).Return(nil, nil)
 			},
 			want: nil,


### PR DESCRIPTION
Resolves: MTV-3935

MOTIVATION
When the populator is done with a LUN is unmaps it , which disconnect it from
ESX, and then rescan to remove dead devices. In some cases the rescan fails
and devices stays dead and then end in status off in the detached list.
If a restart to the pod is happening to restart the copy or the same volume is
used again then the code will show the device is recognized by the
ESX kernel (esxcli core device list -d <naa>) and we won't rescan.
If the device if status 'off' then the vmkfstools will fail,
bacause in status 'off' there is no i/o allowed. It will look in the log that
the device is found, and then the populator continues to the clone,
and then it fails.

MODIFICATION
First the cleanup should be rearranged to:
1. set the state of the device to off. then there is no more i/o; and device
goes to detached list
2. remove the device from the detached
list - esxcli storage core device detached remove -d <naa>
3. unmap - terminates the connection of the array to ESX
4. rescan to delete dead devices

Auto fixing if dead device found:
When we want to connect a device, don't continue to vmkfstools clone if the device is there.
Check if the status is 'off' . If yes then remove it from the detached list (esxcli core devices detached remove -d <naa>) and then rescan to add new devices. With that it will be in status on.

Signed-off-by: Roy Golan <rgolan@redhat.com>
