### PR TITLE
MTV-3966 | copy-offload: Try FC before iSCSI when mapping

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/pure/flashArray.go
@@ -53,12 +53,6 @@ func (f *FlashArrayClonner) EnsureClonnerIgroup(initiatorGroup string, esxAdapte
 	}
 	for _, h := range hosts {
 		klog.Infof("checking host %s, iqns: %v, wwns: %v", h.Name, h.Iqn, h.Wwn)
-		for _, iqn := range h.Iqn {
-			if slices.Contains(esxAdapters, iqn) {
-				klog.Infof("adding host to group %v", h.Name)
-				return populator.MappingContext{"hosts": []string{h.Name}}, nil
-			}
-		}
 		for _, wwn := range h.Wwn {
 			for _, hostAdapter := range esxAdapters {
 				if !strings.HasPrefix(hostAdapter, "fc.") {
@@ -78,6 +72,13 @@ func (f *FlashArrayClonner) EnsureClonnerIgroup(initiatorGroup string, esxAdapte
 				}
 			}
 		}
+		for _, iqn := range h.Iqn {
+			if slices.Contains(esxAdapters, iqn) {
+				klog.Infof("adding host to group %v", h.Name)
+				return populator.MappingContext{"hosts": []string{h.Name}}, nil
+			}
+		}
+
 	}
 	return nil, fmt.Errorf("no hosts found matching any of the provided IQNs/FC adapters: %v", esxAdapters)
 }


### PR DESCRIPTION
Motivation
When an ESXi has both FC and iSCSI online adapters the flashArray.go is
mapping using the iSCSI initiator first. While XCOPY is offloaded to the
array it can fallback to network copy.

Modification
Try mapping using FC before iSCSI

Note
Never map a volume to more than one interface type. Mapping to both FC
and iSCSI is an unsupported configuration and may lead to corruption or
other errors.

Resolves: MTV-3966
Signed-off-by: Roy Golan <rgolan@redhat.com>
