### PR TITLE
MTV-3632 | Expand vsphere osmap

### DIFF
--- a/operator/roles/forkliftcontroller/templates/controller/configmap-osmap-vsphere.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/configmap-osmap-vsphere.yml.j2
@@ -8,22 +8,54 @@ metadata:
     app: {{ app_name }}
     service: {{ controller_service_name }}
 data:
-  centos7_64Guest: "centos.7"
-  centos7Guest: "centos.7"
-  centos8_64Guest: "centos.stream8"
-  centos9_64Guest: "centos.stream9"
+  genericLinuxGuest: "linux"
+
+  ubuntu64Guest: "ubuntu"
+  ubuntuGuest: "ubuntu"
+
   fedora64Guest: "fedora"
   fedoraGuest: "fedora"
+
+  centos7_64Guest: "centos.7"
+  centos8_64Guest: "centos.stream8"
+  centos9_64Guest: "centos.stream9"
+
   rhel7_64Guest: "rhel.7"
   rhel7Guest: "rhel.7"
   rhel8_64Guest: "rhel.8"
   rhel9_64Guest: "rhel.9"
-  ubuntu64Guest: "ubuntu"
-  ubuntuGuest: "ubuntu"
+  rhel10_64Guest: "rhel.10"
+
+  sles10_64Guest: "sles"
+  sles11_64Guest: "sles"
+  sles12_64Guest: "sles"
+  sles15_64Guest: "sles"
+  sles16_64Guest: "sles"
+  opensuse64Guest: "opensuse.leap"
+
+  debian4_64Guest: "debian"
+  debian5_64Guest: "debian"
+  debian6_64Guest: "debian"
+  debian7_64Guest: "debian"
+  debian8_64Guest: "debian"
+  debian9_64Guest: "debian"
+  debian10_64Guest: "debian"
+  debian11_64Guest: "debian"
+  debian12_64Guest: "debian"
+  debian13_64Guest: "debian"
+
+  windows7_64Guest: "windows.7"
+  windows8_64Guest: "windows.8"
+  windows8_64Guest: "windows.8"
+  # This is not typo, VMware naming maps windows9 to windows 10
   windows9_64Guest: "windows.10"
-  windows9Guest: "windows.10"
-  windows9Server64Guest: "windows.10"
   windows11_64Guest: "windows.11"
+  windows12_64Guest: "windows.12"
+
+  windows7Server64Guest: "windows.2k8"
+  windows8Server64Guest: "windows.2k12"
+  windows9Server64Guest: "windows.2k16"
   windows2019srv_64Guest: "windows.2k19"
-  windows2019srvNext_64Guest: "windows.2k19"
-  windows2022srvNext_64Guest: "windows.2k22"
+  # VMware naming of newer windows is the previous version and `Next`
+  windows2019srvNext_64Guest: "windows.2k22"
+  windows2022srvNext_64Guest: "windows.2k25"

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -138,6 +138,7 @@ var osMap = map[string]string{
 	"win2000ProGuest":            "win2k",
 	"win2000ServGuest":           "win2k",
 	"windows7Guest":              "win7",
+	"windows7_64Guest":           "win7",
 	"windows7Server64Guest":      "win2k8r2",
 	"windows8_64Guest":           "win8",
 	"windows8Guest":              "win8",

--- a/pkg/controller/plan/adapter/vsphere/inspectionparser.go
+++ b/pkg/controller/plan/adapter/vsphere/inspectionparser.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"encoding/xml"
 	"fmt"
+	"strings"
 
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 )
@@ -17,20 +18,27 @@ var log = logging.WithName(Name)
 
 // Map of osinfo ids to vmware guest ids.
 var osV2VMap = map[string]string{
-	"centos6":  "centos6_64Guest",
-	"centos7":  "centos7_64Guest",
-	"centos8":  "centos8_64Guest",
-	"centos9":  "centos9_64Guest",
-	"rhel7":    "rhel7_64Guest",
-	"rhel8":    "rhel8_64Guest",
-	"rhel9":    "rhel9_64Guest",
 	"rocky":    "rockylinux_64Guest",
-	"sles10":   "sles10_64Guest",
-	"sles11":   "sles11_64Guest",
-	"sles12":   "sles12_64Guest",
-	"sles15":   "sles15_64Guest",
-	"sles16":   "sles16_64Guest",
 	"opensuse": "opensuse64Guest",
+	"ubuntu":   "ubuntu64Guest",
+	"fedora":   "fedora64Guest",
+
+	"centos6": "centos6_64Guest",
+	"centos7": "centos7_64Guest",
+	"centos8": "centos8_64Guest",
+	"centos9": "centos9_64Guest",
+
+	"rhel7":  "rhel7_64Guest",
+	"rhel8":  "rhel8_64Guest",
+	"rhel9":  "rhel9_64Guest",
+	"rhel10": "rhel10_64Guest",
+
+	"sles10": "sles10_64Guest",
+	"sles11": "sles11_64Guest",
+	"sles12": "sles12_64Guest",
+	"sles15": "sles15_64Guest",
+	"sles16": "sles16_64Guest",
+
 	"debian4":  "debian4_64Guest",
 	"debian5":  "debian5_64Guest",
 	"debian6":  "debian6_64Guest",
@@ -40,15 +48,22 @@ var osV2VMap = map[string]string{
 	"debian10": "debian10_64Guest",
 	"debian11": "debian11_64Guest",
 	"debian12": "debian12_64Guest",
-	"ubuntu":   "ubuntu64Guest",
-	"fedora":   "fedora64Guest",
-	"win7":     "windows7Server64Guest",
-	"win8":     "windows8Server64Guest",
-	"win10":    "windows9Server64Guest",
-	"win11":    "windows11_64Guest",
-	"win12":    "windows12_64Guest",
-	"win2k19":  "windows2019srv_64Guest",
-	"win2k22":  "windows2022srvNext_64Guest",
+	"debian13": "debian13_64Guest",
+
+	"win7":  "windows7_64Guest",
+	"win8":  "windows8_64Guest",
+	"win10": "windows9_64Guest", // This is not typo, VMware naming maps windows9 to windows 10
+	"win11": "windows11_64Guest",
+	"win12": "windows12_64Guest",
+
+	"win2k8r2":  "windows7Server64Guest",
+	"win2k12":   "windows8Server64Guest",
+	"win2k12r2": "windows8Server64Guest",
+	"win2k16":   "windows9Server64Guest",
+	"win2k19":   "windows2019srv_64Guest",
+	// VMware naming of newer windows is the previous version and `Next`
+	"win2k22": "windows2019srvNext_64Guest",
+	"win2k25": "windows2022srvNext_64Guest",
 }
 
 type InspectionOS struct {
@@ -77,9 +92,22 @@ func GetOperationSystemFromConfig(vmConfigXML string) (string, error) {
 		return "", err
 	}
 	os, ok := osV2VMap[inspection.OS.Osinfo]
-	if !ok {
-		log.Info(fmt.Sprintf("Received %s, mapped to: %s", os, os))
-		os = "otherGuest64"
+	if ok {
+		return os, nil
 	}
-	return os, nil
+	// Some operating system can contain a minor version for that we would require large map
+	// Example rhel9.5, rhel9.6 etc.
+	osInfoWithVersion := inspection.OS.Osinfo
+	osInfo := strings.Split(osInfoWithVersion, ".")[0]
+
+	os, ok = osV2VMap[osInfo]
+	if ok {
+		return os, nil
+	}
+	log.Info(fmt.Sprintf("Received %s, mapped to: %s", inspection.OS.Osinfo, os))
+
+	if inspection.OS.Name == "linux" {
+		return "genericLinuxGuest", nil
+	}
+	return "otherGuest64", nil
 }


### PR DESCRIPTION
Issue: When migrating from VMware lot of the OS are not mapped to the preferences.

Fix: This commit expands the osmap with all available preferences in latest kubevirt. Additionally it adds a removal of the minor version inside the osmap, alternative to this we would need to upadte the osmap every time when there would be new minor release.