### PR TITLE
MTV-3049 | RFE: Interfaces' mac addresses are changed after migrating with preserve static ip - btrfs build.

### DIFF
--- a/pkg/virt-v2v/customize/scripts/rhel/run/ifcfg-suse-test.d/expected-udev.rule
+++ b/pkg/virt-v2v/customize/scripts/rhel/run/ifcfg-suse-test.d/expected-udev.rule
@@ -1,0 +1,2 @@
+SUBSYSTEM=="net",ACTION=="add",ATTR{address}=="aa:bb:cc:dd:ee:ff",NAME="eth0"
+SUBSYSTEM=="net",ACTION=="add",ATTR{address}=="aa:bb:cc:dd:ee:fe",NAME="eth1"

--- a/pkg/virt-v2v/customize/scripts/rhel/run/ifcfg-suse-test.d/root/etc/sysconfig/network/ifcfg-eth0
+++ b/pkg/virt-v2v/customize/scripts/rhel/run/ifcfg-suse-test.d/root/etc/sysconfig/network/ifcfg-eth0
@@ -1,0 +1,4 @@
+BOOTPROTO='static'
+IPADDR='192.168.1.10/24'
+STARTMODE='auto'
+

--- a/pkg/virt-v2v/customize/scripts/rhel/run/ifcfg-suse-test.d/root/etc/sysconfig/network/ifcfg-eth1
+++ b/pkg/virt-v2v/customize/scripts/rhel/run/ifcfg-suse-test.d/root/etc/sysconfig/network/ifcfg-eth1
@@ -1,0 +1,4 @@
+BOOTPROTO='static'
+IPADDR='192.168.1.11/24'
+STARTMODE='auto'
+

--- a/pkg/virt-v2v/customize/scripts/rhel/run/ifcfg-suse-test.d/root/tmp/macToIP
+++ b/pkg/virt-v2v/customize/scripts/rhel/run/ifcfg-suse-test.d/root/tmp/macToIP
@@ -1,0 +1,3 @@
+aa:bb:cc:dd:ee:ff:ip:192.168.1.10,gateway:192.168.1.1
+aa:bb:cc:dd:ee:fe:ip:192.168.1.11,gateway:192.168.1.1
+

--- a/pkg/virt-v2v/customize/scripts/rhel/run/test-network_config_util.sh
+++ b/pkg/virt-v2v/customize/scripts/rhel/run/test-network_config_util.sh
@@ -15,6 +15,7 @@ test_dir() {
     # Paths for the test
     export V2V_MAP_FILE="$TEST_DIR/tmp/macToIP"
     export NETWORK_SCRIPTS_DIR="$TEST_DIR/etc/sysconfig/network-scripts"
+    export NETWORK_SCRIPTS_DIR_SUSE="$TEST_DIR/etc/sysconfig/network"
     export NETWORK_CONNECTIONS_DIR="$TEST_DIR/etc/NetworkManager/system-connections"
     export UDEV_RULES_FILE="$TEST_DIR/etc/udev/rules.d/70-persistent-net.rules"
     export SYSTEMD_NETWORK_DIR="$TEST_DIR/run/systemd/network"


### PR DESCRIPTION
Issue:
SUSE VMs migrated from vSphere had swapped network interface MAC addresses because udev rules were not created. The script only checked RHEL's /etc/sysconfig/network-scripts/, missing SUSE's /etc/sysconfig/network/.

Fix:
Add SUSE network config path support to udev_from_ifcfg()
 Extract device name from filename for SUSE (ifcfg-eth0 -> eth0)
Only skip rule creation if existing udev file is non-empty.

Ref: https://issues.redhat.com/browse/MTV-3049