### PR TITLE
fix(virt-v2v): resolve Containerfile build failures

### DIFF
--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -1,6 +1,7 @@
 # Build virt-v2v binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM quay.io/centos/centos:stream9 AS builder
 USER 0
+RUN --mount=type=cache,target=/var/cache/dnf dnf -y install --enablerepo=crb libvirt-devel golang
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"

--- a/build/virt-v2v/Containerfile-upstream-fssupport
+++ b/build/virt-v2v/Containerfile-upstream-fssupport
@@ -1,6 +1,7 @@
 # Build virt-v2v binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM quay.io/centos/centos:stream9 AS builder
 USER 0
+RUN --mount=type=cache,target=/var/cache/dnf dnf -y install --enablerepo=crb libvirt-devel golang
 WORKDIR /app
 COPY --chown=1001:0 ./ ./
 ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
@@ -39,7 +40,9 @@ RUN dnf install -y  https://kojihub.stream.centos.org/kojifiles/vol/koji02/packa
     https://kojihub.stream.centos.org/kojifiles/vol/koji02/packages/kernel/6.12.0/84.el10/x86_64/kernel-core-6.12.0-84.el10.x86_64.rpm \
     https://kojihub.stream.centos.org/kojifiles/vol/koji02/packages/kernel/6.12.0/84.el10/x86_64/kernel-modules-6.12.0-84.el10.x86_64.rpm
 
-RUN dnf install --setopt=sslverify=false -y https://kojihub.stream.centos.org/kojifiles/work/tasks/3821/5793821/libguestfs-fssupport-10.0-1.el10.x86_64.rpm
+# libguestfs-fssupport adds support for additional filesystems (btrfs, f2fs, nilfs2, udf, reiserfs)
+# Use --allowerasing to replace the base image's kernel with the one required by fssupport
+RUN dnf install --setopt=sslverify=false --allowerasing -y https://kojihub.stream.centos.org/kojifiles/packages/libguestfs-fssupport/10.2/1.el10/x86_64/libguestfs-fssupport-10.2-1.el10.x86_64.rpm
 
 RUN test "$(rpm -q kernel)" = "kernel-6.12.0-84.el10.x86_64"
 


### PR DESCRIPTION
Containerfile-upstream-fedora:
- Switch builder to centos:stream9
- Add libvirt-devel (required for virt-v2v-wrapper compilation)

Containerfile-upstream-fssupport:
- Switch builder to centos:stream9
- Add libvirt-devel (required for virt-v2v-wrapper  compilation)
- Update libguestfs-fssupport URL from removed scratch build to official packages (10.2-1.el10)
- Add --allowerasing to handle kernel version conflicts

Resolves: None