### PR TITLE
MTV-2099 | Finish task progress after conversion succeeds

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1726,6 +1726,9 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 	case core.PodSucceeded:
 		step.MarkCompleted()
 		step.Progress.Completed = step.Progress.Total
+		for _, task := range step.Tasks {
+			task.Progress.Completed = task.Progress.Total
+		}
 	case core.PodFailed:
 		step.MarkCompleted()
 		step.AddError("Guest conversion failed. See pod logs for details.")


### PR DESCRIPTION
Resolves: MTV-2099

Issue:
Sometimes the conversion pod can get finished without updating the disk tasks. This causes the status to be not fully finished even if the migrations completed.

Fix:
After the pod successfully finishes, update the task completed progress to the diks total size.