### PR TITLE
MTV-4061 | Allow storage offlaod with skip guest conversion

### DIFF
--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -379,6 +379,17 @@ func (r *Plan) ShouldRunPreflightInspection() bool {
 		r.Spec.RunPreflightInspection
 }
 
+// IsUsingOffloadPlugin determines if any of the mappings is using storage offload
+func (r *Plan) IsUsingOffloadPlugin() bool {
+	dsMapIn := r.Map.Storage.Spec.Map
+	for _, m := range dsMapIn {
+		if m.OffloadPlugin != nil && m.OffloadPlugin.VSphereXcopyPluginConfig != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // PVCNameTemplateData contains fields used in naming templates.
 type PVCNameTemplateData struct {
 	VmName         string `json:"vmName"`

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1407,7 +1407,7 @@ func (r *Reconciler) validateVddkImage(plan *api.Plan) (err error) {
 			Message:  "VDDK image not set on the provider, this is required for the warm migration",
 		})
 	}
-	if plan.Spec.SkipGuestConversion && vddkImage == "" {
+	if plan.Spec.SkipGuestConversion && vddkImage == "" && !plan.IsUsingOffloadPlugin() {
 		plan.Status.SetCondition(libcnd.Condition{
 			Type:     VDDKInitImageUnavailable,
 			Status:   True,


### PR DESCRIPTION
Resolves: MTV-4061

Issue: Right now we have RCM validation that blocks users from running the migraiton without VDDK. This is true for CDI migraiton which requires VDDK, however storage offload does not use the VDDK.