### PR TITLE
MTV-3645 | RFE: Allow setting transfer network to the forklift api pod

### DIFF
--- a/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
@@ -18,6 +18,12 @@ spec:
       labels:
         app: {{ app_name }}
         service: {{ api_service_name }}
+      annotations:
+{% if controller_transfer_network is defined %}
+        k8s.v1.cni.cncf.io/networks: "{{ controller_transfer_network }}"
+{% else %}
+        k8s.v1.cni.cncf.io/networks: null
+{% endif %}
     spec:
       serviceAccountName: forklift-api
       containers:


### PR DESCRIPTION
Issue:
When provider networks are isolated from OCP's default pod network, forklift-api cannot reach providers for webhook validation.

Fix:
Enables forklift-api to reach isolated provider networks by reusing the controller_transfer_network Multus annotation.

Ref: https://issues.redhat.com/browse/MTV-3645