### PR TITLE
MTV-3931 | improve memory allocation to vmkfstools commands

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/version.mk
+++ b/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper/version.mk
@@ -1,1 +1,1 @@
-VIB_VERSION := 0.2.0
+VIB_VERSION := 0.2.1

--- a/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
@@ -154,10 +154,10 @@ var _ = Describe("Populator", func() {
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "list", "-d", "naa.616263"}).Return([]esx.Values{{"Status": {"on"}}}, nil).Times(1)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(),
 					[]string{"vmkfstools", "clone", "-s", "/vmfs/volumes/my-ds/my-vm/vmdisk.vmdk", "-t", "/vmfs/devices/disks/naa.616263"}).
-					Return([]esx.Values{{"message": {`{"taskId": "1"}`}}}, nil)
-				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"vmkfstools", "taskGet", "-i", "1"}).
-					Return([]esx.Values{{"message": {`{"exitCode": "0"}`}}}, nil).Times(2)
-				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"vmkfstools", "taskClean", "-i", "1"}).
+					Return([]esx.Values{{"message": {`{"taskId": "1", "taskPath": "/vmfs/volumes/my-ds/vmkfstools-wrapper-1"}`}}}, nil)
+				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"vmkfstools", "taskGet", "-p", "/vmfs/volumes/my-ds/vmkfstools-wrapper-1"}).
+					Return([]esx.Values{{"message": {`{"taskId": "1", "exitCode": "0"}`}}}, nil).Times(2)
+				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"vmkfstools", "taskClean", "-p", "/vmfs/volumes/my-ds/vmkfstools-wrapper-1"}).
 					Return([]esx.Values{{"message": {`{"exitCode": "0"}`}}}, nil)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "set", "--state", "off", "-d", "naa.616263"}).Return(nil, nil)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "list", "-d", "naa.616263"}).Return([]esx.Values{map[string][]string{"Status": {"off"}}}, nil).AnyTimes()


### PR DESCRIPTION
### Changes to vmkfstools-wrapper
improve memory allocation to vmkfstools commands:
- Optimize taskGet to seek to end of file and read backwards instead of loading all content into memory
fix tech dep:
- Fix issue in taskClean command where rdm file deletion failure would prevent tmp directory cleanup, leaving orphaned tmp files
- Change vmkfstools-wrapper file location from /tmp/vmkfstools-wrapper-<task-id> to datastore directory: /vmfs/volumes/<datastore-name>/vmkfstools-wrapper-<task-id>

Resolves: MTV-3931
Signed-off-by: Amit Weinstock <aweinsto@redhat.com>