### PR TITLE
MTV-4087 | Sort adapters by type

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/populate.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/populate.go
@@ -11,7 +11,7 @@ type Populator interface {
 	// the sourceVMDKFile.
 	// persistentVolume is a slim version of k8s PersistentVolume created by the CSI driver,
 	// to help identify its underlying LUN in the storage system.
-	Populate(vmId string, sourceVMDKFile string, persistentVolume PersistentVolume, hostLocker Hostlocker, progress chan<- uint, quit chan error) error
+	Populate(vmId string, sourceVMDKFile string, persistentVolume PersistentVolume, hostLocker Hostlocker, preferFCAdapters bool ,progress chan<- uint, quit chan error) error
 }
 
 //go:generate go run go.uber.org/mock/mockgen -destination=mocks/hostlocker_mock.go -package=mocks . Hostlocker

--- a/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Populator", func() {
 
 			go func() {
 				defer GinkgoRecover()
-				underTest.Populate(tc.sourceVmId, tc.sourceVMDK, populator.PersistentVolume{Name: tc.targetPVC}, hostLocker, progressCh, quitCh)
+				underTest.Populate(tc.sourceVmId, tc.sourceVMDK, populator.PersistentVolume{Name: tc.targetPVC}, hostLocker, false, progressCh, quitCh)
 			}()
 
 			if tc.want != nil {


### PR DESCRIPTION
## feat(xcopy): Add configurable adapter type precedence
Add ability to control the order in which storage adapters (iSCSI,
NVMe, FC) are tried for XCOPY operations. This allows preferring
certain transport types based on environment or performance
requirements.

Changes:
- Add PreferFCAdapters field to RemoteEsxcliPopulator
- Add preferFCAdapters parameter to Populate() interface
- Sort HBA UIDs based on adapter type preference using slices.SortFunc
- Update constructors to accept adapter preference configuration

The sorting is based on the WWPN/IQN format - WWPNs (FC) contain
colons and are sorted differently from IQNs (iSCSI).

Default behavior: No preference (maintains current behavior)
When preferFCAdapters=true: FC adapters are tried first

Resolves: MTV-3680
Signed-off-by: Amit Weinstock <aweinsto@redhat.com>