### PR TITLE
fix(build): build failure for `make build-operator-bundle-image`

### DIFF
--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -7535,26 +7535,26 @@ spec:
         path: ova_proxy_route_timeout
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Volume Populator CPU limit (default 1000m)
-          displayName: Volume Populator CPU Limit
-          path: populator_container_limits_cpu
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Volume Populator memory limit (default 1Gi)
-          displayName: Volume Populator Memory Limit
-          path: populator_container_limits_memory
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Volume Populator CPU request (default 100m)
-          displayName: Volume Populator CPU Request
-          path: populator_container_requests_cpu
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Volume Populator memory request (default 512Mi)
-          displayName: Volume Populator Memory Request
-          path: populator_container_requests_memory
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator CPU limit (default 1000m)
+        displayName: Volume Populator CPU Limit
+        path: populator_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator memory limit (default 1Gi)
+        displayName: Volume Populator Memory Limit
+        path: populator_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator CPU request (default 100m)
+        displayName: Volume Populator CPU Request
+        path: populator_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator memory request (default 512Mi)
+        displayName: Volume Populator Memory Request
+        path: populator_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Log verbosity level (default 3)
         displayName: Controller Log Level
         path: controller_log_level

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -526,26 +526,26 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       # Volume Populator Settings
-        - description: Volume Populator CPU limit (default 1000m)
-          displayName: Volume Populator CPU Limit
-          path: populator_container_limits_cpu
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Volume Populator memory limit (default 1Gi)
-          displayName: Volume Populator Memory Limit
-          path: populator_container_limits_memory
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Volume Populator CPU request (default 100m)
-          displayName: Volume Populator CPU Request
-          path: populator_container_requests_cpu
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Volume Populator memory request (default 512Mi)
-          displayName: Volume Populator Memory Request
-          path: populator_container_requests_memory
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator CPU limit (default 1000m)
+        displayName: Volume Populator CPU Limit
+        path: populator_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator memory limit (default 1Gi)
+        displayName: Volume Populator Memory Limit
+        path: populator_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator CPU request (default 100m)
+        displayName: Volume Populator CPU Request
+        path: populator_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator memory request (default 512Mi)
+        displayName: Volume Populator Memory Request
+        path: populator_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       # Logging & General Settings
       - description: Log verbosity level (default 3)
         displayName: Controller Log Level


### PR DESCRIPTION
When building the operator bundle image, I encountered the following error:

    time="2025-12-17T20:43:43Z" level=fatal msg="Error generating bundle manifests: error adding operators.coreos.com/v1alpha1, Kind=ClusterServiceVersion to manifest collector: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal object into Go struct field SpecDescriptor.spec.customresourcedefinitions.owned.specDescriptors.x-descriptors of type string"

It seems that the failure was caused by incorrect indentation in the clusterserviceversion yaml file.
