### PR TITLE
Resolves: clair-scans for forklift-api

### DIFF
--- a/build/forklift-api/Containerfile
+++ b/build/forklift-api/Containerfile
@@ -9,7 +9,17 @@ RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldfl
 
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
 # Required to be able to get files from within the pod
-RUN microdnf -y install tar && microdnf clean all
+# Update packages to address security vulnerabilities (CVE fixes)
+# Use dnf --security if available (full UBI), otherwise microdnf update (minimal UBI)
+RUN if command -v dnf &> /dev/null; then \
+        dnf install -y tar && \
+        dnf update -y --security && \
+        dnf clean all; \
+    else \
+        microdnf -y install tar && \
+        microdnf update -y && \
+        microdnf clean all; \
+    fi
 COPY --from=builder /app/forklift-api /usr/local/bin/forklift-api
 
 ENTRYPOINT ["/usr/local/bin/forklift-api"]

--- a/build/forklift-api/Containerfile-downstream
+++ b/build/forklift-api/Containerfile-downstream
@@ -10,7 +10,17 @@ RUN --mount=type=cache,target=${GOCACHE},uid=1001 GOOS=linux GOARCH=amd64 go bui
 FROM registry.redhat.io/ubi9-minimal:9.6-1752587672
 
 # Required to be able to get files from within the pod
-RUN microdnf -y install tar && microdnf clean all
+# Update packages to address security vulnerabilities (CVE fixes)
+# Use dnf --security if available (full UBI), otherwise microdnf update (minimal UBI)
+RUN if command -v dnf &> /dev/null; then \
+        dnf install -y tar && \
+        dnf update -y --security && \
+        dnf clean all; \
+    else \
+        microdnf -y install tar && \
+        microdnf update -y && \
+        microdnf clean all; \
+    fi
 COPY --from=builder /app/forklift-api /usr/local/bin/forklift-api
 
 ENTRYPOINT ["/usr/local/bin/forklift-api"]


### PR DESCRIPTION
Uses `dnf update -y --security` when `dnf` is available (full UBI images) Falls back to `microdnf update -y` when only `microdnf` is available (minimal UBI images)