### PR TITLE
chore(security): apply security updates for MTV images

### DIFF
--- a/build/forklift-api/Containerfile
+++ b/build/forklift-api/Containerfile
@@ -9,7 +9,10 @@ RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldfl
 
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
 # Required to be able to get files from within the pod
-RUN microdnf -y install tar && microdnf clean all
+RUN microdnf -y install tar && \
+    # Update packages to address security vulnerabilities (CVE fixes)
+    microdnf update -y && \
+    microdnf clean all
 COPY --from=builder /app/forklift-api /usr/local/bin/forklift-api
 
 ENTRYPOINT ["/usr/local/bin/forklift-api"]

--- a/build/ova-provider-server/Containerfile
+++ b/build/ova-provider-server/Containerfile
@@ -8,8 +8,12 @@ ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -ldflags="-w -s" -o ova-provider-server github.com/kubev2v/forklift/cmd/ova-provider-server
 
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
+
 # Required to be able to get files from within the pod
-RUN microdnf -y install tar && microdnf clean all
+RUN microdnf -y install tar && \
+    # Update packages to address security vulnerabilities (CVE fixes)
+    microdnf update -y && \
+    microdnf clean all
 
 COPY --from=builder /app/ova-provider-server /usr/local/bin/ova-provider-server
 ENTRYPOINT ["/usr/local/bin/ova-provider-server"]

--- a/build/ova-proxy/Containerfile
+++ b/build/ova-proxy/Containerfile
@@ -9,6 +9,11 @@ RUN echo $(ls)
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o proxy github.com/kubev2v/forklift/cmd/ova-proxy
 
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
+
+# Update packages to address security vulnerabilities (CVE fixes)
+RUN microdnf update -y && \
+    microdnf clean all
+
 COPY --from=builder /app/proxy /usr/local/bin/ova-proxy
 ENTRYPOINT ["/usr/local/bin/ova-proxy"]
 

--- a/build/populator-controller/Containerfile
+++ b/build/populator-controller/Containerfile
@@ -8,8 +8,12 @@ ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -ldflags="-w -s" -o controller github.com/kubev2v/forklift/cmd/populator-controller
 
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
+
 # Required to be able to get files from within the pod
-RUN microdnf -y install tar && microdnf clean all
+RUN microdnf -y install tar && \
+    # Update packages to address security vulnerabilities (CVE fixes)
+    microdnf update -y && \
+    microdnf clean all
 
 COPY --from=builder /app/controller /usr/local/bin/populator-controller
 ENTRYPOINT ["/usr/local/bin/populator-controller"]

--- a/build/vsphere-xcopy-volume-populator/Containerfile
+++ b/build/vsphere-xcopy-volume-populator/Containerfile
@@ -16,6 +16,10 @@ RUN make vmkfstools-wrapper
 
 FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
 
+# Update packages to address security vulnerabilities (CVE fixes)
+RUN microdnf update -y && \
+    microdnf clean all
+
 COPY --from=builder /usr/src/app/cmd/vsphere-xcopy-volume-populator/bin/vsphere-xcopy-volume-populator \
     /bin/vsphere-xcopy-volume-populator
 


### PR DESCRIPTION
Uses `dnf update -y --security` when `dnf` is available (full UBI images) Falls back to `microdnf update -y` when only `microdnf` is available (minimal UBI images)