### PR TITLE
MTV-4161 | Validate NAA label values before adding to PVC labels

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1382,9 +1382,12 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				labels := map[string]string{
 					"migration": string(r.Migration.UID),
 					// we need uniqness and a value which is less than 64 chars, hence using vmRef.id + disk.key
-					"vmdkKey":        fmt.Sprint(disk.Key),
-					"vmID":           vmRef.ID,
-					TemplateNAALabel: naa,
+					"vmdkKey": fmt.Sprint(disk.Key),
+					"vmID":    vmRef.ID,
+				}
+				// Only add the NAA label if it's a valid Kubernetes label value
+				if errs := k8svalidation.IsValidLabelValue(naa); len(errs) == 0 {
+					labels[TemplateNAALabel] = naa
 				}
 
 				r.Log.Info("target namespace for migration", "namespace", namespace)


### PR DESCRIPTION
Use k8svalidation.IsValidLabelValue() to check if the NAA value from vSphere datastores is valid for Kubernetes labels. If invalid, omit the label rather than failing resource creation.

Resolves: MTV-4161