### PR TITLE
MTV-3789 | Use uncached Get in Plan reconciliation.

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -64,6 +64,7 @@ func Add(mgr manager.Manager) error {
 			Client:        mgr.GetClient(),
 			Log:           log,
 		},
+		APIReader: mgr.GetAPIReader(),
 	}
 	cnt, err := controller.New(
 		Name,
@@ -160,6 +161,7 @@ var _ reconcile.Reconciler = &Reconciler{}
 // Reconciles a Plan object.
 type Reconciler struct {
 	base.Reconciler
+	APIReader client.Reader
 }
 
 // Reconcile a Plan CR.
@@ -180,7 +182,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 
 	// Fetch the CR.
 	plan := &api.Plan{}
-	err = r.Get(context.TODO(), request.NamespacedName, plan)
+	err = r.APIReader.Get(context.TODO(), request.NamespacedName, plan)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			r.Log.Info("Plan deleted.")

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -48,6 +48,7 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 	ginkgo.BeforeEach(func() {
 		reconciler = &Reconciler{
 			base.Reconciler{},
+			nil,
 		}
 		fakeClientSet = fake.NewSimpleClientset()
 	})
@@ -387,6 +388,7 @@ func createFakeReconciler(objects ...runtime.Object) *Reconciler {
 			Client: client,
 			Log:    planValidationLog,
 		},
+		client,
 	}
 }
 


### PR DESCRIPTION
Issue: sometimes two Plan reconciliations get queued to run one after the other with no requeue delay, and an Update to the Plan from the first reconciliation does not get propagated to the Get in the second reconciliation. That causes the second reconciliation to re-run the same phase, which causes problems if that phase needs to work with external resources like VMware snapshots. So far I have seen this cause duplicate snapshot creations, duplicate snapshot removals, and duplicate VM poweroffs.

Fix: for a short-term fix, change the Plan reconciliation to use an uncached Get. On my test cluster, I was able to reproduce the bug consistently within about three hours, and with the fix I successfully ran a warm migration for 14 hours with a snapshot interval of 1. I believe it is still possible to hit this, but this fix makes it much rarer. I am not certain that it will fix all the related warm migration bugs listed in MTV-3789, but it at least makes it possible to work on them without running into this every time.

Resolves: [MTV-3789](https://issues.redhat.com/browse/MTV-3789), partially. Longer term work involves carefully making sure the reconciles are idempotent, finding out exactly what else is triggering extra Plan reconciliations, and figuring out why so many migrations started hitting this bug all of a sudden.