### PR TITLE
[release-2.10] MTV-3745 |Fix MAC conflict validation after successful migration

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -760,6 +760,14 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 	for i := range plan.Spec.VMs {
 		vm := &plan.Spec.VMs[i]
 		ref := &vm.Ref
+
+		// Skip VMs that have already succeeded - no validation needed
+		if status, found := plan.Status.Migration.FindVM(*ref); found {
+			if status.HasCondition(api.ConditionSucceeded) {
+				continue
+			}
+		}
+
 		if ref.NotSet() {
 			plan.Status.SetCondition(libcnd.Condition{
 				Type:     VMRefNotValid,


### PR DESCRIPTION
Backport: https://github.com/kubev2v/forklift/pull/3994

This is a complementary PR for https://github.com/kubev2v/forklift/pull/3358

So by skipping validating VMs that the Plan considers to have been successfully migrated, we will also prevent this false mac conflict error.

Ref: https://issues.redhat.com/browse/MTV-4151
https://issues.redhat.com/browse/MTV-3475