### PR TITLE
MTV-4068 | Add v2v XFSv4 build

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -53,6 +53,9 @@ jobs:
           - name: virt-v2v
             file: build/virt-v2v/Containerfile-upstream-fedora
             repo: forklift-virt-v2v-fedora
+          - name: virt-v2v
+            file: build/virt-v2v/Containerfile-upstream-xfs
+            repo: forklift-virt-v2v-xfs
           - name: vsphere-xcopy-volume-populator
             file: build/vsphere-xcopy-volume-populator/Containerfile
             repo: vsphere-xcopy-volume-populator

--- a/build/virt-v2v/Containerfile-upstream-xfs
+++ b/build/virt-v2v/Containerfile-upstream-xfs
@@ -1,0 +1,89 @@
+# Build virt-v2v binary
+FROM quay.io/centos/centos:stream9 AS builder
+USER 0
+RUN --mount=type=cache,target=/var/cache/dnf dnf -y install --enablerepo=crb libvirt-devel golang
+WORKDIR /app
+COPY --chown=1001:0 ./ ./
+ENV GOFLAGS="-mod=vendor -tags=strictfipsruntime"
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN go build -ldflags="-w -s" -o virt-v2v-monitor ./cmd/virt-v2v-monitor/virt-v2v-monitor.go
+RUN go build -ldflags="-w -s" -o image-converter ./cmd/image-converter/image-converter.go
+RUN go build -ldflags="-w -s" -o virt-v2v-wrapper ./cmd/virt-v2v/entrypoint.go
+
+# Main container
+FROM quay.io/centos/centos:stream9
+RUN rm /etc/pki/tls/fips_local.cnf && \
+    echo -e '[fips_sect]\ntls1-prf-ems-check = 0\nactivate = 1' > /etc/pki/tls/fips_local.cnf && \
+    sed -i '/^\\[ crypto_policy \\]/a Options=RHNoEnforceEMSinFIPS' /etc/pki/tls/openssl.cnf
+
+# The virt-v2v-in-place in centos is not in the bin directory and is not accessible via PATH
+ENV PATH="$PATH:/usr/libexec"
+ENV LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+
+RUN mkdir /disks && \
+    source /etc/os-release && \
+    dnf install -y \
+        virt-v2v \
+        kernel && \
+    dnf clean all
+
+# TODO: This should be replaced with `dnf install -y virtio-win` from centos-stream10
+RUN dnf install -y https://kojihub.stream.centos.org/kojifiles/packages/virtio-win/1.9.40/1.el9/noarch/virtio-win-1.9.40-1.el9.noarch.rpm
+
+RUN ( [ "$(rpm -q glibc)" == "glibc-2.34-66.el9.x86_64" ] && dnf -y downgrade glibc-2.34-65.el9.x86_64 || true ) && \
+dnf -y install libguestfs libguestfs-appliance libguestfs-xfs libguestfs-winsupport qemu-img supermin && \
+        depmod $(ls /lib/modules/ |tail -n1)
+
+# Create tarball for the appliance.
+#
+# LIBGUESTFS_BACKEND=direct is required to work around the following bug:
+# https://issues.redhat.com/browse/RHEL-104684
+# and it can be removed when that bug gets fixed.
+RUN mkdir -p /usr/lib64/guestfs/appliance && \
+        cd /usr/lib64/guestfs/appliance && \
+        LIBGUESTFS_BACKEND=direct libguestfs-make-fixed-appliance . && \
+        qemu-img convert -c -O qcow2 root root.qcow2 && \
+        mv -vf root.qcow2 root && \
+        tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance
+
+# This prevents libvirt from attempting to create files in the root directory,
+# which would lead to permission errors.
+# Refer to: https://issues.redhat.com/browse/RHEL-105490
+RUN mkdir -p /home/qemu/.cache/libvirt && \
+    chown -R qemu:qemu /home/qemu
+ENV HOME=/home/qemu
+
+# The libvirt can hang when destroying libguestfs domains due to the
+# absence of an init process to clean up zombie processes. 'catatonit' acts
+# as PID 1 to resolve this.
+# Refer to: https://issues.redhat.com/browse/RHEL-105529
+RUN dnf install -y https://kojihub.stream.centos.org/kojifiles/packages/catatonit/0.2.0/2.el9/x86_64/catatonit-0.2.0-2.el9.x86_64.rpm
+
+# This ensures that the 'libvirt:qemu:///session' connection method, which is
+# the officially tested and supported flow, is utilized instead of direct connections.
+ENV LIBGUESTFS_BACKEND=libvirt:qemu:///session
+
+RUN mkdir -p /etc/pki/CA/ && chown qemu:qemu /etc/pki/CA/
+
+COPY --from=builder /app/virt-v2v-monitor /usr/local/bin/virt-v2v-monitor
+
+COPY --from=builder /app/image-converter /usr/local/bin/image-converter
+
+COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
+
+ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
+
+LABEL \
+        com.redhat.component="forklift-virt-v2v-container" \
+        name="forklift/forklift-virt-v2v-rhel9" \
+        license="Apache License 2.0" \
+        io.k8s.display-name="Forklift" \
+        io.k8s.description="Forklift - Virt-V2V" \
+        io.openshift.tags="migration,mtv,forklift" \
+        summary="Forklift - Virt-V2V" \
+        description="Forklift - Virt-V2V" \
+        io.k8s.description="Forklift - Virt-V2V" \
+        vendor="Red Hat, Inc." \
+        maintainer="Forklift by Konveyor Community <forklift-dev@googlegroups.com>"
+


### PR DESCRIPTION
Issue:
In latest kernel the XFSv4 is nolonger supported.
We need to use older kernel inside the v2v appliance.

Fix:
Add new v2v containerfile based on Centos 9 and install kernel to the container so it will be picked up by the libguestfs.