### PR TITLE
MTV-3659 | PVCs left after migrating VM from ova file to OCP cluster.

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1804,7 +1804,7 @@ func (r *Builder) setPVCNameFromTemplate(objectMeta *metav1.ObjectMeta, vm *mode
 		targetVmName = planVMStatus.NewName
 	} else {
 		// Best-effort DNS1123-safe fallback
-		targetVmName = utils.ChangeVmName(vmName)
+		targetVmName = utils.SanitizeLabel(vmName)
 	}
 
 	// Create template data

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -574,7 +574,7 @@ func (r *Validator) getPlanVMTargetName(vm *model.VM) string {
 	}
 
 	// Otherwise, clean the VM name
-	return util.ChangeVmName(vm.Name)
+	return util.SanitizeLabel(vm.Name)
 }
 
 // Validate that VM has no pre-existing snapshots for warm migration

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"hash/fnv"
 	"math"
 	"math/rand"
 	"regexp"
@@ -70,8 +72,8 @@ func GetDeviceNumber(deviceString string) int {
 
 type HostsFunc func() (map[string]*api.Host, error)
 
-// ChangeVmName changes VM name to match DNS1123 RFC convention.
-func ChangeVmName(currName string) string {
+// SanitizeLabel ensures a string is a valid Kubernetes DNS-1123 label.
+func SanitizeLabel(currName string) string {
 	var validParts []string
 	const labelMax = validation.DNS1123LabelMaxLength
 
@@ -126,10 +128,17 @@ func ChangeVmName(currName string) string {
 
 	// Handle case where name is empty after all processing
 	if newName == "" {
-		newName = "vm-" + GenerateRandomSuffix()
+		//This keeps names stable even when the sanitized name is empty
+		newName = "vm-" + fnv32String(currName)
 	}
 
 	return newName
+}
+
+func fnv32String(s string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	return fmt.Sprintf("%x", h.Sum32())
 }
 
 // GenerateRandomSuffix generates a random string of length four, consisting of lowercase letters and digits.

--- a/pkg/controller/plan/util/utils_test.go
+++ b/pkg/controller/plan/util/utils_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Plan/utils", func() {
 		It("should handle all cases in name adjustments", func() {
 			originalVmName := "----------------Vm!@#$%^&*()_+-Name/.is,';[]-CorREct-<>123----------------------"
 			newVmName := "vm-name.is-correct-123"
-			changedName := ChangeVmName(originalVmName)
+			changedName := SanitizeLabel(originalVmName)
 			Expect(changedName).To(Equal(newVmName))
 			Expect(validateVmName(changedName)).To(BeTrue(), "Changed name should match DNS1123 subdomain format")
 		})
@@ -41,7 +41,7 @@ var _ = Describe("Plan/utils", func() {
 		It("should handle the case that the VM name is empty after all removals", func() {
 			emptyVM := ".__."
 			newVmNameFromId := "vm-"
-			changedEmptyName := ChangeVmName(emptyVM)
+			changedEmptyName := SanitizeLabel(emptyVM)
 			Expect(changedEmptyName).To(ContainSubstring(newVmNameFromId))
 			Expect(validateVmName(changedEmptyName)).To(BeTrue(), "Changed name from empty should match DNS1123 subdomain format")
 		})
@@ -49,13 +49,13 @@ var _ = Describe("Plan/utils", func() {
 		It("should handle multiple consecutive dots", func() {
 			multiDotVM := "mtv.func.-.rhel.-...8.8"
 			expectedMultiDotResult := "mtv.func.rhel.8.8"
-			changedMultiDotName := ChangeVmName(multiDotVM)
+			changedMultiDotName := SanitizeLabel(multiDotVM)
 			Expect(changedMultiDotName).To(Equal(expectedMultiDotResult))
 			Expect(validateVmName(changedMultiDotName)).To(BeTrue(), "Changed name with multiple dots should match DNS1123 subdomain format")
 
 			multiDotVM2 := ".....mtv.func..-...............rhel.-...8.8"
 			expectedMultiDotResult2 := "mtv.func.rhel.8.8"
-			changedMultiDotName2 := ChangeVmName(multiDotVM2)
+			changedMultiDotName2 := SanitizeLabel(multiDotVM2)
 			Expect(changedMultiDotName2).To(Equal(expectedMultiDotResult2))
 			Expect(validateVmName(changedMultiDotName2)).To(BeTrue(), "Changed name with multiple leading dots should match DNS1123 subdomain format")
 		})
@@ -63,7 +63,7 @@ var _ = Describe("Plan/utils", func() {
 		It("should convert spaces to dashes", func() {
 			spaceVM := "vm with spaces in name"
 			expectedSpaceResult := "vm-with-spaces-in-name"
-			changedSpaceName := ChangeVmName(spaceVM)
+			changedSpaceName := SanitizeLabel(spaceVM)
 			Expect(changedSpaceName).To(Equal(expectedSpaceResult))
 			Expect(validateVmName(changedSpaceName)).To(BeTrue(), "Changed name with spaces should match DNS1123 subdomain format")
 		})
@@ -71,7 +71,7 @@ var _ = Describe("Plan/utils", func() {
 		It("should convert + signs to dashes", func() {
 			plusVM := "vm+with+plus+signs"
 			expectedPlusResult := "vm-with-plus-signs"
-			changedPlusName := ChangeVmName(plusVM)
+			changedPlusName := SanitizeLabel(plusVM)
 			Expect(changedPlusName).To(Equal(expectedPlusResult))
 			Expect(validateVmName(changedPlusName)).To(BeTrue(), "Changed name with plus signs should match DNS1123 subdomain format")
 		})
@@ -79,7 +79,7 @@ var _ = Describe("Plan/utils", func() {
 		It("should remove multiple consecutive dashes", func() {
 			multipleDashVM := "vm---with----multiple-----dashes"
 			expectedMultipleDashResult := "vm-with-multiple-dashes"
-			changedMultipleDashName := ChangeVmName(multipleDashVM)
+			changedMultipleDashName := SanitizeLabel(multipleDashVM)
 			Expect(changedMultipleDashName).To(Equal(expectedMultipleDashResult))
 			Expect(validateVmName(changedMultipleDashName)).To(BeTrue(), "Changed name with multiple dashes should match DNS1123 subdomain format")
 		})
@@ -87,7 +87,7 @@ var _ = Describe("Plan/utils", func() {
 		It("should handle complex case with spaces, plus signs, and multiple dashes", func() {
 			complexVM := "vm   +++with   ---mixed+++   ---characters"
 			expectedComplexResult := "vm-with-mixed-characters"
-			changedComplexName := ChangeVmName(complexVM)
+			changedComplexName := SanitizeLabel(complexVM)
 			Expect(changedComplexName).To(Equal(expectedComplexResult))
 			Expect(validateVmName(changedComplexName)).To(BeTrue(), "Changed name with mixed special characters should match DNS1123 subdomain format")
 		})
@@ -95,7 +95,7 @@ var _ = Describe("Plan/utils", func() {
 		It("should convert * (asterisk) to dashes", func() {
 			asteriskVM := "vm*with*asterisk*characters"
 			expectedAsteriskResult := "vm-with-asterisk-characters"
-			changedAsteriskName := ChangeVmName(asteriskVM)
+			changedAsteriskName := SanitizeLabel(asteriskVM)
 			Expect(changedAsteriskName).To(Equal(expectedAsteriskResult))
 			Expect(validateVmName(changedAsteriskName)).To(BeTrue(), "Changed name with asterisk should match DNS1123 subdomain format")
 		})
@@ -104,7 +104,7 @@ var _ = Describe("Plan/utils", func() {
 			const labelMax = validation.DNS1123LabelMaxLength
 
 			long := strings.Repeat("a", labelMax+10)
-			changed := ChangeVmName(long)
+			changed := SanitizeLabel(long)
 			Expect(changed).To(HaveLen(labelMax))
 			Expect(validateVmName(changed)).To(BeTrue())
 		})

--- a/pkg/controller/plan/vm_name_handler.go
+++ b/pkg/controller/plan/vm_name_handler.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (r *KubeVirt) changeVmNameDNS1123(vmName string, vmNamespace string) (generatedName string, err error) {
-	generatedName = util.ChangeVmName(vmName)
+	generatedName = util.SanitizeLabel(vmName)
 	nameExist, errName := r.checkIfVmNameExistsInNamespace(generatedName, vmNamespace)
 	if errName != nil {
 		err = liberr.Wrap(errName)


### PR DESCRIPTION
Issue:
Duplicate PVCs can be created during reconcile or migration retry.
Each Create() call with generateName causes the API server to generate a
new unique name, even if a single PVC is requested.

Reconcile A: Create(generateName="ova-pvc-")
→ API server generates "ova-pvc-abc" → SUCCESS

Reconcile B: Create(generateName="ova-pvc-")
→ API server generates "ova-pvc-def" → SUCCESS

Result: 2 PVCs created instead of 1.

Fix:
Use deterministic name generation and handle AlreadyExists errors properly.
Reconcile A: Create(name="ova-pvc-")
→ does not exist → SUCCESS

Reconcile B: Create(name="ova-pvc-")
→ already exists → AlreadyExists error
→ Get(name) and reuse existing PVC

Result: 1 PVC created.

Note: Fix applied for both OVA and hyperV.

Resolves: MTV-3659
Ref: https://issues.redhat.com/browse/MTV-3659