### PR TITLE
MTV-4214 | Remove non-functional RDM support from ONTAP provider

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/ontap/ontap.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/ontap/ontap.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/populator"
-	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/vmware"
 	drivers "github.com/netapp/trident/storage_drivers"
 	"github.com/netapp/trident/storage_drivers/ontap/api"
 	"k8s.io/klog/v2"
@@ -16,7 +14,6 @@ import (
 const OntapProviderID = "600a0980"
 
 // Ensure NetappClonner implements required interfaces
-var _ populator.RDMCapable = &NetappClonner{}
 var _ populator.VMDKCapable = &NetappClonner{}
 
 type NetappClonner struct {
@@ -118,103 +115,4 @@ func (c *NetappClonner) CurrentMappedGroups(targetLUN populator.LUN, _ populator
 		return nil, fmt.Errorf("Failed to get mapped luns by path %s: %w ", targetLUN.Name, err)
 	}
 	return lunMappedIgroups, nil
-}
-
-// RDMCopy performs a copy operation for RDM-backed disks using NetApp storage APIs
-func (c *NetappClonner) RDMCopy(vsphereClient vmware.Client, vmId string, sourceVMDKFile string, persistentVolume populator.PersistentVolume, progress chan<- uint64) error {
-	klog.Infof("Ontap RDM Copy: Starting RDM copy operation for VM %s", vmId)
-
-	// Get disk backing info to find the RDM device
-	backing, err := vsphereClient.GetVMDiskBacking(context.Background(), vmId, sourceVMDKFile)
-	if err != nil {
-		return fmt.Errorf("failed to get RDM disk backing info: %w", err)
-	}
-
-	if !backing.IsRDM {
-		return fmt.Errorf("disk %s is not an RDM disk", sourceVMDKFile)
-	}
-
-	klog.Infof("Ontap RDM Copy: Found RDM device: %s", backing.DeviceName)
-
-	// Resolve the source LUN from the RDM device name
-	sourceLUN, err := c.resolveRDMToLUN(backing.DeviceName)
-	if err != nil {
-		return fmt.Errorf("failed to resolve RDM device to source LUN: %w", err)
-	}
-
-	// Resolve the target PV to LUN
-	targetLUN, err := c.ResolvePVToLUN(persistentVolume)
-	if err != nil {
-		return fmt.Errorf("failed to resolve target volume: %w", err)
-	}
-
-	klog.Infof("Ontap RDM Copy: Copying from source LUN %s to target LUN %s", sourceLUN.Name, targetLUN.Name)
-
-	// Report progress start
-	progress <- 10
-
-	// Extract volume name from target LUN path for clone operation
-	// LUN path format is typically: /vol/<volume_name>/lun0
-	targetVolName := extractVolumeName(targetLUN.Name)
-	if targetVolName == "" {
-		return fmt.Errorf("failed to extract volume name from LUN path: %s", targetLUN.Name)
-	}
-
-	// Use ONTAP's LUN clone capability to copy data
-	// LunCloneCreate creates a clone from a source LUN to a new LUN in the target volume
-	err = c.api.LunCloneCreate(context.Background(), targetVolName, sourceLUN.Name, "lun0", api.QosPolicyGroup{})
-	if err != nil {
-		return fmt.Errorf("ONTAP LUN clone failed: %w", err)
-	}
-
-	// Report progress complete
-	progress <- 100
-
-	klog.Infof("Ontap RDM Copy: Copy operation completed successfully")
-	return nil
-}
-
-// resolveRDMToLUN resolves an RDM device name to an ONTAP LUN
-func (c *NetappClonner) resolveRDMToLUN(deviceName string) (populator.LUN, error) {
-	klog.Infof("Ontap RDM Copy: Resolving RDM device %s to LUN", deviceName)
-
-	// The device name from RDM typically contains the NAA identifier
-	// Format is usually like "naa.600a0980..." or just the hex serial
-	// We need to find the corresponding LUN in ONTAP
-
-	// List all LUNs and find the one matching the device name
-	luns, err := c.api.LunList(context.Background(), "*")
-	if err != nil {
-		return populator.LUN{}, fmt.Errorf("failed to list LUNs: %w", err)
-	}
-
-	for _, lun := range luns {
-		// Compare serial numbers - the RDM device name contains the serial
-		naa := fmt.Sprintf("naa.%s%x", OntapProviderID, lun.SerialNumber)
-		if naa == deviceName || containsSerial(deviceName, lun.SerialNumber) {
-			klog.Infof("Ontap RDM Copy: Found matching LUN %s for device %s", lun.Name, deviceName)
-			return populator.LUN{
-				Name:         lun.Name,
-				SerialNumber: lun.SerialNumber,
-				NAA:          naa,
-			}, nil
-		}
-	}
-
-	return populator.LUN{}, fmt.Errorf("could not find LUN matching RDM device %s", deviceName)
-}
-
-// extractVolumeName extracts the volume name from a LUN path
-// LUN path format: /vol/<volume_name>/lun0
-func extractVolumeName(lunPath string) string {
-	parts := strings.Split(lunPath, "/")
-	if len(parts) >= 3 && parts[1] == "vol" {
-		return parts[2]
-	}
-	return ""
-}
-
-// containsSerial checks if a device name contains the serial number
-func containsSerial(deviceName, serial string) bool {
-	return strings.Contains(strings.ToLower(deviceName), strings.ToLower(serial))
 }


### PR DESCRIPTION
The RDM functionality for ONTAP provider was not working correctly. Removed RDMCapable interface implementation and all RDM-related methods.

Resolves: MTV-4214