### PR TITLE
fix(security): CVE-2025-61729 - Update Go to 1.25.3

### DIFF
--- a/build/forklift-api/Containerfile
+++ b/build/forklift-api/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/forklift-api/Containerfile-downstream
+++ b/build/forklift-api/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24.4-1752083840 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/forklift-cli-download/Containerfile
+++ b/build/forklift-cli-download/Containerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1766449309 AS builder
 
 USER 0
 WORKDIR /app

--- a/build/forklift-cli-download/Containerfile-downstream
+++ b/build/forklift-cli-download/Containerfile-downstream
@@ -1,5 +1,5 @@
 # Build stage
-FROM registry.redhat.io/ubi9/go-toolset:1.24.4-1752083840 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.25.3-1766449309 AS builder
 
 USER 0
 WORKDIR /app

--- a/build/forklift-controller/Containerfile
+++ b/build/forklift-controller/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/forklift-controller/Containerfile-downstream
+++ b/build/forklift-controller/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24.4-1752083840 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.25.3-1766449309 AS builder
 
 USER 0
 WORKDIR /app

--- a/build/openstack-populator/Containerfile
+++ b/build/openstack-populator/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/openstack-populator/Containerfile-downstream
+++ b/build/openstack-populator/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24.4-1752083840 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/ova-provider-server/Containerfile
+++ b/build/ova-provider-server/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/ova-provider-server/Containerfile-downstream
+++ b/build/ova-provider-server/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24.4-1752083840 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/ova-proxy/Containerfile
+++ b/build/ova-proxy/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/ova-proxy/Containerfile-downstream
+++ b/build/ova-proxy/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24.4-1752083840 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/populator-controller/Containerfile
+++ b/build/populator-controller/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/populator-controller/Containerfile-downstream
+++ b/build/populator-controller/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24.4-1752083840 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/validation/Containerfile-downstream
+++ b/build/validation/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24.6-1758501173 AS mtv-opa
+FROM registry.redhat.io/ubi9/go-toolset:1.25.3-1766449309 AS mtv-opa
 USER 0
 WORKDIR /app/opa
 ENV GOFLAGS="-tags=strictfipsruntime"

--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/local/lib/guestfs/appliance && \
     qemu-img convert -c -O qcow2 root root.qcow2 && \
     mv -vf root.qcow2 root
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER 0
 WORKDIR /app
 COPY --chown=1001:0 ./ ./

--- a/build/vsphere-xcopy-volume-populator/Containerfile
+++ b/build/vsphere-xcopy-volume-populator/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1753221510 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1766449309 AS builder
 USER root
 WORKDIR /usr/src/app
 

--- a/build/vsphere-xcopy-volume-populator/Containerfile-downstream
+++ b/build/vsphere-xcopy-volume-populator/Containerfile-downstream
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.24.4-1752083840 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.25.3-1766449309 AS builder
 COPY --chown=1001:0 . /src
 WORKDIR /src/cmd/vsphere-xcopy-volume-populator
 


### PR DESCRIPTION
Update all UBI 9 Go base images from go-toolset 1.24.x to 1.25.3-1766449309 to address CVE-2025-61729 (excessive resource consumption in crypto/x509 certificate validation error handling).

Affected components:
- forklift-api
- forklift-cli-download
- forklift-controller
- openstack-populator
- ova-provider-server
- populator-controller
- validation
- vsphere-xcopy-volume-populator

Go 1.25.3 includes the fix for this vulnerability.

Resolves: MTV-4217, MTV-4218, MTV-4220, MTV-4221, MTV-4222, MTV-4224,
          MTV-4226, MTV-4227, MTV-4228