### PR TITLE
fix(security): Fix CVE-2025-66418: Update urllib3 in operator

### DIFF
--- a/build/forklift-operator/Containerfile
+++ b/build/forklift-operator/Containerfile
@@ -1,6 +1,9 @@
 FROM quay.io/operator-framework/ansible-operator:main
 
 USER root
+# SECURITY: Fix CVE-2025-66418 in urllib3
+RUN pip3 install --upgrade 'urllib3>=2.6.0' 'brotli>=1.2.0' && pip3 cache purge
+
 # RUN dnf -y update && dnf clean all
 # RUN rm -rf /var/cache/yum /var/cache/dnf
 # Trying to overcome the bug within OCP4.15 and k8s collections (https://issues.redhat.com/browse/MTV-947)

--- a/build/forklift-operator/Containerfile-downstream
+++ b/build/forklift-operator/Containerfile-downstream
@@ -1,5 +1,9 @@
 FROM registry.redhat.io/openshift4/ose-ansible-rhel9-operator:v4.18.0-202504021503.p0.gbd5e2c9.assembly.stream.el9
 
+USER root
+# SECURITY: Fix CVE-2025-66418  in urllib3
+RUN pip3 install --upgrade 'urllib3>=2.6.0' 'brotli>=1.2.0' && pip3 cache purge
+
 USER 1001
 WORKDIR /app
 COPY operator/watches.yaml watches.yaml


### PR DESCRIPTION
Update urllib3 to version 2.6.0 or later to fix CVE-2025-66418 (unbounded decompression chain).
These vulnerabilities allow a malicious server to cause high CPU usage and massive memory allocation through compression attacks.

Affected components:
- forklift-operator (upstream + downstream)

Resolves: MTV-4109
Resolves: MTV-4117
Resolves: MTV-4121