### PR TITLE
fix(manifests): Re-generate manifests to include Condition.suggestion

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -577,6 +577,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -793,6 +796,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -986,6 +992,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -1041,6 +1050,10 @@ spec:
                             type: string
                           status:
                             description: The condition status [true,false].
+                            type: string
+                          suggestion:
+                            description: A suggested action or resolution for the
+                              condition.
                             type: string
                           type:
                             description: The condition type.
@@ -1715,6 +1728,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -1988,6 +2004,9 @@ spec:
                       type: string
                     status:
                       description: The condition status [true,false].
+                      type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
                       type: string
                     type:
                       description: The condition type.
@@ -4758,6 +4777,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -4809,6 +4831,10 @@ spec:
                                 type: string
                               status:
                                 description: The condition status [true,false].
+                                type: string
+                              suggestion:
+                                description: A suggested action or resolution for
+                                  the condition.
                                 type: string
                               type:
                                 description: The condition type.
@@ -5015,6 +5041,10 @@ spec:
                                 type: string
                               status:
                                 description: The condition status [true,false].
+                                type: string
+                              suggestion:
+                                description: A suggested action or resolution for
+                                  the condition.
                                 type: string
                               type:
                                 description: The condition type.
@@ -5618,6 +5648,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -5952,6 +5985,9 @@ spec:
                       type: string
                     status:
                       description: The condition status [true,false].
+                      type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
                       type: string
                     type:
                       description: The condition type.

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -577,6 +577,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -793,6 +796,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -986,6 +992,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -1041,6 +1050,10 @@ spec:
                             type: string
                           status:
                             description: The condition status [true,false].
+                            type: string
+                          suggestion:
+                            description: A suggested action or resolution for the
+                              condition.
                             type: string
                           type:
                             description: The condition type.
@@ -1715,6 +1728,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -1988,6 +2004,9 @@ spec:
                       type: string
                     status:
                       description: The condition status [true,false].
+                      type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
                       type: string
                     type:
                       description: The condition type.
@@ -4758,6 +4777,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -4809,6 +4831,10 @@ spec:
                                 type: string
                               status:
                                 description: The condition status [true,false].
+                                type: string
+                              suggestion:
+                                description: A suggested action or resolution for
+                                  the condition.
                                 type: string
                               type:
                                 description: The condition type.
@@ -5015,6 +5041,10 @@ spec:
                                 type: string
                               status:
                                 description: The condition status [true,false].
+                                type: string
+                              suggestion:
+                                description: A suggested action or resolution for
+                                  the condition.
                                 type: string
                               type:
                                 description: The condition type.
@@ -5618,6 +5648,9 @@ spec:
                     status:
                       description: The condition status [true,false].
                       type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
+                      type: string
                     type:
                       description: The condition type.
                       type: string
@@ -5952,6 +5985,9 @@ spec:
                       type: string
                     status:
                       description: The condition status [true,false].
+                      type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
                       type: string
                     type:
                       description: The condition type.


### PR DESCRIPTION
The 'suggestion' field was added in 12e24f09a but the manifests were not re-generated. Re-generate them so they are up to date.
