### PR TITLE
MTV-3932 | fix duplicate RunSpecs in tests

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/secure_script_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/secure_script_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -16,12 +15,7 @@ import (
 
 	vmware_mocks "github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/vmware/mocks"
 )
-
-func TestSecureScript(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Secure Script Suite")
-}
-
+ 
 var _ = Describe("uploadScript", func() {
 	var (
 		ctrl       *gomock.Controller


### PR DESCRIPTION
Fix Ginkgo duplicate RunSpecs error in populator tests Ginkgo doesn't support multiple RunSpecs calls in the same package. Both secure_script_test.go and remote_esxcli_test.go had their own test suite entry points, causing CI to fail. Removed the duplicate TestSecureScript function and unused testing import. Both test files now share the existing TestRemoteEsxcli entry point, allowing all 22 specs to run successfully.
https://github.com/kubev2v/forklift/pull/4001
Resolves: MTV-3932