### PR TITLE
Revert "Resolves: MTV-2444 | RFE: Enable NVMe disk support for vSphere VM migration"

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -224,6 +224,8 @@ type Validator interface {
 	PowerState(vmRef ref.Ref) (bool, error)
 	// Validate that the VM is inherently compatible with the migration type.
 	VMMigrationType(vmRef ref.Ref) (bool, error)
+	// Validate that the VM disks are supported.
+	UnSupportedDisks(vmRef ref.Ref) ([]string, error)
 	// Validate that the VM disks have valid sizes (> 0).
 	InvalidDiskSizes(vmRef ref.Ref) ([]string, error)
 	// Validate that the VM MAC addresses don't conflict with existing destination VMs.

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -169,6 +169,11 @@ func (r *Validator) MigrationType() bool {
 }
 
 // NOOP
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	return []string{}, nil
+}
+
+// NOOP
 func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {
 	return []string{}, nil
 }

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -72,6 +72,11 @@ func (r *Validator) UdnStaticIPs(vmRef ref.Ref, client client.Client) (ok bool, 
 	return true, nil
 }
 
+// NOOP
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	return []string{}, nil
+}
+
 func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {
 	vm := &model.Workload{}
 	err := r.Source.Inventory.Find(vm, vmRef)

--- a/pkg/controller/plan/adapter/ova/validator.go
+++ b/pkg/controller/plan/adapter/ova/validator.go
@@ -33,6 +33,11 @@ func (r *Validator) MigrationType() bool {
 	}
 }
 
+// NOOP
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	return []string{}, nil
+}
+
 // NO-OP
 func (r *Validator) UdnStaticIPs(vmRef ref.Ref, client client.Client) (ok bool, err error) {
 	return true, nil

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -20,6 +20,11 @@ type Validator struct {
 	*plancontext.Context
 }
 
+// NOOP
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	return []string{}, nil
+}
+
 func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {
 	vm := &model.Workload{}
 	err := r.Source.Inventory.Find(vm, vmRef)

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -282,6 +282,27 @@ func (r *Validator) findRunningVms(vms []model.VM) []string {
 	return resp
 }
 
+func (r *Validator) UnSupportedDisks(vmRef ref.Ref) ([]string, error) {
+	vm := &model.VM{}
+	err := r.Source.Inventory.Find(vm, vmRef)
+	if err != nil {
+		return nil, liberr.Wrap(err, "vm", vmRef)
+	}
+
+	unsupported := []string{}
+	unsupportedBuses := map[string]bool{
+		"nvme": true,
+	}
+
+	for _, disk := range vm.Disks {
+		if unsupportedBuses[disk.Bus] {
+			unsupported = append(unsupported, disk.Bus)
+		}
+	}
+
+	return unsupported, nil
+}
+
 func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {
 	vm := &model.VM{}
 	err := r.Source.Inventory.Find(vm, vmRef)

--- a/validation/policies/io/konveyor/forklift/vmware/nvme_disk test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/nvme_disk test.rego
@@ -1,0 +1,26 @@
+package io.konveyor.forklift.vmware
+
+import rego.v1
+
+test_has_nvme_bus if {
+	mock_vm := {
+		"name": "test",
+		"disks": [
+			{"bus": "scsi"},
+			{"bus": "nvme"},
+		],
+	}
+
+	results := concerns with input as mock_vm
+	count(results) == 1
+}
+
+test_has_no_nvme_bus if {
+	mock_vm := {
+		"name": "test",
+		"disks": [{"bus": "scsi"}],
+	}
+
+	results := concerns with input as mock_vm
+	count(results) == 0
+}

--- a/validation/policies/io/konveyor/forklift/vmware/nvme_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/nvme_disk.rego
@@ -1,0 +1,18 @@
+package io.konveyor.forklift.vmware
+
+import rego.v1
+
+has_nvme_bus if {
+	some i
+	input.disks[i].bus == "nvme"
+}
+
+concerns contains flag if {
+	has_nvme_bus
+	flag := {
+		"id": "vmware.disk.nvme.detected",
+		"category": "Critical",
+		"label": "Disk NVMe was detected",
+		"assessment": "NVMe disks are not currently supported by MTV. The VM cannot be migrated",
+	}
+}


### PR DESCRIPTION
This reverts commit 85fe594fe69cc00b5b6646eb7006a296804a6044.

Ref: https://github.com/kubev2v/forklift/pull/4087