### PR TITLE
MTV-3884 | Remove unused DV builder from EC2

### DIFF
--- a/pkg/provider/ec2/controller/builder/core.go
+++ b/pkg/provider/ec2/controller/builder/core.go
@@ -1,8 +1,6 @@
 package builder
 
 import (
-	"fmt"
-
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 )
@@ -21,19 +19,4 @@ func New(ctx *plancontext.Context) *Builder {
 		Context: ctx,
 		log:     log,
 	}
-}
-
-// getRegion extracts AWS region from provider secret (e.g., "us-east-1").
-// Required for AWS SDK clients and Ec2VolumePopulator specs. Returns error if secret missing or region not configured.
-func (r *Builder) getRegion() (string, error) {
-	if r.Source.Secret == nil {
-		return "", fmt.Errorf("provider secret is nil, cannot determine AWS region")
-	}
-
-	region, found := r.Source.Secret.Data["region"]
-	if !found || len(region) == 0 {
-		return "", fmt.Errorf("region not configured in provider secret, please add 'region' key")
-	}
-
-	return string(region), nil
 }

--- a/pkg/provider/ec2/controller/builder/noop.go
+++ b/pkg/provider/ec2/controller/builder/noop.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	core "k8s.io/api/core/v1"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
 // ConfigMap is a no-op for EC2 - VM configuration derived from EC2 instance metadata, not ConfigMaps.
@@ -40,4 +41,14 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 func (r *Builder) PreferenceName(vmRef ref.Ref, configMap *core.ConfigMap) (name string, err error) {
 	err = liberr.New("preferences are not used by this provider")
 	return
+}
+
+// DataVolumes is a no-op for EC2 - uses direct PV/PVC creation from EBS volumes instead of CDI DataVolumes.
+func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) ([]cdi.DataVolume, error) {
+	return nil, nil
+}
+
+// ResolveDataVolumeIdentifier is a no-op for EC2 - EC2 doesn't create DataVolumes, so nothing to resolve.
+func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
+	return ""
 }


### PR DESCRIPTION
Revmove unuded DV builder from EC2 provider controller

Resolves: MTV-3884

Follow up on: https://github.com/kubev2v/forklift/pull/3731#discussion_r2679320266