### PR TITLE
MTV-3884 | Rename noopclient to client in EC2

### DIFF
--- a/pkg/provider/ec2/controller/adapter/adapter.go
+++ b/pkg/provider/ec2/controller/adapter/adapter.go
@@ -43,11 +43,9 @@ func (r *Adapter) Validator(ctx *plancontext.Context) (base.Validator, error) {
 }
 
 // Client returns EC2-specific client for instance operations: power management, snapshots, volumes.
-// Wrapped in NoopClient to provide no-op implementations for unsupported warm migration methods.
+// EC2 only supports cold migration, so warm migration methods (SetCheckpoints, GetSnapshotDeltas) are no-ops.
 func (r *Adapter) Client(ctx *plancontext.Context) (base.Client, error) {
-	return &NoopClient{
-		Client: &client.Client{Context: ctx},
-	}, nil
+	return &client.Client{Context: ctx}, nil
 }
 
 // DestinationClient returns destination client for managing direct volume ownership.

--- a/pkg/provider/ec2/controller/adapter/noop.go
+++ b/pkg/provider/ec2/controller/adapter/noop.go
@@ -1,41 +1,15 @@
 package adapter
 
 import (
-	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
-	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
-	"github.com/kubev2v/forklift/pkg/controller/plan/util"
 	"github.com/kubev2v/forklift/pkg/provider/ec2/controller/builder"
-	"github.com/kubev2v/forklift/pkg/provider/ec2/controller/client"
 	ec2ensurer "github.com/kubev2v/forklift/pkg/provider/ec2/controller/ensurer"
 	"github.com/kubev2v/forklift/pkg/provider/ec2/controller/validator"
-	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
-
-// NoopClient embeds client.Client and provides no-op implementations for warm migration methods.
-//
-// EC2 migrations only support cold migration, so warm migration features like checkpoints
-// and incremental snapshot deltas are not applicable. This wrapper provides no-op
-// implementations of those methods while delegating supported operations to the embedded
-// EC2 client.
-type NoopClient struct {
-	*client.Client
-}
-
-// SetCheckpoints is a no-op for EC2 - only cold migration supported, no checkpoints or incremental tracking.
-func (r *NoopClient) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool, hostsFunc util.HostsFunc) error {
-	return nil
-}
-
-// GetSnapshotDeltas is a no-op for EC2 - uses complete EBS snapshots, not incremental deltas.
-func (r *NoopClient) GetSnapshotDeltas(vmRef ref.Ref, snapshot string, hostsFunc util.HostsFunc) (map[string]string, error) {
-	return make(map[string]string), nil
-}
 
 // Compile-time interface checks. Ensures types implement required base interfaces.
 // Catches missing/incorrect methods at compile time, prevents runtime panics.
 var _ base.Adapter = &Adapter{}
-var _ base.Client = &NoopClient{}
 var _ base.DestinationClient = &DestinationClient{}
 var _ base.Builder = &builder.Builder{}
 var _ base.Ensurer = &ec2ensurer.Ensurer{}

--- a/pkg/provider/ec2/controller/client/client.go
+++ b/pkg/provider/ec2/controller/client/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
@@ -118,16 +117,6 @@ func (r *Client) Close() {
 	r.sourceClient = nil
 	r.targetClient = nil
 	r.crossAccount = false
-}
-
-// Disconnect is a no-op for EC2 - AWS SDK clients are stateless, no persistent connections.
-func (r *Client) Disconnect() error {
-	return nil
-}
-
-// DetachDisks is a no-op for EC2 - snapshots created from attached volumes after instance shutdown.
-func (r *Client) DetachDisks(vmRef ref.Ref) error {
-	return nil
 }
 
 // getSourceClient returns the source account EC2 client for snapshot and power operations.

--- a/pkg/provider/ec2/controller/client/noop.go
+++ b/pkg/provider/ec2/controller/client/noop.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	"github.com/kubev2v/forklift/pkg/controller/plan/util"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+// Disconnect is a no-op for EC2 - AWS SDK clients are stateless, no persistent connections.
+func (r *Client) Disconnect() error {
+	return nil
+}
+
+// DetachDisks is a no-op for EC2 - snapshots created from attached volumes after instance shutdown.
+func (r *Client) DetachDisks(vmRef ref.Ref) error {
+	return nil
+}
+
+// SetCheckpoints is a no-op for EC2 - only cold migration supported, no checkpoints or incremental tracking.
+func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool, hostsFunc util.HostsFunc) error {
+	return nil
+}
+
+// GetSnapshotDeltas is a no-op for EC2 - uses complete EBS snapshots, not incremental deltas.
+func (r *Client) GetSnapshotDeltas(vmRef ref.Ref, snapshot string, hostsFunc util.HostsFunc) (map[string]string, error) {
+	return make(map[string]string), nil
+}
+
+// Compile-time interface check. Ensures Client implements required base.Client interface.
+var _ base.Client = &Client{}

--- a/pkg/provider/ec2/controller/migrator/core.go
+++ b/pkg/provider/ec2/controller/migrator/core.go
@@ -11,6 +11,7 @@ import (
 	migbase "github.com/kubev2v/forklift/pkg/controller/plan/migrator/base"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	ec2adapter "github.com/kubev2v/forklift/pkg/provider/ec2/controller/adapter"
+	ec2client "github.com/kubev2v/forklift/pkg/provider/ec2/controller/client"
 	ec2ensurer "github.com/kubev2v/forklift/pkg/provider/ec2/controller/ensurer"
 )
 
@@ -57,12 +58,12 @@ func New(ctx *plancontext.Context) (migbase.Migrator, error) {
 		return nil, err
 	}
 
-	noopCli, ok := client.(*ec2adapter.NoopClient)
+	ec2Cli, ok := client.(*ec2client.Client)
 	if !ok {
-		return nil, fmt.Errorf("failed to type assert client to *ec2adapter.NoopClient, got %T", client)
+		return nil, fmt.Errorf("failed to type assert client to *ec2client.Client, got %T", client)
 	}
 
-	if err = noopCli.Client.Connect(); err != nil {
+	if err = ec2Cli.Connect(); err != nil {
 		log.Error(err, "Failed to connect EC2 client")
 		return nil, err
 	}
@@ -119,6 +120,6 @@ func (r *Migrator) getEnsurer() *ec2ensurer.Ensurer {
 }
 
 // getEC2Client returns the EC2-specific client for direct AWS API operations.
-func (r *Migrator) getEC2Client() *ec2adapter.NoopClient {
-	return r.adpClient.(*ec2adapter.NoopClient)
+func (r *Migrator) getEC2Client() *ec2client.Client {
+	return r.adpClient.(*ec2client.Client)
 }

--- a/pkg/provider/ec2/controller/migrator/directvolumes.go
+++ b/pkg/provider/ec2/controller/migrator/directvolumes.go
@@ -15,7 +15,7 @@ import (
 // Returns a map of originalVolumeID -> newVolumeID.
 func (r *Migrator) getVolumeIDs(vm *planapi.VMStatus) (map[string]string, error) {
 	ec2Client := r.getEC2Client()
-	return ec2Client.Client.GetCreatedVolumesForVM(vm.Ref)
+	return ec2Client.GetCreatedVolumesForVM(vm.Ref)
 }
 
 // createVolumes creates EBS volumes from snapshots in the target AZ.
@@ -69,7 +69,7 @@ func (r *Migrator) createVolumes(vm *planapi.VMStatus) (bool, error) {
 			"originalVolumeID", originalVolumeID,
 			"snapshotID", snapshotID)
 
-		newVolumeID, err := ec2Client.Client.CreateVolumeFromSnapshot(vm.Ref, originalVolumeID, snapshotID)
+		newVolumeID, err := ec2Client.CreateVolumeFromSnapshot(vm.Ref, originalVolumeID, snapshotID)
 		if err != nil {
 			r.log.Error(err, "Failed to create volume from snapshot",
 				"vm", vm.Name,
@@ -124,7 +124,7 @@ func (r *Migrator) waitForVolumes(vm *planapi.VMStatus) (bool, error) {
 	ec2Client := r.getEC2Client()
 
 	// Check if all volumes are ready
-	ready, err := ec2Client.Client.CheckVolumesReady(vm.Ref, volumeIDs)
+	ready, err := ec2Client.CheckVolumesReady(vm.Ref, volumeIDs)
 	if err != nil {
 		r.log.Error(err, "Failed to check volume status", "vm", vm.Name)
 		return false, liberr.Wrap(err)

--- a/pkg/provider/ec2/controller/migrator/itinerary.go
+++ b/pkg/provider/ec2/controller/migrator/itinerary.go
@@ -86,7 +86,7 @@ func (p *EC2Predicate) Evaluate(flag libitr.Flag) (bool, error) {
 	if flag&CrossAccountFlag != 0 {
 		if p.migrator != nil {
 			ec2Client := p.migrator.getEC2Client()
-			return ec2Client.Client.IsCrossAccount(), nil
+			return ec2Client.IsCrossAccount(), nil
 		}
 		return false, nil
 	}


### PR DESCRIPTION
Rename noopClient to Client in the EC2 provider

Resolves: MTV-3884

Followup to: https://github.com/kubev2v/forklift/pull/3731#discussion_r2679302846