### PR TITLE
MTV-3884 | JSON to Typed struct in EC2 invelntory

### DIFF
--- a/pkg/provider/ec2/inventory/collector/instance.go
+++ b/pkg/provider/ec2/inventory/collector/instance.go
@@ -43,11 +43,8 @@ func (r *Collector) collectInstances(ctx context.Context) error {
 		}
 		m.Platform = getPlatform(awsInstance.Platform, awsInstance.PlatformDetails)
 
-		// Store complete AWS instance as JSON
-		if err := m.SetObject(awsInstance); err != nil {
-			r.log.Error(err, "Failed to marshal instance", "instanceId", m.UID)
-			continue
-		}
+		// Store complete AWS instance object
+		m.Object = awsInstance
 
 		// Check if record exists and has changed
 		existing := &model.Instance{}

--- a/pkg/provider/ec2/inventory/collector/network.go
+++ b/pkg/provider/ec2/inventory/collector/network.go
@@ -39,10 +39,8 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 			m.CIDR = *awsVpc.CidrBlock
 		}
 
-		if err := m.SetObject(awsVpc); err != nil {
-			r.log.Error(err, "Failed to marshal VPC", "vpcId", m.UID)
-			continue
-		}
+		// VPCs don't populate the Subnet Object field (only subnets do)
+		// The Object field remains zero-valued for VPCs
 
 		// Check if record exists and has changed
 		existing := &model.Network{}
@@ -100,10 +98,8 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 			m.CIDR = *awsSubnet.CidrBlock
 		}
 
-		if err := m.SetObject(awsSubnet); err != nil {
-			r.log.Error(err, "Failed to marshal Subnet", "subnetId", m.UID)
-			continue
-		}
+		// Store complete AWS subnet object
+		m.Object = awsSubnet
 
 		// Check if record exists and has changed
 		existing := &model.Network{}

--- a/pkg/provider/ec2/inventory/collector/storage.go
+++ b/pkg/provider/ec2/inventory/collector/storage.go
@@ -39,17 +39,12 @@ func (r *Collector) collectStorageTypes(ctx context.Context) error {
 		m.Provider = string(r.provider.UID)
 		m.VolumeType = volType.Type
 
-		// Store volume type details as JSON (includes human-readable description)
-		details := map[string]interface{}{
-			"type":          volType.Type,
-			"description":   volType.Description,
-			"maxIOPS":       volType.MaxIOPS,
-			"maxThroughput": volType.MaxThroughput,
-		}
-
-		if err := m.SetObject(details); err != nil {
-			r.log.Error(err, "Failed to marshal storage type", "type", volType.Type)
-			continue
+		// Store volume type details
+		m.Object = model.StorageData{
+			Type:          volType.Type,
+			Description:   volType.Description,
+			MaxIOPS:       volType.MaxIOPS,
+			MaxThroughput: volType.MaxThroughput,
 		}
 
 		// Check if record exists and has changed

--- a/pkg/provider/ec2/inventory/collector/volume.go
+++ b/pkg/provider/ec2/inventory/collector/volume.go
@@ -41,11 +41,8 @@ func (r *Collector) collectVolumes(ctx context.Context) error {
 			m.Size = int64(*awsVolume.Size) // Size in GiB
 		}
 
-		// Store complete AWS volume as JSON
-		if err := m.SetObject(awsVolume); err != nil {
-			r.log.Error(err, "Failed to marshal volume", "volumeId", m.UID)
-			continue
-		}
+		// Store complete AWS volume object
+		m.Object = awsVolume
 
 		// Check if record exists and has changed
 		existing := &model.Volume{}


### PR DESCRIPTION
Use Typed struct instead of JSON in EC2 inventory

Resolves: MTV-3884

Issue:
In EC2 inventory the object field is using un-typed object struct ( JSON encoded ), in MTV we use typed struct for the object struct, see the openshift provider for reference

Ref: https://github.com/kubev2v/forklift/pull/3731#discussion_r2675097520

Fix:
Use types struct for EC2 , similar to the way we do in Openshift provider.