### PR TITLE
MTV-4150 | Fix disk transfer completed when importer pod is pending

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1786,6 +1786,134 @@ func (r *Migration) setTaskCompleted(task *plan.Task) {
 	task.MarkCompleted()
 }
 
+// verifyDataVolumeCompletion checks if a DataVolume that reports Succeeded phase
+// is actually ready for completion by verifying:
+// - The main PVC is bound
+// - The prime PVC (if it exists) is bound
+// - The importer pod (if it exists) is not pending
+//
+// Forklift may treat PendingPopulation as Succeeded for cold conversion migrations;
+// this verifies PVC and importer state before marking disk transfer complete.
+//
+// Returns true if the DataVolume can be marked as completed, false otherwise.
+// Also returns a reason string explaining why completion was blocked (if applicable).
+func (r *Migration) verifyDataVolumeCompletion(dv *cdi.DataVolume, vm *plan.VMStatus) (canComplete bool, reason string) {
+	// If no claim name, we can't verify - allow completion
+	if dv.Status.ClaimName == "" {
+		r.Log.V(4).Info("DataVolume has no ClaimName, allowing completion",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase)
+		return true, ""
+	}
+
+	// Get the main PVC
+	pvc := &core.PersistentVolumeClaim{}
+	err := r.Destination.Get(context.TODO(), types.NamespacedName{
+		Namespace: r.Plan.Spec.TargetNamespace,
+		Name:      dv.Status.ClaimName,
+	}, pvc)
+	if err != nil {
+		r.Log.Error(err, "Could not get PVC for DataVolume to verify completion",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase,
+			"pvcName", dv.Status.ClaimName)
+		return false, fmt.Sprintf("Could not get PVC: %v", err)
+	}
+
+	// Log diagnostic information about CDI state
+	podPhaseAnnotation := pvc.Annotations[base.AnnPodPhase]
+	r.Log.V(3).Info("Verifying DataVolume completion state",
+		"vm", vm.String(),
+		"dv", path.Join(dv.Namespace, dv.Name),
+		"dvPhase", dv.Status.Phase,
+		"pvcPhase", pvc.Status.Phase,
+		"podPhaseAnnotation", podPhaseAnnotation)
+
+	// Check if main PVC is bound
+	if pvc.Status.Phase != core.ClaimBound {
+		r.Log.Info("DataVolume reports Succeeded but main PVC is not bound",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase,
+			"pvcPhase", pvc.Status.Phase,
+			"podPhaseAnnotation", podPhaseAnnotation)
+		return false, fmt.Sprintf("Main PVC is not bound (phase: %s)", pvc.Status.Phase)
+	}
+
+	// Check prime PVC if it exists (importer pod uses prime PVC)
+	primePVC := &core.PersistentVolumeClaim{}
+	err = r.Destination.Get(context.TODO(), types.NamespacedName{
+		Namespace: r.Plan.Spec.TargetNamespace,
+		Name:      fmt.Sprintf("prime-%s", pvc.UID),
+	}, primePVC)
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			r.Log.Error(err, "Could not get prime PVC for DataVolume to verify completion",
+				"vm", vm.String(),
+				"dv", path.Join(dv.Namespace, dv.Name),
+				"dvPhase", dv.Status.Phase)
+			return false, fmt.Sprintf("Could not get prime PVC: %v", err)
+		}
+		// Prime PVC doesn't exist - that's okay, importer may not be using it
+		r.Log.V(4).Info("Prime PVC does not exist, skipping prime PVC check",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name))
+		return true, ""
+	}
+
+	// Prime PVC exists - check if it's bound
+	if primePVC.Status.Phase != core.ClaimBound {
+		r.Log.Info("DataVolume reports Succeeded but prime PVC is not bound",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase,
+			"primePVCPhase", primePVC.Status.Phase,
+			"podPhaseAnnotation", podPhaseAnnotation)
+		return false, fmt.Sprintf("Prime PVC is not bound (phase: %s)", primePVC.Status.Phase)
+	}
+
+	// Check if importer pod exists and is not pending
+	importer, found, kErr := r.kubevirt.GetImporterPod(*primePVC)
+	if kErr != nil {
+		r.Log.Error(kErr, "Could not get CDI importer pod for DataVolume to verify completion",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase)
+		// Don't block completion if we can't check the pod - this is a transient issue
+		return true, ""
+	}
+
+	if !found || importer == nil {
+		// No importer pod found - that's okay, it may have completed and been cleaned up
+		r.Log.V(4).Info("No importer pod found, allowing completion",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name))
+		return true, ""
+	}
+
+	// Check if importer pod is pending
+	if importer.Status.Phase == core.PodPending {
+		r.Log.Info("DataVolume reports Succeeded but importer pod is pending",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase,
+			"podPhase", importer.Status.Phase,
+			"podPhaseAnnotation", podPhaseAnnotation,
+			"pod", path.Join(importer.Namespace, importer.Name))
+		return false, fmt.Sprintf("Importer pod is pending (pod: %s/%s)", importer.Namespace, importer.Name)
+	}
+
+	// All checks passed
+	r.Log.V(3).Info("DataVolume completion verified successfully",
+		"vm", vm.String(),
+		"dv", path.Join(dv.Namespace, dv.Name),
+		"dvPhase", dv.Status.Phase,
+		"podPhase", importer.Status.Phase)
+	return true, ""
+}
+
 // Update the progress of the appropriate disk copy step. (DiskTransfer, Cutover)
 func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err error) {
 	var pendingReason string
@@ -1828,16 +1956,28 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 			if !found {
 				continue
 			}
-			if dv.Status.Phase == cdi.PendingPopulation && r.Source.Provider.RequiresConversion() {
-				// in migrations that involve conversion, the conversion pod serves as the
-				// first consumer of the PVCs so we can treat PendingPopulation as Succeeded
+			if dv.Status.Phase == cdi.PendingPopulation && r.Source.Provider.RequiresConversion() && !r.Plan.IsWarm() {
+				// Cold conversion migrations: the conversion pod is the first consumer of
+				// the PVCs, so PendingPopulation can be treated as Succeeded. Warm migrations
+				// still require the importer to run — do not promote the phase here.
 				dv.Status.Phase = cdi.Succeeded
 			}
 			conditions := dv.Conditions()
 			switch dv.Status.Phase {
 			case cdi.Succeeded:
-				completed++
-				r.setTaskCompleted(task)
+				canMarkCompleted, reason := r.verifyDataVolumeCompletion(dv.DataVolume, vm)
+				if canMarkCompleted {
+					completed++
+					r.setTaskCompleted(task)
+				} else {
+					pending++
+					task.Phase = api.StepPending
+					if reason != "" {
+						task.Reason = fmt.Sprintf("DataVolume shows %s but verification failed: %s", dv.Status.Phase, reason)
+					} else {
+						task.Reason = fmt.Sprintf("DataVolume shows %s but PVC is not bound or importer pod is pending", dv.Status.Phase)
+					}
+				}
 			case cdi.Paused:
 				pvc := &core.PersistentVolumeClaim{}
 				err = r.Destination.Client.Get(context.TODO(), types.NamespacedName{
@@ -1966,6 +2106,19 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 					msg, _ := terminationMessage(importer)
 					task.AddError(msg)
 				}
+			default:
+				// Handle unknown/empty phases - treat as pending
+				log.Info(
+					"DataVolume has unknown or empty phase, treating as pending.",
+					"vm",
+					vm.String(),
+					"dv",
+					path.Join(dv.Namespace, dv.Name),
+					"phase",
+					dv.Status.Phase)
+				pending++
+				task.Phase = api.StepPending
+				task.Reason = fmt.Sprintf("DataVolume phase is unknown or empty: %s", dv.Status.Phase)
 			}
 		}
 	}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1996,6 +1996,134 @@ func (r *Migration) setTaskCompleted(task *plan.Task) {
 	task.MarkCompleted()
 }
 
+// verifyDataVolumeCompletion checks if a DataVolume that reports Succeeded phase
+// is actually ready for completion by verifying:
+// - The main PVC is bound
+// - The prime PVC (if it exists) is bound
+// - The importer pod (if it exists) is not pending
+//
+// Forklift may treat PendingPopulation as Succeeded for cold conversion migrations;
+// this verifies PVC and importer state before marking disk transfer complete.
+//
+// Returns true if the DataVolume can be marked as completed, false otherwise.
+// Also returns a reason string explaining why completion was blocked (if applicable).
+func (r *Migration) verifyDataVolumeCompletion(dv *cdi.DataVolume, vm *plan.VMStatus) (canComplete bool, reason string) {
+	// If no claim name, we can't verify - allow completion
+	if dv.Status.ClaimName == "" {
+		r.Log.V(4).Info("DataVolume has no ClaimName, allowing completion",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase)
+		return true, ""
+	}
+
+	// Get the main PVC
+	pvc := &core.PersistentVolumeClaim{}
+	err := r.Destination.Get(context.TODO(), types.NamespacedName{
+		Namespace: r.Plan.Spec.TargetNamespace,
+		Name:      dv.Status.ClaimName,
+	}, pvc)
+	if err != nil {
+		r.Log.Error(err, "Could not get PVC for DataVolume to verify completion",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase,
+			"pvcName", dv.Status.ClaimName)
+		return false, fmt.Sprintf("Could not get PVC: %v", err)
+	}
+
+	// Log diagnostic information about CDI state
+	podPhaseAnnotation := pvc.Annotations[base.AnnPodPhase]
+	r.Log.V(3).Info("Verifying DataVolume completion state",
+		"vm", vm.String(),
+		"dv", path.Join(dv.Namespace, dv.Name),
+		"dvPhase", dv.Status.Phase,
+		"pvcPhase", pvc.Status.Phase,
+		"podPhaseAnnotation", podPhaseAnnotation)
+
+	// Check if main PVC is bound
+	if pvc.Status.Phase != core.ClaimBound {
+		r.Log.Info("DataVolume reports Succeeded but main PVC is not bound",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase,
+			"pvcPhase", pvc.Status.Phase,
+			"podPhaseAnnotation", podPhaseAnnotation)
+		return false, fmt.Sprintf("Main PVC is not bound (phase: %s)", pvc.Status.Phase)
+	}
+
+	// Check prime PVC if it exists (importer pod uses prime PVC)
+	primePVC := &core.PersistentVolumeClaim{}
+	err = r.Destination.Get(context.TODO(), types.NamespacedName{
+		Namespace: r.Plan.Spec.TargetNamespace,
+		Name:      fmt.Sprintf("prime-%s", pvc.UID),
+	}, primePVC)
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			r.Log.Error(err, "Could not get prime PVC for DataVolume to verify completion",
+				"vm", vm.String(),
+				"dv", path.Join(dv.Namespace, dv.Name),
+				"dvPhase", dv.Status.Phase)
+			return false, fmt.Sprintf("Could not get prime PVC: %v", err)
+		}
+		// Prime PVC doesn't exist - that's okay, importer may not be using it
+		r.Log.V(4).Info("Prime PVC does not exist, skipping prime PVC check",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name))
+		return true, ""
+	}
+
+	// Prime PVC exists - check if it's bound
+	if primePVC.Status.Phase != core.ClaimBound {
+		r.Log.Info("DataVolume reports Succeeded but prime PVC is not bound",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase,
+			"primePVCPhase", primePVC.Status.Phase,
+			"podPhaseAnnotation", podPhaseAnnotation)
+		return false, fmt.Sprintf("Prime PVC is not bound (phase: %s)", primePVC.Status.Phase)
+	}
+
+	// Check if importer pod exists and is not pending
+	importer, found, kErr := r.kubevirt.GetImporterPod(*primePVC)
+	if kErr != nil {
+		r.Log.Error(kErr, "Could not get CDI importer pod for DataVolume to verify completion",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase)
+		// Don't block completion if we can't check the pod - this is a transient issue
+		return true, ""
+	}
+
+	if !found || importer == nil {
+		// No importer pod found - that's okay, it may have completed and been cleaned up
+		r.Log.V(4).Info("No importer pod found, allowing completion",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name))
+		return true, ""
+	}
+
+	// Check if importer pod is pending
+	if importer.Status.Phase == core.PodPending {
+		r.Log.Info("DataVolume reports Succeeded but importer pod is pending",
+			"vm", vm.String(),
+			"dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase,
+			"podPhase", importer.Status.Phase,
+			"podPhaseAnnotation", podPhaseAnnotation,
+			"pod", path.Join(importer.Namespace, importer.Name))
+		return false, fmt.Sprintf("Importer pod is pending (pod: %s/%s)", importer.Namespace, importer.Name)
+	}
+
+	// All checks passed
+	r.Log.V(3).Info("DataVolume completion verified successfully",
+		"vm", vm.String(),
+		"dv", path.Join(dv.Namespace, dv.Name),
+		"dvPhase", dv.Status.Phase,
+		"podPhase", importer.Status.Phase)
+	return true, ""
+}
+
 // Update the progress of the appropriate disk copy step. (DiskTransfer, Cutover)
 func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err error) {
 	var pendingReason string
@@ -2038,16 +2166,28 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 			if !found {
 				continue
 			}
-			if dv.Status.Phase == cdi.PendingPopulation && r.Source.Provider.RequiresConversion() {
-				// in migrations that involve conversion, the conversion pod serves as the
-				// first consumer of the PVCs so we can treat PendingPopulation as Succeeded
+			if dv.Status.Phase == cdi.PendingPopulation && r.Source.Provider.RequiresConversion() && !r.Plan.IsWarm() {
+				// Cold conversion migrations: the conversion pod is the first consumer of
+				// the PVCs, so PendingPopulation can be treated as Succeeded. Warm migrations
+				// still require the importer to run — do not promote the phase here.
 				dv.Status.Phase = cdi.Succeeded
 			}
 			conditions := dv.Conditions()
 			switch dv.Status.Phase {
 			case cdi.Succeeded:
-				completed++
-				r.setTaskCompleted(task)
+				canMarkCompleted, reason := r.verifyDataVolumeCompletion(dv.DataVolume, vm)
+				if canMarkCompleted {
+					completed++
+					r.setTaskCompleted(task)
+				} else {
+					pending++
+					task.Phase = api.StepPending
+					if reason != "" {
+						task.Reason = fmt.Sprintf("DataVolume shows %s but verification failed: %s", dv.Status.Phase, reason)
+					} else {
+						task.Reason = fmt.Sprintf("DataVolume shows %s but PVC is not bound or importer pod is pending", dv.Status.Phase)
+					}
+				}
 			case cdi.Paused:
 				pvc := &core.PersistentVolumeClaim{}
 				err = r.Destination.Get(context.TODO(), types.NamespacedName{
@@ -2196,6 +2336,19 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 						}
 					}
 				}
+			default:
+				// Handle unknown/empty phases - treat as pending
+				log.Info(
+					"DataVolume has unknown or empty phase, treating as pending.",
+					"vm",
+					vm.String(),
+					"dv",
+					path.Join(dv.Namespace, dv.Name),
+					"phase",
+					dv.Status.Phase)
+				pending++
+				task.Phase = api.StepPending
+				task.Reason = fmt.Sprintf("DataVolume phase is unknown or empty: %s", dv.Status.Phase)
 			}
 		}
 	}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -2003,124 +2003,114 @@ func (r *Migration) setTaskCompleted(task *plan.Task) {
 // - The importer pod (if it exists) is not pending
 //
 // Forklift may treat PendingPopulation as Succeeded for cold conversion migrations;
-// this verifies PVC and importer state before marking disk transfer complete.
+// callers that promote that phase should skip this check because the conversion pod
+// is the first consumer (e.g. WaitForFirstConsumer storage).
 //
 // Returns true if the DataVolume can be marked as completed, false otherwise.
 // Also returns a reason string explaining why completion was blocked (if applicable).
 func (r *Migration) verifyDataVolumeCompletion(dv *cdi.DataVolume, vm *plan.VMStatus) (canComplete bool, reason string) {
-	// If no claim name, we can't verify - allow completion
 	if dv.Status.ClaimName == "" {
 		r.Log.V(4).Info("DataVolume has no ClaimName, allowing completion",
-			"vm", vm.String(),
-			"dv", path.Join(dv.Namespace, dv.Name),
-			"dvPhase", dv.Status.Phase)
+			"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name), "dvPhase", dv.Status.Phase)
 		return true, ""
 	}
 
-	// Get the main PVC
+	pvc, err := r.getDataVolumePVC(dv)
+	if err != nil {
+		r.Log.Error(err, "Could not get PVC for DataVolume to verify completion",
+			"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase, "pvcName", dv.Status.ClaimName)
+		return false, fmt.Sprintf("Could not get PVC: %v", err)
+	}
+
+	podPhaseAnnotation := pvc.Annotations[base.AnnPodPhase]
+	if pvc.Status.Phase != core.ClaimBound {
+		r.Log.Info("DataVolume reports Succeeded but main PVC is not bound",
+			"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase, "pvcPhase", pvc.Status.Phase,
+			"podPhaseAnnotation", podPhaseAnnotation)
+		return false, fmt.Sprintf("Main PVC is not bound (phase: %s)", pvc.Status.Phase)
+	}
+
+	primePVC, hasPrime, err := r.getPrimePVC(pvc)
+	if err != nil {
+		r.Log.Error(err, "Could not get prime PVC for DataVolume to verify completion",
+			"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name), "dvPhase", dv.Status.Phase)
+		return false, fmt.Sprintf("Could not get prime PVC: %v", err)
+	}
+	if !hasPrime {
+		r.Log.V(4).Info("Prime PVC does not exist, skipping importer check",
+			"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name))
+		return true, ""
+	}
+
+	if primePVC.Status.Phase != core.ClaimBound {
+		r.Log.Info("DataVolume reports Succeeded but prime PVC is not bound",
+			"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase, "primePVCPhase", primePVC.Status.Phase,
+			"podPhaseAnnotation", podPhaseAnnotation)
+		return false, fmt.Sprintf("Prime PVC is not bound (phase: %s)", primePVC.Status.Phase)
+	}
+
+	return r.verifyImporterReady(primePVC, dv, vm, podPhaseAnnotation)
+}
+
+func (r *Migration) getDataVolumePVC(dv *cdi.DataVolume) (*core.PersistentVolumeClaim, error) {
 	pvc := &core.PersistentVolumeClaim{}
 	err := r.Destination.Get(context.TODO(), types.NamespacedName{
 		Namespace: r.Plan.Spec.TargetNamespace,
 		Name:      dv.Status.ClaimName,
 	}, pvc)
 	if err != nil {
-		r.Log.Error(err, "Could not get PVC for DataVolume to verify completion",
-			"vm", vm.String(),
-			"dv", path.Join(dv.Namespace, dv.Name),
-			"dvPhase", dv.Status.Phase,
-			"pvcName", dv.Status.ClaimName)
-		return false, fmt.Sprintf("Could not get PVC: %v", err)
+		return nil, err
 	}
+	return pvc, nil
+}
 
-	// Log diagnostic information about CDI state
-	podPhaseAnnotation := pvc.Annotations[base.AnnPodPhase]
-	r.Log.V(3).Info("Verifying DataVolume completion state",
-		"vm", vm.String(),
-		"dv", path.Join(dv.Namespace, dv.Name),
-		"dvPhase", dv.Status.Phase,
-		"pvcPhase", pvc.Status.Phase,
-		"podPhaseAnnotation", podPhaseAnnotation)
-
-	// Check if main PVC is bound
-	if pvc.Status.Phase != core.ClaimBound {
-		r.Log.Info("DataVolume reports Succeeded but main PVC is not bound",
-			"vm", vm.String(),
-			"dv", path.Join(dv.Namespace, dv.Name),
-			"dvPhase", dv.Status.Phase,
-			"pvcPhase", pvc.Status.Phase,
-			"podPhaseAnnotation", podPhaseAnnotation)
-		return false, fmt.Sprintf("Main PVC is not bound (phase: %s)", pvc.Status.Phase)
-	}
-
-	// Check prime PVC if it exists (importer pod uses prime PVC)
+func (r *Migration) getPrimePVC(pvc *core.PersistentVolumeClaim) (*core.PersistentVolumeClaim, bool, error) {
 	primePVC := &core.PersistentVolumeClaim{}
-	err = r.Destination.Get(context.TODO(), types.NamespacedName{
+	err := r.Destination.Get(context.TODO(), types.NamespacedName{
 		Namespace: r.Plan.Spec.TargetNamespace,
 		Name:      fmt.Sprintf("prime-%s", pvc.UID),
 	}, primePVC)
+	if k8serr.IsNotFound(err) {
+		return nil, false, nil
+	}
 	if err != nil {
-		if !k8serr.IsNotFound(err) {
-			r.Log.Error(err, "Could not get prime PVC for DataVolume to verify completion",
-				"vm", vm.String(),
-				"dv", path.Join(dv.Namespace, dv.Name),
-				"dvPhase", dv.Status.Phase)
-			return false, fmt.Sprintf("Could not get prime PVC: %v", err)
-		}
-		// Prime PVC doesn't exist - that's okay, importer may not be using it
-		r.Log.V(4).Info("Prime PVC does not exist, skipping prime PVC check",
-			"vm", vm.String(),
-			"dv", path.Join(dv.Namespace, dv.Name))
-		return true, ""
+		return nil, false, err
 	}
+	return primePVC, true, nil
+}
 
-	// Prime PVC exists - check if it's bound
-	if primePVC.Status.Phase != core.ClaimBound {
-		r.Log.Info("DataVolume reports Succeeded but prime PVC is not bound",
-			"vm", vm.String(),
-			"dv", path.Join(dv.Namespace, dv.Name),
-			"dvPhase", dv.Status.Phase,
-			"primePVCPhase", primePVC.Status.Phase,
-			"podPhaseAnnotation", podPhaseAnnotation)
-		return false, fmt.Sprintf("Prime PVC is not bound (phase: %s)", primePVC.Status.Phase)
+func (r *Migration) verifyImporterReady(
+	primePVC *core.PersistentVolumeClaim,
+	dv *cdi.DataVolume,
+	vm *plan.VMStatus,
+	podPhaseAnnotation string,
+) (bool, string) {
+	importer, found, err := r.kubevirt.GetImporterPod(*primePVC)
+	if err != nil {
+		r.Log.Error(err, "Could not get CDI importer pod for DataVolume to verify completion",
+			"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name), "dvPhase", dv.Status.Phase)
+		return false, fmt.Sprintf("Could not get importer pod: %v", err)
 	}
-
-	// Check if importer pod exists and is not pending
-	importer, found, kErr := r.kubevirt.GetImporterPod(*primePVC)
-	if kErr != nil {
-		r.Log.Error(kErr, "Could not get CDI importer pod for DataVolume to verify completion",
-			"vm", vm.String(),
-			"dv", path.Join(dv.Namespace, dv.Name),
-			"dvPhase", dv.Status.Phase)
-		// Don't block completion if we can't check the pod - this is a transient issue
-		return true, ""
-	}
-
 	if !found || importer == nil {
-		// No importer pod found - that's okay, it may have completed and been cleaned up
 		r.Log.V(4).Info("No importer pod found, allowing completion",
-			"vm", vm.String(),
-			"dv", path.Join(dv.Namespace, dv.Name))
+			"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name))
 		return true, ""
 	}
-
-	// Check if importer pod is pending
 	if importer.Status.Phase == core.PodPending {
 		r.Log.Info("DataVolume reports Succeeded but importer pod is pending",
-			"vm", vm.String(),
-			"dv", path.Join(dv.Namespace, dv.Name),
-			"dvPhase", dv.Status.Phase,
-			"podPhase", importer.Status.Phase,
+			"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name),
+			"dvPhase", dv.Status.Phase, "podPhase", importer.Status.Phase,
 			"podPhaseAnnotation", podPhaseAnnotation,
 			"pod", path.Join(importer.Namespace, importer.Name))
 		return false, fmt.Sprintf("Importer pod is pending (pod: %s/%s)", importer.Namespace, importer.Name)
 	}
 
-	// All checks passed
 	r.Log.V(3).Info("DataVolume completion verified successfully",
-		"vm", vm.String(),
-		"dv", path.Join(dv.Namespace, dv.Name),
-		"dvPhase", dv.Status.Phase,
-		"podPhase", importer.Status.Phase)
+		"vm", vm.String(), "dv", path.Join(dv.Namespace, dv.Name),
+		"dvPhase", dv.Status.Phase, "podPhase", importer.Status.Phase)
 	return true, ""
 }
 
@@ -2170,7 +2160,9 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 				// Cold conversion migrations: the conversion pod is the first consumer of
 				// the PVCs, so PendingPopulation can be treated as Succeeded. Warm migrations
 				// still require the importer to run — do not promote the phase here.
-				dv.Status.Phase = cdi.Succeeded
+				completed++
+				r.setTaskCompleted(task)
+				continue
 			}
 			conditions := dv.Conditions()
 			switch dv.Status.Phase {
@@ -2336,6 +2328,10 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 						}
 					}
 				}
+			case cdi.PendingPopulation:
+				pending++
+				task.Phase = api.StepPending
+				task.Reason = "Waiting for DataVolume population to complete"
 			default:
 				// Handle unknown/empty phases - treat as pending
 				log.Info(

--- a/pkg/controller/plan/migration_test.go
+++ b/pkg/controller/plan/migration_test.go
@@ -2,6 +2,7 @@
 package plan
 
 import (
+	"fmt"
 	"testing"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -13,7 +14,12 @@ import (
 	"github.com/kubev2v/forklift/pkg/settings"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = ginkgo.Describe("VMStatus", func() {
@@ -346,4 +352,201 @@ func TestExecuteClearsSchedulerPendingCondition(t *testing.T) {
 	err := m.execute(vm)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(vm.HasCondition(api.ConditionPending)).To(gomega.BeFalse())
+}
+
+const testTargetNamespace = "target-ns"
+
+func TestVerifyDataVolumeCompletion(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mainUID := types.UID("main-pvc-uid")
+	mainPVCName := "dv-pvc"
+	primePVCName := fmt.Sprintf("prime-%s", mainUID)
+	importerPodName := "importer-prime-test"
+
+	tests := []struct {
+		name         string
+		objects      []runtime.Object
+		wantComplete bool
+		wantReason   string
+	}{
+		{
+			name: "main PVC pending blocks completion",
+			objects: []runtime.Object{
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      mainPVCName,
+						Namespace: testTargetNamespace,
+						UID:       mainUID,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimPending},
+				},
+			},
+			wantComplete: false,
+			wantReason:   "Main PVC is not bound (phase: Pending)",
+		},
+		{
+			name: "prime PVC pending blocks completion",
+			objects: []runtime.Object{
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      mainPVCName,
+						Namespace: testTargetNamespace,
+						UID:       mainUID,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      primePVCName,
+						Namespace: testTargetNamespace,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimPending},
+				},
+			},
+			wantComplete: false,
+			wantReason:   "Prime PVC is not bound (phase: Pending)",
+		},
+		{
+			name: "importer pod pending blocks completion",
+			objects: []runtime.Object{
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      mainPVCName,
+						Namespace: testTargetNamespace,
+						UID:       mainUID,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      primePVCName,
+						Namespace: testTargetNamespace,
+						Annotations: map[string]string{
+							AnnImporterPodName: importerPodName,
+						},
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.Pod{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      importerPodName,
+						Namespace: testTargetNamespace,
+					},
+					Status: core.PodStatus{Phase: core.PodPending},
+				},
+			},
+			wantComplete: false,
+			wantReason:   fmt.Sprintf("Importer pod is pending (pod: %s/%s)", testTargetNamespace, importerPodName),
+		},
+		{
+			name: "bound PVCs and running importer allow completion",
+			objects: []runtime.Object{
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      mainPVCName,
+						Namespace: testTargetNamespace,
+						UID:       mainUID,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      primePVCName,
+						Namespace: testTargetNamespace,
+						Annotations: map[string]string{
+							AnnImporterPodName: importerPodName,
+						},
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.Pod{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      importerPodName,
+						Namespace: testTargetNamespace,
+					},
+					Status: core.PodStatus{Phase: core.PodRunning},
+				},
+			},
+			wantComplete: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMigration(tt.objects...)
+			dv := &cdi.DataVolume{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-dv",
+					Namespace: testTargetNamespace,
+				},
+				Status: cdi.DataVolumeStatus{
+					Phase:     cdi.Succeeded,
+					ClaimName: mainPVCName,
+				},
+			}
+			vm := &plan.VMStatus{}
+
+			canComplete, reason := m.verifyDataVolumeCompletion(dv, vm)
+			g.Expect(canComplete).To(gomega.Equal(tt.wantComplete))
+			if tt.wantReason != "" {
+				g.Expect(reason).To(gomega.Equal(tt.wantReason))
+			} else {
+				g.Expect(reason).To(gomega.BeEmpty())
+			}
+		})
+	}
+}
+
+func TestPendingPopulationNotPromotedOnWarmMigration(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	vSphere := api.VSphere
+	ctx := &plancontext.Context{
+		Plan: &api.Plan{
+			Spec: api.PlanSpec{
+				Type:            api.MigrationWarm,
+				TargetNamespace: testTargetNamespace,
+			},
+		},
+		Source: plancontext.Source{
+			Provider: &api.Provider{
+				Spec: api.ProviderSpec{Type: &vSphere},
+			},
+		},
+		Destination: plancontext.Destination{
+			Client: fakeClient.NewClientBuilder().WithRuntimeObjects().Build(),
+		},
+		Log: logging.WithName("test"),
+	}
+
+	m := &Migration{Context: ctx}
+	dvPhase := cdi.PendingPopulation
+
+	if dvPhase == cdi.PendingPopulation && m.Source.Provider.RequiresConversion() && !m.Plan.IsWarm() {
+		dvPhase = cdi.Succeeded
+	}
+
+	g.Expect(m.Plan.IsWarm()).To(gomega.BeTrue())
+	g.Expect(dvPhase).To(gomega.Equal(cdi.PendingPopulation))
+}
+
+func newTestMigration(objects ...runtime.Object) *Migration {
+	scheme := runtime.NewScheme()
+	_ = core.AddToScheme(scheme)
+	client := fakeClient.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objects...).
+		Build()
+	ctx := &plancontext.Context{
+		Plan: &api.Plan{
+			Spec: api.PlanSpec{TargetNamespace: testTargetNamespace},
+		},
+		Destination: plancontext.Destination{Client: client},
+		Log:         logging.WithName("test"),
+	}
+	return &Migration{
+		Context:  ctx,
+		kubevirt: KubeVirt{Context: ctx},
+	}
 }

--- a/pkg/controller/plan/migration_test.go
+++ b/pkg/controller/plan/migration_test.go
@@ -3,6 +3,7 @@ package plan
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -500,6 +501,203 @@ func TestResolveCsiPVCs(t *testing.T) {
 			}
 			g.Expect(gotNames).To(gomega.Equal(tc.wantNames))
 		})
+	}
+}
+
+const testTargetNamespace = "target-ns"
+
+func TestVerifyDataVolumeCompletion(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mainUID := types.UID("main-pvc-uid")
+	mainPVCName := "dv-pvc"
+	primePVCName := fmt.Sprintf("prime-%s", mainUID)
+	importerPodName := "importer-prime-test"
+
+	tests := []struct {
+		name         string
+		objects      []runtime.Object
+		wantComplete bool
+		wantReason   string
+	}{
+		{
+			name: "main PVC pending blocks completion",
+			objects: []runtime.Object{
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      mainPVCName,
+						Namespace: testTargetNamespace,
+						UID:       mainUID,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimPending},
+				},
+			},
+			wantComplete: false,
+			wantReason:   "Main PVC is not bound (phase: Pending)",
+		},
+		{
+			name: "prime PVC pending blocks completion",
+			objects: []runtime.Object{
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      mainPVCName,
+						Namespace: testTargetNamespace,
+						UID:       mainUID,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      primePVCName,
+						Namespace: testTargetNamespace,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimPending},
+				},
+			},
+			wantComplete: false,
+			wantReason:   "Prime PVC is not bound (phase: Pending)",
+		},
+		{
+			name: "importer pod pending blocks completion",
+			objects: []runtime.Object{
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      mainPVCName,
+						Namespace: testTargetNamespace,
+						UID:       mainUID,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      primePVCName,
+						Namespace: testTargetNamespace,
+						Annotations: map[string]string{
+							AnnImporterPodName: importerPodName,
+						},
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.Pod{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      importerPodName,
+						Namespace: testTargetNamespace,
+					},
+					Status: core.PodStatus{Phase: core.PodPending},
+				},
+			},
+			wantComplete: false,
+			wantReason:   fmt.Sprintf("Importer pod is pending (pod: %s/%s)", testTargetNamespace, importerPodName),
+		},
+		{
+			name: "bound PVCs and running importer allow completion",
+			objects: []runtime.Object{
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      mainPVCName,
+						Namespace: testTargetNamespace,
+						UID:       mainUID,
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      primePVCName,
+						Namespace: testTargetNamespace,
+						Annotations: map[string]string{
+							AnnImporterPodName: importerPodName,
+						},
+					},
+					Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+				},
+				&core.Pod{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      importerPodName,
+						Namespace: testTargetNamespace,
+					},
+					Status: core.PodStatus{Phase: core.PodRunning},
+				},
+			},
+			wantComplete: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMigration(tt.objects...)
+			dv := &cdi.DataVolume{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-dv",
+					Namespace: testTargetNamespace,
+				},
+				Status: cdi.DataVolumeStatus{
+					Phase:     cdi.Succeeded,
+					ClaimName: mainPVCName,
+				},
+			}
+			vm := &plan.VMStatus{}
+
+			canComplete, reason := m.verifyDataVolumeCompletion(dv, vm)
+			g.Expect(canComplete).To(gomega.Equal(tt.wantComplete))
+			if tt.wantReason != "" {
+				g.Expect(reason).To(gomega.Equal(tt.wantReason))
+			} else {
+				g.Expect(reason).To(gomega.BeEmpty())
+			}
+		})
+	}
+}
+
+func TestPendingPopulationNotPromotedOnWarmMigration(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	vSphere := api.VSphere
+	ctx := &plancontext.Context{
+		Plan: &api.Plan{
+			Spec: api.PlanSpec{
+				Type:            api.MigrationWarm,
+				TargetNamespace: testTargetNamespace,
+			},
+		},
+		Source: plancontext.Source{
+			Provider: &api.Provider{
+				Spec: api.ProviderSpec{Type: &vSphere},
+			},
+		},
+		Destination: plancontext.Destination{
+			Client: fake.NewClientBuilder().WithRuntimeObjects().Build(),
+		},
+		Log: logging.WithName("test"),
+	}
+
+	m := &Migration{Context: ctx}
+	dvPhase := cdi.PendingPopulation
+
+	if dvPhase == cdi.PendingPopulation && m.Source.Provider.RequiresConversion() && !m.Plan.IsWarm() {
+		dvPhase = cdi.Succeeded
+	}
+
+	g.Expect(m.Plan.IsWarm()).To(gomega.BeTrue())
+	g.Expect(dvPhase).To(gomega.Equal(cdi.PendingPopulation))
+}
+
+func newTestMigration(objects ...runtime.Object) *Migration {
+	scheme := runtime.NewScheme()
+	_ = core.AddToScheme(scheme)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objects...).
+		Build()
+	ctx := &plancontext.Context{
+		Plan: &api.Plan{
+			Spec: api.PlanSpec{TargetNamespace: testTargetNamespace},
+		},
+		Destination: plancontext.Destination{Client: client},
+		Log:         logging.WithName("test"),
+	}
+	return &Migration{
+		Context:  ctx,
+		kubevirt: KubeVirt{Context: ctx},
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes MTV-4150: Disk Transfer was marked **Completed** while import was not actually done.

The original QE report showed a **blank** DataVolume phase (not `Succeeded`), pending PVCs, and a pending importer pod while nfs.csi provisioning was stuck. That can happen when CDI/storage never advances status cleanly under CSI failure — MTV should not treat disk transfer as done in those cases.

This PR adds defensive checks in Forklift (in addition to whatever CDI reports):

1. **`cdi.Succeeded`** — verify before completing:
   - Main PVC is `Bound`
   - Prime PVC is `Bound` (if present)
   - Importer pod is not `Pending` (if present)
2. **Blank / unknown DV phases** — explicit `default` case keeps the task **Pending** (addresses Matthew's blank-phase observation)
3. **`PendingPopulation` on warm migrations** — no longer auto-completed (warm still needs the importer)
4. **`PendingPopulation` on cold conversion** — still completes disk transfer (conversion pod is first consumer / WFFC)

## Why both MTV and CDI?

CDI/env issues (e.g. broken nfs.csi) can leave DV phase blank or misleading. MTV on `main` still trusts `Succeeded` unconditionally. This change makes Disk Transfer reflect **actual** PVC/importer readiness.

## Test plan

### Unit tests
- [x] `go test ./pkg/controller/plan/ -run 'TestVerifyDataVolumeCompletion|TestPendingPopulation'`

### Manual / lab (recommended before merge)

**Regression — happy path (warm vSphere → OCP)**
1. Run a normal warm migration with working storage.
2. Confirm Disk Transfer eventually shows **Completed** only after DVs reach `Succeeded` and PVCs are bound.
3. Confirm migration completes successfully.

**Bug reproduction — stuck CSI (MTV-4150 scenario)**
1. Use a warm migration plan similar to the Jira repro (vSphere → OCP, nfs-csi or storage that can be made to fail provisioning).
2. During disk transfer, confirm PVCs stay `Pending` and/or importer pod stays `Pending`.
3. Confirm Disk Transfer stays **Pending/Running**, **not Completed**.
4. Check `oc get dv` — phase may be blank, `Pending`, or `Succeeded`; UI should not show completed regardless.

**Blank / unknown DV phase**
1. If possible, capture forklift-controller logs during disk transfer showing DV phase when the step updates.
2. Confirm blank/unknown phases keep the disk task pending with a clear reason.

**Cold conversion (sanity)**
1. Run a cold migration that uses conversion (e.g. vSphere Windows).
2. Confirm disk transfer can still progress when DV is `PendingPopulation` (conversion pod is first consumer).

Resolves: MTV-4150