### PR TITLE
MTV-4178 | Fail to create VMware provider if VDDK is skipped

### DIFF
--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/provider-mutator.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/provider-mutator.go
@@ -26,6 +26,7 @@ func (mutator *ProviderMutator) Mutate(ar *admissionv1.AdmissionReview) *admissi
 	}
 
 	specChanged := mutator.setSdkEndpointIfNeeded()
+	specChanged = mutator.cleanupVddkSettingsIfNeeded() || specChanged
 	metadataChanged := mutator.ar.Request.Operation == admissionv1.Create && mutator.setFinalizers()
 
 	var patches []util.PatchOperation
@@ -75,6 +76,43 @@ func (mutator *ProviderMutator) setSdkEndpointIfNeeded() bool {
 			mutator.provider.Spec.Settings[api.SDK] = api.VCenter
 			providerChanged = true
 		}
+	}
+
+	return providerChanged
+}
+
+func (mutator *ProviderMutator) cleanupVddkSettingsIfNeeded() bool {
+	var providerChanged bool
+
+	// Only apply to vSphere providers
+	if mutator.provider.Type() != api.VSphere {
+		return false
+	}
+
+	// Check if VDDK is set
+	vddkImage, hasVddk := mutator.provider.Spec.Settings[api.VDDK]
+	if hasVddk && vddkImage != "" {
+		// VDDK is set, no cleanup needed
+		return false
+	}
+
+	// VDDK is not set, remove VDDK-specific settings
+	if mutator.provider.Spec.Settings == nil {
+		return false
+	}
+
+	// Remove UseVddkAioOptimization if present
+	if _, hasUseVddkAio := mutator.provider.Spec.Settings[api.UseVddkAioOptimization]; hasUseVddkAio {
+		delete(mutator.provider.Spec.Settings, api.UseVddkAioOptimization)
+		log.Info("Removed UseVddkAioOptimization setting because VDDK is not set")
+		providerChanged = true
+	}
+
+	// Remove vddkConfig if present
+	if _, hasVddkConfig := mutator.provider.Spec.Settings[api.VddkConfig]; hasVddkConfig {
+		delete(mutator.provider.Spec.Settings, api.VddkConfig)
+		log.Info("Removed VddkConfig setting because VDDK is not set")
+		providerChanged = true
 	}
 
 	return providerChanged


### PR DESCRIPTION
When creating a VMware provider without VDDK, users were seeing an error about 'UseVddkAioOptimization' being non-configurable and can't be deleted. This prevented them from completing provider creation even though VDDK is optional for cold migrations.

This fix adds automatic cleanup of VDDK-specific settings in the provider mutating webhook when VDDK is not set:
- Removes UseVddkAioOptimization setting
- Removes VddkConfig setting

This allows users to create VMware providers without VDDK, with only a warning that VDDK is recommended (which is expected behavior).