### PR TITLE
MTV-4180 | Fix ovirt disk size validation

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -20,6 +20,15 @@ type Validator struct {
 	*plancontext.Context
 }
 
+func (r *Validator) isLunMissingSize(da model.XDiskAttachment) bool {
+	for _, lun := range da.Disk.Lun.LogicalUnits.LogicalUnit {
+		if lun.Size <= 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {
 	vm := &model.Workload{}
 	err := r.Source.Inventory.Find(vm, vmRef)
@@ -29,8 +38,14 @@ func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {
 
 	invalidDisks := []string{}
 	for _, da := range vm.DiskAttachments {
-		if da.Disk.ProvisionedSize <= 0 {
-			invalidDisks = append(invalidDisks, da.Disk.ID)
+		if da.Disk.IsLun() {
+			if r.isLunMissingSize(da) {
+				invalidDisks = append(invalidDisks, da.Disk.ID)
+			}
+		} else {
+			if da.Disk.ProvisionedSize <= 0 {
+				invalidDisks = append(invalidDisks, da.Disk.ID)
+			}
 		}
 	}
 

--- a/pkg/controller/provider/web/ovirt/disk.go
+++ b/pkg/controller/provider/web/ovirt/disk.go
@@ -19,6 +19,13 @@ const (
 	DiskRoot       = DisksRoot + "/:" + DiskParam
 )
 
+type StorageType string
+
+const (
+	LunStorageType   StorageType = "lun"
+	ImageStorageType StorageType = "image"
+)
+
 // Disk handler.
 type DiskHandler struct {
 	Handler
@@ -173,4 +180,9 @@ func (r *Disk) Content(detail int) interface{} {
 	}
 
 	return r
+}
+
+// is the disk LUN
+func (r *Disk) IsLun() bool {
+	return r.StorageType == string(LunStorageType)
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_size.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_size.rego
@@ -2,20 +2,40 @@ package io.konveyor.forklift.ovirt
 
 import rego.v1
 
-# Match any disk with zero or negative provisioned size
 invalid_disks contains idx if {
-	some idx
-	input.diskAttachments[idx].disk.provisionedSize <= 0
+    some idx
+    disk := input.diskAttachments[idx].disk
+    is_disk_invalid(disk)
+}
+
+is_disk_invalid(disk) if {
+    is_lun(disk)
+    is_lun_missing_size(disk)
+}
+
+is_disk_invalid(disk) if {
+    not is_lun(disk)
+    disk.provisionedSize <= 0
+}
+
+is_lun(disk) if {
+    disk.storageType == "lun"
+}
+
+is_lun_missing_size(disk) if {
+    some unit in disk.lun.logicalUnits.logicalUnit
+    unit.size <= 0
 }
 
 # Raise a concern for each invalid disk
 concerns contains flag if {
-	invalid_disks[idx]
-	disk := input.diskAttachments[idx].disk
-	flag := {
-		"id": "ovirt.disk.capacity.invalid",
-		"category": "Critical",
-		"label": sprintf("Disk has an invalid capacity of %v bytes", [disk.provisionedSize]),
-		"assessment": sprintf("Disk has a provisioned size of %v bytes, which is not allowed. Capacity must be greater than zero.", [disk.provisionedSize]),
-	}
+    invalid_disks[idx]
+    disk := input.diskAttachments[idx].disk
+
+    flag := {
+       "id": "ovirt.disk.capacity.invalid",
+       "category": "Critical",
+       "label": "Disk has an invalid capacity",
+       "assessment": "Disk has an invalid capacity",
+    }
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_size_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_size_test.rego
@@ -46,3 +46,65 @@ test_valid_capacity if {
 	results := concerns with input as test_input
 	count(results) == 0
 }
+
+test_lun_valid_capacity if {
+    test_input := {"diskAttachments": [{
+       "id": "disk-lun-valid",
+       "interface": "virtio_scsi",
+       "disk": {
+          "storageType": "lun",
+          "lun": {
+             "logicalUnits": {
+                "logicalUnit": [
+                   {"size": 1024},
+                   {"size": 2048}
+                ]
+             }
+          }
+       },
+    }]}
+
+    results := concerns with input as test_input
+    count(results) == 0
+}
+
+test_lun_invalid_capacity_zero if {
+    test_input := {"diskAttachments": [{
+       "id": "disk-lun-zero",
+       "interface": "virtio_scsi",
+       "disk": {
+          "storageType": "lun",
+          "lun": {
+             "logicalUnits": {
+                "logicalUnit": [
+                   {"size": 1024},
+                   {"size": 0}
+                ]
+             }
+          }
+       },
+    }]}
+
+    results := concerns with input as test_input
+    count(results) == 1
+}
+
+test_lun_invalid_capacity_missing_or_negative if {
+    test_input := {"diskAttachments": [{
+       "id": "disk-lun-neg",
+       "interface": "virtio_scsi",
+       "disk": {
+          "storageType": "lun",
+          "lun": {
+             "logicalUnits": {
+                "logicalUnit": [
+                   {"size": -500}
+                ]
+             }
+          }
+       },
+    }]}
+
+    results := concerns with input as test_input
+    count(results) == 1
+}


### PR DESCRIPTION
Fixes: MTV-4180

Issue: We are blocking the migration if the VM has LUN attached.

Fix: Check if the diks is LUN and validate the the LUN size instead of the disk size.