### PR TITLE
MTV-3884 | Set node selector for conversion pos in EC2

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -103,6 +103,21 @@ const (
 
 var VolumePopulatorNotSupportedError = liberr.New("provider does not support volume populators")
 
+// ConversionPodConfigResult contains provider-specific configuration for the virt-v2v conversion pod.
+// All fields are optional - nil means no provider-specific configuration for that aspect.
+type ConversionPodConfigResult struct {
+	// NodeSelector specifies provider-required node selection constraints.
+	// These are merged with (but can be overridden by) Plan.Spec.ConvertorNodeSelector.
+	NodeSelector map[string]string
+
+	// Labels specifies provider-specific labels to add to the conversion pod.
+	// These are merged with (but can be overridden by) Plan.Spec.ConvertorLabels.
+	Labels map[string]string
+
+	// Annotations specifies provider-specific annotations to add to the conversion pod.
+	Annotations map[string]string
+}
+
 // Adapter API.
 // Constructs provider-specific implementations
 // of the Builder, Client, and Validator.
@@ -161,6 +176,10 @@ type Builder interface {
 	ConfigMaps(vmRef ref.Ref) (list []core.ConfigMap, err error)
 	// Build VM Secrets
 	Secrets(vmRef ref.Ref) (list []core.Secret, err error)
+	// ConversionPodConfig returns provider-specific configuration for the virt-v2v conversion pod.
+	// Returns an empty struct if no provider-specific configuration is needed.
+	// The returned config is merged with user settings from Plan.Spec (user settings take precedence).
+	ConversionPodConfig(vmRef ref.Ref) (*ConversionPodConfigResult, error)
 }
 
 // Client API.

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -655,3 +655,9 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 	// do nothing
 	return
 }
+
+// ConversionPodConfig returns provider-specific configuration for the virt-v2v conversion pod.
+// OCP provider does not require any special configuration.
+func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
+	return &planbase.ConversionPodConfigResult{}, nil
+}

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1363,3 +1363,9 @@ func (r *Builder) GetPopulatorTaskName(pvc *core.PersistentVolumeClaim) (taskNam
 	taskName = image.Name
 	return
 }
+
+// ConversionPodConfig returns provider-specific configuration for the virt-v2v conversion pod.
+// OpenStack provider does not require any special configuration.
+func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
+	return &planbase.ConversionPodConfigResult{}, nil
+}

--- a/pkg/controller/plan/adapter/ovfbase/builder.go
+++ b/pkg/controller/plan/adapter/ovfbase/builder.go
@@ -559,3 +559,9 @@ func (r *Builder) GetPopulatorTaskName(pvc *core.PersistentVolumeClaim) (taskNam
 	err = planbase.VolumePopulatorNotSupportedError
 	return
 }
+
+// ConversionPodConfig returns provider-specific configuration for the virt-v2v conversion pod.
+// OVF/OVA provider does not require any special configuration.
+func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
+	return &planbase.ConversionPodConfigResult{}, nil
+}

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -1022,3 +1022,9 @@ func (r *Builder) GetPopulatorTaskName(pvc *core.PersistentVolumeClaim) (taskNam
 	taskName = pvc.Annotations[planbase.AnnDiskSource]
 	return
 }
+
+// ConversionPodConfig returns provider-specific configuration for the virt-v2v conversion pod.
+// oVirt provider does not require any special configuration.
+func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
+	return &planbase.ConversionPodConfigResult{}, nil
+}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -2253,3 +2253,9 @@ func (r *Builder) isPVCExistsInList(pvc *core.PersistentVolumeClaim, pvcList *co
 	}
 	return false
 }
+
+// ConversionPodConfig returns provider-specific configuration for the virt-v2v conversion pod.
+// vSphere provider does not require any special configuration.
+func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
+	return &planbase.ConversionPodConfigResult{}, nil
+}


### PR DESCRIPTION
Issue:
Conversion pod in EC2 must run on a node that can access the new volume.

Fix:
Set node selector for conversion pos in EC2

Follow up on: https://github.com/kubev2v/forklift/pull/3731

Resolves: MTV-3884