### PR TITLE
[release-2.10] MTV-4274 | Fix DiskTransfer status for warm migrations with storage offload

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -902,7 +902,9 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			step.MarkStarted()
 			step.Phase = api.StepRunning
 
-			if r.builder.SupportsVolumePopulators() {
+			warmJumpStartDone := r.builder.SupportsVolumePopulators() && r.Plan.IsWarm() && vm.Warm.Successes > 0
+
+			if r.builder.SupportsVolumePopulators() && !warmJumpStartDone {
 				err = r.updatePopulatorCopyProgress(vm, step)
 			} else {
 				// Fallback to non-volume populator path


### PR DESCRIPTION
Issue: warm migrations with storage offload show a white circle in the UI, and never get a green check. The warm migration offload jump-start workflow only runs updatePopulatorCopyProgress, which never updates status from the CDI DataVolume.

Fix: cherry pick a smaller fix from #4208 that only uses updatePopulatorCopyProgress on the first offload copy, then uses updateCopyProgress for subsequent checkpoints.

Reference: [MTV-4274](https://issues.redhat.com/browse/MTV-4274)

Note: this is already fixed in main as part of #4208, which should probably not be backported. This is a 2.10 cherry pick to resolve MTV-4274 if it needs to be fixed in 2.10. Otherwise this pull request can just be closed.