### PR TITLE
MTV-3736 | Move RDM rego from critical to warning

### DIFF
--- a/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
@@ -11,8 +11,8 @@ concerns contains flag if {
 	has_rdm_disk
 	flag := {
 		"id": "vmware.disk.rdm.detected",
-		"category": "Critical",
+		"category": "Warning",
 		"label": "Raw Device Mapped disk detected",
-		"assessment": "RDM disks are not currently supported by Migration Toolkit for Virtualization. The VM cannot be migrated unless the RDM disks are removed. You can reattach them to the VM after migration.",
+		"assessment": "RDM disk migration is currently supported by Migration Toolkit for Virtualization only with Storage Offload. The VM cannot be migrated unless the RDM disks are removed. You can reattach them to the VM after migration.",
 	}
 }


### PR DESCRIPTION
Resolves: MTV-3736

Storage Offload is capable of migrating the RDM disks, we need to lover the category from critical to warning.