### PR TITLE
MTV-4349 | Add interface for EC2 client calls

### DIFF
--- a/pkg/provider/ec2/controller/client/ec2api.go
+++ b/pkg/provider/ec2/controller/client/ec2api.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+// EC2API defines the EC2 operations used by the migration client.
+// This interface allows for mocking AWS EC2 calls in unit tests.
+// The real AWS SDK ec2.Client implements this interface.
+type EC2API interface {
+	// Instance operations
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	StopInstances(ctx context.Context, params *ec2.StopInstancesInput, optFns ...func(*ec2.Options)) (*ec2.StopInstancesOutput, error)
+	StartInstances(ctx context.Context, params *ec2.StartInstancesInput, optFns ...func(*ec2.Options)) (*ec2.StartInstancesOutput, error)
+
+	// Snapshot operations
+	CreateSnapshot(ctx context.Context, params *ec2.CreateSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.CreateSnapshotOutput, error)
+	DeleteSnapshot(ctx context.Context, params *ec2.DeleteSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSnapshotOutput, error)
+	DescribeSnapshots(ctx context.Context, params *ec2.DescribeSnapshotsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error)
+	ModifySnapshotAttribute(ctx context.Context, params *ec2.ModifySnapshotAttributeInput, optFns ...func(*ec2.Options)) (*ec2.ModifySnapshotAttributeOutput, error)
+
+	// Volume operations
+	DescribeVolumes(ctx context.Context, params *ec2.DescribeVolumesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVolumesOutput, error)
+	CreateVolume(ctx context.Context, params *ec2.CreateVolumeInput, optFns ...func(*ec2.Options)) (*ec2.CreateVolumeOutput, error)
+	DeleteVolume(ctx context.Context, params *ec2.DeleteVolumeInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVolumeOutput, error)
+}
+
+// Compile-time check to ensure *ec2.Client implements EC2API
+var _ EC2API = (*ec2.Client)(nil)

--- a/pkg/provider/ec2/inventory/client/client.go
+++ b/pkg/provider/ec2/inventory/client/client.go
@@ -23,7 +23,7 @@ const (
 
 // Client wraps AWS SDK client
 type Client struct {
-	ec2Client *ec2.Client
+	ec2Client EC2API
 	region    string
 }
 
@@ -105,6 +105,20 @@ func createAWSConfig(ctx context.Context, region, accessKeyID, secretAccessKey s
 // Used by inventory collector to discover available resources in the configured region.
 func (c *Client) GetRegion() string {
 	return c.region
+}
+
+// SetEC2Client sets the EC2 API client. Used for testing with mock clients.
+func (c *Client) SetEC2Client(client EC2API) {
+	c.ec2Client = client
+}
+
+// NewWithClient creates a new Client with a custom EC2API implementation.
+// Used for testing with mock clients.
+func NewWithClient(ec2Client EC2API, region string) *Client {
+	return &Client{
+		ec2Client: ec2Client,
+		region:    region,
+	}
 }
 
 // DescribeInstances fetches all EC2 instances in the configured region.

--- a/pkg/provider/ec2/inventory/client/ec2api.go
+++ b/pkg/provider/ec2/inventory/client/ec2api.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+// EC2API defines the EC2 operations used by the inventory client.
+// This interface allows for mocking AWS EC2 calls in unit tests.
+// The real AWS SDK ec2.Client implements this interface.
+//
+// The interface includes methods needed for paginators:
+// - DescribeInstances (used by NewDescribeInstancesPaginator)
+// - DescribeVolumes (used by NewDescribeVolumesPaginator)
+// - DescribeSubnets (used by NewDescribeSubnetsPaginator)
+// - DescribeSecurityGroups (used by NewDescribeSecurityGroupsPaginator)
+// - DescribeVpcs (not paginated in our usage)
+type EC2API interface {
+	// Instance operations
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+
+	// Volume operations
+	DescribeVolumes(ctx context.Context, params *ec2.DescribeVolumesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVolumesOutput, error)
+
+	// Network operations
+	DescribeVpcs(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
+	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
+	DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+}
+
+// Compile-time check to ensure *ec2.Client implements EC2API
+var _ EC2API = (*ec2.Client)(nil)


### PR DESCRIPTION
Issue:
Using EC2 client without an interface makes the code less testable

Fix:
Add interface between us and the EC2 client lib

Ref: https://issues.redhat.com/browse/MTV-4349