### PR TITLE
MTV-4348 | Add test utilities for EC2 provider

### DIFF
--- a/pkg/provider/ec2/testutil/fake_ec2api.go
+++ b/pkg/provider/ec2/testutil/fake_ec2api.go
@@ -1,0 +1,662 @@
+// Package testutil provides test utilities for EC2 provider unit tests.
+// It includes fake EC2 API implementations and test fixtures.
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	controllerclient "github.com/kubev2v/forklift/pkg/provider/ec2/controller/client"
+	inventoryclient "github.com/kubev2v/forklift/pkg/provider/ec2/inventory/client"
+)
+
+// EC2Method represents an EC2 API method name for error injection.
+type EC2Method string
+
+// EC2 API method constants for type-safe error injection.
+const (
+	MethodDescribeInstances       EC2Method = "DescribeInstances"
+	MethodStopInstances           EC2Method = "StopInstances"
+	MethodStartInstances          EC2Method = "StartInstances"
+	MethodCreateSnapshot          EC2Method = "CreateSnapshot"
+	MethodDeleteSnapshot          EC2Method = "DeleteSnapshot"
+	MethodDescribeSnapshots       EC2Method = "DescribeSnapshots"
+	MethodModifySnapshotAttribute EC2Method = "ModifySnapshotAttribute"
+	MethodDescribeVolumes         EC2Method = "DescribeVolumes"
+	MethodCreateVolume            EC2Method = "CreateVolume"
+	MethodDeleteVolume            EC2Method = "DeleteVolume"
+	MethodDescribeVpcs            EC2Method = "DescribeVpcs"
+	MethodDescribeSubnets         EC2Method = "DescribeSubnets"
+	MethodDescribeSecurityGroups  EC2Method = "DescribeSecurityGroups"
+)
+
+// FakeEC2API is a fake implementation of the EC2 API for testing.
+// It implements both controller/client.EC2API and inventory/client.EC2API interfaces.
+// It stores state in memory and allows error injection for testing error handling.
+type FakeEC2API struct {
+	mu sync.Mutex
+
+	// In-memory state
+	Instances      map[string]ec2types.Instance
+	Volumes        map[string]ec2types.Volume
+	Snapshots      map[string]ec2types.Snapshot
+	Vpcs           map[string]ec2types.Vpc
+	Subnets        map[string]ec2types.Subnet
+	SecurityGroups map[string]ec2types.SecurityGroup
+
+	// Snapshot sharing permissions: snapshotID -> []accountID
+	SnapshotPermissions map[string][]string
+
+	// Error injection - map of method to error
+	// Example: fake.Errors[MethodCreateSnapshot] = errors.New("failed")
+	Errors map[EC2Method]error
+
+	// Call tracking for verification
+	Calls []APICall
+
+	// ID counter for generating unique IDs
+	idCounter int
+}
+
+// APICall records a call to the fake API for verification in tests.
+type APICall struct {
+	Method EC2Method
+	Input  interface{}
+}
+
+// NewFakeEC2API creates a new FakeEC2API with empty state.
+func NewFakeEC2API() *FakeEC2API {
+	return &FakeEC2API{
+		Instances:           make(map[string]ec2types.Instance),
+		Volumes:             make(map[string]ec2types.Volume),
+		Snapshots:           make(map[string]ec2types.Snapshot),
+		Vpcs:                make(map[string]ec2types.Vpc),
+		Subnets:             make(map[string]ec2types.Subnet),
+		SecurityGroups:      make(map[string]ec2types.SecurityGroup),
+		SnapshotPermissions: make(map[string][]string),
+		Errors:              make(map[EC2Method]error),
+		Calls:               []APICall{},
+	}
+}
+
+// Compile-time checks to ensure FakeEC2API implements both interfaces
+var _ controllerclient.EC2API = (*FakeEC2API)(nil)
+var _ inventoryclient.EC2API = (*FakeEC2API)(nil)
+
+// recordCall records an API call for later verification.
+func (f *FakeEC2API) recordCall(method EC2Method, input interface{}) {
+	f.Calls = append(f.Calls, APICall{Method: method, Input: input})
+}
+
+// getError returns the error for a method call from the Errors map.
+func (f *FakeEC2API) getError(method EC2Method) error {
+	return f.Errors[method]
+}
+
+// Reset clears all state and recorded calls.
+func (f *FakeEC2API) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.Instances = make(map[string]ec2types.Instance)
+	f.Volumes = make(map[string]ec2types.Volume)
+	f.Snapshots = make(map[string]ec2types.Snapshot)
+	f.Vpcs = make(map[string]ec2types.Vpc)
+	f.Subnets = make(map[string]ec2types.Subnet)
+	f.SecurityGroups = make(map[string]ec2types.SecurityGroup)
+	f.SnapshotPermissions = make(map[string][]string)
+	f.Errors = make(map[EC2Method]error)
+	f.Calls = []APICall{}
+	f.idCounter = 0
+}
+
+// AddInstance adds an instance to the fake state.
+func (f *FakeEC2API) AddInstance(instance ec2types.Instance) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if instance.InstanceId != nil {
+		f.Instances[*instance.InstanceId] = instance
+	}
+}
+
+// AddVolume adds a volume to the fake state.
+func (f *FakeEC2API) AddVolume(volume ec2types.Volume) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if volume.VolumeId != nil {
+		f.Volumes[*volume.VolumeId] = volume
+	}
+}
+
+// AddSnapshot adds a snapshot to the fake state.
+func (f *FakeEC2API) AddSnapshot(snapshot ec2types.Snapshot) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if snapshot.SnapshotId != nil {
+		f.Snapshots[*snapshot.SnapshotId] = snapshot
+	}
+}
+
+// AddVpc adds a VPC to the fake state.
+func (f *FakeEC2API) AddVpc(vpc ec2types.Vpc) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if vpc.VpcId != nil {
+		f.Vpcs[*vpc.VpcId] = vpc
+	}
+}
+
+// AddSubnet adds a subnet to the fake state.
+func (f *FakeEC2API) AddSubnet(subnet ec2types.Subnet) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if subnet.SubnetId != nil {
+		f.Subnets[*subnet.SubnetId] = subnet
+	}
+}
+
+// AddSecurityGroup adds a security group to the fake state.
+func (f *FakeEC2API) AddSecurityGroup(sg ec2types.SecurityGroup) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if sg.GroupId != nil {
+		f.SecurityGroups[*sg.GroupId] = sg
+	}
+}
+
+// SetInstanceState changes the state of an instance.
+func (f *FakeEC2API) SetInstanceState(instanceID string, state ec2types.InstanceStateName) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if instance, ok := f.Instances[instanceID]; ok {
+		instance.State = &ec2types.InstanceState{Name: state}
+		f.Instances[instanceID] = instance
+	}
+}
+
+// SetSnapshotState changes the state of a snapshot.
+func (f *FakeEC2API) SetSnapshotState(snapshotID string, state ec2types.SnapshotState) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if snapshot, ok := f.Snapshots[snapshotID]; ok {
+		snapshot.State = state
+		f.Snapshots[snapshotID] = snapshot
+	}
+}
+
+// SetVolumeState changes the state of a volume.
+func (f *FakeEC2API) SetVolumeState(volumeID string, state ec2types.VolumeState) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if volume, ok := f.Volumes[volumeID]; ok {
+		volume.State = state
+		f.Volumes[volumeID] = volume
+	}
+}
+
+// DescribeInstances implements EC2API.
+func (f *FakeEC2API) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodDescribeInstances, params)
+
+	if err := f.getError(MethodDescribeInstances); err != nil {
+		return nil, err
+	}
+
+	var instances []ec2types.Instance
+
+	if params != nil && len(params.InstanceIds) > 0 {
+		// Filter by specific IDs
+		for _, id := range params.InstanceIds {
+			if instance, ok := f.Instances[id]; ok {
+				instances = append(instances, instance)
+			}
+		}
+		// If specific IDs were requested but none found, this would be an error in real AWS
+		if len(instances) == 0 && len(params.InstanceIds) > 0 {
+			return nil, fmt.Errorf("InvalidInstanceID.NotFound: The instance ID '%s' does not exist", params.InstanceIds[0])
+		}
+	} else {
+		// Return all instances
+		for _, instance := range f.Instances {
+			instances = append(instances, instance)
+		}
+	}
+
+	return &ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{
+			{Instances: instances},
+		},
+	}, nil
+}
+
+// StopInstances implements EC2API.
+func (f *FakeEC2API) StopInstances(ctx context.Context, params *ec2.StopInstancesInput, optFns ...func(*ec2.Options)) (*ec2.StopInstancesOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodStopInstances, params)
+
+	if err := f.getError(MethodStopInstances); err != nil {
+		return nil, err
+	}
+
+	var stoppingInstances []ec2types.InstanceStateChange
+	for _, id := range params.InstanceIds {
+		if instance, ok := f.Instances[id]; ok {
+			previousState := instance.State
+			instance.State = &ec2types.InstanceState{Name: ec2types.InstanceStateNameStopping}
+			f.Instances[id] = instance
+
+			stoppingInstances = append(stoppingInstances, ec2types.InstanceStateChange{
+				InstanceId:    aws.String(id),
+				CurrentState:  instance.State,
+				PreviousState: previousState,
+			})
+		}
+	}
+
+	return &ec2.StopInstancesOutput{
+		StoppingInstances: stoppingInstances,
+	}, nil
+}
+
+// StartInstances implements EC2API.
+func (f *FakeEC2API) StartInstances(ctx context.Context, params *ec2.StartInstancesInput, optFns ...func(*ec2.Options)) (*ec2.StartInstancesOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodStartInstances, params)
+
+	if err := f.getError(MethodStartInstances); err != nil {
+		return nil, err
+	}
+
+	var startingInstances []ec2types.InstanceStateChange
+	for _, id := range params.InstanceIds {
+		if instance, ok := f.Instances[id]; ok {
+			previousState := instance.State
+			instance.State = &ec2types.InstanceState{Name: ec2types.InstanceStateNamePending}
+			f.Instances[id] = instance
+
+			startingInstances = append(startingInstances, ec2types.InstanceStateChange{
+				InstanceId:    aws.String(id),
+				CurrentState:  instance.State,
+				PreviousState: previousState,
+			})
+		}
+	}
+
+	return &ec2.StartInstancesOutput{
+		StartingInstances: startingInstances,
+	}, nil
+}
+
+// CreateSnapshot implements EC2API.
+func (f *FakeEC2API) CreateSnapshot(ctx context.Context, params *ec2.CreateSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.CreateSnapshotOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodCreateSnapshot, params)
+
+	if err := f.getError(MethodCreateSnapshot); err != nil {
+		return nil, err
+	}
+
+	snapshotID := fmt.Sprintf("snap-%s", f.generateID())
+	snapshot := ec2types.Snapshot{
+		SnapshotId: aws.String(snapshotID),
+		VolumeId:   params.VolumeId,
+		State:      ec2types.SnapshotStatePending,
+		Progress:   aws.String("0%"),
+	}
+
+	// Copy tags from input
+	if params.TagSpecifications != nil {
+		for _, tagSpec := range params.TagSpecifications {
+			if tagSpec.ResourceType == ec2types.ResourceTypeSnapshot {
+				snapshot.Tags = tagSpec.Tags
+			}
+		}
+	}
+
+	f.Snapshots[snapshotID] = snapshot
+
+	return &ec2.CreateSnapshotOutput{
+		SnapshotId: aws.String(snapshotID),
+		VolumeId:   params.VolumeId,
+		State:      ec2types.SnapshotStatePending,
+		Progress:   aws.String("0%"),
+		Tags:       snapshot.Tags,
+	}, nil
+}
+
+// DeleteSnapshot implements EC2API.
+func (f *FakeEC2API) DeleteSnapshot(ctx context.Context, params *ec2.DeleteSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSnapshotOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodDeleteSnapshot, params)
+
+	if err := f.getError(MethodDeleteSnapshot); err != nil {
+		return nil, err
+	}
+
+	if params.SnapshotId != nil {
+		if _, ok := f.Snapshots[*params.SnapshotId]; !ok {
+			return nil, fmt.Errorf("InvalidSnapshot.NotFound: The snapshot '%s' does not exist", *params.SnapshotId)
+		}
+		delete(f.Snapshots, *params.SnapshotId)
+		delete(f.SnapshotPermissions, *params.SnapshotId)
+	}
+
+	return &ec2.DeleteSnapshotOutput{}, nil
+}
+
+// DescribeSnapshots implements EC2API.
+func (f *FakeEC2API) DescribeSnapshots(ctx context.Context, params *ec2.DescribeSnapshotsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodDescribeSnapshots, params)
+
+	if err := f.getError(MethodDescribeSnapshots); err != nil {
+		return nil, err
+	}
+
+	var snapshots []ec2types.Snapshot
+
+	if params != nil && len(params.SnapshotIds) > 0 {
+		// Filter by specific IDs
+		for _, id := range params.SnapshotIds {
+			if snapshot, ok := f.Snapshots[id]; ok {
+				snapshots = append(snapshots, snapshot)
+			} else {
+				return nil, fmt.Errorf("InvalidSnapshot.NotFound: The snapshot '%s' does not exist", id)
+			}
+		}
+	} else if params != nil && len(params.Filters) > 0 {
+		// Filter by tags
+		for _, snapshot := range f.Snapshots {
+			if matchesFilters(snapshot.Tags, params.Filters) {
+				snapshots = append(snapshots, snapshot)
+			}
+		}
+	} else {
+		// Return all snapshots
+		for _, snapshot := range f.Snapshots {
+			snapshots = append(snapshots, snapshot)
+		}
+	}
+
+	return &ec2.DescribeSnapshotsOutput{
+		Snapshots: snapshots,
+	}, nil
+}
+
+// ModifySnapshotAttribute implements EC2API.
+func (f *FakeEC2API) ModifySnapshotAttribute(ctx context.Context, params *ec2.ModifySnapshotAttributeInput, optFns ...func(*ec2.Options)) (*ec2.ModifySnapshotAttributeOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodModifySnapshotAttribute, params)
+
+	if err := f.getError(MethodModifySnapshotAttribute); err != nil {
+		return nil, err
+	}
+
+	if params.SnapshotId == nil {
+		return nil, fmt.Errorf("SnapshotId is required")
+	}
+
+	snapshotID := *params.SnapshotId
+	if _, ok := f.Snapshots[snapshotID]; !ok {
+		return nil, fmt.Errorf("InvalidSnapshot.NotFound: The snapshot '%s' does not exist", snapshotID)
+	}
+
+	// Handle permission modifications
+	if params.CreateVolumePermission != nil {
+		// Add permissions
+		for _, perm := range params.CreateVolumePermission.Add {
+			if perm.UserId != nil {
+				f.SnapshotPermissions[snapshotID] = append(f.SnapshotPermissions[snapshotID], *perm.UserId)
+			}
+		}
+		// Remove permissions
+		for _, perm := range params.CreateVolumePermission.Remove {
+			if perm.UserId != nil {
+				perms := f.SnapshotPermissions[snapshotID]
+				for i, p := range perms {
+					if p == *perm.UserId {
+						f.SnapshotPermissions[snapshotID] = append(perms[:i], perms[i+1:]...)
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return &ec2.ModifySnapshotAttributeOutput{}, nil
+}
+
+// DescribeVolumes implements EC2API.
+func (f *FakeEC2API) DescribeVolumes(ctx context.Context, params *ec2.DescribeVolumesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVolumesOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodDescribeVolumes, params)
+
+	if err := f.getError(MethodDescribeVolumes); err != nil {
+		return nil, err
+	}
+
+	var volumes []ec2types.Volume
+
+	if params != nil && len(params.VolumeIds) > 0 {
+		// Filter by specific IDs
+		for _, id := range params.VolumeIds {
+			if volume, ok := f.Volumes[id]; ok {
+				volumes = append(volumes, volume)
+			} else {
+				return nil, fmt.Errorf("InvalidVolume.NotFound: The volume '%s' does not exist", id)
+			}
+		}
+	} else if params != nil && len(params.Filters) > 0 {
+		// Filter by tags
+		for _, volume := range f.Volumes {
+			if matchesFilters(volume.Tags, params.Filters) {
+				volumes = append(volumes, volume)
+			}
+		}
+	} else {
+		// Return all volumes
+		for _, volume := range f.Volumes {
+			volumes = append(volumes, volume)
+		}
+	}
+
+	return &ec2.DescribeVolumesOutput{
+		Volumes: volumes,
+	}, nil
+}
+
+// CreateVolume implements EC2API.
+func (f *FakeEC2API) CreateVolume(ctx context.Context, params *ec2.CreateVolumeInput, optFns ...func(*ec2.Options)) (*ec2.CreateVolumeOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodCreateVolume, params)
+
+	if err := f.getError(MethodCreateVolume); err != nil {
+		return nil, err
+	}
+
+	volumeID := fmt.Sprintf("vol-%s", f.generateID())
+	volume := ec2types.Volume{
+		VolumeId:         aws.String(volumeID),
+		AvailabilityZone: params.AvailabilityZone,
+		VolumeType:       params.VolumeType,
+		State:            ec2types.VolumeStateCreating,
+	}
+
+	if params.SnapshotId != nil {
+		volume.SnapshotId = params.SnapshotId
+	}
+
+	// Copy tags from input
+	if params.TagSpecifications != nil {
+		for _, tagSpec := range params.TagSpecifications {
+			if tagSpec.ResourceType == ec2types.ResourceTypeVolume {
+				volume.Tags = tagSpec.Tags
+			}
+		}
+	}
+
+	f.Volumes[volumeID] = volume
+
+	return &ec2.CreateVolumeOutput{
+		VolumeId:         aws.String(volumeID),
+		AvailabilityZone: params.AvailabilityZone,
+		VolumeType:       params.VolumeType,
+		State:            ec2types.VolumeStateCreating,
+		SnapshotId:       params.SnapshotId,
+		Tags:             volume.Tags,
+	}, nil
+}
+
+// DeleteVolume implements EC2API.
+func (f *FakeEC2API) DeleteVolume(ctx context.Context, params *ec2.DeleteVolumeInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVolumeOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodDeleteVolume, params)
+
+	if err := f.getError(MethodDeleteVolume); err != nil {
+		return nil, err
+	}
+
+	if params.VolumeId != nil {
+		if _, ok := f.Volumes[*params.VolumeId]; !ok {
+			return nil, fmt.Errorf("InvalidVolume.NotFound: The volume '%s' does not exist", *params.VolumeId)
+		}
+		delete(f.Volumes, *params.VolumeId)
+	}
+
+	return &ec2.DeleteVolumeOutput{}, nil
+}
+
+// DescribeVpcs implements EC2API.
+func (f *FakeEC2API) DescribeVpcs(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodDescribeVpcs, params)
+
+	if err := f.getError(MethodDescribeVpcs); err != nil {
+		return nil, err
+	}
+
+	var vpcs []ec2types.Vpc
+	for _, vpc := range f.Vpcs {
+		vpcs = append(vpcs, vpc)
+	}
+
+	return &ec2.DescribeVpcsOutput{
+		Vpcs: vpcs,
+	}, nil
+}
+
+// DescribeSubnets implements EC2API.
+func (f *FakeEC2API) DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodDescribeSubnets, params)
+
+	if err := f.getError(MethodDescribeSubnets); err != nil {
+		return nil, err
+	}
+
+	var subnets []ec2types.Subnet
+	for _, subnet := range f.Subnets {
+		subnets = append(subnets, subnet)
+	}
+
+	return &ec2.DescribeSubnetsOutput{
+		Subnets: subnets,
+	}, nil
+}
+
+// DescribeSecurityGroups implements EC2API.
+func (f *FakeEC2API) DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordCall(MethodDescribeSecurityGroups, params)
+
+	if err := f.getError(MethodDescribeSecurityGroups); err != nil {
+		return nil, err
+	}
+
+	var securityGroups []ec2types.SecurityGroup
+	for _, sg := range f.SecurityGroups {
+		securityGroups = append(securityGroups, sg)
+	}
+
+	return &ec2.DescribeSecurityGroupsOutput{
+		SecurityGroups: securityGroups,
+	}, nil
+}
+
+// Helper functions
+
+// generateID generates a unique ID for this fake instance.
+// Must be called while holding f.mu lock.
+func (f *FakeEC2API) generateID() string {
+	f.idCounter++
+	return fmt.Sprintf("%08d", f.idCounter)
+}
+
+// matchesFilters checks if tags match the provided filters.
+// Only tag-based filters are supported: "tag:<key>" and "tag-key".
+// Non-tag filters (e.g., "instance-state-name", "volume-id") are treated
+// as non-matching and will cause the filter to fail.
+func matchesFilters(tags []ec2types.Tag, filters []ec2types.Filter) bool {
+	for _, filter := range filters {
+		if filter.Name == nil {
+			continue
+		}
+
+		filterName := *filter.Name
+		matched := false
+
+		// Handle tag filters (tag:key-name)
+		if len(filterName) > 4 && filterName[:4] == "tag:" {
+			tagKey := filterName[4:]
+			for _, tag := range tags {
+				if tag.Key != nil && *tag.Key == tagKey {
+					for _, value := range filter.Values {
+						if tag.Value != nil && *tag.Value == value {
+							matched = true
+							break
+						}
+					}
+				}
+				if matched {
+					break
+				}
+			}
+		} else if filterName == "tag-key" {
+			// Match any tag with the given key
+			for _, tag := range tags {
+				for _, value := range filter.Values {
+					if tag.Key != nil && *tag.Key == value {
+						matched = true
+						break
+					}
+				}
+				if matched {
+					break
+				}
+			}
+		}
+
+		if !matched {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/provider/ec2/testutil/fake_stsapi.go
+++ b/pkg/provider/ec2/testutil/fake_stsapi.go
@@ -1,0 +1,106 @@
+// Package testutil provides test utilities for EC2 provider unit tests.
+package testutil
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	controllerclient "github.com/kubev2v/forklift/pkg/provider/ec2/controller/client"
+)
+
+// STSMethod represents an STS API method name for error injection.
+type STSMethod string
+
+// STS API method constants for type-safe error injection.
+const (
+	MethodGetCallerIdentity STSMethod = "GetCallerIdentity"
+)
+
+// FakeSTSAPI is a fake implementation of the STS API for testing.
+// It implements controller/client.STSAPI interface.
+type FakeSTSAPI struct {
+	mu sync.RWMutex
+
+	// AccountID is the account ID returned by GetCallerIdentity
+	AccountID string
+
+	// Arn is the ARN returned by GetCallerIdentity
+	Arn string
+
+	// UserID is the user ID returned by GetCallerIdentity
+	UserID string
+
+	// Error injection - map of method to error
+	Errors map[STSMethod]error
+
+	// Call tracking
+	Calls []STSAPICall
+}
+
+// STSAPICall records a call to the fake STS API for verification in tests.
+type STSAPICall struct {
+	Method STSMethod
+	Input  interface{}
+}
+
+// NewFakeSTSAPI creates a new FakeSTSAPI with empty state.
+func NewFakeSTSAPI() *FakeSTSAPI {
+	return &FakeSTSAPI{
+		Errors: make(map[STSMethod]error),
+		Calls:  []STSAPICall{},
+	}
+}
+
+// Compile-time check to ensure FakeSTSAPI implements STSAPI
+var _ controllerclient.STSAPI = (*FakeSTSAPI)(nil)
+
+// GetCallerIdentity implements STSAPI.
+func (f *FakeSTSAPI) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Calls = append(f.Calls, STSAPICall{Method: MethodGetCallerIdentity, Input: params})
+
+	if err := f.Errors[MethodGetCallerIdentity]; err != nil {
+		return nil, err
+	}
+
+	return &sts.GetCallerIdentityOutput{
+		Account: aws.String(f.AccountID),
+		Arn:     aws.String(f.Arn),
+		UserId:  aws.String(f.UserID),
+	}, nil
+}
+
+// Reset clears all state, recorded calls, and errors.
+func (f *FakeSTSAPI) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.AccountID = ""
+	f.Arn = ""
+	f.UserID = ""
+	f.Errors = make(map[STSMethod]error)
+	f.Calls = []STSAPICall{}
+}
+
+// SetAccountID sets the account ID to return.
+func (f *FakeSTSAPI) SetAccountID(accountID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.AccountID = accountID
+}
+
+// SetArn sets the ARN to return.
+func (f *FakeSTSAPI) SetArn(arn string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Arn = arn
+}
+
+// SetUserID sets the user ID to return.
+func (f *FakeSTSAPI) SetUserID(userID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.UserID = userID
+}

--- a/pkg/provider/ec2/testutil/fixtures.go
+++ b/pkg/provider/ec2/testutil/fixtures.go
@@ -1,0 +1,455 @@
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/provider/testutil"
+	core "k8s.io/api/core/v1"
+)
+
+// InstanceBuilder provides a fluent interface for building test EC2 instances.
+type InstanceBuilder struct {
+	instance ec2types.Instance
+}
+
+// NewInstanceBuilder creates a new InstanceBuilder with default values.
+func NewInstanceBuilder(id, name string) *InstanceBuilder {
+	return &InstanceBuilder{
+		instance: ec2types.Instance{
+			InstanceId:   aws.String(id),
+			InstanceType: ec2types.InstanceTypeT2Micro,
+			State: &ec2types.InstanceState{
+				Name: ec2types.InstanceStateNameRunning,
+				Code: aws.Int32(16), // Running
+			},
+			Tags: []ec2types.Tag{
+				{Key: aws.String("Name"), Value: aws.String(name)},
+			},
+			Placement: &ec2types.Placement{
+				AvailabilityZone: aws.String("us-east-1a"),
+			},
+			BlockDeviceMappings: []ec2types.InstanceBlockDeviceMapping{},
+			NetworkInterfaces:   []ec2types.InstanceNetworkInterface{},
+		},
+	}
+}
+
+// WithInstanceType sets the instance type.
+func (b *InstanceBuilder) WithInstanceType(instanceType ec2types.InstanceType) *InstanceBuilder {
+	b.instance.InstanceType = instanceType
+	return b
+}
+
+// WithState sets the instance state.
+func (b *InstanceBuilder) WithState(state ec2types.InstanceStateName) *InstanceBuilder {
+	b.instance.State = &ec2types.InstanceState{Name: state}
+	return b
+}
+
+// WithAvailabilityZone sets the availability zone.
+func (b *InstanceBuilder) WithAvailabilityZone(az string) *InstanceBuilder {
+	if b.instance.Placement == nil {
+		b.instance.Placement = &ec2types.Placement{}
+	}
+	b.instance.Placement.AvailabilityZone = aws.String(az)
+	return b
+}
+
+// WithVolume adds a block device mapping (EBS volume attachment).
+func (b *InstanceBuilder) WithVolume(deviceName, volumeID string) *InstanceBuilder {
+	b.instance.BlockDeviceMappings = append(b.instance.BlockDeviceMappings, ec2types.InstanceBlockDeviceMapping{
+		DeviceName: aws.String(deviceName),
+		Ebs: &ec2types.EbsInstanceBlockDevice{
+			VolumeId: aws.String(volumeID),
+			Status:   ec2types.AttachmentStatusAttached,
+		},
+	})
+	return b
+}
+
+// WithNetworkInterface adds a network interface.
+func (b *InstanceBuilder) WithNetworkInterface(subnetID, vpcID, privateIP string) *InstanceBuilder {
+	b.instance.NetworkInterfaces = append(b.instance.NetworkInterfaces, ec2types.InstanceNetworkInterface{
+		SubnetId:         aws.String(subnetID),
+		VpcId:            aws.String(vpcID),
+		PrivateIpAddress: aws.String(privateIP),
+		Status:           ec2types.NetworkInterfaceStatusInUse,
+	})
+	return b
+}
+
+// WithTag adds a tag to the instance.
+func (b *InstanceBuilder) WithTag(key, value string) *InstanceBuilder {
+	b.instance.Tags = append(b.instance.Tags, ec2types.Tag{
+		Key:   aws.String(key),
+		Value: aws.String(value),
+	})
+	return b
+}
+
+// Build returns the constructed Instance.
+func (b *InstanceBuilder) Build() ec2types.Instance {
+	return b.instance
+}
+
+// VolumeBuilder provides a fluent interface for building test EBS volumes.
+type VolumeBuilder struct {
+	volume ec2types.Volume
+}
+
+// NewVolumeBuilder creates a new VolumeBuilder with default values.
+func NewVolumeBuilder(id string) *VolumeBuilder {
+	return &VolumeBuilder{
+		volume: ec2types.Volume{
+			VolumeId:         aws.String(id),
+			VolumeType:       ec2types.VolumeTypeGp3,
+			Size:             aws.Int32(100),
+			State:            ec2types.VolumeStateAvailable,
+			AvailabilityZone: aws.String("us-east-1a"),
+			Tags:             []ec2types.Tag{},
+			Attachments:      []ec2types.VolumeAttachment{},
+		},
+	}
+}
+
+// WithVolumeType sets the volume type.
+func (b *VolumeBuilder) WithVolumeType(volumeType ec2types.VolumeType) *VolumeBuilder {
+	b.volume.VolumeType = volumeType
+	return b
+}
+
+// WithSize sets the volume size in GiB.
+func (b *VolumeBuilder) WithSize(sizeGiB int32) *VolumeBuilder {
+	b.volume.Size = aws.Int32(sizeGiB)
+	return b
+}
+
+// WithState sets the volume state.
+func (b *VolumeBuilder) WithState(state ec2types.VolumeState) *VolumeBuilder {
+	b.volume.State = state
+	return b
+}
+
+// WithAvailabilityZone sets the availability zone.
+func (b *VolumeBuilder) WithAvailabilityZone(az string) *VolumeBuilder {
+	b.volume.AvailabilityZone = aws.String(az)
+	return b
+}
+
+// WithAttachment adds an instance attachment.
+func (b *VolumeBuilder) WithAttachment(instanceID, device string) *VolumeBuilder {
+	b.volume.Attachments = append(b.volume.Attachments, ec2types.VolumeAttachment{
+		InstanceId: aws.String(instanceID),
+		Device:     aws.String(device),
+		State:      ec2types.VolumeAttachmentStateAttached,
+		VolumeId:   b.volume.VolumeId,
+	})
+	b.volume.State = ec2types.VolumeStateInUse
+	return b
+}
+
+// WithTag adds a tag to the volume.
+func (b *VolumeBuilder) WithTag(key, value string) *VolumeBuilder {
+	b.volume.Tags = append(b.volume.Tags, ec2types.Tag{
+		Key:   aws.String(key),
+		Value: aws.String(value),
+	})
+	return b
+}
+
+// WithSnapshotID sets the snapshot the volume was created from.
+func (b *VolumeBuilder) WithSnapshotID(snapshotID string) *VolumeBuilder {
+	b.volume.SnapshotId = aws.String(snapshotID)
+	return b
+}
+
+// Build returns the constructed Volume.
+func (b *VolumeBuilder) Build() ec2types.Volume {
+	return b.volume
+}
+
+// SnapshotBuilder provides a fluent interface for building test EBS snapshots.
+type SnapshotBuilder struct {
+	snapshot ec2types.Snapshot
+}
+
+// NewSnapshotBuilder creates a new SnapshotBuilder with default values.
+func NewSnapshotBuilder(id string) *SnapshotBuilder {
+	return &SnapshotBuilder{
+		snapshot: ec2types.Snapshot{
+			SnapshotId: aws.String(id),
+			State:      ec2types.SnapshotStateCompleted,
+			Progress:   aws.String("100%"),
+			VolumeSize: aws.Int32(100),
+			Tags:       []ec2types.Tag{},
+		},
+	}
+}
+
+// WithVolumeID sets the source volume ID.
+func (b *SnapshotBuilder) WithVolumeID(volumeID string) *SnapshotBuilder {
+	b.snapshot.VolumeId = aws.String(volumeID)
+	return b
+}
+
+// WithState sets the snapshot state.
+func (b *SnapshotBuilder) WithState(state ec2types.SnapshotState) *SnapshotBuilder {
+	b.snapshot.State = state
+	return b
+}
+
+// WithProgress sets the snapshot progress.
+func (b *SnapshotBuilder) WithProgress(progress string) *SnapshotBuilder {
+	b.snapshot.Progress = aws.String(progress)
+	return b
+}
+
+// WithVolumeSize sets the volume size in GiB.
+func (b *SnapshotBuilder) WithVolumeSize(sizeGiB int32) *SnapshotBuilder {
+	b.snapshot.VolumeSize = aws.Int32(sizeGiB)
+	return b
+}
+
+// WithTag adds a tag to the snapshot.
+func (b *SnapshotBuilder) WithTag(key, value string) *SnapshotBuilder {
+	b.snapshot.Tags = append(b.snapshot.Tags, ec2types.Tag{
+		Key:   aws.String(key),
+		Value: aws.String(value),
+	})
+	return b
+}
+
+// WithForkliftTags adds standard Forklift migration tags.
+func (b *SnapshotBuilder) WithForkliftTags(vmID, vmName, volumeID string) *SnapshotBuilder {
+	b.snapshot.Tags = append(b.snapshot.Tags,
+		ec2types.Tag{Key: aws.String("forklift.konveyor.io/vmID"), Value: aws.String(vmID)},
+		ec2types.Tag{Key: aws.String("forklift.konveyor.io/vm-name"), Value: aws.String(vmName)},
+		ec2types.Tag{Key: aws.String("forklift.konveyor.io/volume"), Value: aws.String(volumeID)},
+	)
+	return b
+}
+
+// Build returns the constructed Snapshot.
+func (b *SnapshotBuilder) Build() ec2types.Snapshot {
+	return b.snapshot
+}
+
+// VpcBuilder provides a fluent interface for building test VPCs.
+type VpcBuilder struct {
+	vpc ec2types.Vpc
+}
+
+// NewVpcBuilder creates a new VpcBuilder with default values.
+func NewVpcBuilder(id string) *VpcBuilder {
+	return &VpcBuilder{
+		vpc: ec2types.Vpc{
+			VpcId:     aws.String(id),
+			CidrBlock: aws.String("10.0.0.0/16"),
+			State:     ec2types.VpcStateAvailable,
+			Tags:      []ec2types.Tag{},
+		},
+	}
+}
+
+// WithCidrBlock sets the CIDR block.
+func (b *VpcBuilder) WithCidrBlock(cidr string) *VpcBuilder {
+	b.vpc.CidrBlock = aws.String(cidr)
+	return b
+}
+
+// WithTag adds a tag to the VPC.
+func (b *VpcBuilder) WithTag(key, value string) *VpcBuilder {
+	b.vpc.Tags = append(b.vpc.Tags, ec2types.Tag{
+		Key:   aws.String(key),
+		Value: aws.String(value),
+	})
+	return b
+}
+
+// Build returns the constructed Vpc.
+func (b *VpcBuilder) Build() ec2types.Vpc {
+	return b.vpc
+}
+
+// SubnetBuilder provides a fluent interface for building test subnets.
+type SubnetBuilder struct {
+	subnet ec2types.Subnet
+}
+
+// NewSubnetBuilder creates a new SubnetBuilder with default values.
+func NewSubnetBuilder(id, vpcID string) *SubnetBuilder {
+	return &SubnetBuilder{
+		subnet: ec2types.Subnet{
+			SubnetId:         aws.String(id),
+			VpcId:            aws.String(vpcID),
+			CidrBlock:        aws.String("10.0.1.0/24"),
+			AvailabilityZone: aws.String("us-east-1a"),
+			State:            ec2types.SubnetStateAvailable,
+			Tags:             []ec2types.Tag{},
+		},
+	}
+}
+
+// WithCidrBlock sets the CIDR block.
+func (b *SubnetBuilder) WithCidrBlock(cidr string) *SubnetBuilder {
+	b.subnet.CidrBlock = aws.String(cidr)
+	return b
+}
+
+// WithAvailabilityZone sets the availability zone.
+func (b *SubnetBuilder) WithAvailabilityZone(az string) *SubnetBuilder {
+	b.subnet.AvailabilityZone = aws.String(az)
+	return b
+}
+
+// WithTag adds a tag to the subnet.
+func (b *SubnetBuilder) WithTag(key, value string) *SubnetBuilder {
+	b.subnet.Tags = append(b.subnet.Tags, ec2types.Tag{
+		Key:   aws.String(key),
+		Value: aws.String(value),
+	})
+	return b
+}
+
+// Build returns the constructed Subnet.
+func (b *SubnetBuilder) Build() ec2types.Subnet {
+	return b.subnet
+}
+
+// SecurityGroupBuilder provides a fluent interface for building test security groups.
+type SecurityGroupBuilder struct {
+	sg ec2types.SecurityGroup
+}
+
+// NewSecurityGroupBuilder creates a new SecurityGroupBuilder with default values.
+func NewSecurityGroupBuilder(id, vpcID string) *SecurityGroupBuilder {
+	return &SecurityGroupBuilder{
+		sg: ec2types.SecurityGroup{
+			GroupId:   aws.String(id),
+			GroupName: aws.String(fmt.Sprintf("sg-%s", id)),
+			VpcId:     aws.String(vpcID),
+			Tags:      []ec2types.Tag{},
+		},
+	}
+}
+
+// WithGroupName sets the group name.
+func (b *SecurityGroupBuilder) WithGroupName(name string) *SecurityGroupBuilder {
+	b.sg.GroupName = aws.String(name)
+	return b
+}
+
+// WithDescription sets the description.
+func (b *SecurityGroupBuilder) WithDescription(desc string) *SecurityGroupBuilder {
+	b.sg.Description = aws.String(desc)
+	return b
+}
+
+// WithTag adds a tag to the security group.
+func (b *SecurityGroupBuilder) WithTag(key, value string) *SecurityGroupBuilder {
+	b.sg.Tags = append(b.sg.Tags, ec2types.Tag{
+		Key:   aws.String(key),
+		Value: aws.String(value),
+	})
+	return b
+}
+
+// Build returns the constructed SecurityGroup.
+func (b *SecurityGroupBuilder) Build() ec2types.SecurityGroup {
+	return b.sg
+}
+
+// EC2 Secret helpers
+
+// NewEC2Secret creates a Kubernetes Secret with EC2 credentials.
+func NewEC2Secret(name, namespace, region string) *core.Secret {
+	return testutil.NewSecretBuilder().
+		WithName(name).
+		WithNamespace(namespace).
+		WithData("region", region).
+		WithData("accessKeyId", "AKIAIOSFODNN7EXAMPLE").
+		WithData("secretAccessKey", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY").
+		Build()
+}
+
+// NewEC2SecretWithTargetAccount creates a Secret with both source and target account credentials.
+func NewEC2SecretWithTargetAccount(name, namespace, region string) *core.Secret {
+	return testutil.NewSecretBuilder().
+		WithName(name).
+		WithNamespace(namespace).
+		WithData("region", region).
+		WithData("accessKeyId", "AKIAIOSFODNN7EXAMPLE").
+		WithData("secretAccessKey", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY").
+		WithData("targetAccessKeyId", "AKIATARGETACCOUNT123").
+		WithData("targetSecretAccessKey", "targetSecretKey/EXAMPLE/KEY").
+		Build()
+}
+
+// EC2 Provider helpers
+
+// NewEC2ProviderWithSettings creates an EC2 Provider with common settings.
+func NewEC2ProviderWithSettings(name, namespace, targetAZ string) *api.Provider {
+	return testutil.NewProviderBuilder().
+		WithName(name).
+		WithNamespace(namespace).
+		WithType(api.EC2).
+		WithSecretRef(name+"-secret", namespace).
+		WithSetting("target-az", targetAZ).
+		Build()
+}
+
+// Sample test data factories
+
+// NewSampleInstance creates a sample EC2 instance for testing.
+func NewSampleInstance() ec2types.Instance {
+	return NewInstanceBuilder("i-1234567890abcdef0", "test-vm").
+		WithInstanceType(ec2types.InstanceTypeT3Medium).
+		WithState(ec2types.InstanceStateNameRunning).
+		WithAvailabilityZone("us-east-1a").
+		WithVolume("/dev/sda1", "vol-0123456789abcdef0").
+		WithVolume("/dev/sdb", "vol-0123456789abcdef1").
+		WithNetworkInterface("subnet-12345", "vpc-12345", "10.0.1.100").
+		Build()
+}
+
+// NewSampleVolume creates a sample EBS volume for testing.
+func NewSampleVolume() ec2types.Volume {
+	return NewVolumeBuilder("vol-0123456789abcdef0").
+		WithVolumeType(ec2types.VolumeTypeGp3).
+		WithSize(100).
+		WithState(ec2types.VolumeStateInUse).
+		WithAvailabilityZone("us-east-1a").
+		WithAttachment("i-1234567890abcdef0", "/dev/sda1").
+		Build()
+}
+
+// NewSampleSnapshot creates a sample EBS snapshot for testing.
+func NewSampleSnapshot() ec2types.Snapshot {
+	return NewSnapshotBuilder("snap-0123456789abcdef0").
+		WithVolumeID("vol-0123456789abcdef0").
+		WithState(ec2types.SnapshotStateCompleted).
+		WithProgress("100%").
+		WithVolumeSize(100).
+		WithForkliftTags("i-1234567890abcdef0", "test-vm", "vol-0123456789abcdef0").
+		Build()
+}
+
+// NewSampleVpc creates a sample VPC for testing.
+func NewSampleVpc() ec2types.Vpc {
+	return NewVpcBuilder("vpc-12345").
+		WithCidrBlock("10.0.0.0/16").
+		WithTag("Name", "test-vpc").
+		Build()
+}
+
+// NewSampleSubnet creates a sample subnet for testing.
+func NewSampleSubnet() ec2types.Subnet {
+	return NewSubnetBuilder("subnet-12345", "vpc-12345").
+		WithCidrBlock("10.0.1.0/24").
+		WithAvailabilityZone("us-east-1a").
+		WithTag("Name", "test-subnet").
+		Build()
+}

--- a/pkg/provider/testutil/context.go
+++ b/pkg/provider/testutil/context.go
@@ -1,0 +1,171 @@
+package testutil
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ContextBuilder provides a fluent interface for building test plancontext.Context objects.
+type ContextBuilder struct {
+	client     client.Client
+	plan       *api.Plan
+	migration  *api.Migration
+	provider   *api.Provider
+	secret     *core.Secret
+	networkMap *api.NetworkMap
+	storageMap *api.StorageMap
+	destClient client.Client
+	log        logging.LevelLogger
+	objs       []runtime.Object
+}
+
+// NewContextBuilder creates a new ContextBuilder with default values.
+func NewContextBuilder() *ContextBuilder {
+	return &ContextBuilder{
+		log:  logging.WithName("test"),
+		objs: []runtime.Object{},
+	}
+}
+
+// WithClient sets the Kubernetes client.
+func (b *ContextBuilder) WithClient(client client.Client) *ContextBuilder {
+	b.client = client
+	return b
+}
+
+// WithObjects adds runtime objects to the fake client.
+func (b *ContextBuilder) WithObjects(objs ...runtime.Object) *ContextBuilder {
+	b.objs = append(b.objs, objs...)
+	return b
+}
+
+// WithPlan sets the Plan.
+func (b *ContextBuilder) WithPlan(plan *api.Plan) *ContextBuilder {
+	b.plan = plan
+	return b
+}
+
+// WithMigration sets the Migration.
+func (b *ContextBuilder) WithMigration(migration *api.Migration) *ContextBuilder {
+	b.migration = migration
+	return b
+}
+
+// WithSourceProvider sets the source Provider.
+func (b *ContextBuilder) WithSourceProvider(provider *api.Provider) *ContextBuilder {
+	b.provider = provider
+	return b
+}
+
+// WithSecret sets the provider Secret.
+func (b *ContextBuilder) WithSecret(secret *core.Secret) *ContextBuilder {
+	b.secret = secret
+	return b
+}
+
+// WithNetworkMap sets the NetworkMap.
+func (b *ContextBuilder) WithNetworkMap(networkMap *api.NetworkMap) *ContextBuilder {
+	b.networkMap = networkMap
+	return b
+}
+
+// WithStorageMap sets the StorageMap.
+func (b *ContextBuilder) WithStorageMap(storageMap *api.StorageMap) *ContextBuilder {
+	b.storageMap = storageMap
+	return b
+}
+
+// WithDestinationClient sets a separate client for the destination cluster.
+func (b *ContextBuilder) WithDestinationClient(client client.Client) *ContextBuilder {
+	b.destClient = client
+	return b
+}
+
+// WithLogger sets the logger.
+func (b *ContextBuilder) WithLogger(log logging.LevelLogger) *ContextBuilder {
+	b.log = log
+	return b
+}
+
+// Build creates the plancontext.Context with all configured options.
+func (b *ContextBuilder) Build() *plancontext.Context {
+	// Create fake client if not provided
+	if b.client == nil {
+		b.client = NewFakeClient(b.objs...)
+	}
+
+	// Create default plan if not provided, or copy the provided plan
+	// to avoid mutating the caller's Plan when setting Referenced fields.
+	var plan *api.Plan
+	if b.plan == nil {
+		plan = NewPlanBuilder().Build()
+	} else {
+		plan = b.plan.DeepCopy()
+	}
+
+	// Create default migration if not provided
+	if b.migration == nil {
+		b.migration = NewMigrationBuilder().Build()
+	}
+
+	// Set up provider reference in plan
+	if b.provider != nil {
+		plan.Referenced.Provider.Source = b.provider
+	}
+
+	// Set up network map reference in plan
+	if b.networkMap != nil {
+		plan.Referenced.Map.Network = b.networkMap
+	}
+
+	// Set up storage map reference in plan
+	if b.storageMap != nil {
+		plan.Referenced.Map.Storage = b.storageMap
+	}
+
+	// Build the context
+	ctx := &plancontext.Context{
+		Client:    b.client,
+		Plan:      plan,
+		Migration: b.migration,
+		Log:       b.log,
+	}
+
+	// Set up source
+	ctx.Source.Provider = b.provider
+	ctx.Source.Secret = b.secret
+
+	// Set up destination
+	if b.destClient != nil {
+		ctx.Destination.Client = b.destClient
+	} else {
+		ctx.Destination.Client = b.client
+	}
+
+	// Set map references
+	ctx.Map.Network = b.networkMap
+	ctx.Map.Storage = b.storageMap
+
+	return ctx
+}
+
+// NewTestContext creates a minimal test context with common defaults.
+// Use this for simple tests that don't need extensive configuration.
+func NewTestContext(objs ...runtime.Object) *plancontext.Context {
+	return NewContextBuilder().
+		WithObjects(objs...).
+		Build()
+}
+
+// NewTestContextWithProvider creates a test context with a source provider and secret.
+func NewTestContextWithProvider(provider *api.Provider, secret *core.Secret, objs ...runtime.Object) *plancontext.Context {
+	return NewContextBuilder().
+		WithSourceProvider(provider).
+		WithSecret(secret).
+		WithObjects(objs...).
+		Build()
+}

--- a/pkg/provider/testutil/fixtures.go
+++ b/pkg/provider/testutil/fixtures.go
@@ -1,0 +1,314 @@
+package testutil
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+// PlanBuilder provides a fluent interface for building test Plan objects.
+type PlanBuilder struct {
+	plan *api.Plan
+}
+
+// NewPlanBuilder creates a new PlanBuilder with default values.
+func NewPlanBuilder() *PlanBuilder {
+	return &PlanBuilder{
+		plan: &api.Plan{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "test-plan",
+				Namespace: "test",
+				UID:       k8stypes.UID("plan-uid-123"),
+			},
+			Spec: api.PlanSpec{
+				TargetNamespace:                "test",
+				PVCNameTemplateUseGenerateName: true,
+			},
+		},
+	}
+}
+
+// WithName sets the plan name.
+func (b *PlanBuilder) WithName(name string) *PlanBuilder {
+	b.plan.Name = name
+	return b
+}
+
+// WithNamespace sets the plan namespace.
+func (b *PlanBuilder) WithNamespace(namespace string) *PlanBuilder {
+	b.plan.Namespace = namespace
+	b.plan.Spec.TargetNamespace = namespace
+	return b
+}
+
+// WithTargetNamespace sets the target namespace for migrated VMs.
+func (b *PlanBuilder) WithTargetNamespace(namespace string) *PlanBuilder {
+	b.plan.Spec.TargetNamespace = namespace
+	return b
+}
+
+// WithUID sets the plan UID.
+func (b *PlanBuilder) WithUID(uid string) *PlanBuilder {
+	b.plan.UID = k8stypes.UID(uid)
+	return b
+}
+
+// WithVM adds a VM to the plan.
+func (b *PlanBuilder) WithVM(name, id string) *PlanBuilder {
+	b.plan.Spec.VMs = append(b.plan.Spec.VMs, planapi.VM{
+		Ref: ref.Ref{Name: name, ID: id},
+	})
+	return b
+}
+
+// WithVMs adds multiple VMs to the plan.
+func (b *PlanBuilder) WithVMs(vms ...planapi.VM) *PlanBuilder {
+	b.plan.Spec.VMs = append(b.plan.Spec.VMs, vms...)
+	return b
+}
+
+// WithSourceProvider sets the source provider reference.
+func (b *PlanBuilder) WithSourceProvider(provider *api.Provider) *PlanBuilder {
+	b.plan.Referenced.Provider.Source = provider
+	return b
+}
+
+// WithDestinationProvider sets the destination provider reference.
+func (b *PlanBuilder) WithDestinationProvider(provider *api.Provider) *PlanBuilder {
+	b.plan.Referenced.Provider.Destination = provider
+	return b
+}
+
+// WithNetworkMap sets the network map reference.
+func (b *PlanBuilder) WithNetworkMap(networkMap *api.NetworkMap) *PlanBuilder {
+	b.plan.Referenced.Map.Network = networkMap
+	return b
+}
+
+// WithStorageMap sets the storage map reference.
+func (b *PlanBuilder) WithStorageMap(storageMap *api.StorageMap) *PlanBuilder {
+	b.plan.Referenced.Map.Storage = storageMap
+	return b
+}
+
+// WithMigrationType sets the migration type (cold, warm).
+func (b *PlanBuilder) WithMigrationType(migrationType api.MigrationType) *PlanBuilder {
+	b.plan.Spec.Type = migrationType
+	return b
+}
+
+// WithMigrationHistory adds a migration snapshot to the plan history.
+func (b *PlanBuilder) WithMigrationHistory(migrationUID string) *PlanBuilder {
+	b.plan.Status.Migration.History = append(b.plan.Status.Migration.History, planapi.Snapshot{
+		Migration: planapi.SnapshotRef{
+			UID: k8stypes.UID(migrationUID),
+		},
+	})
+	return b
+}
+
+// Build returns the constructed Plan.
+func (b *PlanBuilder) Build() *api.Plan {
+	return b.plan
+}
+
+// ProviderBuilder provides a fluent interface for building test Provider objects.
+type ProviderBuilder struct {
+	provider *api.Provider
+}
+
+// NewProviderBuilder creates a new ProviderBuilder with default values.
+func NewProviderBuilder() *ProviderBuilder {
+	providerType := api.Undefined
+	return &ProviderBuilder{
+		provider: &api.Provider{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "test-provider",
+				Namespace: "test",
+				UID:       k8stypes.UID("provider-uid-123"),
+			},
+			Spec: api.ProviderSpec{
+				Type:     &providerType,
+				Settings: map[string]string{},
+			},
+		},
+	}
+}
+
+// WithName sets the provider name.
+func (b *ProviderBuilder) WithName(name string) *ProviderBuilder {
+	b.provider.Name = name
+	return b
+}
+
+// WithNamespace sets the provider namespace.
+func (b *ProviderBuilder) WithNamespace(namespace string) *ProviderBuilder {
+	b.provider.Namespace = namespace
+	return b
+}
+
+// WithType sets the provider type.
+func (b *ProviderBuilder) WithType(providerType api.ProviderType) *ProviderBuilder {
+	b.provider.Spec.Type = &providerType
+	return b
+}
+
+// WithURL sets the provider URL.
+func (b *ProviderBuilder) WithURL(url string) *ProviderBuilder {
+	b.provider.Spec.URL = url
+	return b
+}
+
+// WithSecretRef sets the secret reference.
+func (b *ProviderBuilder) WithSecretRef(name, namespace string) *ProviderBuilder {
+	b.provider.Spec.Secret = core.ObjectReference{
+		Name:      name,
+		Namespace: namespace,
+	}
+	return b
+}
+
+// WithSetting adds a setting to the provider.
+func (b *ProviderBuilder) WithSetting(key, value string) *ProviderBuilder {
+	if b.provider.Spec.Settings == nil {
+		b.provider.Spec.Settings = map[string]string{}
+	}
+	b.provider.Spec.Settings[key] = value
+	return b
+}
+
+// WithSettings sets multiple settings, replacing any previously configured settings.
+// Use WithSetting to add individual settings without overriding.
+func (b *ProviderBuilder) WithSettings(settings map[string]string) *ProviderBuilder {
+	b.provider.Spec.Settings = settings
+	return b
+}
+
+// Build returns the constructed Provider.
+func (b *ProviderBuilder) Build() *api.Provider {
+	return b.provider
+}
+
+// SecretBuilder provides a fluent interface for building test Secret objects.
+type SecretBuilder struct {
+	secret *core.Secret
+}
+
+// NewSecretBuilder creates a new SecretBuilder with default values.
+func NewSecretBuilder() *SecretBuilder {
+	return &SecretBuilder{
+		secret: &core.Secret{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "test",
+			},
+			Data: map[string][]byte{},
+		},
+	}
+}
+
+// WithName sets the secret name.
+func (b *SecretBuilder) WithName(name string) *SecretBuilder {
+	b.secret.Name = name
+	return b
+}
+
+// WithNamespace sets the secret namespace.
+func (b *SecretBuilder) WithNamespace(namespace string) *SecretBuilder {
+	b.secret.Namespace = namespace
+	return b
+}
+
+// WithData adds a key-value pair to the secret data.
+func (b *SecretBuilder) WithData(key, value string) *SecretBuilder {
+	if b.secret.Data == nil {
+		b.secret.Data = map[string][]byte{}
+	}
+	b.secret.Data[key] = []byte(value)
+	return b
+}
+
+// WithDataMap sets the entire data map.
+func (b *SecretBuilder) WithDataMap(data map[string][]byte) *SecretBuilder {
+	b.secret.Data = data
+	return b
+}
+
+// Build returns the constructed Secret.
+func (b *SecretBuilder) Build() *core.Secret {
+	return b.secret
+}
+
+// MigrationBuilder provides a fluent interface for building test Migration objects.
+type MigrationBuilder struct {
+	migration *api.Migration
+}
+
+// NewMigrationBuilder creates a new MigrationBuilder with default values.
+func NewMigrationBuilder() *MigrationBuilder {
+	return &MigrationBuilder{
+		migration: &api.Migration{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "test-migration",
+				Namespace: "test",
+				UID:       k8stypes.UID("migration-uid-123"),
+			},
+		},
+	}
+}
+
+// WithName sets the migration name.
+func (b *MigrationBuilder) WithName(name string) *MigrationBuilder {
+	b.migration.Name = name
+	return b
+}
+
+// WithNamespace sets the migration namespace.
+func (b *MigrationBuilder) WithNamespace(namespace string) *MigrationBuilder {
+	b.migration.Namespace = namespace
+	return b
+}
+
+// WithUID sets the migration UID.
+func (b *MigrationBuilder) WithUID(uid string) *MigrationBuilder {
+	b.migration.UID = k8stypes.UID(uid)
+	return b
+}
+
+// WithPlanRef sets the reference to the associated Plan.
+func (b *MigrationBuilder) WithPlanRef(name, namespace string) *MigrationBuilder {
+	b.migration.Spec.Plan = core.ObjectReference{
+		Name:      name,
+		Namespace: namespace,
+	}
+	return b
+}
+
+// WithPlan sets the Plan reference from a Plan object.
+func (b *MigrationBuilder) WithPlan(plan *api.Plan) *MigrationBuilder {
+	b.migration.Spec.Plan = core.ObjectReference{
+		Name:      plan.Name,
+		Namespace: plan.Namespace,
+	}
+	return b
+}
+
+// WithCancel adds VMs to the cancel list.
+func (b *MigrationBuilder) WithCancel(vms ...ref.Ref) *MigrationBuilder {
+	b.migration.Spec.Cancel = append(b.migration.Spec.Cancel, vms...)
+	return b
+}
+
+// WithCutover sets the cutover time for warm migrations.
+func (b *MigrationBuilder) WithCutover(cutover meta.Time) *MigrationBuilder {
+	b.migration.Spec.Cutover = &cutover
+	return b
+}
+
+// Build returns the constructed Migration.
+func (b *MigrationBuilder) Build() *api.Migration {
+	return b.migration
+}

--- a/pkg/provider/testutil/k8s.go
+++ b/pkg/provider/testutil/k8s.go
@@ -1,0 +1,37 @@
+// Package testutil provides shared test utilities for provider unit tests.
+// It includes helpers for creating fake Kubernetes clients, test fixtures,
+// and common test setup patterns used across different provider implementations.
+package testutil
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	v1 "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// NewScheme creates a runtime.Scheme with all the types needed for provider tests.
+// Includes core K8s types (core, apps, rbac) and Forklift CRDs (v1beta1).
+func NewScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(v1.AddToScheme(scheme))
+	utilruntime.Must(core.AddToScheme(scheme))
+	utilruntime.Must(rbacv1.AddToScheme(scheme))
+	utilruntime.Must(api.SchemeBuilder.AddToScheme(scheme))
+	return scheme
+}
+
+// NewFakeClient creates a fake controller-runtime client with the standard scheme
+// and the provided runtime objects pre-populated.
+// For more advanced configuration (indexes, etc.), use fake.NewClientBuilder()
+// directly with NewScheme().
+func NewFakeClient(objs ...runtime.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(NewScheme()).
+		WithRuntimeObjects(objs...).
+		Build()
+}


### PR DESCRIPTION
Issue:
Current EC2 implementation lacks testing mocks and fixtures

Fix:
Add mocks and fixtures for unit tests of EC2 provider

Ref: https://issues.redhat.com/browse/MTV-4349

Resolves: MTV-4348