### PR TITLE
MTV-4351 | Add Unit Tests for EC2 Provider Controller Package

### DIFF
--- a/pkg/provider/ec2/controller/inventory/inventory_test.go
+++ b/pkg/provider/ec2/controller/inventory/inventory_test.go
@@ -1,0 +1,505 @@
+package inventory
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"github.com/kubev2v/forklift/pkg/provider/ec2/inventory/model"
+	"github.com/kubev2v/forklift/pkg/provider/ec2/inventory/web"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func TestInventory(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EC2 controller inventory")
+}
+
+// FakeInventory implements the Inventory interface for testing.
+type FakeInventory struct {
+	VMs     map[string]*web.VM
+	Volumes map[string]*web.Volume
+	Error   error
+}
+
+func NewFakeInventory() *FakeInventory {
+	return &FakeInventory{
+		VMs:     make(map[string]*web.VM),
+		Volumes: make(map[string]*web.Volume),
+	}
+}
+
+func (f *FakeInventory) Find(resource interface{}, r ref.Ref) error {
+	if f.Error != nil {
+		return f.Error
+	}
+
+	switch res := resource.(type) {
+	case *web.VM:
+		id := r.ID
+		if id == "" {
+			id = r.Name
+		}
+		if vm, ok := f.VMs[id]; ok {
+			*res = *vm
+			return nil
+		}
+		return errors.New("VM not found")
+	case *web.Volume:
+		id := r.ID
+		if id == "" {
+			id = r.Name
+		}
+		if vol, ok := f.Volumes[id]; ok {
+			*res = *vol
+			return nil
+		}
+		return errors.New("Volume not found")
+	}
+	return errors.New("unknown resource type")
+}
+
+var _ = Describe("EC2 Controller Inventory", func() {
+	Describe("GetAWSInstance", func() {
+		var fakeInv *FakeInventory
+
+		BeforeEach(func() {
+			fakeInv = NewFakeInventory()
+		})
+
+		It("should return instance details when VM exists", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID:   "i-123",
+				Name: "test-vm",
+			}
+			instanceDetails.InstanceId = aws.String("i-123")
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123", Name: "test-vm"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			result, err := GetAWSInstance(fakeInv, vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.ID).To(Equal("i-123"))
+			Expect(result.Name).To(Equal("test-vm"))
+		})
+
+		It("should return error when VM not found", func() {
+			vmRef := ref.Ref{ID: "i-nonexistent"}
+			result, err := GetAWSInstance(fakeInv, vmRef)
+
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+
+		It("should return ErrNoAWSInstanceObject when Object is nil", func() {
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123", Name: "test-vm"},
+				Object:   nil,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			result, err := GetAWSInstance(fakeInv, vmRef)
+
+			Expect(err).To(Equal(ErrNoAWSInstanceObject))
+			Expect(result).To(BeNil())
+		})
+
+		It("should return error when inventory fails", func() {
+			fakeInv.Error = errors.New("inventory error")
+
+			vmRef := ref.Ref{ID: "i-123"}
+			result, err := GetAWSInstance(fakeInv, vmRef)
+
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("GetBlockDevices", func() {
+		It("should return block devices when present", func() {
+			instance := &model.InstanceDetails{
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{DeviceName: aws.String("/dev/sda1")},
+					{DeviceName: aws.String("/dev/sdb")},
+				},
+			}
+
+			devices, found := GetBlockDevices(instance)
+
+			Expect(found).To(BeTrue())
+			Expect(devices).To(HaveLen(2))
+		})
+
+		It("should return false when no block devices", func() {
+			instance := &model.InstanceDetails{
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{},
+			}
+
+			devices, found := GetBlockDevices(instance)
+
+			Expect(found).To(BeFalse())
+			Expect(devices).To(BeEmpty())
+		})
+
+		It("should return false when block devices is nil", func() {
+			instance := &model.InstanceDetails{}
+
+			devices, found := GetBlockDevices(instance)
+
+			Expect(found).To(BeFalse())
+			Expect(devices).To(BeNil())
+		})
+	})
+
+	Describe("GetNetworkInterfaces", func() {
+		It("should return network interfaces when present", func() {
+			instance := &model.InstanceDetails{
+				NetworkInterfaces: []model.InstanceNetworkInterface{
+					{SubnetId: aws.String("subnet-123")},
+					{SubnetId: aws.String("subnet-456")},
+				},
+			}
+
+			interfaces, found := GetNetworkInterfaces(instance)
+
+			Expect(found).To(BeTrue())
+			Expect(interfaces).To(HaveLen(2))
+		})
+
+		It("should return false when no network interfaces", func() {
+			instance := &model.InstanceDetails{
+				NetworkInterfaces: []model.InstanceNetworkInterface{},
+			}
+
+			interfaces, found := GetNetworkInterfaces(instance)
+
+			Expect(found).To(BeFalse())
+			Expect(interfaces).To(BeEmpty())
+		})
+	})
+
+	Describe("GetInstanceName", func() {
+		table.DescribeTable("should return correct name",
+			func(instance *model.InstanceDetails, expected string) {
+				Expect(GetInstanceName(instance)).To(Equal(expected))
+			},
+			table.Entry("returns Name when set",
+				&model.InstanceDetails{Name: "my-instance"},
+				"my-instance"),
+			table.Entry("returns InstanceId when Name is empty",
+				func() *model.InstanceDetails {
+					d := &model.InstanceDetails{}
+					d.InstanceId = aws.String("i-123")
+					return d
+				}(),
+				"i-123"),
+			table.Entry("returns empty when both are empty",
+				&model.InstanceDetails{},
+				""),
+		)
+	})
+
+	Describe("GetInstanceID", func() {
+		It("should return instance ID when set", func() {
+			instance := &model.InstanceDetails{}
+			instance.InstanceId = aws.String("i-123")
+
+			Expect(GetInstanceID(instance)).To(Equal("i-123"))
+		})
+
+		It("should return empty string when nil", func() {
+			instance := &model.InstanceDetails{}
+
+			Expect(GetInstanceID(instance)).To(Equal(""))
+		})
+	})
+
+	Describe("IsInstanceStore", func() {
+		table.DescribeTable("should correctly identify instance store",
+			func(device model.InstanceBlockDeviceMapping, expected bool) {
+				Expect(IsInstanceStore(device)).To(Equal(expected))
+			},
+			table.Entry("true when VirtualName is set",
+				model.InstanceBlockDeviceMapping{VirtualName: aws.String("ephemeral0")},
+				true),
+			table.Entry("false when VirtualName is nil",
+				model.InstanceBlockDeviceMapping{VirtualName: nil},
+				false),
+			table.Entry("false when VirtualName is empty string",
+				model.InstanceBlockDeviceMapping{VirtualName: aws.String("")},
+				false),
+			table.Entry("false for EBS volume",
+				model.InstanceBlockDeviceMapping{
+					Ebs: &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-123")},
+				},
+				false),
+		)
+	})
+
+	Describe("IsEBSVolume", func() {
+		table.DescribeTable("should correctly identify EBS volume",
+			func(device model.InstanceBlockDeviceMapping, expected bool) {
+				Expect(IsEBSVolume(device)).To(Equal(expected))
+			},
+			table.Entry("true when Ebs with VolumeId is set",
+				model.InstanceBlockDeviceMapping{
+					Ebs: &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-123")},
+				},
+				true),
+			table.Entry("false when Ebs is nil",
+				model.InstanceBlockDeviceMapping{},
+				false),
+			table.Entry("false when VolumeId is nil",
+				model.InstanceBlockDeviceMapping{
+					Ebs: &model.EbsInstanceBlockDevice{VolumeId: nil},
+				},
+				false),
+			table.Entry("false for instance store",
+				model.InstanceBlockDeviceMapping{
+					VirtualName: aws.String("ephemeral0"),
+					Ebs:         &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-123")},
+				},
+				false),
+		)
+	})
+
+	Describe("ExtractEBSVolumeID", func() {
+		It("should return volume ID for EBS device", func() {
+			device := model.InstanceBlockDeviceMapping{
+				Ebs: &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-123")},
+			}
+
+			Expect(ExtractEBSVolumeID(device)).To(Equal("vol-123"))
+		})
+
+		It("should return empty string for non-EBS device", func() {
+			device := model.InstanceBlockDeviceMapping{
+				VirtualName: aws.String("ephemeral0"),
+			}
+
+			Expect(ExtractEBSVolumeID(device)).To(Equal(""))
+		})
+
+		It("should return empty string for empty device", func() {
+			device := model.InstanceBlockDeviceMapping{}
+
+			Expect(ExtractEBSVolumeID(device)).To(Equal(""))
+		})
+	})
+
+	Describe("GetDeviceName", func() {
+		It("should return device name when set", func() {
+			device := model.InstanceBlockDeviceMapping{
+				DeviceName: aws.String("/dev/sda1"),
+			}
+
+			Expect(GetDeviceName(device)).To(Equal("/dev/sda1"))
+		})
+
+		It("should return empty string when nil", func() {
+			device := model.InstanceBlockDeviceMapping{}
+
+			Expect(GetDeviceName(device)).To(Equal(""))
+		})
+	})
+
+	Describe("GetVirtualName", func() {
+		It("should return virtual name when set", func() {
+			device := model.InstanceBlockDeviceMapping{
+				VirtualName: aws.String("ephemeral0"),
+			}
+
+			Expect(GetVirtualName(device)).To(Equal("ephemeral0"))
+		})
+
+		It("should return empty string when nil", func() {
+			device := model.InstanceBlockDeviceMapping{}
+
+			Expect(GetVirtualName(device)).To(Equal(""))
+		})
+	})
+
+	Describe("GetVolume", func() {
+		var fakeInv *FakeInventory
+
+		BeforeEach(func() {
+			fakeInv = NewFakeInventory()
+		})
+
+		It("should return volume when found", func() {
+			volumeDetails := &model.VolumeDetails{
+				ID:   "vol-123",
+				Name: "test-volume",
+			}
+			volumeDetails.VolumeType = ec2types.VolumeTypeGp3
+			fakeInv.Volumes["vol-123"] = &web.Volume{
+				Resource: web.Resource{ID: "vol-123", Name: "test-volume"},
+				Object:   volumeDetails,
+			}
+
+			result, err := GetVolume(fakeInv, "vol-123")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.ID).To(Equal("vol-123"))
+		})
+
+		It("should return error when volume not found", func() {
+			result, err := GetVolume(fakeInv, "vol-nonexistent")
+
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("GetVolumeType", func() {
+		var fakeInv *FakeInventory
+
+		BeforeEach(func() {
+			fakeInv = NewFakeInventory()
+		})
+
+		It("should return volume type when found", func() {
+			volumeDetails := &model.VolumeDetails{}
+			volumeDetails.VolumeType = ec2types.VolumeTypeGp3
+			fakeInv.Volumes["vol-123"] = &web.Volume{
+				Resource: web.Resource{ID: "vol-123"},
+				Object:   volumeDetails,
+			}
+
+			result := GetVolumeType(fakeInv, "vol-123")
+
+			Expect(result).To(Equal("gp3"))
+		})
+
+		It("should return empty string for empty volumeID", func() {
+			result := GetVolumeType(fakeInv, "")
+
+			Expect(result).To(Equal(""))
+		})
+
+		It("should return empty string when volume not found", func() {
+			result := GetVolumeType(fakeInv, "vol-nonexistent")
+
+			Expect(result).To(Equal(""))
+		})
+
+		It("should return empty string when Object is nil", func() {
+			fakeInv.Volumes["vol-123"] = &web.Volume{
+				Resource: web.Resource{ID: "vol-123"},
+				Object:   nil,
+			}
+
+			result := GetVolumeType(fakeInv, "vol-123")
+
+			Expect(result).To(Equal(""))
+		})
+	})
+
+	Describe("GetVolumeSize", func() {
+		var fakeInv *FakeInventory
+
+		BeforeEach(func() {
+			fakeInv = NewFakeInventory()
+		})
+
+		It("should return volume size when found", func() {
+			volumeDetails := &model.VolumeDetails{}
+			volumeDetails.Size = aws.Int32(100)
+			fakeInv.Volumes["vol-123"] = &web.Volume{
+				Resource: web.Resource{ID: "vol-123"},
+				Object:   volumeDetails,
+			}
+
+			result := GetVolumeSize(fakeInv, "vol-123")
+
+			Expect(result).To(Equal(int64(100)))
+		})
+
+		It("should return 0 for empty volumeID", func() {
+			result := GetVolumeSize(fakeInv, "")
+
+			Expect(result).To(Equal(int64(0)))
+		})
+
+		It("should return 0 when volume not found", func() {
+			result := GetVolumeSize(fakeInv, "vol-nonexistent")
+
+			Expect(result).To(Equal(int64(0)))
+		})
+
+		It("should return 0 when Size is nil", func() {
+			volumeDetails := &model.VolumeDetails{}
+			volumeDetails.Size = nil
+			fakeInv.Volumes["vol-123"] = &web.Volume{
+				Resource: web.Resource{ID: "vol-123"},
+				Object:   volumeDetails,
+			}
+
+			result := GetVolumeSize(fakeInv, "vol-123")
+
+			Expect(result).To(Equal(int64(0)))
+		})
+	})
+
+	Describe("ParseBlockDevices", func() {
+		It("should parse EBS and instance store devices", func() {
+			instance := &model.InstanceDetails{
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{
+						DeviceName: aws.String("/dev/sda1"),
+						Ebs:        &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-111")},
+					},
+					{
+						DeviceName: aws.String("/dev/sdb"),
+						Ebs:        &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-222")},
+					},
+					{
+						DeviceName:  aws.String("/dev/sdc"),
+						VirtualName: aws.String("ephemeral0"),
+					},
+				},
+			}
+
+			stats := ParseBlockDevices(instance)
+
+			Expect(stats.EBSVolumeIDs).To(ConsistOf("vol-111", "vol-222"))
+			Expect(stats.InstanceStoreDev).To(ConsistOf("/dev/sdc"))
+			Expect(stats.SkippedCount).To(Equal(0))
+		})
+
+		It("should handle empty block devices", func() {
+			instance := &model.InstanceDetails{
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{},
+			}
+
+			stats := ParseBlockDevices(instance)
+
+			Expect(stats.EBSVolumeIDs).To(BeEmpty())
+			Expect(stats.InstanceStoreDev).To(BeEmpty())
+			Expect(stats.SkippedCount).To(Equal(0))
+		})
+
+		It("should count skipped devices", func() {
+			instance := &model.InstanceDetails{
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{DeviceName: aws.String("/dev/sda1")}, // No Ebs or VirtualName
+				},
+			}
+
+			stats := ParseBlockDevices(instance)
+
+			Expect(stats.EBSVolumeIDs).To(BeEmpty())
+			Expect(stats.InstanceStoreDev).To(BeEmpty())
+			Expect(stats.SkippedCount).To(Equal(1))
+		})
+	})
+})

--- a/pkg/provider/ec2/controller/mapping/mapping_test.go
+++ b/pkg/provider/ec2/controller/mapping/mapping_test.go
@@ -1,0 +1,298 @@
+package mapping
+
+import (
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func TestMapping(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EC2 controller mapping")
+}
+
+var _ = Describe("EC2 Controller Mapping", func() {
+	Describe("FindStorageClass", func() {
+		It("should find storage class for volume type", func() {
+			storageMap := &api.StorageMap{
+				Spec: api.StorageMapSpec{
+					Map: []api.StoragePair{
+						{
+							Source:      ref.Ref{Name: "gp2"},
+							Destination: api.DestinationStorage{StorageClass: "standard"},
+						},
+						{
+							Source:      ref.Ref{Name: "gp3"},
+							Destination: api.DestinationStorage{StorageClass: "premium-rwo"},
+						},
+					},
+				},
+			}
+
+			result := FindStorageClass(storageMap, "gp3")
+
+			Expect(result).To(Equal("premium-rwo"))
+		})
+
+		It("should return empty string when volume type not found", func() {
+			storageMap := &api.StorageMap{
+				Spec: api.StorageMapSpec{
+					Map: []api.StoragePair{
+						{
+							Source:      ref.Ref{Name: "gp2"},
+							Destination: api.DestinationStorage{StorageClass: "standard"},
+						},
+					},
+				},
+			}
+
+			result := FindStorageClass(storageMap, "io1")
+
+			Expect(result).To(Equal(""))
+		})
+
+		It("should return empty string when storageMap is nil", func() {
+			result := FindStorageClass(nil, "gp2")
+
+			Expect(result).To(Equal(""))
+		})
+
+		It("should return empty string when map is empty", func() {
+			storageMap := &api.StorageMap{
+				Spec: api.StorageMapSpec{
+					Map: []api.StoragePair{},
+				},
+			}
+
+			result := FindStorageClass(storageMap, "gp2")
+
+			Expect(result).To(Equal(""))
+		})
+	})
+
+	Describe("HasStorageMapping", func() {
+		var storageMap *api.StorageMap
+
+		BeforeEach(func() {
+			storageMap = &api.StorageMap{
+				Spec: api.StorageMapSpec{
+					Map: []api.StoragePair{
+						{
+							Source:      ref.Ref{Name: "gp2"},
+							Destination: api.DestinationStorage{StorageClass: "standard"},
+						},
+						{
+							Source:      ref.Ref{Name: "gp3"},
+							Destination: api.DestinationStorage{StorageClass: "premium-rwo"},
+						},
+						{
+							Source:      ref.Ref{Name: "io1"},
+							Destination: api.DestinationStorage{StorageClass: "io-optimized"},
+						},
+					},
+				},
+			}
+		})
+
+		table.DescribeTable("should check mapping existence",
+			func(volumeType string, expected bool) {
+				Expect(HasStorageMapping(storageMap, volumeType)).To(Equal(expected))
+			},
+			table.Entry("gp2 exists", "gp2", true),
+			table.Entry("gp3 exists", "gp3", true),
+			table.Entry("io1 exists", "io1", true),
+			table.Entry("io2 does not exist", "io2", false),
+			table.Entry("st1 does not exist", "st1", false),
+			table.Entry("empty string does not exist", "", false),
+		)
+
+		It("should return false for nil storageMap", func() {
+			Expect(HasStorageMapping(nil, "gp2")).To(BeFalse())
+		})
+	})
+
+	Describe("FindNetworkPair", func() {
+		It("should find network pair by Source.ID", func() {
+			networkMap := &api.NetworkMap{
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							Source: ref.Ref{ID: "subnet-123", Name: ""},
+							Destination: api.DestinationNetwork{
+								Type: "pod",
+							},
+						},
+					},
+				},
+			}
+
+			result := FindNetworkPair(networkMap, "subnet-123")
+
+			Expect(result).NotTo(BeNil())
+			Expect(result.Source.ID).To(Equal("subnet-123"))
+		})
+
+		It("should find network pair by Source.Name", func() {
+			networkMap := &api.NetworkMap{
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							Source: ref.Ref{ID: "", Name: "subnet-456"},
+							Destination: api.DestinationNetwork{
+								Type: "pod",
+							},
+						},
+					},
+				},
+			}
+
+			result := FindNetworkPair(networkMap, "subnet-456")
+
+			Expect(result).NotTo(BeNil())
+			Expect(result.Source.Name).To(Equal("subnet-456"))
+		})
+
+		It("should return nil when subnet not found", func() {
+			networkMap := &api.NetworkMap{
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							Source: ref.Ref{ID: "subnet-123"},
+							Destination: api.DestinationNetwork{
+								Type: "pod",
+							},
+						},
+					},
+				},
+			}
+
+			result := FindNetworkPair(networkMap, "subnet-nonexistent")
+
+			Expect(result).To(BeNil())
+		})
+
+		It("should return nil when networkMap is nil", func() {
+			result := FindNetworkPair(nil, "subnet-123")
+
+			Expect(result).To(BeNil())
+		})
+
+		It("should return nil when networkMap.Spec.Map is nil", func() {
+			networkMap := &api.NetworkMap{
+				Spec: api.NetworkMapSpec{
+					Map: nil,
+				},
+			}
+
+			result := FindNetworkPair(networkMap, "subnet-123")
+
+			Expect(result).To(BeNil())
+		})
+
+		It("should return nil when map is empty", func() {
+			networkMap := &api.NetworkMap{
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{},
+				},
+			}
+
+			result := FindNetworkPair(networkMap, "subnet-123")
+
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("HasNetworkMapping", func() {
+		var networkMap *api.NetworkMap
+
+		BeforeEach(func() {
+			networkMap = &api.NetworkMap{
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							// Both ID and Name set to prevent empty string matching
+							Source: ref.Ref{ID: "subnet-111", Name: "subnet-111-name"},
+							Destination: api.DestinationNetwork{
+								Type: "pod",
+							},
+						},
+						{
+							Source: ref.Ref{ID: "subnet-222-id", Name: "subnet-222"},
+							Destination: api.DestinationNetwork{
+								Type: "multus",
+							},
+						},
+					},
+				},
+			}
+		})
+
+		table.DescribeTable("should check mapping existence",
+			func(subnetID string, expected bool) {
+				Expect(HasNetworkMapping(networkMap, subnetID)).To(Equal(expected))
+			},
+			table.Entry("subnet-111 exists by ID", "subnet-111", true),
+			table.Entry("subnet-222 exists by Name", "subnet-222", true),
+			table.Entry("subnet-333 does not exist", "subnet-333", false),
+			table.Entry("empty string does not exist", "", false),
+		)
+
+		It("should return false for nil networkMap", func() {
+			Expect(HasNetworkMapping(nil, "subnet-111")).To(BeFalse())
+		})
+	})
+
+	Describe("Multiple mappings", func() {
+		It("should find first matching network pair", func() {
+			networkMap := &api.NetworkMap{
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							Source: ref.Ref{ID: "subnet-123"},
+							Destination: api.DestinationNetwork{
+								Type: "pod",
+							},
+						},
+						{
+							Source: ref.Ref{ID: "subnet-123"}, // Duplicate
+							Destination: api.DestinationNetwork{
+								Type: "multus",
+							},
+						},
+					},
+				},
+			}
+
+			result := FindNetworkPair(networkMap, "subnet-123")
+
+			Expect(result).NotTo(BeNil())
+			Expect(result.Destination.Type).To(Equal("pod")) // First match
+		})
+
+		It("should handle all common EBS volume types", func() {
+			storageMap := &api.StorageMap{
+				Spec: api.StorageMapSpec{
+					Map: []api.StoragePair{
+						{Source: ref.Ref{Name: "gp2"}, Destination: api.DestinationStorage{StorageClass: "gp2-sc"}},
+						{Source: ref.Ref{Name: "gp3"}, Destination: api.DestinationStorage{StorageClass: "gp3-sc"}},
+						{Source: ref.Ref{Name: "io1"}, Destination: api.DestinationStorage{StorageClass: "io1-sc"}},
+						{Source: ref.Ref{Name: "io2"}, Destination: api.DestinationStorage{StorageClass: "io2-sc"}},
+						{Source: ref.Ref{Name: "st1"}, Destination: api.DestinationStorage{StorageClass: "st1-sc"}},
+						{Source: ref.Ref{Name: "sc1"}, Destination: api.DestinationStorage{StorageClass: "sc1-sc"}},
+						{Source: ref.Ref{Name: "standard"}, Destination: api.DestinationStorage{StorageClass: "standard-sc"}},
+					},
+				},
+			}
+
+			volumeTypes := []string{"gp2", "gp3", "io1", "io2", "st1", "sc1", "standard"}
+			for _, vt := range volumeTypes {
+				Expect(HasStorageMapping(storageMap, vt)).To(BeTrue(), "Expected mapping for %s", vt)
+				Expect(FindStorageClass(storageMap, vt)).To(Equal(vt + "-sc"))
+			}
+		})
+	})
+})

--- a/pkg/provider/ec2/controller/validator/validator_test.go
+++ b/pkg/provider/ec2/controller/validator/validator_test.go
@@ -1,0 +1,637 @@
+package validator
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	"github.com/kubev2v/forklift/pkg/provider/ec2/inventory/model"
+	"github.com/kubev2v/forklift/pkg/provider/ec2/inventory/web"
+	"github.com/kubev2v/forklift/pkg/provider/testutil"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EC2 controller validator")
+}
+
+// FakeInventory implements the base.Client interface for testing.
+type FakeInventory struct {
+	VMs     map[string]*web.VM
+	Volumes map[string]*web.Volume
+	Error   error
+}
+
+func NewFakeInventory() *FakeInventory {
+	return &FakeInventory{
+		VMs:     make(map[string]*web.VM),
+		Volumes: make(map[string]*web.Volume),
+	}
+}
+
+// Compile-time check
+var _ base.Client = (*FakeInventory)(nil)
+
+// Finder implements base.Client
+func (f *FakeInventory) Finder() base.Finder { return nil }
+
+// Get implements base.Client
+func (f *FakeInventory) Get(resource interface{}, id string) error {
+	return errors.New("not implemented")
+}
+
+// List implements base.Client
+func (f *FakeInventory) List(list interface{}, param ...base.Param) error {
+	return errors.New("not implemented")
+}
+
+// Watch implements base.Client
+func (f *FakeInventory) Watch(resource interface{}, h base.EventHandler) (*base.Watch, error) {
+	return nil, errors.New("not implemented")
+}
+
+// Find implements base.Client
+func (f *FakeInventory) Find(resource interface{}, r ref.Ref) error {
+	if f.Error != nil {
+		return f.Error
+	}
+
+	switch res := resource.(type) {
+	case *web.VM:
+		id := r.ID
+		if id == "" {
+			id = r.Name
+		}
+		if vm, ok := f.VMs[id]; ok {
+			*res = *vm
+			return nil
+		}
+		return errors.New("VM not found")
+	case *web.Volume:
+		id := r.ID
+		if id == "" {
+			id = r.Name
+		}
+		if vol, ok := f.Volumes[id]; ok {
+			*res = *vol
+			return nil
+		}
+		return errors.New("Volume not found")
+	}
+	return errors.New("unknown resource type")
+}
+
+// VM implements base.Client
+func (f *FakeInventory) VM(r *ref.Ref) (interface{}, error) {
+	return nil, errors.New("not implemented")
+}
+
+// Workload implements base.Client
+func (f *FakeInventory) Workload(r *ref.Ref) (interface{}, error) {
+	return nil, errors.New("not implemented")
+}
+
+// Network implements base.Client
+func (f *FakeInventory) Network(r *ref.Ref) (interface{}, error) {
+	return nil, errors.New("not implemented")
+}
+
+// Storage implements base.Client
+func (f *FakeInventory) Storage(r *ref.Ref) (interface{}, error) {
+	return nil, errors.New("not implemented")
+}
+
+// Host implements base.Client
+func (f *FakeInventory) Host(r *ref.Ref) (interface{}, error) {
+	return nil, errors.New("not implemented")
+}
+
+var _ = Describe("EC2 Controller Validator", func() {
+	var (
+		validator  *Validator
+		fakeInv    *FakeInventory
+		networkMap *api.NetworkMap
+		storageMap *api.StorageMap
+	)
+
+	BeforeEach(func() {
+		fakeInv = NewFakeInventory()
+
+		// Create network map
+		networkMap = &api.NetworkMap{
+			Spec: api.NetworkMapSpec{
+				Map: []api.NetworkPair{
+					{
+						Source: ref.Ref{ID: "subnet-123"},
+						Destination: api.DestinationNetwork{
+							Type: "pod",
+						},
+					},
+				},
+			},
+		}
+
+		// Create storage map
+		storageMap = &api.StorageMap{
+			Spec: api.StorageMapSpec{
+				Map: []api.StoragePair{
+					{
+						Source:      ref.Ref{Name: "gp2"},
+						Destination: api.DestinationStorage{StorageClass: "standard"},
+					},
+					{
+						Source:      ref.Ref{Name: "gp3"},
+						Destination: api.DestinationStorage{StorageClass: "premium-rwo"},
+					},
+				},
+			},
+		}
+
+		// Create plan context using testutil
+		ctx := testutil.NewContextBuilder().
+			WithNetworkMap(networkMap).
+			WithStorageMap(storageMap).
+			Build()
+
+		// Set the fake inventory
+		ctx.Source.Inventory = fakeInv
+
+		// Create validator
+		validator = New(ctx)
+	})
+
+	Describe("MigrationType", func() {
+		It("should return true for empty migration type", func() {
+			validator.Context.Plan.Spec.Type = ""
+			Expect(validator.MigrationType()).To(BeTrue())
+		})
+
+		It("should return true for cold migration", func() {
+			validator.Context.Plan.Spec.Type = api.MigrationCold
+			Expect(validator.MigrationType()).To(BeTrue())
+		})
+
+		table.DescribeTable("should return false for unsupported migration types",
+			func(migrationType api.MigrationType) {
+				validator.Context.Plan.Spec.Type = migrationType
+				Expect(validator.MigrationType()).To(BeFalse())
+			},
+			table.Entry("warm migration", api.MigrationWarm),
+		)
+	})
+
+	Describe("validateStorage", func() {
+		It("should pass when VM has EBS volumes", func() {
+			instanceDetails := createInstanceWithEBS("i-123", "vol-111", "vol-222")
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.validateStorage(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should fail when VM has no block devices", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID:                  "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.validateStorage(vmRef)
+
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("no block devices"))
+		})
+
+		It("should fail when VM has only instance store volumes", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{
+						DeviceName:  aws.String("/dev/sdb"),
+						VirtualName: aws.String("ephemeral0"),
+					},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.validateStorage(vmRef)
+
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("only instance store"))
+		})
+
+		It("should pass when VM has mixed EBS and instance store", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{
+						DeviceName: aws.String("/dev/sda1"),
+						Ebs:        &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-111")},
+					},
+					{
+						DeviceName:  aws.String("/dev/sdb"),
+						VirtualName: aws.String("ephemeral0"),
+					},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.validateStorage(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should fail when VM not found in inventory", func() {
+			vmRef := ref.Ref{ID: "i-nonexistent"}
+			ok, err := validator.validateStorage(vmRef)
+
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("NetworksMapped", func() {
+		It("should pass when all network interfaces are mapped", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				NetworkInterfaces: []model.InstanceNetworkInterface{
+					{SubnetId: aws.String("subnet-123")},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.NetworksMapped(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should fail when network interface is not mapped", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				NetworkInterfaces: []model.InstanceNetworkInterface{
+					{SubnetId: aws.String("subnet-unmapped")},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.NetworksMapped(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should pass when VM has no network interfaces", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID:                "i-123",
+				NetworkInterfaces: []model.InstanceNetworkInterface{},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.NetworksMapped(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should skip interfaces with nil SubnetId", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				NetworkInterfaces: []model.InstanceNetworkInterface{
+					{SubnetId: nil},
+					{SubnetId: aws.String("subnet-123")},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.NetworksMapped(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("StorageMapped", func() {
+		It("should pass when all volume types are mapped", func() {
+			instanceDetails := createInstanceWithEBS("i-123", "vol-111")
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			// Add volume to inventory with gp3 type (which is mapped)
+			volumeDetails := &model.VolumeDetails{}
+			volumeDetails.VolumeType = ec2types.VolumeTypeGp3
+			fakeInv.Volumes["vol-111"] = &web.Volume{
+				Resource: web.Resource{ID: "vol-111"},
+				Object:   volumeDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.StorageMapped(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should fail when volume type is not mapped", func() {
+			instanceDetails := createInstanceWithEBS("i-123", "vol-111")
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			// Add volume to inventory with io2 type (which is NOT mapped)
+			volumeDetails := &model.VolumeDetails{}
+			volumeDetails.VolumeType = ec2types.VolumeTypeIo2
+			fakeInv.Volumes["vol-111"] = &web.Volume{
+				Resource: web.Resource{ID: "vol-111"},
+				Object:   volumeDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.StorageMapped(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should pass when VM has no block devices", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID:                  "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.StorageMapped(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should skip instance store volumes", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{
+						DeviceName:  aws.String("/dev/sdb"),
+						VirtualName: aws.String("ephemeral0"),
+					},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.StorageMapped(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("UnSupportedDisks", func() {
+		It("should return instance store devices", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{
+						DeviceName: aws.String("/dev/sda1"),
+						Ebs:        &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-111")},
+					},
+					{
+						DeviceName:  aws.String("/dev/sdb"),
+						VirtualName: aws.String("ephemeral0"),
+					},
+					{
+						DeviceName:  aws.String("/dev/sdc"),
+						VirtualName: aws.String("ephemeral1"),
+					},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			unsupported, err := validator.UnSupportedDisks(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(unsupported).To(HaveLen(2))
+			Expect(unsupported[0]).To(ContainSubstring("/dev/sdb"))
+			Expect(unsupported[0]).To(ContainSubstring("ephemeral0"))
+		})
+
+		It("should return empty list when no instance store", func() {
+			instanceDetails := createInstanceWithEBS("i-123", "vol-111")
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			unsupported, err := validator.UnSupportedDisks(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(unsupported).To(BeEmpty())
+		})
+
+		It("should return nil when VM has no block devices", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID:                  "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			unsupported, err := validator.UnSupportedDisks(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(unsupported).To(BeNil())
+		})
+	})
+
+	Describe("Validate (integration)", func() {
+		It("should pass when all validations pass", func() {
+			// Setup VM with EBS volume and mapped network
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{
+						DeviceName: aws.String("/dev/sda1"),
+						Ebs:        &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-111")},
+					},
+				},
+				NetworkInterfaces: []model.InstanceNetworkInterface{
+					{SubnetId: aws.String("subnet-123")},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			// Add volume with mapped type
+			volumeDetails := &model.VolumeDetails{}
+			volumeDetails.VolumeType = ec2types.VolumeTypeGp3
+			fakeInv.Volumes["vol-111"] = &web.Volume{
+				Resource: web.Resource{ID: "vol-111"},
+				Object:   volumeDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.Validate(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should fail when storage validation fails", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID:                  "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.Validate(vmRef)
+
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should fail when network mapping fails", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{
+						DeviceName: aws.String("/dev/sda1"),
+						Ebs:        &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-111")},
+					},
+				},
+				NetworkInterfaces: []model.InstanceNetworkInterface{
+					{SubnetId: aws.String("subnet-unmapped")},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.Validate(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should fail when storage mapping fails", func() {
+			instanceDetails := &model.InstanceDetails{
+				ID: "i-123",
+				BlockDeviceMappings: []model.InstanceBlockDeviceMapping{
+					{
+						DeviceName: aws.String("/dev/sda1"),
+						Ebs:        &model.EbsInstanceBlockDevice{VolumeId: aws.String("vol-111")},
+					},
+				},
+				NetworkInterfaces: []model.InstanceNetworkInterface{
+					{SubnetId: aws.String("subnet-123")},
+				},
+			}
+			fakeInv.VMs["i-123"] = &web.VM{
+				Resource: web.Resource{ID: "i-123"},
+				Object:   instanceDetails,
+			}
+
+			// Add volume with unmapped type
+			volumeDetails := &model.VolumeDetails{}
+			volumeDetails.VolumeType = ec2types.VolumeTypeIo2
+			fakeInv.Volumes["vol-111"] = &web.Volume{
+				Resource: web.Resource{ID: "vol-111"},
+				Object:   volumeDetails,
+			}
+
+			vmRef := ref.Ref{ID: "i-123"}
+			ok, err := validator.Validate(vmRef)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+})
+
+// Helper function to create instance with EBS volumes
+func createInstanceWithEBS(instanceID string, volumeIDs ...string) *model.InstanceDetails {
+	instance := &model.InstanceDetails{
+		ID:                  instanceID,
+		BlockDeviceMappings: []model.InstanceBlockDeviceMapping{},
+	}
+	instance.InstanceId = aws.String(instanceID)
+
+	for i, volID := range volumeIDs {
+		device := model.InstanceBlockDeviceMapping{
+			DeviceName: aws.String("/dev/sd" + string(rune('a'+i))),
+			Ebs:        &model.EbsInstanceBlockDevice{VolumeId: aws.String(volID)},
+		}
+		instance.BlockDeviceMappings = append(instance.BlockDeviceMappings, device)
+	}
+
+	return instance
+}


### PR DESCRIPTION
**AI Generated unit tests**
Automaitc unit tests created by Claude AI

**AI Generated Summary**
This PR adds comprehensive unit tests for the EC2 provider's controller package, covering the inventory, mapping, and validator subpackages.

Changes
New Test Files:
pkg/provider/ec2/controller/inventory/inventory_test.go - 42 tests 
pkg/provider/ec2/controller/mapping/mapping_test.go - 24 tests 
pkg/provider/ec2/controller/validator/validator_test.go - 23 tests 
Total: 89 tests

Test Coverage

Inventory Helper Functions:
GetAWSInstance - Fetching EC2 instances from inventory GetBlockDevices, GetNetworkInterfaces - Resource extraction IsInstanceStore, IsEBSVolume, ExtractEBSVolumeID - Block device classification GetVolume, GetVolumeType, GetVolumeSize - EBS volume operations ParseBlockDevices - Block device parsing and statistics

Mapping Utilities:
FindStorageClass, HasStorageMapping - Storage class lookup for EBS volume types (gp2, gp3, io1, io2, st1, sc1, standard) FindNetworkPair, HasNetworkMapping - Network mapping lookup for subnet IDs

Validator:
MigrationType - Migration type validation (cold vs warm) validateStorage - EBS volume existence, instance store detection NetworksMapped - Network interface mapping validation StorageMapped - Volume type mapping validation
UnSupportedDisks - Instance store volume identification Validate - Full validation flow integration tests

Ref: https://issues.redhat.com/browse/MTV-4351

Resolves: MTV-4351