### PR TITLE
MTV-4237 | Use per-host igroups to prevent LUN ID reuse conflicts

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var xcopyInitiatorGroup = "xcopy-esxs"
-
 const (
 	taskPollingInterval = 5 * time.Second
 	rescanSleepInterval = 5 * time.Second
@@ -117,6 +115,10 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv 
 		return err
 	}
 	klog.Infof("Got ESXi host: %s", host)
+
+	hostID := strings.ReplaceAll(strings.ToLower(host.String()), ":", "-")
+	xcopyInitiatorGroup := fmt.Sprintf("xcopy-%s", hostID)
+	klog.Infof("Using per-host initiator group: %s", xcopyInitiatorGroup)
 
 	// Only ensure VIB if using VIB method
 	if !p.UseSSHMethod {

--- a/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Populator", func() {
 				storageClient.EXPECT().EnsureClonnerIgroup(gomock.Any(), gomock.Any()).Return(nil, nil)
 				storageClient.EXPECT().ResolvePVToLUN(gomock.Any()).Return(populator.LUN{NAA: "naa.616263"}, nil)
 				storageClient.EXPECT().CurrentMappedGroups(gomock.Any(), gomock.Any()).Return([]string{}, nil)
-				storageClient.EXPECT().Map("xcopy-esxs", gomock.Any(), nil).Return(populator.LUN{NAA: "naa.616263"}, nil)
+				storageClient.EXPECT().Map(gomock.Any(), gomock.Any(), nil).Return(populator.LUN{NAA: "naa.616263"}, nil)
 				// Mock rescan device list call (happens inside hostLocker.WithLock) - returns "on" status
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "list", "-d", "naa.616263"}).Return([]esx.Values{{"Status": {"on"}}}, nil).Times(1)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(),
@@ -163,7 +163,7 @@ var _ = Describe("Populator", func() {
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "list", "-d", "naa.616263"}).Return([]esx.Values{map[string][]string{"Status": {"off"}}}, nil).AnyTimes()
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "device", "detached", "remove", "-d", "naa.616263"}).Return(nil, nil)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "adapter", "rescan", "-t", "delete", "-A", "vmhbatest"}).Return(nil, nil)
-				storageClient.EXPECT().UnMap("xcopy-esxs", gomock.Any(), nil).Return(nil)
+				storageClient.EXPECT().UnMap(gomock.Any(), gomock.Any(), nil).Return(nil)
 				// Mock hostLocker to actually execute the callback function
 				hostLocker.EXPECT().WithLock(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, hostID string, work func(context.Context) error) error {


### PR DESCRIPTION
When multiple ESXi hosts share one igroup, ONTAP reuses LUN IDs too quickly, causing "UID of device has changed" errors and failed migrations. Fix: Generate unique igroup per ESXi host (xcopy-hostsystem-host-12345) instead of shared xcopy-esxs.

resolves: https://issues.redhat.com/browse/MTV-4237