### PR TITLE
MTV-3934 | Handle changes to Provider secrets

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -6003,6 +6003,11 @@ spec:
               phase:
                 description: Current life cycle phase of the provider.
                 type: string
+              secretResourceVersion:
+                description: |-
+                  The ResourceVersion of the secret referenced by this provider.
+                  Used to detect when credentials have been rotated.
+                type: string
               service:
                 description: Provider service reference
                 properties:

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -6027,6 +6027,11 @@ spec:
               phase:
                 description: Current life cycle phase of the provider.
                 type: string
+              secretResourceVersion:
+                description: |-
+                  The ResourceVersion of the secret referenced by this provider.
+                  Used to detect when credentials have been rotated.
+                type: string
               service:
                 description: Provider service reference
                 properties:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -6003,6 +6003,11 @@ spec:
               phase:
                 description: Current life cycle phase of the provider.
                 type: string
+              secretResourceVersion:
+                description: |-
+                  The ResourceVersion of the secret referenced by this provider.
+                  Used to detect when credentials have been rotated.
+                type: string
               service:
                 description: Provider service reference
                 properties:

--- a/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_providers.yaml
@@ -177,6 +177,11 @@ spec:
               phase:
                 description: Current life cycle phase of the provider.
                 type: string
+              secretResourceVersion:
+                description: |-
+                  The ResourceVersion of the secret referenced by this provider.
+                  Used to detect when credentials have been rotated.
+                type: string
               service:
                 description: Provider service reference
                 properties:

--- a/pkg/apis/forklift/v1beta1/provider.go
+++ b/pkg/apis/forklift/v1beta1/provider.go
@@ -119,6 +119,10 @@ type ProviderStatus struct {
 	// Provider service reference
 	// +optional
 	Service *core.ObjectReference `json:"service,omitempty"`
+	// The ResourceVersion of the secret referenced by this provider.
+	// Used to detect when credentials have been rotated.
+	// +optional
+	SecretResourceVersion string `json:"secretResourceVersion,omitempty"`
 }
 
 // +genclient


### PR DESCRIPTION
Previously, when a Provider secret was rotated, the reconciliation request didn't pick up the changed token if the provider was already reconciled. This is because when we get a reconcile request, we skip updating the container if HasReconciled() returns true, but this only checks if the Provider generation is different than the observedGeneration (i.e. whether the provider object itself has changed). If the provider secret has changed, but the provider spec has not, the container will therefore not be updated. This resulted in the Collector's kubernetes client continuing to use the old authentication token that is cached in memory in its rest.Config.

To solve this, we keep track of the observed resource version of the secret and store it in the provider's status when the container is updated. If the resource version in the provider's status doesn't match the secret's current resource version, we update the container even if the provider hasn't changed since the previous reconciliation.
