### PR TITLE
MTV-3646 | RFE: Allow setting transfer network to the forklift controller pod.

### DIFF
--- a/operator/roles/forkliftcontroller/tasks/main.yml
+++ b/operator/roles/forkliftcontroller/tasks/main.yml
@@ -88,15 +88,21 @@
             - 'namespace/name' format (e.g., 'openshift-mtv/br-eno8403')
             - a JSON string representing a list of transfer networks
 
+      - name: "Detect if controller_transfer_network looks like JSON"
+        set_fact:
+          controller_transfer_network_is_json_string: "{{ controller_transfer_network | trim | regex_search('^[\\[\\{]') is not none }}"
+
       - name: "Try parsing controller_transfer_network as JSON"
+        when: controller_transfer_network_is_json_string
         set_fact:
           controller_transfer_network_parsed: "{{ controller_transfer_network | from_json }}"
         failed_when: false
-        register: parse_json_result
+        register: json_parse_result
 
-      - name: "Detect if controller_transfer_network is JSON"
+      - name: "Verify JSON parsing succeeded"
+        when: controller_transfer_network_is_json_string
         set_fact:
-          controller_transfer_network_is_json_string: "{{ not parse_json_result.failed }}"
+          controller_transfer_network_is_json_string: "{{ json_parse_result is not failed }}"
 
       - name: "Use parsed JSON if provided"
         when: controller_transfer_network_is_json_string


### PR DESCRIPTION
Issue:
controller_transfer_network: namespace/name fails because "from_json filter" throws an exception on non-JSON input, and "failed_when: false" can't catch Jinja2 filter errors.

Fix:
Check if the string looks like JSON before attempting to parse

Ref: https://issues.redhat.com/browse/MTV-3646