### PR TITLE
[release-2.10] MTV-2930 | Prevent mixed copy methods in migration plans

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -91,6 +91,8 @@ const (
 	UnsupportedOvaSource            = "UnsupportedOvaSource"
 	VMPowerStateUnsupported         = "VMPowerStateUnsupported"
 	VMMigrationTypeUnsupported      = "VMMigrationTypeUnsupported"
+	GuestToolsIssue                 = "GuestToolsIssue"
+	VDDKAndOffloadMixedUsage        = "VDDKAndOffloadMixedUsage"
 )
 
 // Categories
@@ -756,10 +758,24 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Message:  "LUKS keys and Clevis cannot be configured together; Clevis will be used.",
 		Items:    []string{},
 	}
+	vddkAndOffloadMixedUsage := libcnd.Condition{
+		Type:     VDDKAndOffloadMixedUsage,
+		Status:   True,
+		Reason:   NotSupported,
+		Category: api.CategoryCritical,
+		Message:  "Copy offload is enabled. MTV does not support mixed copy methods. Each migration plan can use one migration strategy, either VDDK or copy offload. Check your storage map and VMs to ensure they are using the same migration strategy.",
+		Items:    []string{},
+	}
 
 	var sharedDisksConditions []libcnd.Condition
 	setOf := map[string]bool{}
 	setOfTargetName := map[string]bool{}
+
+	// Check if plan uses storage offload (vSphere only)
+	source := plan.Referenced.Provider.Source
+	checkMixedUsage := source != nil && source.Type() == api.VSphere && settings.Settings.Features.CopyOffload
+	planUsesOffload := checkMixedUsage && plan.IsUsingOffloadPlugin()
+
 	//
 	// Referenced VMs.
 	for i := range plan.Spec.VMs {
@@ -846,6 +862,23 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 				}
 				if len(pvcs) != len(vm.Disks) {
 					missingPvcForOnlyConversion.Items = append(missingPvcForOnlyConversion.Items, ref.String())
+				}
+			}
+		}
+
+		// Check for mixed VDDK/Offload usage (vSphere only)
+		// If plan uses offload, add VMs with VDDK disks to the condition
+		if planUsesOffload {
+			if vsphereVM, ok := v.(*vsphere.VM); ok {
+				storageMap := plan.Referenced.Map.Storage
+				if storageMap != nil {
+					curVMHasVddk, err := r.vmUsesVddk(storageMap, vsphereVM, vm.Name)
+					if err != nil {
+						return err
+					}
+					if curVMHasVddk {
+						vddkAndOffloadMixedUsage.Items = append(vddkAndOffloadMixedUsage.Items, ref.String())
+					}
 				}
 			}
 		}
@@ -1169,6 +1202,12 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 	if len(luksAndClevisIncompatibility.Items) > 0 {
 		plan.Status.SetCondition(luksAndClevisIncompatibility)
 	}
+
+	// Set the condition if any VMs with VDDK disks were found when plan uses offload
+	if len(vddkAndOffloadMixedUsage.Items) > 0 {
+		plan.Status.SetCondition(vddkAndOffloadMixedUsage)
+	}
+
 	return nil
 }
 
@@ -1826,4 +1865,19 @@ func (r *Reconciler) IsValidTargetName(targetName string) error {
 	}
 
 	return nil
+}
+
+// vmUsesVddk checks if the VM requires VDDK for migration (i.e., if any disk doesn't use storage offload)
+func (r *Reconciler) vmUsesVddk(storageMap *api.StorageMap, vsphereVM *vsphere.VM, vmName string) (bool, error) {
+	for _, disk := range vsphereVM.Disks {
+		mapping, found := storageMap.FindStorage(disk.Datastore.ID)
+		if !found {
+			continue // Another validation will handle this
+		}
+		if mapping.OffloadPlugin == nil || mapping.OffloadPlugin.VSphereXcopyPluginConfig == nil {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -5,7 +5,10 @@ import (
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	"github.com/kubev2v/forklift/pkg/controller/base"
+	vspheremodel "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
 	"github.com/kubev2v/forklift/pkg/lib/condition"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -109,6 +112,162 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 		})
 	})
 })
+
+var _ = ginkgo.Describe("vmUsesVddk", func() {
+	var (
+		reconciler *Reconciler
+	)
+
+	ginkgo.BeforeEach(func() {
+		reconciler = createFakeReconciler()
+	})
+
+	// Helper to create a vsphere.VM with disks
+	createVSphereVM := func(name string, diskDatastores []string) *vsphere.VM {
+		disks := []vspheremodel.Disk{}
+		for i, dsID := range diskDatastores {
+			disks = append(disks, vspheremodel.Disk{
+				Key: int32(i + 2000),
+				Datastore: vspheremodel.Ref{
+					ID: dsID,
+				},
+			})
+		}
+		return &vsphere.VM{
+			VM1: vsphere.VM1{
+				VM0: vsphere.VM0{
+					ID:   name + "-id",
+					Path: name,
+				},
+				Disks: disks,
+			},
+		}
+	}
+
+	// Helper to create a StorageMap
+	createStorageMap := func(datastorePairs []struct {
+		datastoreID string
+		hasOffload  bool
+	}) *api.StorageMap {
+		pairs := []api.StoragePair{}
+		for _, pair := range datastorePairs {
+			sp := api.StoragePair{
+				Source: ref.Ref{
+					ID: pair.datastoreID,
+				},
+				Destination: api.DestinationStorage{
+					StorageClass: "test-storage-class",
+				},
+			}
+			if pair.hasOffload {
+				sp.OffloadPlugin = &api.OffloadPlugin{
+					VSphereXcopyPluginConfig: &api.VSphereXcopyPluginConfig{
+						StorageVendorProduct: api.StorageVendorProduct("test-vendor"),
+					},
+				}
+			}
+			pairs = append(pairs, sp)
+		}
+		return &api.StorageMap{
+			Spec: api.StorageMapSpec{
+				Map: pairs,
+			},
+		}
+	}
+
+	// Tests for VDDK usage detection
+	ginkgo.DescribeTable("should correctly identify if VM uses VDDK",
+		func(vmName string, diskDatastores []string, storageMapPairs []struct {
+			datastoreID string
+			hasOffload  bool
+		}, expectedUsesVddk bool) {
+			storageMap := createStorageMap(storageMapPairs)
+			vsphereVM := createVSphereVM(vmName, diskDatastores)
+
+			usesVddk, err := reconciler.vmUsesVddk(storageMap, vsphereVM, vmName)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(usesVddk).To(gomega.Equal(expectedUsesVddk))
+		},
+		ginkgo.Entry("one pure VDDK disk",
+			"vm1",
+			[]string{"ds1"},
+			[]struct {
+				datastoreID string
+				hasOffload  bool
+			}{
+				{datastoreID: "ds1", hasOffload: false},
+			},
+			true, // uses VDDK
+		),
+		ginkgo.Entry("one pure offload disk",
+			"vm1",
+			[]string{"ds1"},
+			[]struct {
+				datastoreID string
+				hasOffload  bool
+			}{
+				{datastoreID: "ds1", hasOffload: true},
+			},
+			false, // doesn't use VDDK (uses offload)
+		),
+		ginkgo.Entry("multiple pure VDDK disks",
+			"vm1",
+			[]string{"ds1", "ds2"},
+			[]struct {
+				datastoreID string
+				hasOffload  bool
+			}{
+				{datastoreID: "ds1", hasOffload: false},
+				{datastoreID: "ds2", hasOffload: false},
+			},
+			true, // uses VDDK
+		),
+		ginkgo.Entry("multiple pure offload disks",
+			"vm1",
+			[]string{"ds1", "ds2"},
+			[]struct {
+				datastoreID string
+				hasOffload  bool
+			}{
+				{datastoreID: "ds1", hasOffload: true},
+				{datastoreID: "ds2", hasOffload: true},
+			},
+			false, // doesn't use VDDK (uses offload)
+		),
+		ginkgo.Entry("mixed VM with both VDDK and offload disks",
+			"vm1",
+			[]string{"ds1", "ds2"},
+			[]struct {
+				datastoreID string
+				hasOffload  bool
+			}{
+				{datastoreID: "ds1", hasOffload: false}, // VDDK
+				{datastoreID: "ds2", hasOffload: true},  // Offload
+			},
+			true, // uses VDDK (because at least one disk uses VDDK)
+		),
+	)
+})
+
+// Mock validator for testing GuestToolsIssue aggregation
+type guestToolsResponse struct {
+	ok  bool
+	msg string
+	err error
+}
+
+type mockGuestToolsValidator struct {
+	responses map[string]guestToolsResponse
+}
+
+func (m *mockGuestToolsValidator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
+	if response, exists := m.responses[vmRef.Name]; exists {
+		return response.ok, response.err
+	}
+	// Default: tools are OK
+	return true, nil
+}
 
 //nolint:errcheck
 func createFakeReconciler(objects ...runtime.Object) *Reconciler {


### PR DESCRIPTION
**Backport:** https://github.com/kubev2v/forklift/pull/4475

## Description
Add validation before plan execution to ensure all disks use a consistent copy method (either VDDK or XCOPY/Offload).

## Logic
- **Multi-VM Plans:** If one VM cannot use offload while others can, the plan must be split (all VMs in a plan must share the copy method).
- **Multi-Disk VMs:** If a VM has multiple disks and one does not support offload, the system requires VDDK for all disks attached to that VM.

Resolves: MTV-2930