### PR TITLE
Add volume tagging support for Pure Storage FlashArray migrations

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/storage.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/storage.go
@@ -14,6 +14,11 @@ type StorageApi interface {
 	VMDKCapable
 }
 
+// VolumeTaggingSupport is an optional interface for storage vendors that support volume tagging
+type VolumeTaggingSupport interface {
+	TagVolume(volumeName string, volumeHandle string, migrationType string, copyMethod string, migrationUID string, vmID string) error
+}
+
 // StorageResolver resolves a PersistentVolume to LUN details
 // This interface is embedded by VVolCapable, RDMCapable, and VMDKCapable
 type StorageResolver interface {


### PR DESCRIPTION
Added Pure Storage FlashArray volume tagging support to the vsphere-xcopy-volume-populator. 
It will tag migrated volumes with metadata to help track and manage volumes in Pure Storage environments. Migrated volumes now get tagged with metadata like:

```
pureuser@mm630c-4> purevol list --tags --namespace=openshift-forklift
Name  Key             Value                                       Namespace   Copyable
xxxx  copyMethod      xcopy                                 openshift-forklift  False
xxxx  migrationType   cold                                  openshift-forklift  False
xxxx  migrationUID    0b3f525a-656b-4c6c-8590-89ad19e2feb8  openshift-forklift  False
xxxx  sourceProvider  vsphere                               openshift-forklift  False
xxxx  sourceVmId      vm-3324                               openshift-forklift  False
xxxx  targetProvider  kubevirt                              openshift-forklift  False
```

source/target providers: Track where VMs are migrating from/to
migrationType: Distinguish between warm and cold migrations
copyMethod: Track whether xcopy or volume copy was used
migrationUID + sourceVmId: Together, these help group all volumes from the same VM