### PR TITLE
MTV-4320 | make feature_copy_offload default true

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/README.md
+++ b/cmd/vsphere-xcopy-volume-populator/README.md
@@ -27,7 +27,7 @@
   - [NetApp](#netapp)
 
 ## Forklift Controller
-When the feature flag `feature_copy_offload` is true (off by default), the controller
+When the feature flag `feature_copy_offload` is true (on by default), the controller
 consult the storagemaps offload plugin configuration, to decided if VM disk from
 VMWare could be copied by the storage backend(offloaded) into the newly created PVC.
 When the controller creates the PVC for the v2v pod it will also create
@@ -89,9 +89,18 @@ Alternative, that wrapper can be invoked using SSH. See [SSH Method](#ssh-method
 
 ## Setup Copy Offload
 
-1. Set the feature flag:
+1. Verify the feature flag is enabled (it is enabled by default):
    ```bash
+   oc get forkliftcontrollers.forklift.konveyor.io forklift-controller -n openshift-mtv -o jsonpath='{.spec.feature_copy_offload}'
+   ```
+
+   If you need to explicitly enable or disable it:
+   ```bash
+   # To enable (if not already enabled)
    oc patch forkliftcontrollers.forklift.konveyor.io forklift-controller --type merge -p '{"spec": {"feature_copy_offload": "true"}}' -n openshift-mtv
+
+   # To disable (if you want to opt-out)
+   oc patch forkliftcontrollers.forklift.konveyor.io forklift-controller --type merge -p '{"spec": {"feature_copy_offload": "false"}}' -n openshift-mtv
    ```
 
 2. Create a `StorageMap` according to [this section](#matching-pvc)

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -188,7 +188,7 @@ spec:
                 - "false"
                 type: string
               feature_copy_offload:
-                description: 'Enable copy offload plugins (default: false)'
+                description: 'Enable copy offload plugins (default: true)'
                 enum:
                 - "true"
                 - "false"
@@ -7574,7 +7574,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable copy offload plugins (default false)
+      - description: Enable copy offload plugins (default true)
         displayName: Enable Copy Offload Plugins
         path: feature_copy_offload
         x-descriptors:

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -188,7 +188,7 @@ spec:
                 - "false"
                 type: string
               feature_copy_offload:
-                description: 'Enable copy offload plugins (default: false)'
+                description: 'Enable copy offload plugins (default: true)'
                 enum:
                 - "true"
                 - "false"
@@ -7600,7 +7600,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable copy offload plugins (default false)
+      - description: Enable copy offload plugins (default true)
         displayName: Enable Copy Offload Plugins
         path: feature_copy_offload
         x-descriptors:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -188,7 +188,7 @@ spec:
                 - "false"
                 type: string
               feature_copy_offload:
-                description: 'Enable copy offload plugins (default: false)'
+                description: 'Enable copy offload plugins (default: true)'
                 enum:
                 - "true"
                 - "false"
@@ -7574,7 +7574,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable copy offload plugins (default false)
+      - description: Enable copy offload plugins (default true)
         displayName: Enable Copy Offload Plugins
         path: feature_copy_offload
         x-descriptors:

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -58,7 +58,7 @@ spec:
               feature_copy_offload:
                 type: string
                 enum: ["true", "false"]
-                description: "Enable copy offload plugins (default: false)"
+                description: "Enable copy offload plugins (default: true)"
               feature_ocp_live_migration:
                 type: string
                 enum: ["true", "false"]

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -69,7 +69,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable copy offload plugins (default false)
+      - description: Enable copy offload plugins (default true)
         displayName: Enable Copy Offload Plugins
         path: feature_copy_offload
         x-descriptors:

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -6,7 +6,7 @@ app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
 feature_ui_plugin: true
 feature_validation: true
 feature_volume_populator: true
-feature_copy_offload: false
+feature_copy_offload: true
 feature_ocp_live_migration: false
 feature_vmware_system_serial_number: true
 feature_cli_download: true

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -135,7 +135,7 @@ spec:
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:radio:true
           - urn:alm:descriptor:com.tectonic.ui:radio:false
-        - description: Enable copy offload plugins (default false)
+        - description: Enable copy offload plugins (default true)
           displayName: Enable Copy Offload Plugins
           path: feature_copy_offload
           x-descriptors:

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -139,7 +139,7 @@ spec:
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:radio:true
           - urn:alm:descriptor:com.tectonic.ui:radio:false
-        - description: Enable copy offload plugins (default false)
+        - description: Enable copy offload plugins (default true)
           displayName: Enable Copy Offload Plugins
           path: feature_copy_offload
           x-descriptors:


### PR DESCRIPTION
Resolves: MTV-4320

Now that offload graduates from tech-preview it is going to be enabled
by default.

Signed-off-by: Roy Golan <rgolan@redhat.com>
