### PR TITLE
chore(EC2): EC2 provider plan status not updating to Failed on migration error

### DIFF
--- a/pkg/provider/ec2/controller/migrator/executor.go
+++ b/pkg/provider/ec2/controller/migrator/executor.go
@@ -138,6 +138,8 @@ func (r *Migrator) ExecutePhase(vm *planapi.VMStatus) (ok bool, err error) {
 		r.NextPhase(vm)
 	case api.PhaseCompleted:
 		ok = true
+		vm.MarkCompleted()
+		r.log.Info("EC2 migration completed", "vm", vm.Name)
 	default:
 		err = liberr.New(fmt.Sprintf("Unknown phase: %s", vm.Phase))
 	}


### PR DESCRIPTION
Issue:
When a VM migration failed (e.g., during virt-v2v conversion), the plan status remained as "Executing" instead of being updated to "Failed".

Root cause:
The EC2 migrator's ExecutePhase function handled PhaseCompleted by returning ok=true, but did not call vm.MarkCompleted(). This prevented the end() function from detecting that all VMs had completed, so the plan "Failed" condition was never set.

The fix adds vm.MarkCompleted() to the EC2 migrator's PhaseCompleted case, matching the pattern used by the LiveMigrator (OCP).
