### PR TITLE
MTV-3130 | [GA] Preserve static IP addresses in UDN networks

### DIFF
--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -43,7 +43,7 @@ controller_snapshot_removal_check_retries: 20
 controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_retain_precopy_importer_pods: false
-controller_static_udn_ip_addresses: false
+controller_static_udn_ip_addresses: true
 controller_max_vm_inflight: 20
 controller_host_lease_namespace: "openshift-mtv"
 controller_host_lease_duration_seconds: 10

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -27,6 +27,10 @@ const ocpMinForVmwareSystemSerial = "4.20.0-0"
 //   - https://issues.redhat.com/browse/CNV-66820
 const ocpMinForUdnMacSupport = "4.20.0-0"
 
+// OpenShift version where Forklift can specify static IP addresses in User Defined Network:
+//   - https://issues.redhat.com/browse/CNV-61227
+const ocpMinForUdnPreserveStaticIp = "4.20.0-0"
+
 // OpenShift version where InsecureSkipVerify is supported for ImageIO data sources:
 //   - https://issues.redhat.com/browse/CNV-71978
 //   - https://github.com/kubevirt/containerized-data-importer/pull/3944
@@ -83,7 +87,7 @@ func (r *Features) isOpenShiftVersionAboveMinimum(minimumVersion string) bool {
 func (r *Features) Load() (err error) {
 	r.OvirtWarmMigration = getEnvBool(FeatureOvirtWarmMigration, false)
 	r.RetainPrecopyImporterPods = getEnvBool(FeatureRetainPrecopyImporterPods, false)
-	r.StaticUdnIpAddresses = getEnvBool(FeatureStaticUdnIpAddresses, false)
+	r.StaticUdnIpAddresses = getEnvBool(FeatureStaticUdnIpAddresses, false) && r.isOpenShiftVersionAboveMinimum(ocpMinForUdnPreserveStaticIp)
 	r.VsphereIncrementalBackup = getEnvBool(FeatureVsphereIncrementalBackup, false)
 	r.CopyOffload = getEnvBool(FeatureCopyOffload, false)
 	r.OCPLiveMigration = getEnvBool(FeatureOCPLiveMigration, false)


### PR DESCRIPTION
Resolves: MTV-3130

Fix: Make the feature of preserving IP addresses in UDN networks GA in OpenShift 4.20+