### PR TITLE
MTV-4454 | Separate extra args for virt-v2v conversion and inspection

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -200,7 +200,8 @@ spec:
                 - "false"
                 type: string
               feature_ova_appliance_management:
-                description: 'Enable OVF-based appliance management endpoints (OVA, HyperV) (default: false)'
+                description: 'Enable OVF-based appliance management endpoints (OVA,
+                  HyperV)  (default: false)'
                 enum:
                 - "true"
                 - "false"
@@ -244,6 +245,26 @@ spec:
               hooks_container_requests_memory:
                 description: 'Hooks memory request (default: 150Mi)'
                 example: 300Mi
+                type: string
+              hyperv_container_limits_cpu:
+                description: 'HyperV CPU limit (default: 1000m)'
+                example: 2000m
+                type: string
+              hyperv_container_limits_memory:
+                description: 'HyperV memory limit (default: 1Gi)'
+                example: 2Gi
+                type: string
+              hyperv_container_requests_cpu:
+                description: 'HyperV CPU request (default: 100m)'
+                example: 200m
+                type: string
+              hyperv_container_requests_memory:
+                description: 'HyperV memory request (default: 512Mi)'
+                example: 300Mi
+                type: string
+              hyperv_provider_server_fqin:
+                description: HyperV provider server image
+                example: quay.io/kubev2v/forklift-hyperv-provider-server:latest
                 type: string
               image_pull_policy:
                 description: 'Image pull policy (default: Always)'
@@ -450,8 +471,8 @@ spec:
                 - "false"
                 type: string
               virt_v2v_extra_args:
-                description: Additional arguments for virt-v2v
-                example: --debug-overlays
+                description: Additional arguments for virt-v2v conversion
+                example: --parallel 4
                 type: string
               virt_v2v_extra_conf_config_map:
                 description: ConfigMap name containing extra virt-v2v configuration
@@ -459,6 +480,10 @@ spec:
               virt_v2v_image_fqin:
                 description: Virt-v2v conversion image used by migration pods
                 example: quay.io/kubev2v/forklift-virt-v2v:latest
+                type: string
+              virt_v2v_inspector_extra_args:
+                description: Additional arguments for virt-v2v-inspector
+                example: --root first
                 type: string
               vsphere_osmap_configmap_name:
                 description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
@@ -940,6 +965,9 @@ spec:
                       type: string
                     status:
                       description: The condition status [true,false].
+                      type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
                       type: string
                     type:
                       description: The condition type.
@@ -6703,6 +6731,7 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  - csidrivers
   verbs:
   - get
   - list
@@ -7604,7 +7633,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable OVF-based appliance management endpoints (OVA, HyperV) (default false)
+      - description: Enable OVA appliance management endpoints (default false)
         displayName: Enable OVA Appliance Management
         path: feature_ova_appliance_management
         x-descriptors:
@@ -7935,9 +7964,14 @@ spec:
         path: virt_v2v_dont_request_kvm
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Additional arguments for virt-v2v
+      - description: Additional arguments for virt-v2v conversion
         displayName: Virt-v2v Extra Args
         path: virt_v2v_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v-inspector
+        displayName: Virt-v2v Inspector Extra Args
+        path: virt_v2v_inspector_extra_args
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: ConfigMap name containing extra virt-v2v configuration

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -471,8 +471,8 @@ spec:
                 - "false"
                 type: string
               virt_v2v_extra_args:
-                description: Additional arguments for virt-v2v
-                example: --debug-overlays
+                description: Additional arguments for virt-v2v conversion
+                example: --parallel 4
                 type: string
               virt_v2v_extra_conf_config_map:
                 description: ConfigMap name containing extra virt-v2v configuration
@@ -480,6 +480,10 @@ spec:
               virt_v2v_image_fqin:
                 description: Virt-v2v conversion image used by migration pods
                 example: quay.io/kubev2v/forklift-virt-v2v:latest
+                type: string
+              virt_v2v_inspector_extra_args:
+                description: Additional arguments for virt-v2v-inspector
+                example: --root first
                 type: string
               vsphere_osmap_configmap_name:
                 description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
@@ -7961,9 +7965,14 @@ spec:
         path: virt_v2v_dont_request_kvm
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Additional arguments for virt-v2v
+      - description: Additional arguments for virt-v2v conversion
         displayName: Virt-v2v Extra Args
         path: virt_v2v_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v-inspector
+        displayName: Virt-v2v Inspector Extra Args
+        path: virt_v2v_inspector_extra_args
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: ConfigMap name containing extra virt-v2v configuration

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -200,7 +200,8 @@ spec:
                 - "false"
                 type: string
               feature_ova_appliance_management:
-                description: 'Enable OVF-based appliance management endpoints (OVA, HyperV) (default: false)'
+                description: 'Enable OVF-based appliance management endpoints (OVA,
+                  HyperV)  (default: false)'
                 enum:
                 - "true"
                 - "false"
@@ -244,6 +245,26 @@ spec:
               hooks_container_requests_memory:
                 description: 'Hooks memory request (default: 150Mi)'
                 example: 300Mi
+                type: string
+              hyperv_container_limits_cpu:
+                description: 'HyperV CPU limit (default: 1000m)'
+                example: 2000m
+                type: string
+              hyperv_container_limits_memory:
+                description: 'HyperV memory limit (default: 1Gi)'
+                example: 2Gi
+                type: string
+              hyperv_container_requests_cpu:
+                description: 'HyperV CPU request (default: 100m)'
+                example: 200m
+                type: string
+              hyperv_container_requests_memory:
+                description: 'HyperV memory request (default: 512Mi)'
+                example: 300Mi
+                type: string
+              hyperv_provider_server_fqin:
+                description: HyperV provider server image
+                example: quay.io/kubev2v/forklift-hyperv-provider-server:latest
                 type: string
               image_pull_policy:
                 description: 'Image pull policy (default: Always)'
@@ -450,8 +471,8 @@ spec:
                 - "false"
                 type: string
               virt_v2v_extra_args:
-                description: Additional arguments for virt-v2v
-                example: --debug-overlays
+                description: Additional arguments for virt-v2v conversion
+                example: --parallel 4
                 type: string
               virt_v2v_extra_conf_config_map:
                 description: ConfigMap name containing extra virt-v2v configuration
@@ -459,6 +480,10 @@ spec:
               virt_v2v_image_fqin:
                 description: Virt-v2v conversion image used by migration pods
                 example: quay.io/kubev2v/forklift-virt-v2v:latest
+                type: string
+              virt_v2v_inspector_extra_args:
+                description: Additional arguments for virt-v2v-inspector
+                example: --root first
                 type: string
               vsphere_osmap_configmap_name:
                 description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
@@ -940,6 +965,9 @@ spec:
                       type: string
                     status:
                       description: The condition status [true,false].
+                      type: string
+                    suggestion:
+                      description: A suggested action or resolution for the condition.
                       type: string
                     type:
                       description: The condition type.
@@ -6703,6 +6731,7 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  - csidrivers
   verbs:
   - get
   - list
@@ -7604,7 +7633,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable OVF-based appliance management endpoints (OVA, HyperV) (default false)
+      - description: Enable OVA appliance management endpoints (default false)
         displayName: Enable OVA Appliance Management
         path: feature_ova_appliance_management
         x-descriptors:
@@ -7935,9 +7964,14 @@ spec:
         path: virt_v2v_dont_request_kvm
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Additional arguments for virt-v2v
+      - description: Additional arguments for virt-v2v conversion
         displayName: Virt-v2v Extra Args
         path: virt_v2v_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v-inspector
+        displayName: Virt-v2v Inspector Extra Args
+        path: virt_v2v_inspector_extra_args
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: ConfigMap name containing extra virt-v2v configuration

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -371,8 +371,12 @@ spec:
                 description: "Don't request KVM for virt-v2v"
               virt_v2v_extra_args:
                 type: string
-                description: "Additional arguments for virt-v2v"
-                example: "--debug-overlays"
+                description: "Additional arguments for virt-v2v conversion"
+                example: "--parallel 4"
+              virt_v2v_inspector_extra_args:
+                type: string
+                description: "Additional arguments for virt-v2v-inspector"
+                example: "--root first"
               virt_v2v_extra_conf_config_map:
                 type: string
                 description: "ConfigMap name containing extra virt-v2v configuration"

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -442,9 +442,14 @@ spec:
         path: virt_v2v_dont_request_kvm
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Additional arguments for virt-v2v
+      - description: Additional arguments for virt-v2v conversion
         displayName: Virt-v2v Extra Args
         path: virt_v2v_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v-inspector
+        displayName: Virt-v2v Inspector Extra Args
+        path: virt_v2v_inspector_extra_args
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: ConfigMap name containing extra virt-v2v configuration

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -138,6 +138,7 @@ must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') or lookup( 'env'
 virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V') }}"
 virt_v2v_dont_request_kvm: "{{ lookup( 'env', 'VIRT_V2V_DONT_REQUEST_KVM') }}"
 virt_v2v_extra_args: "{{ lookup( 'env', 'VIRT_V2V_EXTRA_ARGS') }}"
+virt_v2v_inspector_extra_args: "{{ lookup( 'env', 'VIRT_V2V_INSPECTOR_EXTRA_ARGS') }}"
 virt_v2v_extra_conf_config_map: "{{ lookup( 'env', 'VIRT_V2V_EXTRA_CONF_CONFIG_MAP') }}"
 virt_v2v_container_limits_cpu: "4000m"
 virt_v2v_container_limits_memory: "8Gi"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -179,6 +179,8 @@ spec:
 {% endif %}
         - name: VIRT_V2V_EXTRA_ARGS
           value: "{{ virt_v2v_extra_args }}"
+        - name: VIRT_V2V_INSPECTOR_EXTRA_ARGS
+          value: "{{ virt_v2v_inspector_extra_args }}"
         - name: VIRT_V2V_EXTRA_CONF_CONFIG_MAP
           value: "{{ virt_v2v_extra_conf_config_map }}"
         - name: VIRT_V2V_CONTAINER_LIMITS_CPU

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -508,9 +508,14 @@ spec:
           path: virt_v2v_dont_request_kvm
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Additional arguments for virt-v2v
+        - description: Additional arguments for virt-v2v conversion
           displayName: Virt-v2v Extra Args
           path: virt_v2v_extra_args
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Additional arguments for virt-v2v-inspector
+          displayName: Virt-v2v Inspector Extra Args
+          path: virt_v2v_inspector_extra_args
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: ConfigMap name containing extra virt-v2v configuration

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -512,9 +512,14 @@ spec:
           path: virt_v2v_dont_request_kvm
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Additional arguments for virt-v2v
+        - description: Additional arguments for virt-v2v conversion
           displayName: Virt-v2v Extra Args
           path: virt_v2v_extra_args
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Additional arguments for virt-v2v-inspector
+          displayName: Virt-v2v Inspector Extra Args
+          path: virt_v2v_inspector_extra_args
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: ConfigMap name containing extra virt-v2v configuration

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -299,6 +299,10 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 			Name:  "V2V_extra_args",
 			Value: settings.Settings.Migration.VirtV2vExtraArgs,
 		},
+		core.EnvVar{
+			Name:  "V2V_inspector_extra_args",
+			Value: settings.Settings.Migration.VirtV2vInspectorExtraArgs,
+		},
 	)
 	if macsToIps != "" {
 		env = append(env, core.EnvVar{

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -31,6 +31,7 @@ const (
 	VirtCustomizeConfigMap           = "VIRT_CUSTOMIZE_MAP"
 	VddkJobActiveDeadline            = "VDDK_JOB_ACTIVE_DEADLINE"
 	VirtV2vExtraArgs                 = "VIRT_V2V_EXTRA_ARGS"
+	VirtV2vInspectorExtraArgs        = "VIRT_V2V_INSPECTOR_EXTRA_ARGS"
 	VirtV2vExtraConfConfigMap        = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
 	VirtV2vContainerLimitsCpu        = "VIRT_V2V_CONTAINER_LIMITS_CPU"
 	VirtV2vContainerLimitsMemory     = "VIRT_V2V_CONTAINER_LIMITS_MEMORY"
@@ -105,6 +106,8 @@ type Migration struct {
 	VddkJobActiveDeadline int
 	// Additional arguments for virt-v2v
 	VirtV2vExtraArgs string
+	// Additional arguments for virt-v2v-inspector
+	VirtV2vInspectorExtraArgs string
 	// Additional configuration for virt-v2v
 	VirtV2vExtraConfConfigMap        string
 	VirtV2vContainerLimitsCpu        string
@@ -216,6 +219,14 @@ func (r *Migration) Load() (err error) {
 			r.VirtV2vExtraArgs = string(encoded)
 		} else {
 			return liberr.Wrap(err)
+		}
+	}
+	r.VirtV2vInspectorExtraArgs = "[]"
+	if val, found := os.LookupEnv(VirtV2vInspectorExtraArgs); found && len(val) > 0 {
+		if encoded, jsonErr := json.Marshal(strings.Fields(val)); jsonErr == nil {
+			r.VirtV2vInspectorExtraArgs = string(encoded)
+		} else {
+			return liberr.Wrap(jsonErr)
 		}
 	}
 	if val, found := os.LookupEnv(VirtV2vExtraConfConfigMap); found {

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -17,6 +17,7 @@ const (
 	EnvFingerprintName            = "V2V_fingerprint"
 	EnvInPlaceName                = "V2V_inPlace"
 	EnvExtraArgsName              = "V2V_extra_args"
+	EnvInspectorExtraArgsName     = "V2V_inspector_extra_args"
 	EnvNewNameName                = "V2V_NewName"
 	EnvVmNameName                 = "V2V_vmName"
 	EnvRootDiskName               = "V2V_RootDisk"
@@ -69,6 +70,8 @@ type AppConfig struct {
 	IsInPlace bool
 	// V2V_extra_args
 	ExtraArgs []string
+	// V2V_inspector_extra_args
+	InspectorExtraArgs []string
 	// LOCAL_MIGRATION
 	IsLocalMigration bool
 	// V2V_NewName
@@ -112,6 +115,7 @@ type AppConfig struct {
 
 func (s *AppConfig) Load() (err error) {
 	s.ExtraArgs = s.getExtraArgs()
+	s.InspectorExtraArgs = s.getInspectorExtraArgs()
 	flag.BoolVar(&s.IsLocalMigration, "local-migration", s.getEnvBool(EnvLocalMigrationName, true), "Migration is in local or remote cluster")
 	flag.BoolVar(&s.IsInPlace, "in-place", s.getEnvBool(EnvInPlaceName, false), "Run virt-v2v-in-place on already populated disks")
 	flag.BoolVar(&s.NbdeClevis, "nbde-clevis", s.getEnvBool(EnvNbdeClevis, false), "virt-v2v should unencrypt the disks via clevis client")
@@ -150,6 +154,17 @@ func (s *AppConfig) getExtraArgs() []string {
 	var extraArgs []string
 	if envExtraArgs, found := os.LookupEnv(EnvExtraArgsName); found && envExtraArgs != "" {
 		if err := json.Unmarshal([]byte(envExtraArgs), &extraArgs); err != nil {
+			return nil
+		}
+	}
+	return extraArgs
+}
+
+func (s *AppConfig) getInspectorExtraArgs() []string {
+	var extraArgs []string
+	if envExtraArgs, found := os.LookupEnv(EnvInspectorExtraArgsName); found && envExtraArgs != "" {
+		if err := json.Unmarshal([]byte(envExtraArgs), &extraArgs); err != nil {
+			fmt.Printf("Failed to parse %s: %v\n", EnvInspectorExtraArgsName, err)
 			return nil
 		}
 	}


### PR DESCRIPTION
Previously, VIRT_V2V_EXTRA_ARGS was applied to all virt-v2v commands including virt-v2v-inspector. This caused migrations to fail when using conversion-specific args like --parallel that are not recognized by virt-v2v-inspector.

This change introduces a new VIRT_V2V_INSPECTOR_EXTRA_ARGS setting and separates the argument handling:

- VIRT_V2V_EXTRA_ARGS now applies only to virt-v2v and virt-v2v-in-place
- VIRT_V2V_INSPECTOR_EXTRA_ARGS applies only to virt-v2v-inspector
- Shared args (--root, --mac, --key) remain in addCommonArgs() for all

Breaking change: Users who relied on extra args being passed to both conversion and inspection will need to set both env vars.

----------
  - adding new forlklift controller setting:
```
virt_v2v_inspector_extra_args:
                description: Additional arguments for virt-v2v-inspector
                example: --root first
                type: string
```

  - virt_v2v_extra_args works as expected ONLY for the virt-v2v executable
  
----------

How to test:
a. set updated controller and virt-v2v images
b. update plan CRD
c. set virt_v2v_extra_args that only works with  virt-v2v for example --parallel

the migration should pass

-----------


Ref: https://issues.redhat.com/browse/MTV-4454

Resolves: MTV-4454