### PR TITLE
chore(test): Add new unit tests for the virt-v2v wrapper

### DIFF
--- a/pkg/virt-v2v/conversion/conversion_test.go
+++ b/pkg/virt-v2v/conversion/conversion_test.go
@@ -1,6 +1,8 @@
+// Generated-by: Claude
 package conversion
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -38,23 +40,461 @@ var _ = Describe("Conversion", func() {
 		}
 	})
 
-	It("passes virt-v2v-inspection",
-		func() {
-			appConfig.InspectionOutputFile = config.InspectionOutputFile
+	Describe("RunVirtV2VInspection", func() {
+		It("passes virt-v2v-inspection with multiple disks",
+			func() {
+				appConfig.InspectionOutputFile = config.InspectionOutputFile
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/new-vm-name-sda"},
+					{Link: "/var/tmp/v2v/new-vm-name-sdb"},
+				}
+
+				mockCommandBuilder.EXPECT().New("virt-v2v-inspector").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-if", "raw").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/new-vm-name-sda").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/new-vm-name-sdb").Return(mockCommandBuilder)
+
+				mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+
+				mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+				mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+				mockCommandExecutor.EXPECT().Run()
+
+				err := conversion.RunVirtV2VInspection()
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("passes virt-v2v-inspection with inspector extra args",
+			func() {
+				appConfig.InspectionOutputFile = config.InspectionOutputFile
+				appConfig.InspectorExtraArgs = []string{"--extra-arg1", "--extra-arg2"}
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/new-vm-name-sda"},
+				}
+
+				mockCommandBuilder.EXPECT().New("virt-v2v-inspector").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-if", "raw").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddExtraArgs("--extra-arg1", "--extra-arg2").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/new-vm-name-sda").Return(mockCommandBuilder)
+
+				mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+
+				mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+				mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+				mockCommandExecutor.EXPECT().Run()
+
+				err := conversion.RunVirtV2VInspection()
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("returns error when command fails",
+			func() {
+				appConfig.InspectionOutputFile = config.InspectionOutputFile
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/new-vm-name-sda"},
+				}
+
+				mockCommandBuilder.EXPECT().New("virt-v2v-inspector").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-if", "raw").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/new-vm-name-sda").Return(mockCommandBuilder)
+
+				mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+
+				mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+				mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+				mockCommandExecutor.EXPECT().Run().Return(errors.New("command failed"))
+
+				err := conversion.RunVirtV2VInspection()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("command failed"))
+			},
+		)
+	})
+
+	Describe("RunVirtV2vInPlace", func() {
+		It("passes virt-v2v-in-place with libvirtxml",
+			func() {
+				appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+
+				mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
+
+				mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+
+				mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+				mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+				mockCommandExecutor.EXPECT().Run()
+
+				err := conversion.RunVirtV2vInPlace()
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("passes virt-v2v-in-place with extra args",
+			func() {
+				appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+				appConfig.ExtraArgs = []string{"--debug", "--verbose"}
+
+				mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddExtraArgs("--debug", "--verbose").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
+
+				mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+
+				mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+				mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+				mockCommandExecutor.EXPECT().Run()
+
+				err := conversion.RunVirtV2vInPlace()
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("returns error when command fails",
+			func() {
+				appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+
+				mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
+
+				mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+
+				mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+				mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+				mockCommandExecutor.EXPECT().Run().Return(errors.New("in-place conversion failed"))
+
+				err := conversion.RunVirtV2vInPlace()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("in-place conversion failed"))
+			},
+		)
+	})
+
+	Describe("RunVirtV2vInPlaceDisk", func() {
+		It("runs virt-v2v-in-place with disk mode",
+			func() {
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/vm-sda"},
+					{Link: "/var/tmp/v2v/vm-sdb"},
+				}
+
+				mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sdb").Return(mockCommandBuilder)
+
+				mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+
+				mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+				mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+				mockCommandExecutor.EXPECT().Run()
+
+				err := conversion.RunVirtV2vInPlaceDisk()
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("returns error when no disks found",
+			func() {
+				conversion.Disks = []*Disk{}
+
+				err := conversion.RunVirtV2vInPlaceDisk()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("no disks found for in-place conversion"))
+			},
+		)
+
+		It("runs virt-v2v-in-place disk mode with extra args",
+			func() {
+				appConfig.ExtraArgs = []string{"--custom-flag"}
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/vm-sda"},
+				}
+
+				mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddExtraArgs("--custom-flag").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
+
+				mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+
+				mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+				mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+				mockCommandExecutor.EXPECT().Run()
+
+				err := conversion.RunVirtV2vInPlaceDisk()
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+	})
+
+	Describe("addCommonArgs", func() {
+		It("adds common args with root disk and multiple static IPs",
+			func() {
+				appConfig := config.AppConfig{
+					RootDisk:  "/dev/sda",
+					StaticIPs: "00:11:22:33:44:55:ip:192.168.1.100_00:11:22:33:44:56:ip:192.168.1.101",
+				}
+				conversion.AppConfig = &appConfig
+
+				mockCommandBuilder.EXPECT().AddArg("--root", "/dev/sda").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--mac", "00:11:22:33:44:55:ip:192.168.1.100").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--mac", "00:11:22:33:44:56:ip:192.168.1.101").Return(mockCommandBuilder)
+
+				err := conversion.addCommonArgs(mockCommandBuilder)
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("adds common args with root disk and single static IP",
+			func() {
+				appConfig := config.AppConfig{
+					RootDisk:  "/dev/sda",
+					StaticIPs: "00:11:22:33:44:55:ip:192.168.1.100",
+				}
+				conversion.AppConfig = &appConfig
+				mockCommandBuilder.EXPECT().AddArg("--root", "/dev/sda").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--mac", "00:11:22:33:44:55:ip:192.168.1.100").Return(mockCommandBuilder)
+
+				err := conversion.addCommonArgs(mockCommandBuilder)
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("adds common args with root disk as default",
+			func() {
+				appConfig := config.AppConfig{}
+				conversion = &Conversion{
+					AppConfig:      &appConfig,
+					CommandBuilder: mockCommandBuilder,
+				}
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+
+				err := conversion.addCommonArgs(mockCommandBuilder)
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("adds clevis key when NbdeClevis is true",
+			func() {
+				appConfig := config.AppConfig{
+					NbdeClevis: true,
+				}
+				conversion.AppConfig = &appConfig
+
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArgs("--key", "all:clevis").Return(mockCommandBuilder)
+
+				err := conversion.addCommonArgs(mockCommandBuilder)
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("adds LUKS keys when Luksdir is set and files exist",
+			func() {
+				luksDir := "/etc/luks"
+				appConfig := config.AppConfig{
+					Luksdir: luksDir,
+				}
+				conversion.AppConfig = &appConfig
+
+				// Mock filesystem.Stat to indicate directory exists
+				mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+				// Mock filesystem to return empty directory (no LUKS keys)
+				mockFileSystem.EXPECT().ReadDir(luksDir).Return([]os.DirEntry{}, nil)
+
+				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArgs("--key").Return(mockCommandBuilder)
+
+				err := conversion.addCommonArgs(mockCommandBuilder)
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+	})
+
+	Describe("addConversionExtraArgs", func() {
+		It("adds extra args when they are set",
+			func() {
+				appConfig.ExtraArgs = []string{"--arg1", "--arg2", "value"}
+
+				mockCommandBuilder.EXPECT().AddExtraArgs("--arg1", "--arg2", "value").Return(mockCommandBuilder)
+
+				conversion.addConversionExtraArgs(mockCommandBuilder)
+			},
+		)
+
+		It("does nothing when extra args are nil",
+			func() {
+				appConfig.ExtraArgs = nil
+				// No mock expectations - nothing should be called
+				conversion.addConversionExtraArgs(mockCommandBuilder)
+			},
+		)
+
+		It("calls AddExtraArgs with empty slice when extra args are empty",
+			func() {
+				appConfig.ExtraArgs = []string{}
+				// Empty slice is not nil, so AddExtraArgs is still called
+				mockCommandBuilder.EXPECT().AddExtraArgs().Return(mockCommandBuilder)
+				conversion.addConversionExtraArgs(mockCommandBuilder)
+			},
+		)
+	})
+
+	Describe("addInspectorExtraArgs", func() {
+		It("adds inspector extra args when they are set",
+			func() {
+				appConfig.InspectorExtraArgs = []string{"--inspector-arg1", "--inspector-arg2"}
+
+				mockCommandBuilder.EXPECT().AddExtraArgs("--inspector-arg1", "--inspector-arg2").Return(mockCommandBuilder)
+
+				conversion.addInspectorExtraArgs(mockCommandBuilder)
+			},
+		)
+
+		It("does nothing when inspector extra args are nil",
+			func() {
+				appConfig.InspectorExtraArgs = nil
+				// No mock expectations - nothing should be called
+				conversion.addInspectorExtraArgs(mockCommandBuilder)
+			},
+		)
+	})
+
+	Describe("virtV2vOVAArgs", func() {
+		It("adds OVA args correctly",
+			func() {
+				appConfig.DiskPath = "/path/to/ova/disk.ova"
+
+				mockCommandBuilder.EXPECT().AddArg("-i", "ova").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddPositional("/path/to/ova/disk.ova").Return(mockCommandBuilder)
+
+				conversion.virtV2vOVAArgs(mockCommandBuilder)
+			},
+		)
+	})
+
+	Describe("addVirtV2vRemoteInspectionArgs", func() {
+		It("adds remote inspection disk args",
+			func() {
+				appConfig.RemoteInspectionDisks = []string{"[datastore1] vm/disk1.vmdk", "[datastore1] vm/disk2.vmdk"}
+
+				mockCommandBuilder.EXPECT().AddArg("-io", "vddk-file=[datastore1] vm/disk1.vmdk").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-io", "vddk-file=[datastore1] vm/disk2.vmdk").Return(mockCommandBuilder)
+
+				err := conversion.addVirtV2vRemoteInspectionArgs(mockCommandBuilder)
+				Expect(err).ToNot(HaveOccurred())
+			},
+		)
+
+		It("returns error when no remote disks are supplied",
+			func() {
+				appConfig.RemoteInspectionDisks = []string{}
+
+				err := conversion.addVirtV2vRemoteInspectionArgs(mockCommandBuilder)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("No remote disks were supplied"))
+			},
+		)
+	})
+
+	Describe("RunVirtV2vInPlaceDisk error cases", func() {
+		It("returns error when command fails", func() {
 			conversion.Disks = []*Disk{
-				{Link: "/var/tmp/v2v/new-vm-name-sda"},
-				{Link: "/var/tmp/v2v/new-vm-name-sdb"},
+				{Link: "/var/tmp/v2v/vm-sda"},
+			}
+
+			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
+
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run().Return(errors.New("disk conversion failed"))
+
+			err := conversion.RunVirtV2vInPlaceDisk()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("disk conversion failed"))
+		})
+
+		It("returns error when addCommonArgs fails", func() {
+			luksDir := "/etc/luks"
+			appConfig.Luksdir = luksDir
+			conversion.Disks = []*Disk{
+				{Link: "/var/tmp/v2v/vm-sda"},
+			}
+
+			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(luksDir).Return(nil, errors.New("permission denied"))
+
+			err := conversion.RunVirtV2vInPlaceDisk()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error adding LUKS keys"))
+		})
+	})
+
+	Describe("RunVirtV2VInspection with custom root disk", func() {
+		It("passes custom root disk argument", func() {
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
+			appConfig.RootDisk = "/dev/sdb"
+			conversion.Disks = []*Disk{
+				{Link: "/var/tmp/v2v/vm-sda"},
 			}
 
 			mockCommandBuilder.EXPECT().New("virt-v2v-inspector").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-if", "raw").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/new-vm-name-sda").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/new-vm-name-sdb").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "/dev/sdb").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
 
 			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
 
@@ -64,17 +504,20 @@ var _ = Describe("Conversion", func() {
 
 			err := conversion.RunVirtV2VInspection()
 			Expect(err).ToNot(HaveOccurred())
-		},
-	)
-	It("passes virt-v2v-inspection",
-		func() {
+		})
+	})
+
+	Describe("RunVirtV2vInPlace with static IPs", func() {
+		It("passes static IP arguments", func() {
 			appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
 
 			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--mac", "00:11:22:33:44:55:ip:192.168.1.100").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
 
 			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
@@ -85,49 +528,259 @@ var _ = Describe("Conversion", func() {
 
 			err := conversion.RunVirtV2vInPlace()
 			Expect(err).ToNot(HaveOccurred())
-		},
-	)
-	It("adds common args with root disk and static IPs",
-		func() {
+		})
+
+		It("returns error when addCommonArgs fails", func() {
+			appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+			luksDir := "/etc/luks"
+			appConfig.Luksdir = luksDir
+
+			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(luksDir).Return(nil, errors.New("read error"))
+
+			err := conversion.RunVirtV2vInPlace()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error adding LUKS keys"))
+		})
+	})
+
+	Describe("addVirtV2vArgs", func() {
+		It("adds OVA args when source is OVA", func() {
+			appConfig.Source = config.OVA
+			appConfig.Workdir = "/var/tmp/v2v"
+			appConfig.NewVmName = "new-vm"
+			appConfig.DiskPath = "/path/to/disk.ova"
+
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-o", "kubevirt").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-os", "/var/tmp/v2v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-on", "new-vm").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "ova").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("/path/to/disk.ova").Return(mockCommandBuilder)
+
+			err := conversion.addVirtV2vArgs(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("handles unknown source gracefully", func() {
+			appConfig.Source = "unknown"
+			appConfig.Workdir = "/var/tmp/v2v"
+			appConfig.NewVmName = "new-vm"
+
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-o", "kubevirt").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-os", "/var/tmp/v2v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-on", "new-vm").Return(mockCommandBuilder)
+
+			err := conversion.addVirtV2vArgs(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("addCommonArgs with LUKS files", func() {
+		It("adds LUKS keys from files in directory", func() {
+			luksDir := "/etc/luks"
 			appConfig := config.AppConfig{
-				RootDisk:  "/dev/sda",
-				StaticIPs: "00:11:22:33:44:55:ip:192.168.1.100_00:11:22:33:44:56:ip:192.168.1.101",
+				Luksdir: luksDir,
 			}
 			conversion.AppConfig = &appConfig
 
-			mockCommandBuilder.EXPECT().AddArg("--root", "/dev/sda").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--mac", "00:11:22:33:44:55:ip:192.168.1.100").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--mac", "00:11:22:33:44:56:ip:192.168.1.101").Return(mockCommandBuilder)
+			luksFiles := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "key1", FileIsDir: false},
+				{FileName: "key2", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(luksDir).Return(luksFiles, nil)
+
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArgs("--key", "all:file:/etc/luks/key1", "all:file:/etc/luks/key2").Return(mockCommandBuilder)
 
 			err := conversion.addCommonArgs(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
-		},
-	)
-	It("adds common args with root disk and static IPs",
-		func() {
+		})
+
+		It("returns error when LUKS directory read fails", func() {
+			luksDir := "/etc/luks"
 			appConfig := config.AppConfig{
-				RootDisk:  "/dev/sda",
-				StaticIPs: "00:11:22:33:44:55:ip:192.168.1.100",
+				Luksdir: luksDir,
 			}
 			conversion.AppConfig = &appConfig
-			mockCommandBuilder.EXPECT().AddArg("--root", "/dev/sda").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--mac", "00:11:22:33:44:55:ip:192.168.1.100").Return(mockCommandBuilder)
 
-			err := conversion.addCommonArgs(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		},
-	)
-	It("adds common args with root disk as default",
-		func() {
-			appConfig := config.AppConfig{}
-			conversion = &Conversion{
-				AppConfig:      &appConfig,
-				CommandBuilder: mockCommandBuilder,
-			}
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(luksDir).Return(nil, errors.New("permission denied"))
+
 			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 
 			err := conversion.addCommonArgs(mockCommandBuilder)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error adding LUKS keys"))
+		})
+	})
+
+	Describe("addVirtV2vRemoteInspectionArgs with multiple disks", func() {
+		It("adds all remote inspection disk args", func() {
+			appConfig.RemoteInspectionDisks = []string{
+				"[datastore1] vm/disk1.vmdk",
+				"[datastore1] vm/disk2.vmdk",
+				"[datastore2] vm/disk3.vmdk",
+			}
+
+			mockCommandBuilder.EXPECT().AddArg("-io", "vddk-file=[datastore1] vm/disk1.vmdk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-io", "vddk-file=[datastore1] vm/disk2.vmdk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-io", "vddk-file=[datastore2] vm/disk3.vmdk").Return(mockCommandBuilder)
+
+			err := conversion.addVirtV2vRemoteInspectionArgs(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
-		},
-	)
+		})
+	})
+
+	Describe("updateDiskPaths", func() {
+		It("updates file source disk paths in domain XML",
+			func() {
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/vm-sda"},
+				}
+
+				domainXML := `<domain type='kvm'>
+  <name>test-vm</name>
+  <devices>
+    <disk type='file' device='disk'>
+      <source file='/original/path/disk.vmdk'/>
+      <target dev='sda' bus='scsi'/>
+    </disk>
+  </devices>
+</domain>`
+
+				result, err := conversion.updateDiskPaths(domainXML)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sda"))
+				Expect(result).ToNot(ContainSubstring("/original/path/disk.vmdk"))
+			},
+		)
+
+		It("updates block source disk paths in domain XML",
+			func() {
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/vm-sda"},
+				}
+
+				domainXML := `<domain type='kvm'>
+  <name>test-vm</name>
+  <devices>
+    <disk type='block' device='disk'>
+      <source dev='/dev/original-block'/>
+      <target dev='sda' bus='scsi'/>
+    </disk>
+  </devices>
+</domain>`
+
+				result, err := conversion.updateDiskPaths(domainXML)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sda"))
+				Expect(result).ToNot(ContainSubstring("/dev/original-block"))
+			},
+		)
+
+		It("handles multiple disks",
+			func() {
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/vm-sda"},
+					{Link: "/var/tmp/v2v/vm-sdb"},
+				}
+
+				domainXML := `<domain type='kvm'>
+  <name>test-vm</name>
+  <devices>
+    <disk type='file' device='disk'>
+      <source file='/original/path/disk1.vmdk'/>
+      <target dev='sda' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <source file='/original/path/disk2.vmdk'/>
+      <target dev='sdb' bus='scsi'/>
+    </disk>
+  </devices>
+</domain>`
+
+				result, err := conversion.updateDiskPaths(domainXML)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sda"))
+				Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sdb"))
+			},
+		)
+
+		It("handles empty devices section",
+			func() {
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/vm-sda"},
+				}
+
+				domainXML := `<domain type='kvm'>
+  <name>test-vm</name>
+  <devices>
+  </devices>
+</domain>`
+
+				result, err := conversion.updateDiskPaths(domainXML)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).ToNot(ContainSubstring("/var/tmp/v2v/vm-sda"))
+			},
+		)
+
+		It("returns error for invalid XML",
+			func() {
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/vm-sda"},
+				}
+
+				invalidXML := `<domain type='kvm'>
+  <name>test-vm</name>
+  <devices>
+    <disk type='file' device='disk'>
+      <source file='/original/path/disk.vmdk'/>
+    <!-- Missing closing tags -->`
+
+				_, err := conversion.updateDiskPaths(invalidXML)
+				Expect(err).To(HaveOccurred())
+			},
+		)
+
+		It("handles more disks in XML than available",
+			func() {
+				conversion.Disks = []*Disk{
+					{Link: "/var/tmp/v2v/vm-sda"},
+				}
+
+				domainXML := `<domain type='kvm'>
+  <name>test-vm</name>
+  <devices>
+    <disk type='file' device='disk'>
+      <source file='/original/path/disk1.vmdk'/>
+      <target dev='sda' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <source file='/original/path/disk2.vmdk'/>
+      <target dev='sdb' bus='scsi'/>
+    </disk>
+  </devices>
+</domain>`
+
+				result, err := conversion.updateDiskPaths(domainXML)
+				Expect(err).ToNot(HaveOccurred())
+				// First disk should be updated
+				Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sda"))
+				// Second disk should keep original path (warning logged)
+				Expect(result).To(ContainSubstring("/original/path/disk2.vmdk"))
+			},
+		)
+	})
 })

--- a/pkg/virt-v2v/conversion/disk_test.go
+++ b/pkg/virt-v2v/conversion/disk_test.go
@@ -1,6 +1,9 @@
+// Generated-by: Claude
 package conversion
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -19,80 +22,222 @@ var _ = Describe("Disks", func() {
 		mockFileSystem = utils.NewMockFileSystem(mockCtrl)
 	})
 
-	DescribeTable("generate disk name from",
-		func(diskNum int, expected string) {
-			disk = &Disk{}
-			Expect(disk.genName(diskNum)).To(Equal(expected))
-		},
-		Entry("start of alphabet", 1, "a"),
-		Entry("end of alphabet", 26, "z"),
-		Entry("two character name start", 27, "aa"),
-		Entry("two character name next", 28, "ab"),
-		Entry("two character name end", 52, "az"),
-		Entry("two character name start with next", 53, "ba"),
-		Entry("two character name next", 55, "bc"),
-		Entry("two character name end", 702, "zz"),
-		Entry("three character name", 754, "abz"),
-	)
-	DescribeTable("get disk number",
-		func(diskPath string, expected int) {
-			disk = &Disk{
-				Path: diskPath,
-			}
-			num, err := disk.getDiskNumber()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(num).To(Equal(expected))
-		},
-		Entry("block device ending with 0", "/dev/block0", 0),
-		Entry("block device ending with 12", "/dev/block12", 12),
-		Entry("filesystem ending with 0", "/mnt/disks/disk0", 0),
-		Entry("filesystem ending with 13", "/mnt/disks/disk13", 13),
-		Entry("filesystem ending with 0 and pointing to the image", "/mnt/disks/disk0/disk.img", 0),
-		Entry("filesystem ending with 14 and pointing to the image", "/mnt/disks/disk14/disk.img", 14),
-	)
-	DescribeTable("create disk link with new vm name",
-		func(diskPath string, expected string) {
-			cfg := &config.AppConfig{
-				Workdir:   "/var/tmp/v2v",
-				VmName:    "vm-name",
-				NewVmName: "new-vm-name",
-			}
-			disk := Disk{
-				Path:       diskPath,
-				appConfig:  cfg,
-				fileSystem: mockFileSystem,
-			}
-			mockFileSystem.EXPECT().Symlink(diskPath, expected)
-			link, err := disk.createLink()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(link).To(Equal(expected))
-		},
-		Entry("block device ending with 0", "/dev/block0", "/var/tmp/v2v/new-vm-name-sda"),
-		Entry("filesystem image ending with 0", "/mnt/disks/disk0/disk.img", "/var/tmp/v2v/new-vm-name-sda"),
-		Entry("block device ending with 1", "/dev/block1", "/var/tmp/v2v/new-vm-name-sdb"),
-		Entry("filesystem image ending with 1", "/mnt/disks/disk1/disk.img", "/var/tmp/v2v/new-vm-name-sdb"),
-	)
-	DescribeTable("Extracting the author's first and last name",
-		func(diskPath string, expected string) {
-			cfg := &config.AppConfig{
-				Workdir: "/var/tmp/v2v",
-				VmName:  "vm-name",
-			}
-			disk := Disk{
-				Path:       diskPath,
-				appConfig:  cfg,
-				fileSystem: mockFileSystem,
-			}
-			mockFileSystem.EXPECT().Symlink(diskPath, expected)
-			link, err := disk.createLink()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(link).To(Equal(expected))
-		},
-		Entry("block device ending with 0", "/dev/block0", "/var/tmp/v2v/vm-name-sda"),
-		Entry("filesystem image ending with 0", "/mnt/disks/disk0/disk.img", "/var/tmp/v2v/vm-name-sda"),
-		Entry("block device ending with 1", "/dev/block1", "/var/tmp/v2v/vm-name-sdb"),
-		Entry("filesystem image ending with 1", "/mnt/disks/disk1/disk.img", "/var/tmp/v2v/vm-name-sdb"),
-		Entry("block device ending with 12", "/dev/block12", "/var/tmp/v2v/vm-name-sdm"),
-		Entry("filesystem image ending with 13", "/mnt/disks/disk13/disk.img", "/var/tmp/v2v/vm-name-sdn"),
-	)
+	Describe("genName", func() {
+		DescribeTable("generates disk name correctly",
+			func(diskNum int, expected string) {
+				disk = &Disk{}
+				Expect(disk.genName(diskNum)).To(Equal(expected))
+			},
+			Entry("start of alphabet", 1, "a"),
+			Entry("end of alphabet", 26, "z"),
+			Entry("two character name start", 27, "aa"),
+			Entry("two character name next", 28, "ab"),
+			Entry("two character name end", 52, "az"),
+			Entry("two character name start with next", 53, "ba"),
+			Entry("two character name next", 55, "bc"),
+			Entry("two character name end", 702, "zz"),
+			Entry("three character name", 754, "abz"),
+		)
+
+		DescribeTable("handles edge cases",
+			func(diskNum int, expected string) {
+				disk = &Disk{}
+				Expect(disk.genName(diskNum)).To(Equal(expected))
+			},
+			Entry("zero returns empty string", 0, ""),
+			Entry("negative returns empty string", -1, ""),
+			Entry("negative large value returns empty string", -100, ""),
+		)
+	})
+
+	Describe("getDiskNumber", func() {
+		DescribeTable("extracts disk number from path",
+			func(diskPath string, expected int) {
+				disk = &Disk{
+					Path: diskPath,
+				}
+				num, err := disk.getDiskNumber()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(num).To(Equal(expected))
+			},
+			Entry("block device ending with 0", "/dev/block0", 0),
+			Entry("block device ending with 12", "/dev/block12", 12),
+			Entry("filesystem ending with 0", "/mnt/disks/disk0", 0),
+			Entry("filesystem ending with 13", "/mnt/disks/disk13", 13),
+			Entry("filesystem ending with 0 and pointing to the image", "/mnt/disks/disk0/disk.img", 0),
+			Entry("filesystem ending with 14 and pointing to the image", "/mnt/disks/disk14/disk.img", 14),
+			Entry("large disk number", "/dev/block999", 999),
+			Entry("path with multiple numbers takes first", "/mnt/disk1/disk2/disk.img", 1),
+		)
+
+		It("returns error for path without number",
+			func() {
+				disk = &Disk{
+					Path: "/dev/sda",
+				}
+				_, err := disk.getDiskNumber()
+				Expect(err).To(HaveOccurred())
+			},
+		)
+
+		It("returns error for empty path",
+			func() {
+				disk = &Disk{
+					Path: "",
+				}
+				_, err := disk.getDiskNumber()
+				Expect(err).To(HaveOccurred())
+			},
+		)
+	})
+
+	Describe("getDiskName", func() {
+		It("returns NewVmName when set",
+			func() {
+				cfg := &config.AppConfig{
+					VmName:    "original-vm",
+					NewVmName: "new-vm",
+				}
+				disk = &Disk{
+					appConfig: cfg,
+				}
+				Expect(disk.getDiskName()).To(Equal("new-vm"))
+			},
+		)
+
+		It("returns VmName when NewVmName is not set",
+			func() {
+				cfg := &config.AppConfig{
+					VmName:    "original-vm",
+					NewVmName: "",
+				}
+				disk = &Disk{
+					appConfig: cfg,
+				}
+				Expect(disk.getDiskName()).To(Equal("original-vm"))
+			},
+		)
+
+		It("returns empty string when both are empty",
+			func() {
+				cfg := &config.AppConfig{
+					VmName:    "",
+					NewVmName: "",
+				}
+				disk = &Disk{
+					appConfig: cfg,
+				}
+				Expect(disk.getDiskName()).To(Equal(""))
+			},
+		)
+	})
+
+	Describe("createLink", func() {
+		DescribeTable("creates disk link with new vm name",
+			func(diskPath string, expected string) {
+				cfg := &config.AppConfig{
+					Workdir:   "/var/tmp/v2v",
+					VmName:    "vm-name",
+					NewVmName: "new-vm-name",
+				}
+				disk := Disk{
+					Path:       diskPath,
+					appConfig:  cfg,
+					fileSystem: mockFileSystem,
+				}
+				mockFileSystem.EXPECT().Symlink(diskPath, expected)
+				link, err := disk.createLink()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(link).To(Equal(expected))
+			},
+			Entry("block device ending with 0", "/dev/block0", "/var/tmp/v2v/new-vm-name-sda"),
+			Entry("filesystem image ending with 0", "/mnt/disks/disk0/disk.img", "/var/tmp/v2v/new-vm-name-sda"),
+			Entry("block device ending with 1", "/dev/block1", "/var/tmp/v2v/new-vm-name-sdb"),
+			Entry("filesystem image ending with 1", "/mnt/disks/disk1/disk.img", "/var/tmp/v2v/new-vm-name-sdb"),
+		)
+
+		DescribeTable("creates disk link with original vm name",
+			func(diskPath string, expected string) {
+				cfg := &config.AppConfig{
+					Workdir: "/var/tmp/v2v",
+					VmName:  "vm-name",
+				}
+				disk := Disk{
+					Path:       diskPath,
+					appConfig:  cfg,
+					fileSystem: mockFileSystem,
+				}
+				mockFileSystem.EXPECT().Symlink(diskPath, expected)
+				link, err := disk.createLink()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(link).To(Equal(expected))
+			},
+			Entry("block device ending with 0", "/dev/block0", "/var/tmp/v2v/vm-name-sda"),
+			Entry("filesystem image ending with 0", "/mnt/disks/disk0/disk.img", "/var/tmp/v2v/vm-name-sda"),
+			Entry("block device ending with 1", "/dev/block1", "/var/tmp/v2v/vm-name-sdb"),
+			Entry("filesystem image ending with 1", "/mnt/disks/disk1/disk.img", "/var/tmp/v2v/vm-name-sdb"),
+			Entry("block device ending with 12", "/dev/block12", "/var/tmp/v2v/vm-name-sdm"),
+			Entry("filesystem image ending with 13", "/mnt/disks/disk13/disk.img", "/var/tmp/v2v/vm-name-sdn"),
+		)
+
+		It("returns error when symlink fails",
+			func() {
+				cfg := &config.AppConfig{
+					Workdir: "/var/tmp/v2v",
+					VmName:  "vm-name",
+				}
+				disk := Disk{
+					Path:       "/dev/block0",
+					appConfig:  cfg,
+					fileSystem: mockFileSystem,
+				}
+				mockFileSystem.EXPECT().Symlink("/dev/block0", "/var/tmp/v2v/vm-name-sda").Return(errors.New("symlink failed"))
+
+				_, err := disk.createLink()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("symlink failed"))
+			},
+		)
+
+		It("returns error when disk number extraction fails",
+			func() {
+				cfg := &config.AppConfig{
+					Workdir: "/var/tmp/v2v",
+					VmName:  "vm-name",
+				}
+				disk := Disk{
+					Path:       "/dev/sda", // No number in path
+					appConfig:  cfg,
+					fileSystem: mockFileSystem,
+				}
+
+				_, err := disk.createLink()
+				Expect(err).To(HaveOccurred())
+			},
+		)
+
+		DescribeTable("creates correct link for high disk numbers",
+			func(diskPath string, expected string) {
+				cfg := &config.AppConfig{
+					Workdir: "/var/tmp/v2v",
+					VmName:  "vm",
+				}
+				disk := Disk{
+					Path:       diskPath,
+					appConfig:  cfg,
+					fileSystem: mockFileSystem,
+				}
+				mockFileSystem.EXPECT().Symlink(diskPath, expected)
+				link, err := disk.createLink()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(link).To(Equal(expected))
+			},
+			Entry("disk 25 -> sdz", "/dev/block25", "/var/tmp/v2v/vm-sdz"),
+			Entry("disk 26 -> sdaa", "/dev/block26", "/var/tmp/v2v/vm-sdaa"),
+			Entry("disk 27 -> sdab", "/dev/block27", "/var/tmp/v2v/vm-sdab"),
+			Entry("disk 51 -> sdaz", "/dev/block51", "/var/tmp/v2v/vm-sdaz"),
+			Entry("disk 52 -> sdba", "/dev/block52", "/var/tmp/v2v/vm-sdba"),
+		)
+	})
+
 })

--- a/pkg/virt-v2v/customize/customize_test.go
+++ b/pkg/virt-v2v/customize/customize_test.go
@@ -1,3 +1,4 @@
+// Generated-by: Claude
 package customize
 
 import (
@@ -87,33 +88,64 @@ var _ = Describe("Customize", func() {
 		}
 	})
 
-	It("TestCustomizeRHELWithMock", func() {
-		customize.disks = disks
-		mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-		for _, expectedScript := range expectedRunScripts {
-			mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
-		}
-		for _, expectedScript := range expectedFirstBootScripts {
-			mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
-		}
-		for _, disk := range disks {
-			mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-		}
-		mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-		mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-		mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-		mockCommandExecutor.EXPECT().Run().Return(nil)
-		mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-		mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+	Describe("customizeLinux", func() {
+		It("TestCustomizeRHELWithMock", func() {
+			customize.disks = disks
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			for _, expectedScript := range expectedRunScripts {
+				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, expectedScript := range expectedFirstBootScripts {
+				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(nil)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
 
-		mockFileSystem.EXPECT().Stat(gomock.Any()).Return(nil, os.ErrNotExist)
-		mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
-		mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
+			mockFileSystem.EXPECT().Stat(gomock.Any()).Return(nil, os.ErrNotExist)
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
 
-		err := customize.customizeLinux()
-		Expect(err).ToNot(HaveOccurred())
+			err := customize.customizeLinux()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when run command fails", func() {
+			customize.disks = disks
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+			for _, expectedScript := range expectedRunScripts {
+				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, expectedScript := range expectedFirstBootScripts {
+				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(errors.New("command failed"))
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+
+			mockFileSystem.EXPECT().Stat(gomock.Any()).Return(nil, os.ErrNotExist)
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
+
+			err := customize.customizeLinux()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to execute domain customization"))
+		})
 	})
-	Describe("TestHandleStaticIPConfiguration", func() {
+
+	Describe("handleStaticIPConfiguration", func() {
 		It("StaticIPs - It passes", func() {
 			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
 			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n"
@@ -123,6 +155,23 @@ var _ = Describe("Customize", func() {
 			err := customize.handleStaticIPConfiguration(mockCommandBuilder)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("handles multiple static IPs separated by underscore", func() {
+			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100_00:11:22:33:44:56:ip:192.168.1.101"
+			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n00:11:22:33:44:56:ip:192.168.1.101\n"
+			expectedPath := filepath.Join(appConfig.Workdir, "macToIP")
+			mockFileSystem.EXPECT().WriteFile(expectedPath, []byte(expectedContent), fs.FileMode(0755)).Return(nil)
+			mockCommandBuilder.EXPECT().AddArg("--upload", fmt.Sprintf("%s:/tmp/macToIP", expectedPath)).Times(1)
+			err := customize.handleStaticIPConfiguration(mockCommandBuilder)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does nothing when StaticIPs is empty", func() {
+			appConfig.StaticIPs = ""
+			err := customize.handleStaticIPConfiguration(mockCommandBuilder)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("WriteFileFails - It fails", func() {
 			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
 			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n"
@@ -133,7 +182,8 @@ var _ = Describe("Customize", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
-	Describe("TestAddFirstbootScripts", func() {
+
+	Describe("addRhelFirstbootScripts", func() {
 		It("Scripts - It passes", func() {
 			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
 			for _, expectedScript := range expectedFirstBootScripts {
@@ -142,18 +192,21 @@ var _ = Describe("Customize", func() {
 			err := customize.addRhelFirstbootScripts(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
 		It("NoScripts - It does not add", func() {
 			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(nil, nil)
 			err := customize.addRhelFirstbootScripts(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
 		It("ReadDirFails - It fails", func() {
 			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(nil, errors.New("error"))
 			err := customize.addRhelFirstbootScripts(mockCommandBuilder)
 			Expect(err).To(HaveOccurred())
 		})
 	})
-	Describe("TestAddRunScripts", func() {
+
+	Describe("addRhelRunScripts", func() {
 		It("Scripts - It passes", func() {
 			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
 			for _, expectedScript := range expectedRunScripts {
@@ -162,22 +215,701 @@ var _ = Describe("Customize", func() {
 			err := customize.addRhelRunScripts(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
 		It("NoScripts - It does not add", func() {
 			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(nil, nil)
 			err := customize.addRhelRunScripts(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
 		It("ReadDirFails - It fails", func() {
 			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(nil, errors.New("error"))
 			err := customize.addRhelRunScripts(mockCommandBuilder)
 			Expect(err).To(HaveOccurred())
 		})
 	})
-	It("TestAddDisksToCustomize", func() {
-		customize.disks = disks
-		for _, disk := range disks {
-			mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-		}
-		customize.addDisksToCustomize(mockCommandBuilder)
+
+	Describe("addDisksToCustomize", func() {
+		It("adds all disks", func() {
+			customize.disks = disks
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+			customize.addDisksToCustomize(mockCommandBuilder)
+		})
+
+		It("handles empty disks slice", func() {
+			customize.disks = []string{}
+			// No mock expectations - no AddArg calls should be made
+			customize.addDisksToCustomize(mockCommandBuilder)
+		})
+
+		It("handles single disk", func() {
+			customize.disks = []string{"/var/tmp/v2v/single-disk"}
+			mockCommandBuilder.EXPECT().AddArg("--add", "/var/tmp/v2v/single-disk").Return(mockCommandBuilder)
+			customize.addDisksToCustomize(mockCommandBuilder)
+		})
 	})
+
+	Describe("addLuksKeysToCustomize", func() {
+		It("adds clevis key when NbdeClevis is true", func() {
+			appConfig.NbdeClevis = true
+			mockCommandBuilder.EXPECT().AddArgs("--key", "all:clevis").Return(mockCommandBuilder)
+			err := customize.addLuksKeysToCustomize(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("does nothing when Luksdir is empty and NbdeClevis is false", func() {
+			appConfig.Luksdir = ""
+			appConfig.NbdeClevis = false
+			// No mock expectations
+			err := customize.addLuksKeysToCustomize(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("adds LUKS keys from directory", func() {
+			appConfig.Luksdir = "/etc/luks"
+			appConfig.NbdeClevis = false
+
+			files := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "key1", FileIsDir: false},
+				{FileName: "key2", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().Stat("/etc/luks").Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir("/etc/luks").Return(files, nil)
+			mockCommandBuilder.EXPECT().AddArgs("--key", "all:file:/etc/luks/key1", "all:file:/etc/luks/key2").Return(mockCommandBuilder)
+
+			err := customize.addLuksKeysToCustomize(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when LUKS directory read fails", func() {
+			appConfig.Luksdir = "/etc/luks"
+			appConfig.NbdeClevis = false
+
+			mockFileSystem.EXPECT().Stat("/etc/luks").Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir("/etc/luks").Return(nil, errors.New("read error"))
+
+			err := customize.addLuksKeysToCustomize(mockCommandBuilder)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("getScriptsWithSuffix", func() {
+		It("returns scripts with matching suffix", func() {
+			dir := "/test/scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "script1.sh", FileIsDir: false},
+				{FileName: "script2.sh", FileIsDir: false},
+				{FileName: "script3.ps1", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+
+			result, err := customize.getScriptsWithSuffix(dir, ".sh")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(2))
+			Expect(result).To(ContainElement("/test/scripts/script1.sh"))
+			Expect(result).To(ContainElement("/test/scripts/script2.sh"))
+		})
+
+		It("excludes test- prefixed files", func() {
+			dir := "/test/scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "script1.sh", FileIsDir: false},
+				{FileName: "test-script.sh", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+
+			result, err := customize.getScriptsWithSuffix(dir, ".sh")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result).To(ContainElement("/test/scripts/script1.sh"))
+		})
+
+		It("excludes directories", func() {
+			dir := "/test/scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "script1.sh", FileIsDir: false},
+				{FileName: "subdir.sh", FileIsDir: true},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+
+			result, err := customize.getScriptsWithSuffix(dir, ".sh")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+		})
+
+		It("returns empty slice for empty directory", func() {
+			dir := "/test/scripts"
+			mockFileSystem.EXPECT().ReadDir(dir).Return([]os.DirEntry{}, nil)
+
+			result, err := customize.getScriptsWithSuffix(dir, ".sh")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("returns error when ReadDir fails", func() {
+			dir := "/test/scripts"
+			mockFileSystem.EXPECT().ReadDir(dir).Return(nil, errors.New("read error"))
+
+			_, err := customize.getScriptsWithSuffix(dir, ".sh")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("getScriptsWithRegex", func() {
+		It("returns scripts matching regex", func() {
+			dir := "/test/scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "01_linux_run_setup.sh", FileIsDir: false},
+				{FileName: "02_linux_firstboot_config.sh", FileIsDir: false},
+				{FileName: "invalid.sh", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+
+			result, err := customize.getScriptsWithRegex(dir, LinuxDynamicRegex)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(2))
+		})
+
+		It("returns empty for no matches", func() {
+			dir := "/test/scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "invalid.sh", FileIsDir: false},
+				{FileName: "another.txt", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+
+			result, err := customize.getScriptsWithRegex(dir, LinuxDynamicRegex)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("excludes directories", func() {
+			dir := "/test/scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "01_linux_run_setup.sh", FileIsDir: true},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+
+			result, err := customize.getScriptsWithRegex(dir, LinuxDynamicRegex)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("returns error when ReadDir fails", func() {
+			dir := "/test/scripts"
+			mockFileSystem.EXPECT().ReadDir(dir).Return(nil, errors.New("read error"))
+
+			_, err := customize.getScriptsWithRegex(dir, LinuxDynamicRegex)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("addRhelDynamicScripts", func() {
+		It("adds run scripts", func() {
+			dir := "/mnt/dynamic_scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "01_linux_run_setup.sh", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+			mockCommandBuilder.EXPECT().AddArg("--run", filepath.Join(dir, "01_linux_run_setup.sh")).Return(mockCommandBuilder)
+
+			err := customize.addRhelDynamicScripts(mockCommandBuilder, dir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("adds firstboot scripts", func() {
+			dir := "/mnt/dynamic_scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "01_linux_firstboot_config.sh", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+			mockCommandBuilder.EXPECT().AddArg("--firstboot", filepath.Join(dir, "01_linux_firstboot_config.sh")).Return(mockCommandBuilder)
+
+			err := customize.addRhelDynamicScripts(mockCommandBuilder, dir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error for invalid action in regex", func() {
+			dir := "/mnt/dynamic_scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "01_linux_invalid_setup.sh", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+
+			// This should not match the regex, so no error
+			err := customize.addRhelDynamicScripts(mockCommandBuilder, dir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("handles empty directory", func() {
+			dir := "/mnt/dynamic_scripts"
+			mockFileSystem.EXPECT().ReadDir(dir).Return([]os.DirEntry{}, nil)
+
+			err := customize.addRhelDynamicScripts(mockCommandBuilder, dir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("formatUpload", func() {
+		It("formats upload path correctly", func() {
+			result := customize.formatUpload("/local/path/script.sh", "/remote/path/script.sh")
+			Expect(result).To(Equal("/local/path/script.sh:/remote/path/script.sh"))
+		})
+
+		It("handles paths with spaces", func() {
+			result := customize.formatUpload("/local/path with spaces/script.sh", "/remote/path/script.sh")
+			Expect(result).To(Equal("/local/path with spaces/script.sh:/remote/path/script.sh"))
+		})
+	})
+
+	Describe("formatIPs", func() {
+		It("formats single IP", func() {
+			ips := []IPEntry{{IP: "192.168.1.1"}}
+			result := formatIPs(ips)
+			Expect(result).To(Equal("(\n'192.168.1.1'\n)"))
+		})
+
+		It("formats multiple IPs", func() {
+			ips := []IPEntry{
+				{IP: "192.168.1.1"},
+				{IP: "192.168.1.2"},
+			}
+			result := formatIPs(ips)
+			Expect(result).To(Equal("(\n'192.168.1.1',\n'192.168.1.2'\n)"))
+		})
+
+		It("handles empty IPs", func() {
+			ips := []IPEntry{}
+			result := formatIPs(ips)
+			Expect(result).To(Equal("(\n)"))
+		})
+	})
+
+	Describe("formatDNS", func() {
+		It("formats single DNS", func() {
+			dns := []string{"8.8.8.8"}
+			result := formatDNS(dns)
+			Expect(result).To(Equal("(\n'8.8.8.8'\n)"))
+		})
+
+		It("formats multiple DNS", func() {
+			dns := []string{"8.8.8.8", "8.8.4.4"}
+			result := formatDNS(dns)
+			Expect(result).To(Equal("(\n'8.8.8.8',\n'8.8.4.4'\n)"))
+		})
+
+		It("handles empty DNS", func() {
+			dns := []string{}
+			result := formatDNS(dns)
+			Expect(result).To(Equal("(\n)"))
+		})
+	})
+
+	Describe("NewCustomize", func() {
+		It("creates Customize with correct fields", func() {
+			cfg := &config.AppConfig{
+				Workdir: "/test/workdir",
+			}
+			testDisks := []string{"/disk1", "/disk2"}
+			osInfo := utils.InspectionOS{Name: "Fedora"}
+
+			result := NewCustomize(cfg, testDisks, osInfo)
+
+			Expect(result.appConfig).To(Equal(cfg))
+			Expect(result.disks).To(Equal(testDisks))
+			Expect(result.operatingSystem).To(Equal(osInfo))
+			Expect(result.commandBuilder).ToNot(BeNil())
+			Expect(result.fileSystem).ToNot(BeNil())
+			Expect(result.embeddedFileSystem).ToNot(BeNil())
+		})
+	})
+
+	Describe("Run", func() {
+		It("runs Linux customization for non-Windows OS", func() {
+			customize.disks = disks
+			customize.operatingSystem = utils.InspectionOS{Osinfo: "linux"}
+
+			mockEmbedTool.EXPECT().CreateFilesFromFS(appConfig.Workdir).Return(nil)
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+			for _, expectedScript := range expectedRunScripts {
+				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, expectedScript := range expectedFirstBootScripts {
+				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(nil)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+
+			// Stat is called for DynamicScriptsDir and Luksdir
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
+
+			err := customize.Run()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when CreateFilesFromFS fails", func() {
+			customize.disks = disks
+			customize.operatingSystem = utils.InspectionOS{Osinfo: "linux"}
+
+			mockEmbedTool.EXPECT().CreateFilesFromFS(appConfig.Workdir).Return(errors.New("embed error"))
+
+			err := customize.Run()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create files from filesystem"))
+		})
+
+		It("runs Windows customization for Windows OS", func() {
+			customize.disks = disks
+			customize.operatingSystem = utils.InspectionOS{Osinfo: "win10"}
+
+			mockEmbedTool.EXPECT().CreateFilesFromFS(appConfig.Workdir).Return(nil)
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			// DynamicScriptsDir does not exist
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
+
+			// addWinFirstbootScripts
+			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
+
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(nil)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+
+			err := customize.Run()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when Windows customization fails", func() {
+			customize.disks = disks
+			customize.operatingSystem = utils.InspectionOS{Osinfo: "win10"}
+
+			mockEmbedTool.EXPECT().CreateFilesFromFS(appConfig.Workdir).Return(nil)
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
+			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
+
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(errors.New("windows customization failed"))
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+
+			err := customize.Run()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("windows customization failed"))
+		})
+	})
+
+	Describe("customizeWindows", func() {
+		It("customizes Windows with dynamic scripts", func() {
+			customize.disks = disks
+
+			winScripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "01_win_firstboot_setup.ps1", FileIsDir: false},
+			})
+
+			// DynamicScriptsDir exists
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(appConfig.DynamicScriptsDir).Return(winScripts, nil)
+
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			// Dynamic script upload
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder)
+
+			// addWinFirstbootScripts
+			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
+
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(nil)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+
+			err := customize.customizeWindows()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when dynamic scripts read fails", func() {
+			customize.disks = disks
+
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(appConfig.DynamicScriptsDir).Return(nil, errors.New("read error"))
+
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			err := customize.customizeWindows()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to read scripts directory"))
+		})
+	})
+
+	Describe("addWinDynamicScripts", func() {
+		It("adds Windows dynamic scripts matching regex", func() {
+			dir := "/mnt/dynamic_scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "01_win_firstboot_setup.ps1", FileIsDir: false},
+				{FileName: "02_win_firstboot_config.ps1", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder).Times(2)
+
+			err := customize.addWinDynamicScripts(mockCommandBuilder, dir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("ignores non-matching files", func() {
+			dir := "/mnt/dynamic_scripts"
+			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "invalid_script.ps1", FileIsDir: false},
+				{FileName: "random.txt", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
+			// No AddArg calls expected since files don't match regex
+
+			err := customize.addWinDynamicScripts(mockCommandBuilder, dir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when ReadDir fails", func() {
+			dir := "/mnt/dynamic_scripts"
+			mockFileSystem.EXPECT().ReadDir(dir).Return(nil, errors.New("read error"))
+
+			err := customize.addWinDynamicScripts(mockCommandBuilder, dir)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("runCmd", func() {
+		It("runs command successfully", func() {
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run().Return(nil)
+
+			err := customize.runCmd(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when command fails", func() {
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run().Return(errors.New("command execution failed"))
+
+			err := customize.runCmd(mockCommandBuilder)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error executing virt-customize command"))
+		})
+	})
+
+	Describe("customizeLinux with static IPs", func() {
+		It("handles static IP configuration", func() {
+			customize.disks = disks
+			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
+
+			expectedPath := filepath.Join(appConfig.Workdir, "macToIP")
+			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n"
+
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			// Static IP file write
+			mockFileSystem.EXPECT().WriteFile(expectedPath, []byte(expectedContent), fs.FileMode(0755)).Return(nil)
+			mockCommandBuilder.EXPECT().AddArg("--upload", fmt.Sprintf("%s:/tmp/macToIP", expectedPath)).Return(mockCommandBuilder)
+
+			// DynamicScriptsDir does not exist
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
+
+			// Scripts
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
+
+			for _, expectedScript := range expectedRunScripts {
+				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, expectedScript := range expectedFirstBootScripts {
+				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(nil)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+
+			err := customize.customizeLinux()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when static IP file write fails", func() {
+			customize.disks = disks
+			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
+
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			expectedPath := filepath.Join(appConfig.Workdir, "macToIP")
+			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n"
+			mockFileSystem.EXPECT().WriteFile(expectedPath, []byte(expectedContent), fs.FileMode(0755)).Return(errors.New("write error"))
+
+			err := customize.customizeLinux()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to write MAC to IP mapping file"))
+		})
+	})
+
+	Describe("customizeLinux with dynamic scripts", func() {
+		It("adds dynamic scripts when directory exists", func() {
+			customize.disks = disks
+
+			dynamicScripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "01_linux_run_custom.sh", FileIsDir: false},
+				{FileName: "02_linux_firstboot_init.sh", FileIsDir: false},
+			})
+
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			// DynamicScriptsDir exists
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(appConfig.DynamicScriptsDir).Return(dynamicScripts, nil)
+
+			// Dynamic script commands
+			mockCommandBuilder.EXPECT().AddArg("--run", filepath.Join(appConfig.DynamicScriptsDir, "01_linux_run_custom.sh")).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--firstboot", filepath.Join(appConfig.DynamicScriptsDir, "02_linux_firstboot_init.sh")).Return(mockCommandBuilder)
+
+			// Regular scripts
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
+
+			for _, expectedScript := range expectedRunScripts {
+				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, expectedScript := range expectedFirstBootScripts {
+				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(nil)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+
+			err := customize.customizeLinux()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when dynamic scripts read fails", func() {
+			customize.disks = disks
+
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			// DynamicScriptsDir exists but ReadDir fails
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(appConfig.DynamicScriptsDir).Return(nil, errors.New("read error"))
+
+			err := customize.customizeLinux()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to read scripts directory"))
+		})
+	})
+
+	Describe("customizeLinux with LUKS keys", func() {
+		It("adds LUKS keys from directory", func() {
+			customize.disks = disks
+			appConfig.Luksdir = "/etc/luks"
+
+			luksFiles := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+				{FileName: "key1", FileIsDir: false},
+			})
+
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			// DynamicScriptsDir does not exist
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
+
+			// Scripts
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
+			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
+
+			for _, expectedScript := range expectedRunScripts {
+				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, expectedScript := range expectedFirstBootScripts {
+				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
+			}
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+
+			// LUKS keys
+			mockFileSystem.EXPECT().Stat("/etc/luks").Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir("/etc/luks").Return(luksFiles, nil)
+			mockCommandBuilder.EXPECT().AddArgs("--key", "all:file:/etc/luks/key1").Return(mockCommandBuilder)
+
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(nil)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+
+			err := customize.customizeLinux()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 })

--- a/pkg/virt-v2v/server/server_test.go
+++ b/pkg/virt-v2v/server/server_test.go
@@ -1,0 +1,247 @@
+// Generated-by: Claude
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Server test suite")
+}
+
+var _ = Describe("Server", func() {
+	var tempDir string
+	var s Server
+	var appConfig *config.AppConfig
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "server-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		appConfig = &config.AppConfig{
+			Workdir:              tempDir,
+			InspectionOutputFile: filepath.Join(tempDir, "inspection.xml"),
+		}
+		s = Server{AppConfig: appConfig}
+
+		// Reset warnings before each test
+		warnings = nil
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	Describe("vmHandler", func() {
+		It("returns YAML content when file exists", func() {
+			yamlContent := `apiVersion: v1
+kind: VirtualMachine
+metadata:
+  name: test-vm`
+			err := os.WriteFile(filepath.Join(tempDir, "vm.yaml"), []byte(yamlContent), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/vm", nil)
+			w := httptest.NewRecorder()
+
+			s.vmHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Header().Get("Content-Type")).To(Equal("text/yaml"))
+			Expect(w.Body.String()).To(Equal(yamlContent))
+		})
+
+		It("returns 204 No Content for in-place conversion without YAML", func() {
+			appConfig.IsInPlace = true
+
+			req := httptest.NewRequest(http.MethodGet, "/vm", nil)
+			w := httptest.NewRecorder()
+
+			s.vmHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNoContent))
+		})
+
+		It("returns 500 when YAML file path is empty and not in-place", func() {
+			appConfig.IsInPlace = false
+
+			req := httptest.NewRequest(http.MethodGet, "/vm", nil)
+			w := httptest.NewRecorder()
+
+			s.vmHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+
+		It("returns 500 when YAML file cannot be read", func() {
+			// Create a directory instead of a file with .yaml extension
+			yamlDir := filepath.Join(tempDir, "invalid.yaml")
+			err := os.Mkdir(yamlDir, 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a valid YAML file so getVmYamlFile finds something
+			err = os.WriteFile(filepath.Join(tempDir, "vm.yaml"), []byte("content"), 0000)
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/vm", nil)
+			w := httptest.NewRecorder()
+
+			s.vmHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("inspectorHandler", func() {
+		It("returns XML content when inspection file exists", func() {
+			xmlContent := `<?xml version="1.0"?>
+<v2v>
+  <operatingsystem>
+    <name>Fedora</name>
+  </operatingsystem>
+</v2v>`
+			err := os.WriteFile(appConfig.InspectionOutputFile, []byte(xmlContent), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/inspection", nil)
+			w := httptest.NewRecorder()
+
+			s.inspectorHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Header().Get("Content-Type")).To(Equal("application/xml"))
+			Expect(w.Body.String()).To(Equal(xmlContent))
+		})
+
+		It("returns 500 when inspection file does not exist", func() {
+			req := httptest.NewRequest(http.MethodGet, "/inspection", nil)
+			w := httptest.NewRecorder()
+
+			s.inspectorHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("warningsHandler", func() {
+		It("returns 204 when no warnings", func() {
+			req := httptest.NewRequest(http.MethodGet, "/warnings", nil)
+			w := httptest.NewRecorder()
+
+			s.warningsHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNoContent))
+			Expect(w.Header().Get("Content-Type")).To(Equal("application/json"))
+		})
+
+		It("returns JSON warnings when warnings exist", func() {
+			AddWarning(Warning{
+				Reason:  "TestReason",
+				Message: "Test message",
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/warnings", nil)
+			w := httptest.NewRecorder()
+
+			s.warningsHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Header().Get("Content-Type")).To(Equal("application/json"))
+			Expect(w.Body.String()).To(ContainSubstring("TestReason"))
+			Expect(w.Body.String()).To(ContainSubstring("Test message"))
+		})
+
+		It("returns multiple warnings", func() {
+			AddWarning(Warning{Reason: "Reason1", Message: "Message1"})
+			AddWarning(Warning{Reason: "Reason2", Message: "Message2"})
+
+			req := httptest.NewRequest(http.MethodGet, "/warnings", nil)
+			w := httptest.NewRecorder()
+
+			s.warningsHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Body.String()).To(ContainSubstring("Reason1"))
+			Expect(w.Body.String()).To(ContainSubstring("Reason2"))
+		})
+	})
+
+	Describe("shutdownHandler", func() {
+		It("returns 204 No Content", func() {
+			// Create a test server to avoid nil pointer
+			server = &http.Server{}
+
+			req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+			w := httptest.NewRecorder()
+
+			s.shutdownHandler(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNoContent))
+		})
+	})
+
+	Describe("getVmYamlFile", func() {
+		It("returns first YAML file in directory", func() {
+			err := os.WriteFile(filepath.Join(tempDir, "vm.yaml"), []byte("content"), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := s.getVmYamlFile(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(filepath.Join(tempDir, "vm.yaml")))
+		})
+
+		It("returns error when no YAML files exist", func() {
+			result, err := s.getVmYamlFile(tempDir)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("returns first file when multiple YAML files exist", func() {
+			err := os.WriteFile(filepath.Join(tempDir, "a.yaml"), []byte("content"), 0644)
+			Expect(err).ToNot(HaveOccurred())
+			err = os.WriteFile(filepath.Join(tempDir, "b.yaml"), []byte("content"), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := s.getVmYamlFile(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeEmpty())
+		})
+
+		It("ignores non-YAML files", func() {
+			err := os.WriteFile(filepath.Join(tempDir, "readme.txt"), []byte("content"), 0644)
+			Expect(err).ToNot(HaveOccurred())
+			err = os.WriteFile(filepath.Join(tempDir, "config.json"), []byte("{}"), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := s.getVmYamlFile(tempDir)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+	})
+
+	Describe("AddWarning", func() {
+		It("adds warning to global warnings slice", func() {
+			warnings = nil // Reset
+			AddWarning(Warning{Reason: "Test", Message: "Test message"})
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0].Reason).To(Equal("Test"))
+		})
+
+		It("appends multiple warnings", func() {
+			warnings = nil // Reset
+			AddWarning(Warning{Reason: "Test1", Message: "Message1"})
+			AddWarning(Warning{Reason: "Test2", Message: "Message2"})
+			Expect(warnings).To(HaveLen(2))
+		})
+	})
+})

--- a/pkg/virt-v2v/utils/command_test.go
+++ b/pkg/virt-v2v/utils/command_test.go
@@ -1,0 +1,294 @@
+// Generated-by: Claude
+package utils
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Command", func() {
+	Describe("CommandBuilderImpl", func() {
+		var builder *CommandBuilderImpl
+
+		BeforeEach(func() {
+			builder = &CommandBuilderImpl{}
+		})
+
+		Describe("New", func() {
+			It("initializes builder with command name", func() {
+				result := builder.New("virt-customize")
+				Expect(builder.BaseCommand).To(Equal("virt-customize"))
+				Expect(builder.Args).To(BeEmpty())
+				Expect(result).To(Equal(builder))
+			})
+
+			It("resets args when called again", func() {
+				builder.New("first-command")
+				builder.AddFlag("--flag")
+
+				builder.New("second-command")
+				Expect(builder.BaseCommand).To(Equal("second-command"))
+				Expect(builder.Args).To(BeEmpty())
+			})
+		})
+
+		Describe("AddArg", func() {
+			It("adds flag and value to args", func() {
+				builder.New("cmd")
+				result := builder.AddArg("--output", "/tmp/out")
+				Expect(builder.Args).To(Equal([]string{"--output", "/tmp/out"}))
+				Expect(result).To(Equal(builder))
+			})
+
+			It("skips adding when value is empty", func() {
+				builder.New("cmd")
+				builder.AddArg("--output", "")
+				Expect(builder.Args).To(BeEmpty())
+			})
+
+			It("chains multiple AddArg calls", func() {
+				builder.New("cmd")
+				builder.AddArg("--input", "/in").AddArg("--output", "/out")
+				Expect(builder.Args).To(Equal([]string{"--input", "/in", "--output", "/out"}))
+			})
+		})
+
+		Describe("AddArgs", func() {
+			It("adds flag with multiple values", func() {
+				builder.New("cmd")
+				result := builder.AddArgs("--key", "value1", "value2", "value3")
+				Expect(builder.Args).To(Equal([]string{"--key", "value1", "--key", "value2", "--key", "value3"}))
+				Expect(result).To(Equal(builder))
+			})
+
+			It("skips empty values", func() {
+				builder.New("cmd")
+				builder.AddArgs("--key", "value1", "", "value3")
+				Expect(builder.Args).To(Equal([]string{"--key", "value1", "--key", "value3"}))
+			})
+
+			It("handles single value", func() {
+				builder.New("cmd")
+				builder.AddArgs("--key", "single")
+				Expect(builder.Args).To(Equal([]string{"--key", "single"}))
+			})
+
+			It("handles no values", func() {
+				builder.New("cmd")
+				builder.AddArgs("--key")
+				Expect(builder.Args).To(BeEmpty())
+			})
+		})
+
+		Describe("AddFlag", func() {
+			It("adds flag without value", func() {
+				builder.New("cmd")
+				result := builder.AddFlag("--verbose")
+				Expect(builder.Args).To(Equal([]string{"--verbose"}))
+				Expect(result).To(Equal(builder))
+			})
+
+			It("chains multiple flags", func() {
+				builder.New("cmd")
+				builder.AddFlag("-v").AddFlag("-x").AddFlag("--debug")
+				Expect(builder.Args).To(Equal([]string{"-v", "-x", "--debug"}))
+			})
+		})
+
+		Describe("AddPositional", func() {
+			It("adds positional argument", func() {
+				builder.New("cmd")
+				result := builder.AddPositional("/path/to/file")
+				Expect(builder.Args).To(Equal([]string{"/path/to/file"}))
+				Expect(result).To(Equal(builder))
+			})
+
+			It("skips empty positional", func() {
+				builder.New("cmd")
+				builder.AddPositional("")
+				Expect(builder.Args).To(BeEmpty())
+			})
+
+			It("adds multiple positionals", func() {
+				builder.New("cmd")
+				builder.AddPositional("--").AddPositional("vm-name")
+				Expect(builder.Args).To(Equal([]string{"--", "vm-name"}))
+			})
+		})
+
+		Describe("AddExtraArgs", func() {
+			It("adds extra arguments as-is", func() {
+				builder.New("cmd")
+				result := builder.AddExtraArgs("--custom", "value", "--another")
+				Expect(builder.Args).To(Equal([]string{"--custom", "value", "--another"}))
+				Expect(result).To(Equal(builder))
+			})
+
+			It("handles no extra args", func() {
+				builder.New("cmd")
+				builder.AddExtraArgs()
+				Expect(builder.Args).To(BeEmpty())
+			})
+		})
+
+		Describe("Build", func() {
+			It("creates CommandExecutor", func() {
+				builder.New("echo")
+				builder.AddPositional("hello")
+
+				executor := builder.Build()
+				Expect(executor).ToNot(BeNil())
+			})
+		})
+
+		Describe("Full command building scenario", func() {
+			It("builds complete virt-customize command", func() {
+				builder.New("virt-customize")
+				builder.AddFlag("--verbose").
+					AddFlag("-x").
+					AddArg("--format", "raw").
+					AddArg("--add", "/var/tmp/v2v/disk1").
+					AddArg("--add", "/var/tmp/v2v/disk2").
+					AddArg("--run", "/tmp/script.sh").
+					AddArg("--firstboot", "/tmp/firstboot.sh")
+
+				Expect(builder.BaseCommand).To(Equal("virt-customize"))
+				Expect(builder.Args).To(Equal([]string{
+					"--verbose",
+					"-x",
+					"--format", "raw",
+					"--add", "/var/tmp/v2v/disk1",
+					"--add", "/var/tmp/v2v/disk2",
+					"--run", "/tmp/script.sh",
+					"--firstboot", "/tmp/firstboot.sh",
+				}))
+			})
+
+			It("builds complete virt-v2v command", func() {
+				builder.New("virt-v2v")
+				builder.AddFlag("-v").
+					AddFlag("-x").
+					AddArg("-o", "kubevirt").
+					AddArg("-os", "/var/tmp/v2v").
+					AddArg("-on", "new-vm-name").
+					AddArg("-i", "libvirt").
+					AddArg("-ic", "vpx://user@vcenter/Datacenter/host/esxi").
+					AddPositional("--").
+					AddPositional("original-vm-name")
+
+				Expect(builder.BaseCommand).To(Equal("virt-v2v"))
+				Expect(builder.Args).To(Equal([]string{
+					"-v",
+					"-x",
+					"-o", "kubevirt",
+					"-os", "/var/tmp/v2v",
+					"-on", "new-vm-name",
+					"-i", "libvirt",
+					"-ic", "vpx://user@vcenter/Datacenter/host/esxi",
+					"--",
+					"original-vm-name",
+				}))
+			})
+		})
+	})
+
+	Describe("Command", func() {
+		Describe("SetStdout", func() {
+			It("sets stdout writer", func() {
+				builder := &CommandBuilderImpl{}
+				builder.New("echo")
+				builder.AddPositional("test")
+
+				cmd := builder.Build().(*Command)
+				var buf bytes.Buffer
+				cmd.SetStdout(&buf)
+
+				Expect(cmd.cmd.Stdout).To(Equal(&buf))
+			})
+		})
+
+		Describe("SetStderr", func() {
+			It("sets stderr writer", func() {
+				builder := &CommandBuilderImpl{}
+				builder.New("echo")
+				builder.AddPositional("test")
+
+				cmd := builder.Build().(*Command)
+				var buf bytes.Buffer
+				cmd.SetStderr(&buf)
+
+				Expect(cmd.cmd.Stderr).To(Equal(&buf))
+			})
+		})
+
+		Describe("SetStdin", func() {
+			It("sets stdin reader", func() {
+				builder := &CommandBuilderImpl{}
+				builder.New("cat")
+
+				cmd := builder.Build().(*Command)
+				var buf bytes.Buffer
+				cmd.SetStdin(&buf)
+
+				Expect(cmd.cmd.Stdin).To(Equal(&buf))
+			})
+		})
+
+		Describe("Run", func() {
+			It("executes command successfully", func() {
+				builder := &CommandBuilderImpl{}
+				builder.New("true") // Command that always succeeds
+
+				cmd := builder.Build()
+				err := cmd.Run()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns error for failed command", func() {
+				builder := &CommandBuilderImpl{}
+				builder.New("false") // Command that always fails
+
+				cmd := builder.Build()
+				err := cmd.Run()
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("returns error for non-existent command", func() {
+				builder := &CommandBuilderImpl{}
+				builder.New("nonexistent-command-12345")
+
+				cmd := builder.Build()
+				err := cmd.Run()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Start and Wait", func() {
+			It("starts and waits for command", func() {
+				builder := &CommandBuilderImpl{}
+				builder.New("true")
+
+				cmd := builder.Build()
+				err := cmd.Start()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = cmd.Wait()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns error for failed command on wait", func() {
+				builder := &CommandBuilderImpl{}
+				builder.New("false")
+
+				cmd := builder.Build()
+				err := cmd.Start()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = cmd.Wait()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/virt-v2v/utils/filesystem_test.go
+++ b/pkg/virt-v2v/utils/filesystem_test.go
@@ -1,0 +1,220 @@
+// Generated-by: Claude
+package utils
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FileSystem", func() {
+	var tempDir string
+	var fs FileSystemImpl
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "filesystem-test")
+		Expect(err).ToNot(HaveOccurred())
+		fs = FileSystemImpl{}
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	Describe("FileSystemImpl", func() {
+		Describe("Symlink", func() {
+			It("creates symlink successfully", func() {
+				// Create a real file first
+				realFile := filepath.Join(tempDir, "realfile.txt")
+				err := os.WriteFile(realFile, []byte("content"), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				linkPath := filepath.Join(tempDir, "link.txt")
+				err = fs.Symlink(realFile, linkPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify symlink exists and points to correct file
+				target, err := os.Readlink(linkPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(target).To(Equal(realFile))
+			})
+
+			It("returns error when link already exists", func() {
+				realFile := filepath.Join(tempDir, "realfile.txt")
+				err := os.WriteFile(realFile, []byte("content"), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				linkPath := filepath.Join(tempDir, "link.txt")
+				err = fs.Symlink(realFile, linkPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Try to create same link again
+				err = fs.Symlink(realFile, linkPath)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("returns error for invalid destination directory", func() {
+				linkPath := filepath.Join(tempDir, "nonexistent", "link.txt")
+				err := fs.Symlink("/some/file", linkPath)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Stat", func() {
+			It("returns file info for existing file", func() {
+				filePath := filepath.Join(tempDir, "testfile.txt")
+				err := os.WriteFile(filePath, []byte("content"), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				info, err := fs.Stat(filePath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(info.Name()).To(Equal("testfile.txt"))
+				Expect(info.IsDir()).To(BeFalse())
+			})
+
+			It("returns file info for existing directory", func() {
+				dirPath := filepath.Join(tempDir, "testdir")
+				err := os.Mkdir(dirPath, 0755)
+				Expect(err).ToNot(HaveOccurred())
+
+				info, err := fs.Stat(dirPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(info.Name()).To(Equal("testdir"))
+				Expect(info.IsDir()).To(BeTrue())
+			})
+
+			It("returns error for non-existent path", func() {
+				_, err := fs.Stat(filepath.Join(tempDir, "nonexistent"))
+				Expect(err).To(HaveOccurred())
+				Expect(os.IsNotExist(err)).To(BeTrue())
+			})
+		})
+
+		Describe("WriteFile", func() {
+			It("writes file successfully", func() {
+				filePath := filepath.Join(tempDir, "newfile.txt")
+				content := []byte("test content")
+
+				err := fs.WriteFile(filePath, content, 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify content
+				readContent, err := os.ReadFile(filePath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(readContent).To(Equal(content))
+			})
+
+			It("overwrites existing file", func() {
+				filePath := filepath.Join(tempDir, "existing.txt")
+				err := os.WriteFile(filePath, []byte("old content"), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				newContent := []byte("new content")
+				err = fs.WriteFile(filePath, newContent, 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				readContent, err := os.ReadFile(filePath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(readContent).To(Equal(newContent))
+			})
+
+			It("returns error for invalid path", func() {
+				filePath := filepath.Join(tempDir, "nonexistent", "file.txt")
+				err := fs.WriteFile(filePath, []byte("content"), 0644)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("writes executable file with correct permissions", func() {
+				filePath := filepath.Join(tempDir, "script.sh")
+				content := []byte("#!/bin/bash\necho hello")
+
+				err := fs.WriteFile(filePath, content, 0755)
+				Expect(err).ToNot(HaveOccurred())
+
+				info, err := os.Stat(filePath)
+				Expect(err).ToNot(HaveOccurred())
+				// Check executable bit is set
+				Expect(info.Mode().Perm() & 0100).To(Equal(os.FileMode(0100)))
+			})
+		})
+
+		Describe("ReadDir", func() {
+			It("reads directory contents", func() {
+				// Create some files
+				err := os.WriteFile(filepath.Join(tempDir, "file1.txt"), []byte("1"), 0644)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(filepath.Join(tempDir, "file2.txt"), []byte("2"), 0644)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.Mkdir(filepath.Join(tempDir, "subdir"), 0755)
+				Expect(err).ToNot(HaveOccurred())
+
+				entries, err := fs.ReadDir(tempDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(HaveLen(3))
+
+				names := make([]string, len(entries))
+				for i, e := range entries {
+					names[i] = e.Name()
+				}
+				Expect(names).To(ContainElements("file1.txt", "file2.txt", "subdir"))
+			})
+
+			It("returns empty slice for empty directory", func() {
+				emptyDir := filepath.Join(tempDir, "empty")
+				err := os.Mkdir(emptyDir, 0755)
+				Expect(err).ToNot(HaveOccurred())
+
+				entries, err := fs.ReadDir(emptyDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(BeEmpty())
+			})
+
+			It("returns error for non-existent directory", func() {
+				_, err := fs.ReadDir(filepath.Join(tempDir, "nonexistent"))
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("returns error when reading a file instead of directory", func() {
+				filePath := filepath.Join(tempDir, "file.txt")
+				err := os.WriteFile(filePath, []byte("content"), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = fs.ReadDir(filePath)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("ConvertMockDirEntryToOs", func() {
+		It("converts mock entries to os.DirEntry slice", func() {
+			mockEntries := []MockDirEntry{
+				{FileName: "file1.txt", FileIsDir: false},
+				{FileName: "dir1", FileIsDir: true},
+				{FileName: "file2.txt", FileIsDir: false},
+			}
+
+			osEntries := ConvertMockDirEntryToOs(mockEntries)
+			Expect(osEntries).To(HaveLen(3))
+
+			Expect(osEntries[0].Name()).To(Equal("file1.txt"))
+			Expect(osEntries[0].IsDir()).To(BeFalse())
+			Expect(osEntries[1].Name()).To(Equal("dir1"))
+			Expect(osEntries[1].IsDir()).To(BeTrue())
+			Expect(osEntries[2].Name()).To(Equal("file2.txt"))
+			Expect(osEntries[2].IsDir()).To(BeFalse())
+		})
+
+		It("returns empty slice for empty input", func() {
+			osEntries := ConvertMockDirEntryToOs([]MockDirEntry{})
+			Expect(osEntries).To(BeEmpty())
+		})
+
+		It("returns nil for nil input", func() {
+			osEntries := ConvertMockDirEntryToOs(nil)
+			Expect(osEntries).To(BeNil())
+		})
+	})
+})

--- a/pkg/virt-v2v/utils/utils_test.go
+++ b/pkg/virt-v2v/utils/utils_test.go
@@ -1,0 +1,186 @@
+// Generated-by: Claude
+package utils
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils test suite")
+}
+
+var _ = Describe("Utils", func() {
+	var mockCtrl *gomock.Controller
+	var mockFileSystem *MockFileSystem
+	var mockCommandBuilder *MockCommandBuilder
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockFileSystem = NewMockFileSystem(mockCtrl)
+		mockCommandBuilder = NewMockCommandBuilder(mockCtrl)
+	})
+
+	Describe("AddLUKSKeys", func() {
+		It("adds LUKS keys when directory exists and has files", func() {
+			luksDir := "/etc/luks"
+			files := ConvertMockDirEntryToOs([]MockDirEntry{
+				{FileName: "key1", FileIsDir: false},
+				{FileName: "key2", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(luksDir).Return(files, nil)
+			mockCommandBuilder.EXPECT().AddArgs("--key", "all:file:/etc/luks/key1", "all:file:/etc/luks/key2").Return(mockCommandBuilder)
+
+			err := AddLUKSKeys(mockFileSystem, mockCommandBuilder, luksDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("skips directories in LUKS directory", func() {
+			luksDir := "/etc/luks"
+			files := ConvertMockDirEntryToOs([]MockDirEntry{
+				{FileName: "key1", FileIsDir: false},
+				{FileName: "subdir", FileIsDir: true},
+			})
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(luksDir).Return(files, nil)
+			mockCommandBuilder.EXPECT().AddArgs("--key", "all:file:/etc/luks/key1").Return(mockCommandBuilder)
+
+			err := AddLUKSKeys(mockFileSystem, mockCommandBuilder, luksDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("skips files starting with ..", func() {
+			luksDir := "/etc/luks"
+			files := ConvertMockDirEntryToOs([]MockDirEntry{
+				{FileName: "key1", FileIsDir: false},
+				{FileName: "..hidden", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(luksDir).Return(files, nil)
+			mockCommandBuilder.EXPECT().AddArgs("--key", "all:file:/etc/luks/key1").Return(mockCommandBuilder)
+
+			err := AddLUKSKeys(mockFileSystem, mockCommandBuilder, luksDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("does nothing when directory does not exist", func() {
+			luksDir := "/etc/luks"
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, os.ErrNotExist)
+			// No AddArgs call expected
+
+			err := AddLUKSKeys(mockFileSystem, mockCommandBuilder, luksDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when stat returns non-existence error", func() {
+			luksDir := "/etc/luks"
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, errors.New("permission denied"))
+
+			err := AddLUKSKeys(mockFileSystem, mockCommandBuilder, luksDir)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error accessing the LUKS directory"))
+		})
+
+		It("returns error when ReadDir fails", func() {
+			luksDir := "/etc/luks"
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(luksDir).Return(nil, errors.New("read error"))
+
+			err := AddLUKSKeys(mockFileSystem, mockCommandBuilder, luksDir)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error reading files in LUKS directory"))
+		})
+
+		It("handles empty directory", func() {
+			luksDir := "/etc/luks"
+
+			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
+			mockFileSystem.EXPECT().ReadDir(luksDir).Return([]os.DirEntry{}, nil)
+			mockCommandBuilder.EXPECT().AddArgs("--key").Return(mockCommandBuilder)
+
+			err := AddLUKSKeys(mockFileSystem, mockCommandBuilder, luksDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("GetFilesInPath", func() {
+		It("returns file paths from directory", func() {
+			rootPath := "/test/path"
+			files := ConvertMockDirEntryToOs([]MockDirEntry{
+				{FileName: "file1.txt", FileIsDir: false},
+				{FileName: "file2.txt", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(rootPath).Return(files, nil)
+
+			paths, err := GetFilesInPath(mockFileSystem, rootPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(paths).To(HaveLen(2))
+			Expect(paths).To(ContainElement("/test/path/file1.txt"))
+			Expect(paths).To(ContainElement("/test/path/file2.txt"))
+		})
+
+		It("skips directories", func() {
+			rootPath := "/test/path"
+			files := ConvertMockDirEntryToOs([]MockDirEntry{
+				{FileName: "file1.txt", FileIsDir: false},
+				{FileName: "subdir", FileIsDir: true},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(rootPath).Return(files, nil)
+
+			paths, err := GetFilesInPath(mockFileSystem, rootPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(paths).To(HaveLen(1))
+			Expect(paths).To(ContainElement("/test/path/file1.txt"))
+		})
+
+		It("skips files starting with ..", func() {
+			rootPath := "/test/path"
+			files := ConvertMockDirEntryToOs([]MockDirEntry{
+				{FileName: "file1.txt", FileIsDir: false},
+				{FileName: "..data", FileIsDir: false},
+			})
+
+			mockFileSystem.EXPECT().ReadDir(rootPath).Return(files, nil)
+
+			paths, err := GetFilesInPath(mockFileSystem, rootPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(paths).To(HaveLen(1))
+			Expect(paths).To(ContainElement("/test/path/file1.txt"))
+		})
+
+		It("returns error when ReadDir fails", func() {
+			rootPath := "/test/path"
+
+			mockFileSystem.EXPECT().ReadDir(rootPath).Return(nil, errors.New("read error"))
+
+			paths, err := GetFilesInPath(mockFileSystem, rootPath)
+			Expect(err).To(HaveOccurred())
+			Expect(paths).To(BeNil())
+		})
+
+		It("returns empty slice for empty directory", func() {
+			rootPath := "/test/path"
+
+			mockFileSystem.EXPECT().ReadDir(rootPath).Return([]os.DirEntry{}, nil)
+
+			paths, err := GetFilesInPath(mockFileSystem, rootPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(paths).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/virt-v2v/utils/xml_reader_test.go
+++ b/pkg/virt-v2v/utils/xml_reader_test.go
@@ -1,0 +1,124 @@
+// Generated-by: Claude
+package utils
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("XML Reader", func() {
+	var tempDir string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "xml-reader-test")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	Describe("GetInspectionV2vFromFile", func() {
+		It("parses valid XML file correctly", func() {
+			xmlContent := `<?xml version="1.0" encoding="UTF-8"?>
+<v2v>
+  <operatingsystem>
+    <name>Fedora Linux</name>
+    <distro>fedora</distro>
+    <osinfo>linux</osinfo>
+    <arch>x86_64</arch>
+  </operatingsystem>
+</v2v>`
+			xmlPath := filepath.Join(tempDir, "inspection.xml")
+			err := os.WriteFile(xmlPath, []byte(xmlContent), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := GetInspectionV2vFromFile(xmlPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.OS.Name).To(Equal("Fedora Linux"))
+			Expect(result.OS.Distro).To(Equal("fedora"))
+			Expect(result.OS.Osinfo).To(Equal("linux"))
+			Expect(result.OS.Arch).To(Equal("x86_64"))
+		})
+
+		It("parses Windows OS info correctly", func() {
+			xmlContent := `<?xml version="1.0" encoding="UTF-8"?>
+<v2v>
+  <operatingsystem>
+    <name>Windows 10</name>
+    <distro>windows</distro>
+    <osinfo>win10</osinfo>
+    <arch>x86_64</arch>
+  </operatingsystem>
+</v2v>`
+			xmlPath := filepath.Join(tempDir, "inspection.xml")
+			err := os.WriteFile(xmlPath, []byte(xmlContent), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := GetInspectionV2vFromFile(xmlPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.OS.Name).To(Equal("Windows 10"))
+			Expect(result.OS.Osinfo).To(Equal("win10"))
+		})
+
+		It("returns error for non-existent file", func() {
+			result, err := GetInspectionV2vFromFile("/non/existent/file.xml")
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+
+		It("returns error for invalid XML", func() {
+			xmlContent := `<?xml version="1.0" encoding="UTF-8"?>
+<v2v>
+  <operatingsystem>
+    <name>Incomplete XML`
+			xmlPath := filepath.Join(tempDir, "invalid.xml")
+			err := os.WriteFile(xmlPath, []byte(xmlContent), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := GetInspectionV2vFromFile(xmlPath)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+
+		It("handles empty operatingsystem section", func() {
+			xmlContent := `<?xml version="1.0" encoding="UTF-8"?>
+<v2v>
+  <operatingsystem>
+  </operatingsystem>
+</v2v>`
+			xmlPath := filepath.Join(tempDir, "empty.xml")
+			err := os.WriteFile(xmlPath, []byte(xmlContent), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := GetInspectionV2vFromFile(xmlPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.OS.Name).To(BeEmpty())
+			Expect(result.OS.Distro).To(BeEmpty())
+		})
+	})
+
+	Describe("InspectionOS.IsWindows", func() {
+		DescribeTable("correctly identifies Windows OS",
+			func(osinfo string, expected bool) {
+				os := InspectionOS{Osinfo: osinfo}
+				Expect(os.IsWindows()).To(Equal(expected))
+			},
+			Entry("win10", "win10", true),
+			Entry("win2k19", "win2k19", true),
+			Entry("Windows Server 2019", "Windows Server 2019", true),
+			Entry("WIN2K22", "WIN2K22", true),
+			Entry("linux", "linux", false),
+			Entry("fedora", "fedora", false),
+			Entry("rhel8", "rhel8", false),
+			Entry("ubuntu", "ubuntu", false),
+			Entry("empty string", "", false),
+			Entry("centos", "centos", false),
+			Entry("freebsd", "freebsd", false),
+		)
+	})
+})


### PR DESCRIPTION
Assisted-by: Claude

Before the changes:
```
ok  	github.com/kubev2v/forklift/pkg/virt-v2v/conversion	0.012s	coverage: 19.1% of statements
ok  	github.com/kubev2v/forklift/pkg/virt-v2v/customize	(cached)	coverage: 21.4% of statements
	github.com/kubev2v/forklift/pkg/virt-v2v/server		coverage: 0.0% of statements
	github.com/kubev2v/forklift/pkg/virt-v2v/utils		coverage: 0.0% of statements
````

After adding the uinit tests:
```
ok  	github.com/kubev2v/forklift/pkg/virt-v2v/conversion	(cached)	coverage: 41.1% of statements
ok  	github.com/kubev2v/forklift/pkg/virt-v2v/customize	0.019s	coverage: 60.7% of statements
ok  	github.com/kubev2v/forklift/pkg/virt-v2v/server	(cached)	coverage: 67.7% of statements
ok  	github.com/kubev2v/forklift/pkg/virt-v2v/utils	(cached)	coverage: 55.0% of statements
```