### PR TITLE
chore(pr-4509-typo): fix error variable and remove debug print

### DIFF
--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -218,7 +218,7 @@ func (r *Migration) Load() (err error) {
 		if encoded, jsonErr := json.Marshal(strings.Fields(val)); jsonErr == nil {
 			r.VirtV2vExtraArgs = string(encoded)
 		} else {
-			return liberr.Wrap(err)
+			return liberr.Wrap(jsonErr)
 		}
 	}
 	r.VirtV2vInspectorExtraArgs = "[]"

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -164,7 +164,6 @@ func (s *AppConfig) getInspectorExtraArgs() []string {
 	var extraArgs []string
 	if envExtraArgs, found := os.LookupEnv(EnvInspectorExtraArgsName); found && envExtraArgs != "" {
 		if err := json.Unmarshal([]byte(envExtraArgs), &extraArgs); err != nil {
-			fmt.Printf("Failed to parse %s: %v\n", EnvInspectorExtraArgsName, err)
 			return nil
 		}
 	}


### PR DESCRIPTION
- Fix wrong error variable in migration.go: return jsonErr instead of err
- Remove debug fmt.Printf statement from variables.go

Ref: https://issues.redhat.com/browse/MTV-4454

Resolves: MTV-4454