### PR TITLE
MTV-4517 | standardise version embedding using git-describe

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 # Ignore Git files
-.git
 .github/
 
 # Ignore all test-related files

--- a/cmd/vsphere-xcopy-volume-populator/Makefile
+++ b/cmd/vsphere-xcopy-volume-populator/Makefile
@@ -3,6 +3,10 @@
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# The build version which relies on release engineering setting tags that starts with 'v' like v2.10.4
+VERSION := $(shell git describe --always --tags --match 'v*' 2>/dev/null || echo "v0.0.0-dev")
+SCRIPT_VERSION := $(shell sh vmkfstools-wrapper/vmkfstools_wrapper.sh --version --output simple)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -33,19 +37,23 @@ test: fmt vet
 generate:
 	GOFLAGS="-mod=mod" go generate ./...
 
+LDFLAGS := -w -s \
+		   -X 'github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/version.Version=$(VERSION)' \
+		   -X 'github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/version.VibVersion=$(VIB_VERSION)' \
+		   -X 'github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper.Version=$(SCRIPT_VERSION)'
 .PHONY: build
 build: fmt vet
 	$(eval SCRIPT_VERSION := $(shell sh vmkfstools-wrapper/vmkfstools_wrapper.sh --version --output simple))
 	PATH="$(PATH)" \
 	go build \
-	-ldflags="-w -s -X github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/populator.VibVersion=$(VIB_VERSION) -X github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper.Version=$(SCRIPT_VERSION)" \
-	-o bin/vsphere-xcopy-volume-populator \
-	vsphere-xcopy-volume-populator.go
+	    -ldflags="$(LDFLAGS)" \
+	    -o bin/vsphere-xcopy-volume-populator \
+	    vsphere-xcopy-volume-populator.go
 	PATH="$(PATH)" \
-	go build \
-	-ldflags="-w -s" \
-	-o bin/vib-installer \
-	cmd/vib-installer.go
+	    go build \
+	    -ldflags="-w -s" \
+	    -o bin/vib-installer \
+	    cmd/vib-installer.go
 
 MOCKGEN := $(shell which mockgen 2>/dev/null)
 install-mockgen:

--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/remote_esxcli.go
@@ -9,7 +9,8 @@ import (
 	"strings"
 	"time"
 
-	version "github.com/hashicorp/go-version"
+	hversion "github.com/hashicorp/go-version"
+	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/version"
 	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/vmware"
 	vmkfstoolswrapper "github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper"
 	"github.com/kubev2v/forklift/pkg/lib/util"
@@ -126,7 +127,7 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv 
 
 	// Only ensure VIB if using VIB method
 	if !p.UseSSHMethod {
-		err = ensureVib(p.VSphereClient, host, vmDisk.Datastore, VibVersion)
+		err = ensureVib(p.VSphereClient, host, vmDisk.Datastore, version.VibVersion)
 		if err != nil {
 			return fmt.Errorf("failed to ensure VIB is installed: %w", err)
 		}
@@ -521,12 +522,12 @@ func checkScriptVersion(sshClient vmware.SSHClient, datastore, embeddedVersion s
 		return fmt.Errorf("failed to parse version JSON: %w", err)
 	}
 
-	scriptVer, err := version.NewVersion(versionInfo.Version)
+	scriptVer, err := hversion.NewVersion(versionInfo.Version)
 	if err != nil {
 		return fmt.Errorf("invalid script version format %s: %w", versionInfo.Version, err)
 	}
 
-	embeddedVer, err := version.NewVersion(embeddedVersion)
+	embeddedVer, err := hversion.NewVersion(embeddedVersion)
 	if err != nil {
 		return fmt.Errorf("invalid embedded version format %s: %w", embeddedVersion, err)
 	}

--- a/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/populator/vib.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/version"
 	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/vmware"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -18,13 +19,10 @@ const (
 	vibLocation = "/bin/vmkfstools-wrapper.vib"
 )
 
-// VibVersion is set by ldflags
-var VibVersion = "x.x.x"
-
 // ensure vib will fetch the vib version and in case needed will install it
 // on the target ESX
 func ensureVib(client vmware.Client, esx *object.HostSystem, datastore string, desiredVibVersion string) error {
-	klog.Infof("ensuring vib version on ESXi %s: %s", esx.Name(), VibVersion)
+	klog.Infof("ensuring vib version on ESXi %s: %s", esx.Name(), version.VibVersion)
 
 	version, err := getViBVersion(client, esx)
 	if err != nil {
@@ -50,7 +48,7 @@ func ensureVib(client vmware.Client, esx *object.HostSystem, datastore string, d
 	if err != nil {
 		return fmt.Errorf("failed to install the VIB on ESXi %s: %w", esx.Name(), err)
 	}
-	klog.Infof("installed vib on ESXi %s version %s", esx.Name(), VibVersion)
+	klog.Infof("installed vib on ESXi %s version %s", esx.Name(), version)
 	return nil
 }
 

--- a/cmd/vsphere-xcopy-volume-populator/internal/version/version.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/version/version.go
@@ -1,0 +1,20 @@
+package version
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	vmkfstoolswrapper "github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/vmkfstools-wrapper"
+)
+
+// Version of the binary, set by the build process using ldflags
+var Version = "0.0.0"
+
+// Version of the VIB, set by the build process using ldflags
+var VibVersion = "0.0.0"
+
+func Get() string {
+	return fmt.Sprintf("binary=%s version=%s vib_version=%s vmkfstools_wrapper_version=%s",
+		filepath.Base(os.Args[0]), Version, VibVersion, vmkfstoolswrapper.Version)
+}

--- a/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator.go
+++ b/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/primera3par"
 	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/pure"
 	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/vantara"
+	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/version"
 
 	forklift "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,8 +37,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )
-
-var version = "unknown"
 
 var (
 	crName                     string
@@ -74,6 +73,7 @@ var (
 
 func main() {
 	handleArgs()
+	klog.Info(version.Get())
 
 	var storageApi populator.StorageApi
 	product := forklift.StorageVendorProduct(storageVendor)
@@ -310,8 +310,7 @@ func handleArgs() {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Println(os.Args[0], version)
-		fmt.Printf("VIB version: %s\n", populator.VibVersion)
+		klog.Info(version.Get())
 		os.Exit(0)
 	}
 

--- a/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/vsphere-xcopy-volume-populator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/populator"
 	populator_mocks "github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/populator/mocks"
+	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/version"
 	vmware_mocks "github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/vmware/mocks"
 	"github.com/vmware/govmomi/cli/esx"
 	"github.com/vmware/govmomi/object"
@@ -108,7 +109,7 @@ var _ = Describe("Populator", func() {
 			targetPVC:  "pvc-12345",
 			setup: func() {
 				vmwareClient.EXPECT().GetEsxByVm(context.Background(), gomock.Any()).Return(dummyHost, nil)
-				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"software", "vib", "get", "-n", "vmkfstools-wrapper"}).Return([]esx.Values{{"Version": {populator.VibVersion}}}, nil)
+				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"software", "vib", "get", "-n", "vmkfstools-wrapper"}).Return([]esx.Values{{"Version": {version.VibVersion}}}, nil)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "adapter", "list"}).Return([]esx.Values{{"HBAName": {"vmhbatest"}, "UID": {"iqn.test"}, "LinkState": {"link-up"}, "Driver": {"iscsi"}}}, nil)
 				storageClient.EXPECT().EnsureClonnerIgroup(gomock.Any(), gomock.Any()).Return(nil, nil)
 				storageClient.EXPECT().ResolvePVToLUN(populator.PersistentVolume{Name: "pvc-12345"}).Return(populator.LUN{}, fmt.Errorf("some error")).Times(1)
@@ -121,7 +122,7 @@ var _ = Describe("Populator", func() {
 			targetPVC:  "pvc-12345",
 			setup: func() {
 				vmwareClient.EXPECT().GetEsxByVm(context.Background(), gomock.Any()).Return(dummyHost, nil)
-				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"software", "vib", "get", "-n", "vmkfstools-wrapper"}).Return([]esx.Values{{"Version": {populator.VibVersion}}}, nil)
+				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"software", "vib", "get", "-n", "vmkfstools-wrapper"}).Return([]esx.Values{{"Version": {version.VibVersion}}}, nil)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "adapter", "list"}).Return([]esx.Values{{"HBAName": {"vmhbatest"}, "UID": {"iqn.test"}, "LinkState": {"link-up"}, "Driver": {"iscsi"}}}, nil)
 				storageClient.EXPECT().EnsureClonnerIgroup(gomock.Any(), gomock.Any()).Return(nil, nil)
 				storageClient.EXPECT().ResolvePVToLUN(populator.PersistentVolume{Name: "pvc-12345"}).Return(populator.LUN{NAA: "616263"}, nil)
@@ -144,7 +145,7 @@ var _ = Describe("Populator", func() {
 			targetPVC:  "pvc-12345",
 			setup: func() {
 				vmwareClient.EXPECT().GetEsxByVm(context.Background(), gomock.Any()).Return(dummyHost, nil)
-				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"software", "vib", "get", "-n", "vmkfstools-wrapper"}).Return([]esx.Values{{"Version": {populator.VibVersion}}}, nil)
+				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"software", "vib", "get", "-n", "vmkfstools-wrapper"}).Return([]esx.Values{{"Version": {version.VibVersion}}}, nil)
 				vmwareClient.EXPECT().RunEsxCommand(context.Background(), gomock.Any(), []string{"storage", "core", "adapter", "list"}).Return([]esx.Values{{"HBAName": {"vmhbatest"}, "UID": {"iqn.test"}, "LinkState": {"link-up"}, "Driver": {"iscsi"}}}, nil)
 				storageClient.EXPECT().EnsureClonnerIgroup(gomock.Any(), gomock.Any()).Return(nil, nil)
 				storageClient.EXPECT().ResolvePVToLUN(gomock.Any()).Return(populator.LUN{NAA: "naa.616263"}, nil)


### PR DESCRIPTION
Resoles: MTV-4517

By using git describe the version of the binary becomes dependant on git
as source-of-truth. When combined with tags this is how the version
string looks like when the HEAD has the tag 'v2.10.4'

    I0208 19:25:09.323603 3637005 vsphere-xcopy-volume-populator.go:313] binary=vsphere-xcopy-volume-populator version=v2.10.4 vib_version=0.3.0 vmkfstools_wrapper_version=0.3.0

If the HEAD is 2 commits above the tag v2.10.4 then version will be:
v2.10.4-2-g{GIT_COMMIT_SHA}

Signed-off-by: Roy Golan <rgolan@redhat.com>
