### PR TITLE
MTV-3645 | RFE: Allow setting transfer network to forklift controller and api pods

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -7247,6 +7247,14 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -7247,6 +7247,14 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -7247,6 +7247,14 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -87,3 +87,11 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Issue:
When "controller_transfer_network is" configured in ForkliftController, the operator fails with: "403 Forbidden: User system:serviceaccount:openshift-mtv:forklift-operator cannot get resource "network-attachment-definitions"

Fix:
Add NAD permissions to operator role for transfer network validation

Ref: https://issues.redhat.com/browse/MTV-3645