### PR TITLE
chore: Update Containerfile-downstream SHA references for 2-11

### DIFF
--- a/build/forklift-operator-bundle/Containerfile-downstream
+++ b/build/forklift-operator-bundle/Containerfile-downstream
@@ -11,33 +11,33 @@ ARG DEFAULT_CHANNEL
 ARG REGISTRY
 ARG OCP_VERSIONS
 
-ARG API_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-api-rhel9@sha256:035fed5e1cf076ffda7bc3df9a9e3e7e7aa2de97158a39a50fd91c02b1425820"
+ARG API_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-api-rhel9@sha256:00a8431b75433a1d4acdc1911e383681da751ef8cbb23a2e48b316969c739aad"
 
-ARG CONTROLLER_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-controller-rhel9@sha256:066a5e48c6dfc435547bc89684ba4e5ec72c348670b0c2d220b9ec93efc804d0"
+ARG CONTROLLER_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-controller-rhel9@sha256:2eee4dabb0a435a9663bdec6846d9bc82ef8f8ee67a65c9b43f589cd66cb969f"
 
 ARG MUST_GATHER_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8@sha256:b5572a60639fd892b6a663bee963406df49052da2e356e059feec052b2ad57db"
 
-ARG OPENSTACK_POPULATOR_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-openstack-populator-rhel9@sha256:7a778a0af3a20c78c8975c7c7627ac80b742df12522ed22b810ab68f8b09f433"
+ARG OPENSTACK_POPULATOR_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-openstack-populator-rhel9@sha256:51c3c3abb144227ab843865e41a04315c344581468ea414b78589dd2be5108ae"
 
-ARG OPERATOR_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-rhel9-operator@sha256:3200baebc99cd5d12822325c223d40e7d68caaa4c0f33c347d8d02906ee41474"
+ARG OPERATOR_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-rhel9-operator@sha256:26788cf03d74f12cfbc4d46aea7b78622e518a5f4f62b79cdf0c5785a62d3f70"
 
-ARG OVA_PROVIDER_SERVER_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-ova-provider-server-rhel9@sha256:4cef0cc8afa5f7eff29d6e3da49c51ce7f3e06a4920ada14f36e0e112569d0ce"
+ARG OVA_PROVIDER_SERVER_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-ova-provider-server-rhel9@sha256:69aad0bf11cdf1c7478d03ec2892c97bdf2c70334c5f7e7586b9c106717eff1a"
 
-ARG OVA_PROXY_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-ova-proxy-rhel9@sha256:041634cba800c7a784d9304d8e5f7f680d948486a775a409cba800e1634b5081"
+ARG OVA_PROXY_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-ova-proxy-rhel9@sha256:7e9647f2b401045932ec2bc5b40e16deb2f3216bb3ccc7d5bae66536d65569dc"
 
-ARG OVIRT_POPULATOR_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-rhv-populator-rhel8@sha256:b527b9d0ee0010cf430fa01bf09de0ac52a5ccb5b990f47fd6b6a16f4f3008f1"
+ARG OVIRT_POPULATOR_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-rhv-populator-rhel8@sha256:163a74491555ec736141b893037f0c694aee40e52d02c38e3cfefa9048f5da99"
 
-ARG POPULATOR_CONTROLLER_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-populator-controller-rhel9@sha256:d3949f7c65906ebc007642ff1bab6433c8b613ae5ee8bfc87eea54ffe0fbda66"
+ARG POPULATOR_CONTROLLER_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-populator-controller-rhel9@sha256:59ade51a0aa147edbd2243f3317aaf0a5f1e176120300b18410e944cebc1d757"
 
 ARG UI_PLUGIN_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-console-plugin-rhel9@sha256:85712a79d92f5b86f9601108125eff62ac38b573660f8ba4bbea0efdab03235e"
 
 ARG CLI_DOWNLOAD_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-cli-download-rhel9@sha256:7c6fd444a3b14555921879ec05ed508e6cd406e53cc0e77e71adbce3a6263db7"
 
-ARG VALIDATION_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-validation-rhel9@sha256:034573e2ed20d128cacac4c82971e801cbb3a312f0cabe48c40be17510f9ab39"
+ARG VALIDATION_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-validation-rhel9@sha256:45d6d9bcfebc28eb569bbdf7f547c7c9a9941ac8a0d3b2427119ecc9f2eb26fa"
 
 ARG VIRT_V2V_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel10@sha256:17dbb1c37af65e9e9ba1998addcc80754c5378ead1a54b9997fe6fe60e56c2ec"
 
-ARG VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-vsphere-xcopy-volume-populator-rhel9@sha256:d35955f88068f2f2d4d80736e6b4a87225455ccba8b4be418145072398d8a13b"
+ARG VSPHERE_XCOPY_VOLUME_POPULATOR_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-vsphere-xcopy-volume-populator-rhel9@sha256:706df6d21a792e79f3d5fe0822cdacf406b19fc13724c05d334cde8060bd2690"
 
 USER root
 


### PR DESCRIPTION
This PR updates the SHA references in Containerfile-downstream files based on the latest snapshot for version 2-11.

## Changes
- Updated SHA references in all Containerfile-downstream files
- Generated from latest snapshot: forklift-operator-2-11-20260307-101520-000

## Automated Update
This PR was created automatically by the mtv-releng update script.