### PR TITLE
[release-2.10] MTV-4686 | Add plan option to use XFS image

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -443,6 +443,10 @@ spec:
                 description: Virt-v2v conversion image used by migration pods
                 example: quay.io/kubev2v/forklift-virt-v2v:latest
                 type: string
+              virt_v2v_image_xfs_fqin:
+                description: Virt-v2v XFS conversion image used by migration pods
+                example: quay.io/kubev2v/forklift-virt-v2v-xfs:latest
+                type: string
               vsphere_osmap_configmap_name:
                 description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
                 example: custom-vsphere-osmap
@@ -4763,6 +4767,15 @@ spec:
                   Whether this is a warm migration.
                   Deprecated: this field will be deprecated in 2.10. Use Type instead.
                 type: boolean
+              xfsCompatibility:
+                default: false
+                description: |-
+                  XfsCompatibility overrides the global virt-v2v container image for this plan.
+                  When set, virt-v2v pods created by this plan will use the XFS compatible image
+                  VIRT_V2V_IMAGE_XFS instead of the cluster-wide VIRT_V2V_IMAGE setting.
+                  Use this to enable XFSv4 compatibility mode for specific plan.
+                  Warning: Enabling XFSv4 support will drop support for BTRFS for the specific plan. Ensure that the plan only selects VMs with supported filesystem.
+                type: boolean
             required:
             - map
             - provider
@@ -6891,6 +6904,8 @@ spec:
           value: ${VALIDATION_IMAGE}
         - name: VIRT_V2V_IMAGE
           value: ${VIRT_V2V_IMAGE}
+        - name: VIRT_V2V_IMAGE_XFS
+          value: ${VIRT_V2V_IMAGE_RHEL9}
         - name: VIRT_V2V_DONT_REQUEST_KVM
           value: ${VIRT_V2V_DONT_REQUEST_KVM}
         - name: SNAPSHOT_REMOVAL_TIMEOUT
@@ -7176,6 +7191,11 @@ spec:
       - description: Virt-v2v conversion image used by migration pods
         displayName: Virt-v2v Image
         path: virt_v2v_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Virt-v2v XFS conversion image used by migration pods
+        displayName: Virt-v2v XFS Image
+        path: virt_v2v_image_xfs_fqin
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: VDDK image for VMware disk access

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -443,6 +443,10 @@ spec:
                 description: Virt-v2v conversion image used by migration pods
                 example: quay.io/kubev2v/forklift-virt-v2v:latest
                 type: string
+              virt_v2v_image_xfs_fqin:
+                description: Virt-v2v XFS conversion image used by migration pods
+                example: quay.io/kubev2v/forklift-virt-v2v-xfs:latest
+                type: string
               vsphere_osmap_configmap_name:
                 description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
                 example: custom-vsphere-osmap
@@ -4763,6 +4767,15 @@ spec:
                   Whether this is a warm migration.
                   Deprecated: this field will be deprecated in 2.10. Use Type instead.
                 type: boolean
+              xfsCompatibility:
+                default: false
+                description: |-
+                  XfsCompatibility overrides the global virt-v2v container image for this plan.
+                  When set, virt-v2v pods created by this plan will use the XFS compatible image
+                  VIRT_V2V_IMAGE_XFS instead of the cluster-wide VIRT_V2V_IMAGE setting.
+                  Use this to enable XFSv4 compatibility mode for specific plan.
+                  Warning: Enabling XFSv4 support will drop support for BTRFS for the specific plan. Ensure that the plan only selects VMs with supported filesystem.
+                type: boolean
             required:
             - map
             - provider
@@ -6891,6 +6904,8 @@ spec:
           value: ${VALIDATION_IMAGE}
         - name: VIRT_V2V_IMAGE
           value: ${VIRT_V2V_IMAGE}
+        - name: VIRT_V2V_IMAGE_XFS
+          value: ${VIRT_V2V_IMAGE_RHEL9}
         - name: VIRT_V2V_DONT_REQUEST_KVM
           value: ${VIRT_V2V_DONT_REQUEST_KVM}
         - name: SNAPSHOT_REMOVAL_TIMEOUT
@@ -7176,6 +7191,11 @@ spec:
       - description: Virt-v2v conversion image used by migration pods
         displayName: Virt-v2v Image
         path: virt_v2v_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Virt-v2v XFS conversion image used by migration pods
+        displayName: Virt-v2v XFS Image
+        path: virt_v2v_image_xfs_fqin
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: VDDK image for VMware disk access

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -89,6 +89,10 @@ spec:
                 type: string
                 description: "Virt-v2v conversion image used by migration pods"
                 example: "quay.io/kubev2v/forklift-virt-v2v:latest"
+              virt_v2v_image_xfs_fqin:
+                type: string
+                description: "Virt-v2v XFS conversion image used by migration pods"
+                example: "quay.io/kubev2v/forklift-virt-v2v-xfs:latest"
               vddk_image:
                 type: string
                 description: "VDDK image for VMware disk access"

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -2590,6 +2590,15 @@ spec:
                   Whether this is a warm migration.
                   Deprecated: this field will be deprecated in 2.10. Use Type instead.
                 type: boolean
+              xfsCompatibility:
+                default: false
+                description: |-
+                  XfsCompatibility overrides the global virt-v2v container image for this plan.
+                  When set, virt-v2v pods created by this plan will use the XFS compatible image
+                  VIRT_V2V_IMAGE_XFS instead of the cluster-wide VIRT_V2V_IMAGE setting.
+                  Use this to enable XFSv4 compatibility mode for specific plan.
+                  Warning: Enabling XFSv4 support will drop support for BTRFS for the specific plan. Ensure that the plan only selects VMs with supported filesystem.
+                type: boolean
             required:
             - map
             - provider

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -52,6 +52,8 @@ spec:
           value: ${VALIDATION_IMAGE}
         - name: VIRT_V2V_IMAGE
           value: ${VIRT_V2V_IMAGE}
+        - name: VIRT_V2V_IMAGE_XFS
+          value: ${VIRT_V2V_IMAGE_RHEL9}
         - name: VIRT_V2V_DONT_REQUEST_KVM
           value: ${VIRT_V2V_DONT_REQUEST_KVM}
         - name: SNAPSHOT_REMOVAL_TIMEOUT

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -137,6 +137,7 @@ populator_vsphere_xcopy_volume_image_fqin: "{{ lookup( 'env', 'VSPHERE_XCOPY_VOL
 must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_MUST_GATHER') }}"
 
 virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V') }}"
+virt_v2v_image_xfs_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE_XFS') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V_XFS') }}"
 virt_v2v_dont_request_kvm: "{{ lookup( 'env', 'VIRT_V2V_DONT_REQUEST_KVM') }}"
 virt_v2v_extra_args: "{{ lookup( 'env', 'VIRT_V2V_EXTRA_ARGS') }}"
 virt_v2v_extra_conf_config_map: "{{ lookup( 'env', 'VIRT_V2V_EXTRA_CONF_CONFIG_MAP') }}"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -43,6 +43,8 @@ spec:
           value: "v1"
         - name: VIRT_V2V_IMAGE
           value: {{ virt_v2v_image_fqin }}
+        - name: VIRT_V2V_IMAGE_XFS
+          value: {{ virt_v2v_image_xfs_fqin }}
         - name: API_PORT
           value: "8443"
         - name: METRICS_PORT

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -182,6 +182,11 @@ spec:
           path: virt_v2v_image_fqin
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Virt-v2v XFS conversion image used by migration pods
+          displayName: Virt-v2v XFS Image
+          path: virt_v2v_image_xfs_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: VDDK image for VMware disk access
           displayName: VDDK Image
           path: vddk_image

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -186,6 +186,11 @@ spec:
           path: virt_v2v_image_fqin
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Virt-v2v XFS conversion image used by migration pods
+          displayName: Virt-v2v XFS Image
+          path: virt_v2v_image_xfs_fqin
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: VDDK image for VMware disk access
           displayName: VDDK Image
           path: vddk_image

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -245,6 +245,13 @@ type PlanSpec struct {
 	// of the cluster-wide VIRT_V2V_IMAGE setting.
 	// Use this to run different virt-v2v builds for specific migration scenarios
 	VirtV2vImage string `json:"virtV2vImage,omitempty"`
+	// XfsCompatibility overrides the global virt-v2v container image for this plan.
+	// When set, virt-v2v pods created by this plan will use the XFS compatible image
+	// VIRT_V2V_IMAGE_XFS instead of the cluster-wide VIRT_V2V_IMAGE setting.
+	// Use this to enable XFSv4 compatibility mode for specific plan.
+	// Warning: Enabling XFSv4 support will drop support for BTRFS for the specific plan. Ensure that the plan only selects VMs with supported filesystem.
+	// +kubebuilder:default:=false
+	XfsCompatibility bool `json:"xfsCompatibility,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -3374,5 +3374,10 @@ func getVirtV2vImage(plan *api.Plan) string {
 	if plan.Spec.VirtV2vImage != "" {
 		return plan.Spec.VirtV2vImage
 	}
+	if plan.Spec.XfsCompatibility {
+		if Settings.Migration.VirtV2vImageXFS != "" {
+			return Settings.Migration.VirtV2vImageXFS
+		}
+	}
 	return Settings.Migration.VirtV2vImage
 }

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -39,9 +39,11 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 
 	ginkgo.Describe("getVirtV2vImage", func() {
 		const globalImage = "quay.io/kubev2v/forklift-virt-v2v:latest"
+		const xfsImage = "quay.io/kubev2v/forklift-virt-v2v-rhel9:latest"
 
 		ginkgo.BeforeEach(func() {
 			Settings.Migration.VirtV2vImage = globalImage
+			Settings.Migration.VirtV2vImageXFS = xfsImage
 		})
 
 		ginkgo.It("should return the global image when plan has no override", func() {
@@ -60,6 +62,33 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			p := createPlanKubevirt()
 			p.Spec.VirtV2vImage = ""
 			Expect(getVirtV2vImage(p)).To(Equal(globalImage))
+		})
+
+		ginkgo.It("should return the XFS image when XfsCompatibility is enabled", func() {
+			p := createPlanKubevirt()
+			p.Spec.XfsCompatibility = true
+			Expect(getVirtV2vImage(p)).To(Equal(xfsImage))
+		})
+
+		ginkgo.It("should return the global image when XfsCompatibility is false", func() {
+			p := createPlanKubevirt()
+			p.Spec.XfsCompatibility = false
+			Expect(getVirtV2vImage(p)).To(Equal(globalImage))
+		})
+
+		ginkgo.It("should prioritize VirtV2vImage over XfsCompatibility when both are set", func() {
+			perPlanImage := "quay.io/kubev2v/forklift-virt-v2v:custom-build"
+			p := createPlanKubevirt()
+			p.Spec.VirtV2vImage = perPlanImage
+			p.Spec.XfsCompatibility = true
+			Expect(getVirtV2vImage(p)).To(Equal(perPlanImage))
+		})
+
+		ginkgo.It("should return XFS image when XfsCompatibility is true and VirtV2vImage is empty", func() {
+			p := createPlanKubevirt()
+			p.Spec.VirtV2vImage = ""
+			p.Spec.XfsCompatibility = true
+			Expect(getVirtV2vImage(p)).To(Equal(xfsImage))
 		})
 	})
 })

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -16,6 +16,7 @@ const (
 	HookRetry                        = "HOOK_RETRY"
 	ImporterRetry                    = "IMPORTER_RETRY"
 	VirtV2vImage                     = "VIRT_V2V_IMAGE"
+	VirtV2vImageXFS                  = "VIRT_V2V_IMAGE_XFS"
 	vddkImage                        = "VDDK_IMAGE"
 	PrecopyInterval                  = "PRECOPY_INTERVAL"
 	VirtV2vDontRequestKVM            = "VIRT_V2V_DONT_REQUEST_KVM"
@@ -80,6 +81,8 @@ type Migration struct {
 	SnapshotStatusCheckRate int
 	// Virt-v2v image for guest conversion
 	VirtV2vImage string
+	// Virt-v2v image for guest conversion with XFSv4 support
+	VirtV2vImageXFS string
 	// Virt-v2v require KVM flags for guest conversion
 	VirtV2vDontRequestKVM bool
 	// OCP Export token TTL minutes
@@ -170,6 +173,14 @@ func (r *Migration) Load() (err error) {
 		r.VirtV2vImage = virtV2vImage
 	} else if Settings.Role.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtV2vImage))
+	}
+	if virtV2vImageXFS, ok := os.LookupEnv(VirtV2vImageXFS); ok {
+		r.VirtV2vImageXFS = virtV2vImageXFS
+	} else if Settings.Role.Has(MainRole) {
+		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtV2vImageXFS))
+	}
+	if r.VirtV2vImageXFS == "" && Settings.Role.Has(MainRole) {
+		return liberr.Wrap(fmt.Errorf("environment variable %s was empty", VirtV2vImageXFS))
 	}
 	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
 


### PR DESCRIPTION
Adds a plan setting to use the XFS compatible image for guest conversion.

Resolves: MTV-4686

Backport of: https://github.com/kubev2v/forklift/pull/5361