### PR TITLE
[release-2.11] MTV-4825 | add Prometheus metrics labels for storage offload

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
+++ b/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
@@ -90,6 +90,8 @@ type HostPort struct {
 type FlashSystemInfo struct {
 	VdiskProtectionEnabled string `json:"vdisk_protection_enabled"`
 	VdiskProtectionTime    string `json:"vdisk_protection_time"`
+	ProductName            string `json:"product_name"`
+	CodeLevel              string `json:"code_level"`
 }
 
 // FlashSystemAPIClient handles communication with the FlashSystem REST API.
@@ -386,6 +388,15 @@ var _ populator.RDMCapable = &FlashSystemClonner{}
 type FlashSystemClonner struct {
 	api            *FlashSystemAPIClient
 	initiatorGroup string
+	arrayInfo      populator.StorageArrayInfo
+}
+
+// Ensure FlashSystemClonner implements StorageArrayInfoProvider
+var _ populator.StorageArrayInfoProvider = &FlashSystemClonner{}
+
+// GetStorageArrayInfo returns metadata about the FlashSystem array for metric labels.
+func (c *FlashSystemClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
+	return c.arrayInfo
 }
 
 // NewFlashSystemClonner creates a new FlashSystemClonner.
@@ -411,7 +422,17 @@ func NewFlashSystemClonner(managementIP, username, password string, sslSkipVerif
 		return FlashSystemClonner{}, fmt.Errorf("vdisk protection is enabled on the IBM FlashSystem; it must be disabled")
 	}
 
-	return FlashSystemClonner{api: client}, nil
+	clonner := FlashSystemClonner{
+		api: client,
+		arrayInfo: populator.StorageArrayInfo{
+			Vendor:  "IBM",
+			Product: "FlashSystem",
+			Model:   sysInfo.ProductName,
+			Version: sysInfo.CodeLevel,
+		},
+	}
+
+	return clonner, nil
 }
 
 func (c *FlashSystemClonner) MapTarget(targetLUN populator.LUN, context populator.MappingContext) (populator.LUN, error) {

--- a/cmd/vsphere-copy-offload-populator/internal/infinibox/infinibox.go
+++ b/cmd/vsphere-copy-offload-populator/internal/infinibox/infinibox.go
@@ -22,6 +22,15 @@ const (
 type InfiniboxClonner struct {
 	api            iboxapi.Client
 	initiatorGroup string
+	arrayInfo      populator.StorageArrayInfo
+}
+
+// Ensure InfiniboxClonner implements StorageArrayInfoProvider
+var _ populator.StorageArrayInfoProvider = &InfiniboxClonner{}
+
+// GetStorageArrayInfo returns metadata about the InfiniBox array for metric labels.
+func (c *InfiniboxClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
+	return c.arrayInfo
 }
 
 func (c *InfiniboxClonner) MapTarget(targetLUN populator.LUN, context populator.MappingContext) (populator.LUN, error) {
@@ -158,9 +167,24 @@ func NewInfiniboxClonner(hostname, username, password string, insecure bool) (In
 	// Create InfiniBox client
 	client := iboxapi.NewIboxClient(logger, creds)
 
-	return InfiniboxClonner{
+	clonner := InfiniboxClonner{
 		api: client,
-	}, nil
+		arrayInfo: populator.StorageArrayInfo{
+			Vendor:  "Infinidat",
+			Product: "InfiniBox",
+		},
+	}
+
+	// Fetch model and version from the API
+	sysInfo, err := client.GetSystem()
+	if err != nil {
+		klog.Warningf("Failed to get InfiniBox system info for metrics: %v", err)
+	} else {
+		clonner.arrayInfo.Model = sysInfo.Model
+		clonner.arrayInfo.Version = sysInfo.Version
+	}
+
+	return clonner, nil
 }
 
 func (c *InfiniboxClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {

--- a/cmd/vsphere-copy-offload-populator/internal/metrics/metrics.go
+++ b/cmd/vsphere-copy-offload-populator/internal/metrics/metrics.go
@@ -1,0 +1,148 @@
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"k8s.io/klog/v2"
+)
+
+// Label names used for copy metrics.
+const (
+	labelOwnerUID        = "owner_uid"
+	labelResult          = "result"
+	labelStorageVendor   = "storage_vendor"
+	labelCloneMethod     = "clone_method"
+	labelStorageProtocol = "storage_protocol"
+	labelXcopyUsed       = "xcopy_used"
+	labelArrayVendor     = "storage_array_vendor"
+	labelArrayProduct    = "storage_array_product"
+	labelArrayModel      = "storage_array_model"
+	labelArrayVersion    = "storage_array_version"
+	labelDiskSizeType    = "type"
+)
+
+// CopyMetrics holds Prometheus metrics for copy operations and provides labeled recording.
+type CopyMetrics struct {
+	progressCounter       *prometheus.CounterVec
+	xcopyUsedGauge        *prometheus.GaugeVec
+	storageArrayInfoGauge *prometheus.GaugeVec
+	sourceDiskBytesGauge  *prometheus.GaugeVec
+	copyDurationGauge     *prometheus.GaugeVec
+}
+
+func (m *CopyMetrics) RecordProgress(ownerUID string, progress uint64) {
+	metric := dto.Metric{}
+	c := m.progressCounter.WithLabelValues(ownerUID)
+	if err := c.Write(&metric); err != nil {
+		klog.Error(err)
+		return
+	}
+	if float64(progress) > metric.Counter.GetValue() {
+		c.Add(float64(progress) - metric.Counter.GetValue())
+	}
+}
+
+func (m *CopyMetrics) RecordXcopyUsed(ownerUID, storageVendor, cloneMethod string, xcopyUsed int) {
+	m.xcopyUsedGauge.WithLabelValues(ownerUID, storageVendor, cloneMethod).Set(float64(xcopyUsed))
+}
+
+// RecordStorageArrayInfo sets the info metric once with storage array metadata (constant value 1).
+func (m *CopyMetrics) RecordStorageArrayInfo(storageVendor string, arrayInfo populator.StorageArrayInfo) {
+	model := arrayInfo.Model
+	if model == "" {
+		model = "n/a"
+	}
+	ver := arrayInfo.Version
+	if ver == "" {
+		ver = "n/a"
+	}
+	m.storageArrayInfoGauge.WithLabelValues(storageVendor, arrayInfo.Vendor, arrayInfo.Product, model, ver).Set(1)
+}
+
+// RecordSourceDiskBytes records source disk size metrics for each available measurement.
+func (m *CopyMetrics) RecordSourceDiskBytes(ownerUID, storageVendor, cloneMethod, storageProtocol string, sourceDiskCapacityBytes, sourceDatastoreAllocatedBytes int64) {
+	if sourceDatastoreAllocatedBytes > 0 {
+		m.sourceDiskBytesGauge.WithLabelValues(ownerUID, storageVendor, cloneMethod, storageProtocol, "datastore_allocated").Set(float64(sourceDatastoreAllocatedBytes))
+	}
+	if sourceDiskCapacityBytes > 0 {
+		m.sourceDiskBytesGauge.WithLabelValues(ownerUID, storageVendor, cloneMethod, storageProtocol, "provisioned").Set(float64(sourceDiskCapacityBytes))
+	}
+}
+
+// RecordCompletion records copy duration with a result label ("success" or "failure").
+func (m *CopyMetrics) RecordCompletion(result, ownerUID, storageVendor, cloneMethod, storageProtocol string, xcopyUsed int, duration time.Duration) {
+	xcopyUsedStr := strconv.Itoa(xcopyUsed)
+	if xcopyUsedStr != "0" && xcopyUsedStr != "1" {
+		xcopyUsedStr = "0"
+	}
+	labels := []string{ownerUID, result, storageVendor, cloneMethod, xcopyUsedStr, storageProtocol}
+	m.copyDurationGauge.WithLabelValues(labels...).Set(duration.Seconds())
+}
+
+// NewCopyMetrics creates and registers all Prometheus metrics for copy operations.
+func NewCopyMetrics() (*CopyMetrics, error) {
+	// Progress is emitted during the copy and scraped by the controller to update CR status.
+	// Only owner_uid is needed — the controller matches on it to find the right metric line.
+	progressCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vsphere_xcopy_volume_populator_progress",
+			Help: "Progress of vsphere XCOPY volume population (percentage 0-100).",
+		},
+		[]string{labelOwnerUID},
+	)
+	// xcopy_used is emitted during the copy before storageProtocol is known.
+	baseLabels := []string{labelOwnerUID, labelStorageVendor, labelCloneMethod}
+	xcopyUsedGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "vsphere_xcopy_volume_populator_xcopy_used",
+			Help: "Indicates whether XCOPY was used for cloning (0=no, 1=yes). Labels describe what was copied.",
+		},
+		baseLabels,
+	)
+
+	// Info metric (constant value 1) for storage array metadata. Correlate with other metrics via storage_vendor.
+	storageArrayInfoGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "vsphere_xcopy_volume_populator_storage_array_info",
+			Help: "Storage array metadata (constant 1). Join with other metrics on storage_vendor to get array details.",
+		},
+		[]string{labelStorageVendor, labelArrayVendor, labelArrayProduct, labelArrayModel, labelArrayVersion},
+	)
+
+	// Source disk size in bytes, with type label for each measurement source.
+	sourceDiskBytesGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "vsphere_xcopy_volume_populator_source_disk_bytes",
+			Help: "Source disk size in bytes. type=datastore_allocated is actual data on datastore (layoutEx extents); provisioned is guest-visible disk size.",
+		},
+		[]string{labelOwnerUID, labelStorageVendor, labelCloneMethod, labelStorageProtocol, labelDiskSizeType},
+	)
+
+	// Duration of copy in seconds. Its presence signals completion (success or failure).
+	completionLabels := []string{labelOwnerUID, labelResult, labelStorageVendor, labelCloneMethod, labelXcopyUsed, labelStorageProtocol}
+	copyDurationGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "vsphere_xcopy_volume_populator_copy_duration_seconds",
+			Help: "Duration of copy operation in seconds. result label indicates success or failure.",
+		},
+		completionLabels,
+	)
+
+	for _, collector := range []prometheus.Collector{progressCounter, xcopyUsedGauge, storageArrayInfoGauge, sourceDiskBytesGauge, copyDurationGauge} {
+		if err := prometheus.Register(collector); err != nil {
+			return nil, err
+		}
+	}
+
+	return &CopyMetrics{
+		progressCounter:       progressCounter,
+		xcopyUsedGauge:        xcopyUsedGauge,
+		storageArrayInfoGauge: storageArrayInfoGauge,
+		sourceDiskBytesGauge:  sourceDiskBytesGauge,
+		copyDurationGauge:     copyDurationGauge,
+	}, nil
+}

--- a/cmd/vsphere-copy-offload-populator/internal/ontap/ontap.go
+++ b/cmd/vsphere-copy-offload-populator/internal/ontap/ontap.go
@@ -17,10 +17,17 @@ const OntapProviderID = "600a0980"
 
 // Ensure NetappClonner implements required interfaces
 var _ populator.VMDKCapable = &NetappClonner{}
+var _ populator.StorageArrayInfoProvider = &NetappClonner{}
 
 type NetappClonner struct {
 	api                  api.OntapAPI
 	initiatorHostOrGroup string
+	arrayInfo            populator.StorageArrayInfo
+}
+
+// GetStorageArrayInfo returns metadata about the ONTAP array for metric labels.
+func (c *NetappClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
+	return c.arrayInfo
 }
 
 // Map the targetLUN to the initiator group.
@@ -118,7 +125,22 @@ func NewNetappClonner(hostname, username, password string) (NetappClonner, error
 		return NetappClonner{}, fmt.Errorf("failed to initialize ONTAP client (common causes: incorrect password, invalid SVM name, network connectivity): %w", err)
 	}
 
-	nc := NetappClonner{api: client}
+	nc := NetappClonner{
+		api: client,
+		arrayInfo: populator.StorageArrayInfo{
+			Vendor:  "NetApp",
+			Product: "ONTAP",
+		},
+	}
+
+	// Fetch ONTAP API version
+	ontapVersion, err := client.APIVersion(context.TODO())
+	if err != nil {
+		klog.Warningf("Failed to get ONTAP version for metrics: %v", err)
+	} else {
+		nc.arrayInfo.Version = ontapVersion
+	}
+
 	return nc, nil
 }
 

--- a/cmd/vsphere-copy-offload-populator/internal/populator/disk_type.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/disk_type.go
@@ -1,9 +1,6 @@
 package populator
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	"k8s.io/klog/v2"
 )
@@ -31,25 +28,18 @@ type populatorSettings struct {
 	// Note: VMDK cannot be disabled as it's the default fallback
 }
 
-func detectDiskType(ctx context.Context, client vmware.Client, vmId string, vmdkPath string) (DiskType, error) {
+func detectDiskType(backing *vmware.DiskBacking) DiskType {
 	log := klog.Background().WithName("copy-offload").WithName("disk-type")
-	ctx = klog.NewContext(ctx, log)
-	log.V(2).Info("detecting disk type", "vm", vmId, "disk", vmdkPath)
-
-	backing, err := client.GetVMDiskBacking(ctx, vmId, vmdkPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to get disk backing info: %w", err)
-	}
 
 	switch {
 	case backing.VVolId != "":
 		log.Info("detected VVol disk", "vvolId", backing.VVolId)
-		return DiskTypeVVol, nil
+		return DiskTypeVVol
 	case backing.IsRDM:
 		log.Info("detected RDM disk", "device", backing.DeviceName)
-		return DiskTypeRDM, nil
+		return DiskTypeRDM
 	default:
 		log.Info("detected VMDK disk")
-		return DiskTypeVMDK, nil
+		return DiskTypeVMDK
 	}
 }

--- a/cmd/vsphere-copy-offload-populator/internal/populator/factory.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/factory.go
@@ -21,7 +21,9 @@ type SSHConfig struct {
 	PublicKey      []byte
 }
 
-// NewPopulator creates a new PopulatorSelector
+// NewPopulator creates a Populator with an embedded CopyContext describing how the
+// copy will be performed (clone method, source disk sizes). StorageProtocol is
+// detected by the populator during Populate() and available via GetCopyContext().
 func NewPopulator(
 	storageApi StorageApi,
 	vsphereHostname string,
@@ -40,69 +42,99 @@ func NewPopulator(
 	ctx := context.Background()
 	log := klog.Background().WithName("copy-offload").WithName("setup")
 
-	diskType, err := detectDiskType(ctx, vsphereClient, vmId, vmdkPath)
-	if err != nil {
-		log.Info("disk type detection failed, using VMDK/Xcopy", "err", err)
-		return createVMDKPopulator(storageApi, vsphereClient, sshConfig)
-	}
+	// Single vSphere roundtrip: fetch source disk sizes and backing info.
+	sourceDiskCap, sourceDatastoreAlloc, backing := fetchDiskInfo(ctx, log, vsphereClient, vmId, vmdkPath)
 
+	diskType := detectDiskType(backing)
 	log.Info("disk type detected", "type", diskType)
 
 	switch diskType {
 	case DiskTypeVVol:
 		if canUse(storageApi, DiskTypeVVol) {
 			log.Info("using VVol populator")
-			return createVVolPopulator(storageApi, vsphereClient)
+			return createVVolPopulator(storageApi, vsphereClient, sourceDiskCap, sourceDatastoreAlloc)
 		}
 
 	case DiskTypeRDM:
 		if canUse(storageApi, DiskTypeRDM) {
 			log.Info("using RDM populator")
-			return createRDMPopulator(storageApi, vsphereClient)
+			return createRDMPopulator(storageApi, vsphereClient, sourceDiskCap, sourceDatastoreAlloc)
 		}
 	}
 
 	log.Info("using VMDK/Xcopy populator")
-	return createVMDKPopulator(storageApi, vsphereClient, sshConfig)
+	return createVMDKPopulator(storageApi, vsphereClient, sshConfig, sourceDiskCap, sourceDatastoreAlloc)
+}
+
+// fetchDiskInfo retrieves provisioned capacity, datastore-allocated bytes, and disk
+// backing info from vSphere in a single VM lookup. Best-effort: returns zeros and
+// an empty DiskBacking on failure.
+func fetchDiskInfo(ctx context.Context, log klog.Logger, vsphereClient vmware.Client, vmId, vmdkPath string) (int64, int64, *vmware.DiskBacking) {
+	sourceDiskCap, sourceDatastoreAlloc, backing, err := vsphereClient.GetVirtualDiskSizes(ctx, vmId, vmdkPath)
+	if err != nil {
+		log.V(1).Info("could not read source disk info for metrics", "err", err)
+		return 0, 0, &vmware.DiskBacking{}
+	}
+	if sourceDiskCap > 0 {
+		log.V(1).Info("source virtual disk provisioned size for metrics", "bytes", sourceDiskCap)
+	}
+	if sourceDatastoreAlloc > 0 {
+		if sourceDiskCap > 0 && sourceDatastoreAlloc > sourceDiskCap {
+			sourceDatastoreAlloc = sourceDiskCap
+		}
+		log.V(1).Info("source VMDK datastore allocated bytes for metrics", "bytes", sourceDatastoreAlloc)
+	}
+	if backing == nil {
+		backing = &vmware.DiskBacking{}
+	}
+	return sourceDiskCap, sourceDatastoreAlloc, backing
 }
 
 // createVVolPopulator creates VVol populator
-func createVVolPopulator(storageApi StorageApi, vmwareClient vmware.Client) (Populator, error) {
+func createVVolPopulator(storageApi StorageApi, vmwareClient vmware.Client, sourceDiskCap, sourceDatastoreAlloc int64) (Populator, error) {
 	vvolApi, ok := storageApi.(VVolCapable)
 	if !ok {
 		return nil, fmt.Errorf("storage API does not implement VVolCapable")
 	}
 
-	return NewVvolPopulator(vvolApi, vmwareClient)
+	copyCtx := CopyContext{CloneMethod: "vvol", SourceDiskCapacityBytes: sourceDiskCap, SourceDiskDatastoreAllocatedBytes: sourceDatastoreAlloc}
+	return NewVvolPopulator(vvolApi, vmwareClient, copyCtx)
 }
 
 // createRDMPopulator creates RDM populator
-func createRDMPopulator(storageApi StorageApi, vmwareClient vmware.Client) (Populator, error) {
+func createRDMPopulator(storageApi StorageApi, vmwareClient vmware.Client, sourceDiskCap, sourceDatastoreAlloc int64) (Populator, error) {
 	rdmApi, ok := storageApi.(RDMCapable)
 	if !ok {
 		return nil, fmt.Errorf("storage API does not implement RDMCapable")
 	}
 
-	return NewRDMPopulator(rdmApi, vmwareClient)
+	copyCtx := CopyContext{CloneMethod: "rdm", SourceDiskCapacityBytes: sourceDiskCap, SourceDiskDatastoreAllocatedBytes: sourceDatastoreAlloc}
+	return NewRDMPopulator(rdmApi, vmwareClient, copyCtx)
 }
 
 // createVMDKPopulator creates VMDK/Xcopy populator (default/fallback)
-func createVMDKPopulator(storageApi StorageApi, vmwareClient vmware.Client, sshConfig *SSHConfig) (Populator, error) {
+func createVMDKPopulator(storageApi StorageApi, vmwareClient vmware.Client, sshConfig *SSHConfig, sourceDiskCap, sourceDatastoreAlloc int64) (Populator, error) {
 	vmdkApi, ok := storageApi.(VMDKCapable)
 	if !ok {
 		return nil, fmt.Errorf("storage API does not implement VMDKCapable (required)")
 	}
 
+	cloneMethod := "vib"
+	if sshConfig != nil && sshConfig.UseSSH {
+		cloneMethod = "ssh"
+	}
+	copyCtx := CopyContext{CloneMethod: cloneMethod, SourceDiskCapacityBytes: sourceDiskCap, SourceDiskDatastoreAllocatedBytes: sourceDatastoreAlloc}
+
 	var pop Populator
 	var err error
-
 	if sshConfig != nil && sshConfig.UseSSH {
 		pop, err = NewWithRemoteEsxcliSSH(vmdkApi,
 			vmwareClient,
+			copyCtx,
 			sshConfig.PrivateKey,
 			sshConfig.PublicKey)
 	} else {
-		pop, err = NewWithRemoteEsxcli(vmdkApi, vmwareClient)
+		pop, err = NewWithRemoteEsxcli(vmdkApi, vmwareClient, copyCtx)
 	}
 
 	if err != nil {

--- a/cmd/vsphere-copy-offload-populator/internal/populator/populate.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/populate.go
@@ -6,7 +6,26 @@ import (
 	"strings"
 )
 
+// CopyContext describes how the copy is performed (for metric labels).
+// Populated by the factory at construction time; StorageProtocol may be
+// updated by the populator during Populate() when adapter info is available.
+type CopyContext struct {
+	// CloneMethod is the method used for the copy: "vib", "ssh", "vvol", or "rdm".
+	CloneMethod string
+	// StorageProtocol is the storage protocol when known (e.g. "iscsi", "fc"). May be empty.
+	StorageProtocol string
+	// SourceDiskCapacityBytes is provisioned (guest-visible) size of the source disk.
+	SourceDiskCapacityBytes int64
+	// SourceDiskDatastoreAllocatedBytes is datastore footprint (layoutEx diskExtent sizes) when known.
+	// Thin VMFS: approximates allocated blocks; not guest OS used space. 0 if unavailable (VVol/RDM/NFS limits).
+	SourceDiskDatastoreAllocatedBytes int64
+}
+
 type Populator interface {
+	// GetCopyContext returns metadata describing how the copy is performed (clone method,
+	// protocol, source disk sizes). Call after Populate completes for the most up-to-date
+	// values (e.g. StorageProtocol is detected during Populate).
+	GetCopyContext() CopyContext
 	// Populate will populate the volume identified by volumeHanle with the content of
 	// the sourceVMDKFile.
 	// persistentVolume is a slim version of k8s PersistentVolume created by the CSI driver,

--- a/cmd/vsphere-copy-offload-populator/internal/populator/populate_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/populate_test.go
@@ -124,9 +124,9 @@ func TestPopulate(t *testing.T) {
 	xcopyUsed := make(chan int)
 	quit := make(chan error)
 
-	mockPopulator.EXPECT().Populate("vm-1", "source.vmdk", pv, progress, quit, xcopyUsed).Return(nil)
+	mockPopulator.EXPECT().Populate("vm-1", "source.vmdk", pv, gomock.Any(), progress, xcopyUsed, quit).Return(nil)
 
-	err := mockPopulator.Populate("vm-1", "source.vmdk", pv, progress, quit, xcopyUsed)
+	err := mockPopulator.Populate("vm-1", "source.vmdk", pv, nil, progress, xcopyUsed, quit)
 	if err != nil {
 		t.Errorf("Populate() error = %v, wantErr %v", err, false)
 	}

--- a/cmd/vsphere-copy-offload-populator/internal/populator/populator_mocks/populator_mock.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/populator_mocks/populator_mock.go
@@ -40,16 +40,30 @@ func (m *MockPopulator) EXPECT() *MockPopulatorMockRecorder {
 	return m.recorder
 }
 
-// Populate mocks base method.
-func (m *MockPopulator) Populate(vmId, sourceVMDKFile string, persistentVolume populator.PersistentVolume, progress chan<- uint64, quit chan error, xcopyUsed chan<- int) error {
+// GetCopyContext mocks base method.
+func (m *MockPopulator) GetCopyContext() populator.CopyContext {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Populate", vmId, sourceVMDKFile, persistentVolume, progress, quit, xcopyUsed)
+	ret := m.ctrl.Call(m, "GetCopyContext")
+	ret0, _ := ret[0].(populator.CopyContext)
+	return ret0
+}
+
+// GetCopyContext indicates an expected call of GetCopyContext.
+func (mr *MockPopulatorMockRecorder) GetCopyContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCopyContext", reflect.TypeOf((*MockPopulator)(nil).GetCopyContext))
+}
+
+// Populate mocks base method.
+func (m *MockPopulator) Populate(vmId, sourceVMDKFile string, persistentVolume populator.PersistentVolume, hostLocker populator.Hostlocker, progress chan<- uint64, xcopyUsed chan<- int, quit chan error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Populate", vmId, sourceVMDKFile, persistentVolume, hostLocker, progress, xcopyUsed, quit)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Populate indicates an expected call of Populate.
-func (mr *MockPopulatorMockRecorder) Populate(vmId, sourceVMDKFile, persistentVolume, progress, quit, xcopyUsed any) *gomock.Call {
+func (mr *MockPopulatorMockRecorder) Populate(vmId, sourceVMDKFile, persistentVolume, hostLocker, progress, xcopyUsed, quit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Populate", reflect.TypeOf((*MockPopulator)(nil).Populate), vmId, sourceVMDKFile, persistentVolume, progress, quit, xcopyUsed)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Populate", reflect.TypeOf((*MockPopulator)(nil).Populate), vmId, sourceVMDKFile, persistentVolume, hostLocker, progress, xcopyUsed, quit)
 }

--- a/cmd/vsphere-copy-offload-populator/internal/populator/rdm_populator.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/rdm_populator.go
@@ -11,13 +11,19 @@ import (
 type RDMPopulator struct {
 	vSphereClient vmware.Client
 	storageApi    RDMCapable
+	copyCtx       CopyContext
+}
+
+func (p *RDMPopulator) GetCopyContext() CopyContext {
+	return p.copyCtx
 }
 
 // NewRDMPopulator creates a new RDM populator
-func NewRDMPopulator(storageApi RDMCapable, vmwareClient vmware.Client) (Populator, error) {
+func NewRDMPopulator(storageApi RDMCapable, vmwareClient vmware.Client, copyCtx CopyContext) (Populator, error) {
 	return &RDMPopulator{
 		vSphereClient: vmwareClient,
 		storageApi:    storageApi,
+		copyCtx:       copyCtx,
 	}, nil
 }
 

--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
@@ -56,17 +56,23 @@ type RemoteEsxcliPopulator struct {
 	SSHPrivateKey []byte
 	SSHPublicKey  []byte
 	UseSSHMethod  bool
+	copyCtx       CopyContext
 }
 
-func NewWithRemoteEsxcli(storageApi VMDKCapable, vmwareClient vmware.Client) (Populator, error) {
+func (p *RemoteEsxcliPopulator) GetCopyContext() CopyContext {
+	return p.copyCtx
+}
+
+func NewWithRemoteEsxcli(storageApi VMDKCapable, vmwareClient vmware.Client, copyCtx CopyContext) (Populator, error) {
 	return &RemoteEsxcliPopulator{
 		VSphereClient: vmwareClient,
 		StorageApi:    storageApi,
 		UseSSHMethod:  false, // VIB method
+		copyCtx:       copyCtx,
 	}, nil
 }
 
-func NewWithRemoteEsxcliSSH(storageApi VMDKCapable, vmwareClient vmware.Client, sshPrivateKey, sshPublicKey []byte) (Populator, error) {
+func NewWithRemoteEsxcliSSH(storageApi VMDKCapable, vmwareClient vmware.Client, copyCtx CopyContext, sshPrivateKey, sshPublicKey []byte) (Populator, error) {
 	if len(sshPrivateKey) == 0 || len(sshPublicKey) == 0 {
 		return nil, fmt.Errorf("ssh key material must be non-empty")
 	}
@@ -76,6 +82,7 @@ func NewWithRemoteEsxcliSSH(storageApi VMDKCapable, vmwareClient vmware.Client, 
 		SSHPrivateKey: sshPrivateKey,
 		SSHPublicKey:  sshPublicKey,
 		UseSSHMethod:  true,
+		copyCtx:       copyCtx,
 	}, nil
 }
 
@@ -135,6 +142,13 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv 
 	setupLog.Info("Datastore active adapters", "datastore", vmDisk.Datastore, "activeAdapters", dsActiveAdapters)
 	for _, a := range dsActiveAdapters {
 		initiators = append(initiators, a.Id)
+		if p.copyCtx.StorageProtocol == "" {
+			if strings.HasPrefix(a.Id, "iqn.") || strings.HasPrefix(a.Id, "eui.") {
+				p.copyCtx.StorageProtocol = "iscsi"
+			} else if strings.HasPrefix(a.Id, "fc.") || strings.HasPrefix(a.Id, "20:") {
+				p.copyCtx.StorageProtocol = "fc"
+			}
+		}
 	}
 	mappingContext, err := p.StorageApi.EnsureClonnerIgroup(xcopyInitiatorGroup, initiators)
 	if err != nil {

--- a/cmd/vsphere-copy-offload-populator/internal/populator/storage.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/storage.go
@@ -65,3 +65,21 @@ type MappingContext map[string]any
 type SciniAware interface {
 	SciniRequired() bool
 }
+
+// StorageArrayInfo holds metadata about the storage array, retrieved from the API at connection time.
+type StorageArrayInfo struct {
+	// Vendor is the storage array vendor (e.g. "IBM", "Dell", "NetApp").
+	Vendor string
+	// Product is the vendor's product name (e.g. "FlashSystem", "PowerMax", "ONTAP").
+	Product string
+	// Model is the specific model of the storage array, retrieved from the API. May be empty.
+	Model string
+	// Version is the software/firmware version of the storage array, retrieved from the API. May be empty.
+	Version string
+}
+
+// StorageArrayInfoProvider is an optional interface that storage implementations can implement
+// to provide metadata about the storage array for metric labels.
+type StorageArrayInfoProvider interface {
+	GetStorageArrayInfo() StorageArrayInfo
+}

--- a/cmd/vsphere-copy-offload-populator/internal/populator/vvol_populator.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/vvol_populator.go
@@ -10,12 +10,18 @@ import (
 type VvolPopulator struct {
 	vSphereClient vmware.Client
 	storageApi    VVolCapable
+	copyCtx       CopyContext
 }
 
-func NewVvolPopulator(storageApi VVolCapable, vmwareClient vmware.Client) (Populator, error) {
+func (p *VvolPopulator) GetCopyContext() CopyContext {
+	return p.copyCtx
+}
+
+func NewVvolPopulator(storageApi VVolCapable, vmwareClient vmware.Client, copyCtx CopyContext) (Populator, error) {
 	return &VvolPopulator{
 		vSphereClient: vmwareClient,
 		storageApi:    storageApi,
+		copyCtx:       copyCtx,
 	}, nil
 }
 

--- a/cmd/vsphere-copy-offload-populator/internal/powerflex/powerflex.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powerflex/powerflex.go
@@ -18,9 +18,18 @@ const (
 )
 
 type PowerflexClonner struct {
-	Client   *goscaleio.Client
-	systemId string
-	sdcId    string
+	Client    *goscaleio.Client
+	systemId  string
+	sdcId     string
+	arrayInfo populator.StorageArrayInfo
+}
+
+// Ensure PowerflexClonner implements StorageArrayInfoProvider
+var _ populator.StorageArrayInfoProvider = &PowerflexClonner{}
+
+// GetStorageArrayInfo returns metadata about the PowerFlex array for metric labels.
+func (p *PowerflexClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
+	return p.arrayInfo
 }
 
 // CurrentMappedGroups implements populator.StorageApi.
@@ -221,7 +230,14 @@ func NewPowerflexClonner(hostname, username, password string, sslSkipVerify bool
 		return PowerflexClonner{}, fmt.Errorf("error authenticating: %w", err)
 	}
 
-	klog.Infof("successfuly logged in to ScaleIO Gateway at %s version %s", client.GetConfigConnect().Endpoint, client.GetConfigConnect().Version)
+	klog.Infof("successfuly logged in to ScaleIO Gateway at %s", client.GetConfigConnect().Endpoint)
 
-	return PowerflexClonner{Client: client, systemId: systemId}, nil
+	return PowerflexClonner{
+		Client:   client,
+		systemId: systemId,
+		arrayInfo: populator.StorageArrayInfo{
+			Vendor:  "Dell",
+			Product: "PowerFlex",
+		},
+	}, nil
 }

--- a/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
@@ -25,6 +25,15 @@ type PowermaxClonner struct {
 	storageGroupID string
 	hostID         string
 	maskingViewID  string
+	arrayInfo      populator.StorageArrayInfo
+}
+
+// Ensure PowermaxClonner implements StorageArrayInfoProvider
+var _ populator.StorageArrayInfoProvider = &PowermaxClonner{}
+
+// GetStorageArrayInfo returns metadata about the PowerMax array for metric labels.
+func (p *PowermaxClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
+	return p.arrayInfo
 }
 
 func (p *PowermaxClonner) MapTarget(targetLUN populator.LUN, mappingContext populator.MappingContext) (populator.LUN, error) {
@@ -301,7 +310,27 @@ func NewPowermaxClonner(hostname, username, password string, sslSkipVerify bool)
 		return PowermaxClonner{}, err
 	}
 	klog.Info("successfuly logged in to PowerMax")
-	return PowermaxClonner{client: client, symmetrixID: symID, portGroup: portGroup}, nil
+
+	clonner := PowermaxClonner{
+		client:      client,
+		symmetrixID: symID,
+		portGroup:   portGroup,
+		arrayInfo: populator.StorageArrayInfo{
+			Vendor:  "Dell",
+			Product: "PowerMax",
+		},
+	}
+
+	// Fetch model and version from the API
+	sym, err := client.GetSymmetrixByID(context.TODO(), symID)
+	if err != nil {
+		klog.Warningf("Failed to get PowerMax symmetrix info for metrics: %v", err)
+	} else {
+		clonner.arrayInfo.Model = sym.Model
+		clonner.arrayInfo.Version = sym.Ucode
+	}
+
+	return clonner, nil
 }
 
 func generateRandomString(length int) (string, error) {

--- a/cmd/vsphere-copy-offload-populator/internal/powermax/powermax_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powermax/powermax_test.go
@@ -36,6 +36,11 @@ func TestNewPowermaxClonner(t *testing.T) {
 		os.Setenv("POWERMAX_PORT_GROUP_NAME", "456")
 
 		mockClient.EXPECT().Authenticate(gomock.Any(), gomock.Any()).Return(nil)
+		mockClient.EXPECT().GetSymmetrixByID(gomock.Any(), "123").Return(&v100.Symmetrix{
+			SymmetrixID: "123",
+			Model:       "PowerMax_2500",
+			Ucode:       "6079.170.170",
+		}, nil)
 		// not testing the gopowermax constructor
 		origNewClientWithArgs := newClientWithArgs
 		newClientWithArgs = func(string, string, bool, bool, string) (gopowermax.Pmax, error) {
@@ -48,6 +53,10 @@ func TestNewPowermaxClonner(t *testing.T) {
 		g.Expect(clonner).ToNot(gomega.BeNil())
 		g.Expect(clonner.symmetrixID).To(gomega.Equal("123"))
 		g.Expect(clonner.portGroup).To(gomega.Equal("456"))
+		g.Expect(clonner.arrayInfo.Vendor).To(gomega.Equal("Dell"))
+		g.Expect(clonner.arrayInfo.Product).To(gomega.Equal("PowerMax"))
+		g.Expect(clonner.arrayInfo.Model).To(gomega.Equal("PowerMax_2500"))
+		g.Expect(clonner.arrayInfo.Version).To(gomega.Equal("6079.170.170"))
 	})
 }
 

--- a/cmd/vsphere-copy-offload-populator/internal/powerstore/powerstore.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powerstore/powerstore.go
@@ -21,6 +21,15 @@ const (
 type PowerstoreClonner struct {
 	Client         gopowerstore.Client
 	initiatorGroup string
+	arrayInfo      populator.StorageArrayInfo
+}
+
+// Ensure PowerstoreClonner implements StorageArrayInfoProvider
+var _ populator.StorageArrayInfoProvider = &PowerstoreClonner{}
+
+// GetStorageArrayInfo returns metadata about the PowerStore array for metric labels.
+func (p *PowerstoreClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
+	return p.arrayInfo
 }
 
 func (p *PowerstoreClonner) MapTarget(targetLUN populator.LUN, mappingContext populator.MappingContext) (populator.LUN, error) {
@@ -336,5 +345,26 @@ func NewPowerstoreClonner(hostname, username, password string, sslSkipVerify boo
 		return PowerstoreClonner{}, fmt.Errorf("failed to authenticate with PowerStore backend %s: %w", hostname, err)
 	}
 
-	return PowerstoreClonner{Client: client}, nil
+	clonner := PowerstoreClonner{
+		Client: client,
+		arrayInfo: populator.StorageArrayInfo{
+			Vendor:  "Dell",
+			Product: "PowerStore",
+		},
+	}
+
+	// Fetch software version from the API
+	sw, err := client.GetSoftwareInstalled(ctx)
+	if err != nil {
+		klog.Warningf("Failed to get PowerStore software version for metrics: %v", err)
+	} else {
+		for _, s := range sw {
+			if s.IsCluster {
+				clonner.arrayInfo.Version = s.ReleaseVersion
+				break
+			}
+		}
+	}
+
+	return clonner, nil
 }

--- a/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner.go
+++ b/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner.go
@@ -16,17 +16,39 @@ const PROVIDER_ID = "60002ac"
 // Ensure Primera3ParClonner implements required interfaces
 var _ populator.RDMCapable = &Primera3ParClonner{}
 var _ populator.VVolCapable = &Primera3ParClonner{}
+var _ populator.StorageArrayInfoProvider = &Primera3ParClonner{}
 
 type Primera3ParClonner struct {
 	client         Primera3ParClient
 	initiatorGroup string
+	arrayInfo      populator.StorageArrayInfo
+}
+
+// GetStorageArrayInfo returns metadata about the Primera/3PAR array for metric labels.
+func (c *Primera3ParClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
+	return c.arrayInfo
 }
 
 func NewPrimera3ParClonner(storageHostname, storageUsername, storagePassword string, sslSkipVerify bool) (Primera3ParClonner, error) {
 	clon := NewPrimera3ParClientWsImpl(storageHostname, storageUsername, storagePassword, sslSkipVerify)
-	return Primera3ParClonner{
+	clonner := Primera3ParClonner{
 		client: &clon,
-	}, nil
+		arrayInfo: populator.StorageArrayInfo{
+			Vendor:  "HPE",
+			Product: "Primera/3PAR",
+		},
+	}
+
+	// Fetch model and version from the API
+	sysInfo, err := clon.GetSystemInfo()
+	if err != nil {
+		klog.Warningf("Failed to get Primera/3PAR system info for metrics: %v", err)
+	} else {
+		clonner.arrayInfo.Model = sysInfo.Model
+		clonner.arrayInfo.Version = sysInfo.SystemVersion
+	}
+
+	return clonner, nil
 }
 
 // EnsureClonnerIgroup creates or update an initiator group with the clonnerIqn

--- a/cmd/vsphere-copy-offload-populator/internal/primera3par/par3client.go
+++ b/cmd/vsphere-copy-offload-populator/internal/primera3par/par3client.go
@@ -19,6 +19,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// SystemInfo represents the response from GET /api/v1/system
+type SystemInfo struct {
+	SystemVersion string `json:"systemVersion"`
+	Model         string `json:"model"`
+}
+
 type Primera3ParClient interface {
 	GetSessionKey() (string, error)
 	EnsureLunMapped(initiatorGroup string, targetLUN populator.LUN) (populator.LUN, error)
@@ -30,6 +36,7 @@ type Primera3ParClient interface {
 	CurrentMappedGroups(volumeName string, mappingContext populator.MappingContext) ([]string, error)
 	CopyVolume(sourceVolName string, destVolName string) error
 	GetVolumes() ([]Volume, error)
+	GetSystemInfo() (SystemInfo, error)
 }
 
 type Volume struct {
@@ -939,6 +946,22 @@ func (p *Primera3ParClientWsImpl) waitForTask(taskID int) error {
 			klog.Warningf("Task %d has unknown status %d, continuing to poll", taskID, t.Status)
 		}
 	}
+}
+
+func (p *Primera3ParClientWsImpl) GetSystemInfo() (SystemInfo, error) {
+	reqURL := fmt.Sprintf("%s/api/v1/system", p.BaseURL)
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return SystemInfo{}, fmt.Errorf("failed to create GetSystemInfo request: %w", err)
+	}
+
+	var sysInfo SystemInfo
+	if err := p.doRequestUnmarshalResponse(req, "GetSystemInfo", &sysInfo); err != nil {
+		return SystemInfo{}, fmt.Errorf("failed to get system info: %w", err)
+	}
+
+	return sysInfo, nil
 }
 
 func (p *Primera3ParClientWsImpl) GetVolumes() ([]Volume, error) {

--- a/cmd/vsphere-copy-offload-populator/internal/primera3par/par3clientmock.go
+++ b/cmd/vsphere-copy-offload-populator/internal/primera3par/par3clientmock.go
@@ -133,6 +133,13 @@ func (m *MockPrimera3ParClient) CopyVolume(sourceVolName string, destVolName str
 	return nil
 }
 
+func (m *MockPrimera3ParClient) GetSystemInfo() (SystemInfo, error) {
+	return SystemInfo{
+		SystemVersion: "4.0.0",
+		Model:         "HPE Primera 630",
+	}, nil
+}
+
 func (m *MockPrimera3ParClient) GetVolumes() ([]Volume, error) {
 	var result []Volume
 	id := 0

--- a/cmd/vsphere-copy-offload-populator/internal/pure/flashArray.go
+++ b/cmd/vsphere-copy-offload-populator/internal/pure/flashArray.go
@@ -19,12 +19,14 @@ const FlashProviderID = "624a9370"
 var _ populator.RDMCapable = &FlashArrayClonner{}
 var _ populator.VVolCapable = &FlashArrayClonner{}
 var _ populator.VMDKCapable = &FlashArrayClonner{}
+var _ populator.StorageArrayInfoProvider = &FlashArrayClonner{}
 
 type FlashArrayClonner struct {
 	restClient    *RestClient
 	clusterPrefix string
 	// TODO use this instead of mappingContext[hosts]
 	initiatorHostOrGroup string
+	arrayInfo            populator.StorageArrayInfo
 }
 
 const ClusterPrefixEnv = "PURE_CLUSTER_PREFIX"
@@ -48,10 +50,30 @@ func NewFlashArrayClonner(hostname, username, password, apiToken string, skipSSL
 		return FlashArrayClonner{}, fmt.Errorf("failed to create REST client: %w", err)
 	}
 
-	return FlashArrayClonner{
+	clonner := FlashArrayClonner{
 		restClient:    restClient,
 		clusterPrefix: clusterPrefix,
-	}, nil
+		arrayInfo: populator.StorageArrayInfo{
+			Vendor:  "Pure Storage",
+			Product: "FlashArray",
+		},
+	}
+
+	// Fetch model and version from the API
+	info, err := restClient.GetArrayInfo()
+	if err != nil {
+		klog.Warningf("Failed to get Pure FlashArray info for metrics: %v", err)
+	} else {
+		clonner.arrayInfo.Model = info.Model
+		clonner.arrayInfo.Version = info.Version
+	}
+
+	return clonner, nil
+}
+
+// GetStorageArrayInfo returns metadata about the Pure FlashArray for metric labels.
+func (f *FlashArrayClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
+	return f.arrayInfo
 }
 
 // EnsureClonnerIgroup creates or updates an initiator group with the ESX adapters

--- a/cmd/vsphere-copy-offload-populator/internal/pure/rest_client.go
+++ b/cmd/vsphere-copy-offload-populator/internal/pure/rest_client.go
@@ -629,6 +629,100 @@ func (c *RestClient) FindVolumeBySerial(serial string) (*Volume, error) {
 	return &volumesResponse.Items[0], nil
 }
 
+// ArrayInfo holds array metadata aggregated from /arrays and /controllers endpoints.
+type ArrayInfo struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	OS      string `json:"os"`      // e.g. "Purity//FA"
+	Model   string `json:"model"`   // from /controllers, e.g. "FA-m50"
+	Version string `json:"version"` // e.g. "6.10.3"
+}
+
+// arrayGetResponse maps the GET /api/2.x/arrays JSON response.
+type arrayGetResponse struct {
+	Items []struct {
+		ID      string `json:"id"`
+		Name    string `json:"name"`
+		OS      string `json:"os"`
+		Version string `json:"version"`
+	} `json:"items"`
+}
+
+// controllerGetResponse maps the GET /api/2.x/controllers JSON response.
+type controllerGetResponse struct {
+	Items []struct {
+		Model string `json:"model"`
+		Mode  string `json:"mode"`
+	} `json:"items"`
+}
+
+// GetArrayInfo retrieves array metadata from the FlashArray API.
+// It calls GET /arrays for os and version, and GET /controllers for model.
+func (c *RestClient) GetArrayInfo() (*ArrayInfo, error) {
+	info := &ArrayInfo{}
+
+	// Fetch os + version from /arrays
+	arrResp, err := c.apiGet(fmt.Sprintf("https://%s/api/%s/arrays", c.hostname, c.apiV2))
+	if err != nil {
+		return nil, fmt.Errorf("get array info: %w", err)
+	}
+	var arrays arrayGetResponse
+	if err := json.Unmarshal(arrResp, &arrays); err != nil {
+		return nil, fmt.Errorf("failed to parse arrays response: %w", err)
+	}
+	if len(arrays.Items) == 0 {
+		return nil, fmt.Errorf("arrays response did not contain any items")
+	}
+	info.ID = arrays.Items[0].ID
+	info.Name = arrays.Items[0].Name
+	info.OS = arrays.Items[0].OS
+	info.Version = arrays.Items[0].Version
+
+	// Fetch model from /controllers (use the primary controller)
+	ctrlResp, err := c.apiGet(fmt.Sprintf("https://%s/api/%s/controllers", c.hostname, c.apiV2))
+	if err != nil {
+		klog.Warningf("Pure REST Client: could not fetch controllers for model: %v", err)
+	} else {
+		var controllers controllerGetResponse
+		if err := json.Unmarshal(ctrlResp, &controllers); err != nil {
+			klog.Warningf("Pure REST Client: could not parse controllers response: %v", err)
+		} else {
+			for _, ctrl := range controllers.Items {
+				if ctrl.Model != "" {
+					info.Model = ctrl.Model
+					break
+				}
+			}
+		}
+	}
+
+	return info, nil
+}
+
+// apiGet is a small helper for authenticated GET requests.
+func (c *RestClient) apiGet(url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("x-auth-token", c.authToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
 // compareVersions compares two version strings (e.g., "1.19" vs "1.2")
 // Returns > 0 if v1 > v2, 0 if equal, < 0 if v1 < v2
 func compareVersions(v1, v2 string) int {

--- a/cmd/vsphere-copy-offload-populator/internal/vantara/client.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vantara/client.go
@@ -1,5 +1,11 @@
 package vantara
 
+// StorageInfo represents storage system details from the Vantara API
+type StorageInfo struct {
+	Model            string `json:"model"`
+	DkcMicroVersion  string `json:"dkcMicroVersion"`
+}
+
 // VantaraClient defines the interface for interacting with Vantara storage REST API
 // This interface abstracts the HTTP client implementation for better testability
 type VantaraClient interface {
@@ -20,6 +26,9 @@ type VantaraClient interface {
 	// Snapshot and clone operations
 	CreateCloneLdev(snapshotGroupName string, snapshotPoolId string, pvolLdevId string, svolLdevId string, copySpeed string) error
 	GetClonePairs(snapshotGroupName string, pvolLdevId string) (*ClonePairResponse, error)
+
+	// System information
+	GetStorageInfo() (*StorageInfo, error)
 }
 
 // LdevResponse represents the response from GetLdev API call

--- a/cmd/vsphere-copy-offload-populator/internal/vantara/vantara-api.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vantara/vantara-api.go
@@ -453,6 +453,32 @@ func (api *BlockStorageAPI) GetPortDetails() (*PortDetailsResponse, error) {
 	return &portDetails, nil
 }
 
+// GetStorageInfo retrieves the storage system model and microcode version
+func (api *BlockStorageAPI) GetStorageInfo() (*StorageInfo, error) {
+	if err := api.ensureConnected(); err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/objects/storages/%s", api.BaseURL, api.StorageID)
+	headers := api.sessionHeaders()
+
+	r, err := api.makeHTTPRequest("GET", url, nil, headers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get storage info: %w", err)
+	}
+
+	var info StorageInfo
+	jsonBytes, err := json.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal storage info response: %w", err)
+	}
+	if err := json.Unmarshal(jsonBytes, &info); err != nil {
+		return nil, fmt.Errorf("failed to parse storage info response: %w", err)
+	}
+
+	return &info, nil
+}
+
 // ensureConnected checks the connection status and reconnects if needed
 func (api *BlockStorageAPI) ensureConnected() error {
 	if !api.isConnected {

--- a/cmd/vsphere-copy-offload-populator/internal/vantara/vantara.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vantara/vantara.go
@@ -23,6 +23,15 @@ type VantaraCloner struct {
 	envHostGroupIds []string
 	initiatorGroup  string
 	copySpeed       string
+	arrayInfo       populator.StorageArrayInfo
+}
+
+// Ensure VantaraCloner implements StorageArrayInfoProvider
+var _ populator.StorageArrayInfoProvider = &VantaraCloner{}
+
+// GetStorageArrayInfo returns metadata about the Vantara array for metric labels.
+func (v *VantaraCloner) GetStorageArrayInfo() populator.StorageArrayInfo {
+	return v.arrayInfo
 }
 
 func NewVantaraClonner(hostname, username, password string) (VantaraCloner, error) {
@@ -50,11 +59,26 @@ func NewVantaraClonner(hostname, username, password string) (VantaraCloner, erro
 		return VantaraCloner{}, fmt.Errorf("failed to connect to Vantara storage: %w", err)
 	}
 
-	return VantaraCloner{
+	cloner := VantaraCloner{
 		client:          client,
 		envHostGroupIds: envStorage["hostGroupIds"].([]string),
 		copySpeed:       envStorage["copySpeed"].(string),
-	}, nil
+		arrayInfo: populator.StorageArrayInfo{
+			Vendor:  "Hitachi",
+			Product: "Vantara",
+		},
+	}
+
+	// Fetch model and version from the API
+	storageInfo, err := client.GetStorageInfo()
+	if err != nil {
+		klog.Warningf("Failed to get Vantara storage info for metrics: %v", err)
+	} else {
+		cloner.arrayInfo.Model = storageInfo.Model
+		cloner.arrayInfo.Version = storageInfo.DkcMicroVersion
+	}
+
+	return cloner, nil
 }
 
 func (v *VantaraCloner) MapTarget(targetLUN populator.LUN, context populator.MappingContext) (populator.LUN, error) {

--- a/cmd/vsphere-copy-offload-populator/internal/vantara/vantara_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vantara/vantara_test.go
@@ -90,6 +90,13 @@ func (m *mockVantaraClient) GetClonePairs(snapshotGroupName string, pvolLdevId s
 	return m.pairsResp, nil
 }
 
+func (m *mockVantaraClient) GetStorageInfo() (*StorageInfo, error) {
+	return &StorageInfo{
+		Model:           "VSP 5600",
+		DkcMicroVersion: "90-08-01",
+	}, nil
+}
+
 // TestResolvePVToLUN tests PV to LUN resolution
 func TestResolvePVToLUN(t *testing.T) {
 	cloner := VantaraCloner{

--- a/cmd/vsphere-copy-offload-populator/internal/vmware/client.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vmware/client.go
@@ -37,6 +37,12 @@ type Client interface {
 	GetDatastore(ctx context.Context, dc *object.Datacenter, datastore string) (*object.Datastore, error)
 	// GetVMDiskBacking returns disk backing information for detecting disk type (VVol, RDM, VMDK)
 	GetVMDiskBacking(ctx context.Context, vmId string, vmdkPath string) (*DiskBacking, error)
+	// GetVirtualDiskSizes returns provisioned capacity, datastore-allocated bytes, and disk
+	// backing info for the virtual disk matching vmdkPath in a single VM lookup. Provisioned
+	// is the guest-visible disk size; allocated is the sum of diskExtent file sizes from
+	// layoutEx (thin-used blocks on VMFS). VVol/RDM returns (provisioned, 0, backing, nil).
+	// Returns (0, 0, nil, nil) if the disk cannot be matched.
+	GetVirtualDiskSizes(ctx context.Context, vmId, vmdkPath string) (provisionedBytes, datastoreAllocatedBytes int64, backing *DiskBacking, err error)
 	GetDatastoreActiveAdapters(ctx context.Context, host *object.HostSystem, datastoreName string) ([]HostAdapter, error)
 }
 
@@ -428,38 +434,9 @@ func (c *VSphereClient) GetDatastore(ctx context.Context, dc *object.Datacenter,
 // GetVMDiskBacking retrieves disk backing information to determine disk type
 func (c *VSphereClient) GetVMDiskBacking(ctx context.Context, vmId string, vmdkPath string) (*DiskBacking, error) {
 	log := klog.FromContext(ctx).WithName("esxcli")
-	finder := find.NewFinder(c.Client.Client, true)
-	datacenters, err := finder.DatacenterList(ctx, "*")
+	_, vmProps, err := c.getVMWithConfig(ctx, vmId)
 	if err != nil {
-		return nil, fmt.Errorf("failed getting datacenters: %w", err)
-	}
-
-	var vm *object.VirtualMachine
-	for _, dc := range datacenters {
-		finder.SetDatacenter(dc)
-		result, err := finder.VirtualMachine(ctx, vmId)
-		if err != nil {
-			if _, ok := err.(*find.NotFoundError); !ok {
-				return nil, fmt.Errorf("error searching for VM in Datacenter '%s': %w", dc.Name(), err)
-			}
-		} else {
-			vm = result
-			break
-		}
-	}
-	if vm == nil {
-		moref := types.ManagedObjectReference{Type: "VirtualMachine", Value: vmId}
-		vm = object.NewVirtualMachine(c.Client.Client, moref)
-	}
-	if vm == nil {
-		return nil, fmt.Errorf("failed to find VM with ID %s", vmId)
-	}
-
-	// Get VM configuration to inspect disk devices
-	var vmProps mo.VirtualMachine
-	err = vm.Properties(ctx, vm.Reference(), []string{"config.hardware.device"}, &vmProps)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get VM properties: %w", err)
+		return nil, err
 	}
 
 	// Normalize vmdkPath for comparison (remove brackets and spaces)
@@ -528,6 +505,153 @@ func (c *VSphereClient) GetVMDiskBacking(ctx context.Context, vmId string, vmdkP
 		IsRDM:      false,
 		DeviceName: "",
 	}, nil
+}
+
+// getVMWithConfig looks up a VM across all datacenters and fetches its hardware device config.
+// Falls back to a direct moref lookup if the VM is not found by name/path.
+func (c *VSphereClient) getVMWithConfig(ctx context.Context, vmId string) (*object.VirtualMachine, *mo.VirtualMachine, error) {
+	finder := find.NewFinder(c.Client.Client, true)
+	datacenters, err := finder.DatacenterList(ctx, "*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed getting datacenters: %w", err)
+	}
+
+	var vm *object.VirtualMachine
+	for _, dc := range datacenters {
+		finder.SetDatacenter(dc)
+		result, err := finder.VirtualMachine(ctx, vmId)
+		if err != nil {
+			if _, ok := err.(*find.NotFoundError); !ok {
+				return nil, nil, fmt.Errorf("error searching for VM in Datacenter '%s': %w", dc.Name(), err)
+			}
+		} else {
+			vm = result
+			break
+		}
+	}
+	if vm == nil {
+		moref := types.ManagedObjectReference{Type: "VirtualMachine", Value: vmId}
+		vm = object.NewVirtualMachine(c.Client.Client, moref)
+	}
+
+	var vmProps mo.VirtualMachine
+	err = vm.Properties(ctx, vm.Reference(), []string{"config.hardware.device"}, &vmProps)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get VM properties: %w", err)
+	}
+
+	return vm, &vmProps, nil
+}
+
+func virtualDiskProvisionedBytes(d *types.VirtualDisk) int64 {
+	if d.CapacityInBytes > 0 {
+		return d.CapacityInBytes
+	}
+	return d.CapacityInKB * 1024
+}
+
+// GetVirtualDiskSizes implements Client. It returns provisioned bytes, datastore-allocated
+// bytes, and disk backing info for the disk matching vmdkPath in a single VM lookup.
+func (c *VSphereClient) GetVirtualDiskSizes(ctx context.Context, vmId, vmdkPath string) (int64, int64, *DiskBacking, error) {
+	log := klog.FromContext(ctx).WithName("esxcli")
+	vm, vmProps, err := c.getVMWithConfig(ctx, vmId)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	if vmProps.Config == nil {
+		return 0, 0, nil, nil
+	}
+
+	normalizedPath := strings.ToLower(vmdkPath)
+	var matchedDisk *types.VirtualDisk
+	var diskBacking *DiskBacking
+	for _, device := range vmProps.Config.Hardware.Device {
+		disk, ok := device.(*types.VirtualDisk)
+		if !ok {
+			continue
+		}
+		switch backing := disk.Backing.(type) {
+		case *types.VirtualDiskFlatVer2BackingInfo:
+			if !strings.Contains(strings.ToLower(backing.FileName), normalizedPath) &&
+				!strings.Contains(normalizedPath, strings.ToLower(backing.FileName)) {
+				if !diskPathMatches(backing.FileName, vmdkPath) {
+					continue
+				}
+			}
+			matchedDisk = disk
+			if backing.BackingObjectId != "" {
+				log.V(2).Info("disk is VVol-backed", "vmdk", vmdkPath, "backing_object_id", backing.BackingObjectId)
+				diskBacking = &DiskBacking{VVolId: backing.BackingObjectId, DeviceName: backing.FileName}
+			} else {
+				log.V(2).Info("disk is VMDK-backed", "vmdk", vmdkPath)
+				diskBacking = &DiskBacking{DeviceName: backing.FileName}
+			}
+		case *types.VirtualDiskRawDiskMappingVer1BackingInfo:
+			if !strings.Contains(strings.ToLower(backing.FileName), normalizedPath) &&
+				!strings.Contains(normalizedPath, strings.ToLower(backing.FileName)) {
+				if !diskPathMatches(backing.FileName, vmdkPath) {
+					continue
+				}
+			}
+			matchedDisk = disk
+			log.V(2).Info("disk is RDM-backed", "vmdk", vmdkPath, "device", backing.DeviceName, "lunUuid", backing.LunUuid)
+			diskBacking = &DiskBacking{IsRDM: true, DeviceName: backing.DeviceName, LunUuid: backing.LunUuid}
+		}
+		if matchedDisk != nil {
+			break
+		}
+	}
+	if matchedDisk == nil {
+		log.V(2).Info("disk not found, assuming VMDK type", "vmdk", vmdkPath)
+		return 0, 0, &DiskBacking{}, nil
+	}
+
+	provisionedBytes := virtualDiskProvisionedBytes(matchedDisk)
+
+	// VVol/RDM: layoutEx extent semantics differ; return provisioned only.
+	if diskBacking.VVolId != "" || diskBacking.IsRDM {
+		return provisionedBytes, 0, diskBacking, nil
+	}
+
+	// Fetch datastore-allocated bytes from layoutEx for VMDK disks.
+	if err := vm.RefreshStorageInfo(ctx); err != nil {
+		return provisionedBytes, 0, diskBacking, fmt.Errorf("RefreshStorageInfo: %w", err)
+	}
+
+	var moVM mo.VirtualMachine
+	err = vm.Properties(ctx, vm.Reference(), []string{"layoutEx"}, &moVM)
+	if err != nil {
+		return provisionedBytes, 0, diskBacking, fmt.Errorf("layoutEx: %w", err)
+	}
+	if moVM.LayoutEx == nil {
+		return provisionedBytes, 0, diskBacking, nil
+	}
+
+	fileByKey := make(map[int32]types.VirtualMachineFileLayoutExFileInfo, len(moVM.LayoutEx.File))
+	for _, f := range moVM.LayoutEx.File {
+		fileByKey[f.Key] = f
+	}
+
+	extentType := string(types.VirtualMachineFileLayoutExFileTypeDiskExtent)
+	var total int64
+	for _, dl := range moVM.LayoutEx.Disk {
+		if dl.Key != matchedDisk.Key {
+			continue
+		}
+		for _, unit := range dl.Chain {
+			for _, fk := range unit.FileKey {
+				f := fileByKey[fk]
+				if f.Type == extentType {
+					total += f.Size
+				}
+			}
+		}
+		break
+	}
+	if total <= 0 {
+		return provisionedBytes, 0, diskBacking, nil
+	}
+	return provisionedBytes, total, diskBacking, nil
 }
 
 // diskPathMatches compares two VMDK paths accounting for different formats

--- a/cmd/vsphere-copy-offload-populator/internal/vmware/mocks/vmware_mock_client.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vmware/mocks/vmware_mock_client.go
@@ -103,6 +103,23 @@ func (mr *MockClientMockRecorder) GetVMDiskBacking(ctx, vmId, vmdkPath any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMDiskBacking", reflect.TypeOf((*MockClient)(nil).GetVMDiskBacking), ctx, vmId, vmdkPath)
 }
 
+// GetVirtualDiskSizes mocks base method.
+func (m *MockClient) GetVirtualDiskSizes(ctx context.Context, vmId, vmdkPath string) (int64, int64, *vmware.DiskBacking, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVirtualDiskSizes", ctx, vmId, vmdkPath)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(*vmware.DiskBacking)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// GetVirtualDiskSizes indicates an expected call of GetVirtualDiskSizes.
+func (mr *MockClientMockRecorder) GetVirtualDiskSizes(ctx, vmId, vmdkPath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualDiskSizes", reflect.TypeOf((*MockClient)(nil).GetVirtualDiskSizes), ctx, vmId, vmdkPath)
+}
+
 // RunEsxCommand mocks base method.
 func (m *MockClient) RunEsxCommand(ctx context.Context, host *object.HostSystem, command []string) ([]esx.Values, error) {
 	m.ctrl.T.Helper()

--- a/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator.go
+++ b/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator.go
@@ -11,12 +11,15 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/client-go/util/cert"
 
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/flashsystem"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/infinibox"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/metrics"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/ontap"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/powerflex"
@@ -28,9 +31,8 @@ import (
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/version"
 
 	forklift "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -190,8 +192,26 @@ func main() {
 		klog.Fatalf("Failed to fetch the volume handle details from the target pvc %s: %s", ownerName, err)
 	}
 
+	// Get storage array info for metric labels
+	var arrayInfo populator.StorageArrayInfo
+	if infoProvider, ok := storageApi.(populator.StorageArrayInfoProvider); ok {
+		arrayInfo = infoProvider.GetStorageArrayInfo()
+		klog.Infof("Storage array info: vendor=%s, product=%s, model=%s, version=%s",
+			arrayInfo.Vendor, arrayInfo.Product, arrayInfo.Model, arrayInfo.Version)
+	}
+
 	klog.InfoS("populator", "stage", "setupTracing")
-	progressCounter, xcopyUsedGauge, err := setupTracingMetrics()
+	copyCtx := p.GetCopyContext()
+	var volumeSizeBytes int64
+	if q, err := resource.ParseQuantity(pvcSize); err == nil {
+		volumeSizeBytes = q.Value()
+	}
+	_ = volumeSizeBytes // retained for future use
+
+	// Set up metrics server with scrape detection for post-completion exit.
+	var completionReady atomic.Bool
+	scrapedCh := make(chan struct{}, 1)
+	copyMetrics, err := setupTracingMetrics(&completionReady, scrapedCh)
 	if err != nil {
 		klog.Fatal(err)
 	}
@@ -204,34 +224,66 @@ func main() {
 	cloneLog := log.WithName("xcopy").WithName("clone")
 	log.Info("copy-offload started")
 
+	cloneMethod := copyCtx.CloneMethod // always set by factory: "vib", "ssh", "vvol", or "rdm"
+	var copyStartTime time.Time
+	lastXcopyUsed := 0
+
+	// Record storage array info before Populate (no storageProtocol dependency).
+	copyMetrics.RecordStorageArrayInfo(storageVendor, arrayInfo)
+
 	hll := populator.NewHostLeaseLocker(clientSet)
 	klog.InfoS("populator", "stage", "starting")
+	copyStartTime = time.Now()
 	go p.Populate(sourceVmId, sourceVMDKFile, pv, hll, progressCh, xCopyUsedCh, quitCh)
 
 	for {
 		select {
-		case p := <-progressCh:
-			cloneLog.Info("clone progress", "progress", p)
-			metric := dto.Metric{}
-			if err := progressCounter.WithLabelValues(ownerUID).Write(&metric); err != nil {
-				klog.Error(err)
-			} else if float64(p) > metric.Counter.GetValue() {
-				progressCounter.WithLabelValues(ownerUID).Add(float64(p) - metric.Counter.GetValue())
-			}
+		case progress := <-progressCh:
+			cloneLog.Info("clone progress", "progress", progress)
+			copyMetrics.RecordProgress(ownerUID, progress)
 		case c := <-xCopyUsedCh:
 			cloneLog.Info("xcopy", "xcopyUsed", c)
-			metric := dto.Metric{}
-			if err := xcopyUsedGauge.WithLabelValues(ownerUID).Write(&metric); err != nil {
-				log.Error(err, "failed to write xcopy used gauge")
-			} else {
-				xcopyUsedGauge.WithLabelValues(ownerUID).Set(float64(c))
-			}
+			lastXcopyUsed = c
+			copyMetrics.RecordXcopyUsed(ownerUID, storageVendor, cloneMethod, c)
 		case q := <-quitCh:
+			duration := time.Since(copyStartTime)
 			if q != nil {
 				log.Error(q, "copy-offload failed")
+				copyMetrics.RecordCompletion("failure", ownerUID, storageVendor, cloneMethod, "n/a", lastXcopyUsed, duration)
+
+				completionReady.Store(true)
+				log.Info("copy-offload failed, waiting for metrics scrape", "duration", duration)
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				select {
+				case <-scrapedCh:
+					log.Info("metrics scraped after failure, exiting")
+				case <-ctx.Done():
+					log.Info("timeout waiting for post-failure scrape, exiting")
+				}
 				klog.Fatal(q)
 			}
-			log.Info("copy-offload finished")
+			// Read CopyContext after Populate() — StorageProtocol is now available.
+			copyCtx = p.GetCopyContext()
+			storageProtocol := copyCtx.StorageProtocol
+			if storageProtocol == "" {
+				storageProtocol = "n/a" // VVol/RDM paths don't detect protocol from ESXi adapters
+			}
+			copyMetrics.RecordSourceDiskBytes(ownerUID, storageVendor, cloneMethod, storageProtocol, copyCtx.SourceDiskCapacityBytes, copyCtx.SourceDiskDatastoreAllocatedBytes)
+			copyMetrics.RecordCompletion("success", ownerUID, storageVendor, cloneMethod, storageProtocol, lastXcopyUsed, duration)
+
+			// Signal that completion metrics are ready and wait for one final scrape.
+			completionReady.Store(true)
+			log.Info("copy-offload finished, waiting for metrics scrape", "duration", duration)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			select {
+			case <-scrapedCh:
+				log.Info("metrics scraped after completion, exiting")
+			case <-ctx.Done():
+				log.Info("timeout waiting for post-completion scrape, exiting")
+			}
 			return
 		}
 	}
@@ -376,12 +428,24 @@ func validateStorageAuthentication(token, username, password string) error {
 	return nil
 }
 
-func startMetricsServer(certFile, keyFile string) {
+func startMetricsServer(certFile, keyFile string, completionReady *atomic.Bool, scrapedCh chan<- struct{}) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		promhttp.Handler().ServeHTTP(w, r)
+		// After serving, if completion is ready, notify that we've been scraped.
+		if completionReady.Load() {
+			select {
+			case scrapedCh <- struct{}{}:
+			default:
+			}
+		}
+	})
+
 	go func() {
-		http.Handle("/metrics", promhttp.Handler())
 		cfg := tls.Config{MinVersion: tls.VersionTLS12}
 		server := http.Server{
 			Addr:      ":8443",
+			Handler:   mux,
 			TLSConfig: &cfg,
 		}
 		klog.Info("Starting metrics server")
@@ -391,55 +455,35 @@ func startMetricsServer(certFile, keyFile string) {
 	}()
 }
 
-func setupTracingMetrics() (*prometheus.CounterVec, *prometheus.GaugeVec, error) {
+func setupTracingMetrics(completionReady *atomic.Bool, scrapedCh chan<- struct{}) (*metrics.CopyMetrics, error) {
 	certsDirectory, err := os.MkdirTemp("", "certsdir")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	certBytes, keyBytes, err := cert.GenerateSelfSignedCertKey("", nil, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error generating cert for prometheus: %w", err)
+		return nil, fmt.Errorf("Error generating cert for prometheus: %w", err)
 	}
 
 	certFile := path.Join(certsDirectory, "tls.crt")
 	if err = os.WriteFile(certFile, certBytes, 0600); err != nil {
-		return nil, nil, fmt.Errorf("Error writing cert file: %w", err)
+		return nil, fmt.Errorf("Error writing cert file: %w", err)
 	}
 
 	keyFile := path.Join(certsDirectory, "tls.key")
 	if err = os.WriteFile(keyFile, keyBytes, 0600); err != nil {
-		return nil, nil, fmt.Errorf("Error writing key file: %w", err)
+		return nil, fmt.Errorf("Error writing key file: %w", err)
 	}
 
-	// Register metrics
-	progressCounter := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "vsphere_xcopy_volume_populator_progress",
-			Help: "Progress of vsphere XCOPY volume population",
-		},
-		[]string{"ownerUID"},
-	)
-
-	xcopyUsedGauge := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "vsphere_xcopy_volume_populator_xcopy_used",
-			Help: "Indicates whether XCOPY was used for cloning (0=no, 1=yes)",
-		},
-		[]string{"ownerUID"},
-	)
-
-	// Register both to the default registry
-	if err := prometheus.Register(progressCounter); err != nil {
-		return nil, nil, fmt.Errorf("Progress counter not registered: %w", err)
-	}
-	if err := prometheus.Register(xcopyUsedGauge); err != nil {
-		return nil, nil, fmt.Errorf("XCOPY used gauge not registered: %w", err)
+	m, err := metrics.NewCopyMetrics()
+	if err != nil {
+		return nil, fmt.Errorf("metric not registered: %w", err)
 	}
 
-	startMetricsServer(certFile, keyFile)
+	startMetricsServer(certFile, keyFile, completionReady, scrapedCh)
 
-	return progressCounter, xcopyUsedGauge, nil
+	return m, nil
 }
 
 // getSSHKeysFromEnvironment retrieves SSH keys from environment variables set by the provider controller

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -213,6 +213,9 @@ func RunController(masterURL, kubeconfig, imageName, httpEndpoint, metricsPath, 
 		resources:         resources,
 	}
 
+	if gk.Kind == api.VSphereXcopyVolumePopulatorKind {
+		c.metrics.initCompletionMetrics()
+	}
 	c.metrics.startListener(httpEndpoint, metricsPath)
 	defer c.metrics.stopListener()
 
@@ -744,6 +747,10 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 			if corev1.PodFailed == pod.Status.Phase {
 				// Skip retry logic for VSphere xcopy populator - let it fail immediately
 				if c.gk.Kind == api.VSphereXcopyVolumePopulatorKind {
+					// Record failure metrics with available labels from the CR.
+					migration, _, _ := unstructured.NestedString(crInstance.Object, "metadata", "labels", "migration")
+					vendor, _, _ := unstructured.NestedString(crInstance.Object, "spec", "storageVendorProduct")
+					c.metrics.recordCompletionFromScrape(pvc.UID, "failure", migration, string(pvc.UID), vendor, "", "", "", 0, 0, 0)
 					c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPodFailed, "VSphere xcopy populator failed (no retry): Please check the logs of the populator pod, %s/%s", populatorNamespace, pod.Name)
 					return c.deleteFailedPVC(ctx, pvc)
 				}
@@ -830,6 +837,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 	c.metrics.recordMetrics(pvc.UID, "success")
 
 	// *** At this point the volume population is done and we're just cleaning up ***
+	// Completion metrics were already recorded by updateProgress during the final pod scrape.
 	c.recorder.Eventf(pvc, corev1.EventTypeNormal, reasonPodFinished, "Populator finished")
 
 	// If PVC' still exists, delete it
@@ -877,7 +885,6 @@ func (c *controller) updatePvc(ctx context.Context, pvc *corev1.PersistentVolume
 
 func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolumeClaim, cr *unstructured.Unstructured) error {
 	populatorKind := pvc.Spec.DataSourceRef.Kind
-	importRegExp := regexp.MustCompile("progress\\{ownerUID=\"" + string(pvc.UID) + "\"\\} (\\d+\\.?\\d*)")
 
 	url, err := getMetricsURL(pod)
 	if err != nil {
@@ -902,7 +909,22 @@ func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolum
 		return err
 	}
 
-	match := importRegExp.FindStringSubmatch(string(body))
+	bodyStr := string(body)
+
+	// For xcopy populator: detect completion metrics from the scraped body.
+	if populatorKind == api.VSphereXcopyVolumePopulatorKind && !c.metrics.isCompletionRecorded(pvc.UID) {
+		c.parseAndRecordCompletion(bodyStr, pvc, cr)
+	}
+
+	// Pick the right progress regex for the populator type.
+	var importRegExp *regexp.Regexp
+	if populatorKind == api.VSphereXcopyVolumePopulatorKind {
+		importRegExp = regexp.MustCompile(`vsphere_xcopy_volume_populator_progress\{[^}]*owner_uid="` + string(pvc.UID) + `"[^}]*\} (\d+\.?\d*)`)
+	} else {
+		importRegExp = regexp.MustCompile("progress\\{ownerUID=\"" + string(pvc.UID) + "\"\\} (\\d+\\.?\\d*)")
+	}
+
+	match := importRegExp.FindStringSubmatch(bodyStr)
 	if match == nil {
 		klog.V(5).Info("Failed to find matches, regex: ", importRegExp)
 		return nil
@@ -943,6 +965,53 @@ func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolum
 	}
 
 	return nil
+}
+
+// parseAndRecordCompletion extracts completion metrics from the populator pod's /metrics output.
+// The presence of copy_duration_seconds signals that the copy finished (success or failure).
+func (c *controller) parseAndRecordCompletion(body string, pvc *corev1.PersistentVolumeClaim, cr *unstructured.Unstructured) {
+	ownerUID := string(pvc.UID)
+
+	// Use copy_duration_seconds as the completion signal — emitted on both success and failure.
+	durationRegex := regexp.MustCompile(`vsphere_xcopy_volume_populator_copy_duration_seconds\{[^}]*owner_uid="` + ownerUID + `"[^}]*\} ([0-9.]+)`)
+	durationMatch := durationRegex.FindStringSubmatch(body)
+	if durationMatch == nil {
+		return
+	}
+
+	duration, _ := strconv.ParseFloat(durationMatch[1], 64)
+
+	migration, _, _ := unstructured.NestedString(cr.Object, "metadata", "labels", "migration")
+
+	// Parse source disk bytes by type
+	var provisionedBytes, allocatedBytes float64
+	provisionedRegex := regexp.MustCompile(`vsphere_xcopy_volume_populator_source_disk_bytes\{[^}]*owner_uid="` + ownerUID + `"[^}]*type="provisioned"[^}]*\} ([0-9.e+]+)`)
+	if m := provisionedRegex.FindStringSubmatch(body); m != nil {
+		provisionedBytes, _ = strconv.ParseFloat(m[1], 64)
+	}
+	allocatedRegex := regexp.MustCompile(`vsphere_xcopy_volume_populator_source_disk_bytes\{[^}]*owner_uid="` + ownerUID + `"[^}]*type="datastore_allocated"[^}]*\} ([0-9.e+]+)`)
+	if m := allocatedRegex.FindStringSubmatch(body); m != nil {
+		allocatedBytes, _ = strconv.ParseFloat(m[1], 64)
+	}
+
+	// Parse labels from the duration metric line
+	durationLine := durationRegex.FindString(body)
+	result := extractLabel(durationLine, "result")
+	vendor := extractLabel(durationLine, "storage_vendor")
+	method := extractLabel(durationLine, "clone_method")
+	xcopy := extractLabel(durationLine, "xcopy_used")
+	protocol := extractLabel(durationLine, "storage_protocol")
+
+	c.metrics.recordCompletionFromScrape(pvc.UID, result, migration, ownerUID, vendor, method, xcopy, protocol, duration, provisionedBytes, allocatedBytes)
+}
+
+// extractLabel extracts a label value from a Prometheus metric line.
+func extractLabel(line, labelName string) string {
+	re := regexp.MustCompile(labelName + `="([^"]*)"`)
+	if m := re.FindStringSubmatch(line); m != nil {
+		return m[1]
+	}
+	return ""
 }
 
 func updatePopulatorProgress(progress int64, cr *unstructured.Unstructured) error {

--- a/pkg/lib-volume-populator/populator-machinery/metrics.go
+++ b/pkg/lib-volume-populator/populator-machinery/metrics.go
@@ -40,6 +40,10 @@ type metricsManager struct {
 	registry         k8smetrics.KubeRegistry
 	opLatencyMetrics *k8smetrics.HistogramVec
 	opInFlight       *k8smetrics.Gauge
+	// Completion metrics scraped from populator pod /metrics (xcopy only)
+	copyDuration       *k8smetrics.GaugeVec
+	sourceDiskSize     *k8smetrics.GaugeVec
+	completionRecorded map[types.UID]bool
 }
 
 var metricBuckets = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, 300, 600}
@@ -77,6 +81,65 @@ func initMetrics() *metricsManager {
 	go m.scheduleOpsInFlightMetric()
 
 	return m
+}
+
+// initCompletionMetrics registers xcopy-specific completion metrics on the controller.
+// Call only for the vsphere-xcopy populator controller instance.
+func (m *metricsManager) initCompletionMetrics() {
+	completionLabels := []string{"result", "migration", "owner_uid", "storage_vendor", "clone_method", "xcopy_used", "storage_protocol"}
+
+	m.copyDuration = k8smetrics.NewGaugeVec(
+		&k8smetrics.GaugeOpts{
+			Name: "mtv_vsphere_xcopy_volume_populator_copy_duration_seconds",
+			Help: "Duration of copy-offload operation in seconds per disk, scraped from populator pods.",
+		},
+		completionLabels,
+	)
+	m.sourceDiskSize = k8smetrics.NewGaugeVec(
+		&k8smetrics.GaugeOpts{
+			Name: "mtv_vsphere_xcopy_volume_populator_source_disk_bytes",
+			Help: "Source disk size in bytes per disk, scraped from populator pods. type=provisioned is guest-visible size; type=datastore_allocated is actual data on datastore.",
+		},
+		[]string{"result", "migration", "owner_uid", "storage_vendor", "clone_method", "storage_protocol", "type"},
+	)
+
+	m.completionRecorded = make(map[types.UID]bool)
+
+	m.registry.MustRegister(m.copyDuration)
+	m.registry.MustRegister(m.sourceDiskSize)
+}
+
+// isCompletionRecorded returns whether completion metrics have already been recorded for this PVC.
+func (m *metricsManager) isCompletionRecorded(pvcUID types.UID) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.completionRecorded[pvcUID]
+}
+
+// recordCompletionFromScrape records completion metrics with structured values scraped from the populator pod.
+func (m *metricsManager) recordCompletionFromScrape(pvcUID types.UID, result, migration, ownerUID, vendor, method, xcopy, protocol string, duration, provisionedBytes, allocatedBytes float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.completionRecorded[pvcUID] {
+		return // already recorded
+	}
+	m.completionRecorded[pvcUID] = true
+
+	if m.copyDuration != nil {
+		m.copyDuration.WithLabelValues(result, migration, ownerUID, vendor, method, xcopy, protocol).Set(duration)
+	}
+	if m.sourceDiskSize != nil {
+		if provisionedBytes > 0 {
+			m.sourceDiskSize.WithLabelValues(result, migration, ownerUID, vendor, method, protocol, "provisioned").Set(provisionedBytes)
+		}
+		if allocatedBytes > 0 {
+			m.sourceDiskSize.WithLabelValues(result, migration, ownerUID, vendor, method, protocol, "datastore_allocated").Set(allocatedBytes)
+		}
+	}
+
+	klog.Infof("Recorded completion metrics: result=%s, migration=%s, owner_uid=%s, duration=%.1fs, vendor=%s, method=%s, xcopy=%s, provisioned=%.0f, allocated=%.0f",
+		result, migration, ownerUID, duration, vendor, method, xcopy, provisionedBytes, allocatedBytes)
 }
 
 func (m *metricsManager) scheduleOpsInFlightMetric() {


### PR DESCRIPTION
Add labeled Prometheus metrics to the vSphere XCOPY volume populator to enable telemetry on storage array usage, copy performance, and source disk sizes.

New metrics:
- storage_array_info gauge (info pattern, constant=1) with vendor/product/model/version labels
- source_disk_bytes gauge with type label (datastore_allocated, provisioned, pvc_request)
- copy_duration_seconds histogram with storage labels
- copy_throughput_mb_per_second histogram with storage labels

Enhanced existing metrics (progress, xcopy_used) with storage_vendor, clone_method, storage_protocol labels.

Each storage backend now implements StorageArrayInfoProvider to report array metadata. The CopyContext carries source disk capacity and datastore-allocated bytes from the vmware client (via layoutEx extents).

Ref: https://redhat.atlassian.net/browse/MTV-4825
Resolves: MTV-4825