### PR TITLE
chore: Update copy offload readme

### DIFF
--- a/cmd/vsphere-copy-offload-populator/README.md
+++ b/cmd/vsphere-copy-offload-populator/README.md
@@ -191,7 +191,7 @@ metadata:
   namespace: openshift-mtv
 type: Opaque
 stringData:
-  STORAGE_HOSTNAME: "https://192.168.1.1:8080"
+  STORAGE_HOSTNAME: "192.168.1.1:8080"
   STORAGE_USERNAME: "admin"
   STORAGE_PASSWORD: "your-password"
 ```


### PR DESCRIPTION
The `STORAGE_HOSTNAME` in the docs has `https://` prefix