### PR TITLE
MTV-4436 | Configure snapshot consolidation for VMware warm migration

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -4043,6 +4043,13 @@ spec:
                 description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
                 example: custom-vsphere-osmap
                 type: string
+              wait_for_final_snapshot_consolidation:
+                description: 'Wait for final snapshot removal and consolidation in
+                  a VMware warm migration (default: true)'
+                enum:
+                - "true"
+                - "false"
+                type: string
             type: object
           status:
             description: Status defines the observed state of ForkliftController
@@ -6118,22 +6125,6 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
-              allowSnapshotConsolidation:
-                default: Always
-                description: |-
-                  AllowSnapshotConsolidation enables some level of control over when forklift
-                  will allow VMware to consolidate snapshots after removal, and when forklift
-                  will wait for any consolidations to complete.
-                  - "Always" (default): always consolidate snapshots after removal
-                  - "Never": never consolidate snapshots after removal
-                  - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
-                  - "BeforePenultimateSnapshot": consolidate after every snapshot removal until the second-to-last snapshot
-                enum:
-                - Always
-                - Never
-                - AfterFinalSnapshot
-                - BeforePenultimateSnapshot
-                type: string
               archived:
                 description: Whether this plan should be archived.
                 type: boolean

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -6118,6 +6118,21 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
+              allowSnapshotConsolidation:
+                description: |-
+                  AllowSnapshotConsolidation enables some level of control over when forklift
+                  will allow VMware to consolidate snapshots after removal, and when forklift
+                  will wait for any consolidations to complete.
+                  - "Always" (default): always consolidate snapshots after removal
+                  - "Never": never consolidate snapshots after removal
+                  - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
+                  - "BeforePenultimateSnapshot": consolidate after every snapshot removal until the second-to-last snapshot
+                enum:
+                - Always
+                - Never
+                - AfterFinalSnapshot
+                - BeforePenultimateSnapshot
+                type: string
               archived:
                 description: Whether this plan should be archived.
                 type: boolean

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -6119,6 +6119,7 @@ spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
               allowSnapshotConsolidation:
+                default: Always
                 description: |-
                   AllowSnapshotConsolidation enables some level of control over when forklift
                   will allow VMware to consolidate snapshots after removal, and when forklift

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -4043,6 +4043,13 @@ spec:
                 description: 'ConfigMap name for vSphere OS mappings (default: forklift-vsphere-osmap)'
                 example: custom-vsphere-osmap
                 type: string
+              wait_for_final_snapshot_consolidation:
+                description: 'Wait for final snapshot removal and consolidation in
+                  a VMware warm migration (default: true)'
+                enum:
+                - "true"
+                - "false"
+                type: string
             type: object
           status:
             description: Status defines the observed state of ForkliftController
@@ -6118,22 +6125,6 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
-              allowSnapshotConsolidation:
-                default: Always
-                description: |-
-                  AllowSnapshotConsolidation enables some level of control over when forklift
-                  will allow VMware to consolidate snapshots after removal, and when forklift
-                  will wait for any consolidations to complete.
-                  - "Always" (default): always consolidate snapshots after removal
-                  - "Never": never consolidate snapshots after removal
-                  - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
-                  - "BeforePenultimateSnapshot": consolidate after every snapshot removal until the second-to-last snapshot
-                enum:
-                - Always
-                - Never
-                - AfterFinalSnapshot
-                - BeforePenultimateSnapshot
-                type: string
               archived:
                 description: Whether this plan should be archived.
                 type: boolean

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -6118,6 +6118,21 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
+              allowSnapshotConsolidation:
+                description: |-
+                  AllowSnapshotConsolidation enables some level of control over when forklift
+                  will allow VMware to consolidate snapshots after removal, and when forklift
+                  will wait for any consolidations to complete.
+                  - "Always" (default): always consolidate snapshots after removal
+                  - "Never": never consolidate snapshots after removal
+                  - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
+                  - "BeforePenultimateSnapshot": consolidate after every snapshot removal until the second-to-last snapshot
+                enum:
+                - Always
+                - Never
+                - AfterFinalSnapshot
+                - BeforePenultimateSnapshot
+                type: string
               archived:
                 description: Whether this plan should be archived.
                 type: boolean

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -6119,6 +6119,7 @@ spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
               allowSnapshotConsolidation:
+                default: Always
                 description: |-
                   AllowSnapshotConsolidation enables some level of control over when forklift
                   will allow VMware to consolidate snapshots after removal, and when forklift

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -460,6 +460,10 @@ spec:
                 type: string
                 enum: ["true", "false"]
                 description: "Enable static udn IP addresses feature (default: false)"
+              wait_for_final_snapshot_consolidation:
+                type: string
+                enum: ["true", "false"]
+                description: "Wait for final snapshot removal and consolidation in a VMware warm migration (default: true)"
 
               # Storage & Performance Settings
               controller_filesystem_overhead:

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -55,6 +55,7 @@ spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
               allowSnapshotConsolidation:
+                default: Always
                 description: |-
                   AllowSnapshotConsolidation enables some level of control over when forklift
                   will allow VMware to consolidate snapshots after removal, and when forklift

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -54,6 +54,19 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
+              allowSnapshotConsolidation:
+                description: |-
+                  AllowSnapshotConsolidation enables some level of control over when forklift
+                  will allow VMware to consolidate snapshots after removal, and when forklift
+                  will wait for any consolidations to complete.
+                  - "Always" (default): always consolidate snapshots after removal
+                  - "Never": never consolidate snapshots after removal
+                  - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
+                enum:
+                - Always
+                - Never
+                - AfterFinalSnapshot
+                type: string
               archived:
                 description: Whether this plan should be archived.
                 type: boolean

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -62,10 +62,12 @@ spec:
                   - "Always" (default): always consolidate snapshots after removal
                   - "Never": never consolidate snapshots after removal
                   - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
+                  - "BeforePenultimateSnapshot": consolidate after every snapshot removal until the second-to-last snapshot
                 enum:
                 - Always
                 - Never
                 - AfterFinalSnapshot
+                - BeforePenultimateSnapshot
                 type: string
               archived:
                 description: Whether this plan should be archived.

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -54,22 +54,6 @@ spec:
           spec:
             description: PlanSpec defines the desired state of Plan.
             properties:
-              allowSnapshotConsolidation:
-                default: Always
-                description: |-
-                  AllowSnapshotConsolidation enables some level of control over when forklift
-                  will allow VMware to consolidate snapshots after removal, and when forklift
-                  will wait for any consolidations to complete.
-                  - "Always" (default): always consolidate snapshots after removal
-                  - "Never": never consolidate snapshots after removal
-                  - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
-                  - "BeforePenultimateSnapshot": consolidate after every snapshot removal until the second-to-last snapshot
-                enum:
-                - Always
-                - Never
-                - AfterFinalSnapshot
-                - BeforePenultimateSnapshot
-                type: string
               archived:
                 description: Whether this plan should be archived.
                 type: boolean

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -234,3 +234,5 @@ metric_servicemonitor_name: "{{ app_name }}-metrics"
 metric_interval: "30s"
 metric_port_name: "metrics"
 metrics_rule_name: "{{app_name}}-migration-rules"
+
+wait_for_final_snapshot_consolidation: true

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -286,6 +286,8 @@ spec:
           value: "{{ populator_container_requests_cpu }}"
         - name: POPULATOR_CONTAINER_REQUESTS_MEMORY
           value: "{{ populator_container_requests_memory }}"
+        - name: WAIT_FOR_FINAL_SNAPSHOT_CONSOLIDATION
+          value: "{{ wait_for_final_snapshot_consolidation }}"
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -372,17 +372,6 @@ type PlanSpec struct {
 	//       - environment
 	// +optional
 	TagMapping *TagMapping `json:"tagMapping,omitempty"`
-	// AllowSnapshotConsolidation enables some level of control over when forklift
-	// will allow VMware to consolidate snapshots after removal, and when forklift
-	// will wait for any consolidations to complete.
-	// - "Always" (default): always consolidate snapshots after removal
-	// - "Never": never consolidate snapshots after removal
-	// - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
-	// - "BeforePenultimateSnapshot": consolidate after every snapshot removal until the second-to-last snapshot
-	// +optional
-	// +kubebuilder:validation:Enum=Always;Never;AfterFinalSnapshot;BeforePenultimateSnapshot
-	// +kubebuilder:default:=Always
-	AllowSnapshotConsolidation string `json:"allowSnapshotConsolidation,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -378,8 +378,9 @@ type PlanSpec struct {
 	// - "Always" (default): always consolidate snapshots after removal
 	// - "Never": never consolidate snapshots after removal
 	// - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
+	// - "BeforePenultimateSnapshot": consolidate after every snapshot removal until the second-to-last snapshot
 	// +optional
-	// +kubebuilder:validation:Enum=Always;Never;AfterFinalSnapshot
+	// +kubebuilder:validation:Enum=Always;Never;AfterFinalSnapshot;BeforePenultimateSnapshot
 	AllowSnapshotConsolidation string `json:"allowSnapshotConsolidation,omitempty"`
 }
 

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -372,6 +372,15 @@ type PlanSpec struct {
 	//       - environment
 	// +optional
 	TagMapping *TagMapping `json:"tagMapping,omitempty"`
+	// AllowSnapshotConsolidation enables some level of control over when forklift
+	// will allow VMware to consolidate snapshots after removal, and when forklift
+	// will wait for any consolidations to complete.
+	// - "Always" (default): always consolidate snapshots after removal
+	// - "Never": never consolidate snapshots after removal
+	// - "AfterFinalSnapshot": only consolidate after the final snapshot is removed, and do not wait for it to finish
+	// +optional
+	// +kubebuilder:validation:Enum=Always;Never;AfterFinalSnapshot
+	AllowSnapshotConsolidation string `json:"allowSnapshotConsolidation,omitempty"`
 }
 
 // Find a planned VM.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -381,6 +381,7 @@ type PlanSpec struct {
 	// - "BeforePenultimateSnapshot": consolidate after every snapshot removal until the second-to-last snapshot
 	// +optional
 	// +kubebuilder:validation:Enum=Always;Never;AfterFinalSnapshot;BeforePenultimateSnapshot
+	// +kubebuilder:default:=Always
 	AllowSnapshotConsolidation string `json:"allowSnapshotConsolidation,omitempty"`
 }
 

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -271,6 +271,8 @@ type Validator interface {
 	PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (bool, error)
 	// Validate guest tools installation and status (e.g., VMware Tools, VirtIO drivers).
 	GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error)
+	// Validate that VM does not need to collapse any snapshots into a single base file
+	ConsolidationNeeded(vmRef ref.Ref) (needed bool, err error)
 }
 
 // DestinationClient API.

--- a/pkg/controller/plan/adapter/hyperv/validator.go
+++ b/pkg/controller/plan/adapter/hyperv/validator.go
@@ -240,3 +240,8 @@ func (r *Validator) PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (bool
 func (r *Validator) GuestToolsInstalled(_ ref.Ref) (bool, error) {
 	return true, nil
 }
+
+// NO-OP
+func (r *Validator) ConsolidationNeeded(_ ref.Ref) (bool, error) {
+	return false, nil
+}

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -91,6 +91,11 @@ func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
 	return
 }
 
+// NO-OP
+func (r *Validator) ConsolidationNeeded(vmRef ref.Ref) (needed bool, err error) {
+	return
+}
+
 // MaintenanceMode implements base.Validator
 func (r *Validator) MaintenanceMode(vmRef ref.Ref) (bool, error) {
 	return true, nil

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -208,3 +208,8 @@ func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
 	ok = true
 	return
 }
+
+// NO-OP
+func (r *Validator) ConsolidationNeeded(vmRef ref.Ref) (needed bool, err error) {
+	return
+}

--- a/pkg/controller/plan/adapter/ovfbase/validator.go
+++ b/pkg/controller/plan/adapter/ovfbase/validator.go
@@ -193,3 +193,8 @@ func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
 	ok = true
 	return
 }
+
+// NO-OP
+func (r *Validator) ConsolidationNeeded(vmRef ref.Ref) (needed bool, err error) {
+	return
+}

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -264,3 +264,8 @@ func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (ok bool, err error) {
 	ok = true
 	return
 }
+
+// NO-OP
+func (r *Validator) ConsolidationNeeded(vmRef ref.Ref) (needed bool, err error) {
+	return
+}

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -136,6 +136,14 @@ func (r *Client) RemoveSnapshot(vmRef ref.Ref, snapshot string, hosts util.Hosts
 		if found && migrationVM.Phase == v1beta1.PhaseRemoveFinalSnapshot {
 			consolidate = true
 		}
+	case "BeforePenultimateSnapshot":
+		consolidate = true
+		migrationVM, found := r.Plan.Status.Migration.FindVM(vmRef)
+		if found && migrationVM.Phase == v1beta1.PhaseRemoveFinalSnapshot {
+			consolidate = false
+		} else if found && migrationVM.Phase == v1beta1.PhaseRemovePenultimateSnapshot {
+			consolidate = false
+		}
 	default:
 		consolidate = true
 	}

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -124,7 +124,23 @@ func (r *Client) RemoveSnapshot(vmRef ref.Ref, snapshot string, hosts util.Hosts
 		"snapshot", snapshot,
 		"children", false)
 
-	task, err := vm.RemoveSnapshot(context.TODO(), snapshot, false, nil)
+	var consolidate bool
+	switch r.Plan.Spec.AllowSnapshotConsolidation {
+	case "Always":
+		consolidate = true
+	case "Never":
+		consolidate = false
+	case "AfterFinalSnapshot":
+		consolidate = false
+		migrationVM, found := r.Plan.Status.Migration.FindVM(vmRef)
+		if found && migrationVM.Phase == v1beta1.PhaseRemoveFinalSnapshot {
+			consolidate = true
+		}
+	default:
+		consolidate = true
+	}
+
+	task, err := vm.RemoveSnapshot(context.TODO(), snapshot, false, &consolidate)
 	if err != nil {
 		return "", liberr.Wrap(err)
 	}
@@ -316,6 +332,16 @@ func (r *Client) GetSnapshotDeltas(vmRef ref.Ref, snapshotId string, hosts util.
 // Check if a snapshot is removed
 func (r *Client) CheckSnapshotRemove(vmRef ref.Ref, precopy planapi.Precopy, hosts util.HostsFunc) (bool, error) {
 	r.Log.Info("Check Snapshot Remove", "vmRef", vmRef, "precopy", precopy)
+
+	// If configured to allow consolidation after the final snapshot,
+	// do not wait for it to complete.
+	if r.Plan.Spec.AllowSnapshotConsolidation == "AfterFinalSnapshot" {
+		migrationVM, found := r.Plan.Status.Migration.FindVM(vmRef)
+		if found && migrationVM.Phase == v1beta1.PhaseRemoveFinalSnapshot {
+			return true, nil
+		}
+	}
+
 	taskInfo, err := r.getTaskById(vmRef, precopy.RemoveTaskId, hosts)
 	if err != nil {
 		return false, liberr.Wrap(err)

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -337,7 +337,7 @@ func (r *Client) CheckSnapshotRemove(vmRef ref.Ref, precopy planapi.Precopy, hos
 	// do not wait for it to complete.
 	if r.Plan.Spec.AllowSnapshotConsolidation == "AfterFinalSnapshot" {
 		migrationVM, found := r.Plan.Status.Migration.FindVM(vmRef)
-		if found && migrationVM.Phase == v1beta1.PhaseRemoveFinalSnapshot {
+		if found && migrationVM.Phase == v1beta1.PhaseWaitForFinalSnapshotRemoval {
 			return true, nil
 		}
 	}

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -124,31 +124,7 @@ func (r *Client) RemoveSnapshot(vmRef ref.Ref, snapshot string, hosts util.Hosts
 		"snapshot", snapshot,
 		"children", false)
 
-	var consolidate bool
-	switch r.Plan.Spec.AllowSnapshotConsolidation {
-	case "Always":
-		consolidate = true
-	case "Never":
-		consolidate = false
-	case "AfterFinalSnapshot":
-		consolidate = false
-		migrationVM, found := r.Plan.Status.Migration.FindVM(vmRef)
-		if found && migrationVM.Phase == v1beta1.PhaseRemoveFinalSnapshot {
-			consolidate = true
-		}
-	case "BeforePenultimateSnapshot":
-		consolidate = true
-		migrationVM, found := r.Plan.Status.Migration.FindVM(vmRef)
-		if found && migrationVM.Phase == v1beta1.PhaseRemoveFinalSnapshot {
-			consolidate = false
-		} else if found && migrationVM.Phase == v1beta1.PhaseRemovePenultimateSnapshot {
-			consolidate = false
-		}
-	default:
-		consolidate = true
-	}
-
-	task, err := vm.RemoveSnapshot(context.TODO(), snapshot, false, &consolidate)
+	task, err := vm.RemoveSnapshot(context.TODO(), snapshot, false, ptr.To(true))
 	if err != nil {
 		return "", liberr.Wrap(err)
 	}
@@ -340,15 +316,6 @@ func (r *Client) GetSnapshotDeltas(vmRef ref.Ref, snapshotId string, hosts util.
 // Check if a snapshot is removed
 func (r *Client) CheckSnapshotRemove(vmRef ref.Ref, precopy planapi.Precopy, hosts util.HostsFunc) (bool, error) {
 	r.Log.Info("Check Snapshot Remove", "vmRef", vmRef, "precopy", precopy)
-
-	// If configured to allow consolidation after the final snapshot,
-	// do not wait for it to complete.
-	if r.Plan.Spec.AllowSnapshotConsolidation == "AfterFinalSnapshot" {
-		migrationVM, found := r.Plan.Status.Migration.FindVM(vmRef)
-		if found && migrationVM.Phase == v1beta1.PhaseWaitForFinalSnapshotRemoval {
-			return true, nil
-		}
-	}
 
 	taskInfo, err := r.getTaskById(vmRef, precopy.RemoveTaskId, hosts)
 	if err != nil {

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -657,3 +657,13 @@ func isUnknownToolsStatus(s string) bool {
 		return false
 	}
 }
+
+func (r *Validator) ConsolidationNeeded(vmRef ref.Ref) (needed bool, err error) {
+	vm := &model.VM{}
+	err = r.Source.Inventory.Find(vm, vmRef)
+	if err != nil {
+		err = liberr.Wrap(err, "vm", vmRef.String())
+		return
+	}
+	return vm.ConsolidationNeeded, nil
+}

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -592,6 +592,32 @@ var _ = Describe("vsphere validation tests", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	Describe("ConsolidationNeeded", func() {
+		It("should warn on consolidation needed", func() {
+			plan := createPlan()
+			ctx := plancontext.Context{
+				Plan: plan,
+				Source: plancontext.Source{
+					Inventory: &mockInventory{
+						vm: model.VM{
+							VM1: model.VM1{
+								VM0: model.VM0{
+									ID:   "consolidation-vm-1",
+									Name: "consolidation-vm",
+								},
+							},
+							ConsolidationNeeded: true,
+						},
+					},
+				},
+			}
+			validator := Validator{Context: &ctx}
+			needed, err := validator.ConsolidationNeeded(ref.Ref{Name: "consolidation-vm"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(needed).To(BeTrue())
+		})
+	})
 })
 
 func createPlan() *v1beta1.Plan {

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -593,8 +593,8 @@ var _ = Describe("vsphere validation tests", func() {
 		})
 	})
 
-	Describe("ConsolidationNeeded", func() {
-		It("should warn on consolidation needed", func() {
+	DescribeTable("ConsolidationNeeded",
+		func(consolidationNeeded bool) {
 			plan := createPlan()
 			ctx := plancontext.Context{
 				Plan: plan,
@@ -607,7 +607,7 @@ var _ = Describe("vsphere validation tests", func() {
 									Name: "consolidation-vm",
 								},
 							},
-							ConsolidationNeeded: true,
+							ConsolidationNeeded: consolidationNeeded,
 						},
 					},
 				},
@@ -615,9 +615,11 @@ var _ = Describe("vsphere validation tests", func() {
 			validator := Validator{Context: &ctx}
 			needed, err := validator.ConsolidationNeeded(ref.Ref{Name: "consolidation-vm"})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(needed).To(BeTrue())
-		})
-	})
+			Expect(needed).To(Equal(consolidationNeeded))
+		},
+		Entry("should warn on consolidation needed", true),
+		Entry("should not warn when consolidation is not needed", false),
+	)
 })
 
 func createPlan() *v1beta1.Plan {

--- a/pkg/controller/plan/migrator/base/doc.go
+++ b/pkg/controller/plan/migrator/base/doc.go
@@ -30,28 +30,30 @@ func IsWindowsFromInventory(inv web.Client, vmRef ref.Ref) (bool, error) {
 
 // Predicates.
 var (
-	HasPreHook                libitr.Flag = 0x01
-	HasPostHook               libitr.Flag = 0x02
-	RequiresConversion        libitr.Flag = 0x04
-	CDIDiskCopy               libitr.Flag = 0x08
-	VirtV2vDiskCopy           libitr.Flag = 0x10
-	OpenstackImageMigration   libitr.Flag = 0x20
-	VSphere                   libitr.Flag = 0x40
-	RunInspection             libitr.Flag = 0x80
-	WindowsWaitForGuestReboot libitr.Flag = 0x100
+	HasPreHook                        libitr.Flag = 0x01
+	HasPostHook                       libitr.Flag = 0x02
+	RequiresConversion                libitr.Flag = 0x04
+	CDIDiskCopy                       libitr.Flag = 0x08
+	VirtV2vDiskCopy                   libitr.Flag = 0x10
+	OpenstackImageMigration           libitr.Flag = 0x20
+	VSphere                           libitr.Flag = 0x40
+	RunInspection                     libitr.Flag = 0x80
+	WindowsWaitForGuestReboot         libitr.Flag = 0x100
+	WaitForFinalSnapshotConsolidation libitr.Flag = 0x200
 )
 
 // Steps.
 const (
-	Initialize          = "Initialize"
-	Cutover             = "Cutover"
-	DiskAllocation      = "DiskAllocation"
-	DiskTransfer        = "DiskTransfer"
-	ImageConversion     = "ImageConversion"
-	DiskTransferV2v     = "DiskTransferV2v"
-	VMCreation          = "VirtualMachineCreation"
-	PreflightInspection = "PreflightInspection"
-	Unknown             = "Unknown"
+	Initialize                   = "Initialize"
+	Cutover                      = "Cutover"
+	DiskAllocation               = "DiskAllocation"
+	DiskTransfer                 = "DiskTransfer"
+	ImageConversion              = "ImageConversion"
+	DiskTransferV2v              = "DiskTransferV2v"
+	VMCreation                   = "VirtualMachineCreation"
+	PreflightInspection          = "PreflightInspection"
+	WaitForSnapshotConsolidation = "WaitForFinalSnapshotConsolidation"
+	Unknown                      = "Unknown"
 )
 
 type Migrator interface {

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -217,6 +217,17 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Progress:    libitr.Progress{Total: 1},
 					},
 				})
+		case api.PhaseWaitForFinalSnapshotRemoval:
+			pipeline = append(
+				pipeline,
+				&plan.Step{
+					Task: plan.Task{
+						Name:        WaitForSnapshotConsolidation,
+						Description: "Waiting for final snapshot removal and consolidation",
+						Phase:       api.StepPending,
+						Progress:    libitr.Progress{Total: 1},
+					},
+				})
 		}
 		next, done, _ := itinerary.Next(step.Name)
 		if !done {
@@ -277,8 +288,7 @@ func (r *BaseMigrator) Step(status *plan.VMStatus) (step string) {
 			step = Initialize
 		}
 	case api.PhaseRemovePenultimateSnapshot, api.PhaseWaitForPenultimateSnapshotRemoval, api.PhaseCreateFinalSnapshot,
-		api.PhaseWaitForFinalSnapshot, api.PhaseAddFinalCheckpoint, api.PhaseFinalize, api.PhaseRemoveFinalSnapshot,
-		api.PhaseWaitForFinalSnapshotRemoval:
+		api.PhaseWaitForFinalSnapshot, api.PhaseAddFinalCheckpoint, api.PhaseFinalize, api.PhaseRemoveFinalSnapshot:
 		step = Cutover
 	case api.PhaseCreateGuestConversionPod, api.PhaseConvertGuest:
 		step = ImageConversion
@@ -298,6 +308,8 @@ func (r *BaseMigrator) Step(status *plan.VMStatus) (step string) {
 		}
 	case api.PhasePreflightInspection:
 		step = PreflightInspection
+	case api.PhaseWaitForFinalSnapshotRemoval:
+		step = WaitForSnapshotConsolidation
 	default:
 		step = Unknown
 	}
@@ -335,12 +347,12 @@ func (r *BaseMigrator) warmItinerary() *libitr.Itinerary {
 			{Name: api.PhaseAddFinalCheckpoint},
 			{Name: api.PhaseFinalize},
 			{Name: api.PhaseRemoveFinalSnapshot, All: VSphere},
-			{Name: api.PhaseWaitForFinalSnapshotRemoval, All: VSphere},
 			{Name: api.PhaseCreateGuestConversionPod, All: RequiresConversion},
 			{Name: api.PhaseConvertGuest, All: RequiresConversion},
 			{Name: api.PhaseCreateVM},
 			{Name: api.PhaseWaitForGuestReboots, All: WindowsWaitForGuestReboot},
 			{Name: api.PhasePostHook, All: HasPostHook},
+			{Name: api.PhaseWaitForFinalSnapshotRemoval, All: VSphere | WaitForFinalSnapshotConsolidation},
 			{Name: api.PhaseCompleted},
 		},
 	}
@@ -438,6 +450,8 @@ func (r *BasePredicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
 			break
 		}
 		allowed = r.context.Source.Provider.RequiresConversion() && !r.context.Plan.Spec.SkipGuestConversion
+	case WaitForFinalSnapshotConsolidation:
+		allowed = settings.Settings.Migration.WaitForFinalSnapshotConsolidation
 	}
 
 	return

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -458,5 +458,5 @@ func (r *BasePredicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
 }
 
 func (r *BasePredicate) Count() int {
-	return 0x100
+	return 0x200
 }

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -451,7 +451,7 @@ func (r *BasePredicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
 		}
 		allowed = r.context.Source.Provider.RequiresConversion() && !r.context.Plan.Spec.SkipGuestConversion
 	case WaitForFinalSnapshotConsolidation:
-		allowed = settings.Settings.Migration.WaitForFinalSnapshotConsolidation
+		allowed = settings.Settings.WaitForFinalSnapshotConsolidation
 	}
 
 	return

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -69,6 +69,7 @@ const (
 	VMIpNotMatchingUdnSubnet        = "VMIpNotMatchingUdnSubnet"
 	VMMissingChangedBlockTracking   = "VMMissingChangedBlockTracking"
 	VMHasSnapshots                  = "VMHasSnapshots"
+	VMConsolidationNeeded           = "VMConsolidationNeeded"
 	HostNotReady                    = "HostNotReady"
 	DuplicateVM                     = "DuplicateVM"
 	SharedDisks                     = "SharedDisks"
@@ -146,6 +147,7 @@ const (
 	InMaintenanceMode           = "InMaintenanceMode"
 	MissingGuestInfo            = "MissingGuestInformation"
 	MissingChangedBlockTracking = "MissingChangedBlockTracking"
+	ConsolidationNeeded         = "ConsolidationNeeded"
 )
 
 // Statuses
@@ -950,6 +952,14 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 		Message:  "One or more VMs in the plan have critical concerns that block migration.",
 		Items:    []string{},
 	}
+	consolidationNeeded := libcnd.Condition{
+		Type:     VMConsolidationNeeded,
+		Status:   True,
+		Reason:   ConsolidationNeeded,
+		Category: api.CategoryWarn,
+		Message:  "VM has snapshots that require consolidation. This may cause long delays between precopies.",
+		Items:    []string{},
+	}
 
 	shiftSnapshotVMs := libcnd.Condition{
 		Type:     VMHasSnapshots,
@@ -1300,6 +1310,15 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 					vmHasSnapshotsForWarm.Message = msg
 				}
 			}
+
+			// Check for "consolidation needed"
+			consolidation, err := validator.ConsolidationNeeded(*ref)
+			if err != nil {
+				return err
+			}
+			if consolidation {
+				consolidationNeeded.Items = append(consolidationNeeded.Items, ref.String())
+			}
 		}
 		// is valid vm pvc name template
 		if plan.Spec.PVCNameTemplate != "" || vm.PVCNameTemplate != "" {
@@ -1424,6 +1443,9 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 	}
 	if len(vmCriticalConcerns.Items) > 0 {
 		plan.Status.SetCondition(vmCriticalConcerns)
+	}
+	if len(consolidationNeeded.Items) > 0 {
+		plan.Status.SetCondition(consolidationNeeded)
 	}
 	if len(shiftSnapshotVMs.Items) > 0 {
 		plan.Status.SetCondition(shiftSnapshotVMs)

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -144,6 +144,7 @@ const (
 	fRuntimeHost              = "runtime.host"
 	fPowerState               = "runtime.powerState"
 	fConnectionState          = "runtime.connectionState"
+	fConsolidationNeeded      = "runtime.consolidationNeeded"
 	fSnapshot                 = "snapshot"
 	fIsTemplate               = "config.template"
 	fGuestNet                 = "guest.net"
@@ -969,6 +970,7 @@ func (r *Collector) vmPathSet() []string {
 		fRuntimeHost,
 		fPowerState,
 		fConnectionState,
+		fConsolidationNeeded,
 		fIsTemplate,
 		fSnapshot,
 		fChangeTracking,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -1088,6 +1088,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 					}
 				}
 				v.model.CustomValues = customValues
+			case fConsolidationNeeded:
+				if b, cast := p.Val.(bool); cast {
+					v.model.ConsolidationNeeded = b
+				}
 			}
 		}
 	}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -351,6 +351,7 @@ type VM struct {
 	CustomDef                []CustomFieldDef   `sql:""`
 	CustomValues             []CustomFieldValue `sql:""`
 	Tags                     []Tag              `sql:""`
+	ConsolidationNeeded      bool               `sql:""`
 }
 
 // Determine if current revision has been validated.

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -271,6 +271,7 @@ type VM struct {
 	ConnectionState          string                 `json:"connectionState"`
 	Snapshot                 model.Ref              `json:"snapshot"`
 	ChangeTrackingEnabled    bool                   `json:"changeTrackingEnabled"`
+	ConsolidationNeeded      bool                   `json:"consolidationNeeded"`
 	CpuAffinity              []int32                `json:"cpuAffinity"`
 	CpuHotAddEnabled         bool                   `json:"cpuHotAddEnabled"`
 	CpuHotRemoveEnabled      bool                   `json:"cpuHotRemoveEnabled"`
@@ -357,6 +358,7 @@ func (r *VM) With(m *model.VM) {
 	r.CustomDef = m.CustomDef
 	r.CustomValues = m.CustomValues
 	r.Tags = m.Tags
+	r.ConsolidationNeeded = m.ConsolidationNeeded
 }
 
 // Build self link (URI).

--- a/pkg/provider/ec2/controller/validator/noop.go
+++ b/pkg/provider/ec2/controller/validator/noop.go
@@ -81,3 +81,8 @@ func (r *Validator) VMMigrationType(vmRef ref.Ref) (bool, error) {
 func (r *Validator) WarmMigration() bool {
 	return false
 }
+
+// ConsolidationNeeded returns false - snapshot consolidation not applicable for EC2.
+func (r *Validator) ConsolidationNeeded(vmRef ref.Ref) (bool, error) {
+	return false, nil
+}

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -77,6 +77,7 @@ const (
 	AAPTimeout                             = "AAP_TIMEOUT"
 	AAPInsecureSkipVerify                  = "AAP_INSECURE_SKIP_VERIFY"
 	AAPCASecretName                        = "AAP_CA_SECRET_NAME"
+	WaitForFinalSnapshotConsolidation      = "WAIT_FOR_FINAL_SNAPSHOT_CONSOLIDATION"
 )
 
 // Default values for populator container resources
@@ -188,6 +189,8 @@ type Migration struct {
 	AAPInsecureSkipVerify bool
 	// AAPCASecretName is the name of the Secret in the controller namespace holding a custom CA cert (key "ca.crt").
 	AAPCASecretName string
+	// Whether or not to wait for final snapshot removal and consolidation before finishing Plan.
+	WaitForFinalSnapshotConsolidation bool
 }
 
 // Load settings.
@@ -442,5 +445,6 @@ func (r *Migration) Load() (err error) {
 	if val, found := os.LookupEnv(DeepInspectionImageXFS); found {
 		r.DeepInspectionImageXFS = strings.TrimSpace(val)
 	}
+	r.WaitForFinalSnapshotConsolidation = getEnvBool(WaitForFinalSnapshotConsolidation, true)
 	return
 }

--- a/validation/policies/io/konveyor/forklift/vmware/consolidation_needed.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/consolidation_needed.rego
@@ -1,0 +1,17 @@
+package io.konveyor.forklift.vmware
+
+import rego.v1
+
+consolidation_needed if {
+	input.consolidationNeeded == true
+}
+
+concerns contains flag if {
+	consolidation_needed
+	flag := {
+		"id": "vmware.consolidation_needed",
+		"category": "Information",
+		"label": "Snapshot consolidation required",
+		"assessment": "VM has snapshots that require consolidation. This may cause delays between precopies."
+	}
+}

--- a/validation/policies/io/konveyor/forklift/vmware/consolidation_needed.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/consolidation_needed.rego
@@ -10,7 +10,7 @@ concerns contains flag if {
 	consolidation_needed
 	flag := {
 		"id": "vmware.consolidation_needed",
-		"category": "Information",
+		"category": "Warning",
 		"label": "Snapshot consolidation required",
 		"assessment": "VM has snapshots that require consolidation. This may cause delays between precopies."
 	}

--- a/validation/policies/io/konveyor/forklift/vmware/consolidation_needed_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/consolidation_needed_test.rego
@@ -1,0 +1,24 @@
+package io.konveyor.forklift.vmware
+
+import rego.v1
+
+test_consolidation_needed if {
+	mock_vm := {
+		"name": "test",
+		"consolidationNeeded": true
+	}
+
+	results := concerns with input as mock_vm
+	count(results) == 1
+}
+
+test_consolidation_not_needed if {
+	mock_vm := {
+		"name": "test",
+		"consolidationNeeded": false
+	}
+
+	results := concerns with input as mock_vm
+	count(results) == 0
+}
+


### PR DESCRIPTION
Issue: [MTV-4436](https://redhat.atlassian.net/browse/MTV-4436) Warm migration with heavy write stress can cause extremely long cutover delays due to snapshot consolidations, because forklift currently allows VMware to perform a consolidation when calling RemoveSnapshot.

Fix: Move the final snapshot removal step (including consolidation) to the end of the warm migration itinerary, after VM creation. Add a wait_for_final_snapshot_consolidation flag to the forklift controller to avoid waiting for the removal/consolidation to complete before moving on with plan completion.

~~Fix: Add an "allowSnapshotConsolidation" plan setting to allow different consolidation behaviors:~~
~~- Always: consolidate snapshots with every removal~~
~~- Never: never consolidate snapshots~~
~~- AfterFinalSnapshot: only consolidate when removing the very last snapshot, and specifically do not wait for that removal to complete. With this flag, forklift assumes it has completely transferred the disk and does not need to wait for any further operations from the source provider, which may speed up some test scenarios.~~
~~- BeforePenultimateSnapshot: consolidate on every snapshot removal except for the final two, which are taken after the cutover is triggered. This avoids waiting for consolidation after that point to reduce total cutover time.~~

~~These are mostly debug levers to help with performance testing. In my own testing I have found it is possible to get data corruption with enough abuse. I have also observed that allowing snapshot consolidation on snapshot removal does not necessarily consolidate every VMDK, so the "consolidation needed" condition may still stick around without manual intervention.~~

Resolves: MTV-4436

[MTV-4436]: https://redhat.atlassian.net/browse/MTV-4436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ