### PR TITLE
fix(backport): fixes backport pull/5752

### DIFF
--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -123,7 +123,6 @@ func (c *Conversion) RunVirtV2vInPlace() error {
 		return err
 	}
 	v2vCmdBuilder.AddFlag("--no-fstrim")
-	c.addConversionExtraArgs(v2vCmdBuilder)
 	v2vCmdBuilder.AddPositional(c.LibvirtDomainFile)
 	v2vCmd := v2vCmdBuilder.Build()
 	v2vCmd.SetStdout(os.Stdout)
@@ -149,7 +148,6 @@ func (c *Conversion) RunVirtV2vInPlaceDisk() error {
 		return err
 	}
 	v2vCmdBuilder.AddFlag("--no-fstrim")
-	c.addConversionExtraArgs(v2vCmdBuilder)
 
 	// Add all disks as positional arguments
 	for _, disk := range c.Disks {

--- a/pkg/virt-v2v/conversion/conversion_test.go
+++ b/pkg/virt-v2v/conversion/conversion_test.go
@@ -350,55 +350,6 @@ var _ = Describe("Conversion", func() {
 		)
 	})
 
-	Describe("addConversionExtraArgs", func() {
-		It("adds extra args when they are set",
-			func() {
-				appConfig.ExtraArgs = []string{"--arg1", "--arg2", "value"}
-
-				mockCommandBuilder.EXPECT().AddExtraArgs("--arg1", "--arg2", "value").Return(mockCommandBuilder)
-
-				conversion.addConversionExtraArgs(mockCommandBuilder)
-			},
-		)
-
-		It("does nothing when extra args are nil",
-			func() {
-				appConfig.ExtraArgs = nil
-				// No mock expectations - nothing should be called
-				conversion.addConversionExtraArgs(mockCommandBuilder)
-			},
-		)
-
-		It("calls AddExtraArgs with empty slice when extra args are empty",
-			func() {
-				appConfig.ExtraArgs = []string{}
-				// Empty slice is not nil, so AddExtraArgs is still called
-				mockCommandBuilder.EXPECT().AddExtraArgs().Return(mockCommandBuilder)
-				conversion.addConversionExtraArgs(mockCommandBuilder)
-			},
-		)
-	})
-
-	Describe("addInspectorExtraArgs", func() {
-		It("adds inspector extra args when they are set",
-			func() {
-				appConfig.InspectorExtraArgs = []string{"--inspector-arg1", "--inspector-arg2"}
-
-				mockCommandBuilder.EXPECT().AddExtraArgs("--inspector-arg1", "--inspector-arg2").Return(mockCommandBuilder)
-
-				conversion.addInspectorExtraArgs(mockCommandBuilder)
-			},
-		)
-
-		It("does nothing when inspector extra args are nil",
-			func() {
-				appConfig.InspectorExtraArgs = nil
-				// No mock expectations - nothing should be called
-				conversion.addInspectorExtraArgs(mockCommandBuilder)
-			},
-		)
-	})
-
 	Describe("virtV2vOVAArgs", func() {
 		It("adds OVA args correctly",
 			func() {


### PR DESCRIPTION
Backported change relies on this https://github.com/kubev2v/forklift/commit/f4f57c962239f4023665b2852f2d26b4c16ce5f9 commit which is not in 2.11

Instead of backporting the commit and possibly introducing some breakage, remove the method call to ConversionExtraArgs and InspectioExtraArgs.