### PR TITLE
MTV-5003 | Fix missing RBAC for ServiceAccount list/watch

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -7102,6 +7102,9 @@ rules:
   resources:
   - serviceaccounts
   verbs:
+  - get
+  - list
+  - watch
   - create
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -7102,6 +7102,9 @@ rules:
   resources:
   - serviceaccounts
   verbs:
+  - get
+  - list
+  - watch
   - create
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -185,6 +185,9 @@ rules:
   resources:
   - serviceaccounts
   verbs:
+  - get
+  - list
+  - watch
   - create
 - apiGroups:
   - rbac.authorization.k8s.io


### PR DESCRIPTION
Add get, list, and watch verbs to the serviceaccounts rule in the forklift-controller ClusterRole. The cached client requires these permissions when a custom migration ServiceAccount is configured.

Ref: https://issues.redhat.com/browse/MTV-5003
Resolves: MTV-5003