### PR TITLE
[release-2.11] MTV-5003 | Fix missing RBAC for ServiceAccount list/watch

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -6956,6 +6956,8 @@ rules:
   - serviceaccounts
   verbs:
   - get
+  - list
+  - watch
   - create
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -6956,6 +6956,8 @@ rules:
   - serviceaccounts
   verbs:
   - get
+  - list
+  - watch
   - create
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -186,6 +186,8 @@ rules:
   - serviceaccounts
   verbs:
   - get
+  - list
+  - watch
   - create
 - apiGroups:
   - rbac.authorization.k8s.io


### PR DESCRIPTION
Backport of [#5806](https://github.com/kubev2v/forklift/pull/5806) to release-2.11

Add list and watch verbs to the serviceaccounts rule in the forklift-controller ClusterRole. The cached client requires these permissions when a custom migration ServiceAccount is configured.

Ref: https://issues.redhat.com/browse/MTV-5003
Resolves: MTV-5003