### PR TITLE
[release-2.11] MTV-5018 | Add optional VMware driver removal during Windows vSphere …

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -235,6 +235,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_vsphere_vmware_driver_removal:
+                description: 'Run VMware driver removal scripts during Windows vSphere
+                  conversion (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m
@@ -7748,6 +7755,13 @@ spec:
       - description: Use VMware system serial numbers (default true)
         displayName: Use VMware System Serial Numbers
         path: feature_vmware_system_serial_number
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Run VMware driver removal scripts during Windows vSphere conversion
+          (default false)
+        displayName: Enable VMware Driver Removal On Windows vSphere Conversion
+        path: feature_vsphere_vmware_driver_removal
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -235,6 +235,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_vsphere_vmware_driver_removal:
+                description: 'Run VMware driver removal scripts during Windows vSphere
+                  conversion (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m
@@ -7749,6 +7756,13 @@ spec:
       - description: Use VMware system serial numbers (default true)
         displayName: Use VMware System Serial Numbers
         path: feature_vmware_system_serial_number
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Run VMware driver removal scripts during Windows vSphere conversion
+          (default false)
+        displayName: Enable VMware Driver Removal On Windows vSphere Conversion
+        path: feature_vsphere_vmware_driver_removal
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -235,6 +235,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_vsphere_vmware_driver_removal:
+                description: 'Run VMware driver removal scripts during Windows vSphere
+                  conversion (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m
@@ -7748,6 +7755,13 @@ spec:
       - description: Use VMware system serial numbers (default true)
         displayName: Use VMware System Serial Numbers
         path: feature_vmware_system_serial_number
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Run VMware driver removal scripts during Windows vSphere conversion
+          (default false)
+        displayName: Enable VMware Driver Removal On Windows vSphere Conversion
+        path: feature_vsphere_vmware_driver_removal
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -79,6 +79,10 @@ spec:
                 type: string
                 enum: ["true", "false"]
                 description: "Enable CLI download service (default: true)"
+              feature_vsphere_vmware_driver_removal:
+                type: string
+                enum: ["true", "false"]
+                description: "Run VMware driver removal scripts during Windows vSphere conversion (default: false)"
 
               # Container Images
               controller_image_fqin:

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -87,6 +87,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:radio:true
         - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Run VMware driver removal scripts during Windows vSphere conversion (default false)
+        displayName: Enable VMware Driver Removal On Windows vSphere Conversion
+        path: feature_vsphere_vmware_driver_removal
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
       - description: Require authentication (default true)
         displayName: Require Authentication
         path: feature_auth_required

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -9,6 +9,7 @@ feature_volume_populator: true
 feature_copy_offload: true
 feature_ocp_live_migration: true
 feature_vmware_system_serial_number: true
+feature_vsphere_vmware_driver_removal: false
 feature_cli_download: true
 feature_ova_appliance_management: false
 

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -159,6 +159,10 @@ spec:
         - name: FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER
           value: "true"
 {% endif %}
+{% if feature_vsphere_vmware_driver_removal|bool %}
+        - name: FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL
+          value: "true"
+{% endif %}
 {% if ovirt_osmap_configmap_name is defined %}
         - name: OVIRT_OS_MAP
           value: {{ ovirt_osmap_configmap_name }}

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -153,6 +153,12 @@ spec:
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:radio:true
           - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Run VMware driver removal scripts during Windows vSphere conversion (default false)
+          displayName: Enable VMware Driver Removal On Windows vSphere Conversion
+          path: feature_vsphere_vmware_driver_removal
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
         - description: Require authentication (default true)
           displayName: Require Authentication
           path: feature_auth_required

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -157,6 +157,12 @@ spec:
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:radio:true
           - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - description: Run VMware driver removal scripts during Windows vSphere conversion (default false)
+          displayName: Enable VMware Driver Removal On Windows vSphere Conversion
+          path: feature_vsphere_vmware_driver_removal
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:radio:true
+          - urn:alm:descriptor:com.tectonic.ui:radio:false
         - description: Require authentication (default true)
           displayName: Require Authentication
           path: feature_auth_required

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2252,6 +2252,13 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, vddk
 				Value: vm.NewName,
 			})
 	}
+	if settings.Settings.Features.VsphereVmwareDriverRemoval {
+		environment = append(environment,
+			core.EnvVar{
+				Name:  "V2V_vsphereVmwareDriverRemoval",
+				Value: "true",
+			})
+	}
 
 	environment = append(environment,
 		core.EnvVar{

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -8,14 +8,15 @@ import (
 
 // Environment Variables
 const (
-	FeatureOvirtWarmMigration        = "FEATURE_OVIRT_WARM_MIGRATION"
-	FeatureRetainPrecopyImporterPods = "FEATURE_RETAIN_PRECOPY_IMPORTER_PODS"
-	FeatureStaticUdnIpAddresses      = "FEATURE_STATIC_UDN_IP_ADDRESSES"
-	FeatureVsphereIncrementalBackup  = "FEATURE_VSPHERE_INCREMENTAL_BACKUP"
-	FeatureCopyOffload               = "FEATURE_COPY_OFFLOAD"
-	FeatureOCPLiveMigration          = "FEATURE_OCP_LIVE_MIGRATION"
-	FeatureVmwareSystemSerialNumber  = "FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER"
-	FeatureOVFApplianceManagement    = "FEATURE_OVF_APPLIANCE_MANAGEMENT"
+	FeatureOvirtWarmMigration         = "FEATURE_OVIRT_WARM_MIGRATION"
+	FeatureRetainPrecopyImporterPods  = "FEATURE_RETAIN_PRECOPY_IMPORTER_PODS"
+	FeatureStaticUdnIpAddresses       = "FEATURE_STATIC_UDN_IP_ADDRESSES"
+	FeatureVsphereIncrementalBackup   = "FEATURE_VSPHERE_INCREMENTAL_BACKUP"
+	FeatureCopyOffload                = "FEATURE_COPY_OFFLOAD"
+	FeatureOCPLiveMigration           = "FEATURE_OCP_LIVE_MIGRATION"
+	FeatureVmwareSystemSerialNumber   = "FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER"
+	FeatureOVFApplianceManagement     = "FEATURE_OVF_APPLIANCE_MANAGEMENT"
+	FeatureVsphereVmwareDriverRemoval = "FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL"
 )
 
 // OpenShift version where the FeatureVmwareSystemSerialNumber feature is supported:
@@ -59,6 +60,8 @@ type Features struct {
 	OVFApplianceManagement bool
 	// Whether CDI supports InsecureSkipVerify for ImageIO data sources (CNV 4.21+)
 	InsecureSkipVerifySupported bool
+	// Whether to run VMware driver removal scripts during Windows vSphere conversion (virt-customize).
+	VsphereVmwareDriverRemoval bool
 }
 
 // isOpenShiftVersionAboveMinimum checks if OpenShift version is above or equal to minimum version using semantic versioning
@@ -95,5 +98,6 @@ func (r *Features) Load() (err error) {
 	r.UdnSupportsMac = r.isOpenShiftVersionAboveMinimum(ocpMinForUdnMacSupport)
 	r.InsecureSkipVerifySupported = r.isOpenShiftVersionAboveMinimum(ocpMinForInsecureSkipVerify)
 	r.OVFApplianceManagement = getEnvBool(FeatureOVFApplianceManagement, false)
+	r.VsphereVmwareDriverRemoval = getEnvBool(FeatureVsphereVmwareDriverRemoval, false)
 	return
 }

--- a/pkg/settings/features_test.go
+++ b/pkg/settings/features_test.go
@@ -190,6 +190,36 @@ func TestFeatures_Load_VmwareSystemSerialNumber(t *testing.T) {
 	}
 }
 
+func TestFeatures_Load_VsphereVmwareDriverRemoval(t *testing.T) {
+	tests := []struct {
+		name           string
+		envVal         string
+		unset          bool
+		expectedResult bool
+	}{
+		{name: "default off when unset", unset: true, expectedResult: false},
+		{name: "false when false", envVal: "false", expectedResult: false},
+		{name: "true when true", envVal: "true", expectedResult: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unset {
+				t.Setenv(FeatureVsphereVmwareDriverRemoval, "")
+			} else {
+				t.Setenv(FeatureVsphereVmwareDriverRemoval, tt.envVal)
+			}
+			t.Setenv(OpenShiftVersion, "4.20.0")
+			var features Features
+			if err := features.Load(); err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if features.VsphereVmwareDriverRemoval != tt.expectedResult {
+				t.Errorf("VsphereVmwareDriverRemoval = %v, want %v", features.VsphereVmwareDriverRemoval, tt.expectedResult)
+			}
+		})
+	}
+}
+
 func TestFeatures_isOpenShiftVersionAboveMinimum(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -14,24 +14,25 @@ type MountPath string
 
 // Enviroment variables
 const (
-	EnvLibvirtUrlName             = "V2V_libvirtURL"
-	EnvFingerprintName            = "V2V_fingerprint"
-	EnvInPlaceName                = "V2V_inPlace"
-	EnvExtraArgsName              = "V2V_extra_args"
-	EnvNewNameName                = "V2V_NewName"
-	EnvVmNameName                 = "V2V_vmName"
-	EnvRootDiskName               = "V2V_RootDisk"
-	EnvStaticIPsName              = "V2V_staticIPs"
-	EnvSourceName                 = "V2V_source"
-	EnvDiskPathName               = "V2V_diskPath"
-	EnvSecretKeyName              = "V2V_secretKey"
-	EnvLocalMigrationName         = "LOCAL_MIGRATION"
-	EnvVirtIoWinLegacyDriversName = "VIRTIO_WIN"
-	EnvHostName                   = "V2V_HOSTNAME"
-	EnvNbdeClevis                 = "V2V_NBDE_CLEVIS"
-	EnvMultipleIpsPerNicName      = "V2V_multipleIPsPerNic"
-	EnvRemoteInspection           = "V2V_remoteInspection"
-	EnvRemoteInspectionDisk       = "V2V_remoteInspectDisk_"
+	EnvLibvirtUrlName                 = "V2V_libvirtURL"
+	EnvFingerprintName                = "V2V_fingerprint"
+	EnvInPlaceName                    = "V2V_inPlace"
+	EnvExtraArgsName                  = "V2V_extra_args"
+	EnvNewNameName                    = "V2V_NewName"
+	EnvVmNameName                     = "V2V_vmName"
+	EnvRootDiskName                   = "V2V_RootDisk"
+	EnvStaticIPsName                  = "V2V_staticIPs"
+	EnvSourceName                     = "V2V_source"
+	EnvDiskPathName                   = "V2V_diskPath"
+	EnvSecretKeyName                  = "V2V_secretKey"
+	EnvLocalMigrationName             = "LOCAL_MIGRATION"
+	EnvVirtIoWinLegacyDriversName     = "VIRTIO_WIN"
+	EnvHostName                       = "V2V_HOSTNAME"
+	EnvNbdeClevis                     = "V2V_NBDE_CLEVIS"
+	EnvMultipleIpsPerNicName          = "V2V_multipleIPsPerNic"
+	EnvRemoteInspection               = "V2V_remoteInspection"
+	EnvRemoteInspectionDisk           = "V2V_remoteInspectDisk_"
+	EnvVsphereVmwareDriverRemovalName = "V2V_vsphereVmwareDriverRemoval"
 )
 
 const (
@@ -97,6 +98,8 @@ type AppConfig struct {
 	IsRemoteInspection bool
 	// RemoteInspectionDisks
 	RemoteInspectionDisks []string
+	// V2V_vsphereVmwareDriverRemoval
+	VsphereVmwareDriverRemoval bool
 
 	// V2V_multipleIPsPerNic
 	MultipleIpsPerNicName string
@@ -137,6 +140,7 @@ func (s *AppConfig) Load() (err error) {
 	flag.StringVar(&s.HostName, "hostname", os.Getenv(EnvHostName), "Hostname of the vm")
 	flag.StringVar(&s.MultipleIpsPerNicName, "multiple-ips-per-nic", os.Getenv(EnvMultipleIpsPerNicName), "Multiple IPs per NIC")
 	flag.BoolVar(&s.IsRemoteInspection, "remote-inspection", s.getEnvBool(EnvRemoteInspection, false), "Run virt-v2v-inspection on remote disks")
+	flag.BoolVar(&s.VsphereVmwareDriverRemoval, "vsphere-vmware-driver-removal", s.getEnvBool(EnvVsphereVmwareDriverRemovalName, false), "Run VMware driver removal scripts during Windows vSphere conversion")
 	s.RemoteInspectionDisks = s.getRemoteInspectionDisks()
 	flag.Parse()
 

--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -26,6 +26,15 @@ const (
 	FirstbootCmd            = "--firstboot"
 )
 
+// vsphereVmwareDriverRemovalScriptNames are uploaded in filename order (services, drivers, registry).
+var vsphereVmwareDriverRemovalScriptNames = []string{
+	"9101_disable_vmware_services.bat",
+	"9102_remove_vmware_services.bat",
+	"9103_remove_vmware_driver_packages.bat",
+	"9104_query_vmware_registry.bat",
+	"9105_remove_vmware_registry.bat",
+}
+
 //go:embed scripts
 var scriptFS embed.FS
 
@@ -144,6 +153,11 @@ func (c *Customize) customizeWindows() (err error) {
 		if err != nil {
 			return err
 		}
+	}
+
+	if c.appConfig.VsphereVmwareDriverRemoval && c.appConfig.IsVsphereMigration() {
+		fmt.Println("Adding vSphere VMware driver removal scripts")
+		c.addVsphereVmwareDriverRemoval(cmdBuilder)
 	}
 
 	c.addWinFirstbootScripts(cmdBuilder)
@@ -283,6 +297,15 @@ func (c *Customize) runCmd(builder utils.CommandBuilder) error {
 	return nil
 }
 
+// addVsphereVmwareDriverRemoval uploads VMware cleanup scripts to the guest Firstboot scripts directory.
+func (c *Customize) addVsphereVmwareDriverRemoval(cmdBuilder utils.CommandBuilder) {
+	windowsScriptsPath := filepath.Join(c.appConfig.Workdir, "scripts", "windows")
+	for _, name := range vsphereVmwareDriverRemovalScriptNames {
+		src := filepath.Join(windowsScriptsPath, name)
+		cmdBuilder.AddArg(UploadCmd, c.formatUpload(src, filepath.Join(WinFirstbootScriptsPath, name)))
+	}
+}
+
 // addWinFirstbootScripts appends firstboot script arguments to extraArgs
 func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) {
 	windowsScriptsPath := filepath.Join(c.appConfig.Workdir, "scripts", "windows")
@@ -322,7 +345,7 @@ func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) {
 		}
 	}
 	uploadInitPath := c.formatUpload(initPath, WinFirstbootScriptsPath)
-	cmdBuilder.AddArgs("--upload", uploadPreserveIpPath, uploadInitPath, uploadRemoveDuplicatesPath, uploadPreserveMultipleIpPath)
+	cmdBuilder.AddArgs(UploadCmd, uploadPreserveIpPath, uploadInitPath, uploadRemoveDuplicatesPath, uploadPreserveMultipleIpPath)
 }
 
 func (c *Customize) addWinDynamicScripts(cmdBuilder utils.CommandBuilder, dir string) error {

--- a/pkg/virt-v2v/customize/customize_test.go
+++ b/pkg/virt-v2v/customize/customize_test.go
@@ -613,6 +613,34 @@ var _ = Describe("Customize", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to read scripts directory"))
 		})
+
+		It("adds vSphere VMware driver removal script uploads", func() {
+			customize.disks = disks
+			appConfig.VsphereVmwareDriverRemoval = true
+			appConfig.Source = config.VSPHERE
+
+			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
+
+			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
+
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder).Times(5)
+
+			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
+
+			for _, disk := range disks {
+				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
+			}
+
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().Run().Return(nil)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+
+			err := customize.customizeWindows()
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Describe("addWinDynamicScripts", func() {

--- a/pkg/virt-v2v/customize/scripts/windows/9101_disable_vmware_services.bat
+++ b/pkg/virt-v2v/customize/scripts/windows/9101_disable_vmware_services.bat
@@ -1,0 +1,146 @@
+@echo off
+:: ===============================================================
+:: disable_vmware_srv.cmd
+:: Permanently disable all VMware services
+:: ===============================================================
+
+setlocal enabledelayedexpansion
+
+REM =============================
+REM Check for admin privileges
+REM =============================
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: This script must be run as Administrator!
+    echo Please right-click and select "Run as administrator"
+    pause
+    exit /b 1
+)
+
+:: --- Script directory ---
+set "SCRIPT_DIR=%~dp0"
+set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+:: --- Log file ---
+set "LOG=%SCRIPT_DIR%\vmware_disable.log"
+echo =============================================================== > "%LOG%"
+echo   VMware Service Disable Log - %DATE% %TIME% >> "%LOG%"
+echo =============================================================== >> "%LOG%"
+
+echo.
+echo ===============================================================
+echo   VMware Service Disabler (Run as Administrator)
+echo ===============================================================
+echo.
+echo [INFO] Log file: %LOG%
+echo.
+
+:: ===============================================================
+:: Enumerate all services
+:: ===============================================================
+echo [INFO] Enumerating services...
+set "TEMPFILE=%temp%\all_services.txt"
+sc query type= service state= all > "%TEMPFILE%"
+
+:: Initialize
+set "VMWARE_LIST="
+set /a MATCH_COUNT=0
+
+:: ===============================================================
+:: Check each service for VMware
+:: ===============================================================
+for /f "tokens=2 delims=:" %%A in ('findstr /R "^SERVICE_NAME" "%TEMPFILE%"') do (
+    set "SVC=%%A"
+    set "SVC=!SVC: =!"  :: Remove leading space
+    call :CheckVMwareService !SVC!
+)
+
+del "%TEMPFILE%" >nul 2>&1
+
+if %MATCH_COUNT%==0 (
+    echo [INFO] No VMware-related services found. >> "%LOG%"
+    echo [INFO] No VMware-related services found.
+    goto :EOF
+)
+
+echo.
+echo [INFO] Found %MATCH_COUNT% VMware-related services:
+for %%S in (!VMWARE_LIST!) do echo   %%S
+echo.
+
+REM choice /m "Proceed to stop and disable these services permanently?"
+REM if errorlevel 2 (
+REM    echo [INFO] Skipping services. >> "%LOG%"
+REM    goto :EOF
+REM )
+
+:: ===============================================================
+:: Stop and disable VMware services
+:: ===============================================================
+for %%S in (!VMWARE_LIST!) do (
+    call :StopAndDisableService "%%S"
+)
+
+echo.
+echo ===============================================================
+echo VMware services have been processed.
+echo See log for details: %LOG%
+echo ===============================================================
+goto :EOF
+
+:: ===============================================================
+:: SUBROUTINES
+:: ===============================================================
+
+:CheckVMwareService
+setlocal
+set "SVC=%~1"
+set "IS_VMWARE="
+
+:: Query service configuration
+for /f "tokens=*" %%L in ('sc qc "%SVC%" 2^>nul') do (
+    echo %%L | findstr /I "VMware" >nul && set "IS_VMWARE=1"
+)
+
+if defined IS_VMWARE (
+    echo [MATCH] %SVC% appears to be VMware-related.
+    echo [MATCH] %SVC% appears to be VMware-related. >> "%LOG%"
+    endlocal & set "VMWARE_LIST=%VMWARE_LIST% %SVC%" & set /a MATCH_COUNT+=1
+) else (
+    endlocal
+)
+goto :eof
+
+:StopAndDisableService
+setlocal
+set "SVC=%~1"
+echo ---------------------------------------------------------------
+echo [ACTION] Stopping and disabling %SVC%...
+echo [ACTION] Stopping and disabling %SVC%... >> "%LOG%"
+
+:: Stop gracefully
+sc stop "%SVC%" >nul 2>&1
+
+:: Wait a few seconds
+ping 127.0.0.1 -n 3 >nul
+
+:: Force kill if still running
+for /f "tokens=2 delims=:" %%P in ('sc queryex "%SVC%" ^| find "PID"') do (
+    set "PID=%%P"
+    set "PID=!PID: =!"
+    if not "!PID!"=="0" (
+        echo [ACTION] Forcibly killing PID !PID!
+        echo [ACTION] Forcibly killing PID !PID! >> "%LOG%"
+        taskkill /PID !PID! /F >nul 2>&1
+    )
+)
+
+:: Disable permanently
+sc config "%SVC%" start= disabled >nul 2>&1
+
+:: Show final state
+sc query "%SVC%" | findstr /I "STATE"
+
+echo [INFO] %SVC% processed. >> "%LOG%"
+endlocal
+goto :eof

--- a/pkg/virt-v2v/customize/scripts/windows/9102_remove_vmware_services.bat
+++ b/pkg/virt-v2v/customize/scripts/windows/9102_remove_vmware_services.bat
@@ -1,0 +1,152 @@
+@echo off
+:: ===============================================================
+:: remove_vmware_srv.bat
+:: Permanently disable and remove all VMware services
+:: ===============================================================
+
+setlocal enabledelayedexpansion
+
+:: --- Script directory ---
+set "SCRIPT_DIR=%~dp0"
+set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+:: --- Log file ---
+set "LOG=%SCRIPT_DIR%\vmware_disable.log"
+echo =============================================================== > "%LOG%"
+echo   VMware Service Disable Log - %DATE% %TIME% >> "%LOG%"
+echo =============================================================== >> "%LOG%"
+
+echo.
+echo ===============================================================
+echo   VMware Service Disabler (Run as Administrator)
+echo ===============================================================
+echo.
+echo [INFO] Log file: %LOG%
+echo.
+
+:: ===============================================================
+:: Enumerate all services
+:: ===============================================================
+echo [INFO] Enumerating services...
+set "TEMPFILE=%temp%\all_services.txt"
+sc query type= service state= all > "%TEMPFILE%"
+
+:: Initialize
+set "VMWARE_LIST="
+set /a MATCH_COUNT=0
+
+:: ===============================================================
+:: Check each service for VMware
+:: ===============================================================
+for /f "tokens=2 delims=:" %%A in ('findstr /R "^SERVICE_NAME" "%TEMPFILE%"') do (
+    set "SVC=%%A"
+    set "SVC=!SVC: =!"  :: Remove leading space
+    call :CheckVMwareService !SVC!
+)
+
+del "%TEMPFILE%" >nul 2>&1
+
+if %MATCH_COUNT%==0 (
+    echo [INFO] No VMware-related services found. >> "%LOG%"
+    echo [INFO] No VMware-related services found.
+    goto :EOF
+)
+
+echo.
+echo [INFO] Found %MATCH_COUNT% VMware-related services:
+for %%S in (!VMWARE_LIST!) do echo   %%S
+echo.
+
+REM choice /m "Proceed to stop and disable these services permanently?"
+REM if errorlevel 2 (
+REM    echo [INFO] Skipping services. >> "%LOG%"
+REM    goto :EOF
+REM )
+
+:: ===============================================================
+:: Stop and disable VMware services
+:: ===============================================================
+for %%S in (!VMWARE_LIST!) do (
+    call :StopAndDisableService "%%S"
+)
+
+echo.
+echo ===============================================================
+echo VMware services have been processed.
+echo See log for details: %LOG%
+echo ===============================================================
+goto :EOF
+
+:: ===============================================================
+:: SUBROUTINES
+:: ===============================================================
+
+:CheckVMwareService
+setlocal
+set "SVC=%~1"
+set "IS_VMWARE="
+
+:: Query service configuration
+for /f "tokens=*" %%L in ('sc qc "%SVC%" 2^>nul') do (
+    echo %%L | findstr /I "VMware" >nul && set "IS_VMWARE=1"
+)
+
+if defined IS_VMWARE (
+    echo [MATCH] %SVC% appears to be VMware-related.
+    echo [MATCH] %SVC% appears to be VMware-related. >> "%LOG%"
+    endlocal & set "VMWARE_LIST=%VMWARE_LIST% %SVC%" & set /a MATCH_COUNT+=1
+) else (
+    endlocal
+)
+goto :eof
+
+:StopAndDisableService
+setlocal
+set "SVC=%~1"
+echo ---------------------------------------------------------------
+echo [ACTION] Stopping and disabling %SVC%...
+echo [ACTION] Stopping and disabling %SVC%... >> "%LOG%"
+
+:: Stop gracefully
+sc stop "%SVC%" >nul 2>&1
+
+:: Wait a few seconds
+ping 127.0.0.1 -n 3 >nul
+
+:: Force kill if still running
+for /f "tokens=2 delims=:" %%P in ('sc queryex "%SVC%" ^| find "PID"') do (
+    set "PID=%%P"
+    set "PID=!PID: =!"
+    if not "!PID!"=="0" (
+        echo [ACTION] Forcibly killing PID !PID!
+        echo [ACTION] Forcibly killing PID !PID! >> "%LOG%"
+        taskkill /PID !PID! /F >nul 2>&1
+    )
+)
+
+:: Disable permanently
+sc config "%SVC%" start= disabled >nul 2>&1
+if errorlevel 1 (
+    echo [WARNING] Failed to disable %SVC% >> "%LOG%"
+    echo [WARNING] Failed to disable %SVC%
+) else (
+    echo [SUCCESS] %SVC% disabled successfully >> "%LOG%"
+    echo [SUCCESS] %SVC% disabled successfully
+)
+
+:: Show the state before deletion
+sc query "%SVC%" | findstr /I "STATE" 2>nul
+
+:: Uninstall permanently
+sc delete "%SVC%" >nul 2>&1
+if errorlevel 1 (
+    echo [WARNING] Failed to delete %SVC% (may already be deleted) >> "%LOG%"
+    echo [WARNING] Failed to delete %SVC% (may already be deleted)
+) else (
+    echo [SUCCESS] %SVC% deleted successfully >> "%LOG%"
+    echo [SUCCESS] %SVC% deleted successfully
+)
+
+echo [INFO] %SVC% processed. >> "%LOG%"
+endlocal
+goto :eof

--- a/pkg/virt-v2v/customize/scripts/windows/9103_remove_vmware_driver_packages.bat
+++ b/pkg/virt-v2v/customize/scripts/windows/9103_remove_vmware_driver_packages.bat
@@ -1,0 +1,126 @@
+@echo off
+:: ===============================================================
+:: remove_vmware_driver_packages.cmd
+:: Remove all VMware-related driver packages using pnputil.exe
+:: Enumerates all drivers, filters for VMware providers, and removes them
+:: More aggressive than remove_vmware_drivers.bat - removes driver packages
+:: ===============================================================
+
+setlocal enabledelayedexpansion
+
+REM =============================
+REM Check for admin privileges
+REM =============================
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: This script must be run as Administrator!
+    echo Please right-click and select "Run as administrator"
+REM    pause
+    exit /b 1
+)
+
+:: --- Get script directory ---
+set "SCRIPT_DIR=%~dp0"
+set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+echo.
+echo ===============================================================
+echo   Remove VMware Driver Packages Script
+echo   Run as Administrator
+echo ===============================================================
+echo.
+
+echo ==========================================
+echo  Searching for VMware drivers and packages
+echo ==========================================
+echo.
+
+:: --- Enumerate all drivers ---
+pnputil /enum-drivers > "%temp%\all_drivers.txt"
+
+:: --- Filter for VMware drivers ---
+echo Filtering lines with Published Name and VMware...
+findstr /i /c:"Published Name" /c:"Provider Name" "%temp%\all_drivers.txt" > "%temp%\vmware_drivers.txt"
+
+echo.
+echo ===== VMware Drivers Found =====
+
+:: --- Initialize variables ---
+set COUNT=0
+set LAST_PUBLISHED=
+
+:: --- Parse driver list for VMware providers ---
+for /f "tokens=1,* delims=:" %%A in (%temp%\vmware_drivers.txt) do (
+    set LINE=%%A
+    set VALUE=%%B
+    set VALUE=!VALUE: =!
+
+    if /i "!LINE!"=="Published Name" (
+        set LAST_PUBLISHED=!VALUE!
+    )
+
+    if /i "!LINE!"=="Provider Name" (
+        echo !VALUE! | findstr /i "VMware" >nul
+        if !errorlevel! == 0 (
+            REM This Published Name belongs to VMware
+            if not "!LAST_PUBLISHED!"=="" (
+                echo Found VMware INF: !LAST_PUBLISHED!
+                set INF_LIST[!COUNT!]=!LAST_PUBLISHED!
+                set /a COUNT+=1
+            )
+        )
+        set LAST_PUBLISHED=
+    )
+)
+
+:: --- Check if any drivers were found ---
+if %COUNT% EQU 0 (
+    echo No VMware drivers found to remove.
+    echo.
+    echo ===============================================================
+    echo No VMware driver packages found.
+    echo ===============================================================
+REM    pause
+    exit /b 0
+)
+
+echo.
+echo ===============================
+echo  Removing VMware Driver Packages
+echo ===============================
+echo.
+
+:: --- Remove each VMware driver package ---
+set "LOG_FILE=%SCRIPT_DIR%\removal_log.txt"
+set "REBOOT_REQUIRED=0"
+for /l %%I in (0,1,%COUNT%-1) do (
+    set INF=!INF_LIST[%%I]!
+    if not "!INF!"=="" (
+        echo Removing !INF! ...
+        pnputil /delete-driver "!INF!" /uninstall /force > "%temp%\pnputil_output.txt" 2>&1
+        type "%temp%\pnputil_output.txt" >> "%LOG_FILE%"
+        type "%temp%\pnputil_output.txt" | findstr /i "reboot restart" >nul
+        if !errorlevel! == 0 (
+            set REBOOT_REQUIRED=1
+        )
+        echo Done.
+    )
+)
+del "%temp%\pnputil_output.txt" >nul 2>&1
+
+:: --- Clean up temporary files ---
+del "%temp%\all_drivers.txt" >nul 2>&1
+del "%temp%\vmware_drivers.txt" >nul 2>&1
+
+echo.
+echo ===============================================================
+echo  VMware driver removal process finished
+echo  Log saved to: %LOG_FILE%
+if %REBOOT_REQUIRED% EQU 1 (
+    echo.
+    echo WARNING: A system reboot is required to complete the removal.
+    echo Please restart your computer when convenient.
+)
+echo ===============================================================
+REM pause
+exit /b 0

--- a/pkg/virt-v2v/customize/scripts/windows/9104_query_vmware_registry.bat
+++ b/pkg/virt-v2v/customize/scripts/windows/9104_query_vmware_registry.bat
@@ -1,0 +1,257 @@
+@echo off
+:: ===============================================================
+:: query_vmware_registry.cmd
+:: Query all VMware-related registry entries
+:: Displays current registry keys and values
+:: Read-only operation - does not modify registry
+:: ===============================================================
+
+setlocal enabledelayedexpansion
+
+REM =============================
+REM Check for admin privileges
+REM =============================
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: This script must be run as Administrator!
+    echo Please right-click and select "Run as administrator"
+    pause
+    exit /b 1
+)
+
+echo.
+echo ===============================================================
+echo   Query VMware Registry Entries Script
+echo   Run as Administrator
+echo ===============================================================
+echo.
+
+:: --- Initialize counters ---
+set /a FOUND=0
+set /a NOT_FOUND=0
+
+echo ==========================================
+echo  Querying registry entries
+echo ==========================================
+echo.
+
+:: ===============================================================
+:: Embedded Registry Entries
+:: Format: call :QueryRegistryEntry "HKLM\Path" "ValueName"
+:: Empty ValueName means query entire key
+:: ===============================================================
+
+call :QueryRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\shell\open\command" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\InstallInfo" "IconsVisible"
+call :QueryRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE" "LocalizedString"
+call :QueryRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\InstallInfo" "ReinstallCommand"
+call :QueryRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\InstallInfo" "HideIconsCommand"
+call :QueryRegistryEntry "HKLM\SOFTWARE\Classes\Applications\VMwareHostOpen.exe\shell\open\command" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\InstallInfo" "ShowIconsCommand"
+call :QueryRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\DefaultIcon" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocFile\shell\open\command" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocURL\shell\open\command" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "sftp"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "ftp"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".htm"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "news"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "http"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities" "ApplicationDescription"
+call :QueryRegistryEntry "HKLM\SOFTWARE\RegisteredApplications" "VMware Host Open"
+call :QueryRegistryEntry "HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocURL" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocFile" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".shtml"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "mailto"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".xhtml"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "feed"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "https"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "telnet"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".xht"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".html"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "ssh"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\Startmenu" "StartmenuInternet"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmtools" "*"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmtools" "TypesSupported"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmtools" "EventMessageFile"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\networkprovider" "Name"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\networkprovider" "ProviderPath"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\networkprovider" "DeviceName"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\parameters" "ServerName"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\parameters" "ShareName"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware VGAuth" "PreferencesFile"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Tools" "InstallPath"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP" "TypesSupported"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt" "*"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt" "EventMessageFile"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP" "EventMessageFile"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\vmwTimeProvider" "Enabled"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "EventMessageFile"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP" "*"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "TypesSupported"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\vmwTimeProvider" "*"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt" "TypesSupported"
+call :QueryRegistryEntry "HKLM\SOFTWARE\Classes\CLSID\{C73DA087-EDDB-4a7c-B216-8EF8A3B92C7B}\InprocServer32" ""
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\vmwTimeProvider" "InputProvider"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\vmwTimeProvider" "DllName"
+call :QueryRegistryEntry "HKLM\Software\VMware, Inc.\VMware Tools\VMUpgradeHelper" "-"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "CategoryMessageFile"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "EventMessageFile"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "CategoryCount"
+call :QueryRegistryEntry "HKLM\Software\VMware, Inc.\VMware Tools\GuestIntrospection" "-"
+call :QueryRegistryEntry "HKLM\Software\VMware, Inc.\VMware Tools\GuestStoreUpgrade" "-"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMUpgradeHelper" "EventMessageFile"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMUpgradeHelper" "TypesSupported"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VGAuth" "EventMessageFile"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VGAuth" "TypesSupported"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMware Tools" "EventMessageFile"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMware Tools" "TypesSupported"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmrawdsk\Parameters" "CommonAppData"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmrawdsk\Parameters" "PrevBootMode"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmrawdsk\Parameters" "CacheDir"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmrawdsk\Parameters" "Windir"
+
+:: --- VMCI Registry Entries (from export files) ---
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" ""
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Type"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Start"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "ErrorControl"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Tag"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "ImagePath"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "DisplayName"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Group"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Owners"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "vwdk.installers"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci\Enum" ""
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci\Enum" "0"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci\Enum" "Count"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci\Enum" "NextInstance"
+
+:: --- VMMouse Registry Entries (from export files) ---
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" ""
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Type"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Start"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "ErrorControl"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Tag"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "ImagePath"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "DisplayName"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Group"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Owners"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "vwdk.installers"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse\Enum" ""
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse\Enum" "0"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse\Enum" "Count"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse\Enum" "NextInstance"
+
+:: --- VMUsbMouse Registry Entries (from export files) ---
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" ""
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Type"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Start"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "ErrorControl"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Tag"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "ImagePath"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "DisplayName"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Group"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Owners"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "vwdk.installers"
+call :QueryRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse\Parameters" ""
+
+:: --- VMware Software Registry Entries (from vmwreg.txt) ---
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc." ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\CbLauncher" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\CbLauncher" "Cb.LauncherVersion"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\CbLauncher" "Cb.InstallStatus"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "VmciHostDevInst"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmci.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmci.installPath"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vsock.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vsock.installPath"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vsockSys.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vsockDll.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "efifw.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "efifw.installPath"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmxnet3.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmxnet3.installPath"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "pvscsi.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "pvscsi.installPath"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmusbmouse.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmusbmouse.installPath"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmmouse.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmmouse.installPath"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmmemctl.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmmemctl.installPath"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "svga_wddm.status"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "svga_wddm.installPath"
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Tools" ""
+call :QueryRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware VGAuth" ""
+
+echo.
+echo ===============================================================
+echo  Registry query process finished
+echo ===============================================================
+echo.
+echo Summary:
+echo   Found: %FOUND% entries
+echo   Not Found: %NOT_FOUND% entries
+echo ===============================================================
+goto :EOF
+
+:: --- Subroutine: Query registry entry ---
+:QueryRegistryEntry
+setlocal enabledelayedexpansion
+set "REG_PATH=%~1"
+set "VAL_NAME=%~2"
+
+:: Handle registry query based on whether Name field is empty
+if "!VAL_NAME!"=="" (
+    :: Empty name means query entire key
+    echo ---------------------------------------------------------------
+    echo [KEY] !REG_PATH!
+    echo ---------------------------------------------------------------
+    reg query "!REG_PATH!" >nul 2>&1
+    if !errorlevel! equ 0 (
+        reg query "!REG_PATH!" 2>nul
+        if !errorlevel! equ 0 (
+            echo [FOUND] Key exists
+            set "RESULT=FOUND"
+        ) else (
+            echo [NOT FOUND] Key does not exist
+            set "RESULT=NOT_FOUND"
+        )
+    ) else (
+        echo [NOT FOUND] Key does not exist
+        set "RESULT=NOT_FOUND"
+    )
+) else (
+    :: Specific value name - query just that value
+    echo ---------------------------------------------------------------
+    echo [VALUE] !REG_PATH!\!VAL_NAME!
+    echo ---------------------------------------------------------------
+    reg query "!REG_PATH!" /v "!VAL_NAME!" >nul 2>&1
+    if !errorlevel! equ 0 (
+        reg query "!REG_PATH!" /v "!VAL_NAME!" 2>nul
+        if !errorlevel! equ 0 (
+            echo [FOUND] Value exists
+            set "RESULT=FOUND"
+        ) else (
+            echo [NOT FOUND] Value does not exist
+            set "RESULT=NOT_FOUND"
+        )
+    ) else (
+        echo [NOT FOUND] Value or key does not exist
+        set "RESULT=NOT_FOUND"
+    )
+)
+echo.
+
+:: Update counters in parent scope
+for %%R in ("!RESULT!") do (
+    endlocal
+    if "%%~R"=="FOUND" (
+        set /a FOUND+=1
+    ) else if "%%~R"=="NOT_FOUND" (
+        set /a NOT_FOUND+=1
+    )
+)
+goto :eof

--- a/pkg/virt-v2v/customize/scripts/windows/9105_remove_vmware_registry.bat
+++ b/pkg/virt-v2v/customize/scripts/windows/9105_remove_vmware_registry.bat
@@ -1,0 +1,250 @@
+@echo off
+:: ===============================================================
+:: remove_vmware_registry.cmd
+:: Remove all VMware-related registry entries
+:: Processes embedded registry keys and values
+:: Maps all entries to HKEY_LOCAL_MACHINE (HKLM)
+:: Handles both key deletions and individual value deletions
+:: ===============================================================
+
+setlocal enabledelayedexpansion
+
+REM =============================
+REM Check for admin privileges
+REM =============================
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: This script must be run as Administrator!
+    echo Please right-click and select "Run as administrator"
+    pause
+    exit /b 1
+)
+
+echo.
+echo ===============================================================
+echo   Remove VMware Registry Entries Script
+echo   Run as Administrator
+echo ===============================================================
+echo.
+
+:: --- Initialize counters ---
+set /a DELETED=0
+set /a ERRORS=0
+
+echo ==========================================
+echo  Processing registry entries
+echo ==========================================
+echo.
+
+:: ===============================================================
+:: Embedded Registry Entries
+:: Format: call :DeleteRegistryEntry "HKLM\Path" "ValueName"
+:: Empty ValueName means delete entire key
+:: ===============================================================
+
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\shell\open\command" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\InstallInfo" "IconsVisible"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE" "LocalizedString"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\InstallInfo" "ReinstallCommand"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\InstallInfo" "HideIconsCommand"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Classes\Applications\VMwareHostOpen.exe\shell\open\command" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\InstallInfo" "ShowIconsCommand"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE\DefaultIcon" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocFile\shell\open\command" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocURL\shell\open\command" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "sftp"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "ftp"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".htm"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "news"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "http"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities" "ApplicationDescription"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\RegisteredApplications" "VMware Host Open"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocURL" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocFile" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".shtml"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "mailto"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".xhtml"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "feed"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "https"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "telnet"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".xht"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\FileAssociations" ".html"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\UrlAssociations" "ssh"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMwareHostOpen\Capabilities\Startmenu" "StartmenuInternet"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmtools" "*"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmtools" "TypesSupported"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmtools" "EventMessageFile"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\networkprovider" "Name"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\networkprovider" "ProviderPath"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\networkprovider" "DeviceName"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\parameters" "ServerName"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmhgfs\parameters" "ShareName"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware VGAuth" "PreferencesFile"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Tools" "InstallPath"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP" "TypesSupported"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt" "*"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt" "EventMessageFile"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP" "EventMessageFile"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\vmwTimeProvider" "Enabled"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "EventMessageFile"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP" "*"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "TypesSupported"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\vmwTimeProvider" "*"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt" "TypesSupported"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\Classes\CLSID\{C73DA087-EDDB-4a7c-B216-8EF8A3B92C7B}\InprocServer32" ""
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\vmwTimeProvider" "InputProvider"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\vmwTimeProvider" "DllName"
+call :DeleteRegistryEntry "HKLM\Software\VMware, Inc.\VMware Tools\VMUpgradeHelper" "-"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "CategoryMessageFile"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "EventMessageFile"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider" "CategoryCount"
+call :DeleteRegistryEntry "HKLM\Software\VMware, Inc.\VMware Tools\GuestIntrospection" "-"
+call :DeleteRegistryEntry "HKLM\Software\VMware, Inc.\VMware Tools\GuestStoreUpgrade" "-"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMUpgradeHelper" "EventMessageFile"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMUpgradeHelper" "TypesSupported"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VGAuth" "EventMessageFile"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VGAuth" "TypesSupported"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMware Tools" "EventMessageFile"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMware Tools" "TypesSupported"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmrawdsk\Parameters" "CommonAppData"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmrawdsk\Parameters" "PrevBootMode"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmrawdsk\Parameters" "CacheDir"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmrawdsk\Parameters" "Windir"
+
+:: --- VMCI Registry Entries (from export files) ---
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Type"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Start"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "ErrorControl"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Tag"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "ImagePath"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "DisplayName"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Group"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "Owners"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" "vwdk.installers"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci\Enum" "0"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci\Enum" "Count"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci\Enum" "NextInstance"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci\Enum" ""
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmci" ""
+
+:: --- VMMouse Registry Entries ---
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Type"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Start"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "ErrorControl"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Tag"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "ImagePath"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "DisplayName"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Group"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "Owners"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" "vwdk.installers"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse\Enum" "0"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse\Enum" "Count"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse\Enum" "NextInstance"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse\Enum" ""
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmmouse" ""
+
+:: --- VMUsbMouse Registry Entries (from export files) ---
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Type"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Start"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "ErrorControl"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Tag"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "ImagePath"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "DisplayName"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Group"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "Owners"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" "vwdk.installers"
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse\Parameters" ""
+call :DeleteRegistryEntry "HKLM\SYSTEM\CurrentControlSet\Services\vmusbmouse" ""
+
+:: --- VMware Software Registry Entries (from vmwreg.txt) ---
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\CbLauncher" "Cb.LauncherVersion"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\CbLauncher" "Cb.InstallStatus"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\CbLauncher" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "VmciHostDevInst"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmci.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmci.installPath"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vsock.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vsock.installPath"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vsockSys.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vsockDll.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "efifw.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "efifw.installPath"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmxnet3.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmxnet3.installPath"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "pvscsi.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "pvscsi.installPath"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmusbmouse.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmusbmouse.installPath"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmmouse.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmmouse.installPath"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmmemctl.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "vmmemctl.installPath"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "svga_wddm.status"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" "svga_wddm.installPath"
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Drivers" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware Tools" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc.\VMware VGAuth" ""
+call :DeleteRegistryEntry "HKLM\SOFTWARE\VMware, Inc." ""
+
+echo.
+echo ===============================================================
+echo  Registry cleanup process finished
+echo ===============================================================
+echo.
+echo Summary:
+echo   Deleted: %DELETED% entries
+echo   Errors: %ERRORS% entries
+echo ===============================================================
+goto :EOF
+
+:: --- Subroutine: Delete registry entry ---
+:DeleteRegistryEntry
+setlocal enabledelayedexpansion
+set "REG_PATH=%~1"
+set "VAL_NAME=%~2"
+set "RESULT_VAR=RESULT"
+
+:: Handle registry deletion based on whether Name field is empty
+if "!VAL_NAME!"=="" (
+    :: Empty name means default value - delete the entire key
+    echo [DELETE KEY] !REG_PATH!
+    reg delete "!REG_PATH!" /f >nul 2>&1
+    if !errorlevel! equ 0 (
+        echo [SUCCESS] Deleted key: !REG_PATH!
+        set "RESULT=DELETED"
+    ) else (
+        echo [ERROR] Failed to delete key: !REG_PATH!
+        set "RESULT=ERROR"
+    )
+) else (
+    :: Specific value name - delete just that value
+    echo [DELETE VALUE] !REG_PATH!\!VAL_NAME!
+    reg delete "!REG_PATH!" /v "!VAL_NAME!" /f >nul 2>&1
+    if !errorlevel! equ 0 (
+        echo [SUCCESS] Deleted value: !REG_PATH!\!VAL_NAME!
+        set "RESULT=DELETED"
+    ) else (
+        :: If value deletion fails, try deleting parent key
+        echo [WARNING] Value not found, attempting to delete parent key: !REG_PATH!
+        reg delete "!REG_PATH!" /f >nul 2>&1
+        if !errorlevel! equ 0 (
+            echo [SUCCESS] Deleted parent key: !REG_PATH!
+            set "RESULT=DELETED"
+        ) else (
+            echo [ERROR] Failed to delete: !REG_PATH!\!VAL_NAME!
+            set "RESULT=ERROR"
+        )
+    )
+)
+
+:: Return result to parent scope and update counters
+for %%R in ("!RESULT!") do (
+    endlocal
+    if "%%~R"=="DELETED" (
+        set /a DELETED+=1
+    ) else if "%%~R"=="ERROR" (
+        set /a ERRORS+=1
+    )
+)
+goto :eof


### PR DESCRIPTION
…conversion

Issue:
Windows guests migrated from VMware may retain VMware services, driver packages, and registry entries that are no longer needed on OpenShift Virtualization and can interfere with virtio bring-up.

Fix:
Introduce a ForkliftController feature gate (feature_vsphere_vmware_driver_removal) wired through FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL and V2V_vsphereVmwareDriverRemoval on conversion pods. When enabled for vSphere Windows migrations, virt-customize uploads embedded scripts to Guestfs Firstboot scripts (ordered by filename: services, driver packages, registry).

Conflict resolution (backport): merged pkg/virt-v2v/config/variables.go with the 2.11.3 branch by adding only the driver-removal env, field, and flag; main-only virt-v2v options (memsize/smp/inspector extra args) are not present on this branch.

Ref: https://issues.redhat.com/browse/MTV-5018

Resolves: MTV-5018
