### PR TITLE
MTV-5012 | Bridge critical inventory concerns into plan readiness

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -19,9 +19,9 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter"
 	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	modelbase "github.com/kubev2v/forklift/pkg/controller/provider/model/base"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/ocp"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web"
-	"github.com/kubev2v/forklift/pkg/controller/provider/web/ova"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
 	"github.com/kubev2v/forklift/pkg/controller/validation"
 	ocp "github.com/kubev2v/forklift/pkg/lib/client/openshift"
@@ -101,6 +101,7 @@ const (
 	ServiceAccountNotValid          = "ServiceAccountNotValid"
 	RestrictedPodSecurity           = "RestrictedPodSecurity"
 	NetMapDestinationNADNotValid    = "NetMapDestinationNADNotValid"
+	VMCriticalConcerns              = "VMCriticalConcerns"
 )
 
 // Categories
@@ -596,6 +597,35 @@ func (r *Reconciler) validateStorageMap(plan *api.Plan) (err error) {
 	return
 }
 
+// aggregateCriticalConcerns appends critical-category concerns from an
+// inventory VM to the vmCriticalConcerns condition.
+func aggregateCriticalConcerns(v interface{}, vmRef string, vmCriticalConcerns *libcnd.Condition) {
+	ch, ok := v.(modelbase.ConcernHolder)
+	if !ok {
+		return
+	}
+	for _, concern := range ch.GetConcerns() {
+		if concern.Category == "Critical" {
+			vmCriticalConcerns.Items = append(vmCriticalConcerns.Items,
+				fmt.Sprintf("%s (%s)", vmRef, concern.Label))
+		}
+	}
+}
+
+// aggregateWarningConcerns appends well-known warning concerns from an
+// inventory VM to the matching conditions (e.g. unsupported OVA source).
+func aggregateWarningConcerns(v interface{}, vmRef string, unsupportedOVFExportSource *libcnd.Condition) {
+	ch, ok := v.(modelbase.ConcernHolder)
+	if !ok {
+		return
+	}
+	for _, concern := range ch.GetConcerns() {
+		if concern.Id == "ova.source.unsupported" {
+			unsupportedOVFExportSource.Items = append(unsupportedOVFExportSource.Items, vmRef)
+		}
+	}
+}
+
 // Validate listed VMs.
 func (r *Reconciler) validateVM(plan *api.Plan) error {
 	if plan.Status.HasCondition(Executing) {
@@ -827,6 +857,14 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Message:  "Copy offload is enabled. MTV does not support mixed copy methods. Each migration plan can use one migration strategy, either VDDK or copy offload. Check your storage map and VMs to ensure they are using the same migration strategy.",
 		Items:    []string{},
 	}
+	vmCriticalConcerns := libcnd.Condition{
+		Type:     VMCriticalConcerns,
+		Status:   True,
+		Reason:   NotValid,
+		Category: api.CategoryCritical,
+		Message:  "One or more VMs in the plan have critical concerns that block migration.",
+		Items:    []string{},
+	}
 
 	var sharedDisksConditions []libcnd.Condition
 	setOf := map[string]bool{}
@@ -906,15 +944,8 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 				setOfTargetName[vm.TargetName] = true
 			}
 		}
-		// check for supported OVA source
-		if ova, ok := v.(*ova.VM); ok {
-			for _, concern := range ova.Concerns {
-				// match label from ova/export_source.rego
-				if concern.Id == "ova.source.unsupported" {
-					unsupportedOVFExportSource.Items = append(unsupportedOVFExportSource.Items, ref.String())
-				}
-			}
-		}
+		aggregateCriticalConcerns(v, ref.String(), &vmCriticalConcerns)
+		aggregateWarningConcerns(v, ref.String(), &unsupportedOVFExportSource)
 		if plan.Spec.Type == api.MigrationOnlyConversion {
 			if vm, ok := v.(*vsphere.VM); ok {
 				pvcs, err := r.getVmPVCs(plan, vm)
@@ -1268,6 +1299,9 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 	// Set the condition if any VMs with VDDK disks were found when plan uses offload
 	if len(vddkAndOffloadMixedUsage.Items) > 0 {
 		plan.Status.SetCondition(vddkAndOffloadMixedUsage)
+	}
+	if len(vmCriticalConcerns.Items) > 0 {
+		plan.Status.SetCondition(vmCriticalConcerns)
 	}
 
 	return nil

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -1202,3 +1202,147 @@ var _ = ginkgo.Describe("Template Validation", func() {
 		})
 	})
 })
+
+var _ = ginkgo.Describe("aggregateCriticalConcerns", func() {
+	var vmCriticalConcerns libcnd.Condition
+
+	ginkgo.BeforeEach(func() {
+		vmCriticalConcerns = libcnd.Condition{
+			Type:     VMCriticalConcerns,
+			Status:   libcnd.True,
+			Reason:   NotValid,
+			Category: api.CategoryCritical,
+			Message:  "One or more VMs in the plan have critical concerns that block migration.",
+			Items:    []string{},
+		}
+	})
+
+	ginkgo.It("should flag VMs with Critical concerns", func() {
+		vm := &vsphere.VM{
+			VM1: vsphere.VM1{
+				Concerns: []vspheremodel.Concern{
+					{Id: "vmware.passthrough_device.detected", Label: "Passthrough device detected", Category: "Critical"},
+				},
+			},
+		}
+		vmRef := ref.Ref{Name: "vm-with-passthrough", Namespace: "test"}
+
+		aggregateCriticalConcerns(vm, vmRef.String(), &vmCriticalConcerns)
+
+		gomega.Expect(vmCriticalConcerns.Items).To(gomega.HaveLen(1))
+		gomega.Expect(vmCriticalConcerns.Items[0]).To(gomega.ContainSubstring("Passthrough device detected"))
+	})
+
+	ginkgo.It("should not flag VMs with only Warning concerns", func() {
+		vm := &vsphere.VM{
+			VM1: vsphere.VM1{
+				Concerns: []vspheremodel.Concern{
+					{Id: "vmware.disk.rdm.detected", Label: "Raw Device Mapped disk detected", Category: "Warning"},
+				},
+			},
+		}
+		vmRef := ref.Ref{Name: "vm-with-rdm", Namespace: "test"}
+
+		aggregateCriticalConcerns(vm, vmRef.String(), &vmCriticalConcerns)
+
+		gomega.Expect(vmCriticalConcerns.Items).To(gomega.BeEmpty())
+	})
+
+	ginkgo.It("should list all Critical concerns per VM", func() {
+		vm := &vsphere.VM{
+			VM1: vsphere.VM1{
+				Concerns: []vspheremodel.Concern{
+					{Id: "vmware.disk_mode.independent", Label: "Independent disk detected", Category: "Critical"},
+					{Id: "vmware.disk.rdm.detected", Label: "RDM disk detected", Category: "Warning"},
+					{Id: "vmware.passthrough_device.detected", Label: "Passthrough device detected", Category: "Critical"},
+				},
+			},
+		}
+		vmRef := ref.Ref{Name: "vm-multi", Namespace: "test"}
+
+		aggregateCriticalConcerns(vm, vmRef.String(), &vmCriticalConcerns)
+
+		gomega.Expect(vmCriticalConcerns.Items).To(gomega.HaveLen(2))
+		gomega.Expect(vmCriticalConcerns.Items[0]).To(gomega.ContainSubstring("Independent disk detected"))
+		gomega.Expect(vmCriticalConcerns.Items[1]).To(gomega.ContainSubstring("Passthrough device detected"))
+	})
+
+	ginkgo.It("should flag multiple VMs with Critical concerns", func() {
+		vms := []struct {
+			vm  *vsphere.VM
+			ref ref.Ref
+		}{
+			{
+				vm: &vsphere.VM{VM1: vsphere.VM1{Concerns: []vspheremodel.Concern{
+					{Id: "vmware.disk_mode.independent", Label: "Independent disk detected", Category: "Critical"},
+				}}},
+				ref: ref.Ref{Name: "vm1", Namespace: "test"},
+			},
+			{
+				vm: &vsphere.VM{VM1: vsphere.VM1{Concerns: []vspheremodel.Concern{
+					{Id: "vmware.disk.rdm.detected", Label: "RDM disk detected", Category: "Warning"},
+				}}},
+				ref: ref.Ref{Name: "vm2", Namespace: "test"},
+			},
+			{
+				vm: &vsphere.VM{VM1: vsphere.VM1{Concerns: []vspheremodel.Concern{
+					{Id: "vmware.passthrough_device.detected", Label: "Passthrough device detected", Category: "Critical"},
+				}}},
+				ref: ref.Ref{Name: "vm3", Namespace: "test"},
+			},
+		}
+
+		for _, entry := range vms {
+			aggregateCriticalConcerns(entry.vm, entry.ref.String(), &vmCriticalConcerns)
+		}
+
+		gomega.Expect(vmCriticalConcerns.Items).To(gomega.HaveLen(2))
+		gomega.Expect(vmCriticalConcerns.Items[0]).To(gomega.ContainSubstring("vm1"))
+		gomega.Expect(vmCriticalConcerns.Items[1]).To(gomega.ContainSubstring("vm3"))
+	})
+})
+
+var _ = ginkgo.Describe("aggregateWarningConcerns", func() {
+	var unsupportedOVFExport libcnd.Condition
+
+	ginkgo.BeforeEach(func() {
+		unsupportedOVFExport = libcnd.Condition{
+			Type:     UnsupportedOVFExportSource,
+			Status:   libcnd.True,
+			Category: api.CategoryWarn,
+			Message:  "VM appears to have been exported from an unsupported OVF source.",
+			Items:    []string{},
+		}
+	})
+
+	ginkgo.It("should detect OVA unsupported export source", func() {
+		vm := &vsphere.VM{
+			VM1: vsphere.VM1{
+				Concerns: []vspheremodel.Concern{
+					{Id: "ova.source.unsupported", Label: "Unsupported OVF source", Category: "Warning"},
+				},
+			},
+		}
+		vmRef := ref.Ref{Name: "ova-vm", Namespace: "test"}
+
+		aggregateWarningConcerns(vm, vmRef.String(), &unsupportedOVFExport)
+
+		gomega.Expect(unsupportedOVFExport.Items).To(gomega.HaveLen(1))
+		gomega.Expect(unsupportedOVFExport.Items[0]).To(gomega.ContainSubstring("ova-vm"))
+	})
+
+	ginkgo.It("should not flag VMs without the unsupported OVA concern", func() {
+		vm := &vsphere.VM{
+			VM1: vsphere.VM1{
+				Concerns: []vspheremodel.Concern{
+					{Id: "vmware.disk.rdm.detected", Label: "Raw Device Mapped disk detected", Category: "Warning"},
+				},
+			},
+		}
+		vmRef := ref.Ref{Name: "normal-vm", Namespace: "test"}
+
+		aggregateWarningConcerns(vm, vmRef.String(), &unsupportedOVFExport)
+
+		gomega.Expect(unsupportedOVFExport.Items).To(gomega.BeEmpty())
+	})
+})

--- a/pkg/controller/provider/model/base/model.go
+++ b/pkg/controller/provider/model/base/model.go
@@ -50,3 +50,8 @@ type Concern struct {
 	Category   string `json:"category"`
 	Assessment string `json:"assessment"`
 }
+
+// ConcernHolder is implemented by any inventory VM that carries concerns.
+type ConcernHolder interface {
+	GetConcerns() []Concern
+}

--- a/pkg/controller/provider/web/hyperv/vm.go
+++ b/pkg/controller/provider/web/hyperv/vm.go
@@ -195,6 +195,10 @@ type VM struct {
 	GuestNetworks []model.GuestNetwork `json:"guestNetworks"`
 }
 
+func (r *VM) GetConcerns() []model.Concern {
+	return r.Concerns
+}
+
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)

--- a/pkg/controller/provider/web/openstack/vm.go
+++ b/pkg/controller/provider/web/openstack/vm.go
@@ -239,6 +239,10 @@ type AttachedVolume = model.AttachedVolume
 type Concern = model.Concern
 type Fault = model.Fault
 
+func (r *VM) GetConcerns() []model.Concern {
+	return r.Concerns
+}
+
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)

--- a/pkg/controller/provider/web/ovfbase/vm.go
+++ b/pkg/controller/provider/web/ovfbase/vm.go
@@ -231,6 +231,10 @@ type VM struct {
 	Networks              []model.Network `json:"networks"`
 }
 
+func (r *VM) GetConcerns() []model.Concern {
+	return r.Concerns
+}
+
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -268,6 +268,10 @@ type Snapshot = model.Snapshot
 type Concern = model.Concern
 type Guest = model.Guest
 
+func (r *VM) GetConcerns() []model.Concern {
+	return r.Concerns
+}
+
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -296,6 +296,10 @@ type VM struct {
 	NestedHVEnabled    bool   `json:"nestedHVEnabled"`
 }
 
+func (r *VM) GetConcerns() []model.Concern {
+	return r.Concerns
+}
+
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)

--- a/validation/policies/io/konveyor/forklift/openstack/vm_status.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/vm_status.rego
@@ -15,7 +15,7 @@ concerns contains flag if {
 	not legal_vm_status
 	flag := {
 		"id": "openstack.vm.status.invalid",
-		"category": "Critical",
+		"category": "Warning",
 		"label": "VM has a status condition that may prevent successful migration",
 		"assessment": "The VM's status is not 'ACTIVE' or 'SHUTOFF'. Attempting to migrate this VM may fail.",
 	}

--- a/validation/policies/io/konveyor/forklift/ovirt/vm_status.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/vm_status.rego
@@ -19,7 +19,7 @@ concerns contains flag if {
 	not legal_vm_status
 	flag := {
 		"id": "ovirt.vm.status_invalid",
-		"category": "Critical",
+		"category": "Warning",
 		"label": "VM has a status condition that may prevent successful migration",
 		"assessment": "The VM's status is not 'up' or 'down'. Attempting to migrate this VM may fail.",
 	}

--- a/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
@@ -11,8 +11,8 @@ concerns contains flag if {
 	has_rdm_disk
 	flag := {
 		"id": "vmware.disk.rdm.detected",
-		"category": "Critical",
+		"category": "Warning",
 		"label": "Raw Device Mapped disk detected",
-		"assessment": "RDM disks are not currently supported by Migration Toolkit for Virtualization. The VM cannot be migrated unless the RDM disks are removed. You can reattach them to the VM after migration.",
+		"assessment": "RDM disk detected. RDM is supported via the RDMAsLun option at the plan or per-VM level. If RDMAsLun is not enabled, the VM cannot be migrated unless the RDM disks are removed.",
 	}
 }


### PR DESCRIPTION
Plan validation and Rego inventory concerns were disconnected: a VM could have Critical concerns (e.g. passthrough devices, independent disks) while its migration plan was marked Ready, only to fail at runtime.

Add a ConcernHolder interface so validateVM() can read inventory concerns from any provider VM. When any concern has category "Critical", the plan is blocked via a new VMCriticalConcerns condition.

Reclassify three concerns that are not true migration blockers from Critical to Warning:
- vmware.disk.rdm.detected (RDM now supported via RDMAsLun)
- ovirt.vm.status_invalid (assessment says "may fail"; no-op validator)
- openstack.vm.status.invalid (same rationale as oVirt)

Added test script to the JIRA ticket.

Ref: https://issues.redhat.com/browse/MTV-5012
Resolves: MTV-5012