### PR TITLE
chore(hyperv): improve SMB CSI validation message

### DIFF
--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -1288,8 +1288,8 @@ func (r *Reconciler) validateSMBCSI(provider *api.Provider) error {
 			Status:   True,
 			Category: Critical,
 			Reason:   NotFound,
-			Message: "SMB CSI driver (smb.csi.k8s.io) is not installed. " +
-				"Install the CIFS/SMB CSI Driver Operator.",
+			Message: "SMB CSI driver (smb.csi.k8s.io) is not available. " +
+				"Ensure the CIFS/SMB CSI Driver Operator is installed and that the ClusterCSIDriver CR for smb.csi.k8s.io exists.",
 		})
 		return nil
 	}


### PR DESCRIPTION
Improve the validation error message when the SMB CSI driver is not
found. The new message tells users exactly what to check: that the
CIFS/SMB CSI Driver Operator is installed and that the ClusterCSIDriver
CR for smb.csi.k8s.io exists. This is a read-only, validation-only
change with no new RBAC requirements.