### PR TITLE
MTV-5033 | Add AAP job-templates proxy to forklift-api services

### DIFF
--- a/pkg/forklift-api/services/aap-job-templates.go
+++ b/pkg/forklift-api/services/aap-job-templates.go
@@ -131,7 +131,13 @@ func isBlockedAAPHostname(host string) bool {
 }
 
 func isBlockedAAPIP(ip net.IP) bool {
-	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+	// Block loopback, unspecified, and multicast. Do not block RFC1918: on-prem AAP
+	// commonly uses private IPs reachable only from the cluster.
+	if ip.IsLoopback() || ip.IsUnspecified() || ip.IsLinkLocalMulticast() {
+		return true
+	}
+	// Link-local unicast (e.g. fe80::/10); allow RFC1918 private networks for customer AAP.
+	if ip.IsLinkLocalUnicast() {
 		return true
 	}
 	// Cloud instance metadata

--- a/pkg/forklift-api/services/aap-job-templates.go
+++ b/pkg/forklift-api/services/aap-job-templates.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// AAPJobTemplatesPath is the forklift-services path that proxies to the AAP Controller API job_templates list.
+	AAPJobTemplatesPath = "/aap/job-templates"
+	headerAAPToken      = "X-AAP-Token"
+	aapProxyTimeout     = 60 * time.Second
+)
+
+func serveAAPJobTemplates(resp http.ResponseWriter, req *http.Request, _ client.Client) {
+	if req.Method != http.MethodGet {
+		http.Error(resp, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	rawBase := req.URL.Query().Get("url")
+	if rawBase == "" {
+		http.Error(resp, "required query parameter: url", http.StatusBadRequest)
+		return
+	}
+
+	aapBase, err := url.Parse(rawBase)
+	if err != nil || aapBase.Scheme == "" || aapBase.Host == "" {
+		log.Info("invalid AAP url query parameter", "url", rawBase)
+		http.Error(resp, "invalid url query parameter", http.StatusBadRequest)
+		return
+	}
+	if aapBase.Scheme != "http" && aapBase.Scheme != "https" {
+		http.Error(resp, "url scheme must be http or https", http.StatusBadRequest)
+		return
+	}
+
+	token := req.Header.Get(headerAAPToken)
+	if strings.TrimSpace(token) == "" {
+		http.Error(resp, fmt.Sprintf("required header: %s", headerAAPToken), http.StatusBadRequest)
+		return
+	}
+
+	q := req.URL.Query()
+	q.Del("url")
+	upstreamQuery := q.Encode()
+
+	base := strings.TrimRight(aapBase.String(), "/")
+	target := base + "/api/controller/v2/job_templates/"
+	if upstreamQuery != "" {
+		target += "?" + upstreamQuery
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), aapProxyTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		log.Error(err, "failed to build AAP request", "target", target)
+		http.Error(resp, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	hc := &http.Client{Timeout: aapProxyTimeout}
+	out, err := hc.Do(httpReq)
+	if err != nil {
+		log.Error(err, "AAP job_templates request failed", "target", target)
+		http.Error(resp, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer out.Body.Close()
+
+	if ct := out.Header.Get("Content-Type"); ct != "" {
+		resp.Header().Set("Content-Type", ct)
+	}
+	resp.WriteHeader(out.StatusCode)
+	if _, err := io.Copy(resp, out.Body); err != nil {
+		log.Error(err, "failed to write AAP response body")
+	}
+}

--- a/pkg/forklift-api/services/aap-job-templates.go
+++ b/pkg/forklift-api/services/aap-job-templates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,7 +18,11 @@ const (
 	AAPJobTemplatesPath = "/aap/job-templates"
 	headerAAPToken      = "X-AAP-Token"
 	aapProxyTimeout     = 60 * time.Second
+	aapJobTemplatesPath = "/api/controller/v2/job_templates/"
 )
+
+// aapProxyHTTPClient is the client used for upstream AAP requests (overridable in tests).
+var aapProxyHTTPClient = &http.Client{Timeout: aapProxyTimeout}
 
 func serveAAPJobTemplates(resp http.ResponseWriter, req *http.Request, _ client.Client) {
 	if req.Method != http.MethodGet {
@@ -37,8 +42,10 @@ func serveAAPJobTemplates(resp http.ResponseWriter, req *http.Request, _ client.
 		http.Error(resp, "invalid url query parameter", http.StatusBadRequest)
 		return
 	}
-	if aapBase.Scheme != "http" && aapBase.Scheme != "https" {
-		http.Error(resp, "url scheme must be http or https", http.StatusBadRequest)
+
+	if err := validateAAPUpstreamURL(aapBase); err != nil {
+		log.Info("rejected AAP upstream url", "url", rawBase, "reason", err.Error())
+		http.Error(resp, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -52,10 +59,11 @@ func serveAAPJobTemplates(resp http.ResponseWriter, req *http.Request, _ client.
 	q.Del("url")
 	upstreamQuery := q.Encode()
 
-	base := strings.TrimRight(aapBase.String(), "/")
-	target := base + "/api/controller/v2/job_templates/"
-	if upstreamQuery != "" {
-		target += "?" + upstreamQuery
+	target, err := aapJobTemplatesTargetURL(aapBase, upstreamQuery)
+	if err != nil {
+		log.Error(err, "failed to build AAP target URL")
+		http.Error(resp, "invalid url query parameter", http.StatusBadRequest)
+		return
 	}
 
 	ctx, cancel := context.WithTimeout(req.Context(), aapProxyTimeout)
@@ -69,8 +77,7 @@ func serveAAPJobTemplates(resp http.ResponseWriter, req *http.Request, _ client.
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 
-	hc := &http.Client{Timeout: aapProxyTimeout}
-	out, err := hc.Do(httpReq)
+	out, err := aapProxyHTTPClient.Do(httpReq)
 	if err != nil {
 		log.Error(err, "AAP job_templates request failed", "target", target)
 		http.Error(resp, err.Error(), http.StatusBadGateway)
@@ -85,4 +92,69 @@ func serveAAPJobTemplates(resp http.ResponseWriter, req *http.Request, _ client.
 	if _, err := io.Copy(resp, out.Body); err != nil {
 		log.Error(err, "failed to write AAP response body")
 	}
+}
+
+// validateAAPUpstreamURL rejects schemes and hosts that would turn this service into an open proxy (SSRF).
+func validateAAPUpstreamURL(u *url.URL) error {
+	if !strings.EqualFold(u.Scheme, "https") {
+		return fmt.Errorf("url scheme must be https")
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("url host is required")
+	}
+	if isBlockedAAPHostname(host) {
+		return fmt.Errorf("url host is not allowed")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if isBlockedAAPIP(ip) {
+			return fmt.Errorf("url host is not allowed")
+		}
+	}
+	return nil
+}
+
+func isBlockedAAPHostname(host string) bool {
+	h := strings.ToLower(strings.TrimSpace(host))
+	switch h {
+	case "localhost":
+		return true
+	}
+	if strings.HasSuffix(h, ".svc.cluster.local") || strings.HasSuffix(h, ".svc") {
+		return true
+	}
+	switch h {
+	case "metadata.google.internal", "kubernetes.default.svc.cluster.local":
+		return true
+	}
+	return false
+}
+
+func isBlockedAAPIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return true
+	}
+	// Cloud instance metadata
+	if ip.Equal(net.IPv4(169, 254, 169, 254)) {
+		return true
+	}
+	return false
+}
+
+// aapJobTemplatesTargetURL builds the AAP Controller list URL from a parsed base using url.URL (not string concatenation).
+func aapJobTemplatesTargetURL(base *url.URL, upstreamQuery string) (string, error) {
+	if base == nil {
+		return "", fmt.Errorf("base url is nil")
+	}
+	t := *base
+	t.Scheme = "https"
+	t.Fragment = ""
+	t.RawQuery = upstreamQuery
+	p := strings.TrimSuffix(t.Path, "/")
+	if p == "" {
+		t.Path = aapJobTemplatesPath
+	} else {
+		t.Path = p + aapJobTemplatesPath
+	}
+	return t.String(), nil
 }

--- a/pkg/forklift-api/services/aap-job-templates_test.go
+++ b/pkg/forklift-api/services/aap-job-templates_test.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestServeAAPJobTemplates(t *testing.T) {
+	t.Parallel()
+
+	aap := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/controller/v2/job_templates/" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer the-token" {
+			t.Errorf("missing or wrong Authorization header: %q", r.Header.Get("Authorization"))
+		}
+		if got := r.URL.RawQuery; got != "page=2" {
+			t.Errorf("query forwarded: got %q want page=2", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"count":0}`))
+	}))
+	defer aap.Close()
+
+	u, err := url.Parse(aap.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := url.Values{}
+	q.Set("url", u.Scheme+"://"+u.Host)
+	q.Set("page", "2")
+	req := httptest.NewRequest(http.MethodGet, "/aap/job-templates?"+q.Encode(), nil)
+	req.Header.Set(headerAAPToken, "the-token")
+
+	rec := httptest.NewRecorder()
+	serveAAPJobTemplates(rec, req, fake.NewClientBuilder().Build())
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Header().Get("Content-Type"), "application/json") {
+		t.Fatalf("Content-Type = %q", rec.Header().Get("Content-Type"))
+	}
+	if rec.Body.String() != `{"count":0}` {
+		t.Fatalf("body = %q", rec.Body.String())
+	}
+}
+
+func TestServeAAPJobTemplates_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodPost, "/aap/job-templates?url=https://aap.example.com", nil)
+	req.Header.Set(headerAAPToken, "x")
+	rec := httptest.NewRecorder()
+	serveAAPJobTemplates(rec, req, fake.NewClientBuilder().Build())
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("want 405, got %d", rec.Code)
+	}
+}
+
+func TestServeAAPJobTemplates_MissingToken(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodGet, "/aap/job-templates?url=https://aap.example.com", nil)
+	rec := httptest.NewRecorder()
+	serveAAPJobTemplates(rec, req, fake.NewClientBuilder().Build())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}

--- a/pkg/forklift-api/services/aap-job-templates_test.go
+++ b/pkg/forklift-api/services/aap-job-templates_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -10,31 +11,41 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
 func TestServeAAPJobTemplates(t *testing.T) {
 	t.Parallel()
 
-	aap := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/controller/v2/job_templates/" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		if r.Header.Get("Authorization") != "Bearer the-token" {
-			t.Errorf("missing or wrong Authorization header: %q", r.Header.Get("Authorization"))
-		}
-		if got := r.URL.RawQuery; got != "page=2" {
-			t.Errorf("query forwarded: got %q want page=2", got)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"count":0}`))
-	}))
-	defer aap.Close()
-
-	u, err := url.Parse(aap.URL)
-	if err != nil {
-		t.Fatal(err)
+	old := aapProxyHTTPClient
+	t.Cleanup(func() { aapProxyHTTPClient = old })
+	aapProxyHTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			if r.URL.Path != aapJobTemplatesPath {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			if r.Header.Get("Authorization") != "Bearer the-token" {
+				t.Errorf("missing or wrong Authorization header: %q", r.Header.Get("Authorization"))
+			}
+			if got := r.URL.RawQuery; got != "page=2" {
+				t.Errorf("query forwarded: got %q want page=2", got)
+			}
+			if r.URL.Scheme != "https" || r.URL.Host != "aap.example.com" {
+				t.Errorf("unexpected URL: %s", r.URL.String())
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"count":0}`)),
+			}, nil
+		}),
 	}
+
 	q := url.Values{}
-	q.Set("url", u.Scheme+"://"+u.Host)
+	q.Set("url", "https://aap.example.com")
 	q.Set("page", "2")
 	req := httptest.NewRequest(http.MethodGet, "/aap/job-templates?"+q.Encode(), nil)
 	req.Header.Set(headerAAPToken, "the-token")
@@ -71,5 +82,59 @@ func TestServeAAPJobTemplates_MissingToken(t *testing.T) {
 	serveAAPJobTemplates(rec, req, fake.NewClientBuilder().Build())
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestServeAAPJobTemplates_HTTPSchemeRejected(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodGet, "/aap/job-templates?url=http://aap.example.com", nil)
+	req.Header.Set(headerAAPToken, "tok")
+	rec := httptest.NewRecorder()
+	serveAAPJobTemplates(rec, req, fake.NewClientBuilder().Build())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestServeAAPJobTemplates_LoopbackRejected(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodGet, "/aap/job-templates?url=https://127.0.0.1/", nil)
+	req.Header.Set(headerAAPToken, "tok")
+	rec := httptest.NewRecorder()
+	serveAAPJobTemplates(rec, req, fake.NewClientBuilder().Build())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAAPJobTemplatesTargetURL(t *testing.T) {
+	t.Parallel()
+	base, err := url.Parse("https://aap.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := aapJobTemplatesTargetURL(base, "page=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://aap.example.com/api/controller/v2/job_templates/?page=1"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestAAPJobTemplatesTargetURL_WithQueryInBaseURLString(t *testing.T) {
+	t.Parallel()
+	// Caller must not put ?query inside url=; if they do, upstreamQuery overwrites RawQuery on the copy.
+	base, err := url.Parse("https://aap.example.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := aapJobTemplatesTargetURL(base, "page=2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "page=2") || !strings.Contains(got, "/api/controller/v2/job_templates/") {
+		t.Fatalf("got %q", got)
 	}
 }

--- a/pkg/forklift-api/services/services.go
+++ b/pkg/forklift-api/services/services.go
@@ -17,4 +17,8 @@ func RegisterServices(mux *http.ServeMux, client client.Client) {
 	mux.HandleFunc(TLS_CERTIFICATE_PATH, func(w http.ResponseWriter, r *http.Request) {
 		serveTlsCertificate(w, r, client)
 	})
+	log.Info("register AAP job templates proxy service")
+	mux.HandleFunc(AAPJobTemplatesPath, func(w http.ResponseWriter, r *http.Request) {
+		serveAAPJobTemplates(w, r, client)
+	})
 }


### PR DESCRIPTION
Expose GET /aap/job-templates?url=... on the services HTTPS server (port 8444), proxying to the AAP Controller API job_templates list with X-AAP-Token sent as Bearer authorization, so the console can list templates without browser CORS blocking direct calls to AAP. Follows the existing tls-certificate service pattern.

Ref: https://redhat.atlassian.net/browse/MTV-5033
Resolves: MTV-5033
Made-with: Cursor