### PR TITLE
chore(ci): fix redundant or-conditions failing go vet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ __pycache__
 
 .gemini/
 gha-creds-*.json
+
+# developer-private test scenarios (verification, bug reproduction, etc.)
+tests/scenarios/

--- a/pkg/lib/inventory/model/model_test.go
+++ b/pkg/lib/inventory/model/model_test.go
@@ -997,12 +997,12 @@ func TestWatch(t *testing.T) {
 		time.Sleep(time.Millisecond * 10)
 		if len(handlerA.created) != N ||
 			len(handlerA.updated) != N ||
-			len(handlerA.created) != N ||
+			len(handlerA.deleted) != N ||
 			len(handlerB.created) != N ||
 			len(handlerB.updated) != N ||
-			len(handlerB.created) != N ||
+			len(handlerB.deleted) != N ||
 			len(handlerC.created) != N ||
-			len(handlerC.created) != N {
+			len(handlerC.deleted) != N {
 			continue
 		} else {
 			break


### PR DESCRIPTION
The watch test polling loop duplicated `len(handler.created)` checks instead of checking `len(handler.deleted)`, making three conditions no-ops. go vet correctly flags these as "redundant or" expressions, breaking `make test`. Replace with the intended `.deleted` checks.

Resolves: none