### PR TITLE
MTV-5031 | Validate hook ServiceAccount exists in plan namespace

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -99,6 +99,7 @@ const (
 	GuestToolsIssue                 = "GuestToolsIssue"
 	VDDKAndOffloadMixedUsage        = "VDDKAndOffloadMixedUsage"
 	ServiceAccountNotValid          = "ServiceAccountNotValid"
+	HookServiceAccountNotValid      = "HookServiceAccountNotValid"
 	RestrictedPodSecurity           = "RestrictedPodSecurity"
 	NetMapDestinationNADNotValid    = "NetMapDestinationNADNotValid"
 	VMCriticalConcerns              = "VMCriticalConcerns"
@@ -1558,6 +1559,14 @@ func (r *Reconciler) validateHooks(plan *api.Plan) (err error) {
 		Message:  "Hook must set spec.aap or spec.image for a local hook (playbook optional).",
 		Items:    []string{},
 	}
+	hookSANotFound := libcnd.Condition{
+		Type:     HookServiceAccountNotValid,
+		Status:   True,
+		Reason:   NotFound,
+		Category: api.CategoryCritical,
+		Message:  "Hook ServiceAccount not found in plan namespace.",
+		Items:    []string{},
+	}
 	for _, vm := range plan.Spec.VMs {
 		for _, ref := range vm.Hooks {
 			if _, ok := planHookValidSteps[ref.Step]; !ok {
@@ -1590,9 +1599,25 @@ func (r *Reconciler) validateHooks(plan *api.Plan) (err error) {
 			if !hook.Status.HasCondition(libcnd.Ready) {
 				notReady.Items = append(notReady.Items, hookRefDesc)
 			}
+			if sa := hook.Spec.ServiceAccount; sa != "" && hook.Spec.AAP == nil {
+				saKey := client.ObjectKey{
+					Namespace: plan.Namespace,
+					Name:      sa,
+				}
+				if saErr := r.Get(context.TODO(), saKey, &core.ServiceAccount{}); saErr != nil {
+					if k8serr.IsNotFound(saErr) {
+						hookSANotFound.Items = append(hookSANotFound.Items,
+							fmt.Sprintf("VM: %s hook: %s ServiceAccount '%s' not found in namespace '%s'",
+								vm.String(), ref.Hook.String(), sa, plan.Namespace))
+					} else {
+						err = liberr.Wrap(saErr)
+						return
+					}
+				}
+			}
 		}
 	}
-	for _, cnd := range []libcnd.Condition{notSet, notFound, notReady, stepNotValid, hookNotExecutable} {
+	for _, cnd := range []libcnd.Condition{notSet, notFound, notReady, stepNotValid, hookNotExecutable, hookSANotFound} {
 		if len(cnd.Items) > 0 {
 			plan.Status.SetCondition(cnd)
 		}

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -5,6 +5,7 @@ import (
 
 	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	apisplan "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	"github.com/kubev2v/forklift/pkg/controller/base"
@@ -460,6 +461,88 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			err := r.validateNetworkMap(plan)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(plan.Status.HasCondition(NetMapDestinationNADNotValid)).To(gomega.BeFalse())
+		})
+	})
+
+	ginkgo.Describe("validateHooks hook ServiceAccount", func() {
+		const planNS = "openshift-mtv"
+		const hookName = "test-hook"
+
+		newHook := func(sa string, aap *api.AAPConfig) *api.Hook {
+			h := &api.Hook{
+				ObjectMeta: meta.ObjectMeta{Name: hookName, Namespace: planNS},
+				Spec: api.HookSpec{
+					ServiceAccount: sa,
+					Image:          "quay.io/kubev2v/hook-runner:latest",
+					AAP:            aap,
+				},
+			}
+			h.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			return h
+		}
+
+		newPlanWithHook := func() *api.Plan {
+			return &api.Plan{
+				ObjectMeta: meta.ObjectMeta{Name: "test-plan", Namespace: planNS},
+				Spec: api.PlanSpec{
+					VMs: []apisplan.VM{{
+						Ref: ref.Ref{ID: "vm-1", Name: "test-vm"},
+						Hooks: []apisplan.HookRef{{
+							Step: api.PhasePreHook,
+							Hook: core.ObjectReference{Name: hookName, Namespace: planNS},
+						}},
+					}},
+				},
+			}
+		}
+
+		ginkgo.It("should not set condition when hook SA exists in plan namespace", func() {
+			sa := &core.ServiceAccount{ObjectMeta: meta.ObjectMeta{Name: "my-sa", Namespace: planNS}}
+			hook := newHook("my-sa", nil)
+			plan := newPlanWithHook()
+			r := createFakeReconciler(hook, sa)
+
+			err := r.validateHooks(plan)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(plan.Status.HasCondition(HookServiceAccountNotValid)).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should set condition when hook SA does not exist", func() {
+			hook := newHook("nonexistent-sa", nil)
+			plan := newPlanWithHook()
+			r := createFakeReconciler(hook)
+
+			err := r.validateHooks(plan)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(plan.Status.HasCondition(HookServiceAccountNotValid)).To(gomega.BeTrue())
+			cnd := plan.Status.FindCondition(HookServiceAccountNotValid)
+			gomega.Expect(cnd.Items).To(gomega.HaveLen(1))
+			gomega.Expect(cnd.Items[0]).To(gomega.ContainSubstring("nonexistent-sa"))
+		})
+
+		ginkgo.It("should skip SA validation for AAP hooks", func() {
+			aapCfg := &api.AAPConfig{
+				URL:           "https://aap.example.com",
+				JobTemplateID: 42,
+				TokenSecret:   core.ObjectReference{Name: "aap-token", Namespace: planNS},
+			}
+			hook := newHook("nonexistent-sa", aapCfg)
+			plan := newPlanWithHook()
+			r := createFakeReconciler(hook)
+
+			err := r.validateHooks(plan)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(plan.Status.HasCondition(HookServiceAccountNotValid)).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should not set condition when hook has no SA", func() {
+			hook := newHook("", nil)
+			plan := newPlanWithHook()
+			r := createFakeReconciler(hook)
+
+			err := r.validateHooks(plan)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(plan.Status.HasCondition(HookServiceAccountNotValid)).To(gomega.BeFalse())
 		})
 	})
 


### PR DESCRIPTION
When a Hook CR specifies a serviceAccount that does not exist or exists only in a different namespace, the plan passes validation and the migration hangs at the PreHook/PostHook phase with no error.

Fix:
Add validation in validateHooks() to check that each hook's serviceAccount exists in the plan namespace where hook Jobs run.

Ref: https://issues.redhat.com/browse/MTV-5031
Resolves: MTV-5031