### PR TITLE
MTV-4674 | copy-offload allow ssh command run without a timeout

### DIFF
--- a/cmd/vsphere-copy-offload-populator/Makefile
+++ b/cmd/vsphere-copy-offload-populator/Makefile
@@ -63,13 +63,13 @@ install-mockgen:
 test-copy-using-cli: build
 	bin/vsphere-copy-offload-populator \
 		--source-vm-id=vm-92749 \
-		--source-vmdk="[eco-iscsi-ds3] tshefi_40G/tshefi_40G.vmdk" \
+		--source-vmdk="[eco-iscsi-ds3] tshefi_40G_1/tshefi_40G.vmdk" \
 		--owner-name=tshefi40g \
 		--target-namespace=openshift-mtv \
 		--storage-vendor-product=ontap \
 		--secret-name=ontap \
 		--owner-uid=tshefi40g \
-		--esxi-clone-method=vib \
+		--esxi-clone-method=ssh \
 		--kubeconfig=$$KUBECONFIG
 
 test-flashsystem: build

--- a/cmd/vsphere-copy-offload-populator/internal/populator/factory.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/factory.go
@@ -19,7 +19,6 @@ type SSHConfig struct {
 	UseSSH         bool
 	PrivateKey     []byte
 	PublicKey      []byte
-	TimeoutSeconds int
 }
 
 // NewPopulator creates a new PopulatorSelector
@@ -98,15 +97,10 @@ func createVMDKPopulator(storageApi StorageApi, vmwareClient vmware.Client, sshC
 	var err error
 
 	if sshConfig != nil && sshConfig.UseSSH {
-		timeout := sshConfig.TimeoutSeconds
-		if timeout == 0 {
-			timeout = 30
-		}
 		pop, err = NewWithRemoteEsxcliSSH(vmdkApi,
 			vmwareClient,
 			sshConfig.PrivateKey,
-			sshConfig.PublicKey,
-			timeout)
+			sshConfig.PublicKey)
 	} else {
 		pop, err = NewWithRemoteEsxcli(vmdkApi, vmwareClient)
 	}

--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
@@ -56,19 +56,17 @@ type RemoteEsxcliPopulator struct {
 	SSHPrivateKey []byte
 	SSHPublicKey  []byte
 	UseSSHMethod  bool
-	SSHTimeout    time.Duration
 }
 
 func NewWithRemoteEsxcli(storageApi VMDKCapable, vmwareClient vmware.Client) (Populator, error) {
 	return &RemoteEsxcliPopulator{
 		VSphereClient: vmwareClient,
 		StorageApi:    storageApi,
-		UseSSHMethod:  false,            // VIB method
-		SSHTimeout:    30 * time.Second, // Default timeout (not used for VIB method)
+		UseSSHMethod:  false, // VIB method
 	}, nil
 }
 
-func NewWithRemoteEsxcliSSH(storageApi VMDKCapable, vmwareClient vmware.Client, sshPrivateKey, sshPublicKey []byte, sshTimeoutSeconds int) (Populator, error) {
+func NewWithRemoteEsxcliSSH(storageApi VMDKCapable, vmwareClient vmware.Client, sshPrivateKey, sshPublicKey []byte) (Populator, error) {
 	if len(sshPrivateKey) == 0 || len(sshPublicKey) == 0 {
 		return nil, fmt.Errorf("ssh key material must be non-empty")
 	}
@@ -78,7 +76,6 @@ func NewWithRemoteEsxcliSSH(storageApi VMDKCapable, vmwareClient vmware.Client, 
 		SSHPrivateKey: sshPrivateKey,
 		SSHPublicKey:  sshPublicKey,
 		UseSSHMethod:  true,
-		SSHTimeout:    time.Duration(sshTimeoutSeconds) * time.Second,
 	}, nil
 }
 
@@ -135,7 +132,7 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv 
 	var dsActiveAdapters []vmware.HostAdapter
 	dsActiveAdapters, err = p.VSphereClient.GetDatastoreActiveAdapters(context.Background(), host, vmDisk.Datastore)
 	initiators := []string{}
-	setupLog.Info("Datastore active adapters", "datastore",vmDisk.Datastore, "activeAdapters", dsActiveAdapters)
+	setupLog.Info("Datastore active adapters", "datastore", vmDisk.Datastore, "activeAdapters", dsActiveAdapters)
 	for _, a := range dsActiveAdapters {
 		initiators = append(initiators, a.Id)
 	}
@@ -246,8 +243,7 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv 
 	// Execute the clone using the unified task handling approach
 	var executor TaskExecutor
 	if p.UseSSHMethod {
-		sshSetupCtx, sshCancel := context.WithTimeout(context.Background(), p.SSHTimeout)
-		defer sshCancel()
+		sshSetupCtx := klog.NewContext(context.Background(), setupLog)
 
 		// Setup secure script
 		finalScriptPath, err := ensureSecureScript(sshSetupCtx, p.VSphereClient, host, vmDisk.Datastore)
@@ -375,7 +371,7 @@ func deleteDeadDevices(ctx context.Context, client vmware.Client, host *object.H
 	log := klog.FromContext(ctx)
 	failedDevices := []string{}
 	for _, adapter := range hostAdapters {
-		log.V(2).Info("deleting dead devices for adapter","adapter", adapter.Name)
+		log.V(2).Info("deleting dead devices for adapter", "adapter", adapter.Name)
 		success := false
 		for range rescanRetries {
 			_, errClean := client.RunEsxCommand(

--- a/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator.go
+++ b/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator.go
@@ -59,7 +59,6 @@ var (
 	vsphereUsername            string
 	vspherePassword            string
 	esxiCloneMethod            string
-	sshTimeoutSeconds          int
 	storageAPITimeoutSeconds   string
 
 	// kube args
@@ -169,7 +168,6 @@ func main() {
 			UseSSH:         true,
 			PrivateKey:     sshPrivateKey,
 			PublicKey:      sshPublicKey,
-			TimeoutSeconds: sshTimeoutSeconds,
 		}
 	}
 
@@ -311,7 +309,6 @@ func handleArgs() {
 	flag.StringVar(&vsphereUsername, "vsphere-username", os.Getenv("GOVMOMI_USERNAME"), "vSphere's API username")
 	flag.StringVar(&vspherePassword, "vsphere-password", os.Getenv("GOVMOMI_PASSWORD"), "vSphere's API password")
 	flag.StringVar(&esxiCloneMethod, "esxi-clone-method", os.Getenv("ESXI_CLONE_METHOD"), "ESXi clone method: 'vib' (default) or 'ssh'")
-	flag.IntVar(&sshTimeoutSeconds, "ssh-timeout-seconds", 30, "SSH timeout in seconds for ESXi operations (default: 30)")
 	flag.StringVar(&storageAPITimeoutSeconds, "storage-http-timeout-seconds", os.Getenv("STORAGE_HTTP_TIMEOUT_SECONDS"), "HTTP client timeout in seconds for storage API requests (default: 30)")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")


### PR DESCRIPTION
Resolves: MTV-4674

Commit 254555f6b enforced a default 30 sec timeout on the ssh internal
client. This prevents longer copy from working with ssh.

Bringing back the indefinite timeout behaviour on ssh commands.

Signed-off-by: Roy Golan <rgolan@redhat.com>
