### PR TITLE
MTV-5062 | Omit --no-fstrim for virt-v2v when XfsCompatibility is set

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2262,6 +2262,13 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, vddk
 				Value: "true",
 			})
 	}
+	if r.Plan.Spec.XfsCompatibility {
+		environment = append(environment,
+			core.EnvVar{
+				Name:  "V2V_xfsCompatibility",
+				Value: "true",
+			})
+	}
 
 	environment = append(environment,
 		core.EnvVar{

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -36,6 +36,7 @@ const (
 	EnvMemSizeName                    = "V2V_memSize"
 	EnvSmpName                        = "V2V_smp"
 	EnvVsphereVmwareDriverRemovalName = "V2V_vsphereVmwareDriverRemoval"
+	EnvXfsCompatibilityName           = "V2V_xfsCompatibility"
 )
 
 const (
@@ -110,6 +111,9 @@ type AppConfig struct {
 	Smp int
 	// V2V_vsphereVmwareDriverRemoval
 	VsphereVmwareDriverRemoval bool
+	// V2V_xfsCompatibility — use XFS-capable virt-v2v; omit --no-fstrim when true
+	// the el9 v2v is missing the --no-fstrim flag so the conversion would fail
+	XfsCompatibility bool
 
 	// V2V_multipleIPsPerNic
 	MultipleIpsPerNicName string
@@ -154,6 +158,7 @@ func (s *AppConfig) Load() (err error) {
 	flag.IntVar(&s.MemSize, "memsize", s.getEnvInt(EnvMemSizeName, 0), "Amount of memory (in MB) allocated for the conversion appliance")
 	flag.IntVar(&s.Smp, "smp", s.getEnvInt(EnvSmpName, 0), "Number of virtual CPUs used for the conversion appliance")
 	flag.BoolVar(&s.VsphereVmwareDriverRemoval, "vsphere-vmware-driver-removal", s.getEnvBool(EnvVsphereVmwareDriverRemovalName, false), "Run VMware driver removal scripts during Windows vSphere conversion")
+	flag.BoolVar(&s.XfsCompatibility, "xfs-compatibility", s.getEnvBool(EnvXfsCompatibilityName, false), "XFS compatibility mode: do not pass --no-fstrim to virt-v2v")
 	s.RemoteInspectionDisks = s.getRemoteInspectionDisks()
 	flag.Parse()
 

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -112,6 +112,14 @@ func (c *Conversion) addInspectorExtraArgs(cmd utils.CommandBuilder) {
 	}
 }
 
+// addNoFstrimUnlessXfsCompat passes --no-fstrim unless XFS compatibility mode is enabled
+// the el9 v2v is missing the --no-fstrim flag so the conversion would fail
+func (c *Conversion) addNoFstrimUnlessXfsCompat(cmd utils.CommandBuilder) {
+	if !c.XfsCompatibility {
+		cmd.AddFlag("--no-fstrim")
+	}
+}
+
 func (c *Conversion) RunVirtV2VInspection() error {
 	v2vCmdBuilder := c.CommandBuilder.New("virt-v2v-inspector").
 		AddFlag("-v").
@@ -123,7 +131,7 @@ func (c *Conversion) RunVirtV2VInspection() error {
 	if err != nil {
 		return err
 	}
-	v2vCmdBuilder.AddFlag("--no-fstrim")
+	c.addNoFstrimUnlessXfsCompat(v2vCmdBuilder)
 	c.addInspectorExtraArgs(v2vCmdBuilder)
 	for _, disk := range c.Disks {
 		v2vCmdBuilder.AddPositional(disk.Link)
@@ -143,7 +151,7 @@ func (c *Conversion) RunVirtV2vInPlace() error {
 	if err != nil {
 		return err
 	}
-	v2vCmdBuilder.AddFlag("--no-fstrim")
+	c.addNoFstrimUnlessXfsCompat(v2vCmdBuilder)
 	c.addConversionExtraArgs(v2vCmdBuilder)
 	v2vCmdBuilder.AddPositional(c.LibvirtDomainFile)
 	v2vCmd := v2vCmdBuilder.Build()
@@ -169,7 +177,7 @@ func (c *Conversion) RunVirtV2vInPlaceDisk() error {
 	if err != nil {
 		return err
 	}
-	v2vCmdBuilder.AddFlag("--no-fstrim")
+	c.addNoFstrimUnlessXfsCompat(v2vCmdBuilder)
 	c.addConversionExtraArgs(v2vCmdBuilder)
 
 	// Add all disks as positional arguments
@@ -259,7 +267,7 @@ func (c *Conversion) addVirtV2vVsphereArgsForInspection(cmd utils.CommandBuilder
 			cmd.AddArg("-io", fmt.Sprintf("vddk-config=%s", c.VddkConfFile))
 		}
 	}
-	cmd.AddFlag("--no-fstrim")
+	c.addNoFstrimUnlessXfsCompat(cmd)
 	cmd.AddPositional("--")
 	cmd.AddPositional(c.VmName)
 	return nil

--- a/pkg/virt-v2v/conversion/conversion_test.go
+++ b/pkg/virt-v2v/conversion/conversion_test.go
@@ -1146,5 +1146,86 @@ var _ = Describe("Conversion", func() {
 			err := conversion.addVirtV2vVsphereArgsForInspection(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("omits --no-fstrim when XfsCompatibility is enabled", func() {
+			appConfig.LibvirtUrl = "vpx://user@vcenter.example.com/Datacenter/Cluster/esxi-host?no_verify=1"
+			appConfig.SecretKey = "/etc/secret/secretKey"
+			appConfig.HostName = "vcenter.example.com"
+			appConfig.VmName = "test-vm"
+			appConfig.XfsCompatibility = true
+
+			mockCommandBuilder.EXPECT().AddArg("-i", "libvirt").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-ic", appConfig.LibvirtUrl).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-ip", appConfig.SecretKey).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--hostname", appConfig.HostName).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("--").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("test-vm").Return(mockCommandBuilder)
+
+			err := conversion.addVirtV2vVsphereArgsForInspection(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("XfsCompatibility", func() {
+		It("omits --no-fstrim for RunVirtV2VInspection", func() {
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
+			appConfig.XfsCompatibility = true
+			conversion.Disks = []*Disk{{Link: "/var/tmp/v2v/vm-sda"}}
+
+			mockCommandBuilder.EXPECT().New("virt-v2v-inspector").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-if", "raw").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run()
+
+			err := conversion.RunVirtV2VInspection()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("omits --no-fstrim for RunVirtV2vInPlace", func() {
+			appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+			appConfig.XfsCompatibility = true
+
+			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run()
+
+			err := conversion.RunVirtV2vInPlace()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("omits --no-fstrim for RunVirtV2vInPlaceDisk", func() {
+			appConfig.XfsCompatibility = true
+			conversion.Disks = []*Disk{{Link: "/var/tmp/v2v/vm-sda"}}
+
+			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run()
+
+			err := conversion.RunVirtV2vInPlaceDisk()
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
Issue:
Plans with xfsCompatibility RHEL 9 virt-v2v but it does not have the --no-fstrim flag. This causes the v2v to fail.

Fix:
Pass the xfsCompatibility information to the v2v pod and disable the --no-fstrim if xfsCompatibilty is enabled

Ref: https://issues.redhat.com/browse/MTV-5062

Resolves: MTV-5062