### PR TITLE
detect IPv4/IPv6 pod IP for nginx listen directive

### DIFF
--- a/operator/roles/forkliftcontroller/templates/ui-plugin/configmap-ui-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/configmap-ui-plugin.yml.j2
@@ -17,7 +17,7 @@ data:
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              9443 ssl;
+        listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
         root                /opt/app-root/src;

--- a/operator/roles/forkliftcontroller/templates/ui-plugin/deployment-ui-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/deployment-ui-plugin.yml.j2
@@ -21,6 +21,22 @@ spec:
     spec:
       containers:
         - name: "{{ ui_plugin_container_name }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if echo "$POD_IP" | grep -q ':'; then
+                LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="[::]:9443"
+              else
+                LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="9443"
+              fi
+              sed "s/LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/$LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/g" /etc/nginx/nginx.conf > /tmp/nginx.conf
+              exec nginx -c /tmp/nginx.conf -g 'daemon off;'
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           image: "{{ ui_plugin_image_fqin }}"
           ports:
             - containerPort: 9443


### PR DESCRIPTION
## Summary

On IPv6-only OCP clusters the forklift console plugin fails with:
> "Failed to get a valid plugin manifest from /api/plugins/forklift-console-plugin/"

**Root cause:** The nginx ConfigMap template hardcodes `listen 9443 ssl;` which only binds to IPv4. On IPv6-only clusters the pod only has an IPv6 address, so nginx never receives connections from the Service.

**Why a naive dual-listen fix doesn't work:** Adding both `listen 9443 ssl;` and `listen [::]:9443 ssl;` causes nginx to **fail to start** on IPv6-only clusters because binding to `0.0.0.0:9443` fails with `nginx: [emerg] bind() to 0.0.0.0:9443 failed (99: Cannot assign requested address)`.

**Fix:** Apply the same runtime detection pattern used by the [OpenShift cluster-monitoring-operator](https://github.com/openshift/cluster-monitoring-operator/pull/2173) (battle-tested in production since Dec 2023):

1. **ConfigMap** (`configmap-ui-plugin.yml.j2`): Replace the hardcoded port with a `LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME` placeholder
2. **Deployment** (`deployment-ui-plugin.yml.j2`): Inject `POD_IP` via the Kubernetes downward API and add a startup command that detects whether the pod has an IPv4 or IPv6 address, substitutes the correct listen address, and starts nginx

This ensures the plugin works on IPv4-only, IPv6-only, and dual-stack clusters.

## Test plan

- [ ] Deploy on an **IPv6-only** OCP cluster and verify the console plugin loads (the previously broken case)
- [ ] Deploy on an **IPv4** OCP cluster and verify no regression
- [ ] Deploy on a **dual-stack** OCP cluster and verify no regression
- [ ] Verify the forklift-ui-plugin pod starts successfully and serves the plugin manifest on all cluster types

Resolves: https://issues.redhat.com/browse/MTV-3116

Made with [Cursor](https://cursor.com)