### PR TITLE
MTV-5068 | Always use the provider url and not the secret url

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1971,13 +1971,6 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 
 	for key, value := range dst.Data {
 		switch key {
-		case "url":
-			h, err := liburl.Parse(string(value))
-			if err != nil {
-				// ignore and try to use as is
-				dst.Data["GOVMOMI_HOSTNAME"] = value
-			}
-			dst.Data["GOVMOMI_HOSTNAME"] = []byte(h.Hostname())
 		case "user":
 			dst.Data["GOVMOMI_USERNAME"] = value
 			dst.Data["accessKeyId"] = value
@@ -1987,6 +1980,19 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 		case "insecureSkipVerify":
 			dst.Data["GOVMOMI_INSECURE"] = value
 		}
+	}
+
+	// Always derive GOVMOMI_HOSTNAME from the provider spec, which is the
+	// authoritative source for the vCenter URL.
+	providerURL := r.Source.Provider.Spec.URL
+	if providerURL == "" {
+		return fmt.Errorf("provider %s/%s has an empty spec.url", r.Source.Provider.Namespace, r.Source.Provider.Name)
+	}
+	h, err := liburl.Parse(providerURL)
+	if err != nil {
+		dst.Data["GOVMOMI_HOSTNAME"] = []byte(providerURL)
+	} else {
+		dst.Data["GOVMOMI_HOSTNAME"] = []byte(h.Hostname())
 	}
 
 	// Add provider settings to the secret

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -74,9 +74,10 @@ var _ = Describe("vSphere builder", func() {
 			// Assert
 			Expect(err).NotTo(HaveOccurred())
 			Expect(errGet).NotTo(HaveOccurred())
-			Expect(underTest.Data).To(HaveLen(4))
+			Expect(underTest.Data).To(HaveLen(5))
 			Expect(underTest.Data).To(HaveKeyWithValue("storagekey", []byte("storageval")))
 			Expect(underTest.Data).To(HaveKeyWithValue("providerkey", []byte("providerval")))
+			Expect(underTest.Data).To(HaveKeyWithValue("GOVMOMI_HOSTNAME", []byte("vcenter.test.example.com")))
 			Expect(underTest.Data).To(HaveKey("SSH_PRIVATE_KEY"))
 			Expect(underTest.Data).To(HaveKey("SSH_PUBLIC_KEY"))
 			Expect(underTest.OwnerReferences).To(HaveLen(1))
@@ -605,7 +606,7 @@ func createBuilder(objs ...runtime.Object) *Builder {
 					ObjectMeta: meta.ObjectMeta{Name: "test-vsphere-provider", Namespace: "test"},
 					Spec: v1beta1.ProviderSpec{
 						Type: (*v1beta1.ProviderType)(ptr.To("vsphere")),
-						URL:  "test-vsphere-provider",
+						URL:  "https://vcenter.test.example.com/sdk",
 					},
 				},
 				Inventory: nil,


### PR DESCRIPTION
The vsphere provider url is not guaranteed to be in the secret or not
guaranteed to be even correct.
The source of truth of the provider url is from the provider .Spec.Url.
That Provider READY state depends on the Spec.Url to be correct
otherwise the connection test fails and the provider is unusable.
Meaning that if a plan is executing then the provider spec.url is the
only correct url to use.

The fix is specific to storage offload secret handling.

Resolves: MTV-5068

Signed-off-by: Roy Golan <rgolan@redhat.com>
