### PR TITLE
MTV-4872 | Sort disks by controller

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -581,6 +581,18 @@ var _ = Describe("vSphere builder", func() {
 				{Key: 2, Bus: vsphere.NVME},
 			},
 		),
+		Entry("sort SCSI disks by controller key then unit when device keys are not monotonic",
+			[]vsphere.Disk{
+				{Key: 2000, Bus: vsphere.SCSI, ControllerKey: 1001, UnitNumber: 0},
+				{Key: 1800, Bus: vsphere.SCSI, ControllerKey: 1000, UnitNumber: 2},
+				{Key: 1700, Bus: vsphere.SCSI, ControllerKey: 1000, UnitNumber: 0},
+			},
+			[]vsphere.Disk{
+				{Key: 1700, Bus: vsphere.SCSI, ControllerKey: 1000, UnitNumber: 0},
+				{Key: 1800, Bus: vsphere.SCSI, ControllerKey: 1000, UnitNumber: 2},
+				{Key: 2000, Bus: vsphere.SCSI, ControllerKey: 1001, UnitNumber: 0},
+			},
+		),
 	)
 })
 

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -228,18 +228,24 @@ func (r *VM1) filterDisksWithBus(disks []model.Disk, bus string) []model.Disk {
 	return resp
 }
 
-// The disks are first sorted by the buses going in order SCSI, SATA and IDE and within the controller the
-// disks are sorted by the key. This needs to be done because the virt-v2v outputs the files in an order,
-// which it gets from libvirt. The libvirt orders the devices starting with SCSI, SATA and IDE.
-// When we were sorting by the keys the order was IDE, SATA and SCSI. This cause that some PVs were populated by
-// incorrect disks.
+// The disks are first sorted by the buses going in order SCSI, SATA and IDE and within each bus they are
+// sorted by controller (ControllerKey), then unit (UnitNumber), then device key. VMware can assign device keys
+// that are not monotonic with (controller, unit), so sorting by Key alone can interleave disks from different
+// controllers and misalign with libvirt / virt-v2v ordering.
 // https://github.com/libvirt/libvirt/blob/d7b3be8ca35ffcbbece2c65120ab3ac9ec3dff0c/src/vmx/vmx.c#L1730
 func (r *VM1) sortedDisksByBusses(disks []model.Disk, buses []string) []model.Disk {
 	var resp []model.Disk
 	for _, bus := range buses {
 		disksWithBus := r.filterDisksWithBus(disks, bus)
 		sort.Slice(disksWithBus, func(i, j int) bool {
-			return disksWithBus[i].Key < disksWithBus[j].Key
+			a, b := disksWithBus[i], disksWithBus[j]
+			if a.ControllerKey != b.ControllerKey {
+				return a.ControllerKey < b.ControllerKey
+			}
+			if a.UnitNumber != b.UnitNumber {
+				return a.UnitNumber < b.UnitNumber
+			}
+			return a.Key < b.Key
 		})
 		resp = append(resp, disksWithBus...)
 	}


### PR DESCRIPTION
MTV-4872 | Sort disks by controller

When migrating VM from VMware with multiple SCSI controllers Forklift
does not keep the correct order between the controllers. Right now the
order is done by the disk key and bus type, we are ignoring to which
contorller the disk is attached to.

**Incorrect order of controllers**
```
disk key | unit number | controller key | filename |
---
// controller 0:
2014 | 14 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_16.vmdk
2015 | 15 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_17.vmdk

// controller 1:
2016 | 0 | 1001 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_12.vmdk
2017 | 1 | 1001 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_13.vmdk
2018 | 2 | 1001 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_14.vmdk
2019 | 3 | 1001 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_3.vmdk

// controller 0:
131088 | 16 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_18.vmdk
131089 | 17 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_19.vmdk
131090 | 18 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_2.vmdk
131092 | 20 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_20.vmdk
131093 | 21 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_21.vmdk
```

**Libvirt order of controllers**
```
// controller 0:
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_17.vmdk'/>
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_18.vmdk'/>
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_19.vmdk'/>
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_2.vmdk'/>
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_20.vmdk'/>
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_21.vmdk'/>
// controller 1:
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_12.vmdk'/>
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_13.vmdk'/>
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_14.vmdk'/>
      <source file='[nfs-us] mnecas-rhel9_1/mnecas-rhel9_3.vmdk'/>
```

**Fixed order of controllers**
```
disk key | unit number | controller key | filename
---
// controller 0:
2015 | 15 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_17.vmdk
131088 | 16 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_18.vmdk
131089 | 17 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_19.vmdk
131090 | 18 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_2.vmdk
131092 | 20 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_20.vmdk
131093 | 21 | 1000 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_21.vmdk

// controller 1:
2016 | 0 | 1001 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_12.vmdk
2017 | 1 | 1001 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_13.vmdk
2018 | 2 | 1001 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_14.vmdk
2019 | 3 | 1001 | [nfs-us] mnecas-rhel9_1/mnecas-rhel9_3.vmdk
```

Resolves: MTV-4872

Signed-off-by: Martin Necas <mnecas@redhat.com>

