### PR TITLE
MTV-4725 | Add NetApp Shift/Trident support for vSphere migrations

### DIFF
--- a/operator/roles/forkliftcontroller/templates/controller/controller-scc.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/controller-scc.yml.j2
@@ -11,6 +11,10 @@ runAsUser:
 seLinuxContext:
   type: RunAsAny
 allowPrivilegedContainer: false
+allowedCapabilities:
+  - CHOWN
+  - DAC_OVERRIDE
+  - FOWNER
 seccompProfiles:
   - runtime/default
   - localhost/profiles/unshare.json

--- a/pkg/apis/forklift/v1beta1/mapping.go
+++ b/pkg/apis/forklift/v1beta1/mapping.go
@@ -17,13 +17,17 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	core "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Mapped network destination.
@@ -117,6 +121,26 @@ type DestinationStorage struct {
 	// Access mode.
 	// +kubebuilder:validation:Enum=ReadWriteOnce;ReadWriteMany;ReadOnlyMany
 	AccessMode core.PersistentVolumeAccessMode `json:"accessMode,omitempty"`
+}
+
+const (
+	AnnotationNetAppShiftStorageClassType = "shift.netapp.io/storage-class-type"
+	ValueNetAppShiftStorageClassType      = "shift"
+)
+
+func (d *DestinationStorage) IsNetAppShiftStorageClass(client k8sclient.Client) (bool, error) {
+	if client == nil || d == nil || d.StorageClass == "" {
+		return false, nil
+	}
+	sc := &storagev1.StorageClass{}
+	err := client.Get(context.TODO(), k8sclient.ObjectKey{Name: d.StorageClass}, sc)
+	if k8serr.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return sc.Annotations[AnnotationNetAppShiftStorageClassType] == ValueNetAppShiftStorageClassType, nil
 }
 
 // Network map spec.
@@ -248,6 +272,29 @@ func (r *StorageMap) FindStorageByName(storageName string) (pair StoragePair, fo
 	}
 
 	return
+}
+
+// HasNetAppShiftDestination is true if any map entry's destination StorageClass, resolved
+// against the destination cluster, is a NetApp Shift/Trident class. Unique class names are
+// queried at most once. When c is nil or the map is nil, returns (false, nil).
+func (r *StorageMap) HasNetAppShiftDestination(c k8sclient.Client) (bool, error) {
+	if c == nil || r == nil {
+		return false, nil
+	}
+	for _, pair := range r.Spec.Map {
+		name := pair.Destination.StorageClass
+		if name == "" {
+			continue
+		}
+		shift, err := pair.Destination.IsNetAppShiftStorageClass(c)
+		if err != nil {
+			return false, err
+		}
+		if shift {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -421,7 +421,7 @@ func (p *Plan) IsWarm() bool {
 // just use virt-v2v directly to convert the vm while copying data over. In other
 // cases, we use CDI to transfer disks to the destination cluster and then use
 // virt-v2v-in-place to convert these disks after cutover.
-func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref) (bool, error) {
+func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref, destinationClient k8sclient.Client) (bool, error) {
 	source := p.Referenced.Provider.Source
 	if source == nil {
 		return false, liberr.New("Cannot analyze plan, source provider is missing.")
@@ -439,12 +439,20 @@ func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref) (bool, error) {
 		if vm, found := p.Spec.FindVM(vmRef); found && vm.MigrateSharedDisks != nil {
 			migrateSharedDisks = *vm.MigrateSharedDisks
 		}
-		return !p.IsWarm() &&
-				destination.IsHost() &&
-				migrateSharedDisks &&
-				!p.Spec.SkipGuestConversion &&
-				p.Spec.Type != MigrationOnlyConversion,
-			nil
+		if p.IsWarm() || !destination.IsHost() || !migrateSharedDisks ||
+			p.Spec.SkipGuestConversion || p.Spec.Type == MigrationOnlyConversion {
+			return false, nil
+		}
+		if p.Map.Storage != nil {
+			hasNetAppShift, err := p.Map.Storage.HasNetAppShiftDestination(destinationClient)
+			if err != nil {
+				return false, err
+			}
+			if hasNetAppShift {
+				return false, nil
+			}
+		}
+		return true, nil
 	case Ova, HyperV:
 		return true, nil
 	default:

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -99,6 +99,12 @@ const (
 
 	// Explicitly disable CDI's populator auto-detection to avoid webhook validation errors
 	AnnUsePopulator = "cdi.kubevirt.io/storage.usePopulator"
+
+	// Consumer-side disk metadata used by NetApp Shift/Trident integration.
+	AnnNfsServer = "forklift.konveyor.io/nfs-server"
+	AnnNfsPath   = "forklift.konveyor.io/nfs-path"
+	AnnVmId      = "forklift.konveyor.io/vm-id"
+	AnnVmUUID    = "forklift.konveyor.io/vm-uuid"
 )
 
 var VolumePopulatorNotSupportedError = liberr.New("provider does not support volume populators")
@@ -180,6 +186,9 @@ type Builder interface {
 	// Returns an empty struct if no provider-specific configuration is needed.
 	// The returned config is merged with user settings from Plan.Spec (user settings take precedence).
 	ConversionPodConfig(vmRef ref.Ref) (*ConversionPodConfigResult, error)
+	// NetAppShiftPVCs builds PVCs for disks mapped to NetApp Shift StorageClasses.
+	// Returns nil for non-vSphere providers or when no Shift mappings exist.
+	NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]core.PersistentVolumeClaim, error)
 }
 
 // Client API.
@@ -272,4 +281,6 @@ type Ensurer interface {
 	SharedConfigMaps(vm *planapi.VMStatus, configMaps []core.ConfigMap) (err error)
 	// SharedSecrets ensures that shared Secret with VM are present
 	SharedSecrets(vm *planapi.VMStatus, secrets []core.Secret) (err error)
+	// PersistentVolumeClaims ensures that PVCs are present on the destination.
+	PersistentVolumeClaims(vm *planapi.VMStatus, pvcs []core.PersistentVolumeClaim) (err error)
 }

--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -502,3 +502,7 @@ func (r *Builder) Secrets(_ ref.Ref) (list []core.Secret, err error) {
 func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
 	return &planbase.ConversionPodConfigResult{}, nil
 }
+
+func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]core.PersistentVolumeClaim, error) {
+	return nil, nil
+}

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -714,6 +714,10 @@ func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigR
 	return &planbase.ConversionPodConfigResult{}, nil
 }
 
+func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]v1.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+
 // getPlanVM returns the plan VM for the given vmRef
 func (r *Builder) getPlanVM(vmRef ref.Ref) *planapi.VM {
 	var fallback *planapi.VM

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1380,3 +1380,7 @@ func (r *Builder) GetPopulatorTaskName(pvc *core.PersistentVolumeClaim) (taskNam
 func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
 	return &planbase.ConversionPodConfigResult{}, nil
 }
+
+func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]core.PersistentVolumeClaim, error) {
+	return nil, nil
+}

--- a/pkg/controller/plan/adapter/ovfbase/builder.go
+++ b/pkg/controller/plan/adapter/ovfbase/builder.go
@@ -575,3 +575,7 @@ func (r *Builder) GetPopulatorTaskName(pvc *core.PersistentVolumeClaim) (taskNam
 func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
 	return &planbase.ConversionPodConfigResult{}, nil
 }
+
+func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]core.PersistentVolumeClaim, error) {
+	return nil, nil
+}

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -1038,3 +1038,7 @@ func (r *Builder) GetPopulatorTaskName(pvc *core.PersistentVolumeClaim) (taskNam
 func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
 	return &planbase.ConversionPodConfigResult{}, nil
 }
+
+func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]core.PersistentVolumeClaim, error) {
+	return nil, nil
+}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -96,10 +96,6 @@ const (
 	Shareable = "shareable"
 )
 
-const (
-	ManagementNetwork = "Management Network"
-)
-
 // Map of vmware guest ids to osinfo ids.
 var osMap = map[string]string{
 	"centos64Guest":              "centos5.11",
@@ -570,9 +566,17 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 			continue
 		}
 
+		// Shift disks are handled by NetAppShiftPVCs (PVCs, not DVs).
+		if isShift, sErr := mapped.Destination.IsNetAppShiftStorageClass(r.Destination.Client); sErr != nil {
+			err = sErr
+			return
+		} else if isShift {
+			continue
+		}
+
 		storageClass := mapped.Destination.StorageClass
 		var dvSource cdi.DataVolumeSource
-		useV2vForTransfer, vErr := r.Context.Plan.ShouldUseV2vForTransfer(vmRef)
+		useV2vForTransfer, vErr := r.Context.Plan.ShouldUseV2vForTransfer(vmRef, r.Context.Destination.Client)
 		if vErr != nil {
 			err = vErr
 			return
@@ -628,7 +632,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 			dv.ObjectMeta.Labels[Shareable] = "true"
 		}
 
-		// Preserve the disk index as an annotation on the created DataVolume
+		// Preserve the disk index as an annotation on the created DataVolume.
 		// Note: this annotation will be used to match the PVC to the VM disks by
 		//       matching the disk and PVC index.
 		dv.ObjectMeta.Annotations[planbase.AnnDiskIndex] = fmt.Sprintf("%d", diskIndex)
@@ -2318,4 +2322,105 @@ func (r *Builder) ensureXCopyVolumePopulator(vp *api.VSphereXcopyVolumePopulator
 // vSphere provider does not require any special configuration.
 func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
 	return &planbase.ConversionPodConfigResult{}, nil
+}
+
+// NetAppShiftPVCs builds PVCs for disks mapped to a NetApp Shift
+// StorageClass. The PVC size is computed using CDIConfig filesystem overhead (same
+// formula CDI applies to DataVolumes). Returns nil when no disks map to Shift classes.
+func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) (pvcs []core.PersistentVolumeClaim, err error) {
+	vm := &model.VM{}
+	if err = r.Source.Inventory.Find(vm, vmRef); err != nil {
+		err = liberr.Wrap(err, "vm", vmRef.String())
+		return
+	}
+	if !r.shouldMigrateSharedDisks(vm) {
+		vm.RemoveSharedDisks()
+	}
+
+	dsMap, err := r.buildDatastoreMap()
+	if err != nil {
+		return
+	}
+
+	disks := vm.SortedDisksAsVmware()
+	for diskIndex, disk := range disks {
+		mapped, found := dsMap[disk.Datastore.ID]
+		if !found {
+			continue
+		}
+
+		isShift, sErr := mapped.Destination.IsNetAppShiftStorageClass(r.Destination.Client)
+		if sErr != nil {
+			err = sErr
+			return
+		}
+		if !isShift {
+			continue
+		}
+
+		storageClass := mapped.Destination.StorageClass
+
+		capacity, cErr := utils.CalculateSpaceWithCDIOverhead(
+			r.Destination.Client, storageClass, disk.Capacity)
+		if cErr != nil {
+			err = liberr.Wrap(cErr, "CDIConfig overhead", storageClass)
+			return
+		}
+
+		fsMode := core.PersistentVolumeFilesystem
+		accessModes := []core.PersistentVolumeAccessMode{core.ReadWriteMany}
+		if mapped.Destination.AccessMode != "" {
+			accessModes = []core.PersistentVolumeAccessMode{mapped.Destination.AccessMode}
+		}
+
+		pvc := &core.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    r.Plan.Spec.TargetNamespace,
+				Labels:       maps.Clone(labels),
+				Annotations:  make(map[string]string),
+				GenerateName: r.Plan.Name + "-" + vmRef.ID + "-",
+			},
+			Spec: core.PersistentVolumeClaimSpec{
+				AccessModes:      accessModes,
+				VolumeMode:       &fsMode,
+				StorageClassName: &storageClass,
+				Resources: core.VolumeResourceRequirements{
+					Requests: core.ResourceList{
+						core.ResourceStorage: *resource.NewQuantity(capacity, resource.BinarySI),
+					},
+				},
+			},
+		}
+
+		if err = r.setPVCNameFromTemplate(&pvc.ObjectMeta, vm, diskIndex, disk); err != nil {
+			r.Log.Info("Failed to set PVC name from template", "error", err)
+			err = nil
+		}
+
+		ann := pvc.ObjectMeta.Annotations
+		ann[planbase.AnnDiskSource] = baseVolume(disk.File, r.Plan.IsWarm())
+		ann[planbase.AnnDiskIndex] = fmt.Sprintf("%d", diskIndex)
+		ann[planbase.AnnVmId] = vmRef.ID
+		ann[planbase.AnnVmUUID] = vm.UUID
+
+		ds := &model.Datastore{}
+		if fErr := r.Source.Inventory.Find(ds, ref.Ref{ID: disk.Datastore.ID}); fErr != nil {
+			err = liberr.Wrap(fErr, "datastore", disk.Datastore.ID)
+			return
+		}
+		ann[planbase.AnnNfsPath] = ds.NasRemotePath
+		n := len(ds.NasRemoteHostNames)
+		if n > 0 {
+			ann[planbase.AnnNfsServer] = ds.NasRemoteHostNames[n-1]
+		} else {
+			ann[planbase.AnnNfsServer] = ds.NasRemoteHost
+		}
+
+		if disk.Shared {
+			pvc.Labels[Shareable] = "true"
+		}
+
+		pvcs = append(pvcs, *pvc)
+	}
+	return
 }

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -407,7 +407,7 @@ func (r *Client) getTaskById(vmRef ref.Ref, taskId string, hosts util.HostsFunc)
 }
 
 func (r *Client) getClient(vm *model.VM, hosts util.HostsFunc) (client *vim25.Client, err error) {
-	if useV2vForTransfer, vErr := r.Plan.ShouldUseV2vForTransfer(ref.Ref{ID: vm.ID}); vErr == nil && useV2vForTransfer {
+	if useV2vForTransfer, vErr := r.Plan.ShouldUseV2vForTransfer(ref.Ref{ID: vm.ID}, r.Destination.Client); vErr == nil && useV2vForTransfer {
 		// when virt-v2v runs the migration, forklift-controller should interact only
 		// with the component that serves the SDK endpoint of the provider
 		client = r.client.Client

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -743,6 +743,12 @@ func (r *KubeVirt) EnsureDataVolumes(vm *plan.VMStatus, dataVolumes []cdi.DataVo
 	return
 }
 
+// NetAppShiftPVCs builds PVCs for disks mapped to NetApp Shift StorageClasses.
+func (r *KubeVirt) NetAppShiftPVCs(vm *plan.VMStatus) ([]core.PersistentVolumeClaim, error) {
+	labels := r.vmLabels(vm.Ref)
+	return r.Builder.NetAppShiftPVCs(vm.Ref, labels)
+}
+
 func (r *KubeVirt) vddkConfigMap(labels map[string]string) (*core.ConfigMap, error) {
 	data := make(map[string]string)
 	if r.Source.Provider.UseVddkAioOptimization() {
@@ -2126,7 +2132,7 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, vddk
 	nonRoot := true
 	allowPrivilageEscalation := false
 	// virt-v2v image
-	useV2vForTransfer, vErr := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref)
+	useV2vForTransfer, vErr := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref, r.Context.Destination.Client)
 	if vErr != nil {
 		err = vErr
 		return
@@ -2225,6 +2231,11 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, vddk
 				},
 			},
 		})
+	}
+	// The Shift tool migrates the disks, but we need to change the migrated files permissions and ownership to QEMU user
+	if podType == VirtV2vConversionPod && util.AnyNetAppShiftPersistentVolumeClaim(pvcs) {
+		initContainers = append(initContainers,
+			netAppShiftDiskPermsInitContainer(volumeMounts, getVirtV2vImage(r.Plan)))
 	}
 	if vm.RootDisk != "" {
 		environment = append(environment,
@@ -2443,6 +2454,47 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, vddk
 	r.setKvmOnPodSpec(&pod.Spec)
 
 	return
+}
+
+// netAppShiftDiskPermsInitContainer runs as root in a privileged container on filesystem-mode
+// disk PVCs only. It sets the disk image permissions to QEMU user.
+func netAppShiftDiskPermsInitContainer(mounts []core.VolumeMount, image string) core.Container {
+	script := fmt.Sprintf(`
+set -e
+for m in /mnt/disks/disk*; do
+  if [ -f "$m/disk.img" ]; then
+    chown %d:%d "$m/disk.img"
+    chmod 660 "$m/disk.img"
+  fi
+done
+`, qemuUser, qemuGroup)
+	runAsNonRoot := false
+	var runAsUser int64 = 0
+	return core.Container{
+		Name:            "netapp-shift-disk-perms",
+		Image:           image,
+		Command:         []string{"/bin/sh", "-c", script},
+		VolumeMounts:    mounts,
+		ImagePullPolicy: core.PullIfNotPresent,
+		Resources: core.ResourceRequirements{
+			Requests: core.ResourceList{
+				core.ResourceCPU:    resource.MustParse(Settings.Migration.NetAppShiftDiskPermsInitRequestsCpu),
+				core.ResourceMemory: resource.MustParse(Settings.Migration.NetAppShiftDiskPermsInitRequestsMemory),
+			},
+			Limits: core.ResourceList{
+				core.ResourceCPU:    resource.MustParse(Settings.Migration.NetAppShiftDiskPermsInitLimitsCpu),
+				core.ResourceMemory: resource.MustParse(Settings.Migration.NetAppShiftDiskPermsInitLimitsMemory),
+			},
+		},
+		SecurityContext: &core.SecurityContext{
+			RunAsUser:    &runAsUser,
+			RunAsNonRoot: &runAsNonRoot,
+			Capabilities: &core.Capabilities{
+				Add:  []core.Capability{"CHOWN", "DAC_OVERRIDE", "FOWNER"},
+				Drop: []core.Capability{"ALL"},
+			},
+		},
+	}
 }
 
 // Build the inspection pod environment

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -387,7 +387,6 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			Expect(getVirtV2vImage(p)).To(Equal(xfsImage))
 		})
 	})
-
 })
 
 func createKubeVirt(objs ...runtime.Object) *KubeVirt {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -400,13 +400,6 @@ func markStartedStepsCompleted(vm *plan.VMStatus) {
 	}
 }
 
-func (r *Migration) deletePopulatorPVCs(vm *plan.VMStatus) (err error) {
-	if r.builder.SupportsVolumePopulators() {
-		err = r.kubevirt.DeletePopulatedPVCs(vm)
-	}
-	return
-}
-
 // Delete left over migration resources associated with a VM.
 func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool) error {
 	// If the migration fails and the DeleteVmOnFailMigration is enabled, clean up the VM.
@@ -415,7 +408,7 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool) error
 		if err := r.kubevirt.DeleteVM(vm); failOnErr(err) {
 			return err
 		}
-		if err := r.deletePopulatorPVCs(vm); failOnErr(err) {
+		if err := r.kubevirt.DeletePopulatedPVCs(vm); failOnErr(err) {
 			return err
 		}
 		if err := r.kubevirt.DeleteDataVolumes(vm); failOnErr(err) {
@@ -911,6 +904,31 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 							r.Log.Error(err, "error updating DataVolume, retrying", "dv", dataVolume.Name)
 							return
 						}
+					}
+				}
+			}
+
+			shiftPVCs, shiftErr := r.kubevirt.NetAppShiftPVCs(vm)
+			if shiftErr != nil {
+				if !errors.As(shiftErr, &web.ProviderNotReadyError{}) {
+					r.Log.Error(shiftErr, "error building Shift PVCs", "vm", vm.Name)
+					step.AddError(shiftErr.Error())
+					err = nil
+					break
+				} else {
+					err = shiftErr
+					return
+				}
+			}
+			if len(shiftPVCs) > 0 {
+				if shiftErr = r.ensurer.PersistentVolumeClaims(vm, shiftPVCs); shiftErr != nil {
+					if !errors.As(shiftErr, &web.ProviderNotReadyError{}) {
+						step.AddError(shiftErr.Error())
+						err = nil
+						break
+					} else {
+						err = shiftErr
+						return
 					}
 				}
 			}
@@ -1779,7 +1797,7 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 			break
 		}
 
-		useV2vForTransfer, err := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref)
+		useV2vForTransfer, err := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref, r.Destination.Client)
 		switch {
 		case err != nil:
 			return liberr.Wrap(err)

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -252,9 +252,9 @@ func (r *BaseMigrator) Step(status *plan.VMStatus) (step string) {
 		step = Initialize
 	case api.PhaseAllocateDisks:
 		step = DiskAllocation
-	case api.PhaseCopyDisks, api.PhaseCopyingPaused, api.PhaseRemovePreviousSnapshot, api.PhaseWaitForPreviousSnapshotRemoval,
-		api.PhaseCreateSnapshot, api.PhaseWaitForSnapshot, api.PhaseStoreSnapshotDeltas, api.PhaseAddCheckpoint,
-		api.PhaseConvertOpenstackSnapshot:
+	case api.PhaseCopyDisks, api.PhaseCopyingPaused, api.PhaseRemovePreviousSnapshot,
+		api.PhaseWaitForPreviousSnapshotRemoval, api.PhaseCreateSnapshot, api.PhaseWaitForSnapshot,
+		api.PhaseStoreSnapshotDeltas, api.PhaseAddCheckpoint, api.PhaseConvertOpenstackSnapshot:
 		step = DiskTransfer
 	case api.PhaseCreateDataVolumes:
 		// This phase should be present in DiskTransfer step only when executing Preflight Inspection to avoid UI pipeline artifacts.
@@ -345,7 +345,7 @@ func (r *BaseMigrator) coldItinerary() *libitr.Itinerary {
 			{Name: api.PhaseAllocateDisks, All: VirtV2vDiskCopy},
 			{Name: api.PhaseCreateGuestConversionPod, All: RequiresConversion},
 			{Name: api.PhaseConvertGuest, All: RequiresConversion},
-			{Name: api.PhaseCopyDisksVirtV2V, All: RequiresConversion},
+			{Name: api.PhaseCopyDisksVirtV2V, All: RequiresConversion | VirtV2vDiskCopy},
 			{Name: api.PhaseConvertOpenstackSnapshot, All: OpenstackImageMigration},
 			{Name: api.PhaseCreateVM},
 			{Name: api.PhasePostHook, All: HasPostHook},
@@ -382,7 +382,7 @@ type BasePredicate struct {
 
 // Evaluate predicate flags.
 func (r *BasePredicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
-	useV2vForTransfer, vErr := r.context.Plan.ShouldUseV2vForTransfer(r.vm.Ref)
+	useV2vForTransfer, vErr := r.context.Plan.ShouldUseV2vForTransfer(r.vm.Ref, r.context.Destination.Client)
 	if vErr != nil {
 		err = vErr
 		return

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -205,7 +205,7 @@ func (r *Scheduler) buildPending() (err error) {
 }
 
 func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {
-	useV2vForTransfer, _ := r.Plan.ShouldUseV2vForTransfer(vmStatus.Ref)
+	useV2vForTransfer, _ := r.Plan.ShouldUseV2vForTransfer(vmStatus.Ref, r.Destination.Client)
 	if useV2vForTransfer {
 		switch vmStatus.Phase {
 		case CreateVM, PostHook, Completed:

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -1,9 +1,12 @@
 package util
 
 import (
+	"context"
+	"fmt"
 	"math"
 	"math/rand"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -12,6 +15,8 @@ import (
 	"github.com/kubev2v/forklift/pkg/settings"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Disk alignment size used to align FS overhead,
@@ -22,6 +27,12 @@ const (
 
 // KubeVirt resource kind used in owner references and type metadata.
 const VirtualMachineKind = "VirtualMachine"
+
+// NetApp Shift PVC annotations.
+const (
+	AnnNfsServer = "forklift.konveyor.io/nfs-server"
+	AnnNfsPath   = "forklift.konveyor.io/nfs-path"
+)
 
 // RootDisk prefix for boot order.
 const (
@@ -45,6 +56,54 @@ func CalculateSpaceWithOverhead(requestedSpace int64, volumeMode *core.Persisten
 		spaceWithOverhead = alignedSize + settings.Settings.BlockOverhead
 	}
 	return spaceWithOverhead
+}
+
+const (
+	cdiConfigName         = "config"
+	defaultGlobalOverhead = 0.055
+)
+
+// CalculateSpaceWithCDIOverhead computes the PVC size the same way CDI does:
+// it reads CDIConfig.Status.FilesystemOverhead from the destination cluster,
+// uses the per-StorageClass overhead when that key exists (invalid values return
+// an error), otherwise uses Global when set (invalid values return an error),
+// otherwise the CDI default of 5.5%, aligns the raw capacity, and inflates it by
+// ceil(aligned / (1 - overhead)).
+func CalculateSpaceWithCDIOverhead(client k8sclient.Client, storageClassName string, rawCapacity int64) (int64, error) {
+	if client == nil {
+		return 0, fmt.Errorf("destination client is nil, cannot read CDIConfig")
+	}
+	overhead := defaultGlobalOverhead
+
+	cfg := &cdi.CDIConfig{}
+	if err := client.Get(context.TODO(), k8sclient.ObjectKey{Name: cdiConfigName}, cfg); err != nil {
+		return 0, err
+	}
+	if fo := cfg.Status.FilesystemOverhead; fo != nil {
+		if scPercent, hasSC := fo.StorageClass[storageClassName]; hasSC {
+			v, err := strconv.ParseFloat(string(scPercent), 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid filesystem overhead for storage class %q: %w", storageClassName, err)
+			}
+			if v < 0 || v >= 1 {
+				return 0, fmt.Errorf("filesystem overhead for storage class %q must be in [0,1), got %g", storageClassName, v)
+			}
+			overhead = v
+		} else if fo.Global != "" {
+			v, err := strconv.ParseFloat(string(fo.Global), 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid global filesystem overhead: %w", err)
+			}
+			if v < 0 || v >= 1 {
+				return 0, fmt.Errorf("global filesystem overhead must be in [0,1), got %g", v)
+			}
+			overhead = v
+		}
+	}
+
+	aligned := RoundUp(rawCapacity, DefaultAlignBlockSize)
+	inflated := int64(math.Ceil(float64(aligned) / (1.0 - overhead)))
+	return inflated, nil
 }
 
 func GetBootDiskNumber(deviceString string) int {
@@ -146,4 +205,23 @@ func GenerateRandomSuffix() string {
 		b[i] = charset[seededRand.Intn(len(charset))]
 	}
 	return string(b)
+}
+
+// IsNetAppShiftPersistentVolumeClaim reports whether a PVC is a NetApp Shift volume.
+func IsNetAppShiftPersistentVolumeClaim(ann map[string]string) bool {
+	if ann == nil {
+		return false
+	}
+	_, hasServer := ann[AnnNfsServer]
+	_, hasExport := ann[AnnNfsPath]
+	return hasServer && hasExport
+}
+
+func AnyNetAppShiftPersistentVolumeClaim(pvcs []*core.PersistentVolumeClaim) bool {
+	for _, pvc := range pvcs {
+		if pvc != nil && IsNetAppShiftPersistentVolumeClaim(pvc.Annotations) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controller/plan/util/utils_test.go
+++ b/pkg/controller/plan/util/utils_test.go
@@ -1,11 +1,19 @@
 package util
 
 import (
+	"math"
 	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // Helper function to check if VM name is a valid DNS1123 subdomain
@@ -110,3 +118,144 @@ var _ = Describe("Plan/utils", func() {
 		})
 	})
 })
+
+func TestIsNetAppShiftPersistentVolumeClaim(t *testing.T) {
+	t.Parallel()
+	if IsNetAppShiftPersistentVolumeClaim(nil) {
+		t.Fatal("nil")
+	}
+	if IsNetAppShiftPersistentVolumeClaim(map[string]string{AnnNfsServer: "h"}) {
+		t.Fatal("partial")
+	}
+	if !IsNetAppShiftPersistentVolumeClaim(map[string]string{AnnNfsServer: "h", AnnNfsPath: "/p"}) {
+		t.Fatal("expected true")
+	}
+}
+
+func TestCalculateSpaceWithCDIOverhead_NilClient(t *testing.T) {
+	t.Parallel()
+	_, err := CalculateSpaceWithCDIOverhead(nil, "sc", 1<<30)
+	if err == nil {
+		t.Fatal("expected error with nil client")
+	}
+}
+
+func fakeCDIClient(t *testing.T, objs ...runtime.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := cdi.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+}
+
+func inflatedWithOverhead(raw int64, overhead float64) int64 {
+	aligned := RoundUp(raw, DefaultAlignBlockSize)
+	return int64(math.Ceil(float64(aligned) / (1.0 - overhead)))
+}
+
+func TestCalculateSpaceWithCDIOverhead_PerStorageClassSuccess(t *testing.T) {
+	t.Parallel()
+	const scName = "gold"
+	raw := int64(10 * 1024 * 1024)
+	const overheadVal = 0.10
+	cfg := &cdi.CDIConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: cdiConfigName},
+		Spec:       cdi.CDIConfigSpec{},
+		Status: cdi.CDIConfigStatus{
+			FilesystemOverhead: &cdi.FilesystemOverhead{
+				StorageClass: map[string]cdi.Percent{
+					scName: cdi.Percent("0.10"),
+				},
+				Global: cdi.Percent("0.20"),
+			},
+		},
+	}
+	got, err := CalculateSpaceWithCDIOverhead(fakeCDIClient(t, cfg), scName, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := inflatedWithOverhead(raw, overheadVal)
+	if got != want {
+		t.Fatalf("got %d want %d (per-SC overhead should win over global)", got, want)
+	}
+}
+
+func TestCalculateSpaceWithCDIOverhead_PerStorageClassInvalidDoesNotFallBackToGlobal(t *testing.T) {
+	t.Parallel()
+	const scName = "gold"
+	cfg := &cdi.CDIConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: cdiConfigName},
+		Spec:       cdi.CDIConfigSpec{},
+		Status: cdi.CDIConfigStatus{
+			FilesystemOverhead: &cdi.FilesystemOverhead{
+				StorageClass: map[string]cdi.Percent{
+					scName: cdi.Percent("not-a-float"),
+				},
+				Global: cdi.Percent("0.08"),
+			},
+		},
+	}
+	_, err := CalculateSpaceWithCDIOverhead(fakeCDIClient(t, cfg), scName, 1<<20)
+	if err == nil {
+		t.Fatal("expected error when per-SC value is unparseable")
+	}
+	// Must not silently use global (0.08) or default overhead.
+	if !strings.Contains(err.Error(), scName) {
+		t.Fatalf("expected error to name storage class: %v", err)
+	}
+}
+
+func TestCalculateSpaceWithCDIOverhead_GlobalOnly(t *testing.T) {
+	t.Parallel()
+	raw := int64(5 * 1024 * 1024)
+	const overheadVal = 0.08
+	cfg := &cdi.CDIConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: cdiConfigName},
+		Spec:       cdi.CDIConfigSpec{},
+		Status: cdi.CDIConfigStatus{
+			FilesystemOverhead: &cdi.FilesystemOverhead{
+				Global: cdi.Percent("0.08"),
+			},
+		},
+	}
+	got, err := CalculateSpaceWithCDIOverhead(fakeCDIClient(t, cfg), "no-entry-for-this-sc", raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := inflatedWithOverhead(raw, overheadVal)
+	if got != want {
+		t.Fatalf("got %d want %d", got, want)
+	}
+}
+
+func TestCalculateSpaceWithCDIOverhead_MissingCDIConfig(t *testing.T) {
+	t.Parallel()
+	_, err := CalculateSpaceWithCDIOverhead(fakeCDIClient(t), "sc", 1<<30)
+	if err == nil {
+		t.Fatal("expected error when CDIConfig is missing")
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestCalculateSpaceWithCDIOverhead_GlobalInvalidReturnsError(t *testing.T) {
+	t.Parallel()
+	cfg := &cdi.CDIConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: cdiConfigName},
+		Spec:       cdi.CDIConfigSpec{},
+		Status: cdi.CDIConfigStatus{
+			FilesystemOverhead: &cdi.FilesystemOverhead{
+				Global: cdi.Percent("bad"),
+			},
+		},
+	}
+	_, err := CalculateSpaceWithCDIOverhead(fakeCDIClient(t, cfg), "any-sc", 1<<20)
+	if err == nil {
+		t.Fatal("expected error when global overhead is invalid")
+	}
+	if !strings.Contains(err.Error(), "global") {
+		t.Fatalf("expected global overhead in error: %v", err)
+	}
+}

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -104,6 +104,13 @@ const (
 	RestrictedPodSecurity           = "RestrictedPodSecurity"
 	NetMapDestinationNADNotValid    = "NetMapDestinationNADNotValid"
 	VMCriticalConcerns              = "VMCriticalConcerns"
+	// NetAppShift (Advisory) reports whether the plan's storage map uses a NetApp Shift/Trident class.
+	NetAppShift = "NetAppShift"
+	// NetAppShiftWarmNotSupported (Critical) blocks warm migration when the storage map uses NetApp Shift.
+	NetAppShiftWarmNotSupported = "NetAppShiftWarmNotSupported"
+	// NetAppShiftDatastoreNASMissing (Critical) blocks when a disk maps to NetApp Shift but the source
+	// datastore lacks NAS export details in inventory (required for MTV annotations).
+	NetAppShiftDatastoreNASMissing = "NetAppShiftDatastoreNASMissing"
 )
 
 // Categories
@@ -198,6 +205,11 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 		return err
 	}
 
+	err = r.validateNetAppShift(ctx)
+	if err != nil {
+		return err
+	}
+
 	if err = r.validateWarmMigration(ctx); err != nil {
 		return err
 	}
@@ -206,7 +218,7 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 		return err
 	}
 
-	if err = r.validateVM(plan); err != nil {
+	if err = r.validateVM(plan, ctx); err != nil {
 		return err
 	}
 
@@ -344,6 +356,67 @@ func (r *Reconciler) ensureSecretForProvider(plan *api.Plan) error {
 	}
 
 	return nil
+}
+
+// validateNetAppShift checks plan-level NetApp Shift constraints (warm migration blocker)
+// and returns whether the plan uses Shift storage so callers can pass the flag forward.
+func (r *Reconciler) validateNetAppShift(ctx *plancontext.Context) (err error) {
+	plan := ctx.Plan
+	src := plan.Referenced.Provider.Source
+	if src == nil || src.Type() != api.VSphere || plan.Map.Storage == nil {
+		return nil
+	}
+	shift, err := plan.Map.Storage.HasNetAppShiftDestination(ctx.Destination.Client)
+	if err != nil {
+		return liberr.Wrap(err, "check NetApp Shift storage")
+	}
+	if !shift {
+		return nil
+	}
+	if plan.IsWarm() {
+		plan.Status.SetCondition(libcnd.Condition{
+			Type:     NetAppShiftWarmNotSupported,
+			Status:   True,
+			Category: api.CategoryCritical,
+			Reason:   NotSupported,
+			Message:  "NetApp Shift/Trident destination storage is not supported for warm migration. Use a cold migration plan, or map disks to a non-Shift StorageClass.",
+		})
+	}
+	return nil
+}
+
+// hasShiftDiskMissingNAS checks whether any Shift-mapped disk on the VM lacks NAS export
+// details on its backing datastore. Returns true on the first missing entry found.
+func hasShiftDiskMissingNAS(vm *vsphere.VM, storageMap *api.StorageMap, inventory web.Client, destClient client.Client) (string, error) {
+	for _, disk := range vm.SortedDisksAsVmware() {
+		pair, found := storageMap.FindStorage(disk.Datastore.ID)
+		if !found {
+			continue
+		}
+		diskShift, err := pair.Destination.IsNetAppShiftStorageClass(destClient)
+		if err != nil {
+			return "", err
+		}
+		if !diskShift {
+			continue
+		}
+		ds := &vsphere.Datastore{}
+		if err := inventory.Find(ds, refapi.Ref{ID: disk.Datastore.ID}); err != nil {
+			return "", liberr.Wrap(err, "datastore", disk.Datastore.ID)
+		}
+		nfsServer := ds.NasRemoteHost
+		if hn := len(ds.NasRemoteHostNames); hn > 0 {
+			nfsServer = ds.NasRemoteHostNames[hn-1]
+		}
+		if ds.NasRemotePath == "" || nfsServer == "" {
+			label := ds.Name
+			if label == "" {
+				label = disk.Datastore.ID
+			}
+			return label, nil
+		}
+	}
+	return "", nil
 }
 
 // Validate that warm migration is supported from the source provider.
@@ -629,7 +702,7 @@ func aggregateWarningConcerns(v interface{}, vmRef string, unsupportedOVFExportS
 }
 
 // Validate listed VMs.
-func (r *Reconciler) validateVM(plan *api.Plan) error {
+func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error {
 	if plan.Status.HasCondition(Executing) {
 		return nil
 	}
@@ -868,6 +941,22 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Items:    []string{},
 	}
 
+	shiftSnapshotVMs := libcnd.Condition{
+		Type:     VMHasSnapshots,
+		Status:   True,
+		Reason:   NotValid,
+		Category: api.CategoryCritical,
+		Message:  "NetApp Shift plans require VMs to have no VMware snapshots. Remove snapshots before migration.",
+		Items:    []string{},
+	}
+	shiftNASMissing := libcnd.Condition{
+		Type:     NetAppShiftDatastoreNASMissing,
+		Status:   True,
+		Reason:   NotValid,
+		Category: api.CategoryCritical,
+		Message:  "Datastore is missing NAS export details required for NetApp Shift.",
+		Items:    []string{},
+	}
 	var sharedDisksConditions []libcnd.Condition
 	setOf := map[string]bool{}
 	setOfTargetName := map[string]bool{}
@@ -876,8 +965,18 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 	source := plan.Referenced.Provider.Source
 	checkMixedUsage := source != nil && source.Type() == api.VSphere && settings.Settings.Features.CopyOffload
 	planUsesOffload := checkMixedUsage && plan.IsUsingOffloadPlugin()
+	netAppShift := false
+	var err error
+	if source != nil && source.Type() == api.VSphere && plan.Map.Storage != nil {
+		netAppShift, err = plan.Map.Storage.HasNetAppShiftDestination(ctx.Destination.Client)
+		if err != nil {
+			return liberr.Wrap(err, "check NetApp Shift storage")
+		}
+	}
+	if err != nil {
+		return liberr.Wrap(err, "check NetApp Shift storage")
+	}
 
-	//
 	// Referenced VMs.
 	for i := range plan.Spec.VMs {
 		vm := &plan.Spec.VMs[i]
@@ -948,6 +1047,18 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		}
 		aggregateCriticalConcerns(v, ref.String(), &vmCriticalConcerns)
 		aggregateWarningConcerns(v, ref.String(), &unsupportedOVFExportSource)
+		if netAppShift {
+			if vsphereVM, ok := v.(*vsphere.VM); ok {
+				if vsphereVM.Snapshot.ID != "" {
+					shiftSnapshotVMs.Items = append(shiftSnapshotVMs.Items, ref.String())
+				}
+				if label, sErr := hasShiftDiskMissingNAS(vsphereVM, plan.Map.Storage, inventory, ctx.Destination.Client); sErr != nil {
+					return sErr
+				} else if label != "" {
+					shiftNASMissing.Items = append(shiftNASMissing.Items, label)
+				}
+			}
+		}
 		if plan.Spec.Type == api.MigrationOnlyConversion {
 			if vm, ok := v.(*vsphere.VM); ok {
 				pvcs, err := r.getVmPVCs(plan, vm)
@@ -1169,7 +1280,6 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 				missingCbtForWarm.Items = append(missingCbtForWarm.Items, ref.String())
 			}
 
-			// Check for pre-existing snapshots
 			ok, msg, _, err := validator.HasSnapshot(*ref)
 			if err != nil {
 				return err
@@ -1304,6 +1414,12 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 	}
 	if len(vmCriticalConcerns.Items) > 0 {
 		plan.Status.SetCondition(vmCriticalConcerns)
+	}
+	if len(shiftSnapshotVMs.Items) > 0 {
+		plan.Status.SetCondition(shiftSnapshotVMs)
+	}
+	if len(shiftNASMissing.Items) > 0 {
+		plan.Status.SetCondition(shiftNASMissing)
 	}
 
 	return nil

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -614,16 +614,47 @@ func (v *DatastoreAdapter) Apply(u types.ObjectUpdate) {
 					v.model.MaintenanceMode = s
 				}
 			case fVmfsExtent:
-				if s, cast := p.Val.(types.VmfsDatastoreInfo); cast {
-					backingDevList := []string{}
-					for _, val := range s.Vmfs.Extent {
-						backingDevList = append(backingDevList, val.DiskName)
-					}
-					v.model.BackingDevicesNames = backingDevList
-				}
+				applyDatastoreInfoProperty(p.Val, &v.model)
 			}
 		}
 	}
+}
+
+// applyDatastoreInfoProperty decodes the datastore "info" property, which is either
+// VMFS (LUN extent names) or NAS (NfsDatastoreInfo with HostNasVolume details).
+func applyDatastoreInfoProperty(val types.AnyType, ds *model.Datastore) {
+	if val == nil {
+		return
+	}
+	switch t := val.(type) {
+	case types.VmfsDatastoreInfo:
+		backing := []string{}
+		if t.Vmfs != nil {
+			for _, e := range t.Vmfs.Extent {
+				backing = append(backing, e.DiskName)
+			}
+		}
+		ds.BackingDevicesNames = backing
+	case *types.VmfsDatastoreInfo:
+		if t != nil {
+			applyDatastoreInfoProperty(*t, ds)
+		}
+	case types.NasDatastoreInfo:
+		applyNasDatastoreNfsInfo(t, ds)
+	case *types.NasDatastoreInfo:
+		if t != nil {
+			applyNasDatastoreNfsInfo(*t, ds)
+		}
+	}
+}
+
+func applyNasDatastoreNfsInfo(info types.NasDatastoreInfo, ds *model.Datastore) {
+	if info.Nas == nil {
+		return
+	}
+	ds.NasRemoteHost = info.Nas.RemoteHost
+	ds.NasRemotePath = info.Nas.RemotePath
+	ds.NasRemoteHostNames = append([]string(nil), info.Nas.RemoteHostNames...)
 }
 
 // VM model adapter.

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -296,6 +296,9 @@ type Datastore struct {
 	Free                int64    `sql:""`
 	MaintenanceMode     string   `sql:""`
 	BackingDevicesNames []string `sql:""`
+	NasRemoteHost       string   `sql:""`
+	NasRemotePath       string   `sql:""`
+	NasRemoteHostNames  []string `sql:""`
 }
 
 type VM struct {

--- a/pkg/controller/provider/web/vsphere/datastore.go
+++ b/pkg/controller/provider/web/vsphere/datastore.go
@@ -179,6 +179,9 @@ type Datastore struct {
 	Free                int64    `json:"free"`
 	MaintenanceMode     string   `json:"maintenance"`
 	BackingDevicesNames []string `json:"backingDevicesNames"`
+	NasRemoteHost       string   `json:"nasRemoteHost,omitempty"`
+	NasRemotePath       string   `json:"nasRemotePath,omitempty"`
+	NasRemoteHostNames  []string `json:"nasRemoteHostNames,omitempty"`
 }
 
 // Build the resource using the model.
@@ -189,6 +192,9 @@ func (r *Datastore) With(m *model.Datastore) {
 	r.Free = m.Free
 	r.MaintenanceMode = m.MaintenanceMode
 	r.BackingDevicesNames = m.BackingDevicesNames
+	r.NasRemoteHost = m.NasRemoteHost
+	r.NasRemotePath = m.NasRemotePath
+	r.NasRemoteHostNames = m.NasRemoteHostNames
 }
 
 // Build self link (URI).

--- a/pkg/provider/ec2/controller/builder/vm.go
+++ b/pkg/provider/ec2/controller/builder/vm.go
@@ -617,3 +617,7 @@ func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigR
 		},
 	}, nil
 }
+
+func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]core.PersistentVolumeClaim, error) {
+	return nil, nil
+}

--- a/pkg/provider/ec2/controller/ensurer/ensurer.go
+++ b/pkg/provider/ec2/controller/ensurer/ensurer.go
@@ -35,3 +35,8 @@ func (r *Ensurer) SharedSecrets(vm *planapi.VMStatus, secrets []core.Secret) err
 	// EC2 provider doesn't use shared secrets currently
 	return nil
 }
+
+// PersistentVolumeClaims is a no-op for EC2.
+func (r *Ensurer) PersistentVolumeClaims(vm *planapi.VMStatus, pvcs []core.PersistentVolumeClaim) error {
+	return nil
+}

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -13,60 +13,64 @@ import (
 
 // Environment variables.
 const (
-	MaxVmInFlight                    = "MAX_VM_INFLIGHT"
-	HookRetry                        = "HOOK_RETRY"
-	ImporterRetry                    = "IMPORTER_RETRY"
-	VirtV2vImage                     = "VIRT_V2V_IMAGE"
-	VirtV2vImageXFS                  = "VIRT_V2V_IMAGE_XFS"
-	vddkImage                        = "VDDK_IMAGE"
-	PrecopyInterval                  = "PRECOPY_INTERVAL"
-	BlockerGracePeriodMinutes        = "BLOCKER_GRACE_PERIOD_MINUTES"
-	VirtV2vDontRequestKVM            = "VIRT_V2V_DONT_REQUEST_KVM"
-	SnapshotRemovalTimeout           = "SNAPSHOT_REMOVAL_TIMEOUT"
-	SnapshotStatusCheckRate          = "SNAPSHOT_STATUS_CHECK_RATE"
-	CDIExportTokenTTL                = "CDI_EXPORT_TOKEN_TTL"
-	FileSystemOverhead               = "FILESYSTEM_OVERHEAD"
-	BlockOverhead                    = "BLOCK_OVERHEAD"
-	CleanupRetries                   = "CLEANUP_RETRIES"
-	SnapshotRemovalCheckRetries      = "SNAPSHOT_REMOVAL_CHECK_RETRIES"
-	OvirtOsConfigMap                 = "OVIRT_OS_MAP"
-	VsphereOsConfigMap               = "VSPHERE_OS_MAP"
-	VirtCustomizeConfigMap           = "VIRT_CUSTOMIZE_MAP"
-	VddkJobActiveDeadline            = "VDDK_JOB_ACTIVE_DEADLINE"
-	VirtV2vExtraArgs                 = "VIRT_V2V_EXTRA_ARGS"
-	VirtV2vInspectorExtraArgs        = "VIRT_V2V_INSPECTOR_EXTRA_ARGS"
-	VirtV2vExtraConfConfigMap        = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
-	VirtV2vMemSize                   = "VIRT_V2V_MEMSIZE"
-	VirtV2vSmp                       = "VIRT_V2V_SMP"
-	VirtV2vContainerLimitsCpu        = "VIRT_V2V_CONTAINER_LIMITS_CPU"
-	VirtV2vContainerLimitsMemory     = "VIRT_V2V_CONTAINER_LIMITS_MEMORY"
-	VirtV2vContainerRequestsCpu      = "VIRT_V2V_CONTAINER_REQUESTS_CPU"
-	VirtV2vContainerRequestsMemory   = "VIRT_V2V_CONTAINER_REQUESTS_MEMORY"
-	HooksContainerLimitsCpu          = "HOOKS_CONTAINER_LIMITS_CPU"
-	HooksContainerLimitsMemory       = "HOOKS_CONTAINER_LIMITS_MEMORY"
-	HooksContainerRequestsCpu        = "HOOKS_CONTAINER_REQUESTS_CPU"
-	HooksContainerRequestsMemory     = "HOOKS_CONTAINER_REQUESTS_MEMORY"
-	OvaContainerLimitsCpu            = "OVA_CONTAINER_LIMITS_CPU"
-	OvaContainerLimitsMemory         = "OVA_CONTAINER_LIMITS_MEMORY"
-	OvaContainerRequestsCpu          = "OVA_CONTAINER_REQUESTS_CPU"
-	OvaContainerRequestsMemory       = "OVA_CONTAINER_REQUESTS_MEMORY"
-	HyperVContainerLimitsCpu         = "HYPERV_CONTAINER_LIMITS_CPU"
-	HyperVContainerLimitsMemory      = "HYPERV_CONTAINER_LIMITS_MEMORY"
-	HyperVContainerRequestsCpu       = "HYPERV_CONTAINER_REQUESTS_CPU"
-	HyperVContainerRequestsMemory    = "HYPERV_CONTAINER_REQUESTS_MEMORY"
-	PopulatorContainerLimitsCpu      = "POPULATOR_CONTAINER_LIMITS_CPU"
-	PopulatorContainerLimitsMemory   = "POPULATOR_CONTAINER_LIMITS_MEMORY"
-	PopulatorContainerRequestsCpu    = "POPULATOR_CONTAINER_REQUESTS_CPU"
-	PopulatorContainerRequestsMemory = "POPULATOR_CONTAINER_REQUESTS_MEMORY"
-	TlsConnectionTimeout             = "TLS_CONNECTION_TIMEOUT"
-	MaxConcurrentReconciles          = "MAX_CONCURRENT_RECONCILES"
-	MaxParentBackingRetries          = "MAX_PARENT_BACKING_RETRIES"
-	HostLeaseNamespace               = "HOST_LEASE_NAMESPACE"
-	HostLeaseDurationSeconds         = "HOST_LEASE_DURATION_SECONDS"
-	MigrationServiceAccount          = "MIGRATION_SERVICE_ACCOUNT"
-	AAPURL                           = "AAP_URL"
-	AAPTokenSecretName               = "AAP_TOKEN_SECRET_NAME"
-	AAPTimeout                       = "AAP_TIMEOUT"
+	MaxVmInFlight                          = "MAX_VM_INFLIGHT"
+	HookRetry                              = "HOOK_RETRY"
+	ImporterRetry                          = "IMPORTER_RETRY"
+	VirtV2vImage                           = "VIRT_V2V_IMAGE"
+	VirtV2vImageXFS                        = "VIRT_V2V_IMAGE_XFS"
+	vddkImage                              = "VDDK_IMAGE"
+	PrecopyInterval                        = "PRECOPY_INTERVAL"
+	BlockerGracePeriodMinutes              = "BLOCKER_GRACE_PERIOD_MINUTES"
+	VirtV2vDontRequestKVM                  = "VIRT_V2V_DONT_REQUEST_KVM"
+	SnapshotRemovalTimeout                 = "SNAPSHOT_REMOVAL_TIMEOUT"
+	SnapshotStatusCheckRate                = "SNAPSHOT_STATUS_CHECK_RATE"
+	CDIExportTokenTTL                      = "CDI_EXPORT_TOKEN_TTL"
+	FileSystemOverhead                     = "FILESYSTEM_OVERHEAD"
+	BlockOverhead                          = "BLOCK_OVERHEAD"
+	CleanupRetries                         = "CLEANUP_RETRIES"
+	SnapshotRemovalCheckRetries            = "SNAPSHOT_REMOVAL_CHECK_RETRIES"
+	OvirtOsConfigMap                       = "OVIRT_OS_MAP"
+	VsphereOsConfigMap                     = "VSPHERE_OS_MAP"
+	VirtCustomizeConfigMap                 = "VIRT_CUSTOMIZE_MAP"
+	VddkJobActiveDeadline                  = "VDDK_JOB_ACTIVE_DEADLINE"
+	VirtV2vExtraArgs                       = "VIRT_V2V_EXTRA_ARGS"
+	VirtV2vInspectorExtraArgs              = "VIRT_V2V_INSPECTOR_EXTRA_ARGS"
+	VirtV2vExtraConfConfigMap              = "VIRT_V2V_EXTRA_CONF_CONFIG_MAP"
+	VirtV2vMemSize                         = "VIRT_V2V_MEMSIZE"
+	VirtV2vSmp                             = "VIRT_V2V_SMP"
+	VirtV2vContainerLimitsCpu              = "VIRT_V2V_CONTAINER_LIMITS_CPU"
+	VirtV2vContainerLimitsMemory           = "VIRT_V2V_CONTAINER_LIMITS_MEMORY"
+	VirtV2vContainerRequestsCpu            = "VIRT_V2V_CONTAINER_REQUESTS_CPU"
+	VirtV2vContainerRequestsMemory         = "VIRT_V2V_CONTAINER_REQUESTS_MEMORY"
+	HooksContainerLimitsCpu                = "HOOKS_CONTAINER_LIMITS_CPU"
+	HooksContainerLimitsMemory             = "HOOKS_CONTAINER_LIMITS_MEMORY"
+	HooksContainerRequestsCpu              = "HOOKS_CONTAINER_REQUESTS_CPU"
+	HooksContainerRequestsMemory           = "HOOKS_CONTAINER_REQUESTS_MEMORY"
+	OvaContainerLimitsCpu                  = "OVA_CONTAINER_LIMITS_CPU"
+	OvaContainerLimitsMemory               = "OVA_CONTAINER_LIMITS_MEMORY"
+	OvaContainerRequestsCpu                = "OVA_CONTAINER_REQUESTS_CPU"
+	OvaContainerRequestsMemory             = "OVA_CONTAINER_REQUESTS_MEMORY"
+	HyperVContainerLimitsCpu               = "HYPERV_CONTAINER_LIMITS_CPU"
+	HyperVContainerLimitsMemory            = "HYPERV_CONTAINER_LIMITS_MEMORY"
+	HyperVContainerRequestsCpu             = "HYPERV_CONTAINER_REQUESTS_CPU"
+	HyperVContainerRequestsMemory          = "HYPERV_CONTAINER_REQUESTS_MEMORY"
+	PopulatorContainerLimitsCpu            = "POPULATOR_CONTAINER_LIMITS_CPU"
+	PopulatorContainerLimitsMemory         = "POPULATOR_CONTAINER_LIMITS_MEMORY"
+	PopulatorContainerRequestsCpu          = "POPULATOR_CONTAINER_REQUESTS_CPU"
+	PopulatorContainerRequestsMemory       = "POPULATOR_CONTAINER_REQUESTS_MEMORY"
+	TlsConnectionTimeout                   = "TLS_CONNECTION_TIMEOUT"
+	MaxConcurrentReconciles                = "MAX_CONCURRENT_RECONCILES"
+	MaxParentBackingRetries                = "MAX_PARENT_BACKING_RETRIES"
+	HostLeaseNamespace                     = "HOST_LEASE_NAMESPACE"
+	HostLeaseDurationSeconds               = "HOST_LEASE_DURATION_SECONDS"
+	MigrationServiceAccount                = "MIGRATION_SERVICE_ACCOUNT"
+	NetAppShiftDiskPermsInitRequestsCpu    = "NETAPP_SHIFT_DISK_PERMS_INIT_REQUESTS_CPU"
+	NetAppShiftDiskPermsInitRequestsMemory = "NETAPP_SHIFT_DISK_PERMS_INIT_REQUESTS_MEMORY"
+	NetAppShiftDiskPermsInitLimitsCpu      = "NETAPP_SHIFT_DISK_PERMS_INIT_LIMITS_CPU"
+	NetAppShiftDiskPermsInitLimitsMemory   = "NETAPP_SHIFT_DISK_PERMS_INIT_LIMITS_MEMORY"
+	AAPURL                                 = "AAP_URL"
+	AAPTokenSecretName                     = "AAP_TOKEN_SECRET_NAME"
+	AAPTimeout                             = "AAP_TIMEOUT"
 )
 
 // Default values for populator container resources
@@ -157,6 +161,11 @@ type Migration struct {
 	HostLeaseDurationSeconds string
 	// ServiceAccount is the cluster-wide default ServiceAccount for migration pods
 	ServiceAccount string
+	// NetAppShiftDiskPermsInit* are CPU/memory for the privileged NetApp Shift disk-perms init on virt-v2v conversion pods
+	NetAppShiftDiskPermsInitRequestsCpu    string
+	NetAppShiftDiskPermsInitRequestsMemory string
+	NetAppShiftDiskPermsInitLimitsCpu      string
+	NetAppShiftDiskPermsInitLimitsMemory   string
 	// AAPURL is the Ansible Automation Platform base URL (ForkliftController aap_url).
 	AAPURL string
 	// AAPTokenSecretName is the name of the Secret in the controller namespace holding the AAP API token (key "token").
@@ -381,6 +390,10 @@ func (r *Migration) Load() (err error) {
 	if val, found := os.LookupEnv(MigrationServiceAccount); found {
 		r.ServiceAccount = val
 	}
+	r.NetAppShiftDiskPermsInitRequestsCpu = Lookup(NetAppShiftDiskPermsInitRequestsCpu, "10m")
+	r.NetAppShiftDiskPermsInitRequestsMemory = Lookup(NetAppShiftDiskPermsInitRequestsMemory, "32Mi")
+	r.NetAppShiftDiskPermsInitLimitsCpu = Lookup(NetAppShiftDiskPermsInitLimitsCpu, "200m")
+	r.NetAppShiftDiskPermsInitLimitsMemory = Lookup(NetAppShiftDiskPermsInitLimitsMemory, "64Mi")
 	if val, found := os.LookupEnv(AAPURL); found {
 		r.AAPURL = strings.TrimSpace(val)
 	}


### PR DESCRIPTION
RFE:
Instead of CDI or v2v doing the disk copy we leave the copy up to the NetApp Shift. Forklift and NetApp Shift collaborated on e2e integration.

Cluster configuration:
1. Cluster administrator needs to create StorageClass with annotations:
    - shift.netapp.io/storage-class-type: shift

Forklift migration flow:
1. Forklift will create PVC with annotations
    - forklift.konveyor.io/nfs-server
    - forklift.konveyor.io/nfs-path
    - forklift.konveyor.io/disk-path
    - forklift.konveyor.io/vm-id
    - forklift.konveyor.io/vm-uuid
2. This PVC triggers the NetApp CSI and invokes the NetApp Shift copy
    - All VMDKs are in one directory, however in k8s we expect to have one disk per directory. NetApp Shift separates the disks into separate directories so each PVC is independent.
    - Additionally NetApp Shift separates each VMDK disk into separate storage volume
3. Once the Shift copy is done the PVC is marked as Bound
4. Forklift will pick up Bound PVCs, at this point all images are owned by nobody:nobody so we need to change the user to QEMU 107:107. For this forklift will create init container before the v2v. This container will have extra capabilities to change the permissions of the files.
5. Once the init container is done, the virt-v2v-in-place will start and perform the guest conversion.

Ref: https://issues.redhat.com/browse/MTV-4725
Resolves: MTV-4725