### PR TITLE
chore(docs): add Prometheus metrics documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,5 @@ This guide will provide you with hands-on exposure to OpenShift Migration Toolin
 ### Sections
 
 [Section 1 - Migration Hooks](./hooks.md)<br>
+[Section 2 - Metrics](./metrics.md)<br>
+[Section 3 - Metrics Reference](./metrics-reference.md)<br>

--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -1,0 +1,186 @@
+# Forklift Metrics Reference
+
+Catalog of the Prometheus metrics scraped from the forklift-controller, with
+types, labels, descriptions, and example queries. For architecture, labeling
+conventions, and developer guidance see [metrics.md](./metrics.md).
+
+All metrics below are defined in
+[pkg/monitoring/metrics/forklift-controller/metrics.go](../pkg/monitoring/metrics/forklift-controller/metrics.go),
+recorded by
+[migration_metrics.go](../pkg/monitoring/metrics/forklift-controller/migration_metrics.go)
+and
+[plan_metrics.go](../pkg/monitoring/metrics/forklift-controller/plan_metrics.go),
+and served on the controller's `:8443/metrics` endpoint.
+
+> **Note:** The example queries below use `oc metrics` (or equivalently
+> `kubectl metrics`), a kubectl plugin for querying Prometheus / Thanos on
+> OpenShift clusters. Install it from
+> [kubectl-metrics](https://github.com/yaacov/kubectl-metrics#installation).
+
+---
+
+### Common labels
+
+Most metrics carry a subset of these labels:
+
+- **`status`** -- lifecycle state of the migration or plan. Terminal states
+  used by counters: `Succeeded`, `Failed`, `Canceled`. Gauges may also use:
+  `Executing`, `Running`, `Pending`, `Blocked`, `Deleted`.
+- **`provider`** -- source virtualization platform the VMs are migrated from.
+  One of: `openshift`, `vsphere`, `ovirt`, `openstack`, `ova`, `ec2`, `hyperv`.
+- **`mode`** -- migration strategy. `Cold` shuts the source VM down and copies
+  disks in one pass. `Warm` replicates incrementally while the source VM keeps
+  running, then cuts over.
+- **`target`** -- destination cluster. `Local` means the same OpenShift cluster
+  that runs the controller (no URL configured). `Remote` means a different
+  cluster reached via an explicit URL.
+
+Additional labels that appear only on specific metrics are explained inline
+below.
+
+---
+
+### `mtv_migrations_status_total`
+
+| | |
+|---|---|
+| **Type** | Counter |
+| **Labels** | `status`, `provider`, `mode`, `target` |
+| **Description** | Running count of VM migrations that reached a terminal state. |
+
+Incremented once per migration when it transitions to Succeeded, Failed, or
+Canceled. Deduplication ensures each migration UID is counted at most once per
+status.
+
+```bash
+# Total successful migrations from vSphere
+oc metrics query --query 'mtv_migrations_status_total{status="Succeeded", provider="vsphere"}'
+
+# Rate of failed migrations over the last hour
+oc metrics query --query 'rate(mtv_migrations_status_total{status="Failed"}[1h])'
+
+# Discover all mtv migration metrics available on the cluster
+oc metrics discover --keyword mtv_migrations
+
+# Inspect labels present on this metric
+oc metrics labels --metric mtv_migrations_status_total
+```
+
+### `mtv_workload_migrations_status_total`
+
+| | |
+|---|---|
+| **Type** | Counter |
+| **Labels** | `status`, `provider`, `mode`, `target`, `plan` |
+| **Description** | Same as `mtv_migrations_status_total` but adds a `plan` label for per-plan correlation. |
+
+The extra `plan` label is the Kubernetes UID of the `Plan` resource. This
+allows you to break down migration counts per plan when multiple plans share the
+same provider/mode/target combination.
+
+```bash
+# Succeeded migrations for a specific plan
+oc metrics query --query 'mtv_workload_migrations_status_total{status="Succeeded", plan="<plan-uid>"}'
+```
+
+### `mtv_plans_status`
+
+| | |
+|---|---|
+| **Type** | Gauge |
+| **Labels** | `status`, `provider`, `mode`, `target` |
+| **Description** | Current count of plans in each status. Recalculated every 10 seconds; stale combinations are reset to zero. |
+
+Valid `status` values: Succeeded, Failed, Executing, Running, Pending,
+Canceled, Blocked, Deleted.
+
+```bash
+# Number of currently executing plans
+oc metrics query --query 'mtv_plans_status{status="Executing"}'
+
+# Group plan counts by status
+oc metrics query --query 'mtv_plans_status' --group-by status
+```
+
+### `mtv_plan_alert_status`
+
+| | |
+|---|---|
+| **Type** | Gauge |
+| **Labels** | `status`, `provider`, `mode`, `target`, `plan`, `plan_name`, `phase` |
+| **Description** | Set to `1` for plans that are Succeeded, Failed, or Executing; deleted when the plan leaves that state. Designed for alerting rules. |
+
+Extra labels beyond the common set:
+
+- **`plan`** -- Kubernetes UID of the `Plan` resource.
+- **`plan_name`** -- human-readable `.metadata.name` of the plan, so alerting
+  rules can display a friendly name without needing a UID lookup.
+- **`phase`** -- pipeline phase the plan is in or where it failed. `Completed`
+  for succeeded plans, `Executing` for in-progress plans, or a comma-separated
+  list of error phases reported by each failed VM.
+
+```bash
+# Check for any failed plans
+oc metrics query --query 'mtv_plan_alert_status{status="Failed"} == 1'
+
+# Show alert status grouped by plan name
+oc metrics query --query 'mtv_plan_alert_status' --group-by plan_name
+```
+
+### `mtv_migration_duration_seconds`
+
+| | |
+|---|---|
+| **Type** | Gauge |
+| **Labels** | `provider`, `mode`, `target`, `plan` |
+| **Description** | Wall-clock duration in seconds of the last successful migration for each plan. |
+
+The `plan` label is the Kubernetes UID of the `Plan` resource, letting you see
+how long the most recent successful migration took for each individual plan.
+
+Set once when a migration succeeds, calculated as
+`migration.Status.Completed - migration.Status.Started`.
+
+```bash
+# Duration of the last successful migration per plan
+oc metrics query --query 'mtv_migration_duration_seconds' --group-by plan
+```
+
+### `mtv_migrations_duration_seconds`
+
+| | |
+|---|---|
+| **Type** | Histogram |
+| **Labels** | `provider`, `mode`, `target` |
+| **Buckets** | 1h, 2h, 5h, 10h, 24h, 48h (in seconds) |
+| **Description** | Distribution of successful migration durations. |
+
+```bash
+# Median migration duration for vSphere cold migrations
+oc metrics query --query 'histogram_quantile(0.5, rate(mtv_migrations_duration_seconds_bucket{provider="vsphere", mode="Cold"}[24h]))'
+
+# Duration histogram over the last 24 hours (range query, 1h steps)
+oc metrics query-range \
+  --query 'histogram_quantile(0.5, rate(mtv_migrations_duration_seconds_bucket[1h]))' \
+  --start "-24h" --step "1h"
+```
+
+### `mtv_migration_data_transferred_bytes`
+
+| | |
+|---|---|
+| **Type** | Gauge |
+| **Labels** | `provider`, `mode`, `target`, `plan` |
+| **Description** | Total bytes transferred across all VM disks for a migration. Updated on successful migration completion and also during plan execution for in-progress plans. |
+
+The `plan` label is the Kubernetes UID of the `Plan` resource, so you can see
+transfer volumes per plan.
+
+Data is summed from the `DiskTransfer` and `DiskTransferV2v` pipeline steps.
+The `Progress.Completed` value (in MB) is converted to bytes.
+
+```bash
+# Data transferred per plan
+oc metrics query --query 'mtv_migration_data_transferred_bytes' --group-by plan
+```
+

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,165 @@
+# Forklift Metrics
+
+This document covers the architecture behind metric collection, labeling
+conventions, and how to add new metrics as a developer. For the complete list
+of every metric (types, labels, descriptions, and example PromQL queries) see
+the [Metrics Reference](./metrics-reference.md).
+
+## Architecture overview
+
+The forklift-controller exposes all `mtv_*` metrics on a single HTTPS
+endpoint that is scraped by the in-cluster Prometheus stack.
+
+```
+┌─────────────────────────────────────────────────────┐
+│  forklift-controller                                │
+│                                                     │
+│  RecordMigrationMetrics ──┐                         │
+│  RecordPlanMetrics ───────┤  promauto (default reg) │
+│                           ▼                         │
+│              promhttp  :8443/metrics  ◄── ServiceMonitor ◄── Prometheus
+└─────────────────────────────────────────────────────┘
+```
+
+### Metrics endpoint
+
+Metrics are registered with `promauto` into the default Prometheus registry in
+[pkg/monitoring/metrics/forklift-controller/metrics.go](../pkg/monitoring/metrics/forklift-controller/metrics.go).
+The HTTP endpoint is started by `StartPrometheusEndpoint` in
+[pkg/metrics/promethousutil.go](../pkg/metrics/promethousutil.go), which
+generates a self-signed TLS certificate and serves on `:8443/metrics`.
+
+The OpenShift Prometheus stack discovers this endpoint through the
+`ServiceMonitor` resource defined in
+[operator/config/prometheus/monitor.yaml](../operator/config/prometheus/monitor.yaml).
+
+Two background goroutines drive the controller metrics:
+
+- **`RecordMigrationMetrics`** -- started by the Migration controller
+  (`pkg/controller/migration/controller.go`). Polls every 10 seconds, lists all
+  `Migration` objects, and increments counters for terminal states (Succeeded,
+  Failed, Canceled). Uses in-memory maps keyed by migration UID to guarantee
+  each migration is counted exactly once.
+
+- **`RecordPlanMetrics`** -- started by the Plan controller
+  (`pkg/controller/plan/controller.go`). Polls every 10 seconds, lists all
+  `Plan` objects, and recalculates gauge values from scratch. Stale label
+  combinations (plans that no longer exist or changed state) are reset to zero
+  or deleted.
+
+---
+
+## Metric catalog
+
+See the [Metrics Reference](./metrics-reference.md) for the complete catalog of
+every metric, including type, labels, description, and example queries.
+
+At a glance:
+
+| Area | Key metrics | Source |
+|---|---|---|
+| Migrations | `mtv_migrations_status_total`, `mtv_workload_migrations_status_total`, `mtv_migration_duration_seconds`, `mtv_migrations_duration_seconds`, `mtv_migration_data_transferred_bytes` | `pkg/monitoring/metrics/forklift-controller/` |
+| Plans | `mtv_plans_status`, `mtv_plan_alert_status` | `pkg/monitoring/metrics/forklift-controller/` |
+
+---
+
+## Labeling conventions
+
+### Prometheus / OpenShift conventions
+
+Forklift follows standard Prometheus naming conventions adopted by the
+OpenShift ecosystem:
+
+| Convention | Example |
+|---|---|
+| Project prefix | `mtv_` for controller-level metrics |
+| Counter suffix | `_total` (e.g. `mtv_migrations_status_total`) |
+| Duration unit suffix | `_seconds` (e.g. `mtv_migration_duration_seconds`) |
+| Size unit suffix | `_bytes` (e.g. `mtv_migration_data_transferred_bytes`) |
+| Histogram buckets | named `_bucket`, `_sum`, `_count` (auto-generated) |
+| Snake_case labels | `storage_vendor`, `clone_method`, `owner_uid` |
+
+### Forklift-specific label values
+
+These labels are shared across most controller metrics and have a fixed set of
+allowed values:
+
+| Label | Values | Meaning |
+|---|---|---|
+| `status` | `Succeeded`, `Failed`, `Canceled`, `Executing`, `Running`, `Pending`, `Blocked`, `Deleted` | Current lifecycle state of a plan or migration object. Counters only use the terminal states (`Succeeded`, `Failed`, `Canceled`); gauges may use the full set. Not every metric exposes every value -- check the per-metric docs in the [Metrics Reference](./metrics-reference.md). |
+| `provider` | `openshift`, `vsphere`, `ovirt`, `openstack`, `ova`, `ec2`, `hyperv` | The source virtualization platform the VMs are being migrated from. The value comes from `sourceProvider.Type().String()` and matches the `ProviderType` constants defined in `pkg/apis/forklift/v1beta1/provider.go`. |
+| `mode` | `Cold`, `Warm` | The migration strategy. **Cold** shuts down the source VM and copies disks in a single pass. **Warm** performs incremental snapshot-based replication while the source VM stays running, then does a final cutover. |
+| `target` | `Local`, `Remote` | Where the VMs are being migrated to. **Local** means the destination is the same OpenShift cluster that runs the forklift-controller (the destination provider has no URL configured). **Remote** means the destination is a different OpenShift cluster reached via an explicit URL. |
+| `plan` | UID string | The Kubernetes UID of the `Plan` resource that owns the migration. Used to correlate migration-level metrics back to a specific plan, especially when multiple plans target the same provider/mode/target combination. |
+| `plan_name` | string | The human-readable `.metadata.name` of the plan. Present only on `mtv_plan_alert_status` to make alerting rules easier to read without requiring a UID-to-name lookup. |
+| `phase` | string | The pipeline phase the plan is in or where it failed. For succeeded plans this is `Completed`; for executing plans it is `Executing`; for failed plans it is a comma-separated list of the error phases reported by each failed VM. Present only on `mtv_plan_alert_status`. |
+
+### Deduplication strategy
+
+- **Migration counters** (`mtv_migrations_status_total`,
+  `mtv_workload_migrations_status_total`): use three in-memory maps
+  (`processedSucceededMigrations`, `processedFailedMigrations`,
+  `processedCanceledMigrations`) keyed by migration UID. Each migration is
+  counted exactly once per terminal state.
+
+- **Plan gauges** (`mtv_plans_status`, `mtv_plan_alert_status`): recalculated
+  from scratch every 10-second cycle. Label combinations that existed in the
+  previous cycle but are absent in the current one are explicitly set to zero
+  (for `mtv_plans_status`) or deleted (for `mtv_plan_alert_status`).
+
+---
+
+## Developer guide
+
+### Where to define new metrics
+
+All controller-level Prometheus metrics are defined as package-level `var`
+blocks in
+[pkg/monitoring/metrics/forklift-controller/metrics.go](../pkg/monitoring/metrics/forklift-controller/metrics.go)
+using `promauto.NewCounterVec`, `promauto.NewGaugeVec`, or
+`promauto.NewHistogramVec`. The `promauto` package automatically registers
+metrics with the default Prometheus registry -- no manual `Register()` call is
+needed.
+
+### Where to record new metrics
+
+Recording logic lives in the `*_metrics.go` files in the same package:
+
+- [migration_metrics.go](../pkg/monitoring/metrics/forklift-controller/migration_metrics.go) -- migration lifecycle metrics
+- [plan_metrics.go](../pkg/monitoring/metrics/forklift-controller/plan_metrics.go) -- plan status metrics
+
+Both follow the same pattern: a goroutine that polls every 10 seconds, lists
+the relevant CRs, and updates metrics.
+
+### Adding a new controller metric
+
+1. **Define** the metric in `metrics.go`:
+
+   ```go
+   myNewGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+       Name: "mtv_my_new_metric",
+       Help: "Description of what this metric measures",
+   },
+       []string{"label_a", "label_b"},
+   )
+   ```
+
+2. **Record** it in the appropriate `*_metrics.go` file inside the polling
+   loop:
+
+   ```go
+   myNewGauge.With(prometheus.Labels{"label_a": valA, "label_b": valB}).Set(value)
+   ```
+
+3. **Document** the metric in the
+   [Metrics Reference](./metrics-reference.md).
+
+### Key source files
+
+| File | Purpose |
+|---|---|
+| `pkg/monitoring/metrics/forklift-controller/metrics.go` | Metric definitions |
+| `pkg/monitoring/metrics/forklift-controller/migration_metrics.go` | Migration metric recording loop |
+| `pkg/monitoring/metrics/forklift-controller/plan_metrics.go` | Plan metric recording loop |
+| `pkg/metrics/promethousutil.go` | TLS `/metrics` HTTP server setup |
+| `operator/config/prometheus/monitor.yaml` | ServiceMonitor for Prometheus scraping |


### PR DESCRIPTION
Document the mtv_* metrics exposed by the forklift-controller to Prometheus. metrics.md covers the architecture (endpoint, ServiceMonitor, polling goroutines), labeling conventions (OpenShift naming rules and Forklift-specific label values), deduplication strategy, and a developer guide for adding new metrics. metrics-reference.md is a companion reference listing every metric with type, labels, description, and oc metrics CLI examples.

Resolves: none