### PR TITLE
MTV-4365 | Standardize logging across all storage providers

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
+++ b/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	"k8s.io/klog/v2"
@@ -39,17 +40,17 @@ type ExtractedMapping struct {
 
 // extractWWPNsFromFCFormat extracts individual WWPNs from fc.WWNN:WWPN format
 // Uses the second part (after colon) as the real WWPN
-func extractWWPNsFromFCFormat(fcStrings []string) []string {
+func extractWWPNsFromFCFormat(fcStrings []string, log klog.Logger) []string {
 	var wwpns []string
 	for _, fcStr := range fcStrings {
 		if strings.HasPrefix(fcStr, "fc.") {
 			wwpn, err := fcutil.ExtractWWPN(fcStr)
 			if err != nil {
-				klog.Warningf("Failed to extract WWPN from %s: %v", fcStr, err)
+				log.Info("failed to extract WWPN", "fc_string", fcStr, "err", err)
 				continue
 			}
 			wwpns = append(wwpns, wwpn)
-			klog.Infof("Extracted WWPN: %s from %s", wwpn, fcStr)
+			log.V(2).Info("extracted WWPN", "wwpn", wwpn, "fc_string", fcStr)
 		}
 	}
 	return wwpns
@@ -101,6 +102,7 @@ type FlashSystemAPIClient struct {
 	authToken    string // Session token from /auth
 	username     string // Store for re-authentication
 	password     string // Store for re-authentication
+	log          klog.Logger
 }
 
 // NewFlashSystemAPIClient creates and authenticates a new API client.
@@ -115,6 +117,7 @@ func NewFlashSystemAPIClient(managementIP, username, password string, sslSkipVer
 		httpClient:   httpClient,
 		username:     username,
 		password:     password,
+		log:          logutil.NewLogger("flashsystem"),
 	}
 
 	// Initial authentication
@@ -140,7 +143,7 @@ func (c *FlashSystemAPIClient) authenticate() error {
 	req.Header.Set("X-Auth-Username", c.username)
 	req.Header.Set("X-Auth-Password", c.password)
 
-	klog.Infof("Attempting to authenticate with FlashSystem at %s for user %s", c.ManagementIP, c.username)
+	c.log.V(2).Info("authenticating with FlashSystem", "host", c.ManagementIP)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send auth request to FlashSystem: %w", err)
@@ -167,7 +170,7 @@ func (c *FlashSystemAPIClient) authenticate() error {
 
 	c.authToken = authResp.Token
 
-	klog.Infof("Successfully authenticated with FlashSystem and obtained session token.")
+	c.log.V(2).Info("Successfully authenticated with FlashSystem and obtained session token.")
 	return nil
 }
 
@@ -178,7 +181,7 @@ func (c *FlashSystemAPIClient) makeRequest(method, path string, payload interfac
 
 	// Handle 403 Forbidden - token expired, re-authenticate and retry once
 	if statusCode == http.StatusForbidden {
-		klog.Infof("Received 403 Forbidden, token likely expired. Re-authenticating...")
+		c.log.Info("received 403 forbidden, token likely expired, re-authenticating")
 		if authErr := c.authenticate(); authErr != nil {
 			return nil, statusCode, fmt.Errorf("re-authentication failed: %w", authErr)
 		}
@@ -192,7 +195,7 @@ func (c *FlashSystemAPIClient) makeRequest(method, path string, payload interfac
 // doRequest performs the actual HTTP request
 func (c *FlashSystemAPIClient) doRequest(method, path string, payload interface{}) ([]byte, int, error) {
 	fullURL := fmt.Sprintf("https://%s:7443/rest/v1%s", c.ManagementIP, path)
-	klog.Infof("FlashSystem API Request: %s %s", method, fullURL)
+	c.log.V(2).Info("API request", "method", method, "url", fullURL)
 
 	var reqBody *bytes.Buffer
 	if payload != nil {
@@ -201,7 +204,7 @@ func (c *FlashSystemAPIClient) doRequest(method, path string, payload interface{
 			return nil, 0, fmt.Errorf("failed to marshal payload for %s: %w", fullURL, err)
 		}
 		reqBody = bytes.NewBuffer(jsonPayload)
-		klog.Infof("Request Payload JSON: %s", string(jsonPayload))
+		c.log.V(2).Info("request payload", "json", string(jsonPayload))
 	} else {
 		reqBody = bytes.NewBuffer([]byte{})
 	}
@@ -226,7 +229,7 @@ func (c *FlashSystemAPIClient) doRequest(method, path string, payload interface{
 		return nil, resp.StatusCode, fmt.Errorf("failed to read response body from %s: %w", fullURL, readErr)
 	}
 
-	klog.Infof("Response Status: %s, Body: %s", resp.Status, string(respBodyBytes))
+	c.log.V(2).Info("response received", "status", resp.Status, "body", string(respBodyBytes))
 
 	// Enhanced error handling based on IBM Storage Virtualize API status codes
 	if resp.StatusCode >= 400 {
@@ -262,7 +265,7 @@ func (c *FlashSystemAPIClient) handleAPIError(statusCode int, body, url string) 
 
 // GetSystemInfo retrieves system-level settings including volume protection configuration
 func (c *FlashSystemAPIClient) GetSystemInfo() (*FlashSystemInfo, error) {
-	klog.Infof("Fetching system info using lssystem")
+	c.log.V(2).Info("fetching system info using lssystem")
 	respBytes, status, err := c.makeRequest("POST", "/lssystem", map[string]string{})
 	if err != nil || status != http.StatusOK {
 		return nil, fmt.Errorf("failed to get system info: %w, status: %d", err, status)
@@ -273,8 +276,7 @@ func (c *FlashSystemAPIClient) GetSystemInfo() (*FlashSystemInfo, error) {
 		return nil, fmt.Errorf("failed to unmarshal system info: %w", err)
 	}
 
-	klog.Infof("System info: vdisk_protection_enabled=%s, vdisk_protection_time=%s",
-		sysInfo.VdiskProtectionEnabled, sysInfo.VdiskProtectionTime)
+	c.log.V(2).Info("system info", "vdisk_protection_enabled", sysInfo.VdiskProtectionEnabled, "vdisk_protection_time", sysInfo.VdiskProtectionTime)
 	return &sysInfo, nil
 }
 
@@ -329,7 +331,7 @@ func (c *FlashSystemAPIClient) CreateFlashCopyMapping(sourceName, targetName, ma
 		"copyrate":   copyRate,
 		"autodelete": true,
 	}
-	klog.Infof("Creating FlashCopy mapping %s: %s -> %s", mappingName, sourceName, targetName)
+	c.log.Info("creating FlashCopy mapping", "mapping", mappingName, "source", sourceName, "target", targetName)
 	respBytes, status, err := c.makeRequest("POST", "/mkfcmap", payload)
 	if err != nil {
 		return "", status, fmt.Errorf("failed to create FlashCopy mapping: %w", err)
@@ -346,7 +348,7 @@ func (c *FlashSystemAPIClient) CreateFlashCopyMapping(sourceName, targetName, ma
 	if result.ID == "" {
 		return "", status, fmt.Errorf("mkfcmap response did not contain mapping id: %s", string(respBytes))
 	}
-	klog.Infof("FlashCopy mapping %s created successfully (id=%s)", mappingName, result.ID)
+	c.log.Info("FlashCopy mapping created", "mapping", mappingName, "id", result.ID)
 	return result.ID, status, nil
 }
 
@@ -354,7 +356,7 @@ func (c *FlashSystemAPIClient) CreateFlashCopyMapping(sourceName, targetName, ma
 func (c *FlashSystemAPIClient) PrestartFlashCopyMapping(mappingID string) error {
 	path := "/prestartfcmap/" + mappingID
 	payload := map[string]bool{"restore": true}
-	klog.Infof("Preparing FlashCopy mapping id %s", mappingID)
+	c.log.V(2).Info("preparing FlashCopy mapping", "mapping_id", mappingID)
 	respBytes, status, err := c.makeRequest("POST", path, payload)
 	if err != nil {
 		return fmt.Errorf("failed to prepare FlashCopy mapping: %w", err)
@@ -362,14 +364,14 @@ func (c *FlashSystemAPIClient) PrestartFlashCopyMapping(mappingID string) error 
 	if status != http.StatusOK {
 		return fmt.Errorf("prestartfcmap failed with status %d: %s", status, string(respBytes))
 	}
-	klog.Infof("FlashCopy mapping id %s prepared successfully", mappingID)
+	c.log.V(2).Info("FlashCopy mapping prepared", "mapping_id", mappingID)
 	return nil
 }
 
 // StartFlashCopyMapping starts a FlashCopy mapping by id. REST: POST /startfcmap/{id}.
 func (c *FlashSystemAPIClient) StartFlashCopyMapping(mappingID string) error {
 	path := "/startfcmap/" + mappingID
-	klog.Infof("Starting FlashCopy mapping id %s", mappingID)
+	c.log.V(2).Info("starting FlashCopy mapping", "mapping_id", mappingID)
 	respBytes, status, err := c.makeRequest("POST", path, nil)
 	if err != nil {
 		return fmt.Errorf("failed to start FlashCopy mapping: %w", err)
@@ -377,7 +379,7 @@ func (c *FlashSystemAPIClient) StartFlashCopyMapping(mappingID string) error {
 	if status != http.StatusOK {
 		return fmt.Errorf("startfcmap failed with status %d: %s", status, string(respBytes))
 	}
-	klog.Infof("FlashCopy mapping id %s started successfully (autodelete will remove it at 100%%)", mappingID)
+	c.log.Info("FlashCopy mapping started", "mapping_id", mappingID)
 	return nil
 }
 
@@ -389,6 +391,7 @@ type FlashSystemClonner struct {
 	api            *FlashSystemAPIClient
 	initiatorGroup string
 	arrayInfo      populator.StorageArrayInfo
+	log            klog.Logger
 }
 
 // Ensure FlashSystemClonner implements StorageArrayInfoProvider
@@ -403,6 +406,7 @@ func (c *FlashSystemClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
 // It checks that vdisk protection is disabled on the FlashSystem; if protection is enabled,
 // it returns an error because it must be off for Virtual Machines (see README, section IBM FlashSystem).
 func NewFlashSystemClonner(managementIP, username, password string, sslSkipVerify bool) (FlashSystemClonner, error) {
+	log := logutil.NewLogger("flashsystem")
 	client, err := NewFlashSystemAPIClient(managementIP, username, password, sslSkipVerify)
 	if err != nil {
 		return FlashSystemClonner{}, fmt.Errorf("failed to create FlashSystem API client: %w", err)
@@ -414,11 +418,10 @@ func NewFlashSystemClonner(managementIP, username, password string, sslSkipVerif
 	}
 
 	protectionEnabled := sysInfo.VdiskProtectionEnabled == "yes"
-	klog.Infof("FlashSystem volume protection settings: enabled=%v, protection_time=%s minutes",
-		protectionEnabled, sysInfo.VdiskProtectionTime)
+	log.Info("FlashSystem volume protection settings", "enabled", protectionEnabled, "protection_time_minutes", sysInfo.VdiskProtectionTime)
 
 	if protectionEnabled {
-		klog.Error("vdisk protection must be off on the IBM FlashSystem; read about it in the README in the section 'IBM FlashSystem'")
+		log.Error(nil, "vdisk protection must be off on the IBM FlashSystem; read about it in the README in the section 'IBM FlashSystem'")
 		return FlashSystemClonner{}, fmt.Errorf("vdisk protection is enabled on the IBM FlashSystem; it must be disabled")
 	}
 
@@ -430,6 +433,7 @@ func NewFlashSystemClonner(managementIP, username, password string, sslSkipVerif
 			Model:   sysInfo.ProductName,
 			Version: sysInfo.CodeLevel,
 		},
+		log: log,
 	}
 
 	return clonner, nil
@@ -445,8 +449,9 @@ func (c *FlashSystemClonner) UnmapTarget(targetLUN populator.LUN, context popula
 
 // EnsureSingleHost creates or finds a single host with the given identifiers.
 func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentifiers []string) (populator.MappingContext, error) {
+	c.log.Info("ensuring initiator group", "group", hostName, "adapters", clonnerIdentifiers)
+
 	c.initiatorGroup = hostName
-	klog.Infof("Ensuring single host '%s' exists with identifiers: %v", hostName, clonnerIdentifiers)
 	ctx := make(populator.MappingContext)
 
 	if len(clonnerIdentifiers) == 0 {
@@ -460,7 +465,7 @@ func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentif
 	for _, identifier := range clonnerIdentifiers {
 		if strings.HasPrefix(identifier, "fc.") {
 			// It's a FC WWPN - extract and get the first half (non-virtual part)
-			wwpns := extractWWPNsFromFCFormat([]string{identifier})
+			wwpns := extractWWPNsFromFCFormat([]string{identifier}, c.log)
 			fcWWPNs = append(fcWWPNs, wwpns...)
 		} else {
 			// Assume it's an iSCSI IQN
@@ -468,7 +473,7 @@ func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentif
 		}
 	}
 
-	klog.Infof("Categorized identifiers - FC WWPNs: %v, iSCSI IQNs: %v", fcWWPNs, iscsiIQNs)
+	c.log.V(2).Info("categorized identifiers", "fc_wwpns", fcWWPNs, "iscsi_iqns", iscsiIQNs)
 
 	// Step 2: Check for existing hosts with any of these identifiers
 	var existingHostName string
@@ -478,10 +483,10 @@ func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentif
 	if len(fcWWPNs) > 0 {
 		existingFCHosts, err := c.findAllHostsByWWPNs(fcWWPNs)
 		if err != nil {
-			klog.Warningf("Error searching for existing FC hosts: %v", err)
+			c.log.Error(nil, "error searching for existing FC hosts", "err", err)
 		} else if len(existingFCHosts) > 0 {
 			existingHostName = existingFCHosts[0]
-			klog.Infof("Found existing host '%s' with FC WWPNs %v", existingHostName, fcWWPNs)
+			c.log.V(2).Info("found existing host with FC WWPNs", "host", existingHostName, "wwpns", fcWWPNs)
 		}
 	}
 
@@ -489,10 +494,10 @@ func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentif
 	if existingHostName == "" && len(iscsiIQNs) > 0 {
 		existingISCSIHosts, err := c.findAllHostsByIQNs(iscsiIQNs)
 		if err != nil {
-			klog.Warningf("Error searching for existing iSCSI hosts: %v", err)
+			c.log.Error(nil, "error searching for existing iSCSI hosts", "err", err)
 		} else if len(existingISCSIHosts) > 0 {
 			existingHostName = existingISCSIHosts[0]
-			klog.Infof("Found existing host '%s' with iSCSI IQNs %v", existingHostName, iscsiIQNs)
+			c.log.V(2).Info("found existing host with iSCSI IQNs", "host", existingHostName, "iqns", iscsiIQNs)
 		}
 	}
 
@@ -508,7 +513,8 @@ func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentif
 		// Note: created_host is not set (defaults to false) since we're using an existing host
 		ctx[HostNameKey] = hostDetails.Name
 		ctx[HostIdKey] = hostDetails.ID
-		klog.Infof("Using existing host '%s' with ID '%s'", hostDetails.Name, hostDetails.ID)
+		c.log.Info("using existing host", "host", hostDetails.Name, "host_id", hostDetails.ID)
+		c.log.Info("initiator group ready", "group", hostName)
 		return ctx, nil
 	}
 
@@ -517,14 +523,14 @@ func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentif
 	var newHostName string
 	if len(fcWWPNs) > 0 {
 		// Create FC host
-		klog.Infof("Creating new FC host '%s' with WWPNs: %v", hostName, fcWWPNs)
+		c.log.V(2).Info("creating new FC host", "host", hostName, "wwpns", fcWWPNs)
 		newHostName, err = c.createNewHost(hostName, fcWWPNs, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create FC host: %w", err)
 		}
 	} else if len(iscsiIQNs) > 0 {
 		// Create iSCSI host (only if no FC WWPNs exist)
-		klog.Infof("Creating new iSCSI host '%s' with IQNs: %v", hostName, iscsiIQNs)
+		c.log.V(2).Info("creating new iSCSI host", "host", hostName, "iqns", iscsiIQNs)
 		newHostName, err = c.createNewHost(hostName, iscsiIQNs, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create iSCSI host: %w", err)
@@ -544,7 +550,8 @@ func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentif
 	ctx[HostNameKey] = hostDetails.Name
 	ctx[HostIdKey] = hostDetails.ID
 	ctx[HostCreatedKey] = true
-	klog.Infof("Successfully created new host '%s' with ID '%s'", hostDetails.Name, hostDetails.ID)
+	c.log.Info("created new host", "host", hostDetails.Name, "host_id", hostDetails.ID)
+	c.log.Info("initiator group ready", "group", hostName)
 	return ctx, nil
 }
 
@@ -565,12 +572,16 @@ func (c *FlashSystemClonner) createNewHost(hostName string, identifiers []string
 		if err := json.Unmarshal(hostBytes, &existingHosts); err == nil && len(existingHosts) > 0 {
 			// Generate a unique name by appending a suffix
 			hostName = fmt.Sprintf("%s-%d", hostName, time.Now().Unix())
-			klog.Infof("Host name conflict, using alternative name: %s", hostName)
+			c.log.Info("host name conflict, using alternative name", "host", hostName)
 		}
 	}
 
 	// Create new host with unique WWPNs and name
-	klog.Infof("Creating NEW host '%s' with identifiers: %v (FC: %t)", hostName, identifiers, isFibreChannel)
+	protocol := "iSCSI"
+	if isFibreChannel {
+		protocol = "FC"
+	}
+	c.log.Info("creating new host", "host", hostName, "protocol", protocol, "identifier_count", len(identifiers))
 
 	createPayload := map[string]interface{}{
 		"name": hostName,
@@ -583,19 +594,19 @@ func (c *FlashSystemClonner) createNewHost(hostName string, identifiers []string
 		createPayload["force"] = true
 		createPayload["protocol"] = "fcscsi"
 		createPayload["type"] = "generic"
-		klog.Infof("Creating FC host '%s' with WWPNs: %s", hostName, wwpnString)
+		c.log.V(2).Info("creating FC host", "host", hostName, "wwpns", wwpnString)
 	} else {
 		// iSCSI host
 		iqnString := strings.Join(identifiers, ",")
 		createPayload["iscsiname"] = iqnString
 		createPayload["protocol"] = "iscsi"
 		createPayload["type"] = "generic"
-		klog.Infof("Creating iSCSI host '%s' with IQNs: %s", hostName, iqnString)
+		c.log.V(2).Info("creating iSCSI host", "host", hostName, "iqns", iqnString)
 	}
 
 	// Log the exact payload for debugging
 	if payloadJSON, err := json.MarshalIndent(createPayload, "", "  "); err == nil {
-		klog.Infof("FlashSystem mkhost API request payload: %s", string(payloadJSON))
+		c.log.V(2).Info("FlashSystem mkhost API request payload", "payload", string(payloadJSON))
 	}
 
 	// Make the mkhost API call
@@ -608,7 +619,7 @@ func (c *FlashSystemClonner) createNewHost(hostName string, identifiers []string
 		return "", fmt.Errorf("failed to create host: status %d, body: %s", respStatus, string(respBytes))
 	}
 
-	klog.Infof("Successfully created host '%s'", hostName)
+	c.log.Info("host created successfully", "host", hostName)
 	return hostName, nil
 }
 
@@ -617,14 +628,14 @@ func (c *FlashSystemClonner) Map(initiatorGroup string, targetLUN populator.LUN,
 	mapping := extractFromContext(context)
 
 	if !mapping.IsSet {
-		klog.Infof("No mapping context provided, skipping map operation for LUN '%s' to '%s' (assuming already correctly mapped)", targetLUN.Name, initiatorGroup)
+		c.log.V(2).Info("no mapping context provided, skipping map operation", "volume", targetLUN.Name, "group", initiatorGroup)
 		return targetLUN, nil
 	}
 
 	hostID := mapping.HostId
 
 	vdiskID := targetLUN.Name // The LUN.Name field should hold the VDisk ID for this provider.
-	klog.Infof("Mapping LUN (VDisk ID '%s') to Host '%s' (Host ID '%s')", vdiskID, mapping.HostName, hostID)
+	c.log.Info("mapping volume to host", "vdisk_id", vdiskID, "host", mapping.HostName, "host_id", hostID)
 
 	// Create the mapping using mkvdiskhostmap API endpoint
 	mapPayload := map[string]interface{}{
@@ -636,12 +647,12 @@ func (c *FlashSystemClonner) Map(initiatorGroup string, targetLUN populator.LUN,
 
 	// Handle the specific case where mapping already exists to same host
 	if mapErr != nil && mapStatus == http.StatusConflict && strings.Contains(mapErr.Error(), "CMMVC5878E") {
-		klog.Infof("VDisk '%s' is already mapped to Host '%s', continuing...", vdiskID, hostID)
+		c.log.V(2).Info("volume already mapped to host", "vdisk_id", vdiskID, "host_id", hostID)
 	} else if mapErr != nil && mapStatus == http.StatusConflict && strings.Contains(mapErr.Error(), "CMMVC9375E") {
 		// Volume is already mapped to a different host (CMMVC9375E)
 		// Use lshostvdiskmap to find the next available SCSI ID for the target host
 		// Then map with explicit SCSI ID, which allows multi-host mapping
-		klog.Warningf("VDisk '%s' is already mapped to another host. Finding next available SCSI ID for multi-host mapping.", vdiskID)
+		c.log.Info("volume already mapped to another host, finding next available SCSI ID for multi-host mapping", "vdisk_id", vdiskID)
 
 		// Query lshostvdiskmap for the target host to get all current SCSI IDs
 		hostMapEndpoint := fmt.Sprintf("/lshostvdiskmap/%s", hostID)
@@ -670,7 +681,7 @@ func (c *FlashSystemClonner) Map(initiatorGroup string, targetLUN populator.LUN,
 
 		// Use the next available SCSI ID
 		nextSCSIID := maxSCSIID + 1
-		klog.Infof("Found max SCSI ID %d on host '%s', using next available: %d", maxSCSIID, initiatorGroup, nextSCSIID)
+		c.log.V(2).Info("found next available SCSI ID", "max_scsi_id", maxSCSIID, "next_scsi_id", nextSCSIID, "host", initiatorGroup)
 
 		// Retry mapping with explicit SCSI ID for multi-host assignment
 		// Note: REST API may allow multi-host mapping when explicit SCSI ID is provided
@@ -685,14 +696,14 @@ func (c *FlashSystemClonner) Map(initiatorGroup string, targetLUN populator.LUN,
 		} else if mapStatus != http.StatusOK && mapStatus != http.StatusCreated {
 			return populator.LUN{}, fmt.Errorf("failed to map VDisk '%s' to Host '%s' with SCSI ID %d, status: %d, body: %s", vdiskID, hostID, nextSCSIID, mapStatus, string(mapBody))
 		}
-		klog.Infof("Successfully mapped VDisk '%s' to Host '%s' with SCSI ID %d for multi-host access", vdiskID, hostID, nextSCSIID)
+		c.log.Info("volume mapped successfully with SCSI ID for multi-host access", "vdisk_id", vdiskID, "host_id", hostID, "scsi_id", nextSCSIID)
 	} else if mapErr != nil {
 		return populator.LUN{}, fmt.Errorf("failed to create host mapping: %w", mapErr)
 	} else if mapStatus != http.StatusOK && mapStatus != http.StatusCreated {
 		return populator.LUN{}, fmt.Errorf("failed to map VDisk '%s' to Host '%s', status: %d, body: %s", vdiskID, hostID, mapStatus, string(mapBody))
 	}
 
-	klog.Infof("Successfully created mapping of VDisk '%s' to Host '%s'.", vdiskID, hostID)
+	c.log.Info("volume mapped successfully", "vdisk_id", vdiskID, "host_id", hostID)
 
 	return targetLUN, nil
 }
@@ -729,14 +740,14 @@ func extractFromContext(context populator.MappingContext) ExtractedMapping {
 func (c *FlashSystemClonner) UnMap(initiatorGroup string, targetLUN populator.LUN, context populator.MappingContext) error {
 	mapping := extractFromContext(context)
 	if !mapping.IsSet {
-		klog.Infof("mapping context is empty, skipping unmap")
+		c.log.V(2).Info("mapping context is empty, skipping unmap")
 		return nil
 	}
 
 	hostID := mapping.HostId
 
 	vdiskID := targetLUN.Name // VDisk ID from the LUN object.
-	klog.Infof("Unmapping LUN (VDisk ID '%s') from Host '%s' (Host ID '%s')", vdiskID, mapping.HostName, hostID)
+	c.log.Info("unmapping volume from host", "vdisk_id", vdiskID, "host", mapping.HostName, "host_id", hostID)
 
 	// Use v1 API endpoint for removing host mapping
 	payload := map[string]string{
@@ -753,13 +764,13 @@ func (c *FlashSystemClonner) UnMap(initiatorGroup string, targetLUN populator.LU
 	if unmapStatus != http.StatusOK && unmapStatus != http.StatusNoContent {
 		// It's possible the API returns 404 if mapping doesn't exist, which is idempotent.
 		if unmapStatus == http.StatusNotFound {
-			klog.Infof("Mapping for VDisk '%s' to Host '%s' did not exist.", vdiskID, hostID)
+			c.log.V(2).Info("mapping did not exist", "vdisk_id", vdiskID, "host_id", hostID)
 			return nil
 		}
 		return fmt.Errorf("failed to unmap VDisk '%s' from Host '%s', status: %d, body: %s", vdiskID, hostID, unmapStatus, string(unmapBody))
 	}
 
-	klog.Infof("Successfully unmapped LUN (VDisk ID '%s') from Host '%s'", vdiskID, hostID)
+	c.log.Info("volume unmapped successfully", "vdisk_id", vdiskID, "host_id", hostID)
 
 	// Clean up the host if we created it and if it has no more mappings
 	if mapping.HostCreated {
@@ -770,7 +781,7 @@ func (c *FlashSystemClonner) UnMap(initiatorGroup string, targetLUN populator.LU
 	for key := range context {
 		delete(context, key)
 	}
-	klog.Infof("Cleared mapping context after successful unmap")
+	c.log.V(2).Info("cleared mapping context after successful unmap")
 
 	return nil
 }
@@ -784,20 +795,20 @@ func (c *FlashSystemClonner) cleanupEmptyHost(hostID string) {
 
 	mappingsBytes, status, err := c.api.makeRequest("POST", "/lshostvdiskmap", filterPayload)
 	if err != nil {
-		klog.Warningf("Failed to check host mappings before cleanup: %v", err)
+		c.log.Error(nil, "failed to check host mappings before cleanup", "host_id", hostID, "err", err)
 		return
 	}
 
 	if status == http.StatusOK {
 		var mappings []FlashSystemVolumeHostMapping
 		if err := json.Unmarshal(mappingsBytes, &mappings); err == nil && len(mappings) > 0 {
-			klog.Infof("Host id '%s' still has %d mappings, not cleaning up", hostID, len(mappings))
+			c.log.V(2).Info("host still has mappings, not cleaning up", "host_id", hostID, "mapping_count", len(mappings))
 			return
 		}
 	}
 
 	// Host has no mappings, safe to remove it
-	klog.Infof("Cleaning up empty host ID: %s)", hostID)
+	c.log.V(2).Info("cleaning up empty host", "host_id", hostID)
 
 	rmPayload := map[string]string{
 		"host": hostID,
@@ -805,22 +816,22 @@ func (c *FlashSystemClonner) cleanupEmptyHost(hostID string) {
 
 	rmBody, rmStatus, rmErr := c.api.makeRequest("POST", "/rmhost", rmPayload)
 	if rmErr != nil {
-		klog.Warningf("Failed to cleanup host: %v", rmErr)
+		c.log.Error(nil, "failed to cleanup host", "host_id", hostID, "err", rmErr)
 		return
 	}
 
 	if rmStatus != http.StatusOK && rmStatus != http.StatusNoContent {
-		klog.Warningf("Failed to cleanup host id '%s', status: %d, body: %s", hostID, rmStatus, string(rmBody))
+		c.log.Error(nil, "failed to cleanup host", "host_id", hostID, "status", rmStatus, "body", string(rmBody))
 		return
 	}
 
-	klog.Infof("Successfully cleaned up empty host id '%s'", hostID)
+	c.log.V(2).Info("host cleaned up successfully", "host_id", hostID)
 }
 
 // CurrentMappedGroups returns the host names a VDisk is mapped to.
 func (c *FlashSystemClonner) CurrentMappedGroups(targetLUN populator.LUN, context populator.MappingContext) ([]string, error) {
 	vdiskID := targetLUN.Name // VDisk ID is stored in the Name field.
-	klog.Infof("Getting current mapped groups for LUN (VDisk ID '%s')", vdiskID)
+	c.log.V(2).Info("querying current mapped groups", "vdisk_id", vdiskID)
 
 	groupSet := make(map[string]bool)
 	uniqueGroups := []string{}
@@ -845,11 +856,11 @@ func (c *FlashSystemClonner) CurrentMappedGroups(targetLUN populator.LUN, contex
 		if !groupSet[m.HostName] {
 			groupSet[m.HostName] = true
 			uniqueGroups = append(uniqueGroups, m.HostName)
-			klog.Infof("Found host mapping: %s", m.HostName)
+			c.log.V(2).Info("found host mapping", "host", m.HostName)
 		}
 	}
 
-	klog.Infof("LUN (VDisk ID '%s') is mapped to host groups: %v", vdiskID, uniqueGroups)
+	c.log.V(2).Info("found mapped groups", "vdisk_id", vdiskID, "hosts", uniqueGroups)
 	return uniqueGroups, nil
 }
 
@@ -871,14 +882,13 @@ func (c *FlashSystemClonner) createLUNFromVDisk(vdiskDetails FlashSystemVolume, 
 		NAA:          naaDeviceID,
 	}
 
-	klog.Infof("Resolved volume handle '%s' to LUN: Name(ID)=%s, SN(UID)=%s, NAA=%s, VDisk Name=%s",
-		volumeHandle, lun.Name, lun.SerialNumber, lun.NAA, vdiskDetails.Name)
+	c.log.Info("LUN resolved", "lun", lun.Name, "naa", lun.NAA, "serial", lun.SerialNumber, "vdisk", vdiskDetails.Name)
 	return lun, nil
 }
 
 // ResolvePVToLUN resolves a PersistentVolume to a LUN by finding a volume with matching vdisk_UID.
 func (c *FlashSystemClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {
-	klog.Infof("Resolving PersistentVolume '%s' to LUN details", pv.Name)
+	c.log.Info("resolving PV to LUN", "pv", pv.Name, "volume_handle", pv.VolumeHandle)
 
 	// Parse PV VolumeHandle to extract the vdisk_UID
 	// Expected format: 'SVC:5;600507681088804CB800000000001074'
@@ -893,7 +903,7 @@ func (c *FlashSystemClonner) ResolvePVToLUN(pv populator.PersistentVolume) (popu
 		"filtervalue": fmt.Sprintf("vdisk_UID=%s", pvUID),
 	}
 
-	klog.Infof("Querying vdisk with vdisk_UID filter: %s", pvUID)
+	c.log.V(2).Info("querying vdisk by UID", "uid", pvUID)
 	vdisksBytes, vdisksStatus, vdisksErr := c.api.makeRequest("POST", "/lsvdisk", filterPayload)
 	if vdisksErr != nil {
 		return populator.LUN{}, fmt.Errorf("failed to get vdisk with UID %s: %w", pvUID, vdisksErr)
@@ -916,7 +926,7 @@ func (c *FlashSystemClonner) ResolvePVToLUN(pv populator.PersistentVolume) (popu
 	}
 
 	vdisk := vdisks[0]
-	klog.Infof("Found matching volume: '%s' (ID: %s) for PV '%s'", vdisk.Name, vdisk.ID, pv.Name)
+	c.log.V(2).Info("found matching volume", "vdisk", vdisk.Name, "vdisk_id", vdisk.ID, "pv", pv.Name)
 	return c.createLUNFromVDisk(vdisk, pv.VolumeHandle)
 }
 
@@ -947,11 +957,9 @@ func (c *FlashSystemClonner) getVDiskByUID(uid string) (*FlashSystemVolume, erro
 
 // RDMCopy performs a copy from an RDM-backed disk to the target PVC volume using FlashCopy.
 func (c *FlashSystemClonner) RDMCopy(vsphereClient vmware.Client, vmId string, sourceVMDKFile string, persistentVolume populator.PersistentVolume, progress chan<- uint64) error {
-	log := klog.Background().WithName("copy-offload").WithName("rdm")
-	ctx := klog.NewContext(context.Background(), log)
-	log.Info("RDM copy started", "vm", vmId)
+	c.log.Info("RDM copy started", "vm", vmId)
 
-	backing, err := vsphereClient.GetVMDiskBacking(ctx, vmId, sourceVMDKFile)
+	backing, err := vsphereClient.GetVMDiskBacking(context.Background(), vmId, sourceVMDKFile)
 	if err != nil {
 		return fmt.Errorf("failed to get RDM disk backing: %w", err)
 	}
@@ -962,25 +970,25 @@ func (c *FlashSystemClonner) RDMCopy(vsphereClient vmware.Client, vmId string, s
 	if backing.LunUuid == "" {
 		return fmt.Errorf("RDM backing has no LunUuid; cannot resolve volume (need vSphere LunUuid for lsvdisk vdisk_UID)")
 	}
-	log.Info("resolving source by LunUuid", "lun_uuid", backing.LunUuid)
-	resolveCtx := klog.NewContext(ctx, log.WithName("resolve"))
-	sourceLUN, err := c.resolveRDMToLUN(resolveCtx, backing.LunUuid)
+	c.log.Info("found RDM device", "lun_uuid", backing.LunUuid)
+
+	sourceLUN, err := c.resolveRDMToLUN(backing.LunUuid)
 	if err != nil {
 		return fmt.Errorf("failed to resolve RDM LunUuid to source LUN: %w", err)
 	}
 
+	c.log.Info("resolving target PV to LUN", "pv", persistentVolume.Name)
 	targetLUN, err := c.ResolvePVToLUN(persistentVolume)
 	if err != nil {
 		return fmt.Errorf("failed to resolve target volume: %w", err)
 	}
 
-	log.Info("copying via FlashCopy", "source", sourceLUN.Name, "target", targetLUN.Name)
+	c.log.Info("copying volume", "source", sourceLUN.Name, "target", targetLUN.Name)
 	progress <- 10
-	flashcopyCtx := klog.NewContext(ctx, log.WithName("flashcopy"))
-	if err := c.performFlashCopy(flashcopyCtx, sourceLUN, targetLUN, progress); err != nil {
+	if err := c.performFlashCopy(sourceLUN, targetLUN, progress); err != nil {
 		return err
 	}
-	log.Info("RDM copy completed successfully")
+	c.log.Info("RDM copy completed successfully")
 	return nil
 }
 
@@ -998,18 +1006,17 @@ func rdmLunUuidToVdiskUID(lunUuid string) (string, error) {
 }
 
 // resolveRDMToLUN resolves the vSphere RDM LunUuid to an IBM FlashSystem LUN.
-func (c *FlashSystemClonner) resolveRDMToLUN(ctx context.Context, lunUuid string) (populator.LUN, error) {
-	log := klog.FromContext(ctx)
+func (c *FlashSystemClonner) resolveRDMToLUN(lunUuid string) (populator.LUN, error) {
 	vdiskUID, err := rdmLunUuidToVdiskUID(lunUuid)
 	if err != nil {
 		return populator.LUN{}, err
 	}
-	log.V(2).Info("lunUuid to vdisk_UID", "lun_uuid", lunUuid, "vdisk_uid", vdiskUID)
+	c.log.V(2).Info("lunUuid to vdisk_UID", "lun_uuid", lunUuid, "vdisk_uid", vdiskUID)
 	vdisk, err := c.getVDiskByUID(vdiskUID)
 	if err != nil {
 		return populator.LUN{}, fmt.Errorf("could not find volume for LunUuid (vdisk_UID %s): %w", vdiskUID, err)
 	}
-	log.Info("resolved LunUuid to volume", "vdisk_uid", vdiskUID, "volume", vdisk.Name)
+	c.log.V(2).Info("resolved LunUuid to volume", "vdisk_uid", vdiskUID, "volume", vdisk.Name)
 	return c.createLUNFromVDisk(*vdisk, "naa."+strings.ToLower(vdisk.VdiskUID))
 }
 
@@ -1023,8 +1030,7 @@ func firstN(s string, n int) string {
 // performFlashCopy creates a FlashCopy mapping with autodelete and starts it.
 // The target is immediately usable (redirect-on-read); the array will remove the mapping when copy reaches 100%.
 // Mapping name format: mp_<first10_source>_<first10_target>_<uuid> to avoid collisions and stay within IBM's 63-char limit.
-func (c *FlashSystemClonner) performFlashCopy(ctx context.Context, sourceLUN, targetLUN populator.LUN, progress chan<- uint64) error {
-	log := klog.FromContext(ctx)
+func (c *FlashSystemClonner) performFlashCopy(sourceLUN, targetLUN populator.LUN, progress chan<- uint64) error {
 	sourceRef := sourceLUN.VolumeHandle
 	if sourceRef == "" {
 		sourceRef = sourceLUN.Name
@@ -1037,7 +1043,7 @@ func (c *FlashSystemClonner) performFlashCopy(ctx context.Context, sourceLUN, ta
 	tgtPart := firstN(targetRef, flashCopyMappingNamePrefixLen)
 	mappingName := fmt.Sprintf("mp_%s_%s_%s", srcPart, tgtPart, uuid.New().String())
 
-	log.Info("creating FlashCopy mapping", "source", sourceRef, "target", targetRef)
+	c.log.Info("creating FlashCopy mapping", "source", sourceRef, "target", targetRef)
 	mappingID, statusCode, err := c.api.CreateFlashCopyMapping(sourceRef, targetRef, mappingName, defaultFlashCopyRate)
 	if err == nil {
 		if err := c.api.PrestartFlashCopyMapping(mappingID); err != nil {
@@ -1058,14 +1064,14 @@ func (c *FlashSystemClonner) performFlashCopy(ctx context.Context, sourceLUN, ta
 		if existingID == "" {
 			return fmt.Errorf("FlashCopy mapping conflict (target may be in use) and no matching mapping found: %w", err)
 		}
-		log.Info("using existing FlashCopy mapping", "mapping_id", existingID, "source", sourceRef, "target", targetRef)
+		c.log.Info("using existing FlashCopy mapping", "mapping_id", existingID, "source", sourceRef, "target", targetRef)
 		if prestartErr := c.api.PrestartFlashCopyMapping(existingID); prestartErr != nil {
-			log.Info("PrestartFlashCopyMapping for existing mapping failed (may already be prepared)", "err", prestartErr)
+			c.log.Info("PrestartFlashCopyMapping for existing mapping failed (may already be prepared)", "err", prestartErr)
 		}
 		if startErr := c.api.StartFlashCopyMapping(existingID); startErr != nil {
 			// Mapping may already be in copying state (e.g. from first run still running). Treat as success.
 			if isFlashCopyAlreadyCopying(startErr) {
-				log.Info("FlashCopy mapping already in copying state; considering copy in progress", "mapping_id", existingID)
+				c.log.Info("FlashCopy mapping already in copying state; considering copy in progress", "mapping_id", existingID)
 			} else {
 				return fmt.Errorf("StartFlashCopyMapping failed for existing mapping: %w", startErr)
 			}
@@ -1087,7 +1093,7 @@ func isFlashCopyAlreadyCopying(err error) bool {
 
 // getHostPorts gets host ports directly from the API
 func (c *FlashSystemClonner) getHostPorts() ([]HostPort, error) {
-	klog.Infof("Fetching host ports using lshostports")
+	c.log.V(2).Info("fetching host ports using lshostports")
 	hostPortBytes, status, err := c.api.makeRequest("POST", "/lshostports", map[string]string{})
 	if err != nil || status != http.StatusOK {
 		return nil, fmt.Errorf("failed to list host ports: %w, status: %d", err, status)
@@ -1099,7 +1105,7 @@ func (c *FlashSystemClonner) getHostPorts() ([]HostPort, error) {
 		return nil, fmt.Errorf("failed to unmarshal host ports: %w", err)
 	}
 
-	klog.Infof("Retrieved %d host ports from lshostports", len(hostPorts))
+	c.log.V(2).Info("retrieved host ports", "count", len(hostPorts))
 	return hostPorts, nil
 }
 
@@ -1109,7 +1115,7 @@ func (c *FlashSystemClonner) findAllHostsByIdentifiers(identifiers []string, ide
 		return nil, nil
 	}
 
-	klog.Infof("Searching for hosts with %s using host port discovery: %v", identifierType, identifiers)
+	c.log.V(2).Info("searching for hosts using host port discovery", "identifier_type", identifierType, "identifiers", identifiers)
 
 	// Get host ports
 	hostPorts, err := c.getHostPorts()
@@ -1125,7 +1131,7 @@ func (c *FlashSystemClonner) findAllHostsByIdentifiers(identifiers []string, ide
 	for _, identifier := range identifiers {
 		normalized := strings.ToLower(identifier)
 		normalizedIdentifiers[normalized] = identifier
-		klog.V(4).Infof("Normalized %s: %s -> %s", identifierType, identifier, normalized)
+		c.log.V(4).Info("normalized identifier", "type", identifierType, "original", identifier, "normalized", normalized)
 	}
 
 	// Search through host ports for matching identifiers
@@ -1136,12 +1142,12 @@ func (c *FlashSystemClonner) findAllHostsByIdentifiers(identifiers []string, ide
 		for _, fieldValue := range fieldsToCheck {
 			if fieldValue != "" {
 				normalizedFieldValue := strings.ToLower(fieldValue)
-				klog.V(4).Infof("Checking field value: %s (normalized: %s) for host: %s", fieldValue, normalizedFieldValue, port.HostName)
+				c.log.V(4).Info("checking field value", "value", fieldValue, "normalized", normalizedFieldValue, "host", port.HostName)
 
 				// Check if normalized value matches any of our target identifiers
 				if originalIdentifier, exists := normalizedIdentifiers[normalizedFieldValue]; exists {
 					if !foundHosts[port.HostName] {
-						klog.Infof("Found host '%s' for %s %s (port field value: %s) via host port", port.HostName, identifierType, originalIdentifier, fieldValue)
+						c.log.Info("found host via host port", "host", port.HostName, "identifier_type", identifierType, "identifier", originalIdentifier, "port_value", fieldValue)
 						foundHosts[port.HostName] = true
 						hostNames = append(hostNames, port.HostName)
 					}
@@ -1150,7 +1156,7 @@ func (c *FlashSystemClonner) findAllHostsByIdentifiers(identifiers []string, ide
 		}
 	}
 
-	klog.Infof("Found %d existing hosts via host port discovery: %v", len(hostNames), hostNames)
+	c.log.V(2).Info("host port discovery complete", "hosts_found", len(hostNames), "hosts", hostNames)
 	return hostNames, nil
 }
 

--- a/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
+++ b/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	"k8s.io/klog/v2"
@@ -117,7 +117,7 @@ func NewFlashSystemAPIClient(managementIP, username, password string, sslSkipVer
 		httpClient:   httpClient,
 		username:     username,
 		password:     password,
-		log:          logutil.NewLogger("flashsystem"),
+		log:          logger.New("flashsystem"),
 	}
 
 	// Initial authentication
@@ -406,7 +406,7 @@ func (c *FlashSystemClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
 // It checks that vdisk protection is disabled on the FlashSystem; if protection is enabled,
 // it returns an error because it must be off for Virtual Machines (see README, section IBM FlashSystem).
 func NewFlashSystemClonner(managementIP, username, password string, sslSkipVerify bool) (FlashSystemClonner, error) {
-	log := logutil.NewLogger("flashsystem")
+	log := logger.New("flashsystem")
 	client, err := NewFlashSystemAPIClient(managementIP, username, password, sslSkipVerify)
 	if err != nil {
 		return FlashSystemClonner{}, fmt.Errorf("failed to create FlashSystem API client: %w", err)
@@ -483,7 +483,7 @@ func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentif
 	if len(fcWWPNs) > 0 {
 		existingFCHosts, err := c.findAllHostsByWWPNs(fcWWPNs)
 		if err != nil {
-			c.log.Error(nil, "error searching for existing FC hosts", "err", err)
+			c.log.Error(err, "error searching for existing FC hosts")
 		} else if len(existingFCHosts) > 0 {
 			existingHostName = existingFCHosts[0]
 			c.log.V(2).Info("found existing host with FC WWPNs", "host", existingHostName, "wwpns", fcWWPNs)
@@ -494,7 +494,7 @@ func (c *FlashSystemClonner) EnsureClonnerIgroup(hostName string, clonnerIdentif
 	if existingHostName == "" && len(iscsiIQNs) > 0 {
 		existingISCSIHosts, err := c.findAllHostsByIQNs(iscsiIQNs)
 		if err != nil {
-			c.log.Error(nil, "error searching for existing iSCSI hosts", "err", err)
+			c.log.Error(err, "error searching for existing iSCSI hosts")
 		} else if len(existingISCSIHosts) > 0 {
 			existingHostName = existingISCSIHosts[0]
 			c.log.V(2).Info("found existing host with iSCSI IQNs", "host", existingHostName, "iqns", iscsiIQNs)
@@ -577,31 +577,23 @@ func (c *FlashSystemClonner) createNewHost(hostName string, identifiers []string
 	}
 
 	// Create new host with unique WWPNs and name
-	protocol := "iSCSI"
-	if isFibreChannel {
-		protocol = "FC"
-	}
-	c.log.Info("creating new host", "host", hostName, "protocol", protocol, "identifier_count", len(identifiers))
+	c.log.Info("creating new host", "host", hostName, "identifiers", identifiers)
 
 	createPayload := map[string]interface{}{
 		"name": hostName,
 	}
 
 	if isFibreChannel {
-		// Fibre Channel host
 		wwpnString := strings.Join(identifiers, ":")
 		createPayload["fcwwpn"] = wwpnString
 		createPayload["force"] = true
 		createPayload["protocol"] = "fcscsi"
 		createPayload["type"] = "generic"
-		c.log.V(2).Info("creating FC host", "host", hostName, "wwpns", wwpnString)
 	} else {
-		// iSCSI host
 		iqnString := strings.Join(identifiers, ",")
 		createPayload["iscsiname"] = iqnString
 		createPayload["protocol"] = "iscsi"
 		createPayload["type"] = "generic"
-		c.log.V(2).Info("creating iSCSI host", "host", hostName, "iqns", iqnString)
 	}
 
 	// Log the exact payload for debugging
@@ -795,7 +787,7 @@ func (c *FlashSystemClonner) cleanupEmptyHost(hostID string) {
 
 	mappingsBytes, status, err := c.api.makeRequest("POST", "/lshostvdiskmap", filterPayload)
 	if err != nil {
-		c.log.Error(nil, "failed to check host mappings before cleanup", "host_id", hostID, "err", err)
+		c.log.Error(err, "failed to check host mappings before cleanup", "host_id", hostID)
 		return
 	}
 
@@ -816,7 +808,7 @@ func (c *FlashSystemClonner) cleanupEmptyHost(hostID string) {
 
 	rmBody, rmStatus, rmErr := c.api.makeRequest("POST", "/rmhost", rmPayload)
 	if rmErr != nil {
-		c.log.Error(nil, "failed to cleanup host", "host_id", hostID, "err", rmErr)
+		c.log.Error(rmErr, "failed to cleanup host", "host_id", hostID)
 		return
 	}
 

--- a/cmd/vsphere-copy-offload-populator/internal/infinibox/infinibox.go
+++ b/cmd/vsphere-copy-offload-populator/internal/infinibox/infinibox.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/infinidat/infinibox-csi-driver/iboxapi"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"k8s.io/klog/v2"
 )
@@ -165,7 +165,7 @@ func createMappingContext(host *iboxapi.Host, initiatorGroup string) populator.M
 }
 
 func NewInfiniboxClonner(hostname, username, password string, insecure bool) (InfiniboxClonner, error) {
-	log := logutil.NewLogger("infinibox")
+	log := logger.New("infinibox")
 	log.V(2).Info("creating InfiniBox client", "hostname", hostname)
 
 	// Create credentials

--- a/cmd/vsphere-copy-offload-populator/internal/infinibox/infinibox.go
+++ b/cmd/vsphere-copy-offload-populator/internal/infinibox/infinibox.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/infinidat/infinibox-csi-driver/iboxapi"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"k8s.io/klog/v2"
 )
@@ -23,6 +24,7 @@ type InfiniboxClonner struct {
 	api            iboxapi.Client
 	initiatorGroup string
 	arrayInfo      populator.StorageArrayInfo
+	log            klog.Logger
 }
 
 // Ensure InfiniboxClonner implements StorageArrayInfoProvider
@@ -52,7 +54,7 @@ func (c *InfiniboxClonner) Map(initiatorGroup string, targetLUN populator.LUN, m
 	} else {
 		hostName = mappingContext[esxRealHostNameKey].(string)
 	}
-	klog.Infof("mapping volume %s to initiator-group %s", targetLUN.Name, hostName)
+	c.log.Info("mapping volume to group", "volume", targetLUN.Name, "group", hostName)
 
 	host, err := c.api.GetHostByName(hostName)
 	if err != nil {
@@ -60,23 +62,27 @@ func (c *InfiniboxClonner) Map(initiatorGroup string, targetLUN populator.LUN, m
 	}
 
 	volumeID, err := strconv.Atoi(targetLUN.LDeviceID)
+	if err != nil {
+		return targetLUN, fmt.Errorf("invalid volume ID %q, expected integer: %w", targetLUN.LDeviceID, err)
+	}
 	// Idempotency: check if already mapped
 	existingMappings, err := c.api.GetLunsByVolume(volumeID)
 	if err == nil {
 		for _, mapping := range existingMappings {
 			if mapping.HostID == host.ID {
-				klog.Infof("Volume %s already mapped to initiator group %s", targetLUN.Name, hostName)
+				c.log.V(2).Info("volume already mapped to group", "volume", targetLUN.Name, "group", hostName)
 				return targetLUN, nil
 			}
 		}
 	}
 
+	c.log.V(2).Info("mapping volume to host", "volume_id", volumeID, "host_id", host.ID)
 	_, err = c.api.MapVolumeToHost(host.ID, volumeID, 0)
 	if err != nil {
 		return targetLUN, fmt.Errorf("failed to map volume %s to host %s: %w", targetLUN.Name, hostName, err)
 	}
 
-	klog.Infof("Successfully mapped volume %s to initiator group %s", targetLUN.Name, hostName)
+	c.log.Info("volume mapped successfully", "volume", targetLUN.Name, "group", hostName)
 	return targetLUN, nil
 }
 
@@ -91,7 +97,7 @@ func (c *InfiniboxClonner) UnMap(initiatorGroup string, targetLUN populator.LUN,
 	} else {
 		hostName = mappingContext[esxRealHostNameKey].(string)
 	}
-	klog.Infof("unmapping volume %s from initiator-group %s", targetLUN.Name, hostName)
+	c.log.Info("unmapping volume from group", "volume", targetLUN.Name, "group", hostName)
 
 	host, err := c.api.GetHostByName(hostName)
 	if err != nil {
@@ -103,16 +109,19 @@ func (c *InfiniboxClonner) UnMap(initiatorGroup string, targetLUN populator.LUN,
 		return fmt.Errorf("failed to convert volume ID %s to integer: %w", targetLUN.LDeviceID, err)
 	}
 
+	c.log.V(2).Info("unmapping volume from host", "volume_id", volumeID, "host_id", host.ID)
 	_, err = c.api.UnMapVolumeFromHost(host.ID, volumeID)
 	if err != nil {
 		return fmt.Errorf("failed to unmap volume %s from host %s: %w", targetLUN.Name, hostName, err)
 	}
 
-	klog.Infof("Successfully unmapped volume %s from initiator group %s", targetLUN.Name, hostName)
+	c.log.Info("volume unmapped successfully", "volume", targetLUN.Name, "group", hostName)
 	return nil
 }
 
 func (c *InfiniboxClonner) EnsureClonnerIgroup(initiatorGroup string, adapterIds []string) (populator.MappingContext, error) {
+	c.log.Info("ensuring initiator group", "group", initiatorGroup, "adapters", adapterIds)
+
 	c.initiatorGroup = initiatorGroup
 	hosts, err := c.api.GetAllHosts()
 	if err != nil {
@@ -125,16 +134,18 @@ func (c *InfiniboxClonner) EnsureClonnerIgroup(initiatorGroup string, adapterIds
 				if strings.HasPrefix(adapterId, "fc.") {
 					wwpn, err := fcutil.ExtractWWPN(adapterId)
 					if err != nil {
-						klog.Warningf("Failed to extract WWPN from adapter ID %s: %v", adapterId, err)
+						c.log.Info("failed to extract WWPN from adapter ID", "adapter", adapterId, "err", err)
 						continue
 					}
 					if fcutil.CompareWWNs(wwpn, port.Address) {
-						klog.Infof("Found host %s with adapter ID %s (port address: %s)", host.Name, adapterId, port.Address)
+						c.log.Info("found host with matching adapter", "host", host.Name, "adapter", adapterId, "port_address", port.Address)
+						c.log.Info("initiator group ready", "group", initiatorGroup, "host", host.Name)
 						return createMappingContext(&host, initiatorGroup), nil
 					}
 				} else {
 					if port.Address == adapterId {
-						klog.Infof("Found host %s with adapter ID %s (port address: %s)", host.Name, adapterId, port.Address)
+						c.log.Info("found host with matching adapter", "host", host.Name, "adapter", adapterId, "port_address", port.Address)
+						c.log.Info("initiator group ready", "group", initiatorGroup, "host", host.Name)
 						return createMappingContext(&host, initiatorGroup), nil
 					}
 				}
@@ -154,6 +165,9 @@ func createMappingContext(host *iboxapi.Host, initiatorGroup string) populator.M
 }
 
 func NewInfiniboxClonner(hostname, username, password string, insecure bool) (InfiniboxClonner, error) {
+	log := logutil.NewLogger("infinibox")
+	log.V(2).Info("creating InfiniBox client", "hostname", hostname)
+
 	// Create credentials
 	creds := iboxapi.Credentials{
 		Username: username,
@@ -173,27 +187,34 @@ func NewInfiniboxClonner(hostname, username, password string, insecure bool) (In
 			Vendor:  "Infinidat",
 			Product: "InfiniBox",
 		},
+		log: log,
 	}
 
 	// Fetch model and version from the API
 	sysInfo, err := client.GetSystem()
 	if err != nil {
-		klog.Warningf("Failed to get InfiniBox system info for metrics: %v", err)
+		log.Info("failed to get InfiniBox system info for metrics", "err", err)
 	} else {
 		clonner.arrayInfo.Model = sysInfo.Model
 		clonner.arrayInfo.Version = sysInfo.Version
+		log.V(2).Info("InfiniBox array info", "vendor", clonner.arrayInfo.Vendor, "product", clonner.arrayInfo.Product, "model", clonner.arrayInfo.Model, "version", clonner.arrayInfo.Version)
 	}
 
 	return clonner, nil
 }
 
 func (c *InfiniboxClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {
+	c.log.Info("resolving PV to LUN", "pv", pv.Name, "volume_handle", pv.VolumeHandle)
+
 	volumeAttributes := pv.VolumeAttributes
 	volumeName := volumeAttributes["Name"]
+	c.log.V(2).Info("looking up volume by name", "name", volumeName)
+
 	volume, err := c.api.GetVolumeByName(volumeName)
 	if err != nil {
 		return populator.LUN{}, fmt.Errorf("failed to get volume by name %s: %w", volumeName, err)
 	}
+
 	serial := volume.Serial
 	protocol := volumeAttributes["storage_protocol"]
 	protocolPrefix := ""
@@ -205,7 +226,6 @@ func (c *InfiniboxClonner) ResolvePVToLUN(pv populator.PersistentVolume) (popula
 	}
 	IQN := fmt.Sprintf("%s.%s", protocolPrefix, serial)
 	NAA := fmt.Sprintf("naa.6%s", serial)
-	klog.Infof("Successfully resolved volume %s", volumeName)
 
 	lun := populator.LUN{
 		Name:         volumeName,
@@ -215,10 +235,13 @@ func (c *InfiniboxClonner) ResolvePVToLUN(pv populator.PersistentVolume) (popula
 		IQN:          IQN,
 		NAA:          NAA,
 	}
+	c.log.Info("LUN resolved", "lun", lun.Name, "naa", lun.NAA, "serial", lun.SerialNumber, "protocol", protocol)
 	return lun, nil
 }
 
 func (c *InfiniboxClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingContext populator.MappingContext) ([]string, error) {
+	c.log.V(2).Info("querying current mapped groups", "volume", targetLUN.LDeviceID)
+
 	volumeID := targetLUN.LDeviceID
 
 	volumeIDInt, err := strconv.Atoi(volumeID)
@@ -226,16 +249,16 @@ func (c *InfiniboxClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingC
 		return nil, fmt.Errorf("invalid volume ID '%s', expected integer volume ID: %w", volumeID, err)
 	}
 
-	klog.Infof("Checking mappings for volume ID %d (LDeviceID: %s)", volumeIDInt, volumeID)
+	c.log.V(2).Info("checking mappings for volume", "volume_id", volumeIDInt)
 	lunInfos, err := c.api.GetLunsByVolume(volumeIDInt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get LUN mappings for volume %s: %w", volumeID, err)
 	}
 
-	klog.Infof("Found %d LUN mappings for volume %s", len(lunInfos), volumeID)
+	c.log.V(2).Info("found LUN mappings", "volume", volumeID, "mapping_count", len(lunInfos))
 
 	if len(lunInfos) == 0 {
-		klog.Infof("Volume %s is not mapped to any hosts", volumeID)
+		c.log.V(2).Info("volume not mapped to any hosts", "volume", volumeID)
 		return []string{}, nil
 	}
 
@@ -258,33 +281,34 @@ func (c *InfiniboxClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingC
 		}
 
 		if lunInfo.CLustered {
-			klog.Warningf("Volume %s is mapped to host cluster %d (cluster mappings not fully supported)",
-				volumeID, lunInfo.HostClusterID)
+			c.log.Error(nil, "volume mapped to host cluster (cluster mappings not fully supported)", "volume", volumeID, "host_cluster_id", lunInfo.HostClusterID)
 			continue
 		}
 
 		host, exists := hostByID[lunInfo.HostID]
 		if !exists {
-			klog.Warningf("Failed to find host info for host ID %d", lunInfo.HostID)
+			c.log.Info("failed to find host info", "host_id", lunInfo.HostID)
 			continue
 		}
 
 		mappedHosts = append(mappedHosts, host.Name)
 		hostIDsProcessed[lunInfo.HostID] = true
 
-		if _, ok := mappingContext[ocpRealHostNameKey]; !ok {
-			mappingContext[ocpRealHostNameKey] = host.Name
-			klog.Infof("Volume %s is currently mapped to host: %s", volumeID, host.Name)
-			return mappedHosts, nil
+		if mappingContext != nil {
+			if _, ok := mappingContext[ocpRealHostNameKey]; !ok {
+				mappingContext[ocpRealHostNameKey] = host.Name
+				c.log.V(2).Info("volume currently mapped to host", "volume", volumeID, "host", host.Name)
+				return mappedHosts, nil
+			}
 		}
 
-		klog.Infof("Volume %s is mapped to host %s (ID: %d) as LUN %d",
-			volumeID, host.Name, lunInfo.HostID, lunInfo.Lun)
+		c.log.V(2).Info("volume mapped to host", "volume", volumeID, "host", host.Name, "host_id", lunInfo.HostID, "lun", lunInfo.Lun)
 	}
 
 	if len(mappedHosts) == 0 {
 		return nil, fmt.Errorf("volume %s is not mapped to any host", volumeID)
 	}
 
+	c.log.V(2).Info("found mapped groups", "volume", volumeID, "hosts", mappedHosts)
 	return mappedHosts, nil
 }

--- a/cmd/vsphere-copy-offload-populator/internal/logger/logger.go
+++ b/cmd/vsphere-copy-offload-populator/internal/logger/logger.go
@@ -1,9 +1,9 @@
-package logutil
+package logger
 
 import "k8s.io/klog/v2"
 
 const RootName = "copy-offload"
 
-func NewLogger(providerName string) klog.Logger {
+func New(providerName string) klog.Logger {
 	return klog.Background().WithName(RootName).WithName(providerName)
 }

--- a/cmd/vsphere-copy-offload-populator/internal/logutil/logutil.go
+++ b/cmd/vsphere-copy-offload-populator/internal/logutil/logutil.go
@@ -1,0 +1,9 @@
+package logutil
+
+import "k8s.io/klog/v2"
+
+const RootName = "copy-offload"
+
+func NewLogger(providerName string) klog.Logger {
+	return klog.Background().WithName(RootName).WithName(providerName)
+}

--- a/cmd/vsphere-copy-offload-populator/internal/ontap/ontap.go
+++ b/cmd/vsphere-copy-offload-populator/internal/ontap/ontap.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	drivers "github.com/netapp/trident/storage_drivers"
 	"github.com/netapp/trident/storage_drivers/ontap/api"
@@ -23,6 +24,7 @@ type NetappClonner struct {
 	api                  api.OntapAPI
 	initiatorHostOrGroup string
 	arrayInfo            populator.StorageArrayInfo
+	log                  klog.Logger
 }
 
 // GetStorageArrayInfo returns metadata about the ONTAP array for metric labels.
@@ -32,15 +34,27 @@ func (c *NetappClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
 
 // Map the targetLUN to the initiator group.
 func (c *NetappClonner) Map(initatorGroup string, targetLUN populator.LUN, _ populator.MappingContext) (populator.LUN, error) {
+	c.log.Info("mapping volume to group", "volume", targetLUN.Name, "group", initatorGroup)
+
 	_, err := c.api.EnsureLunMapped(context.TODO(), initatorGroup, targetLUN.Name)
 	if err != nil {
 		return populator.LUN{}, fmt.Errorf("Failed to map lun path %s to group %s: %w ", targetLUN.Name, initatorGroup, err)
 	}
+
+	c.log.Info("volume mapped successfully", "volume", targetLUN.Name, "group", initatorGroup)
 	return targetLUN, nil
 }
 
 func (c *NetappClonner) UnMap(initatorGroup string, targetLUN populator.LUN, _ populator.MappingContext) error {
-	return c.api.LunUnmap(context.TODO(), initatorGroup, targetLUN.Name)
+	c.log.Info("unmapping volume from group", "volume", targetLUN.Name, "group", initatorGroup)
+
+	err := c.api.LunUnmap(context.TODO(), initatorGroup, targetLUN.Name)
+	if err != nil {
+		return err
+	}
+
+	c.log.Info("volume unmapped successfully", "volume", targetLUN.Name, "group", initatorGroup)
+	return nil
 }
 
 func (c *NetappClonner) MapTarget(targetLUN populator.LUN, context populator.MappingContext) (populator.LUN, error) {
@@ -52,6 +66,8 @@ func (c *NetappClonner) UnmapTarget(targetLUN populator.LUN, context populator.M
 }
 
 func (c *NetappClonner) EnsureClonnerIgroup(initiatorGroup string, adapterIds []string) (populator.MappingContext, error) {
+	c.log.Info("ensuring initiator group", "group", initiatorGroup, "adapters", adapterIds)
+
 	// Detect protocol from adapters to avoid mixed protocol groups
 	protocol := "mixed"
 	for _, id := range adapterIds {
@@ -67,6 +83,7 @@ func (c *NetappClonner) EnsureClonnerIgroup(initiatorGroup string, adapterIds []
 
 	// Append protocol suffix to avoid mixed protocol igroup errors
 	c.initiatorHostOrGroup = initiatorGroup + "-" + protocol
+	c.log.V(2).Info("detected protocol", "protocol", protocol, "final_group", c.initiatorHostOrGroup)
 
 	// esxs needs "vmware" as the group protocol.
 	err := c.api.IgroupCreate(context.Background(), c.initiatorHostOrGroup, protocol, "vmware")
@@ -83,16 +100,16 @@ func (c *NetappClonner) EnsureClonnerIgroup(initiatorGroup string, adapterIds []
 		if strings.HasPrefix(adapterId, "fc.") {
 			converted, convErr := fcutil.ExtractAndFormatWWPN(adapterId)
 			if convErr != nil {
-				klog.Warningf("Failed to convert FC adapter %s to ONTAP format: %s", adapterId, convErr)
+				c.log.Info("failed to convert FC adapter to ONTAP format", "adapter", adapterId, "err", convErr)
 				continue
 			}
-			klog.Infof("Converted FC adapter %s to ONTAP format: %s", adapterId, converted)
+			c.log.V(2).Info("converted FC adapter to ONTAP format", "adapter", adapterId, "converted", converted)
 			ontapInitiator = converted
 		}
 
 		err = c.api.EnsureIgroupAdded(context.Background(), c.initiatorHostOrGroup, ontapInitiator)
 		if err != nil {
-			klog.Warningf("failed adding host to igroup %s", err)
+			c.log.Info("failed adding initiator to igroup", "initiator", ontapInitiator, "err", err)
 			if strings.Contains(err.Error(), "[409]") {
 				// duplicate initiator in a group
 				atLeastOneAdded = true
@@ -104,10 +121,14 @@ func (c *NetappClonner) EnsureClonnerIgroup(initiatorGroup string, adapterIds []
 	if !atLeastOneAdded {
 		return nil, fmt.Errorf("failed adding any host to igroup")
 	}
+
+	c.log.Info("initiator group ready", "group", c.initiatorHostOrGroup)
 	return nil, nil
 }
 
 func NewNetappClonner(hostname, username, password string) (NetappClonner, error) {
+	log := logutil.NewLogger("ontap")
+
 	// additional ontap values should be passed as env variables using prefix ONTAP_
 	svm := os.Getenv("ONTAP_SVM")
 	config := drivers.OntapStorageDriverConfig{
@@ -121,7 +142,7 @@ func NewNetappClonner(hostname, username, password string) (NetappClonner, error
 
 	client, err := api.NewRestClientFromOntapConfig(context.TODO(), &config)
 	if err != nil {
-		klog.V(2).Infof("ONTAP client initialization error details: %v", err)
+		log.V(2).Info("ONTAP client initialization error details", "err", err)
 		return NetappClonner{}, fmt.Errorf("failed to initialize ONTAP client (common causes: incorrect password, invalid SVM name, network connectivity): %w", err)
 	}
 
@@ -131,14 +152,16 @@ func NewNetappClonner(hostname, username, password string) (NetappClonner, error
 			Vendor:  "NetApp",
 			Product: "ONTAP",
 		},
+		log: log,
 	}
 
 	// Fetch ONTAP API version
 	ontapVersion, err := client.APIVersion(context.TODO())
 	if err != nil {
-		klog.Warningf("Failed to get ONTAP version for metrics: %v", err)
+		log.Info("failed to get ONTAP version for metrics", "err", err)
 	} else {
 		nc.arrayInfo.Version = ontapVersion
+		log.V(2).Info("ONTAP array info", "vendor", nc.arrayInfo.Vendor, "product", nc.arrayInfo.Product, "version", nc.arrayInfo.Version)
 	}
 
 	return nc, nil
@@ -169,17 +192,19 @@ func parseInternalIDToLunPath(internalID string) (string, error) {
 }
 
 func (c *NetappClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {
+	c.log.Info("resolving PV to LUN", "pv", pv.Name, "volume_handle", pv.VolumeHandle)
+
 	var lunPath string
 
 	// Check for ontap-san-economy storage class (has internalID with full path)
 	if internalID, ok := pv.VolumeAttributes["internalID"]; ok {
-		klog.Infof("PV %s has internalID, using economy storage class path resolution", pv.Name)
+		c.log.V(2).Info("using economy storage class path resolution", "pv", pv.Name, "internal_id", internalID)
 		parsedPath, err := parseInternalIDToLunPath(internalID)
 		if err != nil {
 			return populator.LUN{}, fmt.Errorf("failed to parse internalID for PV %s: %w", pv.Name, err)
 		}
 		lunPath = parsedPath
-		klog.Infof("Parsed LUN path from internalID: %s", lunPath)
+		c.log.V(2).Info("parsed LUN path from internalID", "lun_path", lunPath)
 	} else {
 		// Standard ontap-san storage class - uses dedicated FlexVol with lun0
 		internalName, ok := pv.VolumeAttributes["internalName"]
@@ -187,7 +212,7 @@ func (c *NetappClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator
 			return populator.LUN{}, fmt.Errorf("neither internalID nor internalName attribute found on PersistentVolume %s", pv.Name)
 		}
 		lunPath = fmt.Sprintf("/vol/%s/lun0", internalName)
-		klog.Infof("Using standard storage class LUN path: %s", lunPath)
+		c.log.V(2).Info("using standard storage class LUN path", "lun_path", lunPath)
 	}
 
 	l, err := c.api.LunGetByName(context.Background(), lunPath)
@@ -195,11 +220,12 @@ func (c *NetappClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator
 		return populator.LUN{}, fmt.Errorf("failed to get LUN at path %s: %w", lunPath, err)
 	}
 
-	klog.Infof("found lun %s with serial %s", l.Name, l.SerialNumber)
 	// in RHEL lsblk needs that swap. In fedora it doesn't
 	//serialNumber :=  strings.ReplaceAll(l.SerialNumber, "?", "\\\\x3f")
 	naa := fmt.Sprintf("naa.%s%x", OntapProviderID, l.SerialNumber)
 	lun := populator.LUN{Name: l.Name, VolumeHandle: pv.VolumeHandle, SerialNumber: l.SerialNumber, NAA: naa}
+
+	c.log.Info("LUN resolved", "lun", lun.Name, "naa", lun.NAA, "serial", lun.SerialNumber)
 	return lun, nil
 }
 
@@ -215,9 +241,13 @@ func (c *NetappClonner) Get(lun populator.LUN, _ populator.MappingContext) (stri
 }
 
 func (c *NetappClonner) CurrentMappedGroups(targetLUN populator.LUN, _ populator.MappingContext) ([]string, error) {
+	c.log.V(2).Info("querying current mapped groups", "lun", targetLUN.Name)
+
 	lunMappedIgroups, err := c.api.LunListIgroupsMapped(context.Background(), targetLUN.Name)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get mapped luns by path %s: %w ", targetLUN.Name, err)
 	}
+
+	c.log.V(2).Info("found mapped groups", "lun", targetLUN.Name, "groups", lunMappedIgroups)
 	return lunMappedIgroups, nil
 }

--- a/cmd/vsphere-copy-offload-populator/internal/ontap/ontap.go
+++ b/cmd/vsphere-copy-offload-populator/internal/ontap/ontap.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	drivers "github.com/netapp/trident/storage_drivers"
 	"github.com/netapp/trident/storage_drivers/ontap/api"
@@ -127,7 +127,7 @@ func (c *NetappClonner) EnsureClonnerIgroup(initiatorGroup string, adapterIds []
 }
 
 func NewNetappClonner(hostname, username, password string) (NetappClonner, error) {
-	log := logutil.NewLogger("ontap")
+	log := logger.New("ontap")
 
 	// additional ontap values should be passed as env variables using prefix ONTAP_
 	svm := os.Getenv("ONTAP_SVM")

--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	hversion "github.com/hashicorp/go-version"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/version"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	vmkfstoolswrapper "github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/vmkfstools-wrapper"
@@ -87,7 +88,7 @@ func NewWithRemoteEsxcliSSH(storageApi VMDKCapable, vmwareClient vmware.Client, 
 }
 
 func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv PersistentVolume, hostLocker Hostlocker, progress chan<- uint64, xcopyUsed chan<- int, quit chan error) (errFinal error) {
-	log := klog.Background().WithName("copy-offload").WithName("xcopy")
+	log := logutil.NewLogger("xcopy")
 	setupLog := log.WithName("setup")
 	mapLog := log.WithName("map-volume")
 	rescanLog := log.WithName("rescan")
@@ -336,7 +337,7 @@ func waitForDeviceStateOff(ctx context.Context, client vmware.Client, host *obje
 
 // After mapping a volume the ESX needs a rescan to see the device. ESXs can opt-in to do it automatically
 func rescan(ctx context.Context, client vmware.Client, host *object.HostSystem, targetLUN string) error {
-	log := klog.Background().WithName("copy-offload").WithName("xcopy").WithName("rescan")
+	log := logutil.NewLogger("xcopy").WithName("rescan")
 	ctx = klog.NewContext(ctx, log)
 	for i := 1; i <= rescanRetries; i++ {
 		if ctx.Err() != nil {
@@ -480,7 +481,7 @@ To fix this issue:
 
 6. Save and exit
 7. Retry the operation`, embeddedVersion, versionInfo.Version, datastore, restrictedPublicKey)
-		setupLog := klog.Background().WithName("copy-offload").WithName("xcopy").WithName("setup")
+		setupLog := logutil.NewLogger("xcopy").WithName("setup")
 		setupLog.Error(fmt.Errorf("version mismatch: uploaded %s, SSH returned %s", embeddedVersion, versionInfo.Version), "script version mismatch", "instructions", instructions)
 
 		return fmt.Errorf("version mismatch: uploaded %s but SSH returned %s - old SSH key format detected",

--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	hversion "github.com/hashicorp/go-version"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/version"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	vmkfstoolswrapper "github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/vmkfstools-wrapper"
@@ -88,7 +88,7 @@ func NewWithRemoteEsxcliSSH(storageApi VMDKCapable, vmwareClient vmware.Client, 
 }
 
 func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv PersistentVolume, hostLocker Hostlocker, progress chan<- uint64, xcopyUsed chan<- int, quit chan error) (errFinal error) {
-	log := logutil.NewLogger("xcopy")
+	log := logger.New("xcopy")
 	setupLog := log.WithName("setup")
 	mapLog := log.WithName("map-volume")
 	rescanLog := log.WithName("rescan")
@@ -337,7 +337,7 @@ func waitForDeviceStateOff(ctx context.Context, client vmware.Client, host *obje
 
 // After mapping a volume the ESX needs a rescan to see the device. ESXs can opt-in to do it automatically
 func rescan(ctx context.Context, client vmware.Client, host *object.HostSystem, targetLUN string) error {
-	log := logutil.NewLogger("xcopy").WithName("rescan")
+	log := logger.New("xcopy").WithName("rescan")
 	ctx = klog.NewContext(ctx, log)
 	for i := 1; i <= rescanRetries; i++ {
 		if ctx.Err() != nil {
@@ -481,7 +481,7 @@ To fix this issue:
 
 6. Save and exit
 7. Retry the operation`, embeddedVersion, versionInfo.Version, datastore, restrictedPublicKey)
-		setupLog := logutil.NewLogger("xcopy").WithName("setup")
+		setupLog := logger.New("xcopy").WithName("setup")
 		setupLog.Error(fmt.Errorf("version mismatch: uploaded %s, SSH returned %s", embeddedVersion, versionInfo.Version), "script version mismatch", "instructions", instructions)
 
 		return fmt.Errorf("version mismatch: uploaded %s but SSH returned %s - old SSH key format detected",

--- a/cmd/vsphere-copy-offload-populator/internal/powerflex/powerflex.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powerflex/powerflex.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/dell/goscaleio"
 	siotypes "github.com/dell/goscaleio/types/v1"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"k8s.io/klog/v2"
 )
@@ -229,7 +229,7 @@ func (p *PowerflexClonner) UnMap(initatorGroup string, targetLUN populator.LUN, 
 }
 
 func NewPowerflexClonner(hostname, username, password string, sslSkipVerify bool, systemId string) (PowerflexClonner, error) {
-	log := logutil.NewLogger("powerflex")
+	log := logger.New("powerflex")
 
 	if systemId == "" {
 		return PowerflexClonner{}, fmt.Errorf("systemId is empty. Make sure to pass systemId using the env variable %q. The value can be taken from the vxflexos-config secret under the powerflex CSI deployment", SYSTEM_ID_ENV_KEY)

--- a/cmd/vsphere-copy-offload-populator/internal/powerflex/powerflex.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powerflex/powerflex.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dell/goscaleio"
 	siotypes "github.com/dell/goscaleio/types/v1"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"k8s.io/klog/v2"
 )
@@ -22,6 +23,7 @@ type PowerflexClonner struct {
 	systemId  string
 	sdcId     string
 	arrayInfo populator.StorageArrayInfo
+	log       klog.Logger
 }
 
 // Ensure PowerflexClonner implements StorageArrayInfoProvider
@@ -34,10 +36,12 @@ func (p *PowerflexClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
 
 // CurrentMappedGroups implements populator.StorageApi.
 func (p *PowerflexClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingContext populator.MappingContext) ([]string, error) {
-	klog.Infof("getting current mapping to volume %+v", targetLUN)
+	p.log.V(2).Info("querying current mapped groups", "volume", targetLUN.Name)
+
 	csiGraceSeconds := 20
-	klog.Infof("PowerFlex CSI may be slow to refresh data. Sleeping for %d seconds.", csiGraceSeconds)
+	p.log.V(2).Info("waiting for PowerFlex CSI to refresh data", "sleep_seconds", csiGraceSeconds)
 	time.Sleep(time.Second * time.Duration(csiGraceSeconds))
+
 	v, err := p.Client.GetVolume("", "", "", targetLUN.Name, false)
 	if err != nil {
 		return nil, err
@@ -47,20 +51,22 @@ func (p *PowerflexClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingC
 		return nil, fmt.Errorf("found %d volumes while expecting one. Target volume ID %s", len(v), targetLUN.ProviderID)
 	}
 
-	klog.Infof("current mapping %+v", v[0].MappedSdcInfo)
+	p.log.V(2).Info("current mapping info", "volume", targetLUN.Name, "mapped_sdcs", v[0].MappedSdcInfo)
 	if len(v[0].MappedSdcInfo) == 0 {
 		// although shouldn't happen we should not break the flow here.
-		klog.Infof("found 0 Mapped SDC Info for target volume %+v", targetLUN)
+		p.log.V(2).Info("no SDC mappings found for volume", "volume", targetLUN.Name)
 	}
 	for _, sdcInfo := range v[0].MappedSdcInfo {
 		currentMappedSdcs = append(currentMappedSdcs, sdcInfo.SdcID)
 	}
+
+	p.log.V(2).Info("found mapped groups", "volume", targetLUN.Name, "sdc_ids", currentMappedSdcs)
 	return currentMappedSdcs, nil
 }
 
 // EnsureClonnerIgroup implements populator.StorageApi.
 func (p *PowerflexClonner) EnsureClonnerIgroup(initiatorGroup string, clonnerIqn []string) (populator.MappingContext, error) {
-	klog.Infof("ensuring initiator group %s for clonners %v", initiatorGroup, clonnerIqn)
+	p.log.Info("ensuring initiator group", "group", initiatorGroup, "adapters", clonnerIqn)
 
 	mappingContext := make(map[string]any)
 	system, err := p.Client.FindSystem(p.systemId, "", "")
@@ -76,13 +82,14 @@ func (p *PowerflexClonner) EnsureClonnerIgroup(initiatorGroup string, clonnerIqn
 		if sdc.OSType != "Esx" {
 			continue
 		}
-		klog.Infof("Comparing clonner iqn/wwn %s with sdc guid %v", clonnerIqn, sdc.SdcGUID)
+		p.log.V(2).Info("comparing adapter with SDC GUID", "adapters", clonnerIqn, "sdc_guid", sdc.SdcGUID)
 		if slices.ContainsFunc(clonnerIqn, func(e string) bool {
 			return strings.EqualFold(e, sdc.SdcGUID)
 		}) {
-			klog.Infof("found compatible SDC: %+v", sdc)
+			p.log.Info("found compatible SDC", "sdc_name", sdc.Name, "sdc_id", sdc.ID, "sdc_guid", sdc.SdcGUID)
 			mappingContext[sdcIDContextKey] = sdc.ID
 			p.sdcId = sdc.ID
+			p.log.Info("initiator group ready", "group", initiatorGroup, "sdc_id", sdc.ID)
 			return mappingContext, nil
 		}
 	}
@@ -98,7 +105,8 @@ func (p *PowerflexClonner) UnmapTarget(targetLUN populator.LUN, mappingContext p
 }
 
 func (p *PowerflexClonner) Map(initiatorGroup string, targetLUN populator.LUN, mappingContext populator.MappingContext) (populator.LUN, error) {
-	klog.Infof("mapping volume %s to initiator group %s with context %v", targetLUN.Name, initiatorGroup, mappingContext)
+	p.log.Info("mapping volume to group", "volume", targetLUN.Name, "group", initiatorGroup)
+
 	sdc, volume, err := p.fetchSdcVolume(initiatorGroup, targetLUN, mappingContext)
 	if err != nil {
 		return targetLUN, err
@@ -108,18 +116,19 @@ func (p *PowerflexClonner) Map(initiatorGroup string, targetLUN populator.LUN, m
 		SdcID:                 sdc.Sdc.ID,
 		AllowMultipleMappings: "true",
 	}
+	p.log.V(2).Info("mapping volume to SDC", "volume_id", volume.Volume.ID, "sdc_id", sdc.Sdc.ID)
 	err = volume.MapVolumeSdc(&mapParams)
 	if err != nil {
 		return targetLUN, fmt.Errorf("failed to map the volume id %s to sdc id %s: %w", volume.Volume.ID, sdc.Sdc.ID, err)
 	}
 	// the serial or the NAA is the {$systemID$volumeID}
 	targetLUN.NAA = fmt.Sprintf("eui.%s%s", sdc.Sdc.SystemID, volume.Volume.ID)
+	p.log.Info("volume mapped successfully", "volume", targetLUN.Name, "naa", targetLUN.NAA)
 	return targetLUN, nil
 }
 
 // Map implements populator.StorageApi.
 func (p *PowerflexClonner) fetchSdcVolume(initatorGroup string, targetLUN populator.LUN, mappingContext populator.MappingContext) (*goscaleio.Sdc, *goscaleio.Volume, error) {
-
 	// TODO rgolan do we need an instanceID as part of the client?
 	// probably yes for multiple instances
 	system, err := p.Client.FindSystem(p.systemId, "", "")
@@ -131,7 +140,7 @@ func (p *PowerflexClonner) fetchSdcVolume(initatorGroup string, targetLUN popula
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to locate sdc by sdc guid %s", initatorGroup)
 	}
-	klog.Infof("found sdc name %s id %s", sdc.Sdc.Name, sdc.Sdc.ID)
+	p.log.V(2).Info("found SDC", "sdc_name", sdc.Sdc.Name, "sdc_id", sdc.Sdc.ID)
 
 	v, err := p.Client.GetVolume("", "", "", targetLUN.Name, false)
 	if err != nil {
@@ -147,32 +156,37 @@ func (p *PowerflexClonner) fetchSdcVolume(initatorGroup string, targetLUN popula
 
 // ResolveVolumeHandleToLUN implements populator.StorageApi.
 func (p *PowerflexClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {
+	p.log.Info("resolving PV to LUN", "pv", pv.Name, "volume_handle", pv.VolumeHandle)
+
 	name := pv.VolumeAttributes["Name"]
 	if name == "" {
 		return populator.LUN{},
 			fmt.Errorf("the PersistentVolume attribute 'Name' is empty and " +
 				"essential to locate the underlying volume in PowerFlex")
 	}
+
+	p.log.V(2).Info("looking up volume by name", "name", name)
 	id, err := p.Client.FindVolumeID(name)
 	if err != nil {
 		return populator.LUN{}, err
-
 	}
+
 	v, err := p.Client.GetVolume("", id, "", "", false)
 	if err != nil {
-		return populator.LUN{}, nil
+		return populator.LUN{}, fmt.Errorf("failed to get volume by id %s: %w", id, err)
 	}
 
 	if len(v) != 1 {
 		return populator.LUN{}, fmt.Errorf("failed to locate a single volume by name %s", name)
 	}
 
-	klog.Infof("found volume %s", v[0].Name)
-	return populator.LUN{
+	lun := populator.LUN{
 		Name:         v[0].Name,
 		ProviderID:   v[0].ID,
 		VolumeHandle: pv.VolumeHandle,
-	}, nil
+	}
+	p.log.Info("LUN resolved", "lun", lun.Name, "provider_id", lun.ProviderID)
+	return lun, nil
 }
 
 func (p *PowerflexClonner) SciniRequired() bool {
@@ -184,9 +198,9 @@ func (p *PowerflexClonner) UnMap(initatorGroup string, targetLUN populator.LUN, 
 	unmappingAll, _ := mappingContext["UnmapAllSdc"].(bool)
 
 	if unmappingAll {
-		klog.Infof("unmapping all from volume %s", targetLUN.Name)
+		p.log.Info("unmapping all SDCs from volume", "volume", targetLUN.Name)
 	} else {
-		klog.Infof("unmapping volume %s from initiator group %s", targetLUN.Name, initatorGroup)
+		p.log.Info("unmapping volume from group", "volume", targetLUN.Name, "group", initatorGroup)
 	}
 
 	sdc, volume, err := p.fetchSdcVolume(initatorGroup, targetLUN, mappingContext)
@@ -204,17 +218,24 @@ func (p *PowerflexClonner) UnMap(initatorGroup string, targetLUN populator.LUN, 
 		}
 	}
 
+	p.log.V(2).Info("unmapping volume from SDC", "volume_id", volume.Volume.ID, "sdc_id", sdc.Sdc.ID, "all_sdcs", unmappingAll)
 	err = volume.UnmapVolumeSdc(&unmapParams)
 	if err != nil {
 		return err
 	}
+
+	p.log.Info("volume unmapped successfully", "volume", targetLUN.Name)
 	return nil
 }
 
 func NewPowerflexClonner(hostname, username, password string, sslSkipVerify bool, systemId string) (PowerflexClonner, error) {
+	log := logutil.NewLogger("powerflex")
+
 	if systemId == "" {
 		return PowerflexClonner{}, fmt.Errorf("systemId is empty. Make sure to pass systemId using the env variable %q. The value can be taken from the vxflexos-config secret under the powerflex CSI deployment", SYSTEM_ID_ENV_KEY)
 	}
+
+	log.V(2).Info("creating PowerFlex client", "hostname", hostname, "system_id", systemId)
 	client, err := goscaleio.NewClientWithArgs(hostname, "", 10000, sslSkipVerify, true)
 	if err != nil {
 		return PowerflexClonner{}, err
@@ -230,7 +251,7 @@ func NewPowerflexClonner(hostname, username, password string, sslSkipVerify bool
 		return PowerflexClonner{}, fmt.Errorf("error authenticating: %w", err)
 	}
 
-	klog.Infof("successfuly logged in to ScaleIO Gateway at %s", client.GetConfigConnect().Endpoint)
+	log.V(2).Info("authenticated to PowerFlex gateway", "endpoint", client.GetConfigConnect().Endpoint)
 
 	return PowerflexClonner{
 		Client:   client,
@@ -239,5 +260,6 @@ func NewPowerflexClonner(hostname, username, password string, sslSkipVerify bool
 			Vendor:  "Dell",
 			Product: "PowerFlex",
 		},
+		log: log,
 	}, nil
 }

--- a/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
@@ -13,7 +13,7 @@ import (
 
 	gopowermax "github.com/dell/gopowermax/v2"
 	pmxtypes "github.com/dell/gopowermax/v2/types/v100"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"k8s.io/klog/v2"
 )
@@ -295,7 +295,7 @@ func (p *PowermaxClonner) UnMap(_ string, targetLUN populator.LUN, mappingContex
 var newClientWithArgs = gopowermax.NewClientWithArgs
 
 func NewPowermaxClonner(hostname, username, password string, sslSkipVerify bool) (PowermaxClonner, error) {
-	log := logutil.NewLogger("powermax")
+	log := logger.New("powermax")
 
 	symID := os.Getenv("POWERMAX_SYMMETRIX_ID")
 	if symID == "" {

--- a/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
@@ -13,6 +13,7 @@ import (
 
 	gopowermax "github.com/dell/gopowermax/v2"
 	pmxtypes "github.com/dell/gopowermax/v2/types/v100"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"k8s.io/klog/v2"
 )
@@ -26,6 +27,7 @@ type PowermaxClonner struct {
 	hostID         string
 	maskingViewID  string
 	arrayInfo      populator.StorageArrayInfo
+	log            klog.Logger
 }
 
 // Ensure PowermaxClonner implements StorageArrayInfoProvider
@@ -46,6 +48,8 @@ func (p *PowermaxClonner) UnmapTarget(targetLUN populator.LUN, mappingContext po
 
 // CurrentMappedGroups implements populator.StorageApi.
 func (p *PowermaxClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingContext populator.MappingContext) ([]string, error) {
+	p.log.V(2).Info("querying current mapped groups", "volume", targetLUN.ProviderID)
+
 	ctx := context.TODO()
 	volume, err := p.client.GetVolumeByID(ctx, p.symmetrixID, targetLUN.ProviderID)
 	if err != nil {
@@ -56,7 +60,7 @@ func (p *PowermaxClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingCo
 		return nil, fmt.Errorf("Volume %s is not associated with any Storage Group.\n", targetLUN.ProviderID)
 	}
 
-	klog.Infof("Volume %s is in Storage Group(s): %v\n", targetLUN.ProviderID, volume.StorageGroups)
+	p.log.V(2).Info("volume storage groups", "volume", targetLUN.ProviderID, "storage_groups", volume.StorageGroups)
 
 	foundHostGroups := []string{}
 
@@ -64,12 +68,12 @@ func (p *PowermaxClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingCo
 		foundHostGroups = append(foundHostGroups, sgID.StorageGroupName)
 		maskingViewList, err := p.client.GetMaskingViewList(ctx, p.symmetrixID)
 		if err != nil {
-			klog.Infof("Error getting masking views for Storage Group %s: %v", sgID, err)
+			p.log.Info("failed to get masking views for storage group", "storage_group", sgID, "err", err)
 			continue
 		}
 
 		if len(maskingViewList.MaskingViewIDs) == 0 {
-			klog.Infof("No masking views found for Storage Group %s.\n", sgID)
+			p.log.V(2).Info("no masking views found for storage group", "storage_group", sgID)
 			continue
 		}
 
@@ -77,35 +81,34 @@ func (p *PowermaxClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingCo
 		for _, mvID := range maskingViewList.MaskingViewIDs {
 			maskingView, err := p.client.GetMaskingViewByID(ctx, p.symmetrixID, mvID)
 			if err != nil {
-				klog.Errorf("Error getting masking view %s: %v", mvID, err)
+				p.log.Info("failed to get masking view", "masking_view", mvID, "err", err)
 				continue
 			}
 
 			if maskingView.HostID != "" {
 				// This masking view is directly mapped to a Host, not a Host Group
-				klog.Infof("Volume %s is mapped via Masking View %s to Host: %s\n", targetLUN.ProviderID, mvID, maskingView.HostID)
+				p.log.V(2).Info("volume mapped via masking view to host", "volume", targetLUN.ProviderID, "masking_view", mvID, "host", maskingView.HostID)
 				foundHostGroups = append(foundHostGroups, maskingView.HostID)
 			} else if maskingView.HostGroupID != "" {
 				// This masking view is mapped to a Host Group
-				klog.Infof("Volume %s is mapped via Masking View %s to Host Group: %s\n", targetLUN.ProviderID, mvID, maskingView.HostGroupID)
+				p.log.V(2).Info("volume mapped via masking view to host group", "volume", targetLUN.ProviderID, "masking_view", mvID, "host_group", maskingView.HostGroupID)
 				foundHostGroups = append(foundHostGroups, maskingView.HostGroupID)
 			}
 		}
 	}
 
 	if len(foundHostGroups) > 0 {
-		klog.Info("Unique Host Groups found for the volume:")
-		for _, hg := range foundHostGroups {
-			klog.Infof("- %s", hg)
-		}
+		p.log.V(2).Info("found mapped groups", "volume", targetLUN.ProviderID, "groups", foundHostGroups)
 	} else {
-		klog.Info("No host groups found for the volume.")
+		p.log.V(2).Info("no host groups found for volume", "volume", targetLUN.ProviderID)
 	}
 	return foundHostGroups, nil
 }
 
 // EnsureClonnerIgroup implements populator.StorageApi.
 func (p *PowermaxClonner) EnsureClonnerIgroup(_ string, clonnerIqn []string) (populator.MappingContext, error) {
+	p.log.Info("ensuring initiator group", "adapters", clonnerIqn)
+
 	ctx := context.TODO()
 
 	randomString, err := generateRandomString(4)
@@ -113,7 +116,7 @@ func (p *PowermaxClonner) EnsureClonnerIgroup(_ string, clonnerIqn []string) (po
 		return nil, err
 	}
 	p.initiatorID = fmt.Sprintf("xcopy-%s", randomString)
-	klog.Infof("Generated unique initiator group name: %s", p.initiatorID)
+	p.log.V(2).Info("generated unique initiator group name", "group", p.initiatorID)
 
 	// steps:
 	// 1.create the storage group
@@ -122,35 +125,35 @@ func (p *PowermaxClonner) EnsureClonnerIgroup(_ string, clonnerIqn []string) (po
 	// 4. add clonnerIqn to that initiar group
 	// 5. add port group with protocol type that match the cloner IQN type, only if they all online
 	p.storageGroupID = fmt.Sprintf("%s-SG", p.initiatorID)
-	klog.Infof("ensuring storage group %s exists with hosts %v", p.storageGroupID, clonnerIqn)
+	p.log.V(2).Info("ensuring storage group exists", "storage_group", p.storageGroupID)
 	_, err = p.client.GetStorageGroup(ctx, p.symmetrixID, p.storageGroupID)
 	if err == nil {
-		klog.Infof("group %s exists", p.storageGroupID)
-	}
-	if e, ok := err.(*pmxtypes.Error); ok && e.HTTPStatusCode == 404 {
-		klog.Infof("group %s doesn't exist - create it", p.storageGroupID)
+		p.log.V(2).Info("storage group exists", "storage_group", p.storageGroupID)
+	} else if e, ok := err.(*pmxtypes.Error); ok && e.HTTPStatusCode == 404 {
+		p.log.V(2).Info("creating storage group", "storage_group", p.storageGroupID)
 		_, err := p.client.CreateStorageGroup(ctx, p.symmetrixID, p.storageGroupID, "none", "", true, nil)
 		if err != nil {
-			klog.Errorf("failed to create group %v ", err)
-			return nil, err
+			return nil, fmt.Errorf("failed to create group: %w", err)
 		}
+	} else {
+		return nil, fmt.Errorf("failed to check storage group %s: %w", p.storageGroupID, err)
 	}
 
-	klog.Infof("storage group %s", p.storageGroupID)
+	p.log.V(2).Info("storage group ready", "storage_group", p.storageGroupID)
 
 	// Fetch port group to determine protocol type
 	portGroup, err := p.client.GetPortGroupByID(ctx, p.symmetrixID, p.portGroup)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get port group %s: %w", p.portGroup, err)
 	}
-	klog.Infof("port group %s has protocol: %s", p.portGroup, portGroup.PortGroupProtocol)
+	p.log.V(2).Info("port group protocol", "port_group", p.portGroup, "protocol", portGroup.PortGroupProtocol)
 
 	// Filter initiators based on port group protocol
-	filteredInitiators := filterInitiatorsByProtocol(clonnerIqn, portGroup.PortGroupProtocol)
+	filteredInitiators := filterInitiatorsByProtocol(clonnerIqn, portGroup.PortGroupProtocol, p.log)
 	if len(filteredInitiators) == 0 {
 		return nil, fmt.Errorf("no initiators matching protocol %s found in %v", portGroup.PortGroupProtocol, clonnerIqn)
 	}
-	klog.Infof("filtered initiators for protocol %s: %v", portGroup.PortGroupProtocol, filteredInitiators)
+	p.log.V(2).Info("filtered initiators by protocol", "protocol", portGroup.PortGroupProtocol, "initiators", filteredInitiators)
 
 	hosts, err := p.client.GetHostList(ctx, p.symmetrixID)
 	if err != nil {
@@ -162,7 +165,7 @@ h:
 		if err != nil {
 			return nil, err
 		}
-		klog.Infof("host ID %s and initiators %v", host.HostID, host.Initiators)
+		p.log.V(2).Info("checking host for matching initiators", "host_id", host.HostID, "initiators", host.Initiators)
 		for _, initiator := range host.Initiators {
 			for _, filteredInit := range filteredInitiators {
 				if strings.HasSuffix(filteredInit, initiator) {
@@ -177,29 +180,32 @@ h:
 			"Ensure the ESXi host has a corresponding host object in PowerMax with the correct FC/iSCSI initiators registered",
 			p.symmetrixID, filteredInitiators)
 	}
-	klog.Infof("found host ID %s matching protocol %s", p.hostID, portGroup.PortGroupProtocol)
+	p.log.Info("found matching host", "host_id", p.hostID, "protocol", portGroup.PortGroupProtocol)
 
-	klog.Infof("port group ID %s", p.portGroup)
+	p.log.V(2).Info("port group configured", "port_group", p.portGroup)
+	p.log.Info("initiator group ready", "group", p.initiatorID)
 	mappingContext := map[string]any{}
 	return mappingContext, err
 }
 
 // Map implements populator.StorageApi.
 func (p *PowermaxClonner) Map(_ string, targetLUN populator.LUN, mappingContext populator.MappingContext) (populator.LUN, error) {
-	klog.Infof("mapping volume %s to %s", targetLUN.ProviderID, p.storageGroupID)
+	p.log.Info("mapping volume to storage group", "volume", targetLUN.ProviderID, "storage_group", p.storageGroupID)
+
 	ctx := context.TODO()
 	volumesMapped, err := p.client.GetVolumeIDListInStorageGroup(ctx, p.symmetrixID, p.storageGroupID)
 	if err != nil {
 		return targetLUN, err
 	}
 	if slices.Contains(volumesMapped, targetLUN.ProviderID) {
-		klog.Infof("volume %s already mapped to storage-group %s", targetLUN.ProviderID, p.storageGroupID)
+		p.log.V(2).Info("volume already mapped to storage group", "volume", targetLUN.ProviderID, "storage_group", p.storageGroupID)
 		return targetLUN, nil
 	}
 
+	p.log.V(2).Info("adding volume to storage group", "volume", targetLUN.ProviderID, "storage_group", p.storageGroupID)
 	err = p.client.AddVolumesToStorageGroupS(ctx, p.symmetrixID, p.storageGroupID, false, targetLUN.ProviderID)
 	if err != nil {
-		klog.Infof("failed mapping volume %s to %s: %v", targetLUN.ProviderID, p.storageGroupID, err)
+		p.log.Info("failed to add volume to storage group", "volume", targetLUN.ProviderID, "storage_group", p.storageGroupID, "err", err)
 		return targetLUN, err
 	}
 
@@ -207,75 +213,90 @@ func (p *PowermaxClonner) Map(_ string, targetLUN populator.LUN, mappingContext 
 	if err != nil {
 		// probably not found, will be created later
 		if e, ok := err.(*pmxtypes.Error); ok && e.HTTPStatusCode == 404 {
-			klog.Infof("masking view not found %s ", e)
+			p.log.V(2).Info("masking view not found, will be created", "initiator_id", p.initiatorID)
 		} else {
 			return populator.LUN{}, err
 		}
 	}
 
 	if mv == nil {
+		p.log.V(2).Info("creating masking view", "initiator_id", p.initiatorID, "storage_group", p.storageGroupID, "host_id", p.hostID, "port_group", p.portGroup)
 		mv, err = p.client.CreateMaskingView(ctx, p.symmetrixID, p.initiatorID, p.storageGroupID, p.hostID, false, p.portGroup)
 		if err != nil {
 			return populator.LUN{}, err
 		}
 	}
 
-	klog.Infof("successfully mapped volume %s to %s with masking view %s", targetLUN.ProviderID, p.initiatorID, mv.MaskingViewID)
+	p.log.Info("volume mapped successfully", "volume", targetLUN.ProviderID, "masking_view", mv.MaskingViewID)
 	p.maskingViewID = mv.MaskingViewID
 	return targetLUN, err
 }
 
 // ResolvePVToLUN implements populator.StorageApi.
 func (p *PowermaxClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {
+	p.log.Info("resolving PV to LUN", "pv", pv.Name, "volume_handle", pv.VolumeHandle)
+
 	ctx := context.TODO()
 	volID := pv.VolumeHandle[strings.LastIndex(pv.VolumeHandle, "-")+1:]
+	p.log.V(2).Info("extracting volume ID from handle", "volume_id", volID)
+
 	volume, err := p.client.GetVolumeByID(ctx, p.symmetrixID, volID)
 	if err != nil || volume.VolumeID == "" {
 		return populator.LUN{}, fmt.Errorf("failed getting details for volume %v: %v", volume, err)
 	}
-	naa := fmt.Sprintf("naa.%s", volume.WWN)
-	return populator.LUN{Name: volume.VolumeIdentifier, ProviderID: volume.VolumeID, NAA: naa}, nil
 
+	naa := fmt.Sprintf("naa.%s", volume.WWN)
+	lun := populator.LUN{Name: volume.VolumeIdentifier, ProviderID: volume.VolumeID, NAA: naa}
+	p.log.Info("LUN resolved", "lun", lun.Name, "naa", lun.NAA, "provider_id", lun.ProviderID)
+	return lun, nil
 }
 
 // UnMap implements populator.StorageApi.
 func (p *PowermaxClonner) UnMap(_ string, targetLUN populator.LUN, mappingContext populator.MappingContext) error {
+	p.log.Info("unmapping volume from storage group", "volume", targetLUN.ProviderID, "storage_group", p.storageGroupID)
+
 	ctx := context.TODO()
 
 	cleanup, ok := mappingContext[populator.CleanupXcopyInitiatorGroup]
 	if ok && cleanup.(bool) {
-		klog.Infof("deleting masking view %s", p.maskingViewID)
+		p.log.V(2).Info("full cleanup requested, deleting masking view", "masking_view", p.maskingViewID)
 		err := p.client.DeleteMaskingView(ctx, p.symmetrixID, p.maskingViewID)
 		if err != nil {
 			return fmt.Errorf("failed to delete masking view: %w", err)
 		}
 
-		klog.Infof("removing volume ID %s from storage group %s", targetLUN.ProviderID, p.storageGroupID)
+		p.log.V(2).Info("removing volume from storage group", "volume", targetLUN.ProviderID, "storage_group", p.storageGroupID)
 		_, err = p.client.RemoveVolumesFromStorageGroup(ctx, p.symmetrixID, p.storageGroupID, false, targetLUN.ProviderID)
 		if err != nil {
 			return fmt.Errorf("failed removing volume from storage group:  %w", err)
 		}
 
-		klog.Infof("deleting storage group %s", p.storageGroupID)
+		p.log.V(2).Info("deleting storage group", "storage_group", p.storageGroupID)
 		err = p.client.DeleteStorageGroup(ctx, p.symmetrixID, p.storageGroupID)
 		if err != nil {
 			return fmt.Errorf("failed to delete storage group: %w", err)
 		}
+
+		p.log.Info("volume unmapped successfully with full cleanup", "volume", targetLUN.ProviderID)
 		return nil
 	}
 
-	klog.Infof("removing volume ID %s from storage group %s", targetLUN.ProviderID, p.storageGroupID)
+	p.log.V(2).Info("removing volume from storage group", "volume", targetLUN.ProviderID, "storage_group", p.storageGroupID)
 
 	_, err := p.client.RemoveVolumesFromStorageGroup(ctx, p.symmetrixID, p.storageGroupID, false, targetLUN.ProviderID)
 	if err != nil {
 		return fmt.Errorf("failed removing volume from storage group:  %w", err)
 	}
+
+	p.log.Info("volume unmapped successfully", "volume", targetLUN.ProviderID)
 	return nil
 }
 
 var newClientWithArgs = gopowermax.NewClientWithArgs
 
 func NewPowermaxClonner(hostname, username, password string, sslSkipVerify bool) (PowermaxClonner, error) {
+	log := logutil.NewLogger("powermax")
+
 	symID := os.Getenv("POWERMAX_SYMMETRIX_ID")
 	if symID == "" {
 		return PowermaxClonner{}, fmt.Errorf("Please set POWERMAX_SYMMETRIX_ID in the pod environment or in the secret" +
@@ -286,6 +307,9 @@ func NewPowermaxClonner(hostname, username, password string, sslSkipVerify bool)
 		return PowermaxClonner{}, fmt.Errorf("Please set POWERMAX_PORT_GROUP_NAME in the pod environment or in the secret" +
 			" attached to the relevant storage map")
 	}
+
+	log.V(2).Info("creating PowerMax client", "hostname", hostname, "symmetrix_id", symID, "port_group", portGroup)
+
 	// using the same application name as the driver
 	applicationName := "csi"
 	client, err := newClientWithArgs(
@@ -309,7 +333,8 @@ func NewPowermaxClonner(hostname, username, password string, sslSkipVerify bool)
 	if err != nil {
 		return PowermaxClonner{}, err
 	}
-	klog.Info("successfuly logged in to PowerMax")
+
+	log.V(2).Info("authenticated to PowerMax", "symmetrix_id", symID)
 
 	clonner := PowermaxClonner{
 		client:      client,
@@ -319,15 +344,17 @@ func NewPowermaxClonner(hostname, username, password string, sslSkipVerify bool)
 			Vendor:  "Dell",
 			Product: "PowerMax",
 		},
+		log: log,
 	}
 
 	// Fetch model and version from the API
 	sym, err := client.GetSymmetrixByID(context.TODO(), symID)
 	if err != nil {
-		klog.Warningf("Failed to get PowerMax symmetrix info for metrics: %v", err)
+		log.Info("failed to get PowerMax symmetrix info for metrics", "err", err)
 	} else {
 		clonner.arrayInfo.Model = sym.Model
 		clonner.arrayInfo.Version = sym.Ucode
+		log.V(2).Info("PowerMax array info", "vendor", clonner.arrayInfo.Vendor, "product", clonner.arrayInfo.Product, "model", clonner.arrayInfo.Model, "version", clonner.arrayInfo.Version)
 	}
 
 	return clonner, nil
@@ -344,7 +371,7 @@ func generateRandomString(length int) (string, error) {
 // filterInitiatorsByProtocol filters the initiator list based on the port group protocol
 // iSCSI protocol requires IQN format initiators (e.g., "iqn.1994-05.com.redhat:...")
 // SCSI_FC protocol requires FC WWN format initiators (e.g., "10000000c9a12345:10000000c9a12346")
-func filterInitiatorsByProtocol(initiators []string, protocol string) []string {
+func filterInitiatorsByProtocol(initiators []string, protocol string, log klog.Logger) []string {
 	var filtered []string
 
 	for _, initiator := range initiators {
@@ -361,7 +388,7 @@ func filterInitiatorsByProtocol(initiators []string, protocol string) []string {
 				filtered = append(filtered, initiator)
 			}
 		default:
-			klog.Warningf("Unknown protocol %s, skipping initiator filtering", protocol)
+			log.Info("unknown protocol, skipping initiator filtering", "protocol", protocol)
 			// For unknown protocols, return all initiators
 			return initiators
 		}

--- a/cmd/vsphere-copy-offload-populator/internal/powerstore/powerstore.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powerstore/powerstore.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/dell/gopowerstore"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"k8s.io/klog/v2"
 )
@@ -333,7 +333,7 @@ func (p *PowerstoreClonner) UnMap(initiatorGroup string, targetLUN populator.LUN
 }
 
 func NewPowerstoreClonner(hostname, username, password string, sslSkipVerify bool) (PowerstoreClonner, error) {
-	log := logutil.NewLogger("powerstore")
+	log := logger.New("powerstore")
 
 	if hostname == "" {
 		return PowerstoreClonner{}, fmt.Errorf("hostname is required")

--- a/cmd/vsphere-copy-offload-populator/internal/powerstore/powerstore.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powerstore/powerstore.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dell/gopowerstore"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"k8s.io/klog/v2"
 )
@@ -22,6 +23,7 @@ type PowerstoreClonner struct {
 	Client         gopowerstore.Client
 	initiatorGroup string
 	arrayInfo      populator.StorageArrayInfo
+	log            klog.Logger
 }
 
 // Ensure PowerstoreClonner implements StorageArrayInfoProvider
@@ -42,6 +44,8 @@ func (p *PowerstoreClonner) UnmapTarget(targetLUN populator.LUN, mappingContext 
 
 // CurrentMappedGroups implements populator.StorageApi.
 func (p *PowerstoreClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingContext populator.MappingContext) ([]string, error) {
+	p.log.V(2).Info("querying current mapped groups", "volume", targetLUN.Name)
+
 	if targetLUN.IQN == "" {
 		return nil, fmt.Errorf("target LUN IQN is required")
 	}
@@ -57,7 +61,7 @@ func (p *PowerstoreClonner) CurrentMappedGroups(targetLUN populator.LUN, mapping
 	for _, mapping := range mappings {
 		host, err := p.Client.GetHost(ctx, mapping.HostID)
 		if err != nil {
-			klog.Warningf("Failed to get host info for host ID %s: %s", mapping.HostID, err)
+			p.log.Info("failed to get host info", "host_id", mapping.HostID, "err", err)
 			continue
 		}
 		mappedHosts = append(mappedHosts, host.Name)
@@ -66,13 +70,15 @@ func (p *PowerstoreClonner) CurrentMappedGroups(targetLUN populator.LUN, mapping
 		return nil, fmt.Errorf("volume %s is not mapped to any host", targetLUN.Name)
 	}
 
+	p.log.V(2).Info("found mapped groups", "volume", targetLUN.Name, "hosts", mappedHosts)
 	return mappedHosts, nil
 }
 
 // EnsureClonnerIgroup implements populator.StorageApi.
 func (p *PowerstoreClonner) EnsureClonnerIgroup(initiatorGroup string, adapterIds []string) (populator.MappingContext, error) {
+	p.log.Info("ensuring initiator group", "group", initiatorGroup, "adapters", adapterIds)
+
 	p.initiatorGroup = initiatorGroup
-	klog.Infof("ensuring initiator group %s for adapters %v", initiatorGroup, adapterIds)
 
 	ctx := context.Background()
 	mappingContext := make(map[string]any)
@@ -81,11 +87,12 @@ func (p *PowerstoreClonner) EnsureClonnerIgroup(initiatorGroup string, adapterId
 	if err != nil {
 		return nil, fmt.Errorf("failed to get initiator groups: %w", err)
 	}
-	found, mappingContext, err := getHostByInitiator(adapterIds, &hosts, initiatorGroup)
+	found, mappingContext, err := getHostByInitiator(adapterIds, &hosts, initiatorGroup, p.log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get host by initiator: %w", err)
 	}
 	if found {
+		p.log.Info("initiator group ready", "group", initiatorGroup)
 		return mappingContext, nil
 	}
 	hostGroups, err := p.Client.GetHostGroups(ctx)
@@ -93,11 +100,12 @@ func (p *PowerstoreClonner) EnsureClonnerIgroup(initiatorGroup string, adapterId
 		return nil, fmt.Errorf("failed to get host groups: %w", err)
 	}
 	for _, hostGroup := range hostGroups {
-		found, mappingContext, err = getHostByInitiator(adapterIds, &hostGroup.Hosts, initiatorGroup)
+		found, mappingContext, err = getHostByInitiator(adapterIds, &hostGroup.Hosts, initiatorGroup, p.log)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get host by initiator: %w", err)
 		}
 		if found {
+			p.log.Info("initiator group ready", "group", initiatorGroup)
 			return mappingContext, nil
 		}
 	}
@@ -105,7 +113,7 @@ func (p *PowerstoreClonner) EnsureClonnerIgroup(initiatorGroup string, adapterId
 
 	host, err := p.Client.GetHostByName(ctx, initiatorGroup)
 	if err != nil {
-		klog.Infof("initiator group %s not found, creating new initiator group", initiatorGroup)
+		p.log.V(2).Info("initiator group not found, creating new", "group", initiatorGroup)
 		osType := gopowerstore.OSTypeEnumESXi
 		inits := make([]gopowerstore.InitiatorCreateModify, 0, len(adapterIds))
 		for _, a := range adapterIds {
@@ -138,14 +146,14 @@ func (p *PowerstoreClonner) EnsureClonnerIgroup(initiatorGroup string, adapterId
 			return nil, fmt.Errorf("failed to get created initiator group %s: %w", createResp.ID, err)
 		}
 
-		klog.Infof("Successfully created initiator group %s with ID %s", initiatorGroup, host.ID)
+		p.log.Info("created initiator group", "group", initiatorGroup, "host_id", host.ID)
 	} else {
-		klog.Infof("Found existing initiator group %s with ID %s", initiatorGroup, host.ID)
+		p.log.V(2).Info("found existing initiator group", "group", initiatorGroup, "host_id", host.ID)
 	}
 
 	mappingContext = createMappingContext(&host, initiatorGroup)
 
-	klog.Infof("Successfully ensured initiator group %s with %d adapters", initiatorGroup, len(adapterIds))
+	p.log.Info("initiator group ready", "group", initiatorGroup, "adapter_count", len(adapterIds))
 	return mappingContext, nil
 }
 
@@ -166,7 +174,7 @@ func extractAdapterIdByPortType(adapterId string, portType gopowerstore.Initiato
 	return "", fmt.Errorf("invalid port type: %s", portType)
 }
 
-func getHostByInitiator(adapterIds []string, hosts *[]gopowerstore.Host, initiatorGroup string) (bool, populator.MappingContext, error) {
+func getHostByInitiator(adapterIds []string, hosts *[]gopowerstore.Host, initiatorGroup string, log klog.Logger) (bool, populator.MappingContext, error) {
 	for _, host := range *hosts {
 		for _, initiator := range host.Initiators {
 			for _, adapterId := range adapterIds {
@@ -179,7 +187,7 @@ func getHostByInitiator(adapterIds []string, hosts *[]gopowerstore.Host, initiat
 					return false, populator.MappingContext{}, fmt.Errorf("failed to extract adapter ID by port type for adapter %s: %w", adapterId, err)
 				}
 				if initiator.PortName == formattedAdapterId {
-					klog.Infof("Found existing initiator group %s with ID %s name %s port name %s", initiatorGroup, host.ID, host.Name, initiator.PortName)
+					log.V(2).Info("found existing host with matching initiator", "group", initiatorGroup, "host_id", host.ID, "host_name", host.Name, "port_name", initiator.PortName)
 					mappingContext := createMappingContext(&host, initiatorGroup)
 					return true, mappingContext, nil
 				}
@@ -212,14 +220,14 @@ func detectPortType(adapterId string) (gopowerstore.InitiatorProtocolTypeEnum, e
 }
 
 func (p *PowerstoreClonner) Map(initiatorGroup string, targetLUN populator.LUN, mappingContext populator.MappingContext) (populator.LUN, error) {
+	p.log.Info("mapping volume to group", "volume", targetLUN.Name, "group", initiatorGroup)
+
 	if targetLUN.IQN == "" {
 		return targetLUN, fmt.Errorf("target LUN IQN is required")
 	}
 	if mappingContext == nil {
 		return targetLUN, fmt.Errorf("mapping context is required")
 	}
-
-	klog.Infof("mapping volume %s to initiator-group %s", targetLUN.Name, initiatorGroup)
 
 	ctx := context.Background()
 	hostName := initiatorGroup
@@ -240,7 +248,7 @@ func (p *PowerstoreClonner) Map(initiatorGroup string, targetLUN populator.LUN, 
 	if err == nil {
 		for _, m := range existing {
 			if m.HostID == hostID {
-				klog.Infof("Volume %s already mapped to initiatior group %s", targetLUN.Name, hostName)
+				p.log.V(2).Info("volume already mapped to group", "volume", targetLUN.Name, "host", hostName)
 				return targetLUN, nil
 			}
 		}
@@ -250,17 +258,20 @@ func (p *PowerstoreClonner) Map(initiatorGroup string, targetLUN populator.LUN, 
 		VolumeID: &targetLUN.IQN,
 	}
 
+	p.log.V(2).Info("attaching volume to host", "volume_id", targetLUN.IQN, "host_id", hostID)
 	_, err = p.Client.AttachVolumeToHost(ctx, hostID, attachParams)
 	if err != nil {
 		return targetLUN, fmt.Errorf("failed to attach volume %s to initiatior group %s: %w", targetLUN.Name, hostID, err)
 	}
 
-	klog.Infof("Successfully mapped volume %s to initiatior group %s", targetLUN.Name, hostName)
+	p.log.Info("volume mapped successfully", "volume", targetLUN.Name, "host", hostName)
 	return targetLUN, nil
 }
 
 // ResolveVolumeHandleToLUN implements populator.StorageApi.
 func (p *PowerstoreClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {
+	p.log.Info("resolving PV to LUN", "pv", pv.Name, "volume_handle", pv.VolumeHandle)
+
 	if pv.VolumeAttributes == nil {
 		return populator.LUN{}, fmt.Errorf("PersistentVolume attributes are required")
 	}
@@ -269,25 +280,30 @@ func (p *PowerstoreClonner) ResolvePVToLUN(pv populator.PersistentVolume) (popul
 	if name == "" {
 		return populator.LUN{}, fmt.Errorf("PersistentVolume 'Name' attribute is required to locate the volume in PowerStore")
 	}
+
+	p.log.V(2).Info("looking up volume by name", "name", name)
 	ctx := context.Background()
 	volume, err := p.Client.GetVolumeByName(ctx, name)
 	if err != nil {
 		return populator.LUN{}, fmt.Errorf("failed to get volume %s: %w", name, err)
 	}
 
-	klog.Infof("Successfully resolved volume %s", name)
-	return populator.LUN{
+	lun := populator.LUN{
 		Name:         name,
 		VolumeHandle: pv.VolumeHandle,
 		Protocol:     pv.VolumeAttributes["Protocol"],
 		NAA:          volume.Wwn, // volume.Wwn contains naa. prefix
 		ProviderID:   volume.ID,
 		IQN:          volume.ID,
-	}, nil
+	}
+	p.log.Info("LUN resolved", "lun", lun.Name, "naa", lun.NAA, "provider_id", lun.ProviderID)
+	return lun, nil
 }
 
 // UnMap implements populator.StorageApi.
 func (p *PowerstoreClonner) UnMap(initiatorGroup string, targetLUN populator.LUN, mappingContext populator.MappingContext) error {
+	p.log.Info("unmapping volume from group", "volume", targetLUN.Name, "group", initiatorGroup)
+
 	if targetLUN.IQN == "" {
 		return fmt.Errorf("target LUN IQN is required")
 	}
@@ -295,7 +311,6 @@ func (p *PowerstoreClonner) UnMap(initiatorGroup string, targetLUN populator.LUN
 		return fmt.Errorf("mapping context is required")
 	}
 
-	klog.Infof("unmapping volume %s from initiator-group %s", targetLUN.Name, initiatorGroup)
 	hostName := initiatorGroup
 	if initiatorGroup == mappingContext[esxLogicalHostNameKey] {
 		hostName = mappingContext[esxRealHostNameKey].(string)
@@ -307,16 +322,19 @@ func (p *PowerstoreClonner) UnMap(initiatorGroup string, targetLUN populator.LUN
 	detachParams := &gopowerstore.HostVolumeDetach{
 		VolumeID: &targetLUN.IQN,
 	}
+	p.log.V(2).Info("detaching volume from host", "volume_id", targetLUN.IQN, "host_id", hostID)
 	_, err := p.Client.DetachVolumeFromHost(ctx, hostID, detachParams)
 	if err != nil {
 		return fmt.Errorf("failed to detach volume %s from initiator group %s: %w", targetLUN.Name, hostID, err)
 	}
 
-	klog.Infof("Successfully unmapped volume %s from initiator group %s", targetLUN.Name, hostName)
+	p.log.Info("volume unmapped successfully", "volume", targetLUN.Name, "host", hostName)
 	return nil
 }
 
 func NewPowerstoreClonner(hostname, username, password string, sslSkipVerify bool) (PowerstoreClonner, error) {
+	log := logutil.NewLogger("powerstore")
+
 	if hostname == "" {
 		return PowerstoreClonner{}, fmt.Errorf("hostname is required")
 	}
@@ -327,6 +345,7 @@ func NewPowerstoreClonner(hostname, username, password string, sslSkipVerify boo
 		return PowerstoreClonner{}, fmt.Errorf("password is required")
 	}
 
+	log.V(2).Info("creating PowerStore client", "hostname", hostname)
 	clientOptions := gopowerstore.NewClientOptions()
 	clientOptions.SetInsecure(sslSkipVerify)
 
@@ -345,22 +364,26 @@ func NewPowerstoreClonner(hostname, username, password string, sslSkipVerify boo
 		return PowerstoreClonner{}, fmt.Errorf("failed to authenticate with PowerStore backend %s: %w", hostname, err)
 	}
 
+	log.V(2).Info("authenticated to PowerStore backend", "hostname", hostname)
+
 	clonner := PowerstoreClonner{
 		Client: client,
 		arrayInfo: populator.StorageArrayInfo{
 			Vendor:  "Dell",
 			Product: "PowerStore",
 		},
+		log: log,
 	}
 
 	// Fetch software version from the API
 	sw, err := client.GetSoftwareInstalled(ctx)
 	if err != nil {
-		klog.Warningf("Failed to get PowerStore software version for metrics: %v", err)
+		log.Info("failed to get PowerStore software version for metrics", "err", err)
 	} else {
 		for _, s := range sw {
 			if s.IsCluster {
 				clonner.arrayInfo.Version = s.ReleaseVersion
+				log.V(2).Info("PowerStore array info", "vendor", clonner.arrayInfo.Vendor, "product", clonner.arrayInfo.Product, "version", clonner.arrayInfo.Version)
 				break
 			}
 		}

--- a/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner.go
+++ b/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner.go
@@ -7,7 +7,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 )
@@ -32,7 +32,7 @@ func (c *Primera3ParClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
 }
 
 func NewPrimera3ParClonner(storageHostname, storageUsername, storagePassword string, sslSkipVerify bool) (Primera3ParClonner, error) {
-	log := logutil.NewLogger("primera3par")
+	log := logger.New("primera3par")
 	clon := NewPrimera3ParClientWsImpl(storageHostname, storageUsername, storagePassword, sslSkipVerify)
 	clonner := Primera3ParClonner{
 		client: &clon,

--- a/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner.go
+++ b/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 )
@@ -22,6 +23,7 @@ type Primera3ParClonner struct {
 	client         Primera3ParClient
 	initiatorGroup string
 	arrayInfo      populator.StorageArrayInfo
+	log            klog.Logger
 }
 
 // GetStorageArrayInfo returns metadata about the Primera/3PAR array for metric labels.
@@ -30,6 +32,7 @@ func (c *Primera3ParClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
 }
 
 func NewPrimera3ParClonner(storageHostname, storageUsername, storagePassword string, sslSkipVerify bool) (Primera3ParClonner, error) {
+	log := logutil.NewLogger("primera3par")
 	clon := NewPrimera3ParClientWsImpl(storageHostname, storageUsername, storagePassword, sslSkipVerify)
 	clonner := Primera3ParClonner{
 		client: &clon,
@@ -37,15 +40,17 @@ func NewPrimera3ParClonner(storageHostname, storageUsername, storagePassword str
 			Vendor:  "HPE",
 			Product: "Primera/3PAR",
 		},
+		log: log,
 	}
 
 	// Fetch model and version from the API
 	sysInfo, err := clon.GetSystemInfo()
 	if err != nil {
-		klog.Warningf("Failed to get Primera/3PAR system info for metrics: %v", err)
+		log.Info("failed to get Primera/3PAR system info for metrics", "err", err)
 	} else {
 		clonner.arrayInfo.Model = sysInfo.Model
 		clonner.arrayInfo.Version = sysInfo.SystemVersion
+		log.V(2).Info("Primera/3PAR array info", "vendor", clonner.arrayInfo.Vendor, "product", clonner.arrayInfo.Product, "model", clonner.arrayInfo.Model, "version", clonner.arrayInfo.Version)
 	}
 
 	return clonner, nil
@@ -53,6 +58,8 @@ func NewPrimera3ParClonner(storageHostname, storageUsername, storagePassword str
 
 // EnsureClonnerIgroup creates or update an initiator group with the clonnerIqn
 func (c *Primera3ParClonner) EnsureClonnerIgroup(initiatorGroup string, adapterIds []string) (populator.MappingContext, error) {
+	c.log.Info("ensuring initiator group", "group", initiatorGroup, "adapters", adapterIds)
+
 	c.initiatorGroup = initiatorGroup
 	hostNames, err := c.client.EnsureHostsWithIds(adapterIds)
 	if err != nil {
@@ -65,12 +72,13 @@ func (c *Primera3ParClonner) EnsureClonnerIgroup(initiatorGroup string, adapterI
 	}
 
 	for _, hostName := range hostNames {
-		klog.Infof("adding host %s, to initiatorGroup: %s", hostName, initiatorGroup)
+		c.log.V(2).Info("adding host to host set", "host", hostName, "group", initiatorGroup)
 		err = c.client.AddHostToHostSet(initiatorGroup, hostName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to add host to host set: %w", err)
 		}
 	}
+	c.log.Info("initiator group ready", "group", initiatorGroup)
 	return nil, nil
 }
 
@@ -88,35 +96,51 @@ func (c *Primera3ParClonner) UnmapTarget(targetLUN populator.LUN, mappingContext
 
 // Map is responsible to mapping an initiator group to a LUN
 func (c *Primera3ParClonner) Map(initiatorGroup string, targetLUN populator.LUN, mappingContext populator.MappingContext) (populator.LUN, error) {
-	return c.client.EnsureLunMapped(initiatorGroup, targetLUN)
+	c.log.Info("mapping volume to group", "volume", targetLUN.Name, "group", initiatorGroup)
+	lun, err := c.client.EnsureLunMapped(initiatorGroup, targetLUN)
+	if err != nil {
+		return populator.LUN{}, err
+	}
+	c.log.Info("volume mapped successfully", "volume", lun.Name, "group", initiatorGroup)
+	return lun, nil
 }
 
 // UnMap is responsible to unmapping an initiator group from a LUN
 func (c *Primera3ParClonner) UnMap(initiatorGroup string, targetLUN populator.LUN, mappingContext populator.MappingContext) error {
-	return c.client.LunUnmap(context.TODO(), initiatorGroup, targetLUN.Name)
+	c.log.Info("unmapping volume from group", "volume", targetLUN.Name, "group", initiatorGroup)
+	err := c.client.LunUnmap(context.TODO(), initiatorGroup, targetLUN.Name)
+	if err != nil {
+		return err
+	}
+	c.log.Info("volume unmapped successfully", "volume", targetLUN.Name, "group", initiatorGroup)
+	return nil
 }
 
 // Return initiatorGroups the LUN is mapped to
 func (p *Primera3ParClonner) CurrentMappedGroups(targetLUN populator.LUN, mappingContext populator.MappingContext) ([]string, error) {
+	p.log.V(2).Info("querying current mapped groups", "volume", targetLUN.Name)
 	res, err := p.client.CurrentMappedGroups(targetLUN.Name, nil)
 	if err != nil {
 		return []string{}, fmt.Errorf("failed to get current mapped groups: %w", err)
 	}
+	p.log.V(2).Info("found mapped groups", "volume", targetLUN.Name, "groups", res)
 	return res, nil
 }
 
 func (c *Primera3ParClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {
+	c.log.Info("resolving PV to LUN", "pv", pv.Name, "volume_handle", pv.VolumeHandle)
 	lun := populator.LUN{VolumeHandle: pv.VolumeHandle}
 	lun, err := c.client.GetLunDetailsByVolumeName(pv.VolumeHandle, lun)
 	if err != nil {
 		return populator.LUN{}, err
 	}
+	c.log.Info("LUN resolved", "lun", lun.Name, "naa", lun.NAA)
 	return lun, nil
 }
 
 // VvolCopy performs a direct copy operation using vSphere API to discover source volume
 func (c *Primera3ParClonner) VvolCopy(vsphereClient vmware.Client, vmId string, sourceVMDKFile string, persistentVolume populator.PersistentVolume, progress chan<- uint64) error {
-	klog.Infof("Starting VVol copy operation for VM %s", vmId)
+	c.log.Info("VVol copy started", "vm", vmId, "source", sourceVMDKFile)
 
 	backing, err := vsphereClient.GetVMDiskBacking(context.Background(), vmId, sourceVMDKFile)
 	if err != nil {
@@ -127,19 +151,20 @@ func (c *Primera3ParClonner) VvolCopy(vsphereClient vmware.Client, vmId string, 
 		return fmt.Errorf("disk %s is not a VVol disk", sourceVMDKFile)
 	}
 
-	klog.Infof("Found VVol backing with ID %s", backing.VVolId)
+	c.log.Info("found VVol backing", "vvol_id", backing.VVolId)
 
 	sourceVolumeName, err := c.findVolumeByVVolID(backing.VVolId)
 	if err != nil {
 		return fmt.Errorf("failed to find source volume by VVol ID %s: %w", backing.VVolId, err)
 	}
 
+	c.log.Info("resolving target PV to LUN", "pv", persistentVolume.Name)
 	targetLUN, err := c.ResolvePVToLUN(persistentVolume)
 	if err != nil {
 		return fmt.Errorf("failed to resolve target volume: %w", err)
 	}
 
-	klog.Infof("Copying from source volume %s to target volume %s", sourceVolumeName, targetLUN.Name)
+	c.log.Info("copying volume", "source", sourceVolumeName, "target", targetLUN.Name)
 
 	progress <- 10
 
@@ -149,7 +174,7 @@ func (c *Primera3ParClonner) VvolCopy(vsphereClient vmware.Client, vmId string, 
 	}
 
 	progress <- 100
-	klog.Infof("VVol copy operation completed successfully")
+	c.log.Info("VVol copy completed successfully")
 	return nil
 }
 
@@ -160,12 +185,15 @@ func (c *Primera3ParClonner) findVolumeByVVolID(vvolID string) (string, error) {
 	}
 
 	searchID := strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(vvolID, "rfc4122.")), "-", "")
+	c.log.V(2).Info("searching for volume by VVol ID", "vvol_id", vvolID, "search_id", searchID)
 
 	for _, v := range volumes {
 		if strings.Contains(strings.ToLower(v.Name), searchID) {
+			c.log.Info("found volume by name match", "volume", v.Name, "vvol_id", vvolID)
 			return v.Name, nil
 		}
 		if strings.ToLower(v.WWN) == searchID {
+			c.log.Info("found volume by WWN match", "volume", v.Name, "wwn", v.WWN, "vvol_id", vvolID)
 			return v.Name, nil
 		}
 	}
@@ -174,7 +202,7 @@ func (c *Primera3ParClonner) findVolumeByVVolID(vvolID string) (string, error) {
 }
 
 func (c *Primera3ParClonner) RDMCopy(vsphereClient vmware.Client, vmId string, sourceVMDKFile string, persistentVolume populator.PersistentVolume, progress chan<- uint64) error {
-	klog.Infof("3PAR RDM Copy: Starting RDM copy operation for VM %s", vmId)
+	c.log.Info("RDM copy started", "vm", vmId)
 
 	backing, err := vsphereClient.GetVMDiskBacking(context.Background(), vmId, sourceVMDKFile)
 	if err != nil {
@@ -185,19 +213,20 @@ func (c *Primera3ParClonner) RDMCopy(vsphereClient vmware.Client, vmId string, s
 		return fmt.Errorf("disk %s is not an RDM disk", sourceVMDKFile)
 	}
 
-	klog.Infof("3PAR RDM Copy: Found RDM device: %s", backing.DeviceName)
+	c.log.Info("found RDM device", "device", backing.DeviceName)
 
 	sourceLUN, err := c.resolveRDMToLUN(backing.DeviceName)
 	if err != nil {
 		return fmt.Errorf("failed to resolve RDM device to source LUN: %w", err)
 	}
 
+	c.log.Info("resolving target PV to LUN", "pv", persistentVolume.Name)
 	targetLUN, err := c.ResolvePVToLUN(persistentVolume)
 	if err != nil {
 		return fmt.Errorf("failed to resolve target volume: %w", err)
 	}
 
-	klog.Infof("3PAR RDM Copy: Copying from source LUN %s to target LUN %s", sourceLUN.Name, targetLUN.Name)
+	c.log.Info("copying volume", "source", sourceLUN.Name, "target", targetLUN.Name)
 
 	progress <- 10
 
@@ -208,16 +237,16 @@ func (c *Primera3ParClonner) RDMCopy(vsphereClient vmware.Client, vmId string, s
 
 	progress <- 100
 
-	klog.Infof("3PAR RDM Copy: Copy operation completed successfully")
+	c.log.Info("RDM copy completed successfully")
 	return nil
 }
 
 func (c *Primera3ParClonner) resolveRDMToLUN(deviceName string) (populator.LUN, error) {
-	klog.Infof("3PAR RDM Copy: Resolving RDM device %s to LUN", deviceName)
+	c.log.V(2).Info("resolving RDM device to LUN", "device", deviceName)
 
 	serial, err := extractSerialFromNAA(deviceName)
 	if err != nil {
-		klog.Warningf("Could not extract serial from NAA %s: %v, trying to find by listing volumes", deviceName, err)
+		c.log.Info("could not extract serial from NAA, trying to find by listing volumes", "device", deviceName, "err", err)
 		return c.findVolumeByDeviceName(deviceName)
 	}
 
@@ -226,13 +255,16 @@ func (c *Primera3ParClonner) resolveRDMToLUN(deviceName string) (populator.LUN, 
 		return populator.LUN{}, fmt.Errorf("failed to get volumes: %w", err)
 	}
 
+	c.log.V(2).Info("searching for volume by serial", "serial", serial)
 	for _, v := range volumes {
 		if strings.ToLower(v.WWN) == strings.ToLower(serial) {
-			return populator.LUN{
+			lun := populator.LUN{
 				Name:         v.Name,
 				SerialNumber: v.WWN,
 				NAA:          fmt.Sprintf("naa.%s%s", PROVIDER_ID, strings.ToLower(v.WWN)),
-			}, nil
+			}
+			c.log.Info("resolved source LUN", "lun", lun.Name, "serial", lun.SerialNumber, "naa", lun.NAA)
+			return lun, nil
 		}
 	}
 
@@ -263,6 +295,7 @@ func (c *Primera3ParClonner) findVolumeByDeviceName(deviceName string) (populato
 	}
 
 	deviceName = strings.ToLower(deviceName)
+	c.log.V(2).Info("searching for volume by device name", "device", deviceName)
 
 	for _, volume := range volumes {
 		naa := fmt.Sprintf("naa.%s%s", PROVIDER_ID, strings.ToLower(volume.WWN))
@@ -270,7 +303,7 @@ func (c *Primera3ParClonner) findVolumeByDeviceName(deviceName string) (populato
 		if strings.Contains(deviceName, strings.ToLower(volume.WWN)) ||
 			strings.Contains(deviceName, naa) ||
 			deviceName == naa {
-			klog.Infof("3PAR RDM Copy: Found matching volume %s for device %s", volume.Name, deviceName)
+			c.log.Info("found matching volume", "volume", volume.Name, "device", deviceName)
 			return populator.LUN{
 				Name:         volume.Name,
 				SerialNumber: volume.WWN,

--- a/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner_test.go
@@ -3,6 +3,7 @@ package primera3par
 import (
 	"testing"
 
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/stretchr/testify/assert"
 )
@@ -73,7 +74,7 @@ func clonnerWithVolumes(volumes []Volume) *Primera3ParClonner {
 			SerialNumber: v.WWN,
 		}
 	}
-	return &Primera3ParClonner{client: mock}
+	return &Primera3ParClonner{client: mock, log: logutil.NewLogger("primera3par")}
 }
 
 func TestFindVolumeByVVolID(t *testing.T) {

--- a/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/primera3par/clonner_test.go
@@ -3,7 +3,7 @@ package primera3par
 import (
 	"testing"
 
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/stretchr/testify/assert"
 )
@@ -74,7 +74,7 @@ func clonnerWithVolumes(volumes []Volume) *Primera3ParClonner {
 			SerialNumber: v.WWN,
 		}
 	}
-	return &Primera3ParClonner{client: mock, log: logutil.NewLogger("primera3par")}
+	return &Primera3ParClonner{client: mock, log: logger.New("primera3par")}
 }
 
 func TestFindVolumeByVVolID(t *testing.T) {

--- a/cmd/vsphere-copy-offload-populator/internal/pure/flashArray.go
+++ b/cmd/vsphere-copy-offload-populator/internal/pure/flashArray.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	"k8s.io/klog/v2"
@@ -52,7 +52,7 @@ func NewFlashArrayClonner(hostname, username, password, apiToken string, skipSSL
 		return FlashArrayClonner{}, fmt.Errorf("failed to create REST client: %w", err)
 	}
 
-	log := logutil.NewLogger("pure")
+	log := logger.New("pure")
 	clonner := FlashArrayClonner{
 		restClient:    restClient,
 		clusterPrefix: clusterPrefix,

--- a/cmd/vsphere-copy-offload-populator/internal/pure/flashArray.go
+++ b/cmd/vsphere-copy-offload-populator/internal/pure/flashArray.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/fcutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	"k8s.io/klog/v2"
@@ -27,6 +28,7 @@ type FlashArrayClonner struct {
 	// TODO use this instead of mappingContext[hosts]
 	initiatorHostOrGroup string
 	arrayInfo            populator.StorageArrayInfo
+	log                  klog.Logger
 }
 
 const ClusterPrefixEnv = "PURE_CLUSTER_PREFIX"
@@ -50,6 +52,7 @@ func NewFlashArrayClonner(hostname, username, password, apiToken string, skipSSL
 		return FlashArrayClonner{}, fmt.Errorf("failed to create REST client: %w", err)
 	}
 
+	log := logutil.NewLogger("pure")
 	clonner := FlashArrayClonner{
 		restClient:    restClient,
 		clusterPrefix: clusterPrefix,
@@ -57,15 +60,17 @@ func NewFlashArrayClonner(hostname, username, password, apiToken string, skipSSL
 			Vendor:  "Pure Storage",
 			Product: "FlashArray",
 		},
+		log: log,
 	}
 
 	// Fetch model and version from the API
 	info, err := restClient.GetArrayInfo()
 	if err != nil {
-		klog.Warningf("Failed to get Pure FlashArray info for metrics: %v", err)
+		log.Info("failed to get Pure FlashArray info for metrics", "err", err)
 	} else {
 		clonner.arrayInfo.Model = info.Model
 		clonner.arrayInfo.Version = info.Version
+		log.V(2).Info("Pure FlashArray info", "vendor", clonner.arrayInfo.Vendor, "product", clonner.arrayInfo.Product, "model", clonner.arrayInfo.Model, "version", clonner.arrayInfo.Version)
 	}
 
 	return clonner, nil
@@ -79,6 +84,8 @@ func (f *FlashArrayClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
 // EnsureClonnerIgroup creates or updates an initiator group with the ESX adapters
 // Named hgroup in flash terminology
 func (f *FlashArrayClonner) EnsureClonnerIgroup(initiatorGroup string, esxAdapters []string) (populator.MappingContext, error) {
+	f.log.Info("ensuring initiator group", "group", initiatorGroup, "adapters", esxAdapters)
+
 	// pure does not allow a single host to connect to 2 separae groups. Hence
 	// we must connect map the volume to the host, and not to the group
 	hosts, err := f.restClient.ListHosts()
@@ -86,7 +93,7 @@ func (f *FlashArrayClonner) EnsureClonnerIgroup(initiatorGroup string, esxAdapte
 		return nil, err
 	}
 	for _, h := range hosts {
-		klog.Infof("checking host %s, iqns: %v, wwns: %v", h.Name, h.Iqn, h.Wwn)
+		f.log.V(2).Info("checking host", "host", h.Name, "iqns", h.Iqn, "wwns", h.Wwn)
 		for _, wwn := range h.Wwn {
 			for _, hostAdapter := range esxAdapters {
 				if !strings.HasPrefix(hostAdapter, "fc.") {
@@ -94,21 +101,23 @@ func (f *FlashArrayClonner) EnsureClonnerIgroup(initiatorGroup string, esxAdapte
 				}
 				adapterWWPN, err := fcUIDToWWPN(hostAdapter)
 				if err != nil {
-					klog.Warningf("failed to extract WWPN from adapter %s: %s", hostAdapter, err)
+					f.log.Info("failed to extract WWPN from adapter", "adapter", hostAdapter, "err", err)
 					continue
 				}
 
 				// Compare WWNs using the utility function that normalizes formatting
-				klog.Infof("comparing ESX adapter WWPN %s with Pure host WWN %s", adapterWWPN, wwn)
+				f.log.V(2).Info("comparing WWNs", "adapter_wwpn", adapterWWPN, "host_wwn", wwn)
 				if fcutil.CompareWWNs(adapterWWPN, wwn) {
-					klog.Infof("match found. Adding host %s to mapping context.", h.Name)
+					f.log.Info("found matching host", "host", h.Name)
+					f.log.Info("initiator group ready", "group", initiatorGroup, "host", h.Name)
 					return populator.MappingContext{"hosts": []string{h.Name}}, nil
 				}
 			}
 		}
 		for _, iqn := range h.Iqn {
 			if slices.Contains(esxAdapters, iqn) {
-				klog.Infof("adding host to group %v", h.Name)
+				f.log.Info("found matching host by IQN", "host", h.Name, "iqn", iqn)
+				f.log.Info("initiator group ready", "group", initiatorGroup, "host", h.Name)
 				return populator.MappingContext{"hosts": []string{h.Name}}, nil
 			}
 		}
@@ -122,6 +131,7 @@ func (f *FlashArrayClonner) Map(
 	initatorGroup string,
 	targetLUN populator.LUN,
 	context populator.MappingContext) (populator.LUN, error) {
+
 	hosts, ok := context["hosts"]
 	if !ok {
 		return populator.LUN{}, fmt.Errorf("hosts not found in context")
@@ -131,15 +141,17 @@ func (f *FlashArrayClonner) Map(
 		return populator.LUN{}, errors.New("invalid or empty hosts list in mapping context")
 	}
 	for _, host := range hs {
-		klog.Infof("connecting host %s to volume %s", host, targetLUN.Name)
+		f.log.Info("mapping volume to host", "volume", targetLUN.Name, "host", host)
 		err := f.restClient.ConnectHost(host, targetLUN.Name)
 		if err != nil {
 			if strings.Contains(err.Error(), "Connection already exists.") {
+				f.log.V(2).Info("volume already mapped to host", "volume", targetLUN.Name, "host", host)
 				continue
 			}
 			return populator.LUN{}, fmt.Errorf("connect host %q to volume %q: %w", host, targetLUN.Name, err)
 		}
 
+		f.log.Info("volume mapped successfully", "volume", targetLUN.Name, "host", host)
 		return targetLUN, nil
 	}
 	return populator.LUN{}, fmt.Errorf("connection failed for all hosts in context")
@@ -161,12 +173,12 @@ func (f *FlashArrayClonner) UnMap(initatorGroup string, targetLUN populator.LUN,
 		hs, ok := hosts.([]string)
 		if ok && len(hs) > 0 {
 			for _, host := range hs {
-				klog.Infof("disconnecting host %s from volume %s", host, targetLUN.Name)
+				f.log.Info("unmapping volume from host", "volume", targetLUN.Name, "host", host)
 				err := f.restClient.DisconnectHost(host, targetLUN.Name)
 				if err != nil {
 					return err
 				}
-
+				f.log.Info("volume unmapped successfully", "volume", targetLUN.Name, "host", host)
 			}
 		}
 	}
@@ -175,6 +187,7 @@ func (f *FlashArrayClonner) UnMap(initatorGroup string, targetLUN populator.LUN,
 
 // CurrentMappedGroups returns the initiator groups the populator.LUN is mapped to
 func (f *FlashArrayClonner) CurrentMappedGroups(targetLUN populator.LUN, context populator.MappingContext) ([]string, error) {
+	f.log.V(2).Info("querying current mapped groups", "volume", targetLUN.Name)
 	// we don't use the host group feature, as a host in pure flasharray can not belong to two separate groups, and we
 	// definitely don't want to break host from their current groups. insted we'll just map/unmap the volume to individual hosts
 	return nil, nil
@@ -182,11 +195,13 @@ func (f *FlashArrayClonner) CurrentMappedGroups(targetLUN populator.LUN, context
 
 // ResolvePVToLUN resolves a PersistentVolume to Pure FlashArray LUN details
 func (f *FlashArrayClonner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {
+	f.log.Info("resolving PV to LUN", "pv", pv.Name, "volume_handle", pv.VolumeHandle)
+
 	pvVolumeHandle := pv.VolumeHandle
 	v, err := f.restClient.GetVolumeById(pvVolumeHandle)
 	if err != nil {
 		if strings.Contains(err.Error(), "Volume does not exist.") {
-			klog.Errorf("Volume with handle %s does not exist: %v. Trying with Volume Name", pvVolumeHandle, err)
+			f.log.Info("volume not found by handle, trying by name", "volume_handle", pvVolumeHandle, "err", err)
 			volumeName := fmt.Sprintf("%s-%s", f.clusterPrefix, pv.Name)
 			v, err = f.restClient.GetVolume(volumeName)
 			if err != nil {
@@ -195,8 +210,9 @@ func (f *FlashArrayClonner) ResolvePVToLUN(pv populator.PersistentVolume) (popul
 		}
 	}
 
-	klog.Infof("volume %+v\n", v)
+	f.log.V(2).Info("volume details", "volume", v)
 	l := populator.LUN{Name: v.Name, SerialNumber: v.Serial, NAA: fmt.Sprintf("naa.%s%s", FlashProviderID, strings.ToLower(v.Serial))}
+	f.log.Info("LUN resolved", "lun", l.Name, "naa", l.NAA, "serial", l.SerialNumber)
 
 	return l, nil
 }
@@ -210,7 +226,7 @@ func fcUIDToWWPN(fcUid string) (string, error) {
 
 // VvolCopy performs a direct copy operation using vSphere API to discover source volume
 func (f *FlashArrayClonner) VvolCopy(vsphereClient vmware.Client, vmId string, sourceVMDKFile string, persistentVolume populator.PersistentVolume, progress chan<- uint64) error {
-	klog.Infof("Starting VVol copy operation for VM %s", vmId)
+	f.log.Info("VVol copy started", "vm", vmId, "source", sourceVMDKFile)
 
 	backing, err := vsphereClient.GetVMDiskBacking(context.Background(), vmId, sourceVMDKFile)
 	if err != nil {
@@ -221,34 +237,34 @@ func (f *FlashArrayClonner) VvolCopy(vsphereClient vmware.Client, vmId string, s
 		return fmt.Errorf("disk %s is not a VVol disk", sourceVMDKFile)
 	}
 
-	klog.Infof("Found VVol backing with ID %s", backing.VVolId)
+	f.log.Info("found VVol backing", "vvol_id", backing.VVolId)
 
 	sourceVolume, err := f.restClient.FindVolumeByVVolID(backing.VVolId)
 	if err != nil {
 		return fmt.Errorf("failed to find source volume by VVol ID %s: %w", backing.VVolId, err)
 	}
 
+	f.log.Info("resolving target PV to LUN", "pv", persistentVolume.Name)
 	targetLUN, err := f.ResolvePVToLUN(persistentVolume)
 	if err != nil {
 		return fmt.Errorf("failed to resolve target volume: %w", err)
 	}
 
-	klog.Infof("Copying from source volume %s to target volume %s", sourceVolume, targetLUN.Name)
+	f.log.Info("copying volume", "source", sourceVolume, "target", targetLUN.Name)
 
 	err = f.performVolumeCopy(sourceVolume, targetLUN.Name, progress)
 	if err != nil {
 		return fmt.Errorf("copy operation failed: %w", err)
 	}
 
-	klog.Infof("VVol copy operation completed successfully")
+	f.log.Info("VVol copy completed successfully")
 	return nil
 }
 
 // RDMCopy performs a copy operation for RDM-backed disks using Pure FlashArray APIs
 func (f *FlashArrayClonner) RDMCopy(vsphereClient vmware.Client, vmId string, sourceVMDKFile string, persistentVolume populator.PersistentVolume, progress chan<- uint64) error {
-	klog.Infof("Pure RDM Copy: Starting RDM copy operation for VM %s", vmId)
+	f.log.Info("RDM copy started", "vm", vmId)
 
-	// Get disk backing info to find the RDM device
 	backing, err := vsphereClient.GetVMDiskBacking(context.Background(), vmId, sourceVMDKFile)
 	if err != nil {
 		return fmt.Errorf("failed to get RDM disk backing info: %w", err)
@@ -258,66 +274,58 @@ func (f *FlashArrayClonner) RDMCopy(vsphereClient vmware.Client, vmId string, so
 		return fmt.Errorf("disk %s is not an RDM disk", sourceVMDKFile)
 	}
 
-	klog.Infof("Pure RDM Copy: Found RDM device: %s", backing.DeviceName)
+	f.log.Info("found RDM device", "device", backing.DeviceName)
 
-	// Resolve the source LUN from the RDM device name
 	sourceLUN, err := f.resolveRDMToLUN(backing.DeviceName)
 	if err != nil {
 		return fmt.Errorf("failed to resolve RDM device to source LUN: %w", err)
 	}
 
-	// Resolve the target PV to LUN
+	f.log.Info("resolving target PV to LUN", "pv", persistentVolume.Name)
 	targetLUN, err := f.ResolvePVToLUN(persistentVolume)
 	if err != nil {
 		return fmt.Errorf("failed to resolve target volume: %w", err)
 	}
 
-	klog.Infof("Pure RDM Copy: Copying from source LUN %s to target LUN %s", sourceLUN.Name, targetLUN.Name)
+	f.log.Info("copying volume", "source", sourceLUN.Name, "target", targetLUN.Name)
 
-	// Report progress start
 	progress <- 10
 
-	// Perform the copy operation using Pure FlashArray API
 	err = f.restClient.CopyVolume(sourceLUN.Name, targetLUN.Name)
 	if err != nil {
 		return fmt.Errorf("Pure FlashArray CopyVolume failed: %w", err)
 	}
 
-	// Report progress complete
 	progress <- 100
 
-	klog.Infof("Pure RDM Copy: Copy operation completed successfully")
+	f.log.Info("RDM copy completed successfully")
 	return nil
 }
 
 // resolveRDMToLUN resolves an RDM device name to a Pure FlashArray LUN
 func (f *FlashArrayClonner) resolveRDMToLUN(deviceName string) (populator.LUN, error) {
-	klog.Infof("Pure RDM Copy: Resolving RDM device %s to LUN", deviceName)
+	f.log.V(2).Info("resolving RDM device to LUN", "device", deviceName)
 
-	// The device name from RDM typically contains the NAA identifier
-	// For Pure FlashArray, format is "naa.624a9370<serial>" where 624a9370 is the FlashProviderID
-	// We need to extract the serial number and find the corresponding LUN
-
-	// Extract serial number from NAA identifier
 	serial, err := extractSerialFromNAA(deviceName)
 	if err != nil {
-		// Try to find by listing all volumes and matching
-		klog.Warningf("Could not extract serial from NAA %s: %v, trying to find by listing volumes", deviceName, err)
+		f.log.Info("could not extract serial from NAA, trying to find by listing volumes", "device", deviceName, "err", err)
 		return f.findVolumeByDeviceName(deviceName)
 	}
 
 	// Find volume by serial number
+	f.log.V(2).Info("finding volume by serial", "serial", serial)
 	volume, err := f.restClient.FindVolumeBySerial(serial)
 	if err != nil {
 		return populator.LUN{}, fmt.Errorf("failed to find volume by serial %s: %w", serial, err)
 	}
 
-	klog.Infof("Pure RDM Copy: Found matching volume %s for device %s", volume.Name, deviceName)
-	return populator.LUN{
+	lun := populator.LUN{
 		Name:         volume.Name,
 		SerialNumber: volume.Serial,
 		NAA:          fmt.Sprintf("naa.%s%s", FlashProviderID, strings.ToLower(volume.Serial)),
-	}, nil
+	}
+	f.log.Info("resolved source LUN", "lun", lun.Name, "serial", lun.SerialNumber, "naa", lun.NAA)
+	return lun, nil
 }
 
 // extractSerialFromNAA extracts the serial number from a NAA identifier
@@ -345,13 +353,13 @@ func extractSerialFromNAA(naa string) (string, error) {
 
 // findVolumeByDeviceName finds a volume by searching through all volumes
 func (f *FlashArrayClonner) findVolumeByDeviceName(deviceName string) (populator.LUN, error) {
-	// List all volumes and find the one matching the device name
 	volumes, err := f.restClient.ListVolumes()
 	if err != nil {
 		return populator.LUN{}, fmt.Errorf("failed to list volumes: %w", err)
 	}
 
 	deviceName = strings.ToLower(deviceName)
+	f.log.V(2).Info("searching for volume by device name", "device", deviceName)
 
 	for _, volume := range volumes {
 		// Build the expected NAA for this volume
@@ -361,7 +369,7 @@ func (f *FlashArrayClonner) findVolumeByDeviceName(deviceName string) (populator
 		if strings.Contains(deviceName, strings.ToLower(volume.Serial)) ||
 			strings.Contains(deviceName, naa) ||
 			deviceName == naa {
-			klog.Infof("Pure RDM Copy: Found matching volume %s for device %s", volume.Name, deviceName)
+			f.log.Info("found matching volume", "volume", volume.Name, "device", deviceName)
 			return populator.LUN{
 				Name:         volume.Name,
 				SerialNumber: volume.Serial,
@@ -375,6 +383,7 @@ func (f *FlashArrayClonner) findVolumeByDeviceName(deviceName string) (populator
 
 // performVolumeCopy executes the volume copy operation on Pure FlashArray
 func (f *FlashArrayClonner) performVolumeCopy(sourceVolumeName, targetVolumeName string, progress chan<- uint64) error {
+	f.log.V(2).Info("performing FlashArray copy", "source", sourceVolumeName, "target", targetVolumeName)
 	// Perform the copy operation using Pure FlashArray API
 	err := f.restClient.CopyVolume(sourceVolumeName, targetVolumeName)
 	if err != nil {

--- a/cmd/vsphere-copy-offload-populator/internal/vantara/vantara.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vantara/vantara.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	"k8s.io/klog/v2"
@@ -63,7 +63,7 @@ func NewVantaraClonner(hostname, username, password string) (VantaraCloner, erro
 		return VantaraCloner{}, fmt.Errorf("failed to connect to Vantara storage: %w", err)
 	}
 
-	log := logutil.NewLogger("vantara")
+	log := logger.New("vantara")
 	cloner := VantaraCloner{
 		client:          client,
 		envHostGroupIds: envStorage["hostGroupIds"].([]string),
@@ -124,7 +124,7 @@ func getStorageEnvVars() (map[string]interface{}, error) {
 		"hostGroupIds": hgids,
 		"copySpeed":    copySpeed,
 	}
-	log := logutil.NewLogger("vantara")
+	log := logger.New("vantara")
 	log.V(2).Info("storage configuration loaded",
 		"storage_id", storageEnvVars["storageId"],
 		"rest_server_ip", storageEnvVars["restServerIP"],

--- a/cmd/vsphere-copy-offload-populator/internal/vantara/vantara.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vantara/vantara.go
@@ -10,13 +10,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	"k8s.io/klog/v2"
 )
 
-const VantaraProviderID = "60060e80" // Vantara's NAA prefix
-const LengthNAAID = 32
+const (
+	VantaraProviderID = "60060e80" // Vantara's NAA prefix
+	LengthNAAID       = 32
+)
 
 type VantaraCloner struct {
 	client          VantaraClient
@@ -24,6 +27,7 @@ type VantaraCloner struct {
 	initiatorGroup  string
 	copySpeed       string
 	arrayInfo       populator.StorageArrayInfo
+	log             klog.Logger
 }
 
 // Ensure VantaraCloner implements StorageArrayInfoProvider
@@ -59,6 +63,7 @@ func NewVantaraClonner(hostname, username, password string) (VantaraCloner, erro
 		return VantaraCloner{}, fmt.Errorf("failed to connect to Vantara storage: %w", err)
 	}
 
+	log := logutil.NewLogger("vantara")
 	cloner := VantaraCloner{
 		client:          client,
 		envHostGroupIds: envStorage["hostGroupIds"].([]string),
@@ -67,15 +72,17 @@ func NewVantaraClonner(hostname, username, password string) (VantaraCloner, erro
 			Vendor:  "Hitachi",
 			Product: "Vantara",
 		},
+		log: log,
 	}
 
 	// Fetch model and version from the API
 	storageInfo, err := client.GetStorageInfo()
 	if err != nil {
-		klog.Warningf("Failed to get Vantara storage info for metrics: %v", err)
+		log.Info("failed to get Vantara storage info for metrics", "err", err)
 	} else {
 		cloner.arrayInfo.Model = storageInfo.Model
 		cloner.arrayInfo.Version = storageInfo.DkcMicroVersion
+		log.V(2).Info("Vantara array info", "vendor", cloner.arrayInfo.Vendor, "product", cloner.arrayInfo.Product, "model", cloner.arrayInfo.Model, "version", cloner.arrayInfo.Version)
 	}
 
 	return cloner, nil
@@ -117,38 +124,42 @@ func getStorageEnvVars() (map[string]interface{}, error) {
 		"hostGroupIds": hgids,
 		"copySpeed":    copySpeed,
 	}
-	klog.Info(
-		"storageId: ", storageEnvVars["storageId"],
-		"restServerIP: ", storageEnvVars["restServerIP"],
-		"port: ", storageEnvVars["port"],
-		"userID: ", "",
-		"password: ", "",
-		"hostGroupID: ", storageEnvVars["hostGroupIds"],
-		"copySpeed: ", storageEnvVars["copySpeed"],
+	log := logutil.NewLogger("vantara")
+	log.V(2).Info("storage configuration loaded",
+		"storage_id", storageEnvVars["storageId"],
+		"rest_server_ip", storageEnvVars["restServerIP"],
+		"port", storageEnvVars["port"],
+		"host_group_ids", storageEnvVars["hostGroupIds"],
+		"copy_speed", storageEnvVars["copySpeed"],
 	)
 	return storageEnvVars, nil
 }
 
 func (v *VantaraCloner) CurrentMappedGroups(lun populator.LUN, context populator.MappingContext) ([]string, error) {
+	v.log.V(2).Info("querying current mapped groups", "ldev_id", lun.LDeviceID)
+
 	ldevResp, err := v.client.GetLdev(lun.LDeviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get LDEV: %w", err)
 	}
 
-	klog.Infof("LDEV: %+v", ldevResp)
+	v.log.V(2).Info("LDEV response", "ldev", ldevResp)
 
 	hgids := make([]string, 0, len(ldevResp.Ports))
 	for _, port := range ldevResp.Ports {
 		hostGroupNumber := fmt.Sprintf("%d", int(port.HostGroupNumber))
 		hgid := fmt.Sprintf("%s,%s", port.PortId, hostGroupNumber)
 		hgids = append(hgids, hgid)
-		klog.V(2).Infof("Found mapping: portID=%s, hostGroupNumber=%s", port.PortId, hostGroupNumber)
+		v.log.V(2).Info("found mapping", "port_id", port.PortId, "host_group_number", hostGroupNumber)
 	}
 
+	v.log.V(2).Info("found mapped groups", "ldev_id", lun.LDeviceID, "host_group_ids", hgids)
 	return hgids, nil
 }
 
 func (v *VantaraCloner) ResolvePVToLUN(pv populator.PersistentVolume) (populator.LUN, error) {
+	v.log.Info("resolving PV to LUN", "pv", pv.Name, "volume_handle", pv.VolumeHandle)
+
 	parts := strings.Split(pv.VolumeHandle, "--")
 	lun := populator.LUN{}
 	if len(parts) != 5 || parts[0] != "01" {
@@ -170,31 +181,35 @@ func (v *VantaraCloner) ResolvePVToLUN(pv populator.PersistentVolume) (populator
 	//	lun.SerialNumber = ldevnaaid[6:]
 	lun.VolumeHandle = pv.VolumeHandle
 	lun.Name = ldevNickName
-	klog.Infof("Resolved LUN: %+v", lun)
+	v.log.Info("LUN resolved", "lun", lun.Name, "ldev_id", lun.LDeviceID, "protocol", lun.Protocol)
 	return lun, nil
 }
 
 func (v *VantaraCloner) GetNaaID(lun populator.LUN) populator.LUN {
 	ldevResp, err := v.client.GetLdev(lun.LDeviceID)
 	if err != nil {
-		klog.Errorf("Failed to get LDEV NAA ID: %v", err)
+		v.log.Info("failed to get LDEV NAA ID", "ldev_id", lun.LDeviceID, "err", err)
 		return lun
 	}
 	lun.ProviderID = ldevResp.NaaId[:6]
 	lun.SerialNumber = ldevResp.NaaId[6:]
 	lun.NAA = fmt.Sprintf("naa.%s", ldevResp.NaaId)
+	v.log.V(2).Info("NAA ID retrieved", "ldev_id", lun.LDeviceID, "naa", lun.NAA)
 	return lun
 }
 
 func (v *VantaraCloner) EnsureClonnerIgroup(xcopyInitiatorGroup string, hbaUIDs []string) (populator.MappingContext, error) {
+	v.log.Info("ensuring initiator group", "group", xcopyInitiatorGroup, "adapters", hbaUIDs)
+
 	v.initiatorGroup = xcopyInitiatorGroup
 	if len(v.envHostGroupIds) > 0 {
-		klog.Infof("Using host group IDs from environment: %v", v.envHostGroupIds)
+		v.log.Info("using host group IDs from environment", "host_group_ids", v.envHostGroupIds)
+		v.log.Info("initiator group ready", "group", xcopyInitiatorGroup)
 		return populator.MappingContext{"hostGroupIds": v.envHostGroupIds}, nil
 	}
 
 	// Get port details from storage
-	klog.Info("Fetching host group IDs from storage")
+	v.log.V(2).Info("fetching host group IDs from storage")
 	portDetails, err := v.client.GetPortDetails()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get port details: %w", err)
@@ -205,14 +220,14 @@ func (v *VantaraCloner) EnsureClonnerIgroup(xcopyInitiatorGroup string, hbaUIDs 
 	logins := FindHostGroupIDs(jsonData, hbaUIDs)
 
 	jsonBytes, _ := json.MarshalIndent(logins, "", "  ")
-	klog.Infof("Found logins: %s", string(jsonBytes))
+	v.log.V(2).Info("found logins", "logins", string(jsonBytes))
 
 	hostGroupIds := make([]string, len(logins))
 	for i, login := range logins {
 		hostGroupIds[i] = login.HostGroupId
 	}
 
-	klog.Infof("Host group IDs: %v", hostGroupIds)
+	v.log.Info("initiator group ready", "group", xcopyInitiatorGroup, "host_group_ids", hostGroupIds)
 	return populator.MappingContext{"hostGroupIds": hostGroupIds}, nil
 }
 
@@ -227,6 +242,7 @@ func (v *VantaraCloner) Map(xcopyInitiatorGroup string, lun populator.LUN, conte
 		portId := parts[0]
 		hostGroupNumber := parts[1]
 
+		v.log.Info("mapping volume to host group", "ldev_id", lun.LDeviceID, "port_id", portId, "host_group", hostGroupNumber)
 		if err := v.client.AddPath(lun.LDeviceID, portId, hostGroupNumber); err != nil {
 			return populator.LUN{}, fmt.Errorf("failed to add path %s: %w", hostGroupId, err)
 		}
@@ -234,6 +250,7 @@ func (v *VantaraCloner) Map(xcopyInitiatorGroup string, lun populator.LUN, conte
 
 	// Get NAA ID after mapping
 	lun = v.GetNaaID(lun)
+	v.log.Info("volume mapped successfully", "ldev_id", lun.LDeviceID, "naa", lun.NAA)
 	return lun, nil
 }
 
@@ -260,11 +277,13 @@ func (v *VantaraCloner) UnMap(xcopyInitiatorGroup string, lun populator.LUN, con
 			return fmt.Errorf("failed to get LUN ID for %s: %w", hostGroupId, err)
 		}
 
+		v.log.Info("unmapping volume from host group", "ldev_id", lun.LDeviceID, "port_id", portId, "host_group", hostGroupNumber, "lun_id", lunId)
 		if err := v.client.DeletePath(lun.LDeviceID, portId, hostGroupNumber, lunId); err != nil {
 			return fmt.Errorf("failed to delete path %s: %w", hostGroupId, err)
 		}
 	}
 
+	v.log.Info("volume unmapped successfully", "ldev_id", lun.LDeviceID)
 	return nil
 }
 
@@ -280,7 +299,7 @@ func getLunIdFromPorts(ports []PortMapping, portId string, hostGroupNumber strin
 
 // VvolCopy performs a direct copy operation using vSphere API to discover source volume
 func (v *VantaraCloner) VvolCopy(vsphereClient vmware.Client, vmId string, sourceVMDKFile string, persistentVolume populator.PersistentVolume, progress chan<- uint64) error {
-	klog.Infof("Starting VVol copy operation for VM %s", vmId)
+	v.log.Info("VVol copy started", "vm", vmId, "source", sourceVMDKFile)
 
 	backing, err := vsphereClient.GetVMDiskBacking(context.Background(), vmId, sourceVMDKFile)
 	if err != nil {
@@ -291,43 +310,45 @@ func (v *VantaraCloner) VvolCopy(vsphereClient vmware.Client, vmId string, sourc
 		return fmt.Errorf("disk %s is not a VVol disk", sourceVMDKFile)
 	}
 
-	klog.Infof("Found VVol backing with ID %s", backing.VVolId)
+	v.log.Info("found VVol backing", "vvol_id", backing.VVolId)
 
 	sourceVolumeID, err := v.findVolumeByVVolID(backing.VVolId)
 	if err != nil {
 		return fmt.Errorf("failed to find source volume by VVol ID %s: %w", backing.VVolId, err)
 	}
 
+	v.log.Info("resolving target PV to LUN", "pv", persistentVolume.Name)
 	targetLUN, err := v.ResolvePVToLUN(persistentVolume)
 	if err != nil {
 		return fmt.Errorf("failed to resolve target volume: %w", err)
 	}
 
-	klog.Infof("Copying from source volume %s to target volume %s", sourceVolumeID, targetLUN.Name)
+	v.log.Info("copying volume", "source", sourceVolumeID, "target", targetLUN.Name)
 
-	// Get target volume pool ID
 	ldevResp, err := v.client.GetLdev(targetLUN.LDeviceID)
-	klog.Infof("Target LDEV: %v", ldevResp)
+	if err != nil {
+		return fmt.Errorf("failed to get target LDEV %s: %w", targetLUN.LDeviceID, err)
+	}
+	v.log.V(2).Info("target LDEV details", "ldev", ldevResp)
 
-	// Perform the copy operation
 	err = v.performVolumeCopy(sourceVolumeID, ldevResp, progress)
 	if err != nil {
 		return fmt.Errorf("copy operation failed: %w", err)
 	}
 
-	klog.Infof("VVol copy operation completed successfully")
+	v.log.Info("VVol copy completed successfully")
 	return nil
 }
 
 // performVolumeCopy executes the volume copy operation on Vantara
 func (v *VantaraCloner) performVolumeCopy(sourceLdevId string, ldevResp *LdevResponse, progress chan<- uint64) error {
-
 	targetLdevId := fmt.Sprintf("%d", int(ldevResp.LdevId))
 	poolID := fmt.Sprintf("%d", int(ldevResp.PoolId))
 
 	// Perform the copy operation using Vantara API
 	snapshotGroupName := "mtv-ss-copy-" + sourceLdevId + "-to-" + targetLdevId
 
+	v.log.V(2).Info("creating clone LDEV", "snapshot_group", snapshotGroupName, "pool_id", poolID, "source_ldev", sourceLdevId, "target_ldev", targetLdevId)
 	err := v.client.CreateCloneLdev(snapshotGroupName, poolID, sourceLdevId, targetLdevId, v.copySpeed)
 	if err != nil {
 		return fmt.Errorf("Vantara CopyVolume failed: %w", err)
@@ -347,12 +368,12 @@ func (v *VantaraCloner) performVolumeCopy(sourceLdevId string, ldevResp *LdevRes
 		count++
 		respPairs, err := v.client.GetClonePairs(snapshotGroupName, sourceLdevId)
 		if err != nil || len(respPairs.Data) == 0 {
-			klog.Infof("Waiting... (no clone pair yet)")
+			v.log.V(2).Info("waiting for clone pair", "attempt", count, "max", maxcount)
 			continue
 		}
 		for _, cp := range respPairs.Data {
 			if cp.Status == "PSUP" {
-				klog.Infof("Clone pair created: %+v", cp)
+				v.log.V(2).Info("clone pair created", "pair", cp)
 				found = true
 				break
 			}
@@ -360,7 +381,7 @@ func (v *VantaraCloner) performVolumeCopy(sourceLdevId string, ldevResp *LdevRes
 		if found {
 			break
 		}
-		klog.Infof("Waiting for clone pair to be created...")
+		v.log.V(2).Info("waiting for clone pair to be created", "attempt", count, "max", maxcount)
 	}
 	progress <- 100
 	return nil
@@ -381,14 +402,15 @@ func (v *VantaraCloner) findVolumeByVVolID(vvolID string) (string, error) {
 	}
 
 	// Convert to decimal string and return
-	return strconv.FormatUint(value, 10), nil
+	ldevId := strconv.FormatUint(value, 10)
+	v.log.Info("found source volume by VVol ID", "vvol_id", vvolID, "ldev_id", ldevId)
+	return ldevId, nil
 }
 
 // RDMCopy performs a copy operation for RDM-backed disks using Vantara APIs
 func (v *VantaraCloner) RDMCopy(vsphereClient vmware.Client, vmId string, sourceVMDKFile string, persistentVolume populator.PersistentVolume, progress chan<- uint64) error {
-	klog.Infof("Vantara RDM Copy: Starting RDM copy operation for VM %s", vmId)
+	v.log.Info("RDM copy started", "vm", vmId)
 
-	// Get disk backing info to find the RDM device
 	backing, err := vsphereClient.GetVMDiskBacking(context.Background(), vmId, sourceVMDKFile)
 	if err != nil {
 		return fmt.Errorf("failed to get RDM disk backing info: %w", err)
@@ -398,55 +420,51 @@ func (v *VantaraCloner) RDMCopy(vsphereClient vmware.Client, vmId string, source
 		return fmt.Errorf("disk %s is not an RDM disk", sourceVMDKFile)
 	}
 
-	klog.Infof("Vantara RDM Copy: Found RDM device: %s", backing.DeviceName)
+	v.log.Info("found RDM device", "device", backing.DeviceName)
 
-	// Resolve the source LUN from the RDM device name
 	sourceLUN, err := v.resolveRDMToLUN(backing.DeviceName)
 	if err != nil {
 		return fmt.Errorf("failed to resolve RDM device to source LUN: %w", err)
 	}
 
-	// Resolve the target PV to LUN
+	v.log.Info("resolving target PV to LUN", "pv", persistentVolume.Name)
 	targetLUN, err := v.ResolvePVToLUN(persistentVolume)
 	if err != nil {
 		return fmt.Errorf("failed to resolve target volume: %w", err)
 	}
 
-	klog.Infof("Vantara RDM Copy: Copying from source LUN %s to target LUN %s", sourceLUN.LDeviceID, targetLUN.LDeviceID)
+	v.log.Info("copying volume", "source", sourceLUN.LDeviceID, "target", targetLUN.LDeviceID)
 
-	// Report progress start
 	progress <- 10
 
-	// Perform the copy operation using Vantara API
-	// Get target volume pool ID
 	ldevResp, err := v.client.GetLdev(targetLUN.LDeviceID)
-	klog.Infof("Target LDEV: %v", ldevResp)
+	if err != nil {
+		return fmt.Errorf("failed to get target LDEV %s: %w", targetLUN.LDeviceID, err)
+	}
+	v.log.V(2).Info("target LDEV details", "ldev", ldevResp)
 
-	// Perform the copy operation
 	err = v.performVolumeCopy(sourceLUN.LDeviceID, ldevResp, progress)
 	if err != nil {
 		return fmt.Errorf("copy operation failed: %w", err)
 	}
 
-	// Report progress complete
 	progress <- 100
 
-	klog.Infof("Vantara RDM Copy: Copy operation completed successfully")
+	v.log.Info("RDM copy completed successfully")
 	return nil
 }
 
 // resolveRDMToLUN resolves an RDM device name to a Vantara LDEV ID
 func (v *VantaraCloner) resolveRDMToLUN(deviceName string) (populator.LUN, error) {
+	v.log.V(2).Info("resolving RDM device to LUN", "device", deviceName)
 
 	deviceName = strings.ToLower(deviceName)
 	start := strings.Index(deviceName, VantaraProviderID)
 	if start == -1 {
-		fmt.Println("target not found")
 		return populator.LUN{}, fmt.Errorf("target not found")
 	}
 
 	if start+LengthNAAID > len(deviceName) {
-		fmt.Println("string too short")
 		return populator.LUN{}, fmt.Errorf("device name too short")
 	}
 
@@ -459,6 +477,8 @@ func (v *VantaraCloner) resolveRDMToLUN(deviceName string) (populator.LUN, error
 	}
 
 	ldevIds := strconv.FormatUint(ldevId, 10)
+	v.log.V(2).Info("parsing LDEV ID from device", "ldev_id", ldevIds, "hex", ldevIdHex)
+
 	ldevResp, err := v.client.GetLdev(ldevIds)
 	if err != nil {
 		return populator.LUN{}, fmt.Errorf("failed to get LDEV info for device name %s: %w", deviceName, err)
@@ -470,9 +490,11 @@ func (v *VantaraCloner) resolveRDMToLUN(deviceName string) (populator.LUN, error
 		return populator.LUN{}, fmt.Errorf("device name %s does not match LDEV NAA ID %s", naaDevice, naa)
 	}
 
-	return populator.LUN{
+	lun := populator.LUN{
 		LDeviceID: ldevIds,
 		NAA:       naa,
-	}, nil
+	}
+	v.log.Info("resolved source LUN", "ldev_id", lun.LDeviceID, "naa", lun.NAA)
+	return lun, nil
 
 }

--- a/cmd/vsphere-copy-offload-populator/internal/vantara/vantara_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vantara/vantara_test.go
@@ -11,6 +11,7 @@ import (
 	vmware_mocks "github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware/mocks"
 
 	"go.uber.org/mock/gomock"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
 )
 
 // mockVantaraClient is a mock implementation of VantaraClient for testing
@@ -101,6 +102,7 @@ func (m *mockVantaraClient) GetStorageInfo() (*StorageInfo, error) {
 func TestResolvePVToLUN(t *testing.T) {
 	cloner := VantaraCloner{
 		client: &mockVantaraClient{},
+		log:    logutil.NewLogger("vantara"),
 	}
 
 	tests := []struct {
@@ -179,6 +181,7 @@ func TestCurrentMappedGroups(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
+		log:    logutil.NewLogger("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -217,6 +220,7 @@ func TestGetNaaID(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
+		log:    logutil.NewLogger("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -247,6 +251,7 @@ func TestMap(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
+		log:    logutil.NewLogger("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -291,6 +296,7 @@ func TestMapInvalidHostGroupId(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
+		log:    logutil.NewLogger("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -322,6 +328,7 @@ func TestUnMap(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
+		log:    logutil.NewLogger("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -362,6 +369,7 @@ func TestEnsureClonnerIgroupWithEnvVar(t *testing.T) {
 	cloner := VantaraCloner{
 		client:          mock,
 		envHostGroupIds: []string{"CL1-A,1", "CL2-B,2"},
+		log:             logutil.NewLogger("vantara"),
 	}
 
 	context, err := cloner.EnsureClonnerIgroup("xcopy-ig", []string{"fc.0:21000024FF123456"})
@@ -403,6 +411,7 @@ func TestEnsureClonnerIgroupFromStorage(t *testing.T) {
 	cloner := VantaraCloner{
 		client:          mock,
 		envHostGroupIds: []string{}, // Empty - force fetching from storage
+		log:             logutil.NewLogger("vantara"),
 	}
 
 	context, err := cloner.EnsureClonnerIgroup("xcopy-ig", []string{"fc.0:21000024FF123456"})
@@ -507,7 +516,7 @@ func TestGetLunIdFromPorts(t *testing.T) {
 
 func TestVvolCopy_ResolvePVToLUNError(t *testing.T) {
 	mock := &mockVantaraClient{}
-	cloner := &VantaraCloner{client: mock}
+	cloner := &VantaraCloner{client: mock, log: logutil.NewLogger("vantara")}
 
 	progress := make(chan uint64, 10)
 
@@ -562,7 +571,7 @@ func TestPerformVolumeCopy_Success_ImmediatePSUP(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: mock}
+	v := &VantaraCloner{client: mock, log: logutil.NewLogger("vantara")}
 
 	progress := make(chan uint64, 1)
 
@@ -597,7 +606,7 @@ func TestPerformVolumeCopy_CreateCloneError(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: mock}
+	v := &VantaraCloner{client: mock, log: logutil.NewLogger("vantara")}
 
 	progress := make(chan uint64, 1)
 
@@ -621,7 +630,7 @@ func TestPerformVolumeCopy_CreateCloneError(t *testing.T) {
 }
 
 func TestFindVolumeByVVolID_Success(t *testing.T) {
-	v := &VantaraCloner{}
+	v := &VantaraCloner{log: logutil.NewLogger("vantara")}
 
 	// last4 = ABCD (hex) => 43981 (dec)
 	got, err := v.findVolumeByVVolID("00000000-0000-0000-0000-00000000ABCD")
@@ -634,7 +643,7 @@ func TestFindVolumeByVVolID_Success(t *testing.T) {
 }
 
 func TestFindVolumeByVVolID_TooShort(t *testing.T) {
-	v := &VantaraCloner{}
+	v := &VantaraCloner{log: logutil.NewLogger("vantara")}
 
 	_, err := v.findVolumeByVVolID("ABC") // len < 4
 	if err == nil {
@@ -643,7 +652,7 @@ func TestFindVolumeByVVolID_TooShort(t *testing.T) {
 }
 
 func TestFindVolumeByVVolID_NonHexLast4(t *testing.T) {
-	v := &VantaraCloner{}
+	v := &VantaraCloner{log: logutil.NewLogger("vantara")}
 
 	// last4 = "ZZZZ" is not hex
 	_, err := v.findVolumeByVVolID("0000ZZZZ")
@@ -663,6 +672,7 @@ func TestRDMCopy_Error_WhenGetBackingFails(t *testing.T) {
 
 	cloner := &VantaraCloner{
 		client: &mockVantaraClient{getLdevResp: &LdevResponse{}},
+		log:    logutil.NewLogger("vantara"),
 	}
 
 	progress := make(chan uint64, 10)
@@ -682,6 +692,7 @@ func TestRDMCopy_Error_WhenGetBackingFails(t *testing.T) {
 func TestRDMCopy_Error_WhenNotRDM(t *testing.T) {
 	v := &VantaraCloner{
 		client: &mockVantaraClient{getLdevResp: &LdevResponse{}},
+		log:    logutil.NewLogger("vantara"),
 	}
 
 	ctrl := gomock.NewController(t)
@@ -732,7 +743,7 @@ func TestRDMCopy_Success_ProgressSequence(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: fc}
+	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -788,7 +799,7 @@ func TestRDMCopy_Error_WhenResolveRDMToLUNMismatchNAA(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: fc}
+	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -836,7 +847,7 @@ func TestResolveRDMToLUN_Success(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: fc}
+	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
 
 	lun, err := v.resolveRDMToLUN(deviceName)
 	if err != nil {
@@ -853,7 +864,7 @@ func TestResolveRDMToLUN_Success(t *testing.T) {
 
 func TestResolveRDMToLUN_Error_TargetNotFound(t *testing.T) {
 	fc := &mockVantaraClient{}
-	v := &VantaraCloner{client: fc}
+	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
 
 	_, err := v.resolveRDMToLUN("naa.1234567890")
 	if err == nil {
@@ -863,7 +874,7 @@ func TestResolveRDMToLUN_Error_TargetNotFound(t *testing.T) {
 
 func TestResolveRDMToLUN_Error_StringTooShort(t *testing.T) {
 	fc := &mockVantaraClient{}
-	v := &VantaraCloner{client: fc}
+	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
 
 	// provider id is present but total length is insufficient for 32 chars slice
 	deviceName := "naa." + VantaraProviderID + "short"
@@ -879,7 +890,7 @@ func TestResolveRDMToLUN_Error_InvalidHexLast4(t *testing.T) {
 	deviceName := "naa." + naaDevice
 
 	fc := &mockVantaraClient{}
-	v := &VantaraCloner{client: fc}
+	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
 
 	_, err := v.resolveRDMToLUN(deviceName)
 	if err == nil {
@@ -898,7 +909,7 @@ func TestResolveRDMToLUN_Error_NAAMismatch(t *testing.T) {
 			NaaId: VantaraProviderID + "1111111111111111111111ab",
 		},
 	}
-	v := &VantaraCloner{client: fc}
+	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
 
 	_, err := v.resolveRDMToLUN(deviceName)
 	if err == nil {
@@ -918,7 +929,7 @@ func TestResolveRDMToLUN_CaseInsensitiveDeviceName(t *testing.T) {
 			NaaId: naaDeviceLower,
 		},
 	}
-	v := &VantaraCloner{client: fc}
+	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
 
 	lun, err := v.resolveRDMToLUN(deviceNameUpper)
 	if err != nil {

--- a/cmd/vsphere-copy-offload-populator/internal/vantara/vantara_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/vantara/vantara_test.go
@@ -11,7 +11,7 @@ import (
 	vmware_mocks "github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware/mocks"
 
 	"go.uber.org/mock/gomock"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logutil"
+	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
 )
 
 // mockVantaraClient is a mock implementation of VantaraClient for testing
@@ -102,7 +102,7 @@ func (m *mockVantaraClient) GetStorageInfo() (*StorageInfo, error) {
 func TestResolvePVToLUN(t *testing.T) {
 	cloner := VantaraCloner{
 		client: &mockVantaraClient{},
-		log:    logutil.NewLogger("vantara"),
+		log:    logger.New("vantara"),
 	}
 
 	tests := []struct {
@@ -181,7 +181,7 @@ func TestCurrentMappedGroups(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
-		log:    logutil.NewLogger("vantara"),
+		log:    logger.New("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -220,7 +220,7 @@ func TestGetNaaID(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
-		log:    logutil.NewLogger("vantara"),
+		log:    logger.New("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -251,7 +251,7 @@ func TestMap(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
-		log:    logutil.NewLogger("vantara"),
+		log:    logger.New("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -296,7 +296,7 @@ func TestMapInvalidHostGroupId(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
-		log:    logutil.NewLogger("vantara"),
+		log:    logger.New("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -328,7 +328,7 @@ func TestUnMap(t *testing.T) {
 
 	cloner := VantaraCloner{
 		client: mock,
-		log:    logutil.NewLogger("vantara"),
+		log:    logger.New("vantara"),
 	}
 
 	lun := populator.LUN{
@@ -369,7 +369,7 @@ func TestEnsureClonnerIgroupWithEnvVar(t *testing.T) {
 	cloner := VantaraCloner{
 		client:          mock,
 		envHostGroupIds: []string{"CL1-A,1", "CL2-B,2"},
-		log:             logutil.NewLogger("vantara"),
+		log:             logger.New("vantara"),
 	}
 
 	context, err := cloner.EnsureClonnerIgroup("xcopy-ig", []string{"fc.0:21000024FF123456"})
@@ -411,7 +411,7 @@ func TestEnsureClonnerIgroupFromStorage(t *testing.T) {
 	cloner := VantaraCloner{
 		client:          mock,
 		envHostGroupIds: []string{}, // Empty - force fetching from storage
-		log:             logutil.NewLogger("vantara"),
+		log:             logger.New("vantara"),
 	}
 
 	context, err := cloner.EnsureClonnerIgroup("xcopy-ig", []string{"fc.0:21000024FF123456"})
@@ -516,7 +516,7 @@ func TestGetLunIdFromPorts(t *testing.T) {
 
 func TestVvolCopy_ResolvePVToLUNError(t *testing.T) {
 	mock := &mockVantaraClient{}
-	cloner := &VantaraCloner{client: mock, log: logutil.NewLogger("vantara")}
+	cloner := &VantaraCloner{client: mock, log: logger.New("vantara")}
 
 	progress := make(chan uint64, 10)
 
@@ -571,7 +571,7 @@ func TestPerformVolumeCopy_Success_ImmediatePSUP(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: mock, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: mock, log: logger.New("vantara")}
 
 	progress := make(chan uint64, 1)
 
@@ -606,7 +606,7 @@ func TestPerformVolumeCopy_CreateCloneError(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: mock, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: mock, log: logger.New("vantara")}
 
 	progress := make(chan uint64, 1)
 
@@ -630,7 +630,7 @@ func TestPerformVolumeCopy_CreateCloneError(t *testing.T) {
 }
 
 func TestFindVolumeByVVolID_Success(t *testing.T) {
-	v := &VantaraCloner{log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{log: logger.New("vantara")}
 
 	// last4 = ABCD (hex) => 43981 (dec)
 	got, err := v.findVolumeByVVolID("00000000-0000-0000-0000-00000000ABCD")
@@ -643,7 +643,7 @@ func TestFindVolumeByVVolID_Success(t *testing.T) {
 }
 
 func TestFindVolumeByVVolID_TooShort(t *testing.T) {
-	v := &VantaraCloner{log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{log: logger.New("vantara")}
 
 	_, err := v.findVolumeByVVolID("ABC") // len < 4
 	if err == nil {
@@ -652,7 +652,7 @@ func TestFindVolumeByVVolID_TooShort(t *testing.T) {
 }
 
 func TestFindVolumeByVVolID_NonHexLast4(t *testing.T) {
-	v := &VantaraCloner{log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{log: logger.New("vantara")}
 
 	// last4 = "ZZZZ" is not hex
 	_, err := v.findVolumeByVVolID("0000ZZZZ")
@@ -672,7 +672,7 @@ func TestRDMCopy_Error_WhenGetBackingFails(t *testing.T) {
 
 	cloner := &VantaraCloner{
 		client: &mockVantaraClient{getLdevResp: &LdevResponse{}},
-		log:    logutil.NewLogger("vantara"),
+		log:    logger.New("vantara"),
 	}
 
 	progress := make(chan uint64, 10)
@@ -692,7 +692,7 @@ func TestRDMCopy_Error_WhenGetBackingFails(t *testing.T) {
 func TestRDMCopy_Error_WhenNotRDM(t *testing.T) {
 	v := &VantaraCloner{
 		client: &mockVantaraClient{getLdevResp: &LdevResponse{}},
-		log:    logutil.NewLogger("vantara"),
+		log:    logger.New("vantara"),
 	}
 
 	ctrl := gomock.NewController(t)
@@ -743,7 +743,7 @@ func TestRDMCopy_Success_ProgressSequence(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: fc, log: logger.New("vantara")}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -799,7 +799,7 @@ func TestRDMCopy_Error_WhenResolveRDMToLUNMismatchNAA(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: fc, log: logger.New("vantara")}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -847,7 +847,7 @@ func TestResolveRDMToLUN_Success(t *testing.T) {
 		},
 	}
 
-	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: fc, log: logger.New("vantara")}
 
 	lun, err := v.resolveRDMToLUN(deviceName)
 	if err != nil {
@@ -864,7 +864,7 @@ func TestResolveRDMToLUN_Success(t *testing.T) {
 
 func TestResolveRDMToLUN_Error_TargetNotFound(t *testing.T) {
 	fc := &mockVantaraClient{}
-	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: fc, log: logger.New("vantara")}
 
 	_, err := v.resolveRDMToLUN("naa.1234567890")
 	if err == nil {
@@ -874,7 +874,7 @@ func TestResolveRDMToLUN_Error_TargetNotFound(t *testing.T) {
 
 func TestResolveRDMToLUN_Error_StringTooShort(t *testing.T) {
 	fc := &mockVantaraClient{}
-	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: fc, log: logger.New("vantara")}
 
 	// provider id is present but total length is insufficient for 32 chars slice
 	deviceName := "naa." + VantaraProviderID + "short"
@@ -890,7 +890,7 @@ func TestResolveRDMToLUN_Error_InvalidHexLast4(t *testing.T) {
 	deviceName := "naa." + naaDevice
 
 	fc := &mockVantaraClient{}
-	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: fc, log: logger.New("vantara")}
 
 	_, err := v.resolveRDMToLUN(deviceName)
 	if err == nil {
@@ -909,7 +909,7 @@ func TestResolveRDMToLUN_Error_NAAMismatch(t *testing.T) {
 			NaaId: VantaraProviderID + "1111111111111111111111ab",
 		},
 	}
-	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: fc, log: logger.New("vantara")}
 
 	_, err := v.resolveRDMToLUN(deviceName)
 	if err == nil {
@@ -929,7 +929,7 @@ func TestResolveRDMToLUN_CaseInsensitiveDeviceName(t *testing.T) {
 			NaaId: naaDeviceLower,
 		},
 	}
-	v := &VantaraCloner{client: fc, log: logutil.NewLogger("vantara")}
+	v := &VantaraCloner{client: fc, log: logger.New("vantara")}
 
 	lun, err := v.resolveRDMToLUN(deviceNameUpper)
 	if err != nil {


### PR DESCRIPTION
Storage providers used flat `klog.Infof()`/`klog.Warningf()` calls with no
consistent prefix or structure. In production, this made it difficult to filter
logs by provider or correlate a log line with the provider that emitted it —
especially when multiple providers run concurrently during a migration plan.

This PR switches all providers to structured logging via `logr`, with each
provider carrying its own named logger as a struct field. Every log line now
includes the provider name as a key-value pair, making it possible to filter
by provider in any log aggregation tool.

`logr` has no Warning level, so messages that were previously `klog.Warningf()`
are emitted via `log.Error(nil, ...)` — this is the idiomatic `logr` approach
and ensures they surface at a severity above Info.

Resolves: MTV-4365