### PR TITLE
MTV-5216 | Add per-VM counter metrics and Live migration mode

### DIFF
--- a/docs/metrics-reference.md
+++ b/docs/metrics-reference.md
@@ -30,7 +30,8 @@ Most metrics carry a subset of these labels:
   One of: `openshift`, `vsphere`, `ovirt`, `openstack`, `ova`, `ec2`, `hyperv`.
 - **`mode`** -- migration strategy. `Cold` shuts the source VM down and copies
   disks in one pass. `Warm` replicates incrementally while the source VM keeps
-  running, then cuts over.
+  running, then cuts over. `Live` performs a live migration without shutting
+  down the source VM.
 - **`target`** -- destination cluster. `Local` means the same OpenShift cluster
   that runs the controller (no URL configured). `Remote` means a different
   cluster reached via an explicit URL.
@@ -81,6 +82,58 @@ same provider/mode/target combination.
 ```bash
 # Succeeded migrations for a specific plan
 oc metrics query --query 'mtv_workload_migrations_status_total{status="Succeeded", plan="<plan-uid>"}'
+```
+
+### `mtv_planned_vms_total`
+
+| | |
+|---|---|
+| **Type** | Counter |
+| **Labels** | `provider`, `mode`, `target` |
+| **Description** | Number of VMs listed in migration plan specs. |
+
+Incremented once per VM in a plan's `spec.vms`, deduplicated by plan UID + VM
+ID. Counts every VM the user intended to migrate, even if the plan was never
+executed. If a VM is added to a plan later, it is counted on the next poll
+cycle.
+
+This metric counts VMs **per plan, not per migration attempt**. Re-running a
+plan does not change this counter.
+
+```bash
+# Total VMs planned for migration
+oc metrics query --query 'mtv_planned_vms_total'
+
+# Planned VMs from vSphere
+oc metrics query --query 'mtv_planned_vms_total{provider="vsphere"}'
+```
+
+### `mtv_migrated_vms_total`
+
+| | |
+|---|---|
+| **Type** | Counter |
+| **Labels** | `status`, `provider`, `mode`, `target` |
+| **Description** | Individual VM migration outcomes. |
+
+Incremented once per VM that reaches a terminal condition within a migration,
+deduplicated by migration UID + VM ID + status. Valid `status` values:
+`Succeeded`, `Failed`, `Canceled`.
+
+This metric counts **per migration attempt**. If a plan with 10 VMs is
+executed twice (first attempt fails, second succeeds), the counter will show
+10 Failed + 10 Succeeded = 20 total events, even though only 10 unique VMs
+were involved. Each Migration CR is an independent attempt with its own UID.
+
+```bash
+# Total VMs successfully migrated
+oc metrics query --query 'mtv_migrated_vms_total{status="Succeeded"}'
+
+# Failed VMs from vSphere cold migrations
+oc metrics query --query 'mtv_migrated_vms_total{status="Failed", provider="vsphere", mode="Cold"}'
+
+# Rate of individual VM migrations over the last hour
+oc metrics query --query 'rate(mtv_migrated_vms_total[1h])'
 ```
 
 ### `mtv_plans_status`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,14 +38,16 @@ Two background goroutines drive the controller metrics:
 - **`RecordMigrationMetrics`** -- started by the Migration controller
   (`pkg/controller/migration/controller.go`). Polls every 10 seconds, lists all
   `Migration` objects, and increments counters for terminal states (Succeeded,
-  Failed, Canceled). Uses in-memory maps keyed by migration UID to guarantee
-  each migration is counted exactly once.
+  Failed, Canceled). Also counts individual VM terminal states within each
+  migration. Uses in-memory maps keyed by migration UID (and migration
+  UID + VM ID for per-VM counts) to guarantee each entry is counted exactly
+  once.
 
 - **`RecordPlanMetrics`** -- started by the Plan controller
   (`pkg/controller/plan/controller.go`). Polls every 10 seconds, lists all
-  `Plan` objects, and recalculates gauge values from scratch. Stale label
-  combinations (plans that no longer exist or changed state) are reset to zero
-  or deleted.
+  `Plan` objects, and recalculates gauge values from scratch. Also counts
+  Planned VMs from each plan's `spec.vms` list. Stale label combinations
+  (plans that no longer exist or changed state) are reset to zero or deleted.
 
 ---
 
@@ -58,8 +60,8 @@ At a glance:
 
 | Area | Key metrics | Source |
 |---|---|---|
-| Migrations | `mtv_migrations_status_total`, `mtv_workload_migrations_status_total`, `mtv_migration_duration_seconds`, `mtv_migrations_duration_seconds`, `mtv_migration_data_transferred_bytes` | `pkg/monitoring/metrics/forklift-controller/` |
-| Plans | `mtv_plans_status`, `mtv_plan_alert_status` | `pkg/monitoring/metrics/forklift-controller/` |
+| Migrations | `mtv_migrations_status_total`, `mtv_workload_migrations_status_total`, `mtv_migrated_vms_total`, `mtv_migration_duration_seconds`, `mtv_migrations_duration_seconds`, `mtv_migration_data_transferred_bytes` | `pkg/monitoring/metrics/forklift-controller/` |
+| Plans | `mtv_plans_status`, `mtv_plan_alert_status`, `mtv_planned_vms_total` | `pkg/monitoring/metrics/forklift-controller/` |
 
 ---
 
@@ -86,9 +88,9 @@ allowed values:
 
 | Label | Values | Meaning |
 |---|---|---|
-| `status` | `Succeeded`, `Failed`, `Canceled`, `Executing`, `Running`, `Pending`, `Blocked`, `Deleted` | Current lifecycle state of a plan or migration object. Counters only use the terminal states (`Succeeded`, `Failed`, `Canceled`); gauges may use the full set. Not every metric exposes every value -- check the per-metric docs in the [Metrics Reference](./metrics-reference.md). |
+| `status` | `Succeeded`, `Failed`, `Canceled`, `Executing`, `Running`, `Pending`, `Blocked`, `Deleted` | Lifecycle state of a plan, migration, or VM. Counters use the terminal states (`Succeeded`, `Failed`, `Canceled`); gauges may use the full set. Not every metric exposes every value -- check the per-metric docs in the [Metrics Reference](./metrics-reference.md). |
 | `provider` | `openshift`, `vsphere`, `ovirt`, `openstack`, `ova`, `ec2`, `hyperv` | The source virtualization platform the VMs are being migrated from. The value comes from `sourceProvider.Type().String()` and matches the `ProviderType` constants defined in `pkg/apis/forklift/v1beta1/provider.go`. |
-| `mode` | `Cold`, `Warm` | The migration strategy. **Cold** shuts down the source VM and copies disks in a single pass. **Warm** performs incremental snapshot-based replication while the source VM stays running, then does a final cutover. |
+| `mode` | `Cold`, `Warm`, `Live` | The migration strategy. **Cold** shuts down the source VM and copies disks in a single pass. **Warm** performs incremental snapshot-based replication while the source VM stays running, then does a final cutover. **Live** performs a live migration without shutting down the source VM. |
 | `target` | `Local`, `Remote` | Where the VMs are being migrated to. **Local** means the destination is the same OpenShift cluster that runs the forklift-controller (the destination provider has no URL configured). **Remote** means the destination is a different OpenShift cluster reached via an explicit URL. |
 | `plan` | UID string | The Kubernetes UID of the `Plan` resource that owns the migration. Used to correlate migration-level metrics back to a specific plan, especially when multiple plans target the same provider/mode/target combination. |
 | `plan_name` | string | The human-readable `.metadata.name` of the plan. Present only on `mtv_plan_alert_status` to make alerting rules easier to read without requiring a UID-to-name lookup. |
@@ -101,6 +103,15 @@ allowed values:
   (`processedSucceededMigrations`, `processedFailedMigrations`,
   `processedCanceledMigrations`) keyed by migration UID. Each migration is
   counted exactly once per terminal state.
+
+- **Planned VM counter** (`mtv_planned_vms_total`): `processedPlannedVMs`
+  keyed by `planUID/vmID`. Each VM in a plan spec is counted exactly once per
+  plan, regardless of how many times the plan is executed.
+
+- **Migrated VM counter** (`mtv_migrated_vms_total`): `processedVMStatuses`
+  keyed by `migrationUID/vmID/status`. Each VM is counted once per terminal
+  state per migration attempt. Re-running a plan creates a new Migration CR
+  with a new UID, so the same VM will be counted again in the new attempt.
 
 - **Plan gauges** (`mtv_plans_status`, `mtv_plan_alert_status`): recalculated
   from scratch every 10-second cycle. Label combinations that existed in the

--- a/pkg/monitoring/metrics/forklift-controller/metrics.go
+++ b/pkg/monitoring/metrics/forklift-controller/metrics.go
@@ -18,6 +18,7 @@ const (
 	Deleted   = "Deleted"
 	Warm      = "Warm"
 	Cold      = "Cold"
+	Live      = "Live"
 	Local     = "Local"
 	Remote    = "Remote"
 )
@@ -25,7 +26,7 @@ const (
 var (
 	// 'status' - [ Succeeded, Failed, Canceled]
 	// 'provider' - [oVirt, VSphere, Openstack, OVA, Openshift]
-	// 'mode' - [Cold, Warm]
+	// 'mode' - [Cold, Warm, Live]
 	// 'target' - [Local, Remote]
 	migrationStatusCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mtv_migrations_status_total",
@@ -41,7 +42,7 @@ var (
 
 	// 'status' - [ Succeeded, Failed, Executing, Running, Pending, Canceled, Blocked, Deleted]
 	// 'provider' - [oVirt, VSphere, Openstack, OVA, Openshift]
-	// 'mode' - [Cold, Warm]
+	// 'mode' - [Cold, Warm, Live]
 	// 'target' - [Local, Remote]
 	planStatusGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "mtv_plans_status",
@@ -57,7 +58,7 @@ var (
 
 	// 'status' - [Succeeded, Failed]
 	// 'provider' - [oVirt, VSphere, Openstack, OVA, Openshift]
-	// 'mode' - [Cold, Warm]
+	// 'mode' - [Cold, Warm, Live]
 	// 'target' - [Local, Remote]
 	// 'plan' - [Id]
 	// 'plan_name' - [Plan name]
@@ -79,7 +80,7 @@ var (
 
 	// 'status' - [ Succeeded, Failed, Executing, Canceled]
 	// 'provider' - [oVirt, VSphere, Openstack, OVA, Openshift]
-	// 'mode' - [Cold, Warm]
+	// 'mode' - [Cold, Warm, Live]
 	// 'target' - [Local, Remote]
 	// 'plan' - [Id]
 	migrationDurationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -90,7 +91,7 @@ var (
 	)
 
 	// 'provider' - [oVirt, VSphere, Openstack, OVA, Openshift]
-	// 'mode' - [Cold, Warm]
+	// 'mode' - [Cold, Warm, Live]
 	// 'target' - [Local, Remote]
 	// 'plan' - [Id]
 	dataTransferredGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -107,7 +108,7 @@ var (
 
 	// 'status' - [ Succeeded, Failed, Canceled]
 	// 'provider' - [oVirt, VSphere, Openstack, OVA, Openshift]
-	// 'mode' - [Cold, Warm]
+	// 'mode' - [Cold, Warm, Live]
 	// 'target' - [Local, Remote]
 	// 'plan' - [Id]
 	migrationPlanCorrelationStatusCounter = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -124,7 +125,7 @@ var (
 	)
 
 	// 'provider' - [oVirt, VSphere, Openstack, OVA, Openshift]
-	// 'mode' - [Cold, Warm]
+	// 'mode' - [Cold, Warm, Live]
 	// 'target' - [Local, Remote]
 	migrationDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "mtv_migrations_duration_seconds",
@@ -132,6 +133,36 @@ var (
 		Buckets: []float64{1 * 3600, 2 * 3600, 5 * 3600, 10 * 3600, 24 * 3600, 48 * 3600}, // 1, 2, 5, 10, 24, 48 hours in seconds
 	},
 		[]string{
+			"provider",
+			"mode",
+			"target",
+		},
+	)
+
+	// 'provider' - [oVirt, VSphere, Openstack, OVA, Openshift]
+	// 'mode' - [Cold, Warm, Live]
+	// 'target' - [Local, Remote]
+	plannedVMsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "mtv_planned_vms_total",
+		Help: "Number of VMs listed in migration plan specs",
+	},
+		[]string{
+			"provider",
+			"mode",
+			"target",
+		},
+	)
+
+	// 'status' - [Succeeded, Failed, Canceled]
+	// 'provider' - [oVirt, VSphere, Openstack, OVA, Openshift]
+	// 'mode' - [Cold, Warm, Live]
+	// 'target' - [Local, Remote]
+	migratedVMsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "mtv_migrated_vms_total",
+		Help: "Individual VM migration outcomes sorted by status, provider, mode and target",
+	},
+		[]string{
+			"status",
 			"provider",
 			"mode",
 			"target",

--- a/pkg/monitoring/metrics/forklift-controller/migration_metrics.go
+++ b/pkg/monitoring/metrics/forklift-controller/migration_metrics.go
@@ -14,6 +14,7 @@ var (
 	processedSucceededMigrations = make(map[string]struct{})
 	processedFailedMigrations    = make(map[string]struct{})
 	processedCanceledMigrations  = make(map[string]struct{})
+	processedVMStatuses          = make(map[string]struct{})
 )
 
 // Calculate Migrations metrics every 10 seconds
@@ -59,14 +60,18 @@ func RecordMigrationMetrics(c client.Client) {
 				} else {
 					target = Remote
 				}
-				if plan.IsWarm() {
+				switch plan.Spec.Type {
+				case api.MigrationWarm:
 					mode = Warm
-				} else {
+				case api.MigrationLive:
+					mode = Live
+				default:
 					mode = Cold
 				}
 
 				provider := sourceProvider.Type().String()
 				processMigration(m, provider, mode, target, string(plan.UID))
+				processVMStatuses(m, provider, mode, target)
 			}
 		}
 	}()
@@ -105,6 +110,29 @@ func processMigration(migration api.Migration, provider, mode, target, planUID s
 func updateMetricsCount(status, provider, mode, target, plan string) {
 	migrationStatusCounter.With(prometheus.Labels{"status": status, "provider": provider, "mode": mode, "target": target}).Inc()
 	migrationPlanCorrelationStatusCounter.With(prometheus.Labels{"status": status, "provider": provider, "mode": mode, "target": target, "plan": plan}).Inc()
+}
+
+func processVMStatuses(migration api.Migration, provider, mode, target string) {
+	for _, vm := range migration.Status.VMs {
+		var vmStatus string
+		switch {
+		case vm.HasCondition(Succeeded):
+			vmStatus = Succeeded
+		case vm.HasCondition(Failed):
+			vmStatus = Failed
+		case vm.HasCondition(Canceled):
+			vmStatus = Canceled
+		default:
+			continue
+		}
+		vmKey := fmt.Sprintf("%s/%s/%s", string(migration.UID), vm.ID, vmStatus)
+		if _, exists := processedVMStatuses[vmKey]; !exists {
+			migratedVMsCounter.With(prometheus.Labels{
+				"status": vmStatus, "provider": provider, "mode": mode, "target": target,
+			}).Inc()
+			processedVMStatuses[vmKey] = struct{}{}
+		}
+	}
 }
 
 func recordSuccessfulMigrationMetrics(migration api.Migration, provider, mode, target, planUID string) {

--- a/pkg/monitoring/metrics/forklift-controller/migration_metrics_test.go
+++ b/pkg/monitoring/metrics/forklift-controller/migration_metrics_test.go
@@ -1,0 +1,193 @@
+package forklift_controller
+
+import (
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func counterValue(counter *prometheus.CounterVec, labels prometheus.Labels) float64 {
+	m := &dto.Metric{}
+	c, err := counter.GetMetricWith(labels)
+	if err != nil {
+		return 0
+	}
+	_ = c.(prometheus.Metric).Write(m)
+	if m.Counter == nil {
+		return 0
+	}
+	return m.Counter.GetValue()
+}
+
+func resetVMMetrics() {
+	processedVMStatuses = make(map[string]struct{})
+	migratedVMsCounter.Reset()
+}
+
+func vmWithCondition(id, condType string) *plan.VMStatus {
+	return &plan.VMStatus{
+		VM: plan.VM{Ref: ref.Ref{ID: id}},
+		Conditions: libcnd.Conditions{
+			List: []libcnd.Condition{
+				{Type: condType, Status: "True"},
+			},
+		},
+	}
+}
+
+func vmNoCondition(id string) *plan.VMStatus {
+	return &plan.VMStatus{
+		VM: plan.VM{Ref: ref.Ref{ID: id}},
+	}
+}
+
+func migration(uid string, vms ...*plan.VMStatus) api.Migration {
+	return api.Migration{
+		ObjectMeta: meta.ObjectMeta{UID: types.UID(uid)},
+		Status: api.MigrationStatus{
+			VMs: vms,
+		},
+	}
+}
+
+func TestProcessVMStatuses_Succeeded(t *testing.T) {
+	resetVMMetrics()
+
+	m := migration("mig-1", vmWithCondition("vm-a", Succeeded))
+	processVMStatuses(m, "vsphere", Cold, Local)
+
+	labels := prometheus.Labels{"status": Succeeded, "provider": "vsphere", "mode": Cold, "target": Local}
+	got := counterValue(migratedVMsCounter, labels)
+	if got != 1 {
+		t.Fatalf("expected Succeeded counter = 1, got %v", got)
+	}
+}
+
+func TestProcessVMStatuses_Failed(t *testing.T) {
+	resetVMMetrics()
+
+	m := migration("mig-2", vmWithCondition("vm-b", Failed))
+	processVMStatuses(m, "ovirt", Warm, Remote)
+
+	labels := prometheus.Labels{"status": Failed, "provider": "ovirt", "mode": Warm, "target": Remote}
+	got := counterValue(migratedVMsCounter, labels)
+	if got != 1 {
+		t.Fatalf("expected Failed counter = 1, got %v", got)
+	}
+}
+
+func TestProcessVMStatuses_Canceled(t *testing.T) {
+	resetVMMetrics()
+
+	m := migration("mig-3", vmWithCondition("vm-c", Canceled))
+	processVMStatuses(m, "openstack", Live, Local)
+
+	labels := prometheus.Labels{"status": Canceled, "provider": "openstack", "mode": Live, "target": Local}
+	got := counterValue(migratedVMsCounter, labels)
+	if got != 1 {
+		t.Fatalf("expected Canceled counter = 1, got %v", got)
+	}
+}
+
+func TestProcessVMStatuses_MultipleVMs(t *testing.T) {
+	resetVMMetrics()
+
+	m := migration("mig-4",
+		vmWithCondition("vm-1", Succeeded),
+		vmWithCondition("vm-2", Failed),
+		vmWithCondition("vm-3", Succeeded),
+	)
+	processVMStatuses(m, "vsphere", Cold, Local)
+
+	succeeded := counterValue(migratedVMsCounter, prometheus.Labels{
+		"status": Succeeded, "provider": "vsphere", "mode": Cold, "target": Local,
+	})
+	failed := counterValue(migratedVMsCounter, prometheus.Labels{
+		"status": Failed, "provider": "vsphere", "mode": Cold, "target": Local,
+	})
+	if succeeded != 2 {
+		t.Fatalf("expected Succeeded = 2, got %v", succeeded)
+	}
+	if failed != 1 {
+		t.Fatalf("expected Failed = 1, got %v", failed)
+	}
+}
+
+func TestProcessVMStatuses_SkipsNonTerminalVMs(t *testing.T) {
+	resetVMMetrics()
+
+	m := migration("mig-5",
+		vmNoCondition("vm-running"),
+		vmWithCondition("vm-done", Succeeded),
+	)
+	processVMStatuses(m, "vsphere", Cold, Local)
+
+	succeeded := counterValue(migratedVMsCounter, prometheus.Labels{
+		"status": Succeeded, "provider": "vsphere", "mode": Cold, "target": Local,
+	})
+	if succeeded != 1 {
+		t.Fatalf("expected Succeeded = 1, got %v", succeeded)
+	}
+}
+
+func TestProcessVMStatuses_Deduplication(t *testing.T) {
+	resetVMMetrics()
+
+	m := migration("mig-6", vmWithCondition("vm-x", Succeeded))
+	processVMStatuses(m, "vsphere", Cold, Local)
+	processVMStatuses(m, "vsphere", Cold, Local)
+	processVMStatuses(m, "vsphere", Cold, Local)
+
+	labels := prometheus.Labels{"status": Succeeded, "provider": "vsphere", "mode": Cold, "target": Local}
+	got := counterValue(migratedVMsCounter, labels)
+	if got != 1 {
+		t.Fatalf("expected counter = 1 after 3 calls, got %v", got)
+	}
+}
+
+func TestProcessVMStatuses_DifferentMigrationsNotDeduplicated(t *testing.T) {
+	resetVMMetrics()
+
+	m1 := migration("mig-7a", vmWithCondition("vm-same", Succeeded))
+	m2 := migration("mig-7b", vmWithCondition("vm-same", Succeeded))
+	processVMStatuses(m1, "vsphere", Cold, Local)
+	processVMStatuses(m2, "vsphere", Cold, Local)
+
+	labels := prometheus.Labels{"status": Succeeded, "provider": "vsphere", "mode": Cold, "target": Local}
+	got := counterValue(migratedVMsCounter, labels)
+	if got != 2 {
+		t.Fatalf("expected counter = 2 for same VM in different migrations, got %v", got)
+	}
+}
+
+func TestProcessVMStatuses_SameVMDifferentStatuses(t *testing.T) {
+	resetVMMetrics()
+
+	// Unusual but possible: same migration UID, same VM ID, different statuses
+	// inserted across separate calls (e.g. condition list mutated between polls).
+	m1 := migration("mig-8", vmWithCondition("vm-y", Succeeded))
+	processVMStatuses(m1, "vsphere", Cold, Local)
+
+	m2 := migration("mig-8", vmWithCondition("vm-y", Failed))
+	processVMStatuses(m2, "vsphere", Cold, Local)
+
+	succeeded := counterValue(migratedVMsCounter, prometheus.Labels{
+		"status": Succeeded, "provider": "vsphere", "mode": Cold, "target": Local,
+	})
+	failed := counterValue(migratedVMsCounter, prometheus.Labels{
+		"status": Failed, "provider": "vsphere", "mode": Cold, "target": Local,
+	})
+	if succeeded != 1 {
+		t.Fatalf("expected Succeeded = 1, got %v", succeeded)
+	}
+	if failed != 1 {
+		t.Fatalf("expected Failed = 1, got %v", failed)
+	}
+}

--- a/pkg/monitoring/metrics/forklift-controller/plan_metrics.go
+++ b/pkg/monitoring/metrics/forklift-controller/plan_metrics.go
@@ -13,6 +13,7 @@ import (
 
 var activePlanStatuses = make(map[string]struct{})
 var activePlanAlertStatuses = make(map[string]struct{})
+var processedPlannedVMs = make(map[string]struct{})
 
 // Calculate Plans metrics every 10 seconds
 func RecordPlanMetrics(c client.Client) {
@@ -55,9 +56,12 @@ func RecordPlanMetrics(c client.Client) {
 				} else {
 					target = Remote
 				}
-				if m.IsWarm() {
+				switch m.Spec.Type {
+				case api.MigrationWarm:
 					mode = Warm
-				} else {
+				case api.MigrationLive:
+					mode = Live
+				default:
 					mode = Cold
 				}
 
@@ -65,6 +69,16 @@ func RecordPlanMetrics(c client.Client) {
 				planUID := string(m.UID)
 				planName := m.GetName()
 				phase := ""
+
+				for _, vm := range m.Spec.VMs {
+					plannedKey := fmt.Sprintf("%s/%s", planUID, vm.ID)
+					if _, exists := processedPlannedVMs[plannedKey]; !exists {
+						plannedVMsCounter.With(prometheus.Labels{
+							"provider": provider, "mode": mode, "target": target,
+						}).Inc()
+						processedPlannedVMs[plannedKey] = struct{}{}
+					}
+				}
 
 				if m.Status.HasCondition(Succeeded) {
 					key = fmt.Sprintf("%s|%s|%s|%s", Succeeded, provider, mode, target)


### PR DESCRIPTION
Introduce two new Prometheus counters:
- mtv_planned_vms_total: tracks VMs listed in plan specs, deduplicated by plan UID + VM ID.
- mtv_migrated_vms_total: tracks individual VM migration outcomes (Succeeded/Failed/Canceled), deduplicated by migration UID + VM ID + status.

Also add "Live" as a third migration mode alongside Cold and Warm across all existing metrics, and update documentation accordingly.

Ref: https://issues.redhat.com/browse/MTV-5216
Resolves: MTV-5216

Include AI generated unit tests