### PR TITLE
MTV-4667 | Validate virtV2vImage is a qualified container image ref

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -16,6 +16,7 @@ import (
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	apisplan "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	refapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	hookutil "github.com/kubev2v/forklift/pkg/controller/hook"
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter"
 	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
@@ -90,6 +91,7 @@ const (
 	LuksAndClevisIncompatibility    = "LuksAndClevisIncompatibility"
 	UnsupportedUdn                  = "UnsupportedUserDefinedNetwork"
 	unsupportedVersion              = "UnsupportedVersion"
+	VirtV2vImageNotValid            = "VirtV2vImageNotValid"
 	VDDKInvalid                     = "VDDKInvalid"
 	ValidatingVDDK                  = "ValidatingVDDK"
 	VDDKInitImageNotReady           = "VDDKInitImageNotReady"
@@ -234,8 +236,15 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 		return err
 	}
 
-	if err = r.validateVddkImage(plan); err != nil {
+	if err = r.validateVirtV2vImage(plan); err != nil {
 		return err
+	}
+
+	// Skip VDDK validation when VirtV2vImage is invalid to avoid creating unnecessary jobs.
+	if !plan.Status.HasCondition(VirtV2vImageNotValid) {
+		if err = r.validateVddkImage(plan); err != nil {
+			return err
+		}
 	}
 
 	// Validate version only if migration is OCP to OCP
@@ -2432,6 +2441,23 @@ func (r *Reconciler) validatePodSecurity(plan *api.Plan) error {
 			"plan", plan.Name)
 	}
 
+	return nil
+}
+
+func (r *Reconciler) validateVirtV2vImage(plan *api.Plan) error {
+	if plan.Spec.VirtV2vImage == "" {
+		return nil
+	}
+	img := plan.Spec.VirtV2vImage
+	if !hookutil.ReferenceRegexp.MatchString(img) || !strings.Contains(img, "/") {
+		plan.Status.SetCondition(libcnd.Condition{
+			Type:     VirtV2vImageNotValid,
+			Status:   True,
+			Reason:   NotValid,
+			Category: Critical,
+			Message:  "VirtV2vImage is not a valid container image reference. A fully-qualified image is required (e.g. quay.io/kubev2v/forklift-virt-v2v:latest).",
+		})
+	}
 	return nil
 }
 

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -1438,3 +1438,86 @@ var _ = ginkgo.Describe("aggregateWarningConcerns", func() {
 		gomega.Expect(unsupportedOVFExport.Items).To(gomega.BeEmpty())
 	})
 })
+
+var _ = ginkgo.Describe("validateVirtV2vImage", func() {
+	var reconciler *Reconciler
+
+	ginkgo.BeforeEach(func() {
+		reconciler = &Reconciler{
+			base.Reconciler{},
+			nil,
+		}
+	})
+
+	ginkgo.It("should not set condition when VirtV2vImage is empty", func() {
+		plan := &api.Plan{}
+		plan.Spec.VirtV2vImage = ""
+		err := reconciler.validateVirtV2vImage(plan)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should not set condition for a valid fully-qualified image", func() {
+		plan := &api.Plan{}
+		plan.Spec.VirtV2vImage = "quay.io/kubev2v/forklift-virt-v2v:latest"
+		err := reconciler.validateVirtV2vImage(plan)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should not set condition for image with tag and registry port", func() {
+		plan := &api.Plan{}
+		plan.Spec.VirtV2vImage = "registry.example.com:5000/myorg/myimage:v1.2.3"
+		err := reconciler.validateVirtV2vImage(plan)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should set condition for a bare name like 'test'", func() {
+		plan := &api.Plan{}
+		plan.Spec.VirtV2vImage = "test"
+		err := reconciler.validateVirtV2vImage(plan)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("should set condition for an invalid reference with spaces", func() {
+		plan := &api.Plan{}
+		plan.Spec.VirtV2vImage = "invalid image name"
+		err := reconciler.validateVirtV2vImage(plan)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("should set condition for a bare name with tag", func() {
+		plan := &api.Plan{}
+		plan.Spec.VirtV2vImage = "myimage:latest"
+		err := reconciler.validateVirtV2vImage(plan)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("should not set condition for org/image format", func() {
+		plan := &api.Plan{}
+		plan.Spec.VirtV2vImage = "kubev2v/forklift-virt-v2v:custom"
+		err := reconciler.validateVirtV2vImage(plan)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should not set condition for image with double underscore separator", func() {
+		plan := &api.Plan{}
+		plan.Spec.VirtV2vImage = "quay.io/my__org/image:tag"
+		err := reconciler.validateVirtV2vImage(plan)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should not set condition for image with multiple dashes in path", func() {
+		plan := &api.Plan{}
+		plan.Spec.VirtV2vImage = "quay.io/my---image/repo:tag"
+		err := reconciler.validateVirtV2vImage(plan)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeFalse())
+	})
+})


### PR DESCRIPTION
Add validation for the optional per-plan virtV2vImage field that rejects bare names (e.g. "test", "myimage:latest") and requires a fully-qualified reference containing a registry or org prefix (e.g. "quay.io/kubev2v/forklift-virt-v2v:latest"). Plans with an invalid value receive a VirtV2vImageNotValid critical condition and cannot become Ready.

Ref: https://issues.redhat.com/browse/MTV-4667
Resolves: MTV-4667