### PR TITLE
MTV-4732 |  skip redundant script upload to prevent concurrent truncation

### DIFF
--- a/cmd/vsphere-copy-offload-populator/Makefile
+++ b/cmd/vsphere-copy-offload-populator/Makefile
@@ -62,8 +62,8 @@ install-mockgen:
 # pre-requisits: ensure a PVC exists.
 test-copy-using-cli: build
 	bin/vsphere-copy-offload-populator \
-		--source-vm-id=vm-92749 \
-		--source-vmdk="[eco-iscsi-ds3] tshefi_40G_1/tshefi_40G.vmdk" \
+		--source-vm-id=vm-155695 \
+		--source-vmdk="[eco-iscsi-ds3] vm-21/vm-21.vmdk" \
 		--owner-name=tshefi40g \
 		--target-namespace=openshift-mtv \
 		--storage-vendor-product=ontap \

--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
@@ -21,9 +21,34 @@ import (
 )
 
 const (
-	taskPollingInterval = 5 * time.Second
-	rescanSleepInterval = 5 * time.Second
-	rescanRetries       = 5
+	taskPollingInterval    = 5 * time.Second
+	rescanSleepInterval    = 5 * time.Second
+	rescanRetries          = 5
+	sshInstructionTemplate = `Version mismatch detected!
+  - Just uploaded script version: %s
+  - SSH returned version: %s
+
+This indicates the SSH key is executing a different script file.
+Most likely cause: You are using the old Python-based SSH key format
+which executes a file with .py extension or UUID in the filename.
+
+The new shell-based format executes:
+  /vmfs/volumes/%s/secure-vmkfstools-wrapper (no extension)
+
+To fix this issue:
+1. SSH to the ESXi host
+2. Edit /etc/ssh/keys-root/authorized_keys: vi /etc/ssh/keys-root/authorized_keys
+3. Find the line containing the old Python wrapper
+4. DELETE the line containing .py extension or UUID in filename
+   Examples of old format to remove:
+     - Lines ending with: secure-vmkfstools-wrapper.py
+     - Lines ending with: secure-vmkfstools-wrapper-$UUID.py
+5. Add the following NEW SSH key line:
+
+  %s
+
+6. Save and exit
+7. Retry the operation`
 )
 
 // CloneMethod represents the method used for cloning operations
@@ -260,24 +285,23 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv 
 	if p.UseSSHMethod {
 		sshSetupCtx := klog.NewContext(context.Background(), setupLog)
 
-		// Setup secure script
-		finalScriptPath, err := ensureSecureScript(sshSetupCtx, p.VSphereClient, host, vmDisk.Datastore)
-		if err != nil {
-			return fmt.Errorf("failed to ensure secure script: %w", err)
-		}
-		setupLog.V(2).Info("secure script ready", "path", finalScriptPath)
-
-		// Enable SSH access
-		err = vmware.EnableSSHAccess(sshSetupCtx, p.VSphereClient, host, p.SSHPrivateKey, p.SSHPublicKey, finalScriptPath)
-		if err != nil {
-			return fmt.Errorf("failed to enable SSH access: %w", err)
-		}
-
-		// Get host IP
+		// Get host IP (needed for SSH version check and connection)
 		hostIP, err := vmware.GetHostIPAddress(sshSetupCtx, host)
 		if err != nil {
 			return fmt.Errorf("failed to get host IP address: %w", err)
 		}
+
+		err = vmware.EnableSSHAccess(sshSetupCtx, p.VSphereClient, host, p.SSHPrivateKey, p.SSHPublicKey, "")
+		if err != nil {
+			return fmt.Errorf("failed to enable SSH access: %w", err)
+		}
+
+		// Setup secure script (skips upload if remote version already matches)
+		finalScriptPath, err := ensureSecureScript(sshSetupCtx, p.VSphereClient, host, vmDisk.Datastore, hostIP, p.SSHPrivateKey)
+		if err != nil {
+			return fmt.Errorf("failed to ensure secure script: %w", err)
+		}
+		setupLog.V(2).Info("secure script ready", "path", finalScriptPath)
 
 		// Create SSH client; pass setup context so SSH logs show under setup.ssh
 		sshClient := vmware.NewSSHClient()
@@ -410,15 +434,16 @@ func deleteDeadDevices(ctx context.Context, client vmware.Client, host *object.H
 	return nil
 }
 
-func checkScriptVersion(ctx context.Context, sshClient vmware.SSHClient, datastore, embeddedVersion string, publicKey []byte) error {
+// getScriptVersion queries the remote wrapper script version via SSH.
+func getScriptVersion(ctx context.Context, sshClient vmware.SSHClient, datastore string) (string, error) {
 	output, err := sshClient.ExecuteCommand(ctx, datastore, "--version")
 	if err != nil {
-		return fmt.Errorf("old script format detected (likely Python-based). Update script on datastore %s to version %s or newer: %w", datastore, embeddedVersion, err)
+		return "", fmt.Errorf("version command failed: %w", err)
 	}
 
 	var resp XMLResponse
 	if err := xml.Unmarshal([]byte(output), &resp); err != nil {
-		return fmt.Errorf("failed to parse version response: %w", err)
+		return "", fmt.Errorf("failed to parse version response: %w", err)
 	}
 
 	var status, message string
@@ -431,19 +456,28 @@ func checkScriptVersion(ctx context.Context, sshClient vmware.SSHClient, datasto
 		}
 	}
 	if status != "0" || message == "" {
-		return fmt.Errorf("version command failed: status=%s, message=%s", status, message)
+		return "", fmt.Errorf("version command failed: status=%s, message=%s", status, message)
 	}
 
 	var versionInfo struct {
 		Version string `json:"version"`
 	}
 	if err := json.Unmarshal([]byte(message), &versionInfo); err != nil {
-		return fmt.Errorf("failed to parse version JSON: %w", err)
+		return "", fmt.Errorf("failed to parse version JSON: %w", err)
 	}
 
-	scriptVer, err := hversion.NewVersion(versionInfo.Version)
+	return versionInfo.Version, nil
+}
+
+func checkScriptVersion(ctx context.Context, sshClient vmware.SSHClient, datastore, embeddedVersion string, publicKey []byte) error {
+	remoteVersion, err := getScriptVersion(ctx, sshClient, datastore)
 	if err != nil {
-		return fmt.Errorf("invalid script version format %s: %w", versionInfo.Version, err)
+		return fmt.Errorf("old script format detected (likely Python-based). Update script on datastore %s to version %s or newer: %w", datastore, embeddedVersion, err)
+	}
+
+	scriptVer, err := hversion.NewVersion(remoteVersion)
+	if err != nil {
+		return fmt.Errorf("invalid script version format %s: %w", remoteVersion, err)
 	}
 
 	embeddedVer, err := hversion.NewVersion(embeddedVersion)
@@ -456,36 +490,12 @@ func checkScriptVersion(ctx context.Context, sshClient vmware.SSHClient, datasto
 		restrictedPublicKey := fmt.Sprintf(`command="%s",no-port-forwarding,no-agent-forwarding,no-X11-forwarding %s`,
 			util.RestrictedSSHCommandTemplate, publicKeyStr)
 
-		instructions := fmt.Sprintf(`Version mismatch detected!
-  - Just uploaded script version: %s
-  - SSH returned version: %s
-
-This indicates the SSH key is executing a different script file.
-Most likely cause: You are using the old Python-based SSH key format
-which executes a file with .py extension or UUID in the filename.
-
-The new shell-based format executes:
-  /vmfs/volumes/%s/secure-vmkfstools-wrapper (no extension)
-
-To fix this issue:
-1. SSH to the ESXi host
-2. Edit /etc/ssh/keys-root/authorized_keys: vi /etc/ssh/keys-root/authorized_keys
-3. Find the line containing the old Python wrapper
-4. DELETE the line containing .py extension or UUID in filename
-   Examples of old format to remove:
-     - Lines ending with: secure-vmkfstools-wrapper.py
-     - Lines ending with: secure-vmkfstools-wrapper-$UUID.py
-5. Add the following NEW SSH key line:
-
-  %s
-
-6. Save and exit
-7. Retry the operation`, embeddedVersion, versionInfo.Version, datastore, restrictedPublicKey)
 		setupLog := logger.New("xcopy").WithName("setup")
-		setupLog.Error(fmt.Errorf("version mismatch: uploaded %s, SSH returned %s", embeddedVersion, versionInfo.Version), "script version mismatch", "instructions", instructions)
-
-		return fmt.Errorf("version mismatch: uploaded %s but SSH returned %s - old SSH key format detected",
-			embeddedVersion, versionInfo.Version)
+		err := fmt.Errorf("version mismatch: uploaded %s, but SSH returned %s - old SSH key format detected", embeddedVersion, remoteVersion)
+		setupLog.Error(err, "script version mismatch",
+			"instructions",
+			fmt.Sprintf(sshInstructionTemplate, embeddedVersion, remoteVersion, datastore, restrictedPublicKey))
+		return err
 	}
 
 	return nil

--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli_test.go
@@ -193,7 +193,7 @@ var _ = Describe("checkScriptVersion", func() {
 			err := checkScriptVersion(context.Background(), client, datastore, "0.3.0", publicKey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("version mismatch"))
-			Expect(err.Error()).To(ContainSubstring("uploaded 0.3.0 but SSH returned 0.2.0"))
+			Expect(err.Error()).To(ContainSubstring("uploaded 0.3.0, but SSH returned 0.2.0"))
 			Expect(err.Error()).To(ContainSubstring("old SSH key format detected"))
 		})
 	})

--- a/cmd/vsphere-copy-offload-populator/internal/populator/secure_script.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/secure_script.go
@@ -16,6 +16,22 @@ const (
 	scriptName = "secure-vmkfstools-wrapper"
 )
 
+// getRemoteScriptVersion connects via SSH and queries the wrapper script's version.
+// Returns the version string or an error if the check cannot be performed
+// (e.g. SSH keys not yet configured, script not present).
+func getRemoteScriptVersion(ctx context.Context, hostIP string, privateKey []byte, datastore string) (string, error) {
+	checkCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	sshClient := vmware.NewSSHClient()
+	if err := sshClient.Connect(checkCtx, hostIP, "root", privateKey); err != nil {
+		return "", fmt.Errorf("SSH connect failed: %w", err)
+	}
+	defer sshClient.Close()
+
+	return getScriptVersion(checkCtx, sshClient, datastore)
+}
+
 // writeSecureScriptToTemp writes the embedded script to a temporary file
 func writeSecureScriptToTemp() (string, error) {
 	tempFile, err := os.CreateTemp("", "secure-vmkfstools-wrapper-*")
@@ -33,12 +49,27 @@ func writeSecureScriptToTemp() (string, error) {
 	return tempFile.Name(), nil
 }
 
-// ensureSecureScript ensures the secure script is uploaded and available on the target ESX
-// Returns the script path
-func ensureSecureScript(ctx context.Context, client vmware.Client, esx *object.HostSystem, datastore string) (string, error) {
+// ensureSecureScript ensures the secure script is uploaded and available on the target ESX.
+// It first checks the version of any existing script via SSH; if it matches the
+// embedded version, the upload is skipped to avoid racing with other populator pods.
+func ensureSecureScript(ctx context.Context, client vmware.Client, esx *object.HostSystem, datastore, hostIP string, privateKey []byte) (string, error) {
 	log := klog.Background().WithName("copy-offload").WithName("secure-script")
 	log.Info("ensuring secure script on ESXi", "host", esx.Name())
-	log.Info("force uploading secure script to ensure latest version")
+
+	datastorePath := fmt.Sprintf("/vmfs/volumes/%s/%s", datastore, scriptName)
+
+	if vmkfstoolswrapper.Version != "dev" {
+		remoteVersion, err := getRemoteScriptVersion(ctx, hostIP, privateKey, datastore)
+		if err == nil && remoteVersion == vmkfstoolswrapper.Version {
+			log.Info("script version matches, skipping upload", "version", remoteVersion)
+			return datastorePath, nil
+		}
+		if err != nil {
+			log.V(2).Info("could not check remote script version, will upload", "err", err)
+		} else {
+			log.Info("script version mismatch, will upload", "remote", remoteVersion, "embedded", vmkfstoolswrapper.Version)
+		}
+	}
 
 	dc, err := getHostDC(esx)
 	if err != nil {


### PR DESCRIPTION

- When 35+ VMs migrate concurrently, every populator pod force-uploads the wrapper script to the same datastore path, creating a race where one pod truncates the file while another reads it empty (EOF)
- Check remote script version via SSH before uploading; skip upload if version matches
- Extract `getScriptVersion()` as shared helper for version decoding, reused by both pre-upload check and post-upload validation
- Reorder setup so `EnableSSHAccess` runs before `ensureSecureScript`, guaranteeing SSH is available for the version check

Resolves: MTV-4732

🤖 Generated with [Claude Code](https://claude.com/claude-code)