### PR TITLE
MTV-5244 | Add warning for missing IP addresses when preserveStaticIps

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -538,6 +538,10 @@ func (r *Validator) StaticIPs(vmRef ref.Ref) (ok bool, err error) {
 		return
 	}
 
+	if len(vm.NICs) > 0 && len(vm.GuestNetworks) == 0 {
+		return false, nil
+	}
+
 	for _, guestNetwork := range vm.GuestNetworks {
 		found := false
 		for _, nic := range vm.NICs {

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -67,6 +67,9 @@ func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 		if ref.Name == "not_windows_guest" {
 			res.VM.GuestID = "rhel8_64Guest"
 		}
+		if ref.Name == "nics_no_guest_networks" {
+			res.VM.GuestNetworks = nil
+		}
 		if ref.Name == "missing_from_inventory" {
 			return base.NotFoundError{}
 		}
@@ -200,6 +203,7 @@ var _ = Describe("vsphere validation tests", func() {
 			Entry("when the vm have static ips, and the plan set without static ip", "test", false, false),
 			Entry("when the vm doesn't have static ips, and the plan set without static ip, vm is non-windows", "not_windows_guest", false, false),
 			Entry("when the vm doesn't have static ips, and the plan set with static ip, vm is non-windows", "not_windows_guest", true, false),
+			Entry("when the vm has NICs but no guest networks, and the plan set with static ip", "nics_no_guest_networks", true, true),
 			Entry("when the vm doesn't exist", "missing_from_inventory", true, true),
 		)
 	})


### PR DESCRIPTION
Issue: when migrating VM that MTV does not see any IP address we are not showing any warning in the status.

Resolves: MTV-5244