### PR TITLE
MTV-5251 | Use instance UUID instead of moref for VM lookup

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	core "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -44,7 +45,7 @@ type Client struct {
 // Create a VM snapshot and return its ID.
 func (r *Client) CreateSnapshot(vmRef ref.Ref, hostsFunc util.HostsFunc) (snapshotId string, creationTaskId string, err error) {
 	r.Log.V(1).Info("Creating snapshot", "vmRef", vmRef)
-	vm, err := r.getVM(vmRef)
+	vm, err := r.getVM(vmRef, hostsFunc)
 	if err != nil {
 		return
 	}
@@ -110,7 +111,7 @@ func (r *Client) RemoveSnapshot(vmRef ref.Ref, snapshot string, hosts util.Hosts
 	r.Log.V(1).Info("RemoveSnapshot",
 		"vmRef", vmRef,
 		"snapshot", snapshot)
-	vm, err := r.getVM(vmRef)
+	vm, err := r.getVM(vmRef, hosts)
 	if err != nil {
 		return
 	}
@@ -171,7 +172,7 @@ func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, data
 
 // Get the power state of the VM.
 func (r *Client) PowerState(vmRef ref.Ref) (state planapi.VMPowerState, err error) {
-	vm, err := r.getVM(vmRef)
+	vm, err := r.getVM(vmRef, nullableHosts)
 	if err != nil {
 		return
 	}
@@ -193,7 +194,7 @@ func (r *Client) PowerState(vmRef ref.Ref) (state planapi.VMPowerState, err erro
 
 // Power on the VM.
 func (r *Client) PowerOn(vmRef ref.Ref) (err error) {
-	vm, err := r.getVM(vmRef)
+	vm, err := r.getVM(vmRef, nullableHosts)
 	if err != nil {
 		return
 	}
@@ -214,7 +215,7 @@ func (r *Client) PowerOn(vmRef ref.Ref) (err error) {
 
 // Power off the VM. Requires guest tools to be installed.
 func (r *Client) PowerOff(vmRef ref.Ref) (err error) {
-	vm, err := r.getVM(vmRef)
+	vm, err := r.getVM(vmRef, nullableHosts)
 	if err != nil {
 		return
 	}
@@ -236,7 +237,7 @@ func (r *Client) PowerOff(vmRef ref.Ref) (err error) {
 
 // Determine whether the VM has been powered off.
 func (r *Client) PoweredOff(vmRef ref.Ref) (poweredOff bool, err error) {
-	vm, err := r.getVM(vmRef)
+	vm, err := r.getVM(vmRef, nullableHosts)
 	if err != nil {
 		return
 	}
@@ -273,7 +274,7 @@ func (r *Client) PreTransferActions(vmRef ref.Ref) (ready bool, err error) {
 
 // Get a mapping of disks and change IDs for a given snapshot.
 func (r *Client) GetSnapshotDeltas(vmRef ref.Ref, snapshotId string, hosts util.HostsFunc) (changeIdMapping map[string]string, err error) {
-	vm, err := r.getVM(vmRef)
+	vm, err := r.getVM(vmRef, hosts)
 	if err != nil {
 		return
 	}
@@ -494,7 +495,7 @@ func (r *Client) getHostClient(hostDef *v1beta1.Host, host *model.Host) (client 
 }
 
 // Get the VM by ref.
-func (r *Client) getVM(vmRef ref.Ref) (vsphereVm *object.VirtualMachine, err error) {
+func (r *Client) getVM(vmRef ref.Ref, hosts util.HostsFunc) (vsphereVm *object.VirtualMachine, err error) {
 	vm := &model.VM{}
 	err = r.Source.Inventory.Find(vm, vmRef)
 	if err != nil {
@@ -502,16 +503,29 @@ func (r *Client) getVM(vmRef ref.Ref) (vsphereVm *object.VirtualMachine, err err
 		return
 	}
 
-	// vm.ID is the vCenter inventory MoRef, which is only valid on the vCenter
-	// endpoint. Always use the vCenter client here; ESXi host clients are used
-	// separately for task-level operations (getTaskById, findRunningSnapshotTask).
-	moref := types.ManagedObjectReference{Type: "VirtualMachine", Value: vm.ID}
-	if moref.Value == "" {
-		err = liberr.New(
-			fmt.Sprintf("VM %s has empty managed object id; source lookup failed", vmRef.String()))
+	client, err := r.getClient(vm, hosts)
+	if err != nil {
 		return
 	}
-	vsphereVm = object.NewVirtualMachine(r.client.Client, moref)
+
+	searchIndex := object.NewSearchIndex(client)
+	vsphereRef, err := searchIndex.FindByUuid(context.TODO(), nil, vm.UUID, true, ptr.To(false))
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if vsphereRef == nil {
+		err = liberr.New(
+			fmt.Sprintf(
+				"VM %s source lookup failed",
+				vmRef.String()))
+		return
+	}
+	vsphereVm = object.NewVirtualMachine(client, vsphereRef.Reference())
+	return
+}
+
+func nullableHosts() (hosts map[string]*v1beta1.Host, err error) {
 	return
 }
 

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -509,7 +509,12 @@ func (r *Client) getVM(vmRef ref.Ref, hosts util.HostsFunc) (vsphereVm *object.V
 	}
 
 	searchIndex := object.NewSearchIndex(client)
-	vsphereRef, err := searchIndex.FindByUuid(context.TODO(), nil, vm.UUID, true, ptr.To(false))
+	uuid := vm.InstanceUUID
+	useInstanceUUID := uuid != ""
+	if !useInstanceUUID {
+		uuid = vm.UUID
+	}
+	vsphereRef, err := searchIndex.FindByUuid(context.TODO(), nil, uuid, true, ptr.To(useInstanceUUID))
 	if err != nil {
 		err = liberr.Wrap(err)
 		return

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -117,6 +117,7 @@ const (
 	fVmfsExtent  = "info"
 	// VM
 	fUUID                     = "config.uuid"
+	fInstanceUUID             = "config.instanceUuid"
 	fFirmware                 = "config.firmware"
 	fFtInfo                   = "config.ftInfo"
 	fBootOptions              = "config.bootOptions"
@@ -834,6 +835,7 @@ func (r *Collector) vmPathSet() []string {
 		fName,
 		fParent,
 		fUUID,
+		fInstanceUUID,
 		fFirmware,
 		fFtInfo,
 		fCpuAffinity,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -714,6 +714,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if s, cast := p.Val.(string); cast {
 					v.model.UUID = s
 				}
+			case fInstanceUUID:
+				if s, cast := p.Val.(string); cast {
+					v.model.InstanceUUID = s
+				}
 			case fFirmware:
 				if s, cast := p.Val.(string); cast {
 					v.model.Firmware = s

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -308,6 +308,7 @@ type VM struct {
 	RevisionValidated        int64            `sql:"d0,index(revisionValidated)"`
 	PolicyVersion            int              `sql:"d0,index(policyVersion)"`
 	UUID                     string           `sql:""`
+	InstanceUUID             string           `sql:""`
 	Firmware                 string           `sql:""`
 	PowerState               string           `sql:""`
 	ConnectionState          string           `sql:""`

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -266,6 +266,7 @@ type VM struct {
 	VM1
 	PolicyVersion            int                    `json:"policyVersion"`
 	UUID                     string                 `json:"uuid"`
+	InstanceUUID             string                 `json:"instanceUuid"`
 	Firmware                 string                 `json:"firmware"`
 	ConnectionState          string                 `json:"connectionState"`
 	Snapshot                 model.Ref              `json:"snapshot"`
@@ -311,6 +312,7 @@ func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)
 	r.PolicyVersion = m.PolicyVersion
 	r.UUID = m.UUID
+	r.InstanceUUID = m.InstanceUUID
 	r.Firmware = m.Firmware
 	r.ConnectionState = m.ConnectionState
 	r.Snapshot = m.Snapshot


### PR DESCRIPTION
Issue:
PR #5973 switched some parts to use vcenter api instead of esxi this
broke warm migraiton tasks, so we need to revert the changes. And to
properly fix MTV-5091 we will swtich search from bios uuid to instance
uuid.

Fix:
Use FindByUuid with instance UUID (config.instanceUuid) which is
globally unique and valid on both vCenter and ESXi. Add InstanceUUID
field to the VM model and collector.

Ref: https://issues.redhat.com/browse/MTV-5251
Resolves: MTV-5251

Signed-off-by: Martin Necas <mnecas@redhat.com>
