### PR TITLE
MTV-5245 | Add registry-based Windows static IP firstboot scripts

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -271,6 +271,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_windows_registry_network_config:
+                description: 'Use registry-based network configuration scripts for
+                  Windows static IP setup (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -271,6 +271,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_windows_registry_network_config:
+                description: 'Use registry-based network configuration scripts for
+                  Windows static IP setup (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -83,6 +83,10 @@ spec:
                 type: string
                 enum: ["true", "false"]
                 description: "Run VMware driver removal scripts during Windows vSphere conversion (default: false)"
+              feature_windows_registry_network_config:
+                type: string
+                enum: ["true", "false"]
+                description: "Use registry-based network configuration scripts for Windows static IP setup (default: false)"
 
               # Container Images
               controller_image_fqin:

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -10,6 +10,7 @@ feature_copy_offload: true
 feature_ocp_live_migration: true
 feature_vmware_system_serial_number: true
 feature_vsphere_vmware_driver_removal: false
+feature_windows_registry_network_config: false
 feature_cli_download: true
 feature_ova_appliance_management: true
 

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -182,6 +182,10 @@ spec:
         - name: FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL
           value: "true"
 {% endif %}
+{% if feature_windows_registry_network_config|bool %}
+        - name: FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG
+          value: "true"
+{% endif %}
 {% if ovirt_osmap_configmap_name is defined %}
         - name: OVIRT_OS_MAP
           value: {{ ovirt_osmap_configmap_name }}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2280,6 +2280,13 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, vddk
 				Value: "true",
 			})
 	}
+	if settings.Settings.Features.WindowsRegistryNetworkConfig {
+		environment = append(environment,
+			core.EnvVar{
+				Name:  "V2V_windowsRegistryNetworkConfig",
+				Value: "true",
+			})
+	}
 
 	environment = append(environment,
 		core.EnvVar{

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -8,15 +8,16 @@ import (
 
 // Environment Variables
 const (
-	FeatureOvirtWarmMigration         = "FEATURE_OVIRT_WARM_MIGRATION"
-	FeatureRetainPrecopyImporterPods  = "FEATURE_RETAIN_PRECOPY_IMPORTER_PODS"
-	FeatureStaticUdnIpAddresses       = "FEATURE_STATIC_UDN_IP_ADDRESSES"
-	FeatureVsphereIncrementalBackup   = "FEATURE_VSPHERE_INCREMENTAL_BACKUP"
-	FeatureCopyOffload                = "FEATURE_COPY_OFFLOAD"
-	FeatureOCPLiveMigration           = "FEATURE_OCP_LIVE_MIGRATION"
-	FeatureVmwareSystemSerialNumber   = "FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER"
-	FeatureOVFApplianceManagement     = "FEATURE_OVF_APPLIANCE_MANAGEMENT"
-	FeatureVsphereVmwareDriverRemoval = "FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL"
+	FeatureOvirtWarmMigration           = "FEATURE_OVIRT_WARM_MIGRATION"
+	FeatureRetainPrecopyImporterPods    = "FEATURE_RETAIN_PRECOPY_IMPORTER_PODS"
+	FeatureStaticUdnIpAddresses         = "FEATURE_STATIC_UDN_IP_ADDRESSES"
+	FeatureVsphereIncrementalBackup     = "FEATURE_VSPHERE_INCREMENTAL_BACKUP"
+	FeatureCopyOffload                  = "FEATURE_COPY_OFFLOAD"
+	FeatureOCPLiveMigration             = "FEATURE_OCP_LIVE_MIGRATION"
+	FeatureVmwareSystemSerialNumber     = "FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER"
+	FeatureOVFApplianceManagement       = "FEATURE_OVF_APPLIANCE_MANAGEMENT"
+	FeatureVsphereVmwareDriverRemoval   = "FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL"
+	FeatureWindowsRegistryNetworkConfig = "FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG"
 )
 
 // OpenShift version where the FeatureVmwareSystemSerialNumber feature is supported:
@@ -62,6 +63,8 @@ type Features struct {
 	InsecureSkipVerifySupported bool
 	// Whether to run VMware driver removal scripts during Windows vSphere conversion (virt-customize).
 	VsphereVmwareDriverRemoval bool
+	// Whether to use registry-based network configuration scripts for Windows static IP setup.
+	WindowsRegistryNetworkConfig bool
 }
 
 // isOpenShiftVersionAboveMinimum checks if OpenShift version is above or equal to minimum version using semantic versioning
@@ -99,5 +102,6 @@ func (r *Features) Load() (err error) {
 	r.InsecureSkipVerifySupported = r.isOpenShiftVersionAboveMinimum(ocpMinForInsecureSkipVerify)
 	r.OVFApplianceManagement = getEnvBool(FeatureOVFApplianceManagement, false)
 	r.VsphereVmwareDriverRemoval = getEnvBool(FeatureVsphereVmwareDriverRemoval, false)
+	r.WindowsRegistryNetworkConfig = getEnvBool(FeatureWindowsRegistryNetworkConfig, false)
 	return
 }

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -14,29 +14,30 @@ type MountPath string
 
 // Enviroment variables
 const (
-	EnvLibvirtUrlName                 = "V2V_libvirtURL"
-	EnvFingerprintName                = "V2V_fingerprint"
-	EnvInPlaceName                    = "V2V_inPlace"
-	EnvExtraArgsName                  = "V2V_extra_args"
-	EnvInspectorExtraArgsName         = "V2V_inspector_extra_args"
-	EnvNewNameName                    = "V2V_NewName"
-	EnvVmNameName                     = "V2V_vmName"
-	EnvRootDiskName                   = "V2V_RootDisk"
-	EnvStaticIPsName                  = "V2V_staticIPs"
-	EnvSourceName                     = "V2V_source"
-	EnvDiskPathName                   = "V2V_diskPath"
-	EnvSecretKeyName                  = "V2V_secretKey"
-	EnvLocalMigrationName             = "LOCAL_MIGRATION"
-	EnvVirtIoWinLegacyDriversName     = "VIRTIO_WIN"
-	EnvHostName                       = "V2V_HOSTNAME"
-	EnvNbdeClevis                     = "V2V_NBDE_CLEVIS"
-	EnvMultipleIpsPerNicName          = "V2V_multipleIPsPerNic"
-	EnvRemoteInspection               = "V2V_remoteInspection"
-	EnvRemoteInspectionDisk           = "V2V_remoteInspectDisk_"
-	EnvMemSizeName                    = "V2V_memSize"
-	EnvSmpName                        = "V2V_smp"
-	EnvVsphereVmwareDriverRemovalName = "V2V_vsphereVmwareDriverRemoval"
-	EnvXfsCompatibilityName           = "V2V_xfsCompatibility"
+	EnvLibvirtUrlName                   = "V2V_libvirtURL"
+	EnvFingerprintName                  = "V2V_fingerprint"
+	EnvInPlaceName                      = "V2V_inPlace"
+	EnvExtraArgsName                    = "V2V_extra_args"
+	EnvInspectorExtraArgsName           = "V2V_inspector_extra_args"
+	EnvNewNameName                      = "V2V_NewName"
+	EnvVmNameName                       = "V2V_vmName"
+	EnvRootDiskName                     = "V2V_RootDisk"
+	EnvStaticIPsName                    = "V2V_staticIPs"
+	EnvSourceName                       = "V2V_source"
+	EnvDiskPathName                     = "V2V_diskPath"
+	EnvSecretKeyName                    = "V2V_secretKey"
+	EnvLocalMigrationName               = "LOCAL_MIGRATION"
+	EnvVirtIoWinLegacyDriversName       = "VIRTIO_WIN"
+	EnvHostName                         = "V2V_HOSTNAME"
+	EnvNbdeClevis                       = "V2V_NBDE_CLEVIS"
+	EnvMultipleIpsPerNicName            = "V2V_multipleIPsPerNic"
+	EnvRemoteInspection                 = "V2V_remoteInspection"
+	EnvRemoteInspectionDisk             = "V2V_remoteInspectDisk_"
+	EnvMemSizeName                      = "V2V_memSize"
+	EnvSmpName                          = "V2V_smp"
+	EnvVsphereVmwareDriverRemovalName   = "V2V_vsphereVmwareDriverRemoval"
+	EnvWindowsRegistryNetworkConfigName = "V2V_windowsRegistryNetworkConfig"
+	EnvXfsCompatibilityName             = "V2V_xfsCompatibility"
 )
 
 const (
@@ -111,6 +112,8 @@ type AppConfig struct {
 	Smp int
 	// V2V_vsphereVmwareDriverRemoval
 	VsphereVmwareDriverRemoval bool
+	// V2V_windowsRegistryNetworkConfig
+	WindowsRegistryNetworkConfig bool
 	// V2V_xfsCompatibility — use XFS-capable virt-v2v; omit --no-fstrim when true
 	// the el9 v2v is missing the --no-fstrim flag so the conversion would fail
 	XfsCompatibility bool
@@ -158,6 +161,7 @@ func (s *AppConfig) Load() (err error) {
 	flag.IntVar(&s.MemSize, "memsize", s.getEnvInt(EnvMemSizeName, 0), "Amount of memory (in MB) allocated for the conversion appliance")
 	flag.IntVar(&s.Smp, "smp", s.getEnvInt(EnvSmpName, 0), "Number of virtual CPUs used for the conversion appliance")
 	flag.BoolVar(&s.VsphereVmwareDriverRemoval, "vsphere-vmware-driver-removal", s.getEnvBool(EnvVsphereVmwareDriverRemovalName, false), "Run VMware driver removal scripts during Windows vSphere conversion")
+	flag.BoolVar(&s.WindowsRegistryNetworkConfig, "windows-registry-network-config", s.getEnvBool(EnvWindowsRegistryNetworkConfigName, false), "Use registry-based network configuration scripts for Windows static IP setup")
 	flag.BoolVar(&s.XfsCompatibility, "xfs-compatibility", s.getEnvBool(EnvXfsCompatibilityName, false), "XFS compatibility mode: do not pass --no-fstrim to virt-v2v")
 	s.RemoteInspectionDisks = s.getRemoteInspectionDisks()
 	flag.Parse()

--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -160,7 +160,9 @@ func (c *Customize) customizeWindows() (err error) {
 		c.addVsphereVmwareDriverRemoval(cmdBuilder)
 	}
 
-	c.addWinFirstbootScripts(cmdBuilder)
+	if err = c.addWinFirstbootScripts(cmdBuilder); err != nil {
+		return err
+	}
 
 	c.addDisksToCustomize(cmdBuilder)
 
@@ -307,7 +309,7 @@ func (c *Customize) addVsphereVmwareDriverRemoval(cmdBuilder utils.CommandBuilde
 }
 
 // addWinFirstbootScripts appends firstboot script arguments to extraArgs
-func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) {
+func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) error {
 	windowsScriptsPath := filepath.Join(c.appConfig.Workdir, "scripts", "windows")
 	initPath := filepath.Join(windowsScriptsPath, "9999-run-mtv-ps-scripts.bat")
 
@@ -317,35 +319,42 @@ func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) {
 	uploadPreserveMultipleIpPath := ""
 	if c.appConfig.VirtIoWinLegacyDrivers != "" {
 		initPath = filepath.Join(windowsScriptsPath, "9999-run-mtv-ps-scripts-legacy.bat")
-
-		if c.appConfig.StaticIPs != "" {
-			networkConfigtemplate := filepath.Join(windowsScriptsPath, "9999-network-config.ps1.tmpl")
-			networkConfigScript := filepath.Join(windowsScriptsPath, "9999-network-config.ps1")
-
-			err := c.injectStaticIPTemplate(networkConfigtemplate, networkConfigScript)
-			if err != nil {
-				fmt.Printf("Error injecting static IP template: %v", err)
-			}
-			uploadPreserveIpPath = c.formatUpload(networkConfigScript, WinFirstbootScriptsPath)
-		}
 	}
 
-	if c.appConfig.StaticIPs != "" {
-		removeDuplicatesPersistentRoutesPath := filepath.Join(windowsScriptsPath, "9999-remove_duplicate_persistent_routes.ps1")
+	staticIPFirstbootScripts := c.appConfig.VirtIoWinLegacyDrivers != "" || c.appConfig.WindowsRegistryNetworkConfig
+	if c.appConfig.StaticIPs != "" && staticIPFirstbootScripts {
+		var networkConfigTemplate string
+		var removeDuplicatesPersistentRoutesPath string
+		var preserveIpsTemplate string
+		if c.appConfig.WindowsRegistryNetworkConfig {
+			networkConfigTemplate = filepath.Join(windowsScriptsPath, "9999-network-config-registry.ps1.tmpl")
+			removeDuplicatesPersistentRoutesPath = filepath.Join(windowsScriptsPath, "9999-remove_duplicate_persistent_routes-registry.ps1")
+			preserveIpsTemplate = filepath.Join(windowsScriptsPath, "9999-preserve_complementry_ips_per_nic-registry.ps1.tmpl")
+		} else {
+			networkConfigTemplate = filepath.Join(windowsScriptsPath, "9999-network-config.ps1.tmpl")
+			removeDuplicatesPersistentRoutesPath = filepath.Join(windowsScriptsPath, "9999-remove_duplicate_persistent_routes.ps1")
+			preserveIpsTemplate = filepath.Join(windowsScriptsPath, "9999-preserve_complementry_ips_per_nic.ps1.tmpl")
+		}
+
+		networkConfigScript := filepath.Join(windowsScriptsPath, "9999-network-config.ps1")
+		if err := c.injectStaticIPTemplate(networkConfigTemplate, networkConfigScript); err != nil {
+			return fmt.Errorf("inject static IP template from %q to %q: %w", networkConfigTemplate, networkConfigScript, err)
+		}
+		uploadPreserveIpPath = c.formatUpload(networkConfigScript, WinFirstbootScriptsPath)
+
 		uploadRemoveDuplicatesPath = c.formatUpload(removeDuplicatesPersistentRoutesPath, WinFirstbootScriptsPath)
 
 		if c.appConfig.MultipleIpsPerNicName != "" {
-			preserveIpsTemplate := filepath.Join(windowsScriptsPath, "9999-preserve_complementry_ips_per_nic.ps1.tmpl")
 			preserveMultipleNicsPath := filepath.Join(windowsScriptsPath, "9999-preserve_complementry_ips_per_nic.ps1")
-			err := c.injectComplementryStaticIPTemplate(preserveIpsTemplate, preserveMultipleNicsPath)
-			if err != nil {
-				fmt.Printf("Error injecting Complementry StaticIP's template: %v", err)
+			if err := c.injectComplementryStaticIPTemplate(preserveIpsTemplate, preserveMultipleNicsPath); err != nil {
+				return fmt.Errorf("inject complementary static IP template from %q to %q: %w", preserveIpsTemplate, preserveMultipleNicsPath, err)
 			}
 			uploadPreserveMultipleIpPath = c.formatUpload(preserveMultipleNicsPath, WinFirstbootScriptsPath)
 		}
 	}
 	uploadInitPath := c.formatUpload(initPath, WinFirstbootScriptsPath)
 	cmdBuilder.AddArgs(UploadCmd, uploadPreserveIpPath, uploadInitPath, uploadRemoveDuplicatesPath, uploadPreserveMultipleIpPath)
+	return nil
 }
 
 func (c *Customize) addWinDynamicScripts(cmdBuilder utils.CommandBuilder, dir string) error {

--- a/pkg/virt-v2v/customize/customize_test.go
+++ b/pkg/virt-v2v/customize/customize_test.go
@@ -940,4 +940,52 @@ var _ = Describe("Customize", func() {
 		})
 	})
 
+	Describe("addWinFirstbootScripts path selection", func() {
+		It("no static IPs - only init script uploaded", func() {
+			appConfig.StaticIPs = ""
+			mockCommandBuilder.EXPECT().AddArgs("--upload", "", gomock.Any(), "", "").Return(mockCommandBuilder)
+			err := customize.addWinFirstbootScripts(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("static IPs but neither legacy nor registry - no static IP uploads", func() {
+			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
+			appConfig.VirtIoWinLegacyDrivers = ""
+			appConfig.WindowsRegistryNetworkConfig = false
+			mockCommandBuilder.EXPECT().AddArgs("--upload", "", gomock.Any(), "", "").Return(mockCommandBuilder)
+			err := customize.addWinFirstbootScripts(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("legacy init path is selected when VirtIoWinLegacyDrivers is set", func() {
+			appConfig.VirtIoWinLegacyDrivers = "/mnt/virtio.iso"
+			appConfig.StaticIPs = ""
+			var capturedInit string
+			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(flag string, values ...string) {
+					capturedInit = values[1]
+				}).Return(mockCommandBuilder)
+			err := customize.addWinFirstbootScripts(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(capturedInit).To(ContainSubstring("9999-run-mtv-ps-scripts-legacy.bat"))
+		})
+
+		It("static IP with legacy returns error on missing template", func() {
+			appConfig.VirtIoWinLegacyDrivers = "/mnt/virtio.iso"
+			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
+			err := customize.addWinFirstbootScripts(mockCommandBuilder)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("inject static IP template"))
+			Expect(err.Error()).To(ContainSubstring("9999-network-config.ps1.tmpl"))
+		})
+
+		It("static IP with registry returns error referencing registry template", func() {
+			appConfig.WindowsRegistryNetworkConfig = true
+			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
+			err := customize.addWinFirstbootScripts(mockCommandBuilder)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("9999-network-config-registry.ps1.tmpl"))
+		})
+	})
+
 })

--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config-registry.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config-registry.ps1.tmpl
@@ -1,0 +1,133 @@
+# Configures static IP on Windows network interfaces via registry.
+# Registry writes don't depend on RPC or DHCP Client service.
+# Changes take effect after reboot.
+# Input format: MAC:ip:IP,Gateway,Prefix,DNS1,DNS2 (entries separated by '_')
+
+$inputString = "{{.InputString}}"
+$adapterWaitMinutes = 5
+
+function Convert-PrefixToMask($prefix) {
+    $bin = ("1" * $prefix).PadRight(32, "0")
+    $mask = ""
+    for ($i = 0; $i -lt 32; $i += 8) {
+        $chunk = $bin.Substring($i, 8)
+        $num = [Convert]::ToInt32($chunk, 2)
+        if ($mask -ne "") { $mask = $mask + "." }
+        $mask = $mask + $num
+    }
+    return $mask
+}
+
+function Find-AdapterByMAC($mac) {
+    $startTime = Get-Date
+    $deadline = $startTime.AddMinutes($adapterWaitMinutes)
+    Write-Host "[INFO] Waiting for adapter with MAC $mac..."
+
+    while ((Get-Date) -lt $deadline) {
+        $adapters = Get-NetAdapter -Physical -ErrorAction SilentlyContinue
+        foreach ($a in $adapters) {
+            if ($a.MacAddress -and ($a.MacAddress.ToUpper().Replace(":", "-") -eq $mac)) {
+                $elapsed = ((Get-Date) - $startTime).TotalSeconds
+                Write-Host "[INFO] Found adapter '$($a.Name)' (GUID=$($a.InterfaceGuid)) after $([math]::Round($elapsed))s"
+                return $a
+            }
+        }
+        Start-Sleep -Seconds 2
+    }
+    return $null
+}
+
+Write-Host "=============================================="
+Write-Host "[INFO] MTV Network Configuration Script (Registry)"
+Write-Host "[INFO] Input: $inputString"
+Write-Host "=============================================="
+
+# Group entries by MAC so multiple IPs for the same adapter are written together
+$entries = $inputString.Split("_")
+$totalEntries = $entries.Count
+$adapterConfigs = @{}
+
+Write-Host "[INFO] Parsing $totalEntries entries..."
+
+foreach ($entry in $entries) {
+    if ($entry -match "^([0-9A-Fa-f:\-]+):ip:([^,]+),([^,]+),([^,]+),([^,]+),([^,]*)$") {
+        $mac = $matches[1].ToUpper().Replace(":", "-")
+        $ip = $matches[2]
+        $gw = $matches[3]
+        $prefix = [int]$matches[4]
+        $dns1 = $matches[5]
+        $dns2 = $matches[6]
+        $mask = Convert-PrefixToMask $prefix
+
+        if (-not $adapterConfigs.ContainsKey($mac)) {
+            $adapterConfigs[$mac] = @{
+                IPs = @()
+                Masks = @()
+                Gateway = $gw
+                DNS1 = $dns1
+                DNS2 = $dns2
+            }
+        }
+
+        $adapterConfigs[$mac].IPs += $ip
+        $adapterConfigs[$mac].Masks += $mask
+    } else {
+        Write-Warning "[ERROR] Invalid input format: '$entry'"
+        Write-Warning "[ERROR] Expected: MAC:ip:IP,Gateway,Prefix,DNS1,DNS2"
+    }
+}
+
+$successCount = 0
+$failCount = 0
+
+foreach ($mac in $adapterConfigs.Keys) {
+    $config = $adapterConfigs[$mac]
+    Write-Host ""
+    Write-Host "--- Adapter MAC=$mac ---"
+    Write-Host "[INFO] IPs: $($config.IPs -join ', ')"
+    Write-Host "[INFO] Masks: $($config.Masks -join ', ')"
+    Write-Host "[INFO] GW=$($config.Gateway) DNS=$($config.DNS1),$($config.DNS2)"
+
+    $adapter = Find-AdapterByMAC $mac
+    if ($adapter -eq $null) {
+        Write-Warning "[FAIL] Adapter with MAC $mac not found after waiting ${adapterWaitMinutes}m"
+        $failCount++
+        continue
+    }
+
+    $guid = $adapter.InterfaceGuid
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$guid"
+
+    if (-not (Test-Path $regPath)) {
+        Write-Warning "[FAIL] Registry path not found: $regPath"
+        $failCount++
+        continue
+    }
+
+    Write-Host "[INFO] Writing to registry: $regPath"
+    try {
+        Set-ItemProperty -Path $regPath -Name "EnableDHCP" -Value 0 -Type DWord
+        Set-ItemProperty -Path $regPath -Name "IPAddress" -Value ([string[]]$config.IPs) -Type MultiString
+        Set-ItemProperty -Path $regPath -Name "SubnetMask" -Value ([string[]]$config.Masks) -Type MultiString
+        Set-ItemProperty -Path $regPath -Name "DefaultGateway" -Value @($config.Gateway) -Type MultiString
+
+        $dnsServers = $config.DNS1
+        if ($config.DNS2 -ne "") { $dnsServers = "$($config.DNS1),$($config.DNS2)" }
+        Set-ItemProperty -Path $regPath -Name "NameServer" -Value $dnsServers -Type String
+
+        Write-Host "[OK] Registry updated: IPs=($($config.IPs -join ', ')) GW=$($config.Gateway) DNS=$dnsServers"
+        $successCount++
+    } catch {
+        Write-Error "[FAIL] Registry write failed for MAC=$mac at ${regPath}: $_"
+        $failCount++
+    }
+}
+
+Write-Host ""
+Write-Host "=============================================="
+Write-Host "[INFO] Network configuration complete"
+Write-Host "[INFO] Adapters configured: $successCount"
+if ($failCount -gt 0) {
+    Write-Warning "[WARN] Failed: $failCount"
+}
+Write-Host "=============================================="

--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
@@ -81,4 +81,3 @@ foreach ($entry in $entries) {
         Write-Warning "Input string format is invalid`n"
     }
 }
-

--- a/pkg/virt-v2v/customize/scripts/windows/9999-preserve_complementry_ips_per_nic-registry.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-preserve_complementry_ips_per_nic-registry.ps1.tmpl
@@ -1,0 +1,120 @@
+# Adds complementary (additional) IPs to NICs via registry.
+# Registry writes don't depend on RPC or DHCP Client service.
+
+$adapterWaitMinutes = 5
+
+function Convert-PrefixToMask($prefix) {
+    $bin = ("1" * [int]$prefix).PadRight(32, "0")
+    $mask = ""
+    for ($i = 0; $i -lt 32; $i += 8) {
+        $chunk = $bin.Substring($i, 8)
+        $num = [Convert]::ToInt32($chunk, 2)
+        if ($mask -ne "") { $mask = $mask + "." }
+        $mask = $mask + $num
+    }
+    return $mask
+}
+
+# Wait for the netkvm (virtio-net) driver to become active.
+$startdate = Get-Date
+$adapters = @()
+While (-Not $adapters -and $startdate.AddMinutes($adapterWaitMinutes) -gt (Get-Date)) {
+    Start-Sleep -Seconds 5
+    $adapters = Get-NetAdapter -Physical | Where DriverFileName -eq "netkvm.sys"
+    Write-Host "[INFO] Waiting for netkvm.sys adapters..."
+}
+
+# Define MACs and IPs for each adapter
+$networkConfigs = @(
+{{- range $i, $cfg := . }}
+    @{
+        MAC = '{{ lower $cfg.MAC }}'
+        IPs = @{{ formatIPs $cfg.IPs }}
+        PrefixLength = {{ (index $cfg.IPs 0).PrefixLength }}
+        DNS = @{{ formatDNS $cfg }}
+    }{{ if ne (add $i 1) (len $) }},{{ end }}
+{{- end }}
+)
+
+Write-Host "=============================================="
+Write-Host "[INFO] MTV Complementary IPs Configuration (Registry)"
+Write-Host "=============================================="
+
+foreach ($config in $networkConfigs) {
+    $mac = $config.MAC
+    Write-Host ""
+    Write-Host "[INFO] Processing adapter with MAC: $mac"
+
+    $adapter = Get-NetAdapter -Physical | Where-Object {
+        $_.MacAddress -and ($_.MacAddress.ToLower().Replace(":", "-") -eq $mac.Replace(":", "-"))
+    }
+
+    if (-not $adapter) {
+        Write-Warning "[FAIL] Adapter with MAC $mac not found"
+        continue
+    }
+
+    $guid = $adapter.InterfaceGuid
+    $name = $adapter.Name
+    Write-Host "[INFO] Configuring adapter '$name' (GUID=$guid)"
+
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$guid"
+    if (-not (Test-Path $regPath)) {
+        Write-Warning "[FAIL] Registry path not found: $regPath"
+        continue
+    }
+
+    # Read existing IPs from registry
+    $existingIPs = @()
+    $existingMasks = @()
+    $regIPAddress = (Get-ItemProperty -Path $regPath -Name "IPAddress" -ErrorAction SilentlyContinue).IPAddress
+    $regSubnetMask = (Get-ItemProperty -Path $regPath -Name "SubnetMask" -ErrorAction SilentlyContinue).SubnetMask
+
+    if ($regIPAddress) {
+        $existingIPs = @($regIPAddress | Where-Object { $_ -ne "" })
+    }
+    if ($regSubnetMask) {
+        $existingMasks = @($regSubnetMask | Where-Object { $_ -ne "" })
+    }
+
+    Write-Host "[INFO] Existing IPs: $($existingIPs -join ', ')"
+
+    $mask = Convert-PrefixToMask $config.PrefixLength
+    $allIPs = [System.Collections.ArrayList]@($existingIPs)
+    $allMasks = [System.Collections.ArrayList]@($existingMasks)
+
+    foreach ($ip in $config.IPs) {
+        if ($allIPs -contains $ip) {
+            Write-Host "[INFO] IP $ip already present, skipping"
+            continue
+        }
+        Write-Host "[INFO] Adding complementary IP: $ip"
+        $allIPs.Add($ip) | Out-Null
+        $allMasks.Add($mask) | Out-Null
+    }
+
+    if ($allIPs.Count -eq $existingIPs.Count) {
+        Write-Host "[INFO] No new IPs to add for adapter '$name'"
+        continue
+    }
+
+    # Write updated IPs to registry
+    Write-Host "[INFO] Writing to registry: IPs=($($allIPs -join ', ')) Masks=($($allMasks -join ', '))"
+    Set-ItemProperty -Path $regPath -Name "IPAddress" -Value ([string[]]$allIPs) -Type MultiString
+    Set-ItemProperty -Path $regPath -Name "SubnetMask" -Value ([string[]]$allMasks) -Type MultiString
+    Set-ItemProperty -Path $regPath -Name "EnableDHCP" -Value 0 -Type DWord
+
+    # Set DNS
+    if ($config.DNS.Count -gt 0) {
+        $dnsString = $config.DNS -join ","
+        Write-Host "[INFO] Setting DNS: $dnsString"
+        Set-ItemProperty -Path $regPath -Name "NameServer" -Value $dnsString -Type String
+    }
+
+    Write-Host "[OK] Complementary IPs written to registry for '$name'"
+}
+
+Write-Host ""
+Write-Host "=============================================="
+Write-Host "[INFO] Complementary IPs configuration complete"
+Write-Host "=============================================="

--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
@@ -1,0 +1,230 @@
+# Requires Administrator privileges to run
+
+Write-Host "Starting persistent route cleanup script..." -ForegroundColor Green
+
+# Function to convert CIDR prefix length to subnet mask
+function Convert-PrefixToMask($prefix) {
+    $bin = ("1" * $prefix).PadRight(32, "0")
+    $octets = @(
+        $bin.Substring(0, 8)
+        $bin.Substring(8, 8)
+        $bin.Substring(16, 8)
+        $bin.Substring(24, 8)
+    ) | ForEach-Object { [Convert]::ToInt32($_, 2) }
+
+    return ($octets -join ".")
+}
+
+# Get persistent routes
+try {
+    $routes = Get-NetRoute -PolicyStore PersistentStore -ErrorAction Stop
+} catch {
+    Write-Host "Error retrieving persistent routes: $_" -ForegroundColor Red
+    Exit 1
+}
+
+$routes = $routes | Where-Object { $_.AddressFamily -eq "IPv4" }
+
+# Step 1: Preserve ALL default gateways (0.0.0.0/0) with their interface indexes
+$defaultGateways = $routes | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" }
+Write-Host "Found $($defaultGateways.Count) default gateway(s) to preserve:" -ForegroundColor Cyan
+foreach ($gw in $defaultGateways) {
+    Write-Host "  Gateway: $($gw.NextHop) on Interface $($gw.InterfaceIndex) with metric $($gw.RouteMetric)" -ForegroundColor Cyan
+}
+
+# Step 2: Clean up duplicate routes (including default gateways)
+Write-Host "Analyzing routes for duplicates..." -ForegroundColor Yellow
+
+# Group ALL routes for duplicate detection  
+$groupedRoutes = $routes | Group-Object {
+    "$($_.DestinationPrefix)-$($_.NextHop)-$($_.RouteMetric)-$($_.InterfaceIndex)"
+} | Where-Object { $_.Count -gt 1 }
+
+# Separate default gateway duplicates from other duplicates
+$gatewayDuplicates = $groupedRoutes | Where-Object { $_.Name.Trim().StartsWith("0.0.0.0/0-") }
+$nonGatewayDuplicates = $groupedRoutes | Where-Object { -not $_.Name.Trim().StartsWith("0.0.0.0/0-") }
+
+Write-Host "Found $($gatewayDuplicates.Count) duplicate default gateway groups" -ForegroundColor Cyan
+Write-Host "Found $($nonGatewayDuplicates.Count) duplicate non-gateway route groups" -ForegroundColor Cyan
+
+if (-not $groupedRoutes) {
+    Write-Host "No duplicate persistent routes found." -ForegroundColor Green
+} else {
+    Write-Host "Cleaning up duplicate persistent routes..." -ForegroundColor Yellow
+    
+    # First, handle duplicate default gateways
+    foreach ($group in $gatewayDuplicates) {
+        $routes = $group.Group
+        
+        # Choose the route with an interface that actually exists
+        $toKeep = $null
+        foreach ($route in $routes) {
+            $interface = Get-NetAdapter | Where-Object { $_.InterfaceIndex -eq $route.InterfaceIndex } -ErrorAction SilentlyContinue
+            if ($interface) {
+                $toKeep = $route
+                break
+            }
+        }
+        
+        # If no existing interface found, just use the first one
+        if (-not $toKeep) {
+            $toKeep = $routes[0]
+        }
+        
+        $dest = $toKeep.DestinationPrefix
+        $gateway = $toKeep.NextHop
+        $metric = $toKeep.RouteMetric
+        
+        Write-Host "  Cleaning duplicate default gateway: $gateway (metric $metric) - keeping IF $($toKeep.InterfaceIndex)" -ForegroundColor Yellow
+        
+        # Remove ALL instances
+        foreach ($route in $routes) {
+            try {
+                Remove-NetRoute -DestinationPrefix $route.DestinationPrefix -NextHop $route.NextHop -InterfaceIndex $route.InterfaceIndex -PolicyStore PersistentStore -Confirm:$false -ErrorAction Stop
+                Write-Host "    Deleted: $($route.DestinationPrefix) via $($route.NextHop) on IF $($route.InterfaceIndex)" -ForegroundColor Red
+            } catch {
+                Write-Host "      Failed to delete: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+        
+        # Re-add only ONE instance (preserve the first interface)
+        $reAddSucceeded = $false
+        try {
+            New-NetRoute -DestinationPrefix $dest -InterfaceIndex $toKeep.InterfaceIndex -NextHop $gateway -RouteMetric $metric -PolicyStore PersistentStore -ErrorAction Stop
+            Write-Host "    Re-added: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+            $reAddSucceeded = $true
+        } catch {
+            Write-Host "      PolicyStore method failed: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+        
+        # Fallback to route.exe if PolicyStore failed
+        if (-not $reAddSucceeded) {
+            try {
+                $parts = $dest.Split("/")
+                $network = $parts[0]
+                $prefix = [int]$parts[1]
+                $netmask = Convert-PrefixToMask $prefix
+                $metricStr = if ($metric -is [int]) { "METRIC $metric" } else { "" }
+                $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
+                Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
+                cmd /c $command
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error "route.exe failed with exit code $LASTEXITCODE, command: $command"
+                } else {
+                    Write-Host "    Re-added with route.exe: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                }
+            } catch {
+                Write-Host "      route.exe also failed: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+    }
+    
+    # Then handle non-gateway duplicates
+    foreach ($group in $nonGatewayDuplicates) {
+        $toKeep = $group.Group[0]
+        $dest = $toKeep.DestinationPrefix
+        $gateway = $toKeep.NextHop
+        $metric = $toKeep.RouteMetric
+        $interfaceIndex = $toKeep.InterfaceIndex
+
+        $parts = $dest.Split("/")
+        if ($parts.Count -ne 2) {
+            Write-Host "  Invalid destination prefix format: $dest" -ForegroundColor Red
+            continue
+        }
+
+        $network = $parts[0]
+        $prefix = [int]$parts[1]
+        $netmask = Convert-PrefixToMask $prefix
+        $metricStr = if ($metric -is [int]) { "METRIC $metric" } else { "" }
+
+        # Delete all matching routes
+        foreach ($route in $group.Group) {
+            try {
+                Remove-NetRoute -DestinationPrefix $route.DestinationPrefix -NextHop $route.NextHop `
+                    -InterfaceIndex $route.InterfaceIndex -PolicyStore PersistentStore -Confirm:$false -ErrorAction Stop
+                Write-Host "  Deleted: $($route.DestinationPrefix) via $($route.NextHop)" -ForegroundColor Red
+            } catch {
+                Write-Host "    Failed to delete route: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+
+        # Try re-adding route using New-NetRoute with PolicyStore
+        $reAddSucceeded = $false
+        try {
+            New-NetRoute -DestinationPrefix $dest -InterfaceIndex $interfaceIndex `
+                -NextHop $gateway -RouteMetric $metric -PolicyStore PersistentStore -ErrorAction Stop
+            Write-Host "  Re-added with New-NetRoute: $dest via $gateway metric $metric" -ForegroundColor Green
+            $reAddSucceeded = $true
+        } catch {
+            Write-Host "  New-NetRoute failed: $($_.Exception.Message), falling back to route.exe " -ForegroundColor Yellow
+        }
+
+        # Fallback to route.exe if New-NetRoute failed
+        if (-not $reAddSucceeded) {
+            $command = "route -p ADD $network MASK $netmask $gateway IF $interfaceIndex"
+            if ($metricStr -ne "") {
+                $command += " $metricStr"
+            }
+
+            try {
+                cmd /c $command
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error "route.exe failed with exit code $LASTEXITCODE, command: $command"
+                } else {
+                    Write-Host "  Re-added with route.exe: $dest via $gateway metric $metric on IF $interfaceIndex" -ForegroundColor Green
+                }
+            } catch {
+                Write-Host "    Failed to re-add route: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+    }
+}
+
+# Step 3: Configure default gateways at NIC/IP configuration level via registry
+Write-Host "Configuring default gateways at interface level (Registry)..." -ForegroundColor Cyan
+
+# Get current default gateways after cleanup
+$currentDefaultGateways = Get-NetRoute -PolicyStore PersistentStore -AddressFamily IPv4 | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" }
+Write-Host "Configuring $($currentDefaultGateways.Count) remaining default gateway(s)..." -ForegroundColor Cyan
+
+foreach ($gateway in $currentDefaultGateways) {
+    $nextHop = $gateway.NextHop
+    $interfaceIndex = $gateway.InterfaceIndex
+    $metric = $gateway.RouteMetric
+
+    # Check if interface still exists
+    $interface = Get-NetAdapter | Where-Object { $_.InterfaceIndex -eq $interfaceIndex } -ErrorAction SilentlyContinue
+    if (-not $interface) {
+        Write-Host "  Skipping Interface $interfaceIndex - Interface no longer exists" -ForegroundColor Gray
+        continue
+    }
+
+    $interfaceAlias = $interface.Name
+    $guid = $interface.InterfaceGuid
+    Write-Host "  Processing Interface $interfaceIndex ($interfaceAlias) - Gateway $nextHop" -ForegroundColor Yellow
+
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$guid"
+    if (-not (Test-Path $regPath)) {
+        Write-Host "    Registry path not found: $regPath" -ForegroundColor Red
+        continue
+    }
+
+    $regGateways = (Get-ItemProperty -Path $regPath -Name "DefaultGateway" -ErrorAction SilentlyContinue).DefaultGateway
+    $gwList = @()
+    if ($null -ne $regGateways) {
+        $gwList = @($regGateways)
+    }
+    if ($gwList -contains $nextHop) {
+        Write-Host "    Interface already has gateway $nextHop in registry" -ForegroundColor Green
+        continue
+    }
+
+    $merged = ($gwList + @($nextHop)) | Select-Object -Unique
+    Write-Host "    Setting DefaultGateway=$($merged -join ',') in registry" -ForegroundColor Yellow
+    Set-ItemProperty -Path $regPath -Name "DefaultGateway" -Value $merged -Type MultiString
+    Write-Host "    [OK] Gateway written to registry for $interfaceAlias" -ForegroundColor Green
+
+}
+
+Write-Host "Persistent route cleanup completed!" -ForegroundColor Green


### PR DESCRIPTION
Issue:
With the DHCP Client service disabled, applying static IPs via New-NetIPAddress in the firstboot network script can fail with "The RPC server is unavailable".

Fix:
Add ForkliftController feature_windows_registry_network_config into conversion pods. When enabled virt-v2v uses registry-based *-registry firstboot sources for static IP, duplicate route cleanup, and complementary multi-IP scripts; otherwise the existing PowerShell path is used.

Ref: https://issues.redhat.com/browse/MTV-5245

Resolves: MTV-5245