### PR TITLE
MTV-5068 | Derive GOVMOMI_HOSTNAME from provider URL

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1975,13 +1975,6 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 
 	for key, value := range dst.Data {
 		switch key {
-		case "url":
-			h, err := liburl.Parse(string(value))
-			if err != nil {
-				// ignore and try to use as is
-				dst.Data["GOVMOMI_HOSTNAME"] = value
-			}
-			dst.Data["GOVMOMI_HOSTNAME"] = []byte(h.Hostname())
 		case "user":
 			dst.Data["GOVMOMI_USERNAME"] = value
 			dst.Data["accessKeyId"] = value
@@ -1992,6 +1985,12 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 			dst.Data["GOVMOMI_INSECURE"] = value
 		}
 	}
+
+	providerURL, pErr := liburl.Parse(r.Source.Provider.Spec.URL)
+	if pErr != nil {
+		return fmt.Errorf("failed to parse provider URL: %w", pErr)
+	}
+	dst.Data["GOVMOMI_HOSTNAME"] = []byte(providerURL.Hostname())
 
 	// Add provider settings to the secret
 	if esxiCloneMethod, ok := r.Source.Provider.Spec.Settings[api.ESXiCloneMethod]; ok {

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -74,13 +74,61 @@ var _ = Describe("vSphere builder", func() {
 			// Assert
 			Expect(err).NotTo(HaveOccurred())
 			Expect(errGet).NotTo(HaveOccurred())
-			Expect(underTest.Data).To(HaveLen(4))
+			Expect(underTest.Data).To(HaveLen(5))
 			Expect(underTest.Data).To(HaveKeyWithValue("storagekey", []byte("storageval")))
 			Expect(underTest.Data).To(HaveKeyWithValue("providerkey", []byte("providerval")))
+			Expect(underTest.Data).To(HaveKeyWithValue("GOVMOMI_HOSTNAME", []byte("vcenter.example.com")))
 			Expect(underTest.Data).To(HaveKey("SSH_PRIVATE_KEY"))
 			Expect(underTest.Data).To(HaveKey("SSH_PUBLIC_KEY"))
 			Expect(underTest.OwnerReferences).To(HaveLen(1))
 			Expect(underTest.OwnerReferences[0].Name).To(Equal("test-pvc"))
+		})
+		It("should set GOVMOMI_HOSTNAME from provider URL even when secret has no url key", func() {
+			builder := createBuilder(
+				&core.Secret{
+					ObjectMeta: meta.ObjectMeta{Name: "storage-test-secret", Namespace: "test"},
+					Data: map[string][]byte{
+						"storagekey": []byte("storageval"),
+					},
+				},
+				&core.Secret{
+					ObjectMeta: meta.ObjectMeta{Name: "migration-test-secret", Namespace: "test"},
+					Data: map[string][]byte{
+						"user":     []byte("admin"),
+						"password": []byte("secret"),
+					},
+				},
+				&core.Secret{
+					ObjectMeta: meta.ObjectMeta{Name: "offload-ssh-keys-test-vsphere-provider-private", Namespace: "test"},
+					Data: map[string][]byte{
+						"private-key": []byte("fake-private-key"),
+					},
+				},
+				&core.Secret{
+					ObjectMeta: meta.ObjectMeta{Name: "offload-ssh-keys-test-vsphere-provider-public", Namespace: "test"},
+					Data: map[string][]byte{
+						"public-key": []byte("fake-public-key"),
+					},
+				},
+				&core.PersistentVolumeClaim{
+					ObjectMeta: meta.ObjectMeta{Name: "test-pvc", Namespace: "test"},
+				},
+			)
+
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{Name: "test-pvc", Namespace: "test"},
+			}
+			err := builder.mergeSecrets("migration-test-secret", "test", "storage-test-secret", "test", "merged-test-secret", pvc)
+			underTest := core.Secret{}
+			errGet := builder.Destination.Get(context.Background(), client.ObjectKey{
+				Name:      "merged-test-secret",
+				Namespace: "test"}, &underTest)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(errGet).NotTo(HaveOccurred())
+			Expect(underTest.Data).To(HaveKeyWithValue("GOVMOMI_HOSTNAME", []byte("vcenter.example.com")))
+			Expect(underTest.Data).To(HaveKeyWithValue("GOVMOMI_USERNAME", []byte("admin")))
+			Expect(underTest.Data).To(HaveKeyWithValue("GOVMOMI_PASSWORD", []byte("secret")))
 		})
 		It("should set default access mode to ReadWriteMany for block volumes", func() {
 			// Setup
@@ -617,7 +665,7 @@ func createBuilder(objs ...runtime.Object) *Builder {
 					ObjectMeta: meta.ObjectMeta{Name: "test-vsphere-provider", Namespace: "test"},
 					Spec: v1beta1.ProviderSpec{
 						Type: (*v1beta1.ProviderType)(ptr.To("vsphere")),
-						URL:  "test-vsphere-provider",
+						URL:  "https://vcenter.example.com/sdk",
 					},
 				},
 				Inventory: nil,


### PR DESCRIPTION
## Summary
- Fix GOVMOMI_HOSTNAME being unset when the provider
  secret has no `url` key (the common case), causing
  copy-offload populator pods to fail
- Remove nil-pointer bug in the `url` parse error path
- Always derive hostname from `Provider.Spec.URL`

## Test plan
- [ ] Existing `mergeSecrets` test updated to assert
      GOVMOMI_HOSTNAME is always present
- [ ] New test: secret without `url` key still produces
      correct GOVMOMI_HOSTNAME, GOVMOMI_USERNAME,
      GOVMOMI_PASSWORD
- [ ] `go test ./pkg/controller/plan/adapter/vsphere/...`
      passes (104/104)

🤖 Generated with [Claude Code](https://claude.com/claude-code)