### PR TITLE
MTV-3736 | RDM and independent disk concerns should not block migration

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -112,8 +112,6 @@ func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 			res.ToolsStatus = ToolsNotInstalled // Should be ignored when powered off
 		case "tools_unmanaged":
 			res.ToolsVersionStatus = GuestToolsUnmanaged
-		case "missing_from_inventory":
-			return base.NotFoundError{}
 		}
 	}
 	return nil
@@ -620,6 +618,7 @@ var _ = Describe("vsphere validation tests", func() {
 		Entry("should warn on consolidation needed", true),
 		Entry("should not warn when consolidation is not needed", false),
 	)
+
 })
 
 func createPlan() *v1beta1.Plan {

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -108,6 +108,8 @@ const (
 	RestrictedPodSecurity           = "RestrictedPodSecurity"
 	NetMapDestinationNADNotValid    = "NetMapDestinationNADNotValid"
 	VMCriticalConcerns              = "VMCriticalConcerns"
+	RDMDiskWarning                  = "RDMDiskWarning"
+	IndependentDiskWarning          = "IndependentDiskWarning"
 	// NetAppShift (Advisory) reports whether the plan's storage map uses a NetApp Shift/Trident class.
 	NetAppShift = "NetAppShift"
 	// NetAppShiftWarmNotSupported (Critical) blocks warm migration when the storage map uses NetApp Shift.
@@ -960,6 +962,22 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 		Message:  "VM has snapshots that require consolidation. This may cause long delays between precopies.",
 		Items:    []string{},
 	}
+	rdmDiskWarning := libcnd.Condition{
+		Type:     RDMDiskWarning,
+		Status:   True,
+		Reason:   NotSupported,
+		Category: api.CategoryWarn,
+		Message:  "VM has RDM disks which are not supported with VDDK transfer. Enable copy-offload (XCOPY) in the storage mapping to migrate RDM disks.",
+		Items:    []string{},
+	}
+	independentDiskWarning := libcnd.Condition{
+		Type:     IndependentDiskWarning,
+		Status:   True,
+		Reason:   NotSupported,
+		Category: api.CategoryWarn,
+		Message:  "VM has independent disks which are not supported with VDDK transfer. Enable copy-offload (XCOPY) in the storage mapping to migrate independent disks, or change them to 'Dependent' mode in VMware.",
+		Items:    []string{},
+	}
 
 	shiftSnapshotVMs := libcnd.Condition{
 		Type:     VMHasSnapshots,
@@ -1226,6 +1244,25 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			macConflicts.Message += fmt.Sprintf("VM %s has MAC address conflicts: %s", ref.String(), strings.Join(conflictDetails, "; "))
 		}
 
+		// RDM and independent disk checks (vSphere only)
+		if !planUsesOffload {
+			if vsphereVM, ok := v.(*vsphere.VM); ok {
+				isWarm := plan.IsWarm()
+				for _, disk := range vsphereVM.Disks {
+					if disk.RDM && (!isWarm || disk.PhysicalMode) {
+						rdmDiskWarning.Items = append(rdmDiskWarning.Items, ref.String())
+						break
+					}
+				}
+				for _, disk := range vsphereVM.Disks {
+					if disk.Mode == "independent_persistent" || disk.Mode == "independent_nonpersistent" {
+						independentDiskWarning.Items = append(independentDiskWarning.Items, ref.String())
+						break
+					}
+				}
+			}
+		}
+
 		ok, msg, category, err := validator.SharedDisks(*ref, ctx.Destination.Client)
 		if err != nil {
 			return err
@@ -1452,6 +1489,12 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 	}
 	if len(shiftNASMissing.Items) > 0 {
 		plan.Status.SetCondition(shiftNASMissing)
+	}
+	if len(rdmDiskWarning.Items) > 0 {
+		plan.Status.SetCondition(rdmDiskWarning)
+	}
+	if len(independentDiskWarning.Items) > 0 {
+		plan.Status.SetCondition(independentDiskWarning)
 	}
 
 	return nil

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -1317,6 +1317,7 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 					Shared:         backing.Sharing != "sharingNone" && backing.Sharing != "",
 					Mode:           backing.DiskMode,
 					RDM:            true,
+					PhysicalMode:   backing.CompatibilityMode == string(types.VirtualDiskCompatibilityModePhysicalMode),
 					Bus:            bus,
 					Serial:         backing.Uuid,
 					WinDriveLetter: winDriveLetter,
@@ -1331,13 +1332,17 @@ func (v *VmAdapter) updateDisks(devArray *types.ArrayOfVirtualDevice) {
 				disks = append(disks, md)
 			case *types.VirtualDiskRawDiskVer2BackingInfo:
 				md := model.Disk{
-					Key:            disk.Key,
-					UnitNumber:     *disk.UnitNumber,
-					ControllerKey:  disk.ControllerKey,
-					File:           backing.DescriptorFileName,
-					Capacity:       disk.CapacityInBytes,
-					Shared:         backing.Sharing != "sharingNone" && backing.Sharing != "",
-					RDM:            true,
+					Key:           disk.Key,
+					UnitNumber:    *disk.UnitNumber,
+					ControllerKey: disk.ControllerKey,
+					File:          backing.DescriptorFileName,
+					Capacity:      disk.CapacityInBytes,
+					Shared:        backing.Sharing != "sharingNone" && backing.Sharing != "",
+					RDM:           true,
+					// VirtualDiskRawDiskVer2BackingInfo represents direct pass-through
+					// to a physical device without SCSI virtualization, so it is
+					// always treated as physical mode.
+					PhysicalMode:   true,
 					Bus:            bus,
 					WinDriveLetter: winDriveLetter,
 				}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -382,6 +382,7 @@ type Disk struct {
 	Capacity              int64  `json:"capacity"`
 	Shared                bool   `json:"shared"`
 	RDM                   bool   `json:"rdm"`
+	PhysicalMode          bool   `json:"physicalMode,omitempty"`
 	Bus                   string `json:"bus"`
 	Mode                  string `json:"mode,omitempty"`
 	Serial                string `json:"serial,omitempty"`

--- a/validation/policies/io/konveyor/forklift/vmware/disk_mode.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_mode.rego
@@ -11,8 +11,8 @@ concerns contains flag if {
 	independent_disk
 	flag := {
 		"id": "vmware.disk_mode.independent",
-		"category": "Critical",
+		"category": "Warning",
 		"label": "Independent disk detected",
-		"assessment": "Independent disks cannot be transferred using recent versions of VDDK. The VM cannot be migrated unless disks are changed to 'Dependent' mode in VMware.",
+		"assessment": "Independent disks cannot be transferred using VDDK. If copy-offload (XCOPY) is enabled in the migration plan, independent disks can be migrated. Otherwise, the disks must be changed to 'Dependent' mode in VMware before migration.",
 	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/rdm_disk.rego
@@ -13,6 +13,6 @@ concerns contains flag if {
 		"id": "vmware.disk.rdm.detected",
 		"category": "Warning",
 		"label": "Raw Device Mapped disk detected",
-		"assessment": "RDM disk detected. RDM is supported via the RDMAsLun option at the plan or per-VM level. If RDMAsLun is not enabled, the VM cannot be migrated unless the RDM disks are removed.",
+		"assessment": "RDM disks are not supported when using VDDK transfer. If copy-offload (XCOPY) is enabled in the migration plan, RDM disks can be migrated. Otherwise, the RDM disks must be removed before migration and reattached after.",
 	}
 }


### PR DESCRIPTION
Change RDM and independent disk concerns from Critical to Warning so they no longer block migration plans. When copy-offload (XCOPY) is active in the storage mapping, suppress these concerns entirely since XCOPY can handle both disk types.

- Rego policies: change category from "Critical" to "Warning"
- Plan validation: add RDMAndIndependentDiskConcerns() to Validator interface
- vSphere validator: detect RDM/independent disks, suppress when copy-offload active
- validation.go: surface RDMDiskWarning and IndependentDiskWarning as Warn conditions
- Unit tests for all new validation logic

Resolves: MTV-3736