### PR TITLE
MTV-5245 | Fix static IP scripts not injected

### DIFF
--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -321,8 +321,7 @@ func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) erro
 		initPath = filepath.Join(windowsScriptsPath, "9999-run-mtv-ps-scripts-legacy.bat")
 	}
 
-	staticIPFirstbootScripts := c.appConfig.VirtIoWinLegacyDrivers != "" || c.appConfig.WindowsRegistryNetworkConfig
-	if c.appConfig.StaticIPs != "" && staticIPFirstbootScripts {
+	if c.appConfig.StaticIPs != "" {
 		var networkConfigTemplate string
 		var removeDuplicatesPersistentRoutesPath string
 		var preserveIpsTemplate string

--- a/pkg/virt-v2v/customize/customize_test.go
+++ b/pkg/virt-v2v/customize/customize_test.go
@@ -948,13 +948,14 @@ var _ = Describe("Customize", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("static IPs but neither legacy nor registry - no static IP uploads", func() {
+		It("static IPs but neither legacy nor registry - still injects static IP scripts", func() {
 			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
 			appConfig.VirtIoWinLegacyDrivers = ""
 			appConfig.WindowsRegistryNetworkConfig = false
-			mockCommandBuilder.EXPECT().AddArgs("--upload", "", gomock.Any(), "", "").Return(mockCommandBuilder)
 			err := customize.addWinFirstbootScripts(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("inject static IP template"))
+			Expect(err.Error()).To(ContainSubstring("9999-network-config.ps1.tmpl"))
 		})
 
 		It("legacy init path is selected when VirtIoWinLegacyDrivers is set", func() {


### PR DESCRIPTION
Fix static IP firstboot script injection when neither legacy drivers nor registry config was set.

Ref: https://issues.redhat.com/browse/MTV-5245
Resolves: MTV-5245