### PR TITLE
Fix v2v-wrapper regression

### DIFF
--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -335,12 +335,14 @@ func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) erro
 			preserveIpsTemplate = filepath.Join(windowsScriptsPath, "9999-preserve_complementry_ips_per_nic.ps1.tmpl")
 		}
 
-		networkConfigScript := filepath.Join(windowsScriptsPath, "9999-network-config.ps1")
-		if err := c.injectStaticIPTemplate(networkConfigTemplate, networkConfigScript); err != nil {
-			return fmt.Errorf("inject static IP template from %q to %q: %w", networkConfigTemplate, networkConfigScript, err)
+		injectNetworkConfig := c.appConfig.VirtIoWinLegacyDrivers != "" || c.appConfig.WindowsRegistryNetworkConfig
+		if injectNetworkConfig {
+			networkConfigScript := filepath.Join(windowsScriptsPath, "9999-network-config.ps1")
+			if err := c.injectStaticIPTemplate(networkConfigTemplate, networkConfigScript); err != nil {
+				return fmt.Errorf("inject static IP template from %q to %q: %w", networkConfigTemplate, networkConfigScript, err)
+			}
+			uploadPreserveIpPath = c.formatUpload(networkConfigScript, WinFirstbootScriptsPath)
 		}
-		uploadPreserveIpPath = c.formatUpload(networkConfigScript, WinFirstbootScriptsPath)
-
 		uploadRemoveDuplicatesPath = c.formatUpload(removeDuplicatesPersistentRoutesPath, WinFirstbootScriptsPath)
 
 		if c.appConfig.MultipleIpsPerNicName != "" {

--- a/pkg/virt-v2v/customize/customize_test.go
+++ b/pkg/virt-v2v/customize/customize_test.go
@@ -948,14 +948,13 @@ var _ = Describe("Customize", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("static IPs but neither legacy nor registry - still injects static IP scripts", func() {
+		It("static IPs but neither legacy nor registry - skips network config injection", func() {
 			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
 			appConfig.VirtIoWinLegacyDrivers = ""
 			appConfig.WindowsRegistryNetworkConfig = false
+			mockCommandBuilder.EXPECT().AddArgs("--upload", "", gomock.Any(), gomock.Any(), "").Return(mockCommandBuilder)
 			err := customize.addWinFirstbootScripts(mockCommandBuilder)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("inject static IP template"))
-			Expect(err.Error()).To(ContainSubstring("9999-network-config.ps1.tmpl"))
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("legacy init path is selected when VirtIoWinLegacyDrivers is set", func() {


### PR DESCRIPTION
we should not use the network-config.ps1 for non registry or legacy windows.