### PR TITLE
MTV-5316 | Fix secondary static IP loss on Windows VM migration

### DIFF
--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -220,7 +220,7 @@ func (c *Customize) injectComplementryStaticIPTemplate(templatePath, outputPath 
 	var configs []IPConfig
 	for mac, ips := range macMap {
 		if len(ips) > 1 {
-			configs = append(configs, IPConfig{MAC: mac, IPs: ips[1:]}) // Skip the first (primary) IP
+			configs = append(configs, IPConfig{MAC: mac, IPs: ips[1:]})
 		}
 	}
 
@@ -330,19 +330,20 @@ func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) erro
 			removeDuplicatesPersistentRoutesPath = filepath.Join(windowsScriptsPath, "9999-remove_duplicate_persistent_routes-registry.ps1")
 			preserveIpsTemplate = filepath.Join(windowsScriptsPath, "9999-preserve_complementry_ips_per_nic-registry.ps1.tmpl")
 		} else {
-			networkConfigTemplate = filepath.Join(windowsScriptsPath, "9999-network-config.ps1.tmpl")
+			networkConfigTemplate = filepath.Join(windowsScriptsPath, "9999-network-config-legacy.ps1.tmpl")
 			removeDuplicatesPersistentRoutesPath = filepath.Join(windowsScriptsPath, "9999-remove_duplicate_persistent_routes.ps1")
 			preserveIpsTemplate = filepath.Join(windowsScriptsPath, "9999-preserve_complementry_ips_per_nic.ps1.tmpl")
 		}
 
 		injectNetworkConfig := c.appConfig.VirtIoWinLegacyDrivers != "" || c.appConfig.WindowsRegistryNetworkConfig
 		if injectNetworkConfig {
-			networkConfigScript := filepath.Join(windowsScriptsPath, "9999-network-config.ps1")
+			networkConfigScript := filepath.Join(windowsScriptsPath, "9999-network-config-legacy.ps1")
 			if err := c.injectStaticIPTemplate(networkConfigTemplate, networkConfigScript); err != nil {
 				return fmt.Errorf("inject static IP template from %q to %q: %w", networkConfigTemplate, networkConfigScript, err)
 			}
 			uploadPreserveIpPath = c.formatUpload(networkConfigScript, WinFirstbootScriptsPath)
 		}
+
 		uploadRemoveDuplicatesPath = c.formatUpload(removeDuplicatesPersistentRoutesPath, WinFirstbootScriptsPath)
 
 		if c.appConfig.MultipleIpsPerNicName != "" {

--- a/pkg/virt-v2v/customize/customize_test.go
+++ b/pkg/virt-v2v/customize/customize_test.go
@@ -976,11 +976,21 @@ var _ = Describe("Customize", func() {
 			err := customize.addWinFirstbootScripts(mockCommandBuilder)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("inject static IP template"))
-			Expect(err.Error()).To(ContainSubstring("9999-network-config.ps1.tmpl"))
+			Expect(err.Error()).To(ContainSubstring("9999-network-config-legacy.ps1.tmpl"))
 		})
 
-		It("static IP with registry returns error referencing registry template", func() {
+		It("static IP with registry but non-legacy - injects registry template", func() {
 			appConfig.WindowsRegistryNetworkConfig = true
+			appConfig.VirtIoWinLegacyDrivers = ""
+			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
+			err := customize.addWinFirstbootScripts(mockCommandBuilder)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("9999-network-config-registry.ps1.tmpl"))
+		})
+
+		It("static IP with registry and legacy returns error referencing registry template", func() {
+			appConfig.WindowsRegistryNetworkConfig = true
+			appConfig.VirtIoWinLegacyDrivers = "/mnt/virtio.iso"
 			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
 			err := customize.addWinFirstbootScripts(mockCommandBuilder)
 			Expect(err).To(HaveOccurred())

--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config-legacy.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config-legacy.ps1.tmpl
@@ -24,6 +24,10 @@ function Convert-PrefixToMask($prefix) {
 # Split entries by '_'
 $entries = $inputString.Split("_")
 
+# Track which MACs have been configured so we use "set address" (replace) for
+# the first IP on each interface and "add address" for subsequent IPs.
+$configuredMACs = @{}
+
 # Extract parts
 foreach ($entry in $entries) {
     if ($entry -match "^([0-9A-Fa-f:\-]+):ip:([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)$") {
@@ -58,23 +62,30 @@ foreach ($entry in $entries) {
         }
 
         $iface = $adapter.NetConnectionID
-        Write-Host "Using interface: $iface`n"
+        $wshell = New-Object -ComObject WScript.Shell
 
-       $cmd = "netsh interface ip set address name=`"$iface`" static $ip $mask $gw"
-       # Use WScript.Shell COM object to run netsh commands:
-       # - The '0' parameter hides the command window (runs silently)
-       # - The '$true' parameter ensures the script waits for the command to finish before continuing
-       $wshell = New-Object -ComObject WScript.Shell
-       $wshell.Run($cmd, 0, $true)
-
-       $cmd = "netsh interface ip set dns name=`"$iface`" static $dns1"
-       $wshell.Run($cmd, 0, $true)
-        
-        if ($dns2 -ne "") {
-            $cmd = "netsh interface ip add dns name=`"$iface`" $dns2 index=2"
+        if ($configuredMACs.ContainsKey($mac)) {
+            # Secondary IP: use "add address" without gateway
+            Write-Host "Adding secondary IP $ip to interface: $iface`n"
+            $cmd = "netsh interface ip add address name=`"$iface`" $ip $mask"
             $wshell.Run($cmd, 0, $true)
-        } 
-        
+        } else {
+            # Primary IP: use "set address" with gateway
+            Write-Host "Using interface: $iface`n"
+            $cmd = "netsh interface ip set address name=`"$iface`" static $ip $mask $gw"
+            $wshell.Run($cmd, 0, $true)
+
+            $cmd = "netsh interface ip set dns name=`"$iface`" static $dns1"
+            $wshell.Run($cmd, 0, $true)
+
+            if ($dns2 -ne "") {
+                $cmd = "netsh interface ip add dns name=`"$iface`" $dns2 index=2"
+                $wshell.Run($cmd, 0, $true)
+            }
+
+            $configuredMACs[$mac] = $true
+        }
+
         Write-Host "IP configuration applied`n"
     }
     else {

--- a/pkg/virt-v2v/customize/scripts/windows/9999-preserve_complementry_ips_per_nic.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-preserve_complementry_ips_per_nic.ps1.tmpl
@@ -32,10 +32,15 @@ foreach ($config in $networkConfigs) {
         Write-Host "Configuring adapter '$name' ($($config.MAC))"
 
         foreach ($ip in $config.IPs) {
-            Write-Host "Setting IP $ip on '$name'"
-            New-NetIPAddress -InterfaceIndex $ifindex -IPAddress $ip -PrefixLength $config.PrefixLength
-            Set-DnsClientServerAddress -InterfaceIndex $ifindex -ServerAddresses $config.DNS
+            $existing = Get-NetIPAddress -InterfaceIndex $ifindex -IPAddress $ip -ErrorAction SilentlyContinue
+            if ($existing) {
+                Write-Host "IP $ip already exists on '$name', skipping"
+                continue
+            }
+            Write-Host "Adding IP $ip on '$name'"
+            New-NetIPAddress -InterfaceIndex $ifindex -IPAddress $ip -PrefixLength $config.PrefixLength -SkipAsSource $true -ErrorAction Stop
         }
+        Set-DnsClientServerAddress -InterfaceIndex $ifindex -ServerAddresses $config.DNS
     } else {
         Write-Warning "Adapter with MAC $($config.MAC) not found"
     }


### PR DESCRIPTION
The complementary IP script now skips any IP
already configured, and adds secondaries with -SkipAsSource.
The primary-IP setter is gated to legacy/registry mode only.

Ref: https://redhat.atlassian.net/browse/MTV-5316
Resolves: MTV-5316