### PR TITLE
MTV-5327 | Fix broken Jinja2 template and exclude missing deep-inspection image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,6 +480,7 @@ push-deep-inspection-image: build-deep-inspection-image ## Push forklift-deep-in
 	fi
 
 build-all-images: ## Build all container images
+# NOTE: build-deep-inspection-image is excluded until build/deep-inspection/Containerfile-upstream exists
 build-all-images: build-api-image \
                   build-controller-image \
                   build-validation-image \
@@ -494,11 +495,11 @@ build-all-images: build-api-image \
                   build-hyperv-provider-server-image \
                   build-cli-download-image \
                   build-ova-proxy-image \
-                  build-deep-inspection-image \
                   build-operator-bundle-image \
                   build-operator-index-image
 
 push-all-images: ## Push all container images
+# NOTE: push-deep-inspection-image is excluded until build/deep-inspection/Containerfile-upstream exists
 push-all-images:  push-api-image \
                   push-controller-image \
                   push-validation-image \
@@ -513,7 +514,6 @@ push-all-images:  push-api-image \
                   push-hyperv-provider-server-image \
                   push-cli-download-image \
                   push-ova-proxy-image \
-                  push-deep-inspection-image \
                   push-operator-bundle-image \
                   push-operator-index-image
 

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -186,9 +186,12 @@ spec:
 {% endif %}
 {% if feature_windows_registry_network_config|bool %}
         - name: FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG
+          value: "true"
+{% endif %}
 {% if feature_use_conversion_cr|bool %}
         - name: FEATURE_USE_CONVERSION_CR
           value: "{{ feature_use_conversion_cr|bool|lower }}"
+{% endif %}
 {% if ovirt_osmap_configmap_name is defined %}
         - name: OVIRT_OS_MAP
           value: {{ ovirt_osmap_configmap_name }}


### PR DESCRIPTION
Restore missing `value: "true"` and two `{% endif %}` closing tags in deployment-controller.yml.j2. Commit 12adee73b (MTV-3666) accidentally deleted these lines from the FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG block when adding FEATURE_USE_CONVERSION_CR, leaving two unclosed {% if %} blocks that caused the operator Ansible reconcile to fail with a Jinja2 "Unexpected end of template" error.

Also exclude deep-inspection-image from build-all-images and push-all-images until its Containerfile exists, preventing build failures.

Ref: https://redhat.atlassian.net/browse/MTV-5327