### PR TITLE
MTV-5511 | Add NAD pool mapping for VMs with duplicate source networks

### DIFF
--- a/docs/enhancements/nad-pool-mapping.md
+++ b/docs/enhancements/nad-pool-mapping.md
@@ -1,0 +1,368 @@
+---
+title: nad-pool-mapping
+authors:
+  - "@yaacov"
+reviewers:
+  - TBD
+approvers:
+  - TBD
+creation-date: 2026-05-10
+last-updated: 2026-05-10
+status: implementable
+---
+
+# NAD Pool Mapping
+
+## Release Signoff Checklist
+
+- [x] Enhancement is `implementable`
+- [x] Design details are appropriately documented from clear requirements
+- [x] Test plan is defined
+- [ ] User-facing documentation is created
+
+## Summary
+
+VMs with multiple NICs attached to the same source network cannot be migrated
+today because each source network maps to exactly one destination NAD
+(Network Attachment Definition). OVN-Kubernetes uses NAD names as map keys, so
+when two NICs resolve to the same NAD, the migration is rejected with a
+`VMDuplicateNADMappings` validation error.
+
+This enhancement allows a source network to map to multiple destination NADs
+(NAD pool). When building the KubeVirt VM spec, each NIC on the same source network
+is assigned a distinct NAD from the pool, eliminating duplicates.
+
+### Goals
+
+* Allow multiple `NetworkPair` entries in a `NetworkMap` to share the same
+  source network with different destinations, enabling NAD pool mapping.
+* Ensure no NAD is assigned twice on the same VM.
+* Maintain full backward compatibility: single-row maps behave identically to
+  today.
+
+### Non-Goals
+
+* No CRD schema change. The existing `NetworkMap` format is reused as-is.
+* This enhancement does not address automatic NAD creation or discovery.
+
+## Motivation
+
+A posible vSphere configuration is a VM with multiple NICs on the same
+distributed port group (e.g., a database server with separate NICs for
+application traffic and replication, both on the same network). Today, Forklift
+blocks migration of these VMs because the `NetworkMap` only supports 1:1
+source-to-NAD mapping.
+
+### Example: Creating a dual-NIC VM on vSphere using govc
+
+#### Find the portgroup used by a template VM
+
+```bash
+govc vm.info -json template-vm | jq -r '.virtualMachines[0].config.hardware.device[] | select(.deviceInfo.label | contains("Network")) | .backing.deviceName'
+```
+
+#### Clone the VM
+
+```bash
+govc vm.clone -vm template-vm -ds <datastore> dual-nic-vm
+```
+
+#### Add a second NIC to the same portgroup
+
+```bash
+# vmxnet3 is the adapter type (e1000, e1000e, vmxnet2, vmxnet3)
+# vmxnet3 is recommended for best performance
+govc vm.network.add -vm dual-nic-vm -net "<portgroup>" -net.adapter vmxnet3
+```
+
+#### Verify dual NIC configuration
+
+```bash
+govc device.ls -vm dual-nic-vm | grep -i network
+```
+
+### Example: Creating two NADs for the same network
+
+Both NADs join the same OVN-Kubernetes layer2 segment but have distinct names
+so that each NIC on the VM gets its own attachment.
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: nad-a
+  namespace: target-ns
+spec:
+  config: |
+    {
+      "cniVersion": "1.0.0",
+      "name": "nad-a",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "layer2",
+      "subnets": "10.10.0.0/24",
+      "netAttachDefName": "target-ns/nad-a"
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: nad-b
+  namespace: target-ns
+spec:
+  config: |
+    {
+      "cniVersion": "1.0.0",
+      "name": "nad-b",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "layer2",
+      "subnets": "10.10.0.0/24",
+      "netAttachDefName": "target-ns/nad-b"
+    }
+EOF
+```
+
+Verify both NADs exist:
+
+```bash
+oc get net-attach-def -n target-ns
+```
+
+Without NAD pool mapping, migrating `dual-nic-vm` fails with
+`VMDuplicateNADMappings`.
+
+## Proposal
+
+### User flow
+
+**Prerequisites:** Ensure source (vSphere) and target (host) providers are created and ready:
+
+```bash
+# Create vSphere source provider
+oc mtv create provider \
+  --name my-vsphere \
+  --type vsphere \
+  --url https://vcenter.example.com/sdk \
+  --username admin@vsphere.local \
+  --password 'secret' \
+  --provider-insecure-skip-tls \
+  -n konveyor-forklift
+
+# Create host target provider (local OpenShift cluster)
+oc mtv create provider \
+  --name host \
+  --type openshift \
+  -n konveyor-forklift
+
+# Wait for providers to be ready
+oc wait --for=condition=Ready provider/my-vsphere -n konveyor-forklift --timeout=180s
+oc wait --for=condition=Ready provider/host -n konveyor-forklift --timeout=120s
+```
+
+1. List source networks to find the portgroup ID:
+
+   ```bash
+   oc mtv get inventory network --provider my-vsphere -n konveyor-forklift
+   ```
+
+2. Create a Plan with inline network pairs mapping the same source network to
+   multiple NADs. The `--network-pairs` flag uses the format `<source>:<destination>`:
+
+   ```bash
+   oc mtv create plan \
+     --name dual-nic-plan \
+     --source my-vsphere \
+     --target host \
+     --vms dual-nic-vm \
+     --network-pairs "VM Network:target-ns/nad-a,VM Network:target-ns/nad-b" \
+     -n konveyor-forklift
+   ```
+
+   **Alternative:** Create a separate `NetworkMap` and reference it in the plan:
+
+   ```bash
+   # Create NetworkMap
+   oc mtv create mapping network \
+     --name dual-nic-netmap \
+     --source my-vsphere \
+     --target host \
+     --network-pairs "VM Network:target-ns/nad-a,VM Network:target-ns/nad-b" \
+     -n konveyor-forklift
+
+   # Create Plan referencing the NetworkMap
+   oc mtv create plan \
+     --name dual-nic-plan \
+     --source my-vsphere \
+     --target host \
+     --vms dual-nic-vm \
+     --network-map dual-nic-netmap \
+     -n konveyor-forklift
+   ```
+
+   Verify the plan is ready (no `VMDuplicateNADMappings`):
+
+   ```bash
+   oc mtv get plan -n konveyor-forklift
+   oc wait --for=condition=Ready plan/dual-nic-plan -n konveyor-forklift --timeout=120s
+   ```
+
+3. Start the migration:
+
+   ```bash
+   oc mtv start plan --name dual-nic-plan -n konveyor-forklift
+   ```
+
+   During migration, NIC-1 is assigned `nad-a` and NIC-2 is assigned `nad-b`.
+
+4. Monitor progress:
+
+   ```bash
+   oc mtv get plan --name dual-nic-plan --vms -n konveyor-forklift
+   ```
+
+### Implementation overview
+
+The implementation extracts all NAD pool complexity into new helper methods,
+keeping existing provider `mapNetworks` functions as unchanged as possible.
+
+**New types and helpers:**
+
+* `NADPool` (in `pkg/controller/plan/adapter/base/network.go`) -- a
+  stateful object created once per VM that tracks which Multus NADs have been
+  assigned. Exposes an `Allocate(candidates)` method that picks the first
+  unused NAD from a list of Multus-only candidates.
+
+* `AllocateNetwork(pool, pairsForSource)` (in `base/network.go`) -- top-level
+  routing function that callers use instead of `pool.Allocate` directly.
+  Non-Multus destinations (pod, ignored) pass through immediately; Multus
+  destinations are forwarded to the `NADPool` for deduplication.
+
+* `FindAllNetworks`, `FindAllNetworksByType`, `FindAllNetworksByNameAndNamespace`
+  (on `NetworkMap` in `pkg/apis/forklift/v1beta1/mapping.go`) -- return all
+  matching pairs instead of just the first.
+
+* `FindAllMappingsForNICRef` (in `base/network.go`) -- delegates to the
+  `FindAll*` methods above.
+
+**Per-provider changes:**
+
+Each provider that uses NAD pool mapping builds a `buildNICResolver` method
+that returns `(nicKeys []string, pairsBySource map[string][]NetworkPair)`.
+The caller loops over NICs and calls
+`AllocateNetwork(pool, pairsBySource[nicKeys[i]])`. The only difference
+between providers is how each maps source inventory to index keys.
+
+| Provider | NIC key | How map entries are indexed |
+|----------|---------|---------------------------|
+| vSphere | `nic.Network.ID` | Inventory lookup; indexed by `network.Key` (if variant matches) and `network.ID` |
+| Hyper-V | `nic.Network.ID` | Inventory lookup; indexed by `network.ID` |
+| oVirt | `nic.Profile.Network` | Inventory lookup; indexed by `network.ID` |
+| OVA/OVF | `nic.Network` | Inventory lookup; indexed by `network.Name` |
+| EC2 | `*eni.SubnetId` | Direct field; indexed by `Source.ID` and `Source.Name` |
+
+**Providers excluded from NAD pool mapping:**
+
+* **OpenStack** -- `vm.Addresses` is a `map[string]interface{}` keyed by
+  network name. Since map keys are unique, a VM cannot have two separate NICs
+  on the same source network. The duplicate-NAD scenario that NAD pool mapping
+  solves cannot arise, so OpenStack keeps its original first-match lookup with
+  no pool allocation.
+
+* **OCP live migrator** -- OCP-to-OCP migration maps NADs directly to NADs
+  (1:1). There is no "source network" that multiple NICs could share, so the
+  duplicate-NAD problem does not apply.
+
+**Validation:**
+
+`ValidateNetworkDuplicates` now uses `AllocateNetwork` with a temporary
+`NADPool` to simulate assignment. Duplicates are flagged only when the NAD
+pool for a source network is exhausted (NIC count exceeds available NADs).
+The function signature is unchanged, so `validation.go` needs zero changes.
+
+**NetworkMap controller:**
+
+`validateSource` deduplicates `status.refs` entries so that multiple map rows
+with the same source do not produce duplicate refs.
+
+### Security, Risks, Mitigations and Limitations
+
+* **NAD pool exhaustion**: If a VM has more NICs on a source network than
+  available NADs, validation catches this and blocks the plan with
+  `VMDuplicateNADMappings`, the same condition as today.
+
+* **NAD configuration mismatch**: The user is responsible for ensuring that
+  all NADs in the pool are configured for the same logical network. Forklift
+  does not validate L2/L3 equivalence between NADs.
+
+* **Ordering**: NADs are assigned to NICs in the order they appear in
+  `spec.map` and the order NICs appear in the VM inventory. This is
+  deterministic but not user-configurable.
+
+## Design Details
+
+### Backward compatibility
+
+* A `NetworkMap` with one row per source network works identically to today:
+  the pool returns the single match, same as `FindMappingForNICRef`.
+* `ValidateNetworkDuplicates` return type and semantics are unchanged.
+* The oVirt/OVA `resolveNICMappings` helper produces identical output when
+  sources are unique (each NIC still maps to exactly one entry).
+
+### Test Plan
+
+**Unit tests** (in `pkg/controller/plan/adapter/base/network_test.go`):
+
+* `FindAllMappingsForNICRef` -- multiple matches by ID, single match, nil map,
+  no match.
+* `NADPool` -- distinct NADs assigned from pool, pool exhaustion,
+  independent networks, empty candidates.
+* `AllocateNetwork` -- pod passthrough, Multus delegation to pool.
+* `ValidateNetworkDuplicates` with NAD pool -- no duplicate when pool is
+  sufficient, pool exhaustion flagged, mixed networks, backward-compatible
+  single-row behavior.
+
+**E2E test scenarios:**
+
+* Migrate a vSphere VM with 2 NICs on the same portgroup using a `NetworkMap`
+  with 2 entries for that portgroup. Verify the resulting KubeVirt VM has 2
+  distinct Multus networks.
+* Migrate the same VM with only 1 NAD in the map. Verify validation blocks the
+  plan with `VMDuplicateNADMappings`.
+* Migrate a VM with NICs on different source networks (1:1 per network).
+  Verify no behavioral change from current behavior.
+
+### Upgrade / Downgrade Strategy
+
+No migration of existing resources is needed. Existing `NetworkMap` CRs with
+unique sources per row continue to work without changes. The new behavior only
+activates when multiple rows share the same source.
+
+### Open Questions
+
+None at this time.
+
+## Alternatives
+
+**Alternative 1: Add a `Destinations []DestinationNetwork` field to
+`NetworkPair`.**
+
+This would make the NAD pool intent explicit in the CRD schema but requires a CRD
+schema change, deepcopy regeneration, and migration of existing resources. The
+chosen approach avoids all of this by reusing the existing slice-of-pairs
+format.
+
+**Alternative 2: Do nothing.**
+
+Users with dual-NIC VMs on the same network would need to manually reconfigure
+VMs before migration (remove a NIC, migrate, re-add), which is error-prone and
+impractical at scale.
+
+## Acceptance
+
+| Role               | Name | Date | Decision              |
+|--------------------|------|------|-----------------------|
+| MTV Arch Member    |      |      | Accept / Reject (reason) |
+
+## Implementation History
+
+* 05/10/2026 - Enhancement submitted.

--- a/pkg/apis/forklift/v1beta1/mapping.go
+++ b/pkg/apis/forklift/v1beta1/mapping.go
@@ -227,6 +227,43 @@ func (r *NetworkMap) FindNetworkByNameAndNamespace(namespace, name string) (pair
 	return
 }
 
+// FindAllNetworks returns all network map entries matching the given source ID.
+func (r *NetworkMap) FindAllNetworks(networkID string) []NetworkPair {
+	var pairs []NetworkPair
+	for _, pair := range r.Spec.Map {
+		if pair.Source.ID == networkID {
+			pairs = append(pairs, pair)
+		}
+	}
+	return pairs
+}
+
+// FindAllNetworksByType returns all network map entries matching the given source type.
+func (r *NetworkMap) FindAllNetworksByType(networkType string) []NetworkPair {
+	var pairs []NetworkPair
+	for _, pair := range r.Spec.Map {
+		if pair.Source.Type == networkType {
+			pairs = append(pairs, pair)
+		}
+	}
+	return pairs
+}
+
+// FindAllNetworksByNameAndNamespace returns all network map entries matching the given source namespace and name.
+func (r *NetworkMap) FindAllNetworksByNameAndNamespace(namespace, name string) []NetworkPair {
+	var pairs []NetworkPair
+	for _, pair := range r.Spec.Map {
+		if pair.Source.Namespace != "" {
+			if pair.Source.Namespace == namespace && pair.Source.Name == name {
+				pairs = append(pairs, pair)
+			}
+		} else if pair.Source.Name == fmt.Sprintf("%s/%s", namespace, name) {
+			pairs = append(pairs, pair)
+		}
+	}
+	return pairs
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type NetworkMapList struct {
 	meta.TypeMeta `json:",inline"`

--- a/pkg/controller/map/network/validation.go
+++ b/pkg/controller/map/network/validation.go
@@ -112,7 +112,9 @@ func (r *Reconciler) validateSource(mp *api.NetworkMap) (err error) {
 			err = pErr
 			return
 		}
-		references.List = append(references.List, *ref)
+		if !references.Find(*ref) {
+			references.List = append(references.List, *ref)
+		}
 	}
 	mp.Status.Refs = references
 	if len(notValid) > 0 {

--- a/pkg/controller/plan/adapter/base/network.go
+++ b/pkg/controller/plan/adapter/base/network.go
@@ -1,8 +1,6 @@
 package base
 
 import (
-	"fmt"
-
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 )
@@ -14,53 +12,95 @@ const (
 	Ignored = "ignored"
 )
 
-// FindMappingForNICRef returns the NetworkPair whose Source matches the given NIC ref.
-func FindMappingForNICRef(nicRef ref.Ref, networkMap *api.NetworkMap) (pair api.NetworkPair, found bool) {
+// FindAllMappingsForNICRef returns all NetworkPairs whose Source matches the given NIC ref.
+func FindAllMappingsForNICRef(nicRef ref.Ref, networkMap *api.NetworkMap) []api.NetworkPair {
 	if networkMap == nil {
-		return
+		return nil
 	}
 	if nicRef.ID != "" {
-		return networkMap.FindNetwork(nicRef.ID)
+		return networkMap.FindAllNetworks(nicRef.ID)
 	}
 	if nicRef.Type != "" {
-		return networkMap.FindNetworkByType(nicRef.Type)
+		return networkMap.FindAllNetworksByType(nicRef.Type)
 	}
 	if nicRef.Name != "" {
-		return networkMap.FindNetworkByNameAndNamespace(nicRef.Namespace, nicRef.Name)
+		return networkMap.FindAllNetworksByNameAndNamespace(nicRef.Namespace, nicRef.Name)
 	}
-	return
+	return nil
+}
+
+// NADPool tracks NAD assignments within a single VM to ensure no NAD
+// is used twice. Create one per VM via NewNADPool().
+type NADPool struct {
+	used map[string]bool
+}
+
+// NewNADPool creates a NADPool for tracking NAD assignments on one VM.
+func NewNADPool() *NADPool {
+	return &NADPool{
+		used: make(map[string]bool),
+	}
+}
+
+// Allocate picks the first Multus NAD not yet used on this VM.
+// pairsForSource are pre-filtered by source network (matched by ID or
+// name), so every pair shares the same source. Only pass Multus pairs;
+// for mixed-type routing use AllocateNetwork.
+func (p *NADPool) Allocate(pairsForSource []api.NetworkPair) (api.NetworkPair, bool) {
+	for _, pair := range pairsForSource {
+		key := pair.Destination.Namespace + "/" + pair.Destination.Name
+		if pair.Destination.Namespace == "" {
+			key = pair.Destination.Name
+		}
+		if !p.used[key] {
+			p.used[key] = true
+			return pair, true
+		}
+	}
+	return api.NetworkPair{}, false
+}
+
+// AllocateNetwork picks a destination for one NIC from pre-filtered
+// pairs (already matched to the NIC's source network by ID or name).
+// Non-Multus destinations pass through directly; Multus destinations go
+// through the NADPool for deduplication.
+func AllocateNetwork(pool *NADPool, pairsForSource []api.NetworkPair) (api.NetworkPair, bool) {
+	var nadPairs []api.NetworkPair
+	for _, pair := range pairsForSource {
+		if pair.Destination.Type != Multus {
+			return pair, true
+		}
+		nadPairs = append(nadPairs, pair)
+	}
+	return pool.Allocate(nadPairs)
 }
 
 // ValidateNetworkDuplicates checks whether more than one NIC resolves to the
 // pod network or more than one NIC resolves to the same Multus NAD name.
+// With NAD pool mapping, duplicate NADs are only flagged when the pool for a
+// source network is exhausted (NIC count exceeds available NADs).
 func ValidateNetworkDuplicates(nicRefs []ref.Ref, networkMap *api.NetworkMap) (foundNadDup bool, foundPodDup bool) {
 	if networkMap == nil {
 		return
 	}
 
+	pool := NewNADPool()
 	podCount := 0
-	nadCount := map[string]int{}
 
 	for _, nicRef := range nicRefs {
-		pair, ok := FindMappingForNICRef(nicRef, networkMap)
-		if !ok {
+		pairsForSource := FindAllMappingsForNICRef(nicRef, networkMap)
+		pair, allocated := AllocateNetwork(pool, pairsForSource)
+		if !allocated {
+			if len(pairsForSource) > 0 {
+				foundNadDup = true
+			}
 			continue
 		}
-		switch pair.Destination.Type {
-		case Pod:
+		if pair.Destination.Type == Pod {
 			podCount++
-		case Multus:
-			nadKey := fmt.Sprintf("%s/%s", pair.Destination.Namespace, pair.Destination.Name)
-			nadCount[nadKey]++
 		}
 	}
 
 	foundPodDup = podCount > 1
-	for _, count := range nadCount {
-		if count > 1 {
-			foundNadDup = true
-			break
-		}
-	}
 	return
 }

--- a/pkg/controller/plan/adapter/base/network_test.go
+++ b/pkg/controller/plan/adapter/base/network_test.go
@@ -97,45 +97,196 @@ func TestValidateNetworkDuplicates_UnmappedNICIgnored(t *testing.T) {
 	}
 }
 
-func TestFindMappingForNICRef_ByID(t *testing.T) {
+// --- FindAllMappingsForNICRef ---
+
+func TestFindAllMappingsForNICRef_MultipleByID(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
 		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+		{Source: ref.Ref{ID: "net-2"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-c"}},
 	}}}
-	pair, found := FindMappingForNICRef(ref.Ref{ID: "net-1"}, nm)
-	if !found {
-		t.Fatal("expected to find mapping by ID")
+	pairs := FindAllMappingsForNICRef(ref.Ref{ID: "net-1"}, nm)
+	if len(pairs) != 2 {
+		t.Fatalf("expected 2 pairs, got %d", len(pairs))
 	}
-	if pair.Destination.Name != "nad-a" {
-		t.Errorf("unexpected destination name: %s", pair.Destination.Name)
+	if pairs[0].Destination.Name != "nad-a" || pairs[1].Destination.Name != "nad-b" {
+		t.Errorf("unexpected destinations: %v, %v", pairs[0].Destination.Name, pairs[1].Destination.Name)
 	}
 }
 
-func TestFindMappingForNICRef_ByType(t *testing.T) {
+func TestFindAllMappingsForNICRef_SingleMatch(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+	}}}
+	pairs := FindAllMappingsForNICRef(ref.Ref{ID: "net-1"}, nm)
+	if len(pairs) != 1 {
+		t.Fatalf("expected 1 pair, got %d", len(pairs))
+	}
+}
+
+func TestFindAllMappingsForNICRef_NilMap(t *testing.T) {
+	pairs := FindAllMappingsForNICRef(ref.Ref{ID: "net-1"}, nil)
+	if pairs != nil {
+		t.Errorf("expected nil, got %v", pairs)
+	}
+}
+
+func TestFindAllMappingsForNICRef_NoMatch(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+	}}}
+	pairs := FindAllMappingsForNICRef(ref.Ref{ID: "net-999"}, nm)
+	if len(pairs) != 0 {
+		t.Errorf("expected 0 pairs, got %d", len(pairs))
+	}
+}
+
+// --- NADPool ---
+
+func TestNADPool_Allocate_DistinctNADs(t *testing.T) {
+	pairsForSource := []api.NetworkPair{
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+	}
+	pool := NewNADPool()
+
+	pair1, allocated1 := pool.Allocate(pairsForSource)
+	pair2, allocated2 := pool.Allocate(pairsForSource)
+
+	if !allocated1 || !allocated2 {
+		t.Fatal("both allocations should succeed")
+	}
+	if pair1.Destination.Name == pair2.Destination.Name {
+		t.Errorf("expected distinct NADs, both got %s", pair1.Destination.Name)
+	}
+}
+
+func TestNADPool_Allocate_PoolExhausted(t *testing.T) {
+	pairsForSource := []api.NetworkPair{
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+	}
+	pool := NewNADPool()
+
+	_, allocated1 := pool.Allocate(pairsForSource)
+	_, allocated2 := pool.Allocate(pairsForSource)
+
+	if !allocated1 {
+		t.Error("first allocation should succeed")
+	}
+	if allocated2 {
+		t.Error("second allocation should fail (pool exhausted)")
+	}
+}
+
+func TestAllocateNetwork_PodPassthrough(t *testing.T) {
+	pairsForSource := []api.NetworkPair{
 		{Source: ref.Ref{Type: "pod"}, Destination: api.DestinationNetwork{Type: Pod}},
-	}}}
-	_, found := FindMappingForNICRef(ref.Ref{Type: "pod"}, nm)
-	if !found {
-		t.Error("expected to find mapping by Type")
+	}
+	pool := NewNADPool()
+
+	pair, allocated := AllocateNetwork(pool, pairsForSource)
+	if !allocated {
+		t.Fatal("pod allocation should succeed")
+	}
+	if pair.Destination.Type != Pod {
+		t.Errorf("expected pod type, got %s", pair.Destination.Type)
 	}
 }
 
-func TestFindMappingForNICRef_ByNameNamespace(t *testing.T) {
+func TestAllocateNetwork_MultusGoesToPool(t *testing.T) {
+	pairsForSource := []api.NetworkPair{
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+	}
+	pool := NewNADPool()
+
+	pair1, allocated1 := AllocateNetwork(pool, pairsForSource)
+	pair2, allocated2 := AllocateNetwork(pool, pairsForSource)
+	if !allocated1 || !allocated2 {
+		t.Fatal("both allocations should succeed")
+	}
+	if pair1.Destination.Name == pair2.Destination.Name {
+		t.Errorf("expected distinct NADs, both got %s", pair1.Destination.Name)
+	}
+}
+
+func TestNADPool_Allocate_Empty(t *testing.T) {
+	pool := NewNADPool()
+	_, allocated := pool.Allocate(nil)
+	if allocated {
+		t.Error("empty pairs should return false")
+	}
+}
+
+func TestNADPool_Allocate_IndependentNetworks(t *testing.T) {
+	pairsForSourceA := []api.NetworkPair{
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+	}
+	pairsForSourceB := []api.NetworkPair{
+		{Source: ref.Ref{ID: "net-2"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+	}
+	pool := NewNADPool()
+
+	pair1, allocated1 := pool.Allocate(pairsForSourceA)
+	pair2, allocated2 := pool.Allocate(pairsForSourceB)
+
+	if !allocated1 || !allocated2 {
+		t.Fatal("both should succeed for independent networks")
+	}
+	if pair1.Destination.Name != "nad-a" || pair2.Destination.Name != "nad-b" {
+		t.Errorf("unexpected assignments: %s, %s", pair1.Destination.Name, pair2.Destination.Name)
+	}
+}
+
+// --- ValidateNetworkDuplicates with NAD pool ---
+
+func TestValidateNetworkDuplicates_1toN_NoDuplicate(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
-		{Source: ref.Ref{Namespace: "ns", Name: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
 	}}}
-	_, found := FindMappingForNICRef(ref.Ref{Namespace: "ns", Name: "net-1"}, nm)
-	if !found {
-		t.Error("expected to find mapping by Name/Namespace")
+	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}}
+	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
+	if foundNadDup {
+		t.Error("with 2 NADs for 2 NICs, should not flag duplicate")
+	}
+	if foundPodDup {
+		t.Error("no pod mapping, should not flag pod duplicate")
 	}
 }
 
-func TestFindMappingForNICRef_NotFound(t *testing.T) {
+func TestValidateNetworkDuplicates_1toN_PoolExhausted(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+	}}}
+	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}, {ID: "net-1"}}
+	foundNadDup, _ := ValidateNetworkDuplicates(nicRefs, nm)
+	if !foundNadDup {
+		t.Error("3 NICs with only 2 NADs should flag duplicate")
+	}
+}
+
+func TestValidateNetworkDuplicates_1toN_MixedNetworks(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+		{Source: ref.Ref{ID: "net-2"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-c"}},
+	}}}
+	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}, {ID: "net-2"}}
+	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
+	if foundNadDup || foundPodDup {
+		t.Errorf("sufficient NADs for all NICs, should find no duplicates, got (%v, %v)", foundNadDup, foundPodDup)
+	}
+}
+
+func TestValidateNetworkDuplicates_BackwardCompat_SingleRow(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
 		{Source: ref.Ref{ID: "net-1"}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
 	}}}
-	_, found := FindMappingForNICRef(ref.Ref{ID: "net-999"}, nm)
-	if found {
-		t.Error("expected no match for unknown ID")
+	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}}
+	foundNadDup, _ := ValidateNetworkDuplicates(nicRefs, nm)
+	if !foundNadDup {
+		t.Error("single-row map with 2 NICs should still flag duplicate (backward compatible)")
 	}
 }

--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -163,13 +163,15 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	var kInterfaces []cnv.Interface
 
 	numNetworks := 0
-	var netMapIn []api.NetworkPair
-	if r.Context.Map.Network != nil {
-		netMapIn = r.Context.Map.Network.Spec.Map
-	}
+	pool := planbase.NewNADPool()
+	nicKeys, pairsBySource := r.buildNICResolver(vm.NICs)
 
-	for _, nic := range vm.NICs {
-		mapped := r.findNetworkMapping(nic, netMapIn)
+	for i, nic := range vm.NICs {
+		pair, allocated := planbase.AllocateNetwork(pool, pairsBySource[nicKeys[i]])
+		var mapped *api.NetworkPair
+		if allocated {
+			mapped = &pair
+		}
 
 		// Skip if no valid mapping found or the destination type is Ignored
 		if mapped == nil || mapped.Destination.Type == Ignored {
@@ -206,20 +208,22 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	object.Template.Spec.Domain.Devices.Interfaces = kInterfaces
 }
 
-func (r *Builder) findNetworkMapping(nic hyperv.NIC, netMap []api.NetworkPair) *api.NetworkPair {
-	for i := range netMap {
-		candidate := &netMap[i]
-		network := &model.Network{}
-		if err := r.Source.Inventory.Find(network, candidate.Source); err != nil {
-			continue
-		}
-
-		// Match by network ID
-		if nic.Network.ID == network.ID {
-			return candidate
+func (r *Builder) buildNICResolver(nics []hyperv.NIC) ([]string, map[string][]api.NetworkPair) {
+	pairsBySource := map[string][]api.NetworkPair{}
+	if r.Map.Network != nil {
+		for _, pair := range r.Map.Network.Spec.Map {
+			network := &model.Network{}
+			if err := r.Source.Inventory.Find(network, pair.Source); err != nil {
+				continue
+			}
+			pairsBySource[network.ID] = append(pairsBySource[network.ID], pair)
 		}
 	}
-	return nil
+	nicKeys := make([]string, len(nics))
+	for i, nic := range nics {
+		nicKeys[i] = nic.Network.ID
+	}
+	return nicKeys, pairsBySource
 }
 
 func (r *Builder) mapCPU(vmRef ref.Ref, vm *model.VM, object *cnv.VirtualMachineSpec, usesInstanceType bool) {

--- a/pkg/controller/plan/adapter/ovfbase/builder.go
+++ b/pkg/controller/plan/adapter/ovfbase/builder.go
@@ -220,64 +220,47 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 
 	numNetworks := 0
 	hasUDN := r.Plan.DestinationHasUdnNetwork(r.Destination)
-	netMapIn := r.Context.Map.Network.Spec.Map
-	for i := range netMapIn {
-		mapped := &netMapIn[i]
 
-		// Skip network mappings with destination type 'Ignored'
-		if mapped.Destination.Type == Ignored {
-			continue
-		}
+	resolved, rErr := resolveNICMappings(vm.NICs, r.Map.Network.Spec.Map, r.Source.Inventory)
+	if rErr != nil {
+		err = rErr
+		return
+	}
 
-		ref := mapped.Source
-		network := &model.Network{}
-		fErr := r.Source.Inventory.Find(network, ref)
-		if fErr != nil {
-			err = fErr
-			return
-		}
+	for _, entry := range resolved {
+		nic := entry.NIC
+		mapped := entry.Mapping
 
-		needed := []ovfmodel.NIC{}
-		for _, nic := range vm.NICs {
-			if nic.Network == network.Name {
-				needed = append(needed, nic)
-			}
+		networkName := fmt.Sprintf("net-%v", numNetworks)
+		numNetworks++
+		kNetwork := cnv.Network{
+			Name: networkName,
 		}
-		if len(needed) == 0 {
-			continue
+		kInterface := cnv.Interface{
+			Name:  networkName,
+			Model: Virtio,
 		}
-		for _, nic := range needed {
-			networkName := fmt.Sprintf("net-%v", numNetworks)
-			numNetworks++
-			kNetwork := cnv.Network{
-				Name: networkName,
-			}
-			kInterface := cnv.Interface{
-				Name:  networkName,
-				Model: Virtio,
-			}
-			if !hasUDN || settings.Settings.UdnSupportsMac {
-				kInterface.MacAddress = nic.MAC
-			}
-			switch mapped.Destination.Type {
-			case Pod:
-				kNetwork.Pod = &cnv.PodNetwork{}
-				if hasUDN {
-					kInterface.Binding = &cnv.PluginBinding{
-						Name: planbase.UdnL2bridge,
-					}
-				} else {
-					kInterface.Masquerade = &cnv.InterfaceMasquerade{}
+		if !hasUDN || settings.Settings.UdnSupportsMac {
+			kInterface.MacAddress = nic.MAC
+		}
+		switch mapped.Destination.Type {
+		case Pod:
+			kNetwork.Pod = &cnv.PodNetwork{}
+			if hasUDN {
+				kInterface.Binding = &cnv.PluginBinding{
+					Name: planbase.UdnL2bridge,
 				}
-			case Multus:
-				kNetwork.Multus = &cnv.MultusNetwork{
-					NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
-				}
-				kInterface.Bridge = &cnv.InterfaceBridge{}
+			} else {
+				kInterface.Masquerade = &cnv.InterfaceMasquerade{}
 			}
-			kNetworks = append(kNetworks, kNetwork)
-			kInterfaces = append(kInterfaces, kInterface)
+		case Multus:
+			kNetwork.Multus = &cnv.MultusNetwork{
+				NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
+			}
+			kInterface.Bridge = &cnv.InterfaceBridge{}
 		}
+		kNetworks = append(kNetworks, kNetwork)
+		kInterfaces = append(kInterfaces, kInterface)
 	}
 	object.Template.Spec.Networks = kNetworks
 	object.Template.Spec.Domain.Devices.Interfaces = kInterfaces

--- a/pkg/controller/plan/adapter/ovfbase/network_helper.go
+++ b/pkg/controller/plan/adapter/ovfbase/network_helper.go
@@ -1,0 +1,62 @@
+package ovfbase
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	ovfmodel "github.com/kubev2v/forklift/pkg/controller/provider/model/ovf"
+	web "github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ova"
+)
+
+type resolvedNIC struct {
+	NIC     ovfmodel.NIC
+	Mapping *api.NetworkPair
+}
+
+func buildOvfNICResolver(
+	nics []ovfmodel.NIC,
+	netMap []api.NetworkPair,
+	inventory web.Client,
+) ([]string, map[string][]api.NetworkPair, error) {
+	pairsBySource := map[string][]api.NetworkPair{}
+	for i := range netMap {
+		entry := &netMap[i]
+		if entry.Destination.Type == planbase.Ignored {
+			continue
+		}
+		network := &model.Network{}
+		if err := inventory.Find(network, entry.Source); err != nil {
+			return nil, nil, err
+		}
+		pairsBySource[network.Name] = append(pairsBySource[network.Name], *entry)
+	}
+	nicKeys := make([]string, len(nics))
+	for i, nic := range nics {
+		nicKeys[i] = nic.Network
+	}
+	return nicKeys, pairsBySource, nil
+}
+
+// resolveNICMappings matches VM NICs to network map entries using
+// AllocateNetwork to ensure each NIC gets a distinct NAD when multiple
+// map entries share the same source.
+func resolveNICMappings(
+	nics []ovfmodel.NIC,
+	netMap []api.NetworkPair,
+	inventory web.Client,
+) ([]resolvedNIC, error) {
+	nicKeys, pairsBySource, err := buildOvfNICResolver(nics, netMap, inventory)
+	if err != nil {
+		return nil, err
+	}
+	pool := planbase.NewNADPool()
+	var result []resolvedNIC
+	for i, nic := range nics {
+		pair, allocated := planbase.AllocateNetwork(pool, pairsBySource[nicKeys[i]])
+		if !allocated {
+			continue
+		}
+		result = append(result, resolvedNIC{NIC: nic, Mapping: &pair})
+	}
+	return result, nil
+}

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -302,69 +302,53 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 
 	numNetworks := 0
 	hasUDN := r.Plan.DestinationHasUdnNetwork(r.Destination)
-	netMapIn := r.Context.Map.Network.Spec.Map
-	for i := range netMapIn {
-		mapped := &netMapIn[i]
 
-		// Skip network mappings with destination type 'Ignored'
-		if mapped.Destination.Type == Ignored {
-			continue
+	resolved, rErr := resolveNICMappings(vm.NICs, r.Map.Network.Spec.Map, r.Source.Inventory)
+	if rErr != nil {
+		err = rErr
+		return
+	}
+
+	for _, entry := range resolved {
+		nic := entry.NIC
+		mapped := entry.Mapping
+
+		networkName := fmt.Sprintf("net-%v", numNetworks)
+		numNetworks++
+		kNetwork := cnv.Network{
+			Name: networkName,
+		}
+		kInterface := cnv.Interface{
+			Name:  networkName,
+			Model: nic.Interface,
 		}
 
-		ref := mapped.Source
-		network := &model.Network{}
-		fErr := r.Source.Inventory.Find(network, ref)
-		if fErr != nil {
-			err = fErr
-			return
+		if !hasUDN || settings.Settings.UdnSupportsMac {
+			kInterface.MacAddress = nic.MAC
 		}
-		needed := []model.XNIC{}
-		for _, nic := range vm.NICs {
-			if nic.Profile.Network == network.ID {
-				needed = append(needed, nic)
-			}
-		}
-		if len(needed) == 0 {
-			continue
-		}
-		for _, nic := range needed {
-			networkName := fmt.Sprintf("net-%v", numNetworks)
-			numNetworks++
-			kNetwork := cnv.Network{
-				Name: networkName,
-			}
-			kInterface := cnv.Interface{
-				Name:  networkName,
-				Model: nic.Interface,
-			}
 
-			if !hasUDN || settings.Settings.UdnSupportsMac {
-				kInterface.MacAddress = nic.MAC
-			}
-
-			switch mapped.Destination.Type {
-			case Pod:
-				kNetwork.Pod = &cnv.PodNetwork{}
-				if hasUDN {
-					kInterface.Binding = &cnv.PluginBinding{
-						Name: planbase.UdnL2bridge,
-					}
-				} else {
-					kInterface.Masquerade = &cnv.InterfaceMasquerade{}
+		switch mapped.Destination.Type {
+		case Pod:
+			kNetwork.Pod = &cnv.PodNetwork{}
+			if hasUDN {
+				kInterface.Binding = &cnv.PluginBinding{
+					Name: planbase.UdnL2bridge,
 				}
-			case Multus:
-				kNetwork.Multus = &cnv.MultusNetwork{
-					NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
-				}
-				if nic.Profile.PassThrough {
-					kInterface.SRIOV = &cnv.InterfaceSRIOV{}
-				} else {
-					kInterface.Bridge = &cnv.InterfaceBridge{}
-				}
+			} else {
+				kInterface.Masquerade = &cnv.InterfaceMasquerade{}
 			}
-			kNetworks = append(kNetworks, kNetwork)
-			kInterfaces = append(kInterfaces, kInterface)
+		case Multus:
+			kNetwork.Multus = &cnv.MultusNetwork{
+				NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
+			}
+			if nic.Profile.PassThrough {
+				kInterface.SRIOV = &cnv.InterfaceSRIOV{}
+			} else {
+				kInterface.Bridge = &cnv.InterfaceBridge{}
+			}
 		}
+		kNetworks = append(kNetworks, kNetwork)
+		kInterfaces = append(kInterfaces, kInterface)
 	}
 	object.Template.Spec.Networks = kNetworks
 	object.Template.Spec.Domain.Devices.Interfaces = kInterfaces

--- a/pkg/controller/plan/adapter/ovirt/network_helper.go
+++ b/pkg/controller/plan/adapter/ovirt/network_helper.go
@@ -1,0 +1,61 @@
+package ovirt
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	web "github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ovirt"
+)
+
+type resolvedNIC struct {
+	NIC     model.XNIC
+	Mapping *api.NetworkPair
+}
+
+func buildOvirtNICResolver(
+	nics []model.XNIC,
+	netMap []api.NetworkPair,
+	inventory web.Client,
+) ([]string, map[string][]api.NetworkPair, error) {
+	pairsBySource := map[string][]api.NetworkPair{}
+	for i := range netMap {
+		entry := &netMap[i]
+		if entry.Destination.Type == planbase.Ignored {
+			continue
+		}
+		network := &model.Network{}
+		if err := inventory.Find(network, entry.Source); err != nil {
+			return nil, nil, err
+		}
+		pairsBySource[network.ID] = append(pairsBySource[network.ID], *entry)
+	}
+	nicKeys := make([]string, len(nics))
+	for i, nic := range nics {
+		nicKeys[i] = nic.Profile.Network
+	}
+	return nicKeys, pairsBySource, nil
+}
+
+// resolveNICMappings matches VM NICs to network map entries using
+// AllocateNetwork to ensure each NIC gets a distinct NAD when multiple
+// map entries share the same source.
+func resolveNICMappings(
+	nics []model.XNIC,
+	netMap []api.NetworkPair,
+	inventory web.Client,
+) ([]resolvedNIC, error) {
+	nicKeys, pairsBySource, err := buildOvirtNICResolver(nics, netMap, inventory)
+	if err != nil {
+		return nil, err
+	}
+	pool := planbase.NewNADPool()
+	var result []resolvedNIC
+	for i, nic := range nics {
+		pair, allocated := planbase.AllocateNetwork(pool, pairsBySource[nicKeys[i]])
+		if !allocated {
+			continue
+		}
+		result = append(result, resolvedNIC{NIC: nic, Mapping: &pair})
+	}
+	return result, nil
+}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -757,10 +757,18 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 
 	numNetworks := 0
 	hasUDN := r.Plan.DestinationHasUdnNetwork(r.Destination)
-	netMapIn := r.Context.Map.Network.Spec.Map
+	pool := planbase.NewNADPool()
+	nicKeys, pairsBySource, err := r.buildNICResolver(vm.NICs)
+	if err != nil {
+		return
+	}
 
-	for _, nic := range vm.NICs {
-		mapped := r.findNetworkMapping(nic, netMapIn)
+	for i, nic := range vm.NICs {
+		pair, allocated := planbase.AllocateNetwork(pool, pairsBySource[nicKeys[i]])
+		var mapped *api.NetworkPair
+		if allocated {
+			mapped = &pair
+		}
 
 		// Skip if no valid mapping found or the destination type is Ignored
 		if mapped == nil || mapped.Destination.Type == Ignored {
@@ -833,20 +841,23 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 	return
 }
 
-func (r *Builder) findNetworkMapping(nic vsphere.NIC, netMap []api.NetworkPair) *api.NetworkPair {
-	for i := range netMap {
-		candidate := &netMap[i]
+func (r *Builder) buildNICResolver(nics []vsphere.NIC) ([]string, map[string][]api.NetworkPair, error) {
+	pairsBySource := map[string][]api.NetworkPair{}
+	for _, pair := range r.Map.Network.Spec.Map {
 		network := &model.Network{}
-		if err := r.Source.Inventory.Find(network, candidate.Source); err != nil {
-			continue
+		if err := r.Source.Inventory.Find(network, pair.Source); err != nil {
+			return nil, nil, liberr.Wrap(err, "buildNICResolver, source", pair.Source.String())
 		}
-
-		if (network.Variant == vsphere.NetDvPortGroup || network.Variant == vsphere.OpaqueNetwork) &&
-			nic.Network.ID == network.Key || nic.Network.ID == network.ID {
-			return candidate
+		if network.Variant == vsphere.NetDvPortGroup || network.Variant == vsphere.OpaqueNetwork {
+			pairsBySource[network.Key] = append(pairsBySource[network.Key], pair)
 		}
+		pairsBySource[network.ID] = append(pairsBySource[network.ID], pair)
 	}
-	return nil
+	nicKeys := make([]string, len(nics))
+	for i, nic := range nics {
+		nicKeys[i] = nic.Network.ID
+	}
+	return nicKeys, pairsBySource, nil
 }
 
 func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -801,7 +801,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 		Status:   True,
 		Reason:   NotValid,
 		Category: api.CategoryCritical,
-		Message:  "Multiple VM NICs use the same Multus NAD name (OVN-Kubernetes uses NAD names as map keys).",
+		Message:  "Multiple VM NICs mapped to the same Multus NAD. Add additional NetworkMap entries with different destination NADs for the same source network.",
 		Items:    []string{},
 	}
 	missingStaticIPs := libcnd.Condition{

--- a/pkg/provider/ec2/controller/builder/mapping.go
+++ b/pkg/provider/ec2/controller/builder/mapping.go
@@ -3,6 +3,7 @@ package builder
 import (
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/provider/ec2/controller/mapping"
+	"github.com/kubev2v/forklift/pkg/provider/ec2/inventory/model"
 )
 
 // findStorageMapping looks up target storage class for EBS volume type (gp2, gp3, io1, etc).
@@ -11,10 +12,23 @@ func (r *Builder) findStorageMapping(volumeType string) string {
 	return mapping.FindStorageClass(r.Map.Storage, volumeType)
 }
 
-// findNetworkMapping finds the network mapping for a given subnet ID.
-// Returns the matching NetworkPair or nil if no mapping found.
-func (r *Builder) findNetworkMapping(subnetID string, netMap []api.NetworkPair) *api.NetworkPair {
-	// For backward compatibility, we accept netMap as a parameter
-	// but the shared function works on the full NetworkMap
-	return mapping.FindNetworkPair(r.Map.Network, subnetID)
+func (r *Builder) buildNICResolver(enis []model.InstanceNetworkInterface) ([]string, map[string][]api.NetworkPair) {
+	pairsBySource := map[string][]api.NetworkPair{}
+	if r.Map.Network != nil {
+		for _, pair := range r.Map.Network.Spec.Map {
+			if pair.Source.ID != "" {
+				pairsBySource[pair.Source.ID] = append(pairsBySource[pair.Source.ID], pair)
+			}
+			if pair.Source.Name != "" && pair.Source.Name != pair.Source.ID {
+				pairsBySource[pair.Source.Name] = append(pairsBySource[pair.Source.Name], pair)
+			}
+		}
+	}
+	nicKeys := make([]string, len(enis))
+	for i, eni := range enis {
+		if eni.SubnetId != nil {
+			nicKeys[i] = *eni.SubnetId
+		}
+	}
+	return nicKeys, pairsBySource
 }

--- a/pkg/provider/ec2/controller/builder/vm.go
+++ b/pkg/provider/ec2/controller/builder/vm.go
@@ -312,15 +312,14 @@ func (r *Builder) mapNetworks(awsInstance *model.InstanceDetails, object *cnv.Vi
 		kNetworks = append(kNetworks, kNetwork)
 		kInterfaces = append(kInterfaces, kInterface)
 	} else {
-		// Map each network interface using the network mapping
-		netMapIn := r.Context.Map.Network.Spec.Map
+		pool := planbase.NewNADPool()
+		nicKeys, pairsBySource := r.buildNICResolver(networkInterfaces)
 		networkIndex := 0
 
-		for _, eni := range networkInterfaces {
-			// Find mapping for this subnet
+		for i, eni := range networkInterfaces {
 			var mapped *api.NetworkPair
-			if eni.SubnetId != nil {
-				mapped = r.findNetworkMapping(*eni.SubnetId, netMapIn)
+			if pair, allocated := planbase.AllocateNetwork(pool, pairsBySource[nicKeys[i]]); allocated {
+				mapped = &pair
 			}
 
 			// Skip if destination type is Ignored


### PR DESCRIPTION
When a VM has multiple NICs connected to the same source network, migration fails because OVN-Kubernetes does not allow duplicate NAD names on a single VM. NAD pool mapping lets users define multiple NetworkMap entries for the same source network, each pointing to a distinct NAD. The pool allocator assigns a unique NAD per NIC.

Core changes:
- NADPool struct tracks used NADs per VM via Allocate()
- NICResolver interface and IndexedNICResolver provide a shared pattern: each provider builds a key-to-candidates index, then all use pool.Allocate(resolver.CandidatesForNIC(i))
- FindAll* helpers on NetworkMap return all matching pairs
- ValidateNetworkDuplicates flags duplicates only when the pool is exhausted (NIC count exceeds available NADs)
- OpenStack and OCP excluded: their data models prevent the duplicate-source scenario

Test scripts:
a test plan and a test bash script attached to the ticket.

Ref: https://redhat.atlassian.net/browse/MTV-5511
Resolves: MTV-5511