### PR TITLE
MTV-5345 | Add WaitForGuestReboots pipeline step for Windows VMs

### DIFF
--- a/build/virt-v2v-rhel9/Containerfile
+++ b/build/virt-v2v-rhel9/Containerfile
@@ -29,6 +29,7 @@ ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-monitor github.com/kubev2v/forklift/cmd/virt-v2v-monitor
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o image-converter github.com/kubev2v/forklift/cmd/image-converter
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-wrapper github.com/kubev2v/forklift/cmd/virt-v2v
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o forklift-wait-for-reboot github.com/kubev2v/forklift/cmd/forklift-wait-for-reboot
 
 FROM registry.access.redhat.com/ubi9:9.6-1760340943
 
@@ -72,6 +73,7 @@ COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
+COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 

--- a/build/virt-v2v-rhel9/Containerfile-downstream
+++ b/build/virt-v2v-rhel9/Containerfile-downstream
@@ -34,6 +34,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-monitor github.com/kubev2v/forklift/cmd/virt-v2v-monitor
 RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o image-converter github.com/kubev2v/forklift/cmd/image-converter
 RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-wrapper github.com/kubev2v/forklift/cmd/virt-v2v
+RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o forklift-wait-for-reboot github.com/kubev2v/forklift/cmd/forklift-wait-for-reboot
 
 FROM registry.redhat.io/ubi9:9.6-1760340943 AS runtime
 
@@ -75,6 +76,8 @@ COPY --from=builder /app/virt-v2v-monitor /usr/local/bin/virt-v2v-monitor
 COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
+
+COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
 COPY --from=winlegacyiso /usr/share/virtio-win/virtio-win.iso /usr/local/virtio-win-legacy.iso
 

--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -29,6 +29,7 @@ ENV GOCACHE=/go-build/cache
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-monitor github.com/kubev2v/forklift/cmd/virt-v2v-monitor
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o image-converter github.com/kubev2v/forklift/cmd/image-converter
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-wrapper github.com/kubev2v/forklift/cmd/virt-v2v
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o forklift-wait-for-reboot github.com/kubev2v/forklift/cmd/forklift-wait-for-reboot
 
 FROM registry.access.redhat.com/ubi9:9.7-1778576335
 
@@ -72,6 +73,7 @@ COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
+COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 

--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -34,6 +34,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-monitor github.com/kubev2v/forklift/cmd/virt-v2v-monitor
 RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o image-converter github.com/kubev2v/forklift/cmd/image-converter
 RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-wrapper github.com/kubev2v/forklift/cmd/virt-v2v
+RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o forklift-wait-for-reboot github.com/kubev2v/forklift/cmd/forklift-wait-for-reboot
 
 FROM registry.redhat.io/ubi10:10.1-1778562845 AS runtime
 
@@ -85,6 +86,8 @@ COPY --from=builder /app/virt-v2v-monitor /usr/local/bin/virt-v2v-monitor
 COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
+
+COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
 COPY --from=winlegacyiso /usr/share/virtio-win/virtio-win.iso /usr/local/virtio-win-legacy.iso
 

--- a/build/virt-v2v/Containerfile-downstream-fssupport
+++ b/build/virt-v2v/Containerfile-downstream-fssupport
@@ -7,6 +7,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-monitor github.com/kubev2v/forklift/cmd/virt-v2v-monitor
 RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o image-converter github.com/kubev2v/forklift/cmd/image-converter
 RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-wrapper github.com/kubev2v/forklift/cmd/virt-v2v
+RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o forklift-wait-for-reboot github.com/kubev2v/forklift/cmd/forklift-wait-for-reboot
 
 FROM registry.redhat.io/ubi10:10.1-1778562845
 
@@ -84,6 +85,8 @@ COPY --from=builder /app/virt-v2v-monitor /usr/local/bin/virt-v2v-monitor
 COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
+
+COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 

--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -10,6 +10,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 RUN go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-monitor ./cmd/virt-v2v-monitor/virt-v2v-monitor.go
 RUN go build -buildvcs=false -ldflags="-w -s" -o image-converter ./cmd/image-converter/image-converter.go
 RUN go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-wrapper ./cmd/virt-v2v/entrypoint.go
+RUN go build -buildvcs=false -ldflags="-w -s" -o forklift-wait-for-reboot github.com/kubev2v/forklift/cmd/forklift-wait-for-reboot
 
 # Main container
 FROM quay.io/centos/centos:stream9
@@ -70,6 +71,8 @@ COPY --from=builder /app/virt-v2v-monitor /usr/local/bin/virt-v2v-monitor
 COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
+
+COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 

--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -10,6 +10,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 RUN go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-monitor ./cmd/virt-v2v-monitor/virt-v2v-monitor.go
 RUN go build -buildvcs=false -ldflags="-w -s" -o image-converter ./cmd/image-converter/image-converter.go
 RUN go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-wrapper ./cmd/virt-v2v/entrypoint.go
+RUN go build -buildvcs=false -ldflags="-w -s" -o forklift-wait-for-reboot github.com/kubev2v/forklift/cmd/forklift-wait-for-reboot
 
 # Main container
 FROM quay.io/fedora/fedora:41
@@ -66,6 +67,8 @@ COPY --from=builder /app/virt-v2v-monitor /usr/local/bin/virt-v2v-monitor
 COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
+
+COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 

--- a/build/virt-v2v/Containerfile-upstream-xfs
+++ b/build/virt-v2v/Containerfile-upstream-xfs
@@ -10,6 +10,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 RUN go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-monitor ./cmd/virt-v2v-monitor/virt-v2v-monitor.go
 RUN go build -buildvcs=false -ldflags="-w -s" -o image-converter ./cmd/image-converter/image-converter.go
 RUN go build -buildvcs=false -ldflags="-w -s" -o virt-v2v-wrapper ./cmd/virt-v2v/entrypoint.go
+RUN go build -buildvcs=false -ldflags="-w -s" -o forklift-wait-for-reboot github.com/kubev2v/forklift/cmd/forklift-wait-for-reboot
 
 # Main container
 FROM quay.io/centos/centos:stream9
@@ -71,6 +72,8 @@ COPY --from=builder /app/virt-v2v-monitor /usr/local/bin/virt-v2v-monitor
 COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
+
+COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 

--- a/cmd/forklift-wait-for-reboot/main.go
+++ b/cmd/forklift-wait-for-reboot/main.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// forklift-wait-for-reboot watches a KubeVirt VMI serial console for a conversion
+// signal, then polls VMI phase to detect a guest reboot.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	waitforreboot "github.com/kubev2v/forklift/pkg/wait-for-reboot"
+	"k8s.io/client-go/rest"
+)
+
+func main() {
+	log.SetPrefix("forklift-wait-for-reboot: ")
+	log.SetFlags(log.LstdFlags)
+
+	cfg, err := waitforreboot.ParseConfig()
+	if err != nil {
+		log.Fatalf("configuration: %v", err)
+	}
+
+	restCfg, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatalf("in-cluster config: %v", err)
+	}
+
+	code := waitforreboot.Watch(context.Background(), restCfg, log.Default(), cfg)
+	os.Exit(code)
+}

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3600,6 +3600,11 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              controller_windows_reboot_timeout:
+                description: 'Timeout in seconds for the wait-for-reboot step (default:
+                  1800)'
+                minimum: 1
+                type: integer
               deep_inspection_image_fqin:
                 description: Deep inspection image used by deep-inspection pods
                 example: quay.io/kubev2v/deep-inspection:latest
@@ -3688,6 +3693,13 @@ spec:
               feature_windows_registry_network_config:
                 description: 'Use registry-based network configuration scripts for
                   Windows static IP setup (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
+              feature_windows_wait_for_reboot:
+                description: 'Enable automatic wait-for-reboot step for Windows VM
+                  migrations (default: false)'
                 enum:
                 - "true"
                 - "false"

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3600,6 +3600,11 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              controller_windows_reboot_timeout:
+                description: 'Timeout in seconds for the wait-for-reboot step (default:
+                  1800)'
+                minimum: 1
+                type: integer
               deep_inspection_image_fqin:
                 description: Deep inspection image used by deep-inspection pods
                 example: quay.io/kubev2v/deep-inspection:latest
@@ -3688,6 +3693,13 @@ spec:
               feature_windows_registry_network_config:
                 description: 'Use registry-based network configuration scripts for
                   Windows static IP setup (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
+              feature_windows_wait_for_reboot:
+                description: 'Enable automatic wait-for-reboot step for Windows VM
+                  migrations (default: false)'
                 enum:
                 - "true"
                 - "false"

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -91,6 +91,10 @@ spec:
                 type: string
                 enum: ["true", "false"]
                 description: "Use registry-based network configuration scripts for Windows static IP setup (default: false)"
+              feature_windows_wait_for_reboot:
+                type: string
+                enum: ["true", "false"]
+                description: "Enable automatic wait-for-reboot step for Windows VM migrations (default: false)"
               feature_use_conversion_cr:
                 type: string
                 enum: ["true", "false"]
@@ -403,6 +407,10 @@ spec:
               controller_tls_connection_timeout_sec:
                 x-kubernetes-int-or-string: true
                 description: "TLS connection timeout seconds (default: 5)"
+              controller_windows_reboot_timeout:
+                type: integer
+                minimum: 1
+                description: "Timeout in seconds for the wait-for-reboot step (default: 1800)"
               controller_max_parent_backing_retries:
                 x-kubernetes-int-or-string: true
                 description: "Max retries when getting parent disks (default: 10)"

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -11,6 +11,7 @@ feature_ocp_live_migration: true
 feature_vmware_system_serial_number: true
 feature_vsphere_vmware_driver_removal: false
 feature_windows_registry_network_config: false
+feature_windows_wait_for_reboot: false
 feature_use_conversion_cr: true
 feature_cli_download: true
 feature_mcp_server: false
@@ -57,6 +58,7 @@ controller_filesystem_overhead: 10
 controller_block_overhead: 0
 controller_vddk_job_active_deadline_sec: 300
 controller_tls_connection_timeout_sec: 5
+controller_windows_reboot_timeout: 1800
 controller_max_concurrent_reconciles: 10
 controller_max_parent_backing_retries: 10
 controller_migration_service_account: ""

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -116,6 +116,10 @@ spec:
         - name: TLS_CONNECTION_TIMEOUT
           value: "{{ controller_tls_connection_timeout_sec }}"
 {% endif %}
+{% if controller_windows_reboot_timeout is number %}
+        - name: CONTROLLER_WINDOWS_REBOOT_TIMEOUT
+          value: "{{ controller_windows_reboot_timeout }}"
+{% endif %}
 {% if controller_max_concurrent_reconciles is number %}
         - name: MAX_CONCURRENT_RECONCILES
           value: "{{ controller_max_concurrent_reconciles }}"
@@ -200,6 +204,10 @@ spec:
 {% endif %}
 {% if feature_windows_registry_network_config|bool %}
         - name: FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG
+          value: "true"
+{% endif %}
+{% if feature_windows_wait_for_reboot|bool %}
+        - name: FEATURE_WINDOWS_WAIT_FOR_REBOOT
           value: "true"
 {% endif %}
         - name: FEATURE_USE_CONVERSION_CR

--- a/pkg/apis/forklift/v1beta1/doc.go
+++ b/pkg/apis/forklift/v1beta1/doc.go
@@ -74,6 +74,7 @@ const (
 	PhaseCreateInitialSnapshot             = "CreateInitialSnapshot"
 	PhaseCreateSnapshot                    = "CreateSnapshot"
 	PhaseCreateVM                          = "CreateVM"
+	PhaseWaitForGuestReboots               = "WaitForGuestReboots"
 	PhaseFinalize                          = "Finalize"
 	PhasePreflightInspection               = "PreflightInspection"
 	PhasePowerOffSource                    = "PowerOffSource"

--- a/pkg/controller/conversion/builder.go
+++ b/pkg/controller/conversion/builder.go
@@ -464,6 +464,13 @@ func (b *Builder) BuildV2vPodEnvironment(env []core.EnvVar, vm *plan.VMStatus) (
 				Value: "true",
 			})
 	}
+	if settings.Settings.WindowsWaitForReboot {
+		env = append(env,
+			core.EnvVar{
+				Name:  "V2V_waitForGuestReboot",
+				Value: "true",
+			})
+	}
 
 	env = append(env, core.EnvVar{
 		Name:  "LOCAL_MIGRATION",

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -31,6 +31,7 @@ import (
 	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	inspectionparser "github.com/kubev2v/forklift/pkg/controller/plan/adapter/vsphere"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	migbase "github.com/kubev2v/forklift/pkg/controller/plan/migrator/base"
 	"github.com/kubev2v/forklift/pkg/controller/plan/util"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
@@ -139,8 +140,9 @@ const (
 
 // Resource labels
 const (
-	ResourceVMConfig   = "vm-config"
-	ResourceVDDKConfig = "vddk-config"
+	ResourceVMConfig      = "vm-config"
+	ResourceVDDKConfig    = "vddk-config"
+	ResourceWaitForReboot = "wait-for-reboot"
 )
 
 // User
@@ -983,6 +985,83 @@ func (r *KubeVirt) EnsureGuestConversionPod(vm *plan.VMStatus, step *plan.Step) 
 	}
 
 	return r.checkProviderReady(vm.ID)
+}
+
+// EnsureWaitForRebootPod creates a pod that runs the forklift-wait-for-reboot binary to monitor the target VMI serial console (idempotent).
+func (r *KubeVirt) EnsureWaitForRebootPod(vm *plan.VMStatus) (err error) {
+	img := getVirtV2vImage(r.Plan)
+	if img == "" {
+		err = liberr.New("virt-v2v image is not set; cannot create Windows wait-for-reboot pod")
+		return
+	}
+
+	existing, gErr := r.GetWaitForRebootPod(vm)
+	if gErr != nil {
+		err = liberr.Wrap(gErr)
+		return
+	}
+	if existing != nil {
+		return nil
+	}
+
+	activeDeadline := int64(settings.Settings.WindowsRebootTimeout + 600)
+	pod := &core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			GenerateName: "forklift-wait-reboot-",
+			Namespace:    r.Plan.Spec.TargetNamespace,
+			Labels:       r.waitForRebootLabels(vm.Ref),
+		},
+		Spec: core.PodSpec{
+			RestartPolicy:         core.RestartPolicyNever,
+			ServiceAccountName:    resolveServiceAccount(r.Plan),
+			ActiveDeadlineSeconds: &activeDeadline,
+			Containers: []core.Container{
+				{
+					Name:    "forklift-wait-for-reboot",
+					Image:   img,
+					Command: []string{"/usr/local/bin/forklift-wait-for-reboot"},
+					Env: []core.EnvVar{
+						{Name: "VMI_NAME", Value: r.getNewVMName(vm)},
+						{Name: "VMI_NAMESPACE", Value: r.Plan.Spec.TargetNamespace},
+						{Name: "SIGNAL", Value: "CONVERSION_DONE"},
+						{Name: "TIMEOUT", Value: strconv.Itoa(settings.Settings.WindowsRebootTimeout)},
+					},
+				},
+			},
+		},
+	}
+	err = r.Destination.Create(context.TODO(), pod)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	r.Log.Info("Created Windows wait-for-reboot pod.", "podNamespace", pod.Namespace, "podName", pod.Name, "vm", vm.String())
+	return nil
+}
+
+// GetWaitForRebootPod finds the GetWaitForRebootPod-wait-for-reboot pod for the VM migration, if present.
+func (r *KubeVirt) GetWaitForRebootPod(vm *plan.VMStatus) (*core.Pod, error) {
+	list, err := r.GetPodsWithLabels(r.waitForRebootLabels(vm.Ref))
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	if len(list.Items) == 0 {
+		return nil, nil //nolint:nilnil
+	}
+	return &list.Items[0], nil
+}
+
+// DeleteWaitForRebootPod removes the forklift-wait-for-reboot pod for the VM migration.
+func (r *KubeVirt) DeleteWaitForRebootPod(vm *plan.VMStatus) error {
+	pod, err := r.GetWaitForRebootPod(vm)
+	if err != nil || pod == nil {
+		return err
+	}
+	err = r.Destination.Delete(context.TODO(), pod)
+	if err != nil && !k8serr.IsNotFound(err) {
+		return liberr.Wrap(err)
+	}
+	return nil
 }
 
 // EnsureGuestInspectionPod resolves all data and creates the inspection pod
@@ -3445,6 +3524,13 @@ func (r *KubeVirt) inspectionLabels(vmRef ref.Ref) (labels map[string]string) {
 	return
 }
 
+func (r *KubeVirt) waitForRebootLabels(vmRef ref.Ref) map[string]string {
+	labels := r.vmLabels(vmRef)
+	labels[kApp] = "forklift-wait-for-reboot"
+	labels[kResource] = ResourceWaitForReboot
+	return labels
+}
+
 // Labels for a VM on a plan.
 func (r *KubeVirt) vmLabels(vmRef ref.Ref) (labels map[string]string) {
 	labels = r.planLabels()
@@ -4169,6 +4255,16 @@ func (r *KubeVirt) determineRunStrategy(vm *plan.VMStatus) cnv.VirtualMachineRun
 	targetPowerState := vm.TargetPowerState
 	if targetPowerState == "" {
 		targetPowerState = r.Plan.Spec.TargetPowerState
+	}
+
+	if settings.Settings.WindowsWaitForReboot &&
+		targetPowerState != plan.TargetPowerStateOff {
+		win, wErr := migbase.IsWindowsFromInventory(r.Source.Inventory, vm.Ref)
+		if wErr != nil {
+			r.Log.Error(wErr, "Windows inventory lookup failed; falling back to default run strategy.", "vm", vm.String())
+		} else if win {
+			return cnv.RunStrategyAlways
+		}
 	}
 
 	switch targetPowerState {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/controller/plan/migrator"
+	planmigrbase "github.com/kubev2v/forklift/pkg/controller/plan/migrator/base"
 	"github.com/kubev2v/forklift/pkg/controller/plan/scheduler"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web"
 
@@ -452,6 +453,9 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, cance
 		return err
 	}
 	if err := r.kubevirt.DeleteHookJobs(vm); failOnErr(err) {
+		return err
+	}
+	if err := r.kubevirt.DeleteWaitForRebootPod(vm); failOnErr(err) {
 		return err
 	}
 	if r.Plan.Provider.Destination.IsHost() {
@@ -995,6 +999,73 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				return
 			}
 			r.NextPhase(vm)
+		case api.PhaseWaitForGuestReboots:
+			step, found := vm.FindStep(r.migrator.Step(vm))
+			if !found {
+				vm.AddError(fmt.Sprintf("Step '%s' not found", r.migrator.Step(vm)))
+				break
+			}
+			step.MarkStarted()
+			step.Phase = api.StepRunning
+
+			targetPS := vm.TargetPowerState
+			if targetPS == "" {
+				targetPS = r.Plan.Spec.TargetPowerState
+			}
+			if !settings.Settings.WindowsWaitForReboot ||
+				targetPS == plan.TargetPowerStateOff {
+				r.NextPhase(vm)
+				break
+			}
+			win, wErr := planmigrbase.IsWindowsFromInventory(r.Source.Inventory, vm.Ref)
+			if wErr != nil {
+				r.Log.Info("Windows inventory lookup failed; skipping wait-for-reboot.", "vm", vm.String(), "error", wErr)
+				r.NextPhase(vm)
+				break
+			}
+			if !win {
+				r.NextPhase(vm)
+				break
+			}
+
+			if ierr := r.kubevirt.EnsureWaitForRebootPod(vm); ierr != nil {
+				step.AddError(ierr.Error())
+				err = nil
+				break
+			}
+
+			pod, ierr := r.kubevirt.GetWaitForRebootPod(vm)
+			if ierr != nil {
+				step.AddError(ierr.Error())
+				err = nil
+				break
+			}
+			if pod == nil {
+				return
+			}
+
+			switch pod.Status.Phase {
+			case core.PodSucceeded:
+				_ = r.kubevirt.DeleteWaitForRebootPod(vm)
+				r.NextPhase(vm)
+			case core.PodFailed:
+				r.Log.Info(
+					"Windows wait-for-reboot watcher ended without success; continuing migration.",
+					"vm", vm.String(),
+					"podNamespace", pod.Namespace,
+					"podName", pod.Name)
+				vm.SetCondition(libcnd.Condition{
+					Type:     "WaitForGuestReboots",
+					Status:   libcnd.True,
+					Category: api.CategoryWarn,
+					Message:  "Windows guest reboot wait did not complete successfully; migration continues.",
+					Durable:  true,
+				})
+				_ = r.kubevirt.DeleteWaitForRebootPod(vm)
+				r.NextPhase(vm)
+			default:
+				// Pending or Running — wait for next reconcile.
+			}
 		case api.PhaseAllocateDisks, api.PhaseCopyDisks:
 			step, found := vm.FindStep(r.migrator.Step(vm))
 			if !found {
@@ -1493,6 +1564,9 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				)
 				err = nil
 			}
+		}
+		if ierr := r.kubevirt.DeleteWaitForRebootPod(vm); ierr != nil {
+			r.Log.Error(ierr, "Could not remove Windows wait-for-reboot pod for finished VM.", "vm", vm.String())
 		}
 		vm.SetCondition(
 			libcnd.Condition{

--- a/pkg/controller/plan/migrator/base/doc.go
+++ b/pkg/controller/plan/migrator/base/doc.go
@@ -5,20 +5,40 @@ import (
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web"
 	libitr "github.com/kubev2v/forklift/pkg/lib/itinerary"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 )
 
+// WindowsDetectable is implemented by provider VM/Workload models that can report whether the guest is Windows.
+type WindowsDetectable interface {
+	IsWindows() bool
+}
+
+// IsWindowsFromInventory determines whether the source VM appears to be Windows using inventory.
+func IsWindowsFromInventory(inv web.Client, vmRef ref.Ref) (bool, error) {
+	wl, err := inv.Workload(&vmRef)
+	if err != nil {
+		return false, err
+	}
+	if wd, ok := wl.(WindowsDetectable); ok {
+		return wd.IsWindows(), nil
+	}
+	return false, nil
+}
+
 // Predicates.
 var (
-	HasPreHook              libitr.Flag = 0x01
-	HasPostHook             libitr.Flag = 0x02
-	RequiresConversion      libitr.Flag = 0x04
-	CDIDiskCopy             libitr.Flag = 0x08
-	VirtV2vDiskCopy         libitr.Flag = 0x10
-	OpenstackImageMigration libitr.Flag = 0x20
-	VSphere                 libitr.Flag = 0x40
-	RunInspection           libitr.Flag = 0x80
+	HasPreHook                libitr.Flag = 0x01
+	HasPostHook               libitr.Flag = 0x02
+	RequiresConversion        libitr.Flag = 0x04
+	CDIDiskCopy               libitr.Flag = 0x08
+	VirtV2vDiskCopy           libitr.Flag = 0x10
+	OpenstackImageMigration   libitr.Flag = 0x20
+	VSphere                   libitr.Flag = 0x40
+	RunInspection             libitr.Flag = 0x80
+	WindowsWaitForGuestReboot libitr.Flag = 0x100
 )
 
 // Steps.

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -10,6 +10,7 @@ import (
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libitr "github.com/kubev2v/forklift/pkg/lib/itinerary"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/settings"
 )
 
 type BaseMigrator struct {
@@ -194,6 +195,17 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Progress:    libitr.Progress{Total: 1},
 					},
 				})
+		case api.PhaseWaitForGuestReboots:
+			pipeline = append(
+				pipeline,
+				&plan.Step{
+					Task: plan.Task{
+						Name:        api.PhaseWaitForGuestReboots,
+						Description: "Wait for Windows guest reboot after conversion.",
+						Phase:       api.StepPending,
+						Progress:    libitr.Progress{Total: 1},
+					},
+				})
 		case api.PhasePreflightInspection:
 			pipeline = append(
 				pipeline,
@@ -274,6 +286,8 @@ func (r *BaseMigrator) Step(status *plan.VMStatus) (step string) {
 		step = DiskTransferV2v
 	case api.PhaseCreateVM:
 		step = VMCreation
+	case api.PhaseWaitForGuestReboots:
+		step = api.PhaseWaitForGuestReboots
 	case api.PhasePreHook, api.PhasePostHook:
 		step = status.Phase
 	case api.PhaseStorePowerState, api.PhasePowerOffSource, api.PhaseWaitForPowerOff:
@@ -325,6 +339,7 @@ func (r *BaseMigrator) warmItinerary() *libitr.Itinerary {
 			{Name: api.PhaseCreateGuestConversionPod, All: RequiresConversion},
 			{Name: api.PhaseConvertGuest, All: RequiresConversion},
 			{Name: api.PhaseCreateVM},
+			{Name: api.PhaseWaitForGuestReboots, All: WindowsWaitForGuestReboot},
 			{Name: api.PhasePostHook, All: HasPostHook},
 			{Name: api.PhaseCompleted},
 		},
@@ -348,6 +363,7 @@ func (r *BaseMigrator) coldItinerary() *libitr.Itinerary {
 			{Name: api.PhaseCopyDisksVirtV2V, All: RequiresConversion | VirtV2vDiskCopy},
 			{Name: api.PhaseConvertOpenstackSnapshot, All: OpenstackImageMigration},
 			{Name: api.PhaseCreateVM},
+			{Name: api.PhaseWaitForGuestReboots, All: WindowsWaitForGuestReboot},
 			{Name: api.PhasePostHook, All: HasPostHook},
 			{Name: api.PhaseCompleted},
 		},
@@ -366,6 +382,7 @@ func (r *BaseMigrator) onlyConversionItinerary() *libitr.Itinerary {
 			{Name: api.PhaseCreateGuestConversionPod, All: RequiresConversion},
 			{Name: api.PhaseConvertGuest, All: RequiresConversion},
 			{Name: api.PhaseCreateVM},
+			{Name: api.PhaseWaitForGuestReboots, All: WindowsWaitForGuestReboot},
 			{Name: api.PhasePostHook, All: HasPostHook},
 			{Name: api.PhaseCompleted},
 		},
@@ -405,11 +422,27 @@ func (r *BasePredicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
 		allowed = r.context.Plan.IsSourceProviderVSphere()
 	case RunInspection:
 		allowed = r.context.Plan.ShouldRunPreflightInspection()
+	case WindowsWaitForGuestReboot:
+		if !settings.Settings.WindowsWaitForReboot {
+			break
+		}
+		target := r.vm.TargetPowerState
+		if target == "" {
+			target = r.context.Plan.Spec.TargetPowerState
+		}
+		if target == plan.TargetPowerStateOff {
+			break
+		}
+		win, _ := IsWindowsFromInventory(r.context.Source.Inventory, r.vm.Ref)
+		if !win {
+			break
+		}
+		allowed = r.context.Source.Provider.RequiresConversion() && !r.context.Plan.Spec.SkipGuestConversion
 	}
 
 	return
 }
 
 func (r *BasePredicate) Count() int {
-	return 0x80
+	return 0x100
 }

--- a/pkg/controller/provider/web/hyperv/vm.go
+++ b/pkg/controller/provider/web/hyperv/vm.go
@@ -199,6 +199,10 @@ func (r *VM) GetConcerns() []model.Concern {
 	return r.Concerns
 }
 
+func (r *VM) IsWindows() bool {
+	return strings.Contains(strings.ToLower(r.GuestOS), "win")
+}
+
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)

--- a/pkg/controller/provider/web/hyperv/workload.go
+++ b/pkg/controller/provider/web/hyperv/workload.go
@@ -3,6 +3,7 @@ package hyperv
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -95,6 +96,10 @@ type Workload struct {
 	GuestNetworks []model.GuestNetwork `json:"guestNetworks"`
 	Concerns      []model.Concern      `json:"concerns"`
 	config        Config               // unexported, not serialized
+}
+
+func (r *Workload) IsWindows() bool {
+	return strings.Contains(strings.ToLower(r.GuestOS), "win")
 }
 
 // With populates the workload from a VM model.

--- a/pkg/controller/provider/web/openstack/workload.go
+++ b/pkg/controller/provider/web/openstack/workload.go
@@ -2,7 +2,9 @@ package openstack
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -79,6 +81,14 @@ func (h WorkloadHandler) Get(ctx *gin.Context) {
 type Workload struct {
 	SelfLink string `json:"selfLink"`
 	XVM
+}
+
+func (r *Workload) IsWindows() bool {
+	if d, ok := r.Image.Properties["os_distro"]; ok {
+		distro := strings.ToLower(fmt.Sprint(d))
+		return distro == "windows" || strings.Contains(distro, "win")
+	}
+	return false
 }
 
 // Build self link (URI).

--- a/pkg/controller/provider/web/ovfbase/vm.go
+++ b/pkg/controller/provider/web/ovfbase/vm.go
@@ -235,6 +235,10 @@ func (r *VM) GetConcerns() []model.Concern {
 	return r.Concerns
 }
 
+func (r *VM) IsWindows() bool {
+	return strings.Contains(strings.ToLower(r.OsType), "win")
+}
+
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)

--- a/pkg/controller/provider/web/ovirt/vm.go
+++ b/pkg/controller/provider/web/ovirt/vm.go
@@ -272,6 +272,11 @@ func (r *VM) GetConcerns() []model.Concern {
 	return r.Concerns
 }
 
+func (r *VM) IsWindows() bool {
+	os := strings.ToLower(r.OSType + " " + r.GuestName)
+	return strings.Contains(os, "win")
+}
+
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -310,6 +310,12 @@ func (r *VM) GetConcerns() []model.Concern {
 	return r.Concerns
 }
 
+func (r *VM) IsWindows() bool {
+	gid := strings.ToLower(r.GuestID)
+	gname := strings.ToLower(r.GuestName)
+	return strings.Contains(gid, "win") || strings.Contains(gname, "win")
+}
+
 // Build the resource using the model.
 func (r *VM) With(m *model.VM) {
 	r.VM1.With(m)

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -18,6 +18,7 @@ const (
 	FeatureOVFApplianceManagement       = "FEATURE_OVF_APPLIANCE_MANAGEMENT"
 	FeatureVsphereVmwareDriverRemoval   = "FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL"
 	FeatureWindowsRegistryNetworkConfig = "FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG"
+	FeatureWindowsWaitForReboot         = "FEATURE_WINDOWS_WAIT_FOR_REBOOT"
 	FeatureUseConversionCR              = "FEATURE_USE_CONVERSION_CR"
 	FeatureRetainPopulatorPods          = "FEATURE_RETAIN_POPULATOR_PODS"
 )
@@ -67,6 +68,8 @@ type Features struct {
 	VsphereVmwareDriverRemoval bool
 	// Whether to use registry-based network configuration scripts for Windows static IP setup.
 	WindowsRegistryNetworkConfig bool
+	// Whether to enable automatic wait-for-reboot step for Windows VM migrations.
+	WindowsWaitForReboot bool
 	// Whether to delegate VM conversion to Conversion CRs instead of managing it directly.
 	UseConversionCR bool
 	// Whether populator pods should be retained after migration for debugging.
@@ -109,6 +112,7 @@ func (r *Features) Load() (err error) {
 	r.OVFApplianceManagement = getEnvBool(FeatureOVFApplianceManagement, false)
 	r.VsphereVmwareDriverRemoval = getEnvBool(FeatureVsphereVmwareDriverRemoval, false)
 	r.WindowsRegistryNetworkConfig = getEnvBool(FeatureWindowsRegistryNetworkConfig, false)
+	r.WindowsWaitForReboot = getEnvBool(FeatureWindowsWaitForReboot, false)
 	r.UseConversionCR = getEnvBool(FeatureUseConversionCR, true)
 	r.RetainPopulatorPods = getEnvBool(FeatureRetainPopulatorPods, false)
 	return

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -61,6 +61,7 @@ const (
 	PopulatorContainerRequestsCpu          = "POPULATOR_CONTAINER_REQUESTS_CPU"
 	PopulatorContainerRequestsMemory       = "POPULATOR_CONTAINER_REQUESTS_MEMORY"
 	TlsConnectionTimeout                   = "TLS_CONNECTION_TIMEOUT"
+	ControllerWindowsRebootTimeout         = "CONTROLLER_WINDOWS_REBOOT_TIMEOUT"
 	MaxConcurrentReconciles                = "MAX_CONCURRENT_RECONCILES"
 	MaxParentBackingRetries                = "MAX_PARENT_BACKING_RETRIES"
 	HostLeaseNamespace                     = "HOST_LEASE_NAMESPACE"
@@ -159,6 +160,8 @@ type Migration struct {
 	VddkImage string
 	// TlsConnectionTimeout is the timeout for TLS connections in seconds
 	TlsConnectionTimeout int
+	// WindowsRebootTimeout is the timeout in seconds for the Windows wait-for-reboot migration step.
+	WindowsRebootTimeout int
 	// MaxConcurrentReconciles is the limit of how many reconciles can run at once
 	MaxConcurrentReconciles int
 	// MaxParentBackingRetries is the limit of how many retries can happen while getting parent backing of a disk
@@ -268,6 +271,9 @@ func (r *Migration) Load() (err error) {
 		return liberr.Wrap(err)
 	}
 	if r.TlsConnectionTimeout, err = getPositiveEnvLimit(TlsConnectionTimeout, 5); err != nil {
+		return liberr.Wrap(err)
+	}
+	if r.WindowsRebootTimeout, err = getPositiveEnvLimit(ControllerWindowsRebootTimeout, 1800); err != nil {
 		return liberr.Wrap(err)
 	}
 	r.VirtV2vExtraArgs = "[]"

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -38,6 +38,7 @@ const (
 	EnvSmpName                          = "V2V_smp"
 	EnvVsphereVmwareDriverRemovalName   = "V2V_vsphereVmwareDriverRemoval"
 	EnvWindowsRegistryNetworkConfigName = "V2V_windowsRegistryNetworkConfig"
+	EnvWaitForGuestRebootName           = "V2V_waitForGuestReboot"
 	EnvXfsCompatibilityName             = "V2V_xfsCompatibility"
 )
 
@@ -115,6 +116,8 @@ type AppConfig struct {
 	VsphereVmwareDriverRemoval bool
 	// V2V_windowsRegistryNetworkConfig
 	WindowsRegistryNetworkConfig bool
+	// V2V_waitForGuestReboot — upload first-boot script signaling CONVERSION_DONE on COM1
+	WaitForGuestReboot bool
 	// V2V_xfsCompatibility — use XFS-capable virt-v2v; omit --no-fstrim when true
 	XfsCompatibility bool
 	// SupportsNoFstrim is true when the virt-v2v binary supports --no-fstrim
@@ -165,6 +168,7 @@ func (s *AppConfig) Load() (err error) {
 	flag.IntVar(&s.Smp, "smp", s.getEnvInt(EnvSmpName, 0), "Number of virtual CPUs used for the conversion appliance")
 	flag.BoolVar(&s.VsphereVmwareDriverRemoval, "vsphere-vmware-driver-removal", s.getEnvBool(EnvVsphereVmwareDriverRemovalName, false), "Run VMware driver removal scripts during Windows vSphere conversion")
 	flag.BoolVar(&s.WindowsRegistryNetworkConfig, "windows-registry-network-config", s.getEnvBool(EnvWindowsRegistryNetworkConfigName, false), "Use registry-based network configuration scripts for Windows static IP setup")
+	flag.BoolVar(&s.WaitForGuestReboot, "wait-for-guest-reboot", s.getEnvBool(EnvWaitForGuestRebootName, false), "Inject first-boot script to signal conversion completion on guest serial (COM1)")
 	flag.BoolVar(&s.XfsCompatibility, "xfs-compatibility", s.getEnvBool(EnvXfsCompatibilityName, false), "XFS compatibility mode: do not pass --no-fstrim to virt-v2v")
 	s.RemoteInspectionDisks = s.getRemoteInspectionDisks()
 	flag.Parse()

--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -355,6 +355,10 @@ func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) erro
 	}
 	uploadInitPath := c.formatUpload(initPath, WinFirstbootScriptsPath)
 	cmdBuilder.AddArgs(UploadCmd, uploadPreserveIpPath, uploadInitPath, uploadRemoveDuplicatesPath, uploadPreserveMultipleIpPath)
+	if c.appConfig.WaitForGuestReboot {
+		signalScript := filepath.Join(windowsScriptsPath, "99999-signal-conversion-done.ps1")
+		cmdBuilder.AddArg(UploadCmd, c.formatUpload(signalScript, filepath.Join(WinFirstbootScriptsPath, "99999-signal-conversion-done.ps1")))
+	}
 	return nil
 }
 

--- a/pkg/virt-v2v/customize/scripts/windows/99999-signal-conversion-done.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/99999-signal-conversion-done.ps1
@@ -1,0 +1,10 @@
+$port = New-Object System.IO.Ports.SerialPort "COM1", 9600, "None", 8, "One"
+try {
+    $port.Open()
+    $port.WriteLine("CONVERSION_DONE")
+} catch {
+    if ($port.IsOpen) { try { $port.Close() } catch {} }
+    [System.IO.File]::WriteAllText("\\.\COM1", "CONVERSION_DONE`r`n")
+} finally {
+    if ($port.IsOpen) { try { $port.Close() } catch {} }
+}

--- a/pkg/wait-for-reboot/watcher.go
+++ b/pkg/wait-for-reboot/watcher.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2019 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package waitforreboot hosts the Windows wait-for-reboot watcher used by the
+// forklift-wait-for-reboot command. The directory uses a hyphen to match
+// deployment naming; the package name is waitforreboot.
+package waitforreboot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/rest"
+	k8swebsocket "k8s.io/client-go/transport/websocket"
+	cnv "kubevirt.io/api/core/v1"
+)
+
+const (
+	defaultSignal        = "CONVERSION_DONE"
+	defaultOverallSec    = 1800
+	defaultRebootSec     = 300
+	phasePollInterval    = 5 * time.Second
+	vmiNotRunningSnippet = "VMI is not running"
+)
+
+// Config holds watcher settings loaded from environment variables.
+type Config struct {
+	Signal          string
+	OverallTimeout  time.Duration
+	RebootTimeout   time.Duration
+	VMIName         string
+	VMINamespace    string
+	ConsoleProtocol string
+}
+
+// ParseConfig builds Config from process environment.
+func ParseConfig() (*Config, error) {
+	cfg := &Config{
+		Signal:          os.Getenv("SIGNAL"),
+		VMIName:         os.Getenv("VMI_NAME"),
+		VMINamespace:    os.Getenv("VMI_NAMESPACE"),
+		ConsoleProtocol: "plain.kubevirt.io",
+	}
+	if cfg.Signal == "" {
+		cfg.Signal = defaultSignal
+	}
+	var err error
+	cfg.OverallTimeout, err = durationFromEnvSec(os.Getenv, "TIMEOUT", defaultOverallSec)
+	if err != nil {
+		return nil, err
+	}
+	cfg.RebootTimeout, err = durationFromEnvSec(os.Getenv, "REBOOT_TIMEOUT", defaultRebootSec)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.VMIName == "" {
+		return nil, fmt.Errorf("VMI_NAME is required")
+	}
+	if cfg.VMINamespace == "" {
+		return nil, fmt.Errorf("VMI_NAMESPACE is required")
+	}
+	return cfg, nil
+}
+
+func durationFromEnvSec(getenv func(string) string, key string, defaultSec int) (time.Duration, error) {
+	v := getenv(key)
+	if v == "" {
+		return time.Duration(defaultSec) * time.Second, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid %s %q (expect non-negative integer seconds)", key, v)
+	}
+	return time.Duration(n) * time.Second, nil
+}
+
+const (
+	// ExitSuccess means the watcher finished without a hard serial-timeout failure.
+	ExitSuccess = 0
+	// ExitSignalTimeout indicates the overall TIMEOUT elapsed before SIGNAL was observed.
+	ExitSignalTimeout = 1
+)
+
+// Watch connects to the VMI serial console, waits for SIGNAL, then polls VMI
+// phase for a reboot pattern (Running → non-Running → Running). Missing the
+// reboot pattern before REBOOT_TIMEOUT still returns ExitSuccess (soft success).
+func Watch(ctx context.Context, restCfg *rest.Config, lg *log.Logger, cfg *Config) int {
+	if lg == nil {
+		lg = log.Default()
+	}
+	overallCtx, cancelOverall := context.WithTimeout(ctx, cfg.OverallTimeout)
+	defer cancelOverall()
+
+	kvREST, err := kubevirtRESTClient(restCfg)
+	if err != nil {
+		lg.Printf("creating kubevirt REST client: %v", err)
+		return ExitSignalTimeout
+	}
+
+	lg.Printf("waiting for signal %q on VMI %s/%s serial console (overall TIMEOUT=%s)",
+		cfg.Signal, cfg.VMINamespace, cfg.VMIName, cfg.OverallTimeout)
+
+	conn, err := connectSerialConsoleUntil(overallCtx, restCfg, cfg, lg)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			lg.Printf("overall timeout exceeded before observing serial signal %q", cfg.Signal)
+			return ExitSignalTimeout
+		}
+		lg.Printf("giving up on serial console: %v", err)
+		return ExitSignalTimeout
+	}
+
+	gotSignal := waitForSignalOnConn(overallCtx, conn, cfg.Signal, lg)
+	_ = conn.Close()
+
+	if gotSignal {
+		cancelOverall()
+	}
+
+	if !gotSignal {
+		if errors.Is(overallCtx.Err(), context.DeadlineExceeded) {
+			lg.Printf("overall TIMEOUT elapsed without seeing signal %q", cfg.Signal)
+		} else {
+			lg.Printf("stopped waiting for signal %q before overall TIMEOUT (see errors above)", cfg.Signal)
+		}
+		return ExitSignalTimeout
+	}
+
+	lg.Printf("signal received; polling VMI.phase every %s for up to %s (want Running→non-Running→Running)",
+		phasePollInterval, cfg.RebootTimeout)
+
+	rebootCtx, cancelReboot := context.WithTimeout(ctx, cfg.RebootTimeout)
+	defer cancelReboot()
+
+	if rebootSeen := pollPhaseReboot(rebootCtx, kvREST, cfg.VMINamespace, cfg.VMIName, lg); rebootSeen {
+		lg.Printf("detected reboot from VMI phase transitions; exiting 0")
+	} else if errors.Is(rebootCtx.Err(), context.DeadlineExceeded) {
+		lg.Printf("REBOOT_TIMEOUT reached without detecting phase reboot; exiting 0 (soft success)")
+	} else {
+		lg.Printf("stopped polling phase without detecting reboot pattern; exiting 0 (soft success)")
+	}
+
+	return ExitSuccess
+}
+
+func kubevirtRESTClient(cfg *rest.Config) (*rest.RESTClient, error) {
+	gv := cnv.SchemeGroupVersion
+	copyCfg := rest.CopyConfig(cfg)
+	copyCfg.GroupVersion = &gv
+	copyCfg.APIPath = "/apis"
+	scheme := runtime.NewScheme()
+	_ = cnv.AddToScheme(scheme)
+	copyCfg.NegotiatedSerializer = serializer.NewCodecFactory(scheme).WithoutConversion()
+	copyCfg.ContentType = runtime.ContentTypeJSON
+	if copyCfg.UserAgent == "" {
+		copyCfg.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	return rest.RESTClientFor(copyCfg)
+}
+
+func connectSerialConsoleUntil(ctx context.Context, restCfg *rest.Config, cfg *Config, lg *log.Logger) (*websocket.Conn, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		rt, holder, err := k8swebsocket.RoundTripperFor(restCfg)
+		if err != nil {
+			return nil, err
+		}
+		apiHost := strings.TrimSuffix(restCfg.Host, "/")
+		u := fmt.Sprintf("%s/apis/subresources.kubevirt.io/v1/namespaces/%s/virtualmachineinstances/%s/console",
+			apiHost, cfg.VMINamespace, cfg.VMIName)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return nil, err
+		}
+		conn, err := k8swebsocket.Negotiate(rt, holder, req, cfg.ConsoleProtocol)
+		if err == nil {
+			lg.Printf("connected to serial console subresource WebSocket")
+			return conn, nil
+		}
+		if !isVMINotRunningDialErr(err) {
+			return nil, err
+		}
+		lg.Printf("VMI is not running yet; retrying console connection in %s (%v)", phasePollInterval, err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(phasePollInterval):
+		}
+	}
+}
+
+func isVMINotRunningDialErr(err error) bool {
+	var upgrade *httpstream.UpgradeFailureError
+	if errors.As(err, &upgrade) && upgrade.Cause != nil {
+		var st *apierrors.StatusError
+		if errors.As(upgrade.Cause, &st) {
+			return strings.Contains(st.ErrStatus.Message, vmiNotRunningSnippet)
+		}
+		return strings.Contains(upgrade.Cause.Error(), vmiNotRunningSnippet)
+	}
+	return strings.Contains(err.Error(), vmiNotRunningSnippet)
+}
+
+func waitForSignalOnConn(ctx context.Context, conn *websocket.Conn, signal string, lg *log.Logger) bool {
+	keep := max(len(signal)*2, 4096)
+	buf := ""
+
+	for {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			deadline = time.Now().Add(365 * 24 * time.Hour)
+		}
+		if err := conn.SetReadDeadline(deadline); err != nil {
+			lg.Printf("set read deadline on serial websocket: %v", err)
+			return false
+		}
+
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return false
+			}
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				if ctx.Err() != nil {
+					return false
+				}
+			}
+			lg.Printf("serial websocket read stopped: %v", err)
+			return false
+		}
+
+		buf += string(msg)
+		if len(buf) > keep {
+			buf = buf[len(buf)-keep:]
+		}
+		if strings.Contains(buf, signal) {
+			lg.Printf("serial signal matched %q", signal)
+			return true
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+	}
+}
+
+func fetchVMIPhase(ctx context.Context, c *rest.RESTClient, namespace, name string) (cnv.VirtualMachineInstancePhase, error) {
+	vmi := &cnv.VirtualMachineInstance{}
+	err := c.Get().
+		Namespace(namespace).
+		Resource("virtualmachineinstances").
+		Name(name).
+		Do(ctx).
+		Into(vmi)
+	if err != nil {
+		return "", err
+	}
+	return vmi.Status.Phase, nil
+}
+
+// pollPhaseReboot returns true if phase goes Running → distinct non-running → Running.
+func pollPhaseReboot(ctx context.Context, c *rest.RESTClient, namespace, name string, lg *log.Logger) bool {
+	t := time.NewTicker(phasePollInterval)
+	defer t.Stop()
+
+	sawRunning := false
+	leftRunning := false
+
+	for {
+		phase, err := fetchVMIPhase(ctx, c, namespace, name)
+		if err != nil {
+			lg.Printf("GET virtualmachineinstance (phase poll): %v", err)
+		} else {
+			lg.Printf("VMI.phase=%s", phase)
+			if phase == cnv.Running {
+				if leftRunning {
+					return true
+				}
+				sawRunning = true
+			} else if sawRunning && phase != "" && phase != cnv.Running {
+				if !leftRunning {
+					lg.Printf("VMI left Running phase (now %s); waiting for return to Running", phase)
+				}
+				leftRunning = true
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return false
+		case <-t.C:
+		}
+	}
+}


### PR DESCRIPTION
Introduce a native wait-for-reboot mechanism that blocks the migration pipeline until a Windows guest completes its firstboot scripts and reboots. A signal script is injected via virt-customize that writes CONVERSION_DONE to COM1; a watcher pod monitors the VMI serial console and polls for VMI phase transitions before allowing the pipeline to continue.

The feature is gated behind feature_windows_wait_for_reboot (default false) on the ForkliftController CR. When enabled, the step is automatically inserted between CreateVM and PostHook for Windows VMs detected via inventory. On timeout or failure the migration continues with a warning rather than failing.

Ref: https://redhat.atlassian.net/browse/MTV-5345
Resolves: MTV-5345