### PR TITLE
MTV-5320 | Remove automatic VIB installation from populator

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
@@ -11,7 +11,6 @@ import (
 
 	hversion "github.com/hashicorp/go-version"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/logger"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/version"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	vmkfstoolswrapper "github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/vmkfstools-wrapper"
 	"github.com/kubev2v/forklift/pkg/lib/util"
@@ -152,14 +151,6 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, sourceVMDKFile string, pv 
 	hostID := strings.ReplaceAll(strings.ToLower(host.String()), ":", "-")
 	xcopyInitiatorGroup := fmt.Sprintf("xcopy-%s", hostID)
 	setupLog.Info("initiator group", "group", xcopyInitiatorGroup)
-
-	// Only ensure VIB if using VIB method
-	if !p.UseSSHMethod {
-		err = ensureVib(setupCtx, p.VSphereClient, host, vmDisk.Datastore, version.VibVersion)
-		if err != nil {
-			return fmt.Errorf("failed to ensure VIB is installed: %w", err)
-		}
-	}
 
 	// Filter HBA UIDs based on datastore active adapters
 	var dsActiveAdapters []vmware.HostAdapter

--- a/cmd/vsphere-copy-offload-populator/internal/populator/vib.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/vib.go
@@ -3,55 +3,13 @@ package populator
 import (
 	"context"
 	"fmt"
-	"strings"
 
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
 	"k8s.io/klog/v2"
 )
-
-const (
-	vibName     = "vmkfstools-wrapper"
-	vibLocation = "/bin/vmkfstools-wrapper.vib"
-)
-
-// ensure vib will fetch the vib version and in case needed will install it
-// on the target ESX. Caller should pass a context; vib adds its logger to it for RunEsxCommand.
-func ensureVib(ctx context.Context, client vmware.Client, esx *object.HostSystem, datastore string, desiredVibVersion string) error {
-	log := klog.Background().WithName("copy-offload").WithName("vib")
-	ctx = klog.NewContext(ctx, log)
-	log.Info("ensuring VIB version on ESXi", "host", esx.Name(), "desired_version", desiredVibVersion)
-
-	currentVersion, err := getViBVersion(ctx, client, esx)
-	if err != nil {
-		return fmt.Errorf("failed to get the VIB version from ESXi %s: %w", esx.Name(), err)
-	}
-
-	log.Info("current VIB version on ESXi", "host", esx.Name(), "version", currentVersion)
-	if currentVersion == desiredVibVersion {
-		return nil
-	}
-
-	dc, err := getHostDC(esx)
-	if err != nil {
-		return err
-	}
-	vibPath, err := uploadVib(client, dc, datastore)
-	if err != nil {
-		return fmt.Errorf("failed to upload the VIB to ESXi %s: %w", esx.Name(), err)
-	}
-	log.Info("uploaded VIB to ESXi", "host", esx.Name())
-
-	err = installVib(ctx, client, esx, vibPath)
-	if err != nil {
-		return fmt.Errorf("failed to install the VIB on ESXi %s: %w", esx.Name(), err)
-	}
-	log.Info("installed VIB on ESXi", "host", esx.Name(), "version", desiredVibVersion)
-	return nil
-}
 
 func getHostDC(esx *object.HostSystem) (*object.Datacenter, error) {
 	ctx := context.Background()
@@ -91,48 +49,4 @@ func getHostDC(esx *object.HostSystem) (*object.Datacenter, error) {
 	}
 
 	return nil, fmt.Errorf("could not determine datacenter for host '%s'.", esx.Name())
-}
-
-func getViBVersion(ctx context.Context, client vmware.Client, esxi *object.HostSystem) (string, error) {
-	r, err := client.RunEsxCommand(ctx, esxi, []string{"software", "vib", "get", "-n", vibName})
-	if err != nil {
-		vFault, conversonErr := vmware.ErrToFault(err)
-		if conversonErr != nil {
-			return "", err
-		}
-		if vFault != nil {
-			for _, m := range vFault.ErrMsgs {
-				if strings.Contains(m, "[NoMatchError]") {
-					// vib is not installed. return empty object
-					return "", nil
-				}
-			}
-		}
-		return "", err
-	}
-
-	klog.FromContext(ctx).V(2).Info("VIB get result", "response", r)
-	return r[0].Value("Version"), err
-}
-
-func uploadVib(client vmware.Client, dc *object.Datacenter, datastore string) (string, error) {
-	ds, err := client.GetDatastore(context.Background(), dc, datastore)
-	if err != nil {
-		return "", fmt.Errorf("failed to upload file: %w", err)
-	}
-
-	if err = ds.UploadFile(context.Background(), vibLocation, vibName+".vib", nil); err != nil {
-		return "", fmt.Errorf("failed to upload %s: %w", vibLocation, err)
-	}
-	return fmt.Sprintf("/vmfs/volumes/%s/%s", datastore, vibName+".vib"), nil
-}
-
-func installVib(ctx context.Context, client vmware.Client, esx *object.HostSystem, vibPath string) error {
-	r, err := client.RunEsxCommand(ctx, esx, []string{"software", "vib", "install", "-f", "1", "-v", vibPath})
-	if err != nil {
-		return err
-	}
-
-	klog.FromContext(ctx).V(2).Info("VIB install result", "response", r)
-	return nil
 }

--- a/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator_test.go
+++ b/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator"
 	populator_mocks "github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/populator/mocks"
-	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/version"
 	"github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware"
 	vmware_mocks "github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware/mocks"
 	"github.com/vmware/govmomi/cli/esx"
@@ -111,7 +110,7 @@ var _ = Describe("Populator", func() {
 			setup: func() {
 				vmwareClient.EXPECT().GetEsxByVm(gomock.Any(), gomock.Any()).Return(dummyHost, nil)
 				vmwareClient.EXPECT().GetDatastoreActiveAdapters(context.Background(), gomock.Any(), "my-ds").Return([]vmware.HostAdapter{{Name: "vmhb64", Id: "iqn.foobar"}}, nil)
-				vmwareClient.EXPECT().RunEsxCommand(gomock.Any(), gomock.Any(), []string{"software", "vib", "get", "-n", "vmkfstools-wrapper"}).Return([]esx.Values{{"Version": {version.VibVersion}}}, nil)
+
 				storageClient.EXPECT().EnsureClonnerIgroup(gomock.Any(), gomock.Any()).Return(nil, nil)
 				storageClient.EXPECT().ResolvePVToLUN(populator.PersistentVolume{Name: "pvc-12345"}).Return(populator.LUN{}, fmt.Errorf("some error")).Times(1)
 			},
@@ -124,7 +123,7 @@ var _ = Describe("Populator", func() {
 			setup: func() {
 				vmwareClient.EXPECT().GetEsxByVm(gomock.Any(), gomock.Any()).Return(dummyHost, nil)
 				vmwareClient.EXPECT().GetDatastoreActiveAdapters(context.Background(), gomock.Any(), "my-ds").Return([]vmware.HostAdapter{{Name: "vmhb64", Id: "iqn.foobar"}}, nil)
-				vmwareClient.EXPECT().RunEsxCommand(gomock.Any(), gomock.Any(), []string{"software", "vib", "get", "-n", "vmkfstools-wrapper"}).Return([]esx.Values{{"Version": {version.VibVersion}}}, nil)
+
 				storageClient.EXPECT().EnsureClonnerIgroup(gomock.Any(), gomock.Any()).Return(nil, nil)
 				storageClient.EXPECT().ResolvePVToLUN(populator.PersistentVolume{Name: "pvc-12345"}).Return(populator.LUN{NAA: "616263"}, nil)
 				storageClient.EXPECT().CurrentMappedGroups(populator.LUN{NAA: "616263"}, nil).Return(nil, fmt.Errorf("some error"))
@@ -147,7 +146,7 @@ var _ = Describe("Populator", func() {
 			setup: func() {
 				vmwareClient.EXPECT().GetEsxByVm(gomock.Any(), gomock.Any()).Return(dummyHost, nil)
 				vmwareClient.EXPECT().GetDatastoreActiveAdapters(context.Background(), gomock.Any(), "my-ds").Return([]vmware.HostAdapter{{Name: "vmhbatest", Id: "iqn.foobar"}}, nil)
-				vmwareClient.EXPECT().RunEsxCommand(gomock.Any(), gomock.Any(), []string{"software", "vib", "get", "-n", "vmkfstools-wrapper"}).Return([]esx.Values{{"Version": {version.VibVersion}}}, nil)
+
 				storageClient.EXPECT().EnsureClonnerIgroup(gomock.Any(), gomock.Any()).Return(nil, nil)
 				storageClient.EXPECT().ResolvePVToLUN(gomock.Any()).Return(populator.LUN{NAA: "naa.616263"}, nil)
 				storageClient.EXPECT().CurrentMappedGroups(gomock.Any(), gomock.Any()).Return([]string{}, nil)


### PR DESCRIPTION
## Problem

The populator was installing the vmkfstools-wrapper VIB on every clone operation, which caused failures due to memory issues on ESXi hosts.

## What it achieves

Removes automatic VIB installation from the populator. Users who need the VIB must install it manually, avoiding unexpected failures during migration.

## Test plan

- [x] Run a migration without VIB pre-installed — verify populator no longer attempts VIB install
- [x] Run a migration with VIB pre-installed — verify clone succeeds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)