### PR TITLE
MTV-5359 | Restore KVM device request on conversion pods

### DIFF
--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/conversion.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/conversion.go
@@ -133,6 +133,10 @@ type PodSettings struct {
 	// GenerateName prefix for the managed pod.
 	// +optional
 	GenerateName string `json:"generateName,omitempty"`
+	// RequestKVM adds devices.kubevirt.io/kvm to the conversion pod
+	// so that virt-v2v uses hardware virtualisation instead of emulation.
+	// +optional
+	RequestKVM bool `json:"requestKVM,omitempty"`
 }
 
 // ConversionSpec defines the desired state of Conversion.

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3053,6 +3053,11 @@ spec:
                       type: string
                     description: Node selector constraints for the conversion pod.
                     type: object
+                  requestKVM:
+                    default: true
+                    description: Whether the pod needs a KVM device and kubevirt.io/schedulable
+                      node selector.
+                    type: boolean
                   serviceAccount:
                     description: ServiceAccount for the conversion pod.
                     type: string

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3053,6 +3053,11 @@ spec:
                       type: string
                     description: Node selector constraints for the conversion pod.
                     type: object
+                  requestKVM:
+                    default: true
+                    description: Whether the pod needs a KVM device and kubevirt.io/schedulable
+                      node selector.
+                    type: boolean
                   serviceAccount:
                     description: ServiceAccount for the conversion pod.
                     type: string

--- a/operator/config/crd/bases/forklift.konveyor.io_conversions.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_conversions.yaml
@@ -3047,6 +3047,11 @@ spec:
                       type: string
                     description: Node selector constraints for the conversion pod.
                     type: object
+                  requestKVM:
+                    default: true
+                    description: Whether the pod needs a KVM device and kubevirt.io/schedulable
+                      node selector.
+                    type: boolean
                   serviceAccount:
                     description: ServiceAccount for the conversion pod.
                     type: string

--- a/pkg/apis/forklift/v1beta1/conversion.go
+++ b/pkg/apis/forklift/v1beta1/conversion.go
@@ -133,6 +133,10 @@ type PodSettings struct {
 	// GenerateName prefix for the managed pod.
 	// +optional
 	GenerateName string `json:"generateName,omitempty"`
+	// Whether the pod needs a KVM device and kubevirt.io/schedulable node selector.
+	// +optional
+	// +kubebuilder:default:=true
+	RequestKVM bool `json:"requestKVM,omitempty"`
 }
 
 // ConversionSpec defines the desired state of Conversion.

--- a/pkg/controller/conversion/builder.go
+++ b/pkg/controller/conversion/builder.go
@@ -220,6 +220,7 @@ func (b *Builder) GetVirtV2vPodSpec(vm *plan.VMStatus, volumes []core.Volume, vo
 	if sa := convctx.ResolveServiceAccount(cfg); sa != "" {
 		pod.Spec.ServiceAccountName = sa
 	}
+	SetKvmOnPodSpec(&pod.Spec, cfg.RequestKVM)
 	return
 }
 
@@ -523,4 +524,27 @@ done
 			},
 		},
 	}
+}
+
+// SetKvmOnPodSpec adds the devices.kubevirt.io/kvm resource request/limit
+// and the kubevirt.io/schedulable node selector when requestKVM is true.
+// This ensures the pod lands on a node with /dev/kvm so the virt-v2v
+// appliance uses hardware virtualisation instead of emulation.
+func SetKvmOnPodSpec(podSpec *core.PodSpec, requestKVM bool) {
+	if !requestKVM {
+		return
+	}
+	if podSpec.NodeSelector == nil {
+		podSpec.NodeSelector = make(map[string]string)
+	}
+	podSpec.NodeSelector["kubevirt.io/schedulable"] = "true"
+	container := &podSpec.Containers[0]
+	if container.Resources.Limits == nil {
+		container.Resources.Limits = make(map[core.ResourceName]resource.Quantity)
+	}
+	container.Resources.Limits["devices.kubevirt.io/kvm"] = resource.MustParse("1")
+	if container.Resources.Requests == nil {
+		container.Resources.Requests = make(map[core.ResourceName]resource.Quantity)
+	}
+	container.Resources.Requests["devices.kubevirt.io/kvm"] = resource.MustParse("1")
 }

--- a/pkg/controller/conversion/context/doc.go
+++ b/pkg/controller/conversion/context/doc.go
@@ -77,6 +77,10 @@ type PodConfig struct {
 	// ExtraInitContainers are prepended to the pod's init container list before the VDDK sidecar.
 	// Used by callers that need provider-specific init work (e.g. NetApp Shift disk-perms fixer).
 	ExtraInitContainers []core.Container
+	// RequestKVM, when true, adds devices.kubevirt.io/kvm resource
+	// request/limit and the kubevirt.io/schedulable node selector so that
+	// virt-v2v runs with hardware virtualisation instead of emulation.
+	RequestKVM bool
 }
 
 // PodConfigFromSpec builds a PodConfig from a Conversion CR spec.
@@ -101,6 +105,7 @@ func PodConfigFromSpec(conversion *api.Conversion) PodConfig {
 	podConfig.PodAnnotations = conversion.Annotations
 	podConfig.PodNodeSelector = podSettings.NodeSelector
 	podConfig.Affinity = podSettings.Affinity
+	podConfig.RequestKVM = podSettings.RequestKVM
 	if podSettings.ServiceAccount != "" {
 		podConfig.ServiceAccount = podSettings.ServiceAccount
 	}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -216,6 +216,8 @@ func (r *KubeVirt) resolveConversionResources(vm *plan.VMStatus, podType convctx
 	res.podConfig = convctx.PodConfigFromPlan(r.Plan)
 	res.podConfig.Affinity = r.getConvertorAffinity()
 
+	res.podConfig.RequestKVM = shouldRequestKVM(r.Plan.Provider.Source)
+
 	var vmVolumes []cnv.Volume
 	if podType == convctx.VirtV2vConversionPod {
 		vmVolumes, err = r.getVMVolumes(vm)
@@ -464,6 +466,7 @@ func (r *KubeVirt) EnsureConversion(vm *plan.VMStatus, conversionType api.Conver
 				GenerateName:               resources.podConfig.GenerateName,
 				TransferNetworkAnnotations: resources.podConfig.TransferNetworkAnnotations,
 				NodeSelector:               resources.podConfig.PodNodeSelector,
+				RequestKVM:                 resources.podConfig.RequestKVM,
 			},
 			ExtraVolumes: resources.extraVolumes,
 			ExtraMounts:  resources.extraMounts,
@@ -1869,7 +1872,7 @@ func (r *KubeVirt) createPodToBindPVCs(vm *plan.VMStatus, pvcNames []string) (er
 	if sa := resolveServiceAccount(r.Plan); sa != "" {
 		pod.Spec.ServiceAccountName = sa
 	}
-	r.setKvmOnPodSpec(&pod.Spec)
+	convbuilder.SetKvmOnPodSpec(&pod.Spec, shouldRequestKVM(r.Plan.Provider.Source))
 
 	err = r.Client.Create(context.TODO(), pod, &client.CreateOptions{})
 	if err != nil {
@@ -1885,25 +1888,16 @@ func (r *KubeVirt) getListOptionsNamespaced() (listOptions *client.ListOptions) 
 	}
 }
 
-func (r *KubeVirt) setKvmOnPodSpec(podSpec *core.PodSpec) {
+// shouldRequestKVM returns true for provider types that need KVM passthrough.
+func shouldRequestKVM(provider *api.Provider) bool {
 	if Settings.VirtV2vDontRequestKVM {
-		return
+		return false
 	}
-	switch *r.Plan.Provider.Source.Spec.Type {
+	switch provider.Type() {
 	case api.VSphere, api.Ova, api.HyperV:
-		if podSpec.NodeSelector == nil {
-			podSpec.NodeSelector = make(map[string]string)
-		}
-		podSpec.NodeSelector["kubevirt.io/schedulable"] = "true"
-		container := &podSpec.Containers[0]
-		if container.Resources.Limits == nil {
-			container.Resources.Limits = make(map[core.ResourceName]resource.Quantity)
-		}
-		container.Resources.Limits["devices.kubevirt.io/kvm"] = resource.MustParse("1")
-		if container.Resources.Requests == nil {
-			container.Resources.Requests = make(map[core.ResourceName]resource.Quantity)
-		}
-		container.Resources.Requests["devices.kubevirt.io/kvm"] = resource.MustParse("1")
+		return true
+	default:
+		return false
 	}
 }
 


### PR DESCRIPTION
The MTV-3666 refactor moved pod construction into
pkg/controller/conversion/builder.go but dropped the setKvmOnPodSpec call that added devices.kubevirt.io/kvm resource requests/limits and the kubevirt.io/schedulable node selector. Without /dev/kvm the virt-v2v appliance falls back to QEMU emulation, which is significantly slower.

Add a RequestKVM flag to PodConfig, set it based on source provider type (vSphere, OVA, HyperV) and the VIRT_V2V_DONT_REQUEST_KVM setting, and apply it in the builder. The flag is also propagated through the
Conversion CR PodSettings so both the direct-pod and CR-based paths get KVM.

Ref: https://redhat.atlassian.net/browse/MTV-5359
Resolves: MTV-5359