### PR TITLE
MTV-5365 | Correctly propagate xfsCompatibility to CR spec

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -456,10 +456,11 @@ func (r *KubeVirt) EnsureConversion(vm *plan.VMStatus, conversionType api.Conver
 					Name:      resources.secret.Name,
 				},
 			},
-			Image:          convctx.GetVirtV2vImage(&resources.podConfig),
-			Settings:       envSettings,
-			VDDKImage:      resources.vddkImage,
-			LocalMigration: resources.localMigration,
+			Image:            convctx.GetVirtV2vImage(&resources.podConfig),
+			XfsCompatibility: resources.podConfig.XfsCompatibility,
+			Settings:         envSettings,
+			VDDKImage:        resources.vddkImage,
+			LocalMigration:   resources.localMigration,
 			PodSettings: api.PodSettings{
 				ServiceAccount:             resolveServiceAccount(r.Plan),
 				Affinity:                   resources.podConfig.Affinity,
@@ -750,8 +751,9 @@ func (r *KubeVirt) CreateDeepInspectionConversion(
 		Settings: map[string]string{
 			api.SpecSettingsSnapshotMorefKey: snapshotMoref,
 		},
-		VDDKImage:      settings.GetVDDKImage(r.Source.Provider.Spec.Settings),
-		DiskEncryption: diskEncryption,
+		XfsCompatibility: r.Plan.Spec.XfsCompatibility,
+		VDDKImage:        settings.GetVDDKImage(r.Source.Provider.Spec.Settings),
+		DiskEncryption:   diskEncryption,
 		PodSettings: api.PodSettings{
 			ServiceAccount: resolveServiceAccount(r.Plan),
 		},


### PR DESCRIPTION
Issue: When plan set xfsCompatibility to true, it updated to XFS image with no `--no-fstrim` option coming from RHEL9. This resulted in conversion CR trying to use RHEL9 and setting `--no-fstrim` option in virt-v2v-inspector which would fail at the end of migrtion.

Fix: Correctly pass the xfsCompatibility option to the conversion CR.

Resolves: MTV-5365