### PR TITLE
MTV-4593 | Add missing StorePowerState phase to EC2 migration itinerary

### DIFF
--- a/pkg/provider/ec2/controller/migrator/executor.go
+++ b/pkg/provider/ec2/controller/migrator/executor.go
@@ -116,6 +116,8 @@ func (r *Migrator) ExecutePhase(vm *planapi.VMStatus) (ok bool, err error) {
 		if ready {
 			r.NextPhase(vm)
 		}
+	case api.PhaseStorePowerState:
+		ok = false
 	case api.PhaseCreateGuestConversionPod, api.PhaseConvertGuest:
 		ok = false
 	case api.PhaseFinalize:
@@ -175,7 +177,7 @@ func (r *Migrator) Step(status *planapi.VMStatus) (step string) {
 		step = Initialize
 	case api.PhasePreHook:
 		step = api.PhasePreHook
-	case api.PhasePowerOffSource, api.PhaseWaitForPowerOff:
+	case api.PhaseStorePowerState, api.PhasePowerOffSource, api.PhaseWaitForPowerOff:
 		step = PrepareSource
 	case PhaseCreateSnapshots, PhaseWaitForSnapshots:
 		step = CreateSnapshots

--- a/pkg/provider/ec2/controller/migrator/itinerary.go
+++ b/pkg/provider/ec2/controller/migrator/itinerary.go
@@ -27,6 +27,7 @@ func (r *Migrator) Itinerary(vm planapi.VM) *libitr.Itinerary {
 		Pipeline: libitr.Pipeline{
 			{Name: api.PhaseStarted},
 			{Name: api.PhasePreHook, All: PreHookFlag},
+			{Name: api.PhaseStorePowerState},
 			{Name: api.PhasePowerOffSource},
 			{Name: api.PhaseWaitForPowerOff},
 			{Name: PhaseCreateSnapshots},

--- a/pkg/provider/ec2/controller/migrator/pipeline.go
+++ b/pkg/provider/ec2/controller/migrator/pipeline.go
@@ -36,7 +36,7 @@ func (r *Migrator) Pipeline(vm planapi.VM) (pipeline []*planapi.Step, err error)
 				},
 			})
 
-		case api.PhasePowerOffSource, api.PhaseWaitForPowerOff:
+		case api.PhaseStorePowerState, api.PhasePowerOffSource, api.PhaseWaitForPowerOff:
 			if step.Name == api.PhasePowerOffSource {
 				pipeline = append(pipeline, &planapi.Step{
 					Task: planapi.Task{


### PR DESCRIPTION
The EC2 cold migration itinerary was missing the PhaseStorePowerState phase that all other providers include before PhasePowerOffSource. Without it, RestorePowerState is never recorded on the VMStatus, so determineRunStrategy sees an empty value and defaults to RunStrategyHalted regardless of the source instance's actual power state.

Add PhaseStorePowerState between PhasePreHook and PhasePowerOffSource in the EC2 itinerary, consistent with the base cold/warm itineraries.

Ref: https://redhat.atlassian.net/browse/MTV-4593
Resolves: MTV-4593