### PR TITLE
chore(upstream): skip --no-fstrim on upstream virt-v2v images

### DIFF
--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bufio"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -115,8 +116,10 @@ type AppConfig struct {
 	// V2V_windowsRegistryNetworkConfig
 	WindowsRegistryNetworkConfig bool
 	// V2V_xfsCompatibility — use XFS-capable virt-v2v; omit --no-fstrim when true
-	// the el9 v2v is missing the --no-fstrim flag so the conversion would fail
 	XfsCompatibility bool
+	// SupportsNoFstrim is true when the virt-v2v binary supports --no-fstrim
+	// (RHEL-only downstream patch. upstream CentOS/Fedora builds lack this flag)
+	SupportsNoFstrim bool
 
 	// V2V_multipleIPsPerNic
 	MultipleIpsPerNicName string
@@ -165,6 +168,8 @@ func (s *AppConfig) Load() (err error) {
 	flag.BoolVar(&s.XfsCompatibility, "xfs-compatibility", s.getEnvBool(EnvXfsCompatibilityName, false), "XFS compatibility mode: do not pass --no-fstrim to virt-v2v")
 	s.RemoteInspectionDisks = s.getRemoteInspectionDisks()
 	flag.Parse()
+
+	s.SupportsNoFstrim = detectNoFstrimSupport("/etc/os-release")
 
 	return s.validate()
 }
@@ -241,6 +246,29 @@ func (s *AppConfig) getEnvBool(name string, def bool) bool {
 
 func (s *AppConfig) envMissingError(env string) error {
 	return fmt.Errorf("the env variable '%s' is needed for the migration", env)
+}
+
+// detectNoFstrimSupport reads an os-release file and returns true if the
+// OS is RHEL, which ships a downstream virt-v2v with --no-fstrim support.
+// Upstream builds (CentOS Stream, Fedora) lack this flag.
+func detectNoFstrimSupport(osReleasePath string) bool {
+	f, err := os.Open(osReleasePath)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if key, val, ok := strings.Cut(line, "="); ok {
+			if strings.TrimSpace(key) == "ID" {
+				id := strings.Trim(strings.TrimSpace(val), "\"'")
+				return id == "rhel"
+			}
+		}
+	}
+	return false
 }
 
 func (s *AppConfig) validate() error {

--- a/pkg/virt-v2v/config/variables_test.go
+++ b/pkg/virt-v2v/config/variables_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectNoFstrimSupport(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "RHEL 10",
+			content:  "NAME=\"Red Hat Enterprise Linux\"\nVERSION=\"10\"\nID=\"rhel\"\n",
+			expected: true,
+		},
+		{
+			name:     "RHEL 9 unquoted",
+			content:  "NAME=Red Hat Enterprise Linux\nVERSION=9\nID=rhel\n",
+			expected: true,
+		},
+		{
+			name:     "CentOS Stream 10",
+			content:  "NAME=\"CentOS Stream\"\nVERSION=\"10\"\nID=\"centos\"\n",
+			expected: false,
+		},
+		{
+			name:     "CentOS Stream 9",
+			content:  "NAME=\"CentOS Stream\"\nVERSION=\"9\"\nID=\"centos\"\n",
+			expected: false,
+		},
+		{
+			name:     "Fedora 41",
+			content:  "NAME=\"Fedora Linux\"\nVERSION=\"41\"\nID=fedora\n",
+			expected: false,
+		},
+		{
+			name:     "missing file",
+			content:  "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.content == "" {
+				got := detectNoFstrimSupport("/nonexistent/os-release")
+				if got != tt.expected {
+					t.Errorf("detectNoFstrimSupport() = %v, want %v", got, tt.expected)
+				}
+				return
+			}
+
+			tmpDir := t.TempDir()
+			path := filepath.Join(tmpDir, "os-release")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			got := detectNoFstrimSupport(path)
+			if got != tt.expected {
+				t.Errorf("detectNoFstrimSupport() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -112,10 +112,11 @@ func (c *Conversion) addInspectorExtraArgs(cmd utils.CommandBuilder) {
 	}
 }
 
-// addNoFstrimUnlessXfsCompat passes --no-fstrim unless XFS compatibility mode is enabled
-// the el9 v2v is missing the --no-fstrim flag so the conversion would fail
+// addNoFstrimUnlessXfsCompat passes --no-fstrim when the binary supports it
+// and XFS compatibility mode is not enabled. The --no-fstrim flag is a
+// RHEL-only downstream patch. upstream virt-v2v (CentOS/Fedora) lacks it.
 func (c *Conversion) addNoFstrimUnlessXfsCompat(cmd utils.CommandBuilder) {
-	if !c.XfsCompatibility {
+	if !c.XfsCompatibility && c.SupportsNoFstrim {
 		cmd.AddFlag("--no-fstrim")
 	}
 }

--- a/pkg/virt-v2v/conversion/conversion_test.go
+++ b/pkg/virt-v2v/conversion/conversion_test.go
@@ -32,7 +32,9 @@ var _ = Describe("Conversion", func() {
 		mockCommandBuilder = utils.NewMockCommandBuilder(mockCtrl)
 		mockFileSystem = utils.NewMockFileSystem(mockCtrl)
 
-		appConfig = &config.AppConfig{}
+		appConfig = &config.AppConfig{
+			SupportsNoFstrim: true,
+		}
 		conversion = &Conversion{
 			AppConfig:      appConfig,
 			CommandBuilder: mockCommandBuilder,
@@ -1211,6 +1213,68 @@ var _ = Describe("Conversion", func() {
 
 		It("omits --no-fstrim for RunVirtV2vInPlaceDisk", func() {
 			appConfig.XfsCompatibility = true
+			conversion.Disks = []*Disk{{Link: "/var/tmp/v2v/vm-sda"}}
+
+			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run()
+
+			err := conversion.RunVirtV2vInPlaceDisk()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Upstream image (SupportsNoFstrim=false)", func() {
+		It("omits --no-fstrim for RunVirtV2VInspection on upstream images", func() {
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
+			appConfig.SupportsNoFstrim = false
+			conversion.Disks = []*Disk{{Link: "/var/tmp/v2v/vm-sda"}}
+
+			mockCommandBuilder.EXPECT().New("virt-v2v-inspector").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-if", "raw").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run()
+
+			err := conversion.RunVirtV2VInspection()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("omits --no-fstrim for RunVirtV2vInPlace on upstream images", func() {
+			appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+			appConfig.SupportsNoFstrim = false
+
+			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run()
+
+			err := conversion.RunVirtV2vInPlace()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("omits --no-fstrim for RunVirtV2vInPlaceDisk on upstream images", func() {
+			appConfig.SupportsNoFstrim = false
 			conversion.Disks = []*Disk{{Link: "/var/tmp/v2v/vm-sda"}}
 
 			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)


### PR DESCRIPTION
The --no-fstrim flag is a RHEL-only downstream patch that does not exist in upstream virt-v2v (CentOS Stream or Fedora). The wrapper was unconditionally passing this flag, causing migrations to fail with "unrecognized option" on upstream images.

Detect the OS at startup by reading /etc/os-release and only pass --no-fstrim when running on RHEL (ID=rhel). On upstream images the flag is silently omitted; fstrim runs by default and logs a non-fatal warning if it fails.

Resolves: none