### PR TITLE
MTV-5389 | Add TLS settings for global AAP connection

### DIFF
--- a/docs/compatibility/forkliftcontroller-settings.md
+++ b/docs/compatibility/forkliftcontroller-settings.md
@@ -225,6 +225,22 @@ For storage copy offload (XCOPY) feature:
 
 ---
 
+## Ansible Automation Platform (AAP) Settings
+
+Settings for the centralized AAP connection used by migration hooks and the job-template inventory endpoint.
+
+| Setting | Default | Environment Variable | Description |
+|---------|---------|---------------------|-------------|
+| `aap_url` | `""` | `AAP_URL` | AAP base URL (e.g. `https://aap.example.com`) |
+| `aap_token_secret_name` | `""` | `AAP_TOKEN_SECRET_NAME` | Secret name holding the AAP Bearer token (key `token`) |
+| `aap_timeout` | `""` | `AAP_TIMEOUT` | Default timeout (seconds) for AAP HTTP calls and job polling |
+| `aap_insecure_skip_verify` | `false` | `AAP_INSECURE_SKIP_VERIFY` | Skip TLS certificate verification for AAP connections |
+| `aap_ca_secret_name` | `""` | `AAP_CA_SECRET_NAME` | Secret name holding a custom CA certificate (key `ca.crt`) for AAP TLS |
+
+When `aap_insecure_skip_verify` is `true`, the controller will not verify the AAP server's TLS certificate. When `aap_ca_secret_name` is set (and insecure is `false`), the specified Secret's `ca.crt` key is used as the trusted CA for TLS verification instead of the system CA bundle.
+
+---
+
 ## Logging and Debugging
 
 | Setting | Default | Environment Variable | Description |

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3410,6 +3410,20 @@ spec:
             additionalProperties: true
             description: Spec defines the desired state of ForkliftController
             properties:
+              aap_ca_secret_name:
+                description: 'Name of the Secret in the operator namespace containing
+                  a custom CA certificate (data key: ca.crt) for verifying the AAP
+                  server TLS certificate. Optional; when unset, the system CA bundle
+                  is used.'
+                type: string
+              aap_insecure_skip_verify:
+                description: 'Skip TLS certificate verification when connecting to
+                  AAP (default: false). Use only for testing or when the AAP server
+                  uses a self-signed certificate and no CA is provided.'
+                enum:
+                - "true"
+                - "false"
+                type: string
               aap_timeout:
                 description: Default timeout in seconds for AAP HTTP calls and job
                   polling when Hook spec.deadline is 0 (optional).

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3410,6 +3410,20 @@ spec:
             additionalProperties: true
             description: Spec defines the desired state of ForkliftController
             properties:
+              aap_ca_secret_name:
+                description: 'Name of the Secret in the operator namespace containing
+                  a custom CA certificate (data key: ca.crt) for verifying the AAP
+                  server TLS certificate. Optional; when unset, the system CA bundle
+                  is used.'
+                type: string
+              aap_insecure_skip_verify:
+                description: 'Skip TLS certificate verification when connecting to
+                  AAP (default: false). Use only for testing or when the AAP server
+                  uses a self-signed certificate and no CA is provided.'
+                enum:
+                - "true"
+                - "false"
+                type: string
               aap_timeout:
                 description: Default timeout in seconds for AAP HTTP calls and job
                   polling when Hook spec.deadline is 0 (optional).

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -411,6 +411,13 @@ spec:
               aap_timeout:
                 x-kubernetes-int-or-string: true
                 description: "Default timeout in seconds for AAP HTTP calls and job polling when Hook spec.deadline is 0 (optional)."
+              aap_insecure_skip_verify:
+                type: string
+                enum: ["true", "false"]
+                description: "Skip TLS certificate verification when connecting to AAP (default: false). Use only for testing or when the AAP server uses a self-signed certificate and no CA is provided."
+              aap_ca_secret_name:
+                type: string
+                description: "Name of the Secret in the operator namespace containing a custom CA certificate (data key: ca.crt) for verifying the AAP server TLS certificate. Optional; when unset, the system CA bundle is used."
 
               # Migration Feature-Specific Settings
               controller_vsphere_incremental_backup:

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -63,6 +63,8 @@ controller_migration_service_account: ""
 aap_url: ""
 aap_token_secret_name: ""
 aap_timeout: ""
+aap_insecure_skip_verify: false
+aap_ca_secret_name: ""
 profiler_volume_path: "/var/cache/profiler"
 
 inventory_volume_path: "/var/cache/inventory"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -141,6 +141,14 @@ spec:
         - name: AAP_TIMEOUT
           value: "{{ aap_timeout }}"
 {% endif %}
+{% if aap_insecure_skip_verify is defined and aap_insecure_skip_verify|bool %}
+        - name: AAP_INSECURE_SKIP_VERIFY
+          value: "true"
+{% endif %}
+{% if aap_ca_secret_name is defined and aap_ca_secret_name is string and aap_ca_secret_name|length > 0 %}
+        - name: AAP_CA_SECRET_NAME
+          value: "{{ aap_ca_secret_name }}"
+{% endif %}
 {% if controller_cdi_export_token_ttl is number %}
         - name: CDI_EXPORT_TOKEN_TTL
           value: "{{ controller_cdi_export_token_ttl }}"
@@ -309,6 +317,14 @@ spec:
 {% elif aap_timeout is defined and aap_timeout is number %}
         - name: AAP_TIMEOUT
           value: "{{ aap_timeout }}"
+{% endif %}
+{% if aap_insecure_skip_verify is defined and aap_insecure_skip_verify|bool %}
+        - name: AAP_INSECURE_SKIP_VERIFY
+          value: "true"
+{% endif %}
+{% if aap_ca_secret_name is defined and aap_ca_secret_name is string and aap_ca_secret_name|length > 0 %}
+        - name: AAP_CA_SECRET_NAME
+          value: "{{ aap_ca_secret_name }}"
 {% endif %}
         - name: API_PORT
           value: "8443"

--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"encoding/base64"
-	"os"
 	"path"
 	"strings"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/lib/aap"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	"github.com/kubev2v/forklift/pkg/settings"
 	"gopkg.in/yaml.v2"
 	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
@@ -437,19 +437,12 @@ func (r *HookRunner) runAAPJob(step *planapi.Step) (err error) {
 		)
 		err = tokErr
 	} else {
-		// Centralized token Secret lives in the forklift-controller deployment namespace (POD_NAMESPACE).
 		aapURL = strings.TrimSpace(m.AAPURL)
-		ns := strings.TrimSpace(os.Getenv("POD_NAMESPACE"))
-		if ns == "" {
-			step.AddError("POD_NAMESPACE is not set; cannot load AAP token Secret")
-			step.MarkCompleted()
-			return
-		}
 		var tokErr error
 		token, tokErr = aap.GetTokenFromSecretName(
 			context.TODO(),
 			r.Client,
-			ns,
+			settings.ControllerNamespace(),
 			m.AAPTokenSecretName,
 		)
 		err = tokErr
@@ -464,7 +457,15 @@ func (r *HookRunner) runAAPJob(step *planapi.Step) (err error) {
 	if m.AAPTimeoutSeconds > 0 {
 		httpTimeout = time.Duration(m.AAPTimeoutSeconds) * time.Second
 	}
-	aapClient := aap.NewClient(aapURL, token, httpTimeout)
+
+	transport, tlsErr := aap.TLSTransportFromSettings(context.TODO(), r.Client, m.AAPInsecureSkipVerify, m.AAPCASecretName)
+	if tlsErr != nil {
+		step.AddError(tlsErr.Error())
+		step.MarkCompleted()
+		return
+	}
+
+	aapClient := aap.NewClient(aapURL, token, httpTimeout, transport)
 
 	extraVars := r.aapJobExtraVars()
 

--- a/pkg/controller/provider/web/aap/handler.go
+++ b/pkg/controller/provider/web/aap/handler.go
@@ -36,17 +36,12 @@ func (h *Handler) AddRoutes(e *gin.Engine) {
 
 // ListJobTemplates returns all configured AAP job templates (flat list). Pagination is handled inside pkg/lib/aap.
 func (h *Handler) ListJobTemplates(ctx *gin.Context) {
-	invNS := settings.Settings.Inventory.Namespace
-	if invNS == "" {
-		log.Error(nil, "inventory namespace not set for AAP handler")
-		ctx.Status(http.StatusInternalServerError)
-		return
-	}
+	ns := settings.ControllerNamespace()
 
 	if base.Settings.AuthRequired {
 		nsForAuth := ctx.Request.URL.Query().Get(base.NsParam)
 		if nsForAuth == "" {
-			nsForAuth = invNS
+			nsForAuth = ns
 		}
 		orig := ctx.Request.URL.RawQuery
 		q := ctx.Request.URL.Query()
@@ -69,7 +64,6 @@ func (h *Handler) ListJobTemplates(ctx *gin.Context) {
 		})
 		return
 	}
-	ns := invNS
 	token, err := aap.GetTokenFromSecretName(ctx.Request.Context(), h.Client, ns, m.AAPTokenSecretName)
 	if err != nil {
 		log.Error(err, "failed to read AAP token Secret")
@@ -93,7 +87,15 @@ func (h *Handler) ListJobTemplates(ctx *gin.Context) {
 	if m.AAPTimeoutSeconds > 0 {
 		httpTimeout = time.Duration(m.AAPTimeoutSeconds) * time.Second
 	}
-	cl := aap.NewClient(m.AAPURL, token, httpTimeout)
+
+	transport, tlsErr := aap.TLSTransportFromSettings(ctx.Request.Context(), h.Client, m.AAPInsecureSkipVerify, m.AAPCASecretName)
+	if tlsErr != nil {
+		log.Error(tlsErr, "failed to read AAP CA Secret")
+		ctx.JSON(http.StatusBadGateway, gin.H{"message": "failed to read AAP CA Secret"})
+		return
+	}
+
+	cl := aap.NewClient(m.AAPURL, token, httpTimeout, transport)
 	results, err := cl.ListAllJobTemplates(ctx.Request.Context(), maxJobs)
 	if err != nil {
 		log.Error(err, "AAP list job templates failed")

--- a/pkg/lib/aap/client.go
+++ b/pkg/lib/aap/client.go
@@ -60,9 +60,6 @@ type Client struct {
 	apiPathPrefix string
 }
 
-// ClientOption configures [NewClient].
-type ClientOption func(*Client)
-
 // LaunchJobResponse represents the response from AAP job launch.
 type LaunchJobResponse struct {
 	ID     int    `json:"id"`
@@ -89,14 +86,6 @@ type JobTemplateListResponse struct {
 	Next     string               `json:"next"`
 	Previous string               `json:"previous"`
 	Results  []JobTemplateSummary `json:"results"`
-}
-
-// WithPathPrefix sets a fixed API path prefix and skips GET /api discovery. For tests; production
-// should omit this option so the first HTTP call can discover the prefix from GET {baseURL}/api.
-func WithPathPrefix(prefix string) ClientOption {
-	return func(c *Client) {
-		c.staticPathPrefix = prefix
-	}
 }
 
 // resolvePathPrefix sets apiPathPrefix once: optional static ([WithPathPrefix]), else GET {baseURL}/api
@@ -187,7 +176,7 @@ func (c *Client) resourceURL(ctx context.Context, path string) (string, error) {
 }
 
 // NewClient creates an AAP API client with the given HTTP timeout.
-func NewClient(aapURL, token string, httpTimeout time.Duration, opts ...ClientOption) *Client {
+func NewClient(aapURL, token string, httpTimeout time.Duration, transport *http.Transport) *Client {
 	if httpTimeout <= 0 {
 		httpTimeout = 30 * time.Second
 	}
@@ -198,8 +187,8 @@ func NewClient(aapURL, token string, httpTimeout time.Duration, opts ...ClientOp
 			Timeout: httpTimeout,
 		},
 	}
-	for _, o := range opts {
-		o(c)
+	if transport != nil {
+		c.client.Transport = transport
 	}
 	return c
 }

--- a/pkg/lib/aap/client_test.go
+++ b/pkg/lib/aap/client_test.go
@@ -50,7 +50,7 @@ func TestClientResolveAPIPrefixFromGetAPI(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cl := NewClient(srv.URL, "tok", 0)
+	cl := NewClient(srv.URL, "tok", 0, nil)
 	_, err := cl.ListJobTemplates(context.Background(), 1, 20)
 	if err != nil {
 		t.Fatal(err)
@@ -60,33 +60,5 @@ func TestClientResolveAPIPrefixFromGetAPI(t *testing.T) {
 	}
 	if jtHits != 1 {
 		t.Fatalf("expected one GET to discovered job_templates path, got %d", jtHits)
-	}
-}
-
-func TestWithPathPrefixSkipsDiscovery(t *testing.T) {
-	called := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called++
-		if r.URL.Path == "/static/job_templates/" {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"count": 0, "next": null, "previous": null, "results": []}`))
-			return
-		}
-		if r.URL.Path == "/api/" {
-			_, _ = w.Write([]byte(`{"current_version": "/nope"}`))
-			return
-		}
-		t.Fatalf("unexpected: %s", r.URL.Path)
-	}))
-	defer srv.Close()
-
-	cl := NewClient(srv.URL, "tok", 0, WithPathPrefix("/static"))
-	_, err := cl.ListJobTemplates(context.Background(), 1, 20)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// /api/ should not be called when prefix is set manually; only /static/job_templates.
-	if called != 1 {
-		t.Fatalf("expected 1 request (no GET /api), got %d", called)
 	}
 }

--- a/pkg/lib/aap/token.go
+++ b/pkg/lib/aap/token.go
@@ -2,10 +2,16 @@ package aap
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"net"
+	"net/http"
 	"strings"
+	"time"
 
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	"github.com/kubev2v/forklift/pkg/settings"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,4 +68,66 @@ func tokenStringFromSecretData(data map[string][]byte, ns, name string) (string,
 		return "", fmt.Errorf("secret %s/%s contains an empty 'token' value", ns, name)
 	}
 	return string(tokenBytes), nil
+}
+
+// GetCACertFromSecretName reads a CA certificate (PEM) from the "ca.crt" key
+// of the named Secret in the given namespace.
+func GetCACertFromSecretName(ctx context.Context, k8sClient client.Client, namespace, name string) ([]byte, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("CA secret name must be non-empty")
+	}
+	ns := strings.TrimSpace(namespace)
+	if ns == "" {
+		return nil, fmt.Errorf("namespace must be non-empty")
+	}
+	secret := &core.Secret{}
+	err := k8sClient.Get(
+		ctx,
+		types.NamespacedName{Namespace: ns, Name: name},
+		secret,
+	)
+	if err != nil {
+		return nil, liberr.Wrap(err, fmt.Sprintf("failed to get CA secret %s/%s", ns, name))
+	}
+	ca, ok := secret.Data["ca.crt"]
+	if !ok || len(ca) == 0 {
+		return nil, fmt.Errorf("secret %s/%s does not contain a non-empty 'ca.crt' key", ns, name)
+	}
+	return ca, nil
+}
+
+// TLSTransportFromSettings builds an *http.Transport for AAP TLS configuration.
+// It reads the CA cert from the controller namespace if a CA secret name is
+// configured and insecure is not set.
+func TLSTransportFromSettings(ctx context.Context, k8sClient client.Client, insecureSkipVerify bool, caSecretName string) (*http.Transport, error) {
+	var tlsCfg *tls.Config
+	if insecureSkipVerify {
+		tlsCfg = &tls.Config{
+			InsecureSkipVerify: true, //#nosec G402 -- user-configured setting
+		}
+	} else if caSecretName != "" {
+		caCert, err := GetCACertFromSecretName(ctx, k8sClient, settings.ControllerNamespace(), caSecretName)
+		if err != nil {
+			return nil, err
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("invalid AAP CA bundle: failed to parse PEM from secret %s/%s",
+				settings.ControllerNamespace(), caSecretName)
+		}
+		tlsCfg = &tls.Config{RootCAs: pool}
+	}
+	return &http.Transport{
+		TLSClientConfig:       tlsCfg,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+	}, nil
 }

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -72,6 +72,8 @@ const (
 	AAPURL                                 = "AAP_URL"
 	AAPTokenSecretName                     = "AAP_TOKEN_SECRET_NAME"
 	AAPTimeout                             = "AAP_TIMEOUT"
+	AAPInsecureSkipVerify                  = "AAP_INSECURE_SKIP_VERIFY"
+	AAPCASecretName                        = "AAP_CA_SECRET_NAME"
 )
 
 // Default values for populator container resources
@@ -175,6 +177,10 @@ type Migration struct {
 	AAPTokenSecretName string
 	// AAPTimeoutSeconds is the default wall-clock timeout in seconds for AAP job polling when not set on the Hook.
 	AAPTimeoutSeconds int
+	// AAPInsecureSkipVerify skips TLS certificate verification when connecting to AAP.
+	AAPInsecureSkipVerify bool
+	// AAPCASecretName is the name of the Secret in the controller namespace holding a custom CA cert (key "ca.crt").
+	AAPCASecretName string
 }
 
 // Load settings.
@@ -415,6 +421,10 @@ func (r *Migration) Load() (err error) {
 			}
 			r.AAPTimeoutSeconds = n
 		}
+	}
+	r.AAPInsecureSkipVerify = getEnvBool(AAPInsecureSkipVerify, false)
+	if val, found := os.LookupEnv(AAPCASecretName); found {
+		r.AAPCASecretName = strings.TrimSpace(val)
 	}
 	if val, found := os.LookupEnv(DeepInspectionImage); found {
 		r.DeepInspectionImage = strings.TrimSpace(val)

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -140,6 +140,12 @@ func GetVDDKImage(providerSpecSettings map[string]string) string {
 	return vddkImage
 }
 
+// ControllerNamespace returns the namespace where the forklift-controller
+// pod is deployed (set via fieldRef in the deployment template).
+func ControllerNamespace() string {
+	return os.Getenv("POD_NAMESPACE")
+}
+
 // Lookup the value of an environment variable and
 // return a fallback value if it isn't found.
 func Lookup(env string, fallback string) string {


### PR DESCRIPTION
Add aap_insecure_skip_verify and aap_ca_secret_name to the ForkliftController CR so that the AAP client can use a custom CA certificate or skip TLS verification.

Previously the AAP HTTP client relied solely on system CA certificates with no way to trust a private CA or self-signed certificate, unlike all other provider clients.

Ref: https://redhat.atlassian.net/browse/MTV-5389
Resolves: MTV-5389