### PR TITLE
MTV-5271 | Map ca.crt secret key to cacert env var in populator pod

### DIFF
--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -1045,6 +1045,22 @@ func makePopulatePodSpec(pvcPrimeName, secretName string) corev1.PodSpec {
 						},
 					},
 				},
+				// Explicit mapping required because Kubernetes drops dotted keys (ca.crt)
+				// when injecting via EnvFrom. Populator binaries expect "cacert" env var.
+				Env: []corev1.EnvVar{
+					{
+						Name: "cacert",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: secretName,
+								},
+								Key:      "ca.crt",
+								Optional: ptr.To(true),
+							},
+						},
+					},
+				},
 			},
 		},
 		SecurityContext: &corev1.PodSecurityContext{


### PR DESCRIPTION
Issue:
PR 5549 normalized the CA certificate key in provider secrets from "cacert" to the standard Kubernetes "ca.crt". However, Kubernetes silently drops secret keys containing dots when injecting them as environment variables via EnvFrom. The oVirt populator binary reads the certificate from os.Getenv("cacert"), which became empty after the normalization.

Fix:
Add an explicit Env entry in the populator pod spec that maps the "ca.crt" secret key to the "cacert" environment variable. The mapping is optional so pods still start when the key is absent (e.g. insecure providers).

Ref: https://redhat.atlassian.net/browse/MTV-5271
Resolves: MTV-5271