### PR TITLE
MTV-5263 | Use instance UUIDs for VMware warm migrations.

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -10991,6 +10991,12 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - cdi.kubevirt.io
+  resources:
+  - cdis
+  verbs:
+  - list
+- apiGroups:
   - security.openshift.io
   resourceNames:
   - anyuid

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -10991,6 +10991,12 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - cdi.kubevirt.io
+  resources:
+  - cdis
+  verbs:
+  - list
+- apiGroups:
   - security.openshift.io
   resourceNames:
   - anyuid

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -127,6 +127,12 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - cdi.kubevirt.io
+  resources:
+  - cdis
+  verbs:
+  - list
+- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -575,12 +575,16 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 			}
 		} else {
 			vddkImage := settings.GetVDDKImage(r.Source.Provider.Spec.Settings)
+			uuid := vm.InstanceUUID
+			if uuid == "" {
+				uuid = vm.UUID
+			}
 
 			// Let CDI do the copying
 			dvSource = cdi.DataVolumeSource{
 				VDDK: &cdi.DataVolumeSourceVDDK{
 					BackingFile:  baseVolume(disk.File, r.Plan.IsWarm()),
-					UUID:         vm.UUID,
+					UUID:         uuid,
 					URL:          url,
 					SecretRef:    secret.Name,
 					Thumbprint:   thumbprint,
@@ -1337,6 +1341,10 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 		err = liberr.Wrap(err, "vm", vmRef.String())
 		return
 	}
+	uuid := vm.InstanceUUID
+	if uuid == "" {
+		uuid = vm.UUID
+	}
 
 	// Get a list of existing PVCs to avoid creating duplicates
 	pvcLabels := map[string]string{
@@ -1554,7 +1562,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 
 					pvc.Annotations[planbase.AnnEndpoint] = url
 					pvc.Annotations[planbase.AnnImportBackingFile] = baseVolume(disk.File, r.Plan.IsWarm())
-					pvc.Annotations[planbase.AnnUUID] = vm.UUID
+					pvc.Annotations[planbase.AnnUUID] = uuid
 					pvc.Annotations[planbase.AnnThumbprint] = thumbprint
 					pvc.Annotations[planbase.AnnVddkInitImageURL] = settings.GetVDDKImage(r.Source.Provider.Spec.Settings)
 					pvc.Annotations[planbase.AnnPodPhase] = "Succeeded"

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -47,6 +47,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/utils/ptr"
 	cnv "kubevirt.io/api/core/v1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -490,6 +491,43 @@ func (r *Builder) buildDatastoreMap() (map[string]*api.StoragePair, error) {
 	return dsMap, nil
 }
 
+// Check destination CDI version to see if we can use instance UUIDs instead of
+// BIOS UUIDs, which can be duplicated.
+func (r *Builder) canUseInstanceUUID() bool {
+	cdiList := &cdi.CDIList{}
+	err := r.Destination.List(context.TODO(), cdiList)
+	if err != nil {
+		r.Log.Error(err, "Failed to get destination CDI version, assuming use of BIOS UUIDs")
+		return false
+	}
+	if len(cdiList.Items) < 1 {
+		r.Log.Info("No CDI installations found on destination")
+		return false
+	}
+
+	cdiCDI := cdiList.Items[0]
+	cdiVersion, err := version.ParseSemantic(cdiCDI.Status.ObservedVersion)
+	if err != nil {
+		r.Log.Error(err, "Failed to parse destination CDI version, assuming use of BIOS UUIDs")
+		return false
+	}
+
+	// Minimum CNV versions supporting instance UUIDs: 4.22.1, 4.21.9, 4.20.16
+	// This can be removed when these versions fall off the support list.
+	if cdiVersion.AtLeast(version.MustParse("v4.22.0")) &&
+		cdiVersion.LessThan(version.MustParse("v4.22.1")) {
+		return false
+	} else if cdiVersion.AtLeast(version.MustParse("v4.21.0")) &&
+		cdiVersion.LessThan(version.MustParse("v4.21.9")) {
+		return false
+	} else if cdiVersion.AtLeast(version.MustParse("v4.0.0")) &&
+		cdiVersion.LessThan(version.MustParse("v4.20.16")) {
+		return false // Cover all real OpenShift versions below 4.20.16, but try not to touch upstream CDI versions (1.65 etc.)
+	}
+
+	return true
+}
+
 // Create DataVolume specs for the VM.
 func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) (dvs []cdi.DataVolume, err error) {
 	vm := &model.VM{}
@@ -508,6 +546,8 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 	if err != nil {
 		return
 	}
+
+	canUseInstanceUUID := r.canUseInstanceUUID()
 
 	// Build datastore map for more efficient lookups
 	dsMap, err := r.buildDatastoreMap()
@@ -575,9 +615,9 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 			}
 		} else {
 			vddkImage := settings.GetVDDKImage(r.Source.Provider.Spec.Settings)
-			uuid := vm.InstanceUUID
-			if uuid == "" {
-				uuid = vm.UUID
+			uuid := vm.UUID
+			if canUseInstanceUUID && vm.InstanceUUID != "" {
+				uuid = vm.InstanceUUID
 			}
 
 			// Let CDI do the copying
@@ -1341,9 +1381,9 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 		err = liberr.Wrap(err, "vm", vmRef.String())
 		return
 	}
-	uuid := vm.InstanceUUID
-	if uuid == "" {
-		uuid = vm.UUID
+	uuid := vm.UUID
+	if r.canUseInstanceUUID() && vm.InstanceUUID != "" {
+		uuid = vm.InstanceUUID
 	}
 
 	// Get a list of existing PVCs to avoid creating duplicates

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -6,6 +6,7 @@ import (
 	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
@@ -1041,6 +1042,87 @@ var _ = Describe("vSphere builder", func() {
 				{Key: 2000, Bus: vsphere.SCSI, ControllerKey: 1001, UnitNumber: 0},
 			},
 		),
+	)
+
+	DescribeTable("should set instance UUID if available", func(instanceUUID, biosUUID, expectedUUID string) {
+		builder := createBuilder(
+			&core.Secret{
+				ObjectMeta: meta.ObjectMeta{Name: "storage-test-secret", Namespace: "test"},
+				Data: map[string][]byte{
+					"storagekey": []byte("storageval"),
+				},
+			},
+			&core.Secret{
+				ObjectMeta: meta.ObjectMeta{Name: "migration-test-secret", Namespace: "test"},
+				Data: map[string][]byte{
+					"providerkey": []byte("providerval"),
+				},
+			},
+			&core.Secret{
+				ObjectMeta: meta.ObjectMeta{Name: "offload-ssh-keys-test-vsphere-provider-private", Namespace: "test"},
+				Data: map[string][]byte{
+					"private-key": []byte("fake-private-key"),
+				},
+			},
+			&core.Secret{
+				ObjectMeta: meta.ObjectMeta{Name: "offload-ssh-keys-test-vsphere-provider-public", Namespace: "test"},
+				Data: map[string][]byte{
+					"public-key": []byte("fake-public-key"),
+				},
+			},
+			&core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{Name: "test-pvc", Namespace: "test"},
+			},
+		)
+		vm := model.VM{
+			InstanceUUID: instanceUUID,
+			UUID:         biosUUID,
+			VM1: model.VM1{
+				VM0: model.VM0{ID: "vm-2", Name: "vm"},
+				Disks: []vsphere.Disk{
+					{
+						Datastore: vsphere.Ref{ID: "ds-2"},
+						File:      "[datastore2] vm-2/vm-2.vmdk",
+						Bus:       vsphere.SCSI, Capacity: 1 << 20, Key: 2000,
+					},
+				},
+			},
+		}
+		builder.Source.Inventory = &mockInventory{ds: model.Datastore{Resource: model.Resource{ID: "ds-2"}}, vm: vm}
+		builder.Map.Storage = &v1beta1.StorageMap{
+			Spec: v1beta1.StorageMapSpec{
+				Map: []v1beta1.StoragePair{{
+					Source: ref.Ref{ID: "ds-2"},
+					Destination: v1beta1.DestinationStorage{
+						StorageClass: "test-sc",
+						AccessMode:   core.ReadWriteOnce,
+						VolumeMode:   core.PersistentVolumeFilesystem,
+					},
+					OffloadPlugin: &v1beta1.OffloadPlugin{
+						VSphereXcopyPluginConfig: &v1beta1.VSphereXcopyPluginConfig{
+							StorageVendorProduct: "test-vendor",
+							SecretRef:            "migration-test-secret",
+						},
+					},
+				}},
+			},
+		}
+		builder.Plan.Spec.Type = v1beta1.MigrationWarm
+		builder.Plan.Status.Migration.VMs = []*plan.VMStatus{
+			{
+				VM: plan.VM{
+					Ref: ref.Ref{ID: vm.ID, Name: vm.Name},
+				},
+				Warm: &plan.Warm{},
+			},
+		}
+		pvcs, err := builder.PopulatorVolumes(ref.Ref{ID: vm.ID}, map[string]string{}, "migration-test-secret")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvcs).To(HaveLen(1))
+		Expect(pvcs[0].Annotations[planbase.AnnUUID]).To(Equal(expectedUUID))
+	},
+		Entry("should set instance UUID correctly", "12345", "", "12345"),
+		Entry("should set BIOS UUID if instance UUID is missing", "", "54321", "54321"),
 	)
 })
 

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -22,6 +22,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	cnv "kubevirt.io/api/core/v1"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -1074,6 +1075,15 @@ var _ = Describe("vSphere builder", func() {
 				ObjectMeta: meta.ObjectMeta{Name: "test-pvc", Namespace: "test"},
 			},
 		)
+		cdiCDI := &cdi.CDI{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "test-cdi",
+			},
+		}
+		cdiCDI.Status.ObservedVersion = "4.22.1"
+		_ = cdi.AddToScheme(builder.Destination.Scheme())
+		err := builder.Destination.Create(context.TODO(), cdiCDI)
+		Expect(err).ToNot(HaveOccurred())
 		vm := model.VM{
 			InstanceUUID: instanceUUID,
 			UUID:         biosUUID,
@@ -1500,6 +1510,35 @@ var _ = Describe("mapDisks SCSI reservation", func() {
 	})
 })
 
+var _ = DescribeTable("instance UUID check", func(cdiVersion string, expected bool) {
+	builder := createBuilder()
+	cdiCDI := &cdi.CDI{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "test-cdi",
+		},
+	}
+	cdiCDI.Status.ObservedVersion = cdiVersion
+	_ = cdi.AddToScheme(builder.Destination.Scheme())
+	err := builder.Destination.Create(context.TODO(), cdiCDI)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(builder.canUseInstanceUUID()).To(Equal(expected))
+},
+	Entry("should use instance UUIDs on 4.22.1", "4.22.1", true),
+	Entry("should use instance UUIDs on 4.22.2", "4.22.2", true),
+	Entry("should use instance UUIDs on 4.22.3", "4.22.3", true),
+	Entry("should use instance UUIDs on 4.21.9", "4.21.9", true),
+	Entry("should use instance UUIDs on 4.21.200", "4.21.200", true),
+	Entry("should use instance UUIDs on 4.20.16", "4.20.16", true),
+	Entry("should use instance UUIDs on 4.20.17", "4.20.17", true),
+	Entry("should use instance UUIDs on 4.23.0", "4.23.0", true),
+	Entry("should use instance UUIDs on upstream 1.65.0", "1.65.0", true),
+	Entry("should not use instance UUIDs on 4.22.0", "4.22.0", false),
+	Entry("should not use instance UUIDs on 4.21.2", "4.21.2", false),
+	Entry("should not use instance UUIDs on 4.20.0", "4.20.0", false),
+	Entry("should not use instance UUIDs on 4.19.0", "4.19.0", false),
+	Entry("should not use instance UUIDs on 4.18.5", "4.18.5", false),
+)
+
 //nolint:errcheck
 func createBuilder(objs ...runtime.Object) *Builder {
 	scheme := runtime.NewScheme()
@@ -1515,6 +1554,12 @@ func createBuilder(objs ...runtime.Object) *Builder {
 		Context: &plancontext.Context{
 			Destination: plancontext.Destination{
 				Client: client,
+				Provider: &v1beta1.Provider{
+					ObjectMeta: meta.ObjectMeta{Name: "test-openshift", Namespace: "test"},
+					Spec: v1beta1.ProviderSpec{
+						Type: (*v1beta1.ProviderType)(ptr.To(v1beta1.OpenShift)),
+					},
+				},
 			},
 			Source: plancontext.Source{
 				Provider: &v1beta1.Provider{


### PR DESCRIPTION
Issue: BIOS UUIDs can be duplicated in VMware, so migrations might power off and transfer the wrong VM. This pull request is specifically for warm migration, #6088 already addressed cold migration. 

Fix: use instance UUIDs as in #6088. This will require a new release of CDI with this change: https://github.com/kubevirt/containerized-data-importer/pull/4127. ~Leaving as draft until this is available.~ Current stable CNV is 4.22.2, this should be available now. 

Reference: [MTV-5263](https://redhat.atlassian.net/browse/MTV-5263)

Resolves: MTV-5263

[MTV-5263]: https://redhat.atlassian.net/browse/MTV-5263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ