### PR TITLE
MTV-5237 | Validate image with pattern

### DIFF
--- a/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/api/deployment-forklift-api.yml.j2
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: forklift-api
       containers:
         - name: {{ api_container_name }}
-          image: {{ api_image_fqin }}
+          image: "{{ api_image_fqin or lookup('env', 'API_IMAGE') or lookup('env', 'RELATED_IMAGE_API') }}"
           imagePullPolicy: {{ image_pull_policy }}
           ports:
           - name: api

--- a/operator/roles/forkliftcontroller/templates/cli-download/deployment-cli-download.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/cli-download/deployment-cli-download.yml.j2
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: "{{ cli_download_container_name }}"
-          image: "{{ cli_download_image_fqin }}"
+          image: "{{ cli_download_image_fqin or lookup('env', 'CLI_DOWNLOAD_IMAGE') or lookup('env', 'RELATED_IMAGE_CLI_DOWNLOAD') }}"
           ports:
             - containerPort: 8443
               protocol: TCP

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -47,13 +47,13 @@ spec:
         - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
           value: "v1"
         - name: VIRT_V2V_IMAGE
-          value: {{ virt_v2v_image_fqin }}
+          value: "{{ virt_v2v_image_fqin or lookup('env', 'VIRT_V2V_IMAGE') or lookup('env', 'RELATED_IMAGE_VIRT_V2V') }}"
         - name: VIRT_V2V_IMAGE_XFS
-          value: {{ virt_v2v_image_xfs_fqin }}
+          value: "{{ virt_v2v_image_xfs_fqin or lookup('env', 'VIRT_V2V_IMAGE_XFS') or lookup('env', 'RELATED_IMAGE_VIRT_V2V_XFS') }}"
         - name: DEEP_INSPECTION_IMAGE
-          value: {{ deep_inspection_image_fqin }}
+          value: "{{ deep_inspection_image_fqin or lookup('env', 'DEEP_INSPECTION_IMAGE') or lookup('env', 'RELATED_IMAGE_DEEP_INSPECTION') }}"
         - name: DEEP_INSPECTION_IMAGE_XFS
-          value: {{ deep_inspection_image_xfs_fqin }}
+          value: "{{ deep_inspection_image_xfs_fqin or lookup('env', 'DEEP_INSPECTION_IMAGE_XFS') or lookup('env', 'RELATED_IMAGE_DEEP_INSPECTION_XFS') }}"
         - name: API_PORT
           value: "8443"
         - name: METRICS_PORT
@@ -275,7 +275,7 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}
-        image: {{ controller_image_fqin }}
+        image: "{{ controller_image_fqin or lookup('env', 'CONTROLLER_IMAGE') or lookup('env', 'RELATED_IMAGE_CONTROLLER') }}"
         imagePullPolicy: {{ image_pull_policy }}
         resources:
           limits:
@@ -337,9 +337,9 @@ spec:
         - name: METRICS_PORT
           value: '8082'
         - name: OVA_PROVIDER_SERVER_IMAGE
-          value: {{ ova_provider_server_fqin }}
+          value: "{{ ova_provider_server_fqin or lookup('env', 'OVA_PROVIDER_SERVER_IMAGE') or lookup('env', 'RELATED_IMAGE_OVA_PROVIDER_SERVER') }}"
         - name: HYPERV_PROVIDER_SERVER_IMAGE
-          value: {{ hyperv_provider_server_fqin }}
+          value: "{{ hyperv_provider_server_fqin or lookup('env', 'HYPERV_PROVIDER_SERVER_IMAGE') or lookup('env', 'RELATED_IMAGE_HYPERV_PROVIDER_SERVER') }}"
 {% if feature_ova_appliance_management|bool %}
         - name: FEATURE_OVF_APPLIANCE_MANAGEMENT
           value: "true"
@@ -378,7 +378,7 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}
-        image: {{ controller_image_fqin }}
+        image: "{{ controller_image_fqin or lookup('env', 'CONTROLLER_IMAGE') or lookup('env', 'RELATED_IMAGE_CONTROLLER') }}"
         imagePullPolicy: {{ image_pull_policy }}
         ports:
         - name: api

--- a/operator/roles/forkliftcontroller/templates/mcp-server/deployment-mcp-server.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/mcp-server/deployment-mcp-server.yml.j2
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: "{{ mcp_server_container_name }}"
-          image: "{{ cli_download_image_fqin }}"
+          image: "{{ cli_download_image_fqin or lookup('env', 'CLI_DOWNLOAD_IMAGE') or lookup('env', 'RELATED_IMAGE_CLI_DOWNLOAD') }}"
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/operator/roles/forkliftcontroller/templates/ova-proxy/deployment.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ova-proxy/deployment.yml.j2
@@ -34,7 +34,7 @@ spec:
           value: "/var/run/secrets/{{ ova_proxy_tls_secret_name }}/tls.crt"
         - name: TLS_KEY
           value: /var/run/secrets/{{ ova_proxy_tls_secret_name }}/tls.key
-        image: {{ ova_proxy_fqin }}
+        image: "{{ ova_proxy_fqin or lookup('env', 'OVA_PROXY_IMAGE') or lookup('env', 'RELATED_IMAGE_OVA_PROXY') }}"
         imagePullPolicy: {{ image_pull_policy }}
         resources:
           limits:

--- a/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: forklift-populator-controller
       containers:
         - name: {{ populator_controller_container_name }}
-          image: {{ populator_controller_image_fqin }}
+          image: "{{ populator_controller_image_fqin or lookup('env', 'POPULATOR_CONTROLLER_IMAGE') or lookup('env', 'RELATED_IMAGE_POPULATOR_CONTROLLER') }}"
           imagePullPolicy: {{ image_pull_policy }}
           env:
           - name: POD_NAMESPACE
@@ -25,12 +25,12 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
           - name: OVIRT_POPULATOR_IMAGE
-            value: {{ populator_ovirt_image_fqin }}
+            value: "{{ populator_ovirt_image_fqin or lookup('env', 'OVIRT_POPULATOR_IMAGE') or lookup('env', 'RELATED_IMAGE_RHV_POPULATOR') }}"
           - name: OPENSTACK_POPULATOR_IMAGE
-            value: {{ populator_openstack_image_fqin }}
+            value: "{{ populator_openstack_image_fqin or lookup('env', 'OPENSTACK_POPULATOR_IMAGE') or lookup('env', 'RELATED_IMAGE_OPENSTACK_POPULATOR') }}"
 {% if feature_copy_offload|bool %}
           - name: VSPHERE_COPY_OFFLOAD_POPULATOR_IMAGE
-            value: {{ populator_vsphere_copy_offload_image_fqin }}
+            value: "{{ populator_vsphere_copy_offload_image_fqin or lookup('env', 'VSPHERE_COPY_OFFLOAD_POPULATOR_IMAGE') or lookup('env', 'RELATED_IMAGE_VSPHERE_COPY_OFFLOAD_POPULATOR') }}"
 {% if controller_host_lease_namespace is defined %}
           - name: HOST_LEASE_NAMESPACE
             value: "{{ controller_host_lease_namespace }}"

--- a/operator/roles/forkliftcontroller/templates/ui-plugin/deployment-ui-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/deployment-ui-plugin.yml.j2
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: "{{ ui_plugin_container_name }}"
-          image: "{{ ui_plugin_image_fqin }}"
+          image: "{{ ui_plugin_image_fqin or lookup('env', 'UI_PLUGIN_IMAGE') or lookup('env', 'RELATED_IMAGE_UI_PLUGIN') }}"
           ports:
             - containerPort: 9443
               protocol: TCP

--- a/operator/roles/forkliftcontroller/templates/validation/deployment-validation.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/validation/deployment-validation.yml.j2
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: {{ validation_container_name }}
-          image: {{ validation_image_fqin }}
+          image: "{{ validation_image_fqin or lookup('env', 'VALIDATION_IMAGE') or lookup('env', 'RELATED_IMAGE_VALIDATION') }}"
           imagePullPolicy: {{ image_pull_policy }}
           ports:
             - name: opa


### PR DESCRIPTION
Issue: forklift-controller currently call panic() when an invalid
setting is set.

Fix: If user defined value is empty string, use the default.

Resolves: MTV-5237

Signed-off-by: Stefan Olenocin <solenoci@redhat.com>