### PR TITLE
MTV-5323 | Preserve advanced Windows network settings during migration

### DIFF
--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -3,10 +3,12 @@ package main
 import (
 	_ "embed"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
 	"github.com/kubev2v/forklift/pkg/virt-v2v/conversion"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/customize/advancednet"
 	"github.com/kubev2v/forklift/pkg/virt-v2v/server"
 	utils "github.com/kubev2v/forklift/pkg/virt-v2v/utils"
 )
@@ -84,6 +86,26 @@ func main() {
 		if err != nil {
 			fmt.Println("Failed to get inspection file", err)
 			os.Exit(1)
+		}
+
+		// Collect advanced network settings from the Windows boot disk.
+		// The SYSTEM hive is always on Disks[0] (the boot disk).
+		if inspection.OS.IsWindows() && len(convert.Disks) > 0 {
+			settings, advErr := advancednet.ReadAdvancedNetworkSettings(
+				convert.Disks[0].Link, env.Workdir,
+			)
+			if advErr != nil {
+				slog.Error("failed to read advanced network settings",
+					"disk", convert.Disks[0].Link,
+					"workdir", env.Workdir,
+					"error", advErr)
+			} else if settings != nil && settings.HasNonDefaultSettings() {
+				if writeErr := advancednet.WriteSettingsFile(settings, env.Workdir); writeErr != nil {
+					slog.Error("failed to write advanced network settings",
+						"workdir", env.Workdir,
+						"error", writeErr)
+				}
+			}
 		}
 
 		// virt-customize

--- a/pkg/virt-v2v/customize/advancednet/reader.go
+++ b/pkg/virt-v2v/customize/advancednet/reader.go
@@ -1,0 +1,430 @@
+package advancednet
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	systemHivePath = "/Windows/System32/config/SYSTEM"
+	localHiveFile  = "SYSTEM.hive"
+)
+
+// networkClassGUID is the well-known GUID for the "Network Adapter" device class.
+const networkClassGUID = "{4D36E972-E325-11CE-BFC1-08002BE10318}"
+
+// ReadAdvancedNetworkSettings extracts and parses the SYSTEM hive from a
+// converted disk, reading MAC addresses directly from the registry.
+func ReadAdvancedNetworkSettings(diskPath, workdir string) (*AdvancedNetSettings, error) {
+	hivePath := filepath.Join(workdir, localHiveFile)
+
+	if err := extractHive(diskPath, hivePath); err != nil {
+		return nil, fmt.Errorf("extract SYSTEM hive: %w", err)
+	}
+	defer func() { _ = os.Remove(hivePath) }()
+
+	data, err := os.ReadFile(hivePath)
+	if err != nil {
+		return nil, fmt.Errorf("read SYSTEM hive: %w", err)
+	}
+
+	return ParseAdvancedNetworkSettings(data)
+}
+
+// extractHive pulls the SYSTEM hive from a raw disk image via virt-cat.
+func extractHive(diskPath, outPath string) error {
+	cmd := exec.Command("virt-cat",
+		"--format=raw",
+		"-a", diskPath,
+		systemHivePath,
+	)
+	out, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	cmd.Stdout = out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("virt-cat failed: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close hive file: %w", err)
+	}
+	return nil
+}
+
+// ParseAdvancedNetworkSettings parses a raw SYSTEM hive and returns
+// advanced network settings. MAC addresses are read directly from the
+// registry (NetworkSetup2 or NetworkAddress) without needing provider input.
+func ParseAdvancedNetworkSettings(hiveData []byte) (result *AdvancedNetSettings, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = nil
+			retErr = fmt.Errorf("regf: corrupt hive data: %v", r)
+		}
+	}()
+
+	hive, err := ParseHive(hiveData)
+	if err != nil {
+		return nil, err
+	}
+
+	controlSet, err := hive.ResolveCurrentControlSet()
+	if err != nil {
+		return nil, err
+	}
+
+	guidToMAC := buildGUIDToMAC(hive, controlSet)
+
+	settings := &AdvancedNetSettings{}
+
+	if err := readInterfaceSettings(hive, controlSet, guidToMAC, settings); err != nil {
+		return nil, err
+	}
+
+	if err := readLanmanServer(hive, controlSet, settings); err != nil {
+		return nil, err
+	}
+
+	if err := readFilePrinterSharing(hive, controlSet, guidToMAC, settings); err != nil {
+		return nil, err
+	}
+
+	return settings, nil
+}
+
+// buildGUIDToMAC maps adapter GUIDs to MACs by reading them directly from
+// the registry. It tries two sources in order:
+//  1. NetworkSetup2\Interfaces\{GUID}\Kernel\CurrentAddress (REG_BINARY, 6 bytes)
+//  2. Control\Class\{4D36E972-...}\XXXX\NetworkAddress (REG_SZ, user-set override)
+func buildGUIDToMAC(hive *Hive, controlSet string) map[string]string {
+	result := make(map[string]string)
+	readMACsFromNetworkSetup2(hive, controlSet, result)
+	readMACsFromNICClass(hive, controlSet, result)
+	return result
+}
+
+// readMACsFromNetworkSetup2 populates guidToMAC from the NetworkSetup2
+// Kernel\CurrentAddress or PermanentAddress binary values.
+func readMACsFromNetworkSetup2(hive *Hive, controlSet string, guidToMAC map[string]string) {
+	ns2Path := controlSet + "\\Control\\NetworkSetup2\\Interfaces"
+	ns2Key, err := hive.OpenKey(ns2Path)
+	if err != nil || ns2Key == nil {
+		return
+	}
+	guidKeys, err := hive.EnumerateSubkeys(ns2Key)
+	if err != nil {
+		slog.Warn("Failed to enumerate NetworkSetup2 subkeys", "error", err)
+		return
+	}
+	for _, gk := range guidKeys {
+		guid := gk.name
+		if !strings.HasPrefix(guid, "{") {
+			continue
+		}
+		mac := readMACFromKernelKey(hive, ns2Path+"\\"+guid+"\\Kernel", guid)
+		if mac != "" {
+			guidToMAC[strings.ToUpper(guid)] = mac
+		}
+	}
+}
+
+// readMACFromKernelKey reads a 6-byte MAC from CurrentAddress or PermanentAddress.
+func readMACFromKernelKey(hive *Hive, kernelPath, guid string) string {
+	kernelKey, err := hive.OpenKey(kernelPath)
+	if err != nil {
+		slog.Warn("Failed to open Kernel subkey", "guid", guid, "error", err)
+		return ""
+	}
+	if kernelKey == nil {
+		return ""
+	}
+	for _, valueName := range []string{"CurrentAddress", "PermanentAddress"} {
+		macBytes, found, err := hive.ReadBinary(kernelKey, valueName)
+		if err != nil {
+			slog.Warn("Failed to read "+valueName, "guid", guid, "error", err)
+		}
+		if found && len(macBytes) == 6 {
+			return fmt.Sprintf("%02X:%02X:%02X:%02X:%02X:%02X",
+				macBytes[0], macBytes[1], macBytes[2],
+				macBytes[3], macBytes[4], macBytes[5])
+		}
+	}
+	return ""
+}
+
+// readMACsFromNICClass populates guidToMAC from the NIC device class
+// NetworkAddress or OriginalNetworkAddress string values, skipping GUIDs
+// already resolved by NetworkSetup2.
+func readMACsFromNICClass(hive *Hive, controlSet string, guidToMAC map[string]string) {
+	classPath := controlSet + "\\Control\\Class\\" + networkClassGUID
+	classKey, err := hive.OpenKey(classPath)
+	if err != nil || classKey == nil {
+		return
+	}
+	subkeys, err := hive.EnumerateSubkeys(classKey)
+	if err != nil {
+		return
+	}
+	for _, sk := range subkeys {
+		instanceID, found, err := hive.ReadSZ(sk, "NetCfgInstanceId")
+		if err != nil || !found || instanceID == "" {
+			continue
+		}
+		guid := strings.ToUpper(instanceID)
+		if _, exists := guidToMAC[guid]; exists {
+			continue
+		}
+		mac := readMACFromClassEntry(hive, sk, guid)
+		if mac != "" {
+			guidToMAC[guid] = mac
+		}
+	}
+}
+
+// readMACFromClassEntry reads a MAC string from NetworkAddress or OriginalNetworkAddress.
+func readMACFromClassEntry(hive *Hive, sk *nkCell, guid string) string {
+	for _, valueName := range []string{"NetworkAddress", "OriginalNetworkAddress"} {
+		mac, found, err := hive.ReadSZ(sk, valueName)
+		if err != nil {
+			slog.Warn("Failed to read "+valueName, "guid", guid, "error", err)
+		}
+		if found && mac != "" {
+			return normalizeMACAddress(mac)
+		}
+	}
+	return ""
+}
+
+// normalizeMACAddress converts any MAC format to "AA:BB:CC:DD:EE:FF".
+func normalizeMACAddress(mac string) string {
+	mac = strings.ToUpper(strings.ReplaceAll(mac, "-", ""))
+	mac = strings.ReplaceAll(mac, ":", "")
+	mac = strings.ReplaceAll(mac, ".", "")
+	if len(mac) != 12 {
+		return mac
+	}
+	return fmt.Sprintf("%s:%s:%s:%s:%s:%s",
+		mac[0:2], mac[2:4], mac[4:6], mac[6:8], mac[8:10], mac[10:12])
+}
+
+// readInterfaceSettings reads per-adapter InterfaceMetric, RegistrationEnabled,
+// and NetbiosOptions from Tcpip\Parameters\Interfaces.
+func readInterfaceSettings(hive *Hive, controlSet string, guidToMAC map[string]string, settings *AdvancedNetSettings) error {
+	tcpipInterfaces, err := hive.OpenKey(
+		controlSet + "\\Services\\Tcpip\\Parameters\\Interfaces",
+	)
+	if err != nil {
+		return fmt.Errorf("open Tcpip\\Parameters\\Interfaces: %w", err)
+	}
+	if tcpipInterfaces == nil {
+		return nil
+	}
+
+	guidKeys, err := hive.EnumerateSubkeys(tcpipInterfaces)
+	if err != nil {
+		return fmt.Errorf("enumerate interface GUIDs: %w", err)
+	}
+
+	for _, guidKey := range guidKeys {
+		guid := guidKey.name
+		if !strings.HasPrefix(guid, "{") || !strings.HasSuffix(guid, "}") {
+			continue
+		}
+		mac, hasMac := guidToMAC[strings.ToUpper(guid)]
+		if !hasMac || mac == "" {
+			continue
+		}
+		iface, err := readSingleInterfaceSettings(hive, controlSet, guidKey, guid)
+		if err != nil {
+			return err
+		}
+		iface.MAC = mac
+		if iface.hasNonDefaultSettings() {
+			settings.Interfaces = append(settings.Interfaces, iface)
+		}
+	}
+	return nil
+}
+
+// readSingleInterfaceSettings reads metric, DNS registration, and NetBIOS
+// settings for one adapter GUID key.
+func readSingleInterfaceSettings(hive *Hive, controlSet string, guidKey *nkCell, guid string) (InterfaceSettings, error) {
+	iface := InterfaceSettings{}
+
+	metric, found, err := hive.ReadDWORD(guidKey, "InterfaceMetric")
+	if err != nil {
+		return iface, err
+	}
+	if found {
+		iface.InterfaceMetric = metric
+	} else {
+		iface.InterfaceMetricAuto = true
+	}
+
+	regEnabled, found, err := hive.ReadDWORD(guidKey, "RegistrationEnabled")
+	if err != nil {
+		return iface, err
+	}
+	if found {
+		iface.RegistrationEnabled = regEnabled
+	} else {
+		iface.RegistrationEnabled = DNSRegistrationEnabled
+	}
+
+	netbtPath := controlSet + "\\Services\\NetBT\\Parameters\\Interfaces\\Tcpip_" + guid
+	netbtKey, err := hive.OpenKey(netbtPath)
+	if err != nil {
+		return iface, err
+	}
+	if netbtKey != nil {
+		nbOpt, found, err := hive.ReadDWORD(netbtKey, "NetbiosOptions")
+		if err != nil {
+			return iface, err
+		}
+		if found {
+			iface.NetbiosOptions = nbOpt
+		}
+	}
+
+	return iface, nil
+}
+
+// hasNonDefaultSettings returns true if at least one setting deviates from
+// the Windows default.
+func (i InterfaceSettings) hasNonDefaultSettings() bool {
+	if !i.InterfaceMetricAuto && i.InterfaceMetric != 0 {
+		return true
+	}
+	if i.RegistrationEnabled != DNSRegistrationEnabled {
+		return true
+	}
+	return i.NetbiosOptions == NetbiosOptionsEnabled || i.NetbiosOptions == NetbiosOptionsDisabled
+}
+
+// readLanmanServer reads the LanmanServer service start type.
+func readLanmanServer(hive *Hive, controlSet string, settings *AdvancedNetSettings) error {
+	lanmanKey, err := hive.OpenKey(controlSet + "\\Services\\LanmanServer")
+	if err != nil {
+		return err
+	}
+	if lanmanKey == nil {
+		return nil
+	}
+	start, found, err := hive.ReadDWORD(lanmanKey, "Start")
+	if err != nil {
+		return err
+	}
+	if found {
+		settings.LanmanServerStart = start
+	}
+	return nil
+}
+
+// readFilePrinterSharing determines which adapters have File & Printer Sharing
+// disabled by comparing LanmanServer\Linkage\Bind against all interface GUIDs.
+func readFilePrinterSharing(hive *Hive, controlSet string, guidToMAC map[string]string, settings *AdvancedNetSettings) error {
+	boundGUIDs, err := readBoundGUIDs(hive, controlSet)
+	if err != nil {
+		return err
+	}
+	if boundGUIDs == nil {
+		return nil
+	}
+
+	tcpipInterfaces, err := hive.OpenKey(
+		controlSet + "\\Services\\Tcpip\\Parameters\\Interfaces",
+	)
+	if err != nil || tcpipInterfaces == nil {
+		return err
+	}
+	guidKeys, err := hive.EnumerateSubkeys(tcpipInterfaces)
+	if err != nil {
+		return err
+	}
+	for _, gk := range guidKeys {
+		guid := gk.name
+		if !strings.HasPrefix(guid, "{") {
+			continue
+		}
+		upperGUID := strings.ToUpper(guid)
+		if boundGUIDs[upperGUID] {
+			continue
+		}
+		mac, hasMac := guidToMAC[upperGUID]
+		if !hasMac || mac == "" {
+			continue
+		}
+		settings.FilePrinterSharingDisabled = append(
+			settings.FilePrinterSharingDisabled,
+			AdapterRef{GUID: guid, MAC: mac},
+		)
+	}
+	return nil
+}
+
+// readBoundGUIDs parses the LanmanServer\Linkage\Bind multi-string value and
+// returns the set of adapter GUIDs that have File & Printer Sharing bound.
+// Returns nil if the Linkage key or Bind value is absent.
+func readBoundGUIDs(hive *Hive, controlSet string) (map[string]bool, error) {
+	linkageKey, err := hive.OpenKey(controlSet + "\\Services\\LanmanServer\\Linkage")
+	if err != nil {
+		return nil, err
+	}
+	if linkageKey == nil {
+		return map[string]bool{}, nil
+	}
+	bindValues, found, err := hive.ReadMultiSZ(linkageKey, "Bind")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return map[string]bool{}, nil
+	}
+	result := make(map[string]bool)
+	for _, bind := range bindValues {
+		for _, p := range strings.Split(bind, "_") {
+			if strings.HasPrefix(p, "{") && strings.HasSuffix(p, "}") {
+				result[strings.ToUpper(p)] = true
+			}
+		}
+	}
+	return result, nil
+}
+
+// WriteSettingsFile writes the settings as JSON to workdir.
+func WriteSettingsFile(settings *AdvancedNetSettings, workdir string) error {
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal advanced net settings: %w", err)
+	}
+	outPath := filepath.Join(workdir, AdvancedNetSettingsFile)
+	if err := os.WriteFile(outPath, data, 0644); err != nil {
+		return fmt.Errorf("write advanced net settings: %w", err)
+	}
+	slog.Info("Advanced network settings written", "path", outPath)
+	return nil
+}
+
+// ReadSettingsFile loads the settings JSON from workdir; returns nil if absent.
+func ReadSettingsFile(workdir string) (*AdvancedNetSettings, error) {
+	path := filepath.Join(workdir, AdvancedNetSettingsFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil //nolint:nilnil // nil signals "no file found" to caller
+		}
+		return nil, err
+	}
+	var settings AdvancedNetSettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, fmt.Errorf("unmarshal advanced net settings: %w", err)
+	}
+	return &settings, nil
+}

--- a/pkg/virt-v2v/customize/advancednet/regf.go
+++ b/pkg/virt-v2v/customize/advancednet/regf.go
@@ -1,0 +1,587 @@
+package advancednet
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"unicode/utf16"
+)
+
+// Registry value types
+const (
+	regNone     = 0
+	regSZ       = 1
+	regExpandSZ = 2
+	regBinary   = 3
+	regDWORD    = 4
+	regMultiSZ  = 7
+	regQWORD    = 11
+)
+
+// Cell signatures
+const (
+	sigRegf = "regf"
+	sigHbin = "hbin"
+	sigNK   = 0x6B6E // "nk" little-endian
+	sigVK   = 0x6B76 // "vk" little-endian
+	sigLF   = 0x666C // "lf" little-endian
+	sigLH   = 0x686C // "lh" little-endian
+	sigLI   = 0x696C // "li" little-endian
+	sigRI   = 0x6972 // "ri" little-endian
+)
+
+// nkFlagCompressed indicates the key name is stored as ASCII (compressed).
+const nkFlagCompressed = 0x0020
+
+// Common cell layout sizes.
+const (
+	cellSizeLen = 4 // int32 cell-size prefix on every cell
+	sigLen      = 2 // uint16 signature ("nk", "vk", "lf", etc.)
+	flagsLen    = 2 // uint16 flags field
+)
+
+// NK cell body offsets (relative to body start, after sig + flags).
+const (
+	nkOffSubkeysList = 0x18
+	nkOffValuesCount = 0x20
+	nkOffValuesList  = 0x24
+	nkOffNameLen     = 0x44
+	nkOffNameData    = 0x48
+	nkMinSize        = sigLen + flagsLen + nkOffNameData // from sig to start of variable name (checked after skipping cell-size)
+)
+
+// VK cell offsets (relative to start of VK record, after cell-size prefix).
+const (
+	vkOffNameLen    = 2
+	vkOffDataSize   = 4
+	vkOffDataOffset = 8
+	vkOffDataType   = 12
+	vkOffFlags      = 16
+	vkOffNameData   = 20
+	vkMinSize       = vkOffNameData // from sig to start of variable name (checked after skipping cell-size)
+)
+
+// Subkey list header: cell-size(4) + sig(2) + count(2).
+// Checked before skipping cell-size, so includes cellSizeLen.
+const subkeyListHeaderSize = cellSizeLen + sigLen + flagsLen
+
+// Hive represents a parsed Windows NT registry hive (regf format).
+type Hive struct {
+	data     []byte
+	rootCell int32
+}
+
+// nkCell is a parsed NK (key node) record.
+type nkCell struct {
+	subkeysListOffset int32
+	valuesListOffset  int32
+	valuesCount       uint32
+	name              string
+}
+
+// vkCell is a parsed VK (value) record.
+type vkCell struct {
+	name     string
+	dataType uint32
+	dataSize uint32
+	// dataOffset stores the raw offset field. When dataSize <= 4 the data is
+	// stored inline (the high bit of dataSize is set).
+	dataOffset uint32
+}
+
+// ParseHive validates a regf header and returns a Hive handle.
+func ParseHive(data []byte) (*Hive, error) {
+	if len(data) < 4096 {
+		return nil, fmt.Errorf("regf: data too short (%d bytes)", len(data))
+	}
+	if string(data[0:4]) != sigRegf {
+		return nil, fmt.Errorf("regf: invalid signature %q", string(data[0:4]))
+	}
+	rootOffset := int32(binary.LittleEndian.Uint32(data[36:40]))
+	return &Hive{
+		data:     data,
+		rootCell: rootOffset,
+	}, nil
+}
+
+// cellOffset translates a hive-relative offset (from the root of the first
+// hbin) to an absolute byte offset in the data slice. All registry offsets
+// are relative to the start of the hbin data at file offset 0x1000.
+func cellOffset(off int32) int {
+	return int(off) + 0x1000
+}
+
+// readInt32 reads a signed 32-bit LE value.
+func (h *Hive) readInt32(off int) int32 {
+	return int32(binary.LittleEndian.Uint32(h.data[off : off+4]))
+}
+
+// readUint32 reads an unsigned 32-bit LE value.
+func (h *Hive) readUint32(off int) uint32 {
+	return binary.LittleEndian.Uint32(h.data[off : off+4])
+}
+
+// readUint16 reads an unsigned 16-bit LE value.
+func (h *Hive) readUint16(off int) uint16 {
+	return binary.LittleEndian.Uint16(h.data[off : off+2])
+}
+
+// parseNK parses an NK cell at the given hive-relative offset.
+func (h *Hive) parseNK(off int32) (*nkCell, error) {
+	abs := cellOffset(off)
+	if abs < 0 || abs+cellSizeLen > len(h.data) {
+		return nil, fmt.Errorf("regf: NK offset 0x%x out of range", off)
+	}
+	abs += cellSizeLen
+	if abs+nkMinSize > len(h.data) {
+		return nil, fmt.Errorf("regf: NK record too short at offset 0x%x", off)
+	}
+	sig := h.readUint16(abs)
+	if sig != sigNK {
+		return nil, fmt.Errorf("regf: expected NK signature, got 0x%04x at 0x%x", sig, off)
+	}
+	flags := h.readUint16(abs + sigLen)
+
+	bodyStart := abs + sigLen + flagsLen
+	subkeysListOff := h.readInt32(bodyStart + nkOffSubkeysList)
+	valuesCount := h.readUint32(bodyStart + nkOffValuesCount)
+	valuesListOff := h.readInt32(bodyStart + nkOffValuesList)
+	nameLen := h.readUint16(bodyStart + nkOffNameLen)
+
+	nameStart := bodyStart + nkOffNameData
+	if nameStart+int(nameLen) > len(h.data) {
+		return nil, fmt.Errorf("regf: NK name overflows at 0x%x", off)
+	}
+	var name string
+	if flags&nkFlagCompressed != 0 {
+		name = string(h.data[nameStart : nameStart+int(nameLen)])
+	} else {
+		name = decodeUTF16LE(h.data[nameStart : nameStart+int(nameLen)])
+	}
+
+	return &nkCell{
+		subkeysListOffset: subkeysListOff,
+		valuesListOffset:  valuesListOff,
+		valuesCount:       valuesCount,
+		name:              name,
+	}, nil
+}
+
+// parseVK parses a VK cell at the given hive-relative offset.
+func (h *Hive) parseVK(off int32) (*vkCell, error) {
+	abs := cellOffset(off)
+	if abs < 0 || abs+cellSizeLen > len(h.data) {
+		return nil, fmt.Errorf("regf: VK offset 0x%x out of range", off)
+	}
+	abs += cellSizeLen
+	if abs+vkMinSize > len(h.data) {
+		return nil, fmt.Errorf("regf: VK record too short at offset 0x%x", off)
+	}
+	sig := h.readUint16(abs)
+	if sig != sigVK {
+		return nil, fmt.Errorf("regf: expected VK signature, got 0x%04x at 0x%x", sig, off)
+	}
+	nameLen := h.readUint16(abs + vkOffNameLen)
+	dataSize := h.readUint32(abs + vkOffDataSize)
+	dataOffset := h.readUint32(abs + vkOffDataOffset)
+	dataType := h.readUint32(abs + vkOffDataType)
+	flags := h.readUint16(abs + vkOffFlags)
+
+	nameStart := abs + vkOffNameData
+	if nameStart+int(nameLen) > len(h.data) {
+		return nil, fmt.Errorf("regf: VK name overflows at 0x%x", off)
+	}
+	var name string
+	if nameLen == 0 {
+		name = "(Default)"
+	} else if flags&0x0001 != 0 {
+		// Compressed (ASCII) name
+		name = string(h.data[nameStart : nameStart+int(nameLen)])
+	} else {
+		name = decodeUTF16LE(h.data[nameStart : nameStart+int(nameLen)])
+	}
+
+	return &vkCell{
+		name:       name,
+		dataType:   dataType,
+		dataSize:   dataSize,
+		dataOffset: dataOffset,
+	}, nil
+}
+
+// FindSubkey performs a case-insensitive lookup for a direct subkey of the
+// given NK cell. Returns nil if not found.
+func (h *Hive) FindSubkey(parent *nkCell, name string) (*nkCell, error) {
+	if parent.subkeysListOffset == -1 {
+		return nil, nil //nolint:nilnil // nil signals "not found"
+	}
+	return h.findInSubkeyList(parent.subkeysListOffset, name)
+}
+
+// maxSubkeyListDepth caps recursion through ri (index-of-index) structures to
+// guard against stack overflow on malformed hives. Real-world hives use at most
+// one ri level.
+const maxSubkeyListDepth = 10
+
+// findInSubkeyList walks lf/lh/li/ri index structures to locate a named subkey.
+func (h *Hive) findInSubkeyList(listOff int32, name string) (*nkCell, error) {
+	return h.findInSubkeyListDepth(listOff, name, 0)
+}
+
+func (h *Hive) findInSubkeyListDepth(listOff int32, name string, depth int) (*nkCell, error) {
+	if depth > maxSubkeyListDepth {
+		return nil, fmt.Errorf("regf: subkey list recursion exceeded %d levels", maxSubkeyListDepth)
+	}
+	abs, sig, count, err := h.readSubkeyListHeader(listOff)
+	if err != nil {
+		return nil, err
+	}
+
+	switch sig {
+	case sigLF, sigLH:
+		return h.findNKInList(abs, count, 8, name, listOff)
+	case sigLI:
+		return h.findNKInList(abs, count, 4, name, listOff)
+	case sigRI:
+		return h.findNKInRI(abs, count, name, depth, listOff)
+	default:
+		return nil, fmt.Errorf("regf: unknown subkey list signature 0x%04x at 0x%x", sig, listOff)
+	}
+}
+
+// readSubkeyListHeader validates and reads the header of a subkey list cell.
+// Returns the absolute offset past cell-size, signature, and element count.
+func (h *Hive) readSubkeyListHeader(listOff int32) (abs int, sig, count uint16, err error) {
+	abs = cellOffset(listOff)
+	if abs < 0 || abs+subkeyListHeaderSize > len(h.data) {
+		return 0, 0, 0, fmt.Errorf("regf: subkey list offset 0x%x out of range", listOff)
+	}
+	abs += cellSizeLen
+	sig = h.readUint16(abs)
+	count = h.readUint16(abs + sigLen)
+	return abs, sig, count, nil
+}
+
+// findNKInList scans an LF/LH/LI element array for a named subkey.
+// stride is 8 for LF/LH (offset + hash) or 4 for LI (offset only).
+func (h *Hive) findNKInList(abs int, count uint16, stride int, name string, listOff int32) (*nkCell, error) {
+	required := 4 + int(count)*stride
+	if abs+required > len(h.data) {
+		return nil, fmt.Errorf("regf: subkey list overflows at 0x%x (count=%d, stride=%d)", listOff, count, stride)
+	}
+	for i := 0; i < int(count); i++ {
+		nkOff := h.readInt32(abs + 4 + i*stride)
+		nk, err := h.parseNK(nkOff)
+		if err != nil {
+			return nil, err
+		}
+		if strings.EqualFold(nk.name, name) {
+			return nk, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // nil signals "not found"
+}
+
+// findNKInRI recurses through an RI (index-of-index) structure.
+func (h *Hive) findNKInRI(abs int, count uint16, name string, depth int, listOff int32) (*nkCell, error) {
+	required := 4 + int(count)*4
+	if abs+required > len(h.data) {
+		return nil, fmt.Errorf("regf: subkey list overflows at 0x%x (RI count=%d)", listOff, count)
+	}
+	for i := 0; i < int(count); i++ {
+		childListOff := h.readInt32(abs + 4 + i*4)
+		nk, err := h.findInSubkeyListDepth(childListOff, name, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		if nk != nil {
+			return nk, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // nil signals "not found"
+}
+
+// EnumerateSubkeys returns all direct child NK cells of the parent.
+func (h *Hive) EnumerateSubkeys(parent *nkCell) ([]*nkCell, error) {
+	if parent.subkeysListOffset == -1 {
+		return nil, nil
+	}
+	return h.collectSubkeys(parent.subkeysListOffset)
+}
+
+func (h *Hive) collectSubkeys(listOff int32) ([]*nkCell, error) {
+	return h.collectSubkeysDepth(listOff, 0)
+}
+
+func (h *Hive) collectSubkeysDepth(listOff int32, depth int) ([]*nkCell, error) {
+	if depth > maxSubkeyListDepth {
+		return nil, fmt.Errorf("regf: subkey list recursion exceeded %d levels", maxSubkeyListDepth)
+	}
+	abs, sig, count, err := h.readSubkeyListHeader(listOff)
+	if err != nil {
+		return nil, err
+	}
+
+	switch sig {
+	case sigLF, sigLH:
+		return h.collectNKsFromList(abs, count, 8, listOff)
+	case sigLI:
+		return h.collectNKsFromList(abs, count, 4, listOff)
+	case sigRI:
+		return h.collectNKsFromRI(abs, count, depth, listOff)
+	default:
+		return nil, fmt.Errorf("regf: unknown subkey list signature 0x%04x", sig)
+	}
+}
+
+// collectNKsFromList parses all NK cells from an LF/LH/LI element array.
+func (h *Hive) collectNKsFromList(abs int, count uint16, stride int, listOff int32) ([]*nkCell, error) {
+	required := 4 + int(count)*stride
+	if abs+required > len(h.data) {
+		return nil, fmt.Errorf("regf: subkey list overflows at 0x%x (count=%d, stride=%d)", listOff, count, stride)
+	}
+	result := make([]*nkCell, 0, count)
+	for i := 0; i < int(count); i++ {
+		nkOff := h.readInt32(abs + 4 + i*stride)
+		nk, err := h.parseNK(nkOff)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, nk)
+	}
+	return result, nil
+}
+
+// collectNKsFromRI recurses through an RI structure collecting all NK cells.
+func (h *Hive) collectNKsFromRI(abs int, count uint16, depth int, listOff int32) ([]*nkCell, error) {
+	required := 4 + int(count)*4
+	if abs+required > len(h.data) {
+		return nil, fmt.Errorf("regf: subkey list overflows at 0x%x (RI count=%d)", listOff, count)
+	}
+	var result []*nkCell
+	for i := 0; i < int(count); i++ {
+		childListOff := h.readInt32(abs + 4 + i*4)
+		children, err := h.collectSubkeysDepth(childListOff, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, children...)
+	}
+	return result, nil
+}
+
+// FindValue performs a case-insensitive lookup for a named value in the NK cell.
+func (h *Hive) FindValue(nk *nkCell, name string) (*vkCell, error) {
+	if nk.valuesCount == 0 || nk.valuesListOffset == -1 {
+		return nil, nil //nolint:nilnil // nil signals "not found"
+	}
+	abs := cellOffset(nk.valuesListOffset)
+	requiredSize := 4 + int(nk.valuesCount)*4 // cell size + array of VK offsets
+	if abs < 0 || abs+requiredSize > len(h.data) {
+		return nil, fmt.Errorf("regf: values list offset 0x%x out of range", nk.valuesListOffset)
+	}
+	abs += 4 // skip cell size
+	for i := 0; i < int(nk.valuesCount); i++ {
+		vkOff := h.readInt32(abs + i*4)
+		vk, err := h.parseVK(vkOff)
+		if err != nil {
+			return nil, err
+		}
+		if strings.EqualFold(vk.name, name) {
+			return vk, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // nil signals "not found"
+}
+
+// ReadDWORD reads a REG_DWORD value. Returns (value, true) if found, or
+// (0, false) if the value does not exist.
+func (h *Hive) ReadDWORD(nk *nkCell, name string) (uint32, bool, error) {
+	vk, err := h.FindValue(nk, name)
+	if err != nil {
+		return 0, false, err
+	}
+	if vk == nil {
+		return 0, false, nil
+	}
+	if vk.dataType != regDWORD {
+		return 0, false, fmt.Errorf("regf: value %q is type %d, expected DWORD", name, vk.dataType)
+	}
+	// Inline data when dataSize high bit is set or size <= 4
+	realSize := vk.dataSize & 0x7FFFFFFF
+	if vk.dataSize&0x80000000 != 0 || realSize <= 4 {
+		return vk.dataOffset, true, nil
+	}
+	dataAbs := cellOffset(int32(vk.dataOffset)) + 4
+	if dataAbs+4 > len(h.data) {
+		return 0, false, fmt.Errorf("regf: DWORD data offset out of range")
+	}
+	return h.readUint32(dataAbs), true, nil
+}
+
+// ReadSZ reads a REG_SZ or REG_EXPAND_SZ value, returning the string.
+func (h *Hive) ReadSZ(nk *nkCell, name string) (string, bool, error) {
+	vk, err := h.FindValue(nk, name)
+	if err != nil {
+		return "", false, err
+	}
+	if vk == nil {
+		return "", false, nil
+	}
+	if vk.dataType != regSZ && vk.dataType != regExpandSZ {
+		return "", false, fmt.Errorf("regf: value %q is type %d, expected SZ/EXPAND_SZ", name, vk.dataType)
+	}
+	realSize := vk.dataSize & 0x7FFFFFFF
+	if realSize == 0 {
+		return "", true, nil
+	}
+	// Inline data when high bit is set and size <= 4
+	if vk.dataSize&0x80000000 != 0 && realSize <= 4 {
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, vk.dataOffset)
+		return decodeUTF16LE(buf[:realSize]), true, nil
+	}
+	dataAbs := cellOffset(int32(vk.dataOffset)) + 4
+	if dataAbs+int(realSize) > len(h.data) {
+		return "", false, fmt.Errorf("regf: SZ data overflows at 0x%x", vk.dataOffset)
+	}
+	raw := h.data[dataAbs : dataAbs+int(realSize)]
+	s := decodeUTF16LE(raw)
+	s = strings.TrimRight(s, "\x00")
+	return s, true, nil
+}
+
+// ReadBinary reads a REG_BINARY value, returning the raw bytes.
+func (h *Hive) ReadBinary(nk *nkCell, name string) ([]byte, bool, error) {
+	vk, err := h.FindValue(nk, name)
+	if err != nil {
+		return nil, false, err
+	}
+	if vk == nil {
+		return nil, false, nil
+	}
+	if vk.dataType != regBinary {
+		return nil, false, fmt.Errorf("regf: value %q is type %d, expected BINARY", name, vk.dataType)
+	}
+	realSize := vk.dataSize & 0x7FFFFFFF
+	if realSize == 0 {
+		return nil, true, nil
+	}
+	// Bit 31 set means data is stored inline in the dataOffset field (REGF resident-data optimization).
+	if vk.dataSize&0x80000000 != 0 && realSize <= 4 {
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, vk.dataOffset)
+		return buf[:realSize], true, nil
+	}
+	dataAbs := cellOffset(int32(vk.dataOffset)) + 4
+	if dataAbs+int(realSize) > len(h.data) {
+		return nil, false, fmt.Errorf("regf: BINARY data overflows at 0x%x", vk.dataOffset)
+	}
+	result := make([]byte, realSize)
+	copy(result, h.data[dataAbs:dataAbs+int(realSize)])
+	return result, true, nil
+}
+
+// ReadMultiSZ reads a REG_MULTI_SZ value, returning the list of strings.
+func (h *Hive) ReadMultiSZ(nk *nkCell, name string) ([]string, bool, error) {
+	vk, err := h.FindValue(nk, name)
+	if err != nil {
+		return nil, false, err
+	}
+	if vk == nil {
+		return nil, false, nil
+	}
+	if vk.dataType != regMultiSZ {
+		return nil, false, fmt.Errorf("regf: value %q is type %d, expected MULTI_SZ", name, vk.dataType)
+	}
+	realSize := vk.dataSize & 0x7FFFFFFF
+	if realSize == 0 {
+		return nil, true, nil
+	}
+	// Bit 31 set means data is stored inline in the dataOffset field (REGF resident-data optimization).
+	var raw []byte
+	if vk.dataSize&0x80000000 != 0 && realSize <= 4 {
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, vk.dataOffset)
+		raw = buf[:realSize]
+	} else {
+		dataAbs := cellOffset(int32(vk.dataOffset)) + 4
+		if dataAbs+int(realSize) > len(h.data) {
+			return nil, false, fmt.Errorf("regf: MULTI_SZ data overflows at 0x%x", vk.dataOffset)
+		}
+		raw = h.data[dataAbs : dataAbs+int(realSize)]
+	}
+	decoded := decodeUTF16LE(raw)
+	// Split on null characters; the last entry is an empty string from the
+	// double-null terminator.
+	parts := strings.Split(decoded, "\x00")
+	var result []string
+	for _, p := range parts {
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result, true, nil
+}
+
+// RootKey returns the root NK cell of the hive.
+func (h *Hive) RootKey() (*nkCell, error) {
+	return h.parseNK(h.rootCell)
+}
+
+// OpenKey traverses a backslash-separated path from the root and returns
+// the NK cell at the end. Returns nil if any component is not found.
+func (h *Hive) OpenKey(path string) (*nkCell, error) {
+	parts := strings.Split(path, "\\")
+	root, err := h.RootKey()
+	if err != nil {
+		return nil, err
+	}
+	current := root
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		child, err := h.FindSubkey(current, part)
+		if err != nil {
+			return nil, err
+		}
+		if child == nil {
+			return nil, nil //nolint:nilnil // nil signals "key not found"
+		}
+		current = child
+	}
+	return current, nil
+}
+
+// ResolveCurrentControlSet reads SYSTEM\Select\Current to determine which
+// ControlSet is active and returns its name (e.g. "ControlSet001").
+func (h *Hive) ResolveCurrentControlSet() (string, error) {
+	selectKey, err := h.OpenKey("Select")
+	if err != nil {
+		return "", fmt.Errorf("regf: failed to open Select key: %w", err)
+	}
+	if selectKey == nil {
+		return "", fmt.Errorf("regf: Select key not found in hive")
+	}
+	current, found, err := h.ReadDWORD(selectKey, "Current")
+	if err != nil {
+		return "", fmt.Errorf("regf: failed to read Select\\Current: %w", err)
+	}
+	if !found {
+		return "", fmt.Errorf("regf: Select\\Current value not found")
+	}
+	return fmt.Sprintf("ControlSet%03d", current), nil
+}
+
+// decodeUTF16LE decodes a byte slice of UTF-16LE data to a Go string.
+func decodeUTF16LE(b []byte) string {
+	if len(b)%2 != 0 {
+		b = b[:len(b)-1]
+	}
+	u16 := make([]uint16, len(b)/2)
+	for i := range u16 {
+		u16[i] = binary.LittleEndian.Uint16(b[i*2 : i*2+2])
+	}
+	return string(utf16.Decode(u16))
+}

--- a/pkg/virt-v2v/customize/advancednet/regf_test.go
+++ b/pkg/virt-v2v/customize/advancednet/regf_test.go
@@ -1,0 +1,1163 @@
+package advancednet
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// hiveBuilder creates a minimal synthetic regf hive for testing.
+// The hive layout:
+//
+//	file offset 0x0000: regf header (4096 bytes)
+//	file offset 0x1000: hbin (variable)
+//
+// All cell offsets are relative to 0x1000 (start of first hbin).
+type hiveBuilder struct {
+	hbin []byte
+}
+
+func newHiveBuilder() *hiveBuilder {
+	return &hiveBuilder{
+		// Start with hbin header (32 bytes)
+		hbin: make([]byte, 32),
+	}
+}
+
+func (b *hiveBuilder) init() {
+	copy(b.hbin[0:4], "hbin")
+	binary.LittleEndian.PutUint32(b.hbin[4:8], 0)       // offset from start
+	binary.LittleEndian.PutUint32(b.hbin[8:12], 0x1000) // size (placeholder, updated at build)
+}
+
+// allocCell allocates space for a cell and returns the hive-relative offset.
+// The first 4 bytes of the cell are the (negative) size.
+func (b *hiveBuilder) allocCell(size int) int32 {
+	// Align to 8 bytes
+	if size%8 != 0 {
+		size += 8 - size%8
+	}
+	offset := len(b.hbin) // hive-relative offset = absolute - 0x1000
+	b.hbin = append(b.hbin, make([]byte, size)...)
+	// Write negative cell size (allocated cell)
+	negSize := -int32(size)
+	binary.LittleEndian.PutUint32(b.hbin[offset:offset+4], uint32(negSize))
+	return int32(offset)
+}
+
+// writeNK writes an NK cell. Returns the hive-relative offset.
+func (b *hiveBuilder) writeNK(name string, subkeysListOff int32, valuesListOff int32, valuesCount uint32, compressed bool) int32 {
+	nameBytes := []byte(name)
+	// NK body: sig(2) + flags(2) + timestamp(8) + access(4) + parent(4) +
+	// subkeyCount(4) + volatileSubkeys(4) + subkeysListOff(4) + volatileListOff(4) +
+	// valuesCount(4) + valuesListOff(4) + securityOff(4) + classOff(4) +
+	// maxSubkeyNameLen(4) + maxSubkeyClassLen(4) + maxValueNameLen(4) + maxValueDataLen(4) +
+	// unused(4) + nameLen(2) + classLen(2) + name(variable)
+	// Total fixed: 76 + name
+	bodySize := 4 + 76 + len(nameBytes) // cell-size(4) + body(76) + name
+	off := b.allocCell(bodySize)
+	abs := int(off) + 4 // past cell size
+
+	// Signature "nk"
+	binary.LittleEndian.PutUint16(b.hbin[abs:abs+2], sigNK)
+
+	// Flags
+	var flags uint16
+	if compressed {
+		flags |= nkFlagCompressed
+	}
+	binary.LittleEndian.PutUint16(b.hbin[abs+2:abs+4], flags)
+
+	// Body layout (from abs+4, which is past sig+flags):
+	bodyStart := abs + 4
+	// +0x00: timestamp (8 bytes) - zero
+	// +0x08: access bits (4 bytes) - zero
+	// +0x0C: parent offset (4 bytes) - zero
+	// +0x10: subkeys count (4 bytes)
+	// +0x14: volatile subkeys count (4 bytes) - zero
+	// +0x18: subkeys list offset (4 bytes)
+	// +0x1C: volatile list offset (4 bytes) - -1
+	// +0x20: values count (4 bytes)
+	// +0x24: values list offset (4 bytes)
+	// +0x28: security offset (4 bytes) - -1
+	// +0x2C: class offset (4 bytes) - -1
+	// +0x30: max subkey name len (4 bytes)
+	// +0x34: max subkey class len (4 bytes)
+	// +0x38: max value name len (4 bytes)
+	// +0x3C: max value data len (4 bytes)
+	// +0x40: unused (4 bytes)
+	// +0x44: name len (2 bytes)
+	// +0x46: class len (2 bytes)
+	// +0x48: name (variable)
+
+	// subkeys count — derived from subkeysListOff being non -1
+	if subkeysListOff != -1 {
+		binary.LittleEndian.PutUint32(b.hbin[bodyStart+0x10:bodyStart+0x14], 1) // placeholder count
+	}
+	binary.LittleEndian.PutUint32(b.hbin[bodyStart+0x14:bodyStart+0x18], 0)
+	binary.LittleEndian.PutUint32(b.hbin[bodyStart+0x18:bodyStart+0x1C], uint32(subkeysListOff))
+	binary.LittleEndian.PutUint32(b.hbin[bodyStart+0x1C:bodyStart+0x20], 0xFFFFFFFF) // volatile = -1
+	binary.LittleEndian.PutUint32(b.hbin[bodyStart+0x20:bodyStart+0x24], valuesCount)
+	binary.LittleEndian.PutUint32(b.hbin[bodyStart+0x24:bodyStart+0x28], uint32(valuesListOff))
+	binary.LittleEndian.PutUint32(b.hbin[bodyStart+0x28:bodyStart+0x2C], 0xFFFFFFFF) // security = -1
+	binary.LittleEndian.PutUint32(b.hbin[bodyStart+0x2C:bodyStart+0x30], 0xFFFFFFFF) // class = -1
+	binary.LittleEndian.PutUint16(b.hbin[bodyStart+0x44:bodyStart+0x46], uint16(len(nameBytes)))
+	binary.LittleEndian.PutUint16(b.hbin[bodyStart+0x46:bodyStart+0x48], 0) // class len
+	copy(b.hbin[bodyStart+0x48:], nameBytes)
+
+	return off
+}
+
+// writeVKDword writes a VK cell with a DWORD value (inline). Returns hive-relative offset.
+func (b *hiveBuilder) writeVKDword(name string, value uint32) int32 {
+	nameBytes := []byte(name)
+	bodySize := 4 + 20 + len(nameBytes) // cell-size + VK header + name
+	off := b.allocCell(bodySize)
+	abs := int(off) + 4
+
+	binary.LittleEndian.PutUint16(b.hbin[abs:abs+2], sigVK)
+	binary.LittleEndian.PutUint16(b.hbin[abs+2:abs+4], uint16(len(nameBytes)))
+	// dataSize with high bit set (inline)
+	binary.LittleEndian.PutUint32(b.hbin[abs+4:abs+8], 0x80000004)
+	// dataOffset = the DWORD value itself (inline)
+	binary.LittleEndian.PutUint32(b.hbin[abs+8:abs+12], value)
+	// dataType = REG_DWORD
+	binary.LittleEndian.PutUint32(b.hbin[abs+12:abs+16], regDWORD)
+	// flags: 0x0001 = compressed name
+	binary.LittleEndian.PutUint16(b.hbin[abs+16:abs+18], 0x0001)
+	copy(b.hbin[abs+20:], nameBytes)
+
+	return off
+}
+
+// writeVKMultiSZ writes a VK cell with a REG_MULTI_SZ value. Returns hive-relative offset.
+func (b *hiveBuilder) writeVKMultiSZ(name string, values []string) int32 {
+	// Build UTF-16LE data: each string null-terminated, followed by extra null
+	var u16data []byte
+	for _, s := range values {
+		for _, r := range s {
+			var buf [2]byte
+			binary.LittleEndian.PutUint16(buf[:], uint16(r))
+			u16data = append(u16data, buf[:]...)
+		}
+		u16data = append(u16data, 0, 0) // null terminator
+	}
+	u16data = append(u16data, 0, 0) // double-null terminator
+
+	// Write data cell
+	dataCellSize := 4 + len(u16data)
+	dataOff := b.allocCell(dataCellSize)
+	copy(b.hbin[int(dataOff)+4:], u16data)
+
+	// Write VK cell
+	nameBytes := []byte(name)
+	bodySize := 4 + 20 + len(nameBytes)
+	off := b.allocCell(bodySize)
+	abs := int(off) + 4
+
+	binary.LittleEndian.PutUint16(b.hbin[abs:abs+2], sigVK)
+	binary.LittleEndian.PutUint16(b.hbin[abs+2:abs+4], uint16(len(nameBytes)))
+	binary.LittleEndian.PutUint32(b.hbin[abs+4:abs+8], uint32(len(u16data)))
+	binary.LittleEndian.PutUint32(b.hbin[abs+8:abs+12], uint32(dataOff))
+	binary.LittleEndian.PutUint32(b.hbin[abs+12:abs+16], regMultiSZ)
+	binary.LittleEndian.PutUint16(b.hbin[abs+16:abs+18], 0x0001) // compressed name
+	copy(b.hbin[abs+20:], nameBytes)
+
+	return off
+}
+
+// writeVKSZ writes a VK cell with a REG_SZ value. Returns hive-relative offset.
+func (b *hiveBuilder) writeVKSZ(name, value string) int32 {
+	// Build UTF-16LE data with null terminator
+	var u16data []byte
+	for _, r := range value {
+		var buf [2]byte
+		binary.LittleEndian.PutUint16(buf[:], uint16(r))
+		u16data = append(u16data, buf[:]...)
+	}
+	u16data = append(u16data, 0, 0) // null terminator
+
+	// Write data cell
+	dataCellSize := 4 + len(u16data)
+	dataOff := b.allocCell(dataCellSize)
+	copy(b.hbin[int(dataOff)+4:], u16data)
+
+	// Write VK cell
+	nameBytes := []byte(name)
+	bodySize := 4 + 20 + len(nameBytes)
+	off := b.allocCell(bodySize)
+	abs := int(off) + 4
+
+	binary.LittleEndian.PutUint16(b.hbin[abs:abs+2], sigVK)
+	binary.LittleEndian.PutUint16(b.hbin[abs+2:abs+4], uint16(len(nameBytes)))
+	binary.LittleEndian.PutUint32(b.hbin[abs+4:abs+8], uint32(len(u16data)))
+	binary.LittleEndian.PutUint32(b.hbin[abs+8:abs+12], uint32(dataOff))
+	binary.LittleEndian.PutUint32(b.hbin[abs+12:abs+16], regSZ)
+	binary.LittleEndian.PutUint16(b.hbin[abs+16:abs+18], 0x0001) // compressed name
+	copy(b.hbin[abs+20:], nameBytes)
+
+	return off
+}
+
+// writeVKBinary writes a VK cell with a REG_BINARY value. Returns hive-relative offset.
+func (b *hiveBuilder) writeVKBinary(name string, data []byte) int32 {
+	// Write data cell
+	dataCellSize := 4 + len(data)
+	dataOff := b.allocCell(dataCellSize)
+	copy(b.hbin[int(dataOff)+4:], data)
+
+	// Write VK cell
+	nameBytes := []byte(name)
+	bodySize := 4 + 20 + len(nameBytes)
+	off := b.allocCell(bodySize)
+	abs := int(off) + 4
+
+	binary.LittleEndian.PutUint16(b.hbin[abs:abs+2], sigVK)
+	binary.LittleEndian.PutUint16(b.hbin[abs+2:abs+4], uint16(len(nameBytes)))
+	binary.LittleEndian.PutUint32(b.hbin[abs+4:abs+8], uint32(len(data)))
+	binary.LittleEndian.PutUint32(b.hbin[abs+8:abs+12], uint32(dataOff))
+	binary.LittleEndian.PutUint32(b.hbin[abs+12:abs+16], regBinary)
+	binary.LittleEndian.PutUint16(b.hbin[abs+16:abs+18], 0x0001) // compressed name
+	copy(b.hbin[abs+20:], nameBytes)
+
+	return off
+}
+
+// writeValuesList writes a values list cell containing the given VK offsets.
+func (b *hiveBuilder) writeValuesList(vkOffsets []int32) int32 {
+	size := 4 + len(vkOffsets)*4
+	off := b.allocCell(size)
+	abs := int(off) + 4
+	for i, vkOff := range vkOffsets {
+		binary.LittleEndian.PutUint32(b.hbin[abs+i*4:abs+i*4+4], uint32(vkOff))
+	}
+	return off
+}
+
+// writeLH writes an LH (hash-based) subkey index. Returns hive-relative offset.
+func (b *hiveBuilder) writeLH(nkOffsets []int32) int32 {
+	// Each element: 4 bytes NK offset + 4 bytes hash
+	size := 4 + 4 + len(nkOffsets)*8 // cell-size + sig(2)+count(2) + elements
+	off := b.allocCell(size)
+	abs := int(off) + 4
+	binary.LittleEndian.PutUint16(b.hbin[abs:abs+2], sigLH)
+	binary.LittleEndian.PutUint16(b.hbin[abs+2:abs+4], uint16(len(nkOffsets)))
+	for i, nkOff := range nkOffsets {
+		elemOff := abs + 4 + i*8
+		binary.LittleEndian.PutUint32(b.hbin[elemOff:elemOff+4], uint32(nkOff))
+		// hash = 0 (we don't check it)
+	}
+	return off
+}
+
+// build produces the complete hive byte slice (header + hbin).
+func (b *hiveBuilder) build(rootCellOff int32) []byte {
+	// Update hbin size
+	hbinSize := len(b.hbin)
+	if hbinSize%4096 != 0 {
+		hbinSize += 4096 - hbinSize%4096
+	}
+	if hbinSize < 4096 {
+		hbinSize = 4096
+	}
+	padded := make([]byte, hbinSize)
+	copy(padded, b.hbin)
+	binary.LittleEndian.PutUint32(padded[8:12], uint32(hbinSize))
+
+	header := make([]byte, 4096)
+	copy(header[0:4], "regf")
+	binary.LittleEndian.PutUint32(header[36:40], uint32(rootCellOff))
+
+	result := make([]byte, 0, len(header)+len(padded))
+	result = append(result, header...)
+	result = append(result, padded...)
+	return result
+}
+
+// buildTestHive creates a synthetic SYSTEM hive with:
+//   - Select\Current = 1 (ControlSet001)
+//   - ControlSet001\Services\Tcpip\Parameters\Interfaces\{TEST-GUID-1}
+//   - InterfaceMetric = 25
+//   - RegistrationEnabled = 0
+//   - ControlSet001\Services\NetBT\Parameters\Interfaces\Tcpip_{TEST-GUID-1}
+//   - NetbiosOptions = 2
+//   - ControlSet001\Services\LanmanServer
+//   - Start = 4  (disabled)
+//   - ControlSet001\Services\LanmanServer\Linkage
+//   - Bind = ["\Device\NetBT_Tcpip_{TEST-GUID-2}"]  (GUID-1 not bound = F&PS disabled)
+func buildTestHive() []byte {
+	b := newHiveBuilder()
+	b.init()
+
+	// === Values ===
+
+	// Select\Current = 1
+	vkSelectCurrent := b.writeVKDword("Current", 1)
+
+	// InterfaceMetric = 25
+	vkInterfaceMetric := b.writeVKDword("InterfaceMetric", 25)
+	// RegistrationEnabled = 0
+	vkRegEnabled := b.writeVKDword("RegistrationEnabled", 0)
+
+	// NetbiosOptions = 2
+	vkNetbios := b.writeVKDword("NetbiosOptions", 2)
+
+	// LanmanServer Start = 4
+	vkLanmanStart := b.writeVKDword("Start", 4)
+
+	// LanmanServer\Linkage Bind (only GUID-2 bound, GUID-1 missing = disabled)
+	vkBind := b.writeVKMultiSZ("Bind", []string{`\Device\NetBT_Tcpip_{TEST-GUID-2}`})
+
+	// === Value lists ===
+	vlSelect := b.writeValuesList([]int32{vkSelectCurrent})
+	vlInterface := b.writeValuesList([]int32{vkInterfaceMetric, vkRegEnabled})
+	vlNetbt := b.writeValuesList([]int32{vkNetbios})
+	vlLanman := b.writeValuesList([]int32{vkLanmanStart})
+	vlLinkage := b.writeValuesList([]int32{vkBind})
+
+	// === NK cells (bottom-up) ===
+
+	// Select key
+	nkSelect := b.writeNK("Select", -1, vlSelect, 1, true)
+
+	// {TEST-GUID-1} under Tcpip\Parameters\Interfaces
+	nkGUID1 := b.writeNK("{TEST-GUID-1}", -1, vlInterface, 2, true)
+
+	// {TEST-GUID-2} under Tcpip\Parameters\Interfaces (no custom values)
+	nkGUID2 := b.writeNK("{TEST-GUID-2}", -1, -1, 0, true)
+
+	// Interfaces (parent of GUID keys)
+	lhInterfaces := b.writeLH([]int32{nkGUID1, nkGUID2})
+	nkInterfaces := b.writeNK("Interfaces", lhInterfaces, -1, 0, true)
+
+	// Parameters
+	lhParameters := b.writeLH([]int32{nkInterfaces})
+	nkParameters := b.writeNK("Parameters", lhParameters, -1, 0, true)
+
+	// Tcpip
+	lhTcpip := b.writeLH([]int32{nkParameters})
+	nkTcpip := b.writeNK("Tcpip", lhTcpip, -1, 0, true)
+
+	// Tcpip_{TEST-GUID-1} under NetBT\Parameters\Interfaces
+	nkNetbtGUID1 := b.writeNK("Tcpip_{TEST-GUID-1}", -1, vlNetbt, 1, true)
+
+	// NetBT Interfaces
+	lhNetbtInterfaces := b.writeLH([]int32{nkNetbtGUID1})
+	nkNetbtInterfaces := b.writeNK("Interfaces", lhNetbtInterfaces, -1, 0, true)
+
+	// NetBT Parameters
+	lhNetbtParams := b.writeLH([]int32{nkNetbtInterfaces})
+	nkNetbtParams := b.writeNK("Parameters", lhNetbtParams, -1, 0, true)
+
+	// NetBT
+	lhNetbt := b.writeLH([]int32{nkNetbtParams})
+	nkNetbt := b.writeNK("NetBT", lhNetbt, -1, 0, true)
+
+	// Linkage under LanmanServer
+	nkLinkage := b.writeNK("Linkage", -1, vlLinkage, 1, true)
+
+	// LanmanServer
+	lhLanmanSubs := b.writeLH([]int32{nkLinkage})
+	nkLanman := b.writeNK("LanmanServer", lhLanmanSubs, vlLanman, 1, true)
+
+	// Services (parent of Tcpip, NetBT, LanmanServer)
+	lhServices := b.writeLH([]int32{nkTcpip, nkNetbt, nkLanman})
+	nkServices := b.writeNK("Services", lhServices, -1, 0, true)
+
+	// ControlSet001
+	lhCS001 := b.writeLH([]int32{nkServices})
+	nkCS001 := b.writeNK("ControlSet001", lhCS001, -1, 0, true)
+
+	// Root key (CMI-CreateHive) with children: Select, ControlSet001
+	lhRoot := b.writeLH([]int32{nkSelect, nkCS001})
+	nkRoot := b.writeNK("CMI-CreateHive{2A7FB991-7BBE-4F9D-B91E-7CB51D4737F5}", lhRoot, -1, 0, true)
+
+	return b.build(nkRoot)
+}
+
+func TestParseHive_InvalidSignature(t *testing.T) {
+	data := make([]byte, 8192)
+	copy(data[0:4], "BAAD")
+	_, err := ParseHive(data)
+	if err == nil {
+		t.Fatal("expected error for invalid signature")
+	}
+}
+
+func TestParseHive_TooShort(t *testing.T) {
+	data := make([]byte, 100)
+	copy(data[0:4], "regf")
+	_, err := ParseHive(data)
+	if err == nil {
+		t.Fatal("expected error for data too short")
+	}
+}
+
+func TestParseHive_ValidHeader(t *testing.T) {
+	data := buildTestHive()
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	root, err := hive.RootKey()
+	if err != nil {
+		t.Fatalf("RootKey: %v", err)
+	}
+	if root == nil {
+		t.Fatal("root key is nil")
+	}
+}
+
+func TestResolveCurrentControlSet(t *testing.T) {
+	data := buildTestHive()
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	cs, err := hive.ResolveCurrentControlSet()
+	if err != nil {
+		t.Fatalf("ResolveCurrentControlSet: %v", err)
+	}
+	if cs != "ControlSet001" {
+		t.Fatalf("expected ControlSet001, got %s", cs)
+	}
+}
+
+func TestOpenKey(t *testing.T) {
+	data := buildTestHive()
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		path   string
+		exists bool
+	}{
+		{"Select key", "Select", true},
+		{"ControlSet001 key", "ControlSet001", true},
+		{"Services key", "ControlSet001\\Services", true},
+		{"Tcpip Interfaces", "ControlSet001\\Services\\Tcpip\\Parameters\\Interfaces", true},
+		{"GUID-1 interface", "ControlSet001\\Services\\Tcpip\\Parameters\\Interfaces\\{TEST-GUID-1}", true},
+		{"NetBT GUID-1", "ControlSet001\\Services\\NetBT\\Parameters\\Interfaces\\Tcpip_{TEST-GUID-1}", true},
+		{"LanmanServer key", "ControlSet001\\Services\\LanmanServer", true},
+		{"LanmanServer Linkage", "ControlSet001\\Services\\LanmanServer\\Linkage", true},
+		{"NonExistent key", "NonExistent", false},
+		{"NonExistent service", "ControlSet001\\Services\\NonExistent", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nk, err := hive.OpenKey(tt.path)
+			if err != nil {
+				t.Fatalf("OpenKey(%q): %v", tt.path, err)
+			}
+			if tt.exists && nk == nil {
+				t.Errorf("OpenKey(%q): expected key to exist", tt.path)
+			}
+			if !tt.exists && nk != nil {
+				t.Errorf("OpenKey(%q): expected key to not exist", tt.path)
+			}
+		})
+	}
+}
+
+func TestReadDWORD(t *testing.T) {
+	data := buildTestHive()
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+
+	nk, err := hive.OpenKey("ControlSet001\\Services\\Tcpip\\Parameters\\Interfaces\\{TEST-GUID-1}")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v (nk=%v)", err, nk)
+	}
+
+	metric, found, err := hive.ReadDWORD(nk, "InterfaceMetric")
+	if err != nil {
+		t.Fatalf("ReadDWORD InterfaceMetric: %v", err)
+	}
+	if !found {
+		t.Fatal("InterfaceMetric not found")
+	}
+	if metric != 25 {
+		t.Fatalf("InterfaceMetric: expected 25, got %d", metric)
+	}
+
+	regEnabled, found, err := hive.ReadDWORD(nk, "RegistrationEnabled")
+	if err != nil {
+		t.Fatalf("ReadDWORD RegistrationEnabled: %v", err)
+	}
+	if !found {
+		t.Fatal("RegistrationEnabled not found")
+	}
+	if regEnabled != 0 {
+		t.Fatalf("RegistrationEnabled: expected 0, got %d", regEnabled)
+	}
+
+	_, found, err = hive.ReadDWORD(nk, "NonExistent")
+	if err != nil {
+		t.Fatalf("ReadDWORD NonExistent: %v", err)
+	}
+	if found {
+		t.Fatal("NonExistent should not be found")
+	}
+}
+
+func TestReadMultiSZ(t *testing.T) {
+	data := buildTestHive()
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+
+	nk, err := hive.OpenKey("ControlSet001\\Services\\LanmanServer\\Linkage")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v (nk=%v)", err, nk)
+	}
+
+	bind, found, err := hive.ReadMultiSZ(nk, "Bind")
+	if err != nil {
+		t.Fatalf("ReadMultiSZ Bind: %v", err)
+	}
+	if !found {
+		t.Fatal("Bind not found")
+	}
+	if len(bind) != 1 {
+		t.Fatalf("Bind: expected 1 entry, got %d", len(bind))
+	}
+	if bind[0] != `\Device\NetBT_Tcpip_{TEST-GUID-2}` {
+		t.Fatalf("Bind[0]: expected \\Device\\NetBT_Tcpip_{TEST-GUID-2}, got %q", bind[0])
+	}
+}
+
+func TestEnumerateSubkeys(t *testing.T) {
+	data := buildTestHive()
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+
+	nk, err := hive.OpenKey("ControlSet001\\Services\\Tcpip\\Parameters\\Interfaces")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v", err)
+	}
+
+	children, err := hive.EnumerateSubkeys(nk)
+	if err != nil {
+		t.Fatalf("EnumerateSubkeys: %v", err)
+	}
+	if len(children) != 2 {
+		t.Fatalf("expected 2 interface subkeys, got %d", len(children))
+	}
+	names := map[string]bool{}
+	for _, c := range children {
+		names[c.name] = true
+	}
+	if !names["{TEST-GUID-1}"] || !names["{TEST-GUID-2}"] {
+		t.Fatalf("unexpected subkey names: %v", names)
+	}
+}
+
+func TestParseAdvancedNetworkSettings(t *testing.T) {
+	data := buildTestHive()
+	settings, err := ParseAdvancedNetworkSettings(data)
+	if err != nil {
+		t.Fatalf("ParseAdvancedNetworkSettings: %v", err)
+	}
+
+	if settings.LanmanServerStart != 4 {
+		t.Errorf("LanmanServerStart: expected 4, got %d", settings.LanmanServerStart)
+	}
+
+	// buildTestHive has no NetworkSetup2 keys and no NetworkAddress values,
+	// so adapters can't be resolved to MACs and are skipped.
+	if len(settings.Interfaces) != 0 {
+		t.Errorf("expected 0 interfaces without MAC source, got %d", len(settings.Interfaces))
+	}
+	if len(settings.FilePrinterSharingDisabled) != 0 {
+		t.Errorf("expected 0 F&PS disabled adapters without MAC source, got %d", len(settings.FilePrinterSharingDisabled))
+	}
+}
+
+func TestHasNonDefaultSettings(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings AdvancedNetSettings
+		expected bool
+	}{
+		{
+			name:     "empty settings",
+			settings: AdvancedNetSettings{},
+			expected: false,
+		},
+		{
+			name: "LanmanServer disabled",
+			settings: AdvancedNetSettings{
+				LanmanServerStart: 4,
+			},
+			expected: true,
+		},
+		{
+			name: "LanmanServer auto (default)",
+			settings: AdvancedNetSettings{
+				LanmanServerStart: 2,
+			},
+			expected: false,
+		},
+		{
+			name: "F&PS disabled adapter",
+			settings: AdvancedNetSettings{
+				FilePrinterSharingDisabled: []AdapterRef{{GUID: "{GUID}"}},
+			},
+			expected: true,
+		},
+		{
+			name: "custom metric",
+			settings: AdvancedNetSettings{
+				Interfaces: []InterfaceSettings{
+					{InterfaceMetric: 10},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "DNS registration disabled (explicit)",
+			settings: AdvancedNetSettings{
+				Interfaces: []InterfaceSettings{
+					{RegistrationEnabled: 3},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "DNS registration disabled (value 0)",
+			settings: AdvancedNetSettings{
+				Interfaces: []InterfaceSettings{
+					{RegistrationEnabled: 0},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "NetBIOS enabled",
+			settings: AdvancedNetSettings{
+				Interfaces: []InterfaceSettings{
+					{NetbiosOptions: 1},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "auto metric (default)",
+			settings: AdvancedNetSettings{
+				Interfaces: []InterfaceSettings{
+					{InterfaceMetricAuto: true, RegistrationEnabled: 1},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.settings.HasNonDefaultSettings()
+			if got != tt.expected {
+				t.Errorf("HasNonDefaultSettings() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDecodeUTF16LE(t *testing.T) {
+	// "ABC" in UTF-16LE
+	input := []byte{0x41, 0x00, 0x42, 0x00, 0x43, 0x00}
+	result := decodeUTF16LE(input)
+	if result != "ABC" {
+		t.Errorf("expected ABC, got %q", result)
+	}
+}
+
+func TestWriteAndReadSettingsFile(t *testing.T) {
+	dir := t.TempDir()
+	settings := &AdvancedNetSettings{
+		Interfaces: []InterfaceSettings{
+			{
+				MAC:                 "{TEST-GUID}",
+				InterfaceMetric:     25,
+				RegistrationEnabled: 0,
+				NetbiosOptions:      2,
+			},
+		},
+		LanmanServerStart:          4,
+		FilePrinterSharingDisabled: []AdapterRef{{GUID: "{TEST-GUID}", MAC: "00:11:22:33:44:55"}},
+	}
+
+	err := WriteSettingsFile(settings, dir)
+	if err != nil {
+		t.Fatalf("WriteSettingsFile: %v", err)
+	}
+
+	read, err := ReadSettingsFile(dir)
+	if err != nil {
+		t.Fatalf("ReadSettingsFile: %v", err)
+	}
+	if read == nil {
+		t.Fatal("ReadSettingsFile returned nil")
+	}
+	if len(read.Interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(read.Interfaces))
+	}
+	if read.Interfaces[0].InterfaceMetric != 25 {
+		t.Errorf("InterfaceMetric: expected 25, got %d", read.Interfaces[0].InterfaceMetric)
+	}
+	if read.LanmanServerStart != 4 {
+		t.Errorf("LanmanServerStart: expected 4, got %d", read.LanmanServerStart)
+	}
+}
+
+func TestReadSettingsFile_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	read, err := ReadSettingsFile(dir)
+	if err != nil {
+		t.Fatalf("ReadSettingsFile: %v", err)
+	}
+	if read != nil {
+		t.Fatal("expected nil for non-existent file")
+	}
+}
+
+// buildTestHiveWithNetworkSetup2 creates a hive with NetworkSetup2\Interfaces
+// containing CurrentAddress (REG_BINARY) for direct GUID-to-MAC resolution.
+func buildTestHiveWithNetworkSetup2() []byte {
+	b := newHiveBuilder()
+	b.init()
+
+	// === Values ===
+	vkSelectCurrent := b.writeVKDword("Current", 1)
+	vkInterfaceMetric := b.writeVKDword("InterfaceMetric", 25)
+	vkRegEnabled := b.writeVKDword("RegistrationEnabled", 0)
+	vkNetbios := b.writeVKDword("NetbiosOptions", 2)
+	vkLanmanStart := b.writeVKDword("Start", 4)
+	vkBind := b.writeVKMultiSZ("Bind", []string{`\Device\NetBT_Tcpip_{TEST-GUID-2}`})
+
+	// NetworkSetup2 CurrentAddress values (6-byte raw MAC)
+	vkMAC1 := b.writeVKBinary("CurrentAddress", []byte{0x00, 0x50, 0x56, 0xBE, 0x56, 0xA1})
+	vkMAC2 := b.writeVKBinary("CurrentAddress", []byte{0x00, 0x50, 0x56, 0xBE, 0x56, 0xA2})
+
+	// === Value lists ===
+	vlSelect := b.writeValuesList([]int32{vkSelectCurrent})
+	vlInterface := b.writeValuesList([]int32{vkInterfaceMetric, vkRegEnabled})
+	vlNetbt := b.writeValuesList([]int32{vkNetbios})
+	vlLanman := b.writeValuesList([]int32{vkLanmanStart})
+	vlLinkage := b.writeValuesList([]int32{vkBind})
+	vlKernel1 := b.writeValuesList([]int32{vkMAC1})
+	vlKernel2 := b.writeValuesList([]int32{vkMAC2})
+
+	// === NK cells (bottom-up) ===
+	nkSelect := b.writeNK("Select", -1, vlSelect, 1, true)
+
+	// Tcpip\Parameters\Interfaces
+	nkGUID1 := b.writeNK("{TEST-GUID-1}", -1, vlInterface, 2, true)
+	nkGUID2 := b.writeNK("{TEST-GUID-2}", -1, -1, 0, true)
+	lhInterfaces := b.writeLH([]int32{nkGUID1, nkGUID2})
+	nkInterfaces := b.writeNK("Interfaces", lhInterfaces, -1, 0, true)
+	lhParameters := b.writeLH([]int32{nkInterfaces})
+	nkParameters := b.writeNK("Parameters", lhParameters, -1, 0, true)
+	lhTcpip := b.writeLH([]int32{nkParameters})
+	nkTcpip := b.writeNK("Tcpip", lhTcpip, -1, 0, true)
+
+	// NetBT
+	nkNetbtGUID1 := b.writeNK("Tcpip_{TEST-GUID-1}", -1, vlNetbt, 1, true)
+	lhNetbtInterfaces := b.writeLH([]int32{nkNetbtGUID1})
+	nkNetbtInterfaces := b.writeNK("Interfaces", lhNetbtInterfaces, -1, 0, true)
+	lhNetbtParams := b.writeLH([]int32{nkNetbtInterfaces})
+	nkNetbtParams := b.writeNK("Parameters", lhNetbtParams, -1, 0, true)
+	lhNetbt := b.writeLH([]int32{nkNetbtParams})
+	nkNetbt := b.writeNK("NetBT", lhNetbt, -1, 0, true)
+
+	// LanmanServer
+	nkLinkage := b.writeNK("Linkage", -1, vlLinkage, 1, true)
+	lhLanmanSubs := b.writeLH([]int32{nkLinkage})
+	nkLanman := b.writeNK("LanmanServer", lhLanmanSubs, vlLanman, 1, true)
+
+	// NetworkSetup2\Interfaces\{GUID}\Kernel
+	nkKernel1 := b.writeNK("Kernel", -1, vlKernel1, 1, true)
+	lhNS2GUID1 := b.writeLH([]int32{nkKernel1})
+	nkNS2GUID1 := b.writeNK("{TEST-GUID-1}", lhNS2GUID1, -1, 0, true)
+
+	nkKernel2 := b.writeNK("Kernel", -1, vlKernel2, 1, true)
+	lhNS2GUID2 := b.writeLH([]int32{nkKernel2})
+	nkNS2GUID2 := b.writeNK("{TEST-GUID-2}", lhNS2GUID2, -1, 0, true)
+
+	lhNS2Interfaces := b.writeLH([]int32{nkNS2GUID1, nkNS2GUID2})
+	nkNS2Interfaces := b.writeNK("Interfaces", lhNS2Interfaces, -1, 0, true)
+	lhNetworkSetup2 := b.writeLH([]int32{nkNS2Interfaces})
+	nkNetworkSetup2 := b.writeNK("NetworkSetup2", lhNetworkSetup2, -1, 0, true)
+
+	// Control (parent of NetworkSetup2)
+	lhControl := b.writeLH([]int32{nkNetworkSetup2})
+	nkControl := b.writeNK("Control", lhControl, -1, 0, true)
+
+	// Services
+	lhServices := b.writeLH([]int32{nkTcpip, nkNetbt, nkLanman})
+	nkServices := b.writeNK("Services", lhServices, -1, 0, true)
+
+	// ControlSet001
+	lhCS001 := b.writeLH([]int32{nkServices, nkControl})
+	nkCS001 := b.writeNK("ControlSet001", lhCS001, -1, 0, true)
+
+	// Root
+	lhRoot := b.writeLH([]int32{nkSelect, nkCS001})
+	nkRoot := b.writeNK("CMI-CreateHive{2A7FB991-7BBE-4F9D-B91E-7CB51D4737F5}", lhRoot, -1, 0, true)
+
+	return b.build(nkRoot)
+}
+
+func TestParseAdvancedNetworkSettings_NetworkSetup2(t *testing.T) {
+	data := buildTestHiveWithNetworkSetup2()
+	settings, err := ParseAdvancedNetworkSettings(data)
+	if err != nil {
+		t.Fatalf("ParseAdvancedNetworkSettings: %v", err)
+	}
+
+	// {TEST-GUID-1} has InterfaceMetric=25, RegistrationEnabled=0 (non-default)
+	if len(settings.Interfaces) != 1 {
+		t.Fatalf("expected 1 interface with non-default settings, got %d", len(settings.Interfaces))
+	}
+	iface := settings.Interfaces[0]
+	if iface.MAC != "00:50:56:BE:56:A1" {
+		t.Errorf("MAC: expected 00:50:56:BE:56:A1, got %s", iface.MAC)
+	}
+	if iface.InterfaceMetric != 25 {
+		t.Errorf("InterfaceMetric: expected 25, got %d", iface.InterfaceMetric)
+	}
+	if iface.RegistrationEnabled != 0 {
+		t.Errorf("RegistrationEnabled: expected 0, got %d", iface.RegistrationEnabled)
+	}
+
+	// F&PS: {TEST-GUID-1} is unbound (only GUID-2 in Bind list)
+	if len(settings.FilePrinterSharingDisabled) != 1 {
+		t.Fatalf("expected 1 F&PS disabled adapter, got %d", len(settings.FilePrinterSharingDisabled))
+	}
+	fps := settings.FilePrinterSharingDisabled[0]
+	if fps.GUID != "{TEST-GUID-1}" {
+		t.Errorf("F&PS GUID: expected {TEST-GUID-1}, got %s", fps.GUID)
+	}
+	if fps.MAC != "00:50:56:BE:56:A1" {
+		t.Errorf("F&PS MAC: expected 00:50:56:BE:56:A1, got %s", fps.MAC)
+	}
+
+	if settings.LanmanServerStart != 4 {
+		t.Errorf("LanmanServerStart: expected 4, got %d", settings.LanmanServerStart)
+	}
+}
+
+func TestParseAdvancedNetworkSettings_NoMACSource(t *testing.T) {
+	data := buildTestHive()
+
+	// buildTestHive has no NetworkSetup2 and no NetworkAddress values,
+	// so no GUID-to-MAC mapping is possible.
+	settings, err := ParseAdvancedNetworkSettings(data)
+	if err != nil {
+		t.Fatalf("ParseAdvancedNetworkSettings: %v", err)
+	}
+	if len(settings.Interfaces) != 0 {
+		t.Errorf("expected 0 interfaces without MAC source, got %d", len(settings.Interfaces))
+	}
+}
+
+func TestReadSZ(t *testing.T) {
+	b := newHiveBuilder()
+	b.init()
+
+	vkHello := b.writeVKSZ("Greeting", "Hello")
+	vl := b.writeValuesList([]int32{vkHello})
+	nkTestKey := b.writeNK("TestKey", -1, vl, 1, true)
+	lhRoot := b.writeLH([]int32{nkTestKey})
+	nkRoot := b.writeNK("CMI-CreateHive{2A7FB991-7BBE-4F9D-B91E-7CB51D4737F5}", lhRoot, -1, 0, true)
+	data := b.build(nkRoot)
+
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	nk, err := hive.OpenKey("TestKey")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v (nk=%v)", err, nk)
+	}
+
+	val, found, err := hive.ReadSZ(nk, "Greeting")
+	if err != nil {
+		t.Fatalf("ReadSZ: %v", err)
+	}
+	if !found {
+		t.Fatal("Greeting not found")
+	}
+	if val != "Hello" {
+		t.Fatalf("expected %q, got %q", "Hello", val)
+	}
+
+	_, found, err = hive.ReadSZ(nk, "Missing")
+	if err != nil {
+		t.Fatalf("ReadSZ Missing: %v", err)
+	}
+	if found {
+		t.Fatal("Missing should not be found")
+	}
+}
+
+func TestReadBinary(t *testing.T) {
+	b := newHiveBuilder()
+	b.init()
+
+	mac := []byte{0x00, 0x50, 0x56, 0xBE, 0x56, 0xA1}
+	vkMAC := b.writeVKBinary("CurrentAddress", mac)
+	vl := b.writeValuesList([]int32{vkMAC})
+	nkTestKey := b.writeNK("TestKey", -1, vl, 1, true)
+	lhRoot := b.writeLH([]int32{nkTestKey})
+	nkRoot := b.writeNK("CMI-CreateHive{2A7FB991-7BBE-4F9D-B91E-7CB51D4737F5}", lhRoot, -1, 0, true)
+	data := b.build(nkRoot)
+
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	nk, err := hive.OpenKey("TestKey")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v (nk=%v)", err, nk)
+	}
+
+	val, found, err := hive.ReadBinary(nk, "CurrentAddress")
+	if err != nil {
+		t.Fatalf("ReadBinary: %v", err)
+	}
+	if !found {
+		t.Fatal("CurrentAddress not found")
+	}
+	if len(val) != 6 {
+		t.Fatalf("expected 6 bytes, got %d", len(val))
+	}
+	for i, b := range mac {
+		if val[i] != b {
+			t.Fatalf("byte %d: expected 0x%02X, got 0x%02X", i, b, val[i])
+		}
+	}
+
+	_, found, err = hive.ReadBinary(nk, "Missing")
+	if err != nil {
+		t.Fatalf("ReadBinary Missing: %v", err)
+	}
+	if found {
+		t.Fatal("Missing should not be found")
+	}
+}
+
+func TestReadDWORD_TypeMismatch(t *testing.T) {
+	b := newHiveBuilder()
+	b.init()
+
+	vkSZ := b.writeVKSZ("NotADword", "hello")
+	vl := b.writeValuesList([]int32{vkSZ})
+	nkTestKey := b.writeNK("TestKey", -1, vl, 1, true)
+	lhRoot := b.writeLH([]int32{nkTestKey})
+	nkRoot := b.writeNK("CMI-CreateHive{2A7FB991-7BBE-4F9D-B91E-7CB51D4737F5}", lhRoot, -1, 0, true)
+	data := b.build(nkRoot)
+
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	nk, err := hive.OpenKey("TestKey")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v", err)
+	}
+
+	_, _, err = hive.ReadDWORD(nk, "NotADword")
+	if err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+	if !strings.Contains(err.Error(), "expected DWORD") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadBinary_TypeMismatch(t *testing.T) {
+	b := newHiveBuilder()
+	b.init()
+
+	vkDW := b.writeVKDword("NotBinary", 42)
+	vl := b.writeValuesList([]int32{vkDW})
+	nkTestKey := b.writeNK("TestKey", -1, vl, 1, true)
+	lhRoot := b.writeLH([]int32{nkTestKey})
+	nkRoot := b.writeNK("CMI-CreateHive{2A7FB991-7BBE-4F9D-B91E-7CB51D4737F5}", lhRoot, -1, 0, true)
+	data := b.build(nkRoot)
+
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	nk, err := hive.OpenKey("TestKey")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v", err)
+	}
+
+	_, _, err = hive.ReadBinary(nk, "NotBinary")
+	if err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+	if !strings.Contains(err.Error(), "expected BINARY") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadMultiSZ_TypeMismatch(t *testing.T) {
+	b := newHiveBuilder()
+	b.init()
+
+	vkDW := b.writeVKDword("NotMultiSZ", 99)
+	vl := b.writeValuesList([]int32{vkDW})
+	nkTestKey := b.writeNK("TestKey", -1, vl, 1, true)
+	lhRoot := b.writeLH([]int32{nkTestKey})
+	nkRoot := b.writeNK("CMI-CreateHive{2A7FB991-7BBE-4F9D-B91E-7CB51D4737F5}", lhRoot, -1, 0, true)
+	data := b.build(nkRoot)
+
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	nk, err := hive.OpenKey("TestKey")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v", err)
+	}
+
+	_, _, err = hive.ReadMultiSZ(nk, "NotMultiSZ")
+	if err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+	if !strings.Contains(err.Error(), "expected MULTI_SZ") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadBinary_InlineData(t *testing.T) {
+	b := newHiveBuilder()
+	b.init()
+
+	// Manually write a VK cell with inline binary data (2 bytes, bit 31 set)
+	nameBytes := []byte("TinyMAC")
+	bodySize := 4 + 20 + len(nameBytes)
+	off := b.allocCell(bodySize)
+	abs := int(off) + 4
+
+	binary.LittleEndian.PutUint16(b.hbin[abs:abs+2], sigVK)
+	binary.LittleEndian.PutUint16(b.hbin[abs+2:abs+4], uint16(len(nameBytes)))
+	// dataSize = 2 | 0x80000000 (inline, 2 bytes)
+	binary.LittleEndian.PutUint32(b.hbin[abs+4:abs+8], 0x80000002)
+	// dataOffset holds the inline data: [0xAB, 0xCD, 0x00, 0x00]
+	binary.LittleEndian.PutUint32(b.hbin[abs+8:abs+12], 0x0000CDAB)
+	binary.LittleEndian.PutUint32(b.hbin[abs+12:abs+16], regBinary)
+	binary.LittleEndian.PutUint16(b.hbin[abs+16:abs+18], 0x0001)
+	copy(b.hbin[abs+20:], nameBytes)
+
+	vl := b.writeValuesList([]int32{off})
+	nkTestKey := b.writeNK("TestKey", -1, vl, 1, true)
+	lhRoot := b.writeLH([]int32{nkTestKey})
+	nkRoot := b.writeNK("CMI-CreateHive{2A7FB991-7BBE-4F9D-B91E-7CB51D4737F5}", lhRoot, -1, 0, true)
+	data := b.build(nkRoot)
+
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	nk, err := hive.OpenKey("TestKey")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v", err)
+	}
+
+	val, found, err := hive.ReadBinary(nk, "TinyMAC")
+	if err != nil {
+		t.Fatalf("ReadBinary inline: %v", err)
+	}
+	if !found {
+		t.Fatal("TinyMAC not found")
+	}
+	if len(val) != 2 || val[0] != 0xAB || val[1] != 0xCD {
+		t.Fatalf("expected [0xAB, 0xCD], got %v", val)
+	}
+}
+
+func TestOpenKey_EmptyPath(t *testing.T) {
+	data := buildTestHive()
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	nk, err := hive.OpenKey("")
+	if err != nil {
+		t.Fatalf("OpenKey empty: %v", err)
+	}
+	if nk == nil {
+		t.Fatal("expected root key for empty path")
+	}
+}
+
+func TestOpenKey_CaseInsensitive(t *testing.T) {
+	data := buildTestHive()
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	nk, err := hive.OpenKey("CONTROLSET001\\SERVICES\\TCPIP")
+	if err != nil {
+		t.Fatalf("OpenKey case-insensitive: %v", err)
+	}
+	if nk == nil {
+		t.Fatal("expected key to exist (case-insensitive)")
+	}
+}
+
+func TestEnumerateSubkeys_NoChildren(t *testing.T) {
+	data := buildTestHive()
+	hive, err := ParseHive(data)
+	if err != nil {
+		t.Fatalf("ParseHive: %v", err)
+	}
+	nk, err := hive.OpenKey("ControlSet001\\Services\\Tcpip\\Parameters\\Interfaces\\{TEST-GUID-2}")
+	if err != nil || nk == nil {
+		t.Fatalf("OpenKey: %v", err)
+	}
+	children, err := hive.EnumerateSubkeys(nk)
+	if err != nil {
+		t.Fatalf("EnumerateSubkeys: %v", err)
+	}
+	if len(children) != 0 {
+		t.Fatalf("expected 0 children, got %d", len(children))
+	}
+}
+
+func TestParseAdvancedNetworkSettings_CorruptHive(t *testing.T) {
+	// Take a valid hive and corrupt an internal offset so that parsing
+	// reaches a point where a read helper slices out of bounds.
+	data := buildTestHive()
+
+	// Corrupt the root cell's subkeys-list offset to point far beyond the data,
+	// bypassing the NK parse (which succeeds) but panicking when following
+	// the bogus subkeys-list pointer.
+	rootOff := int(binary.LittleEndian.Uint32(data[36:40]))
+	abs := rootOff + 0x1000 + 4 // past cell-size
+	bodyStart := abs + 4        // past sig + flags
+	// Overwrite subkeysListOff with a value that's within hbin range check
+	// but will cause OOB in the LH/LF parsing due to element count mismatch.
+	binary.LittleEndian.PutUint32(data[bodyStart+0x18:bodyStart+0x1C], uint32(len(data)-0x1000-8))
+
+	_, err := ParseAdvancedNetworkSettings(data)
+	if err == nil {
+		t.Fatal("expected error for corrupt hive, got nil")
+	}
+	if !strings.Contains(err.Error(), "corrupt") && !strings.Contains(err.Error(), "regf") {
+		t.Errorf("expected regf-related error, got: %v", err)
+	}
+}

--- a/pkg/virt-v2v/customize/advancednet/types.go
+++ b/pkg/virt-v2v/customize/advancednet/types.go
@@ -1,0 +1,63 @@
+package advancednet
+
+// AdvancedNetSettingsFile is the filename written to Workdir.
+const AdvancedNetSettingsFile = "advanced_net.json"
+
+// Windows default values for network settings.
+const (
+	LanmanServerStartAutomatic uint32 = 2 // Service starts at boot (default)
+	DNSRegistrationEnabled     uint32 = 1 // Adapter registers in DNS (default)
+	NetbiosOptionsDefault      uint32 = 0 // Use DHCP-assigned setting (default)
+	NetbiosOptionsEnabled      uint32 = 1
+	NetbiosOptionsDisabled     uint32 = 2
+)
+
+// AdvancedNetSettings holds per-interface and global network settings
+// extracted from a Windows SYSTEM registry hive. Only non-default values
+// are populated, the consumer should skip writing any zero-valued field.
+type AdvancedNetSettings struct {
+	Interfaces                 []InterfaceSettings `json:"interfaces"`
+	LanmanServerStart          uint32              `json:"lanmanServerStart"`
+	FilePrinterSharingDisabled []AdapterRef        `json:"filePrinterSharingDisabledAdapters"`
+}
+
+// AdapterRef identifies a network adapter by both GUID and MAC so the
+// firstboot script can match by MAC when the GUID changes after migration.
+type AdapterRef struct {
+	GUID string `json:"guid"`
+	MAC  string `json:"mac,omitempty"`
+}
+
+// InterfaceSettings captures per-NIC advanced settings. MAC is the adapter's
+// hardware address (resolved from the SYSTEM hive when possible, otherwise
+// the GUID is stored as a fallback identifier).
+type InterfaceSettings struct {
+	MAC                 string `json:"mac"`
+	InterfaceMetric     uint32 `json:"interfaceMetric"`
+	InterfaceMetricAuto bool   `json:"interfaceMetricAuto"`
+	RegistrationEnabled uint32 `json:"registrationEnabled"`
+	NetbiosOptions      uint32 `json:"netbiosOptions"`
+}
+
+// HasNonDefaultSettings returns true when at least one setting differs from
+// the Windows default, meaning a firstboot script should be generated.
+func (s *AdvancedNetSettings) HasNonDefaultSettings() bool {
+	if s.LanmanServerStart != 0 && s.LanmanServerStart != LanmanServerStartAutomatic {
+		return true
+	}
+	if len(s.FilePrinterSharingDisabled) > 0 {
+		return true
+	}
+	for _, iface := range s.Interfaces {
+		if !iface.InterfaceMetricAuto && iface.InterfaceMetric != 0 {
+			return true
+		}
+		if iface.RegistrationEnabled != DNSRegistrationEnabled {
+			return true
+		}
+		if iface.NetbiosOptions == NetbiosOptionsEnabled || iface.NetbiosOptions == NetbiosOptionsDisabled {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -3,6 +3,8 @@ package customize
 import (
 	"bytes"
 	"embed"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,8 +14,13 @@ import (
 	"text/template"
 
 	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/customize/advancednet"
 	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
 )
+
+// ErrNoAdvancedNetSettings is returned when no advanced network settings file
+// exists or all values are defaults, meaning no firstboot script is needed.
+var ErrNoAdvancedNetSettings = errors.New("advanced net settings not found or all defaults")
 
 const (
 	WinFirstbootPath        = "/Program Files/Guestfs/Firstboot"
@@ -183,12 +190,6 @@ func (c *Customize) addDisksToCustomize(cmdBuilder utils.CommandBuilder) {
 // In case of multiple IP's per NIC on windows there is an existing setup script that assign only primary IP's
 // With this function and its corresponding template we will inject all the complementry IP's to the NICs
 func (c *Customize) injectComplementryStaticIPTemplate(templatePath, outputPath string) error {
-
-	tmplContent, err := os.ReadFile(templatePath)
-	if err != nil {
-		return fmt.Errorf("failed to read template: %w", err)
-	}
-
 	segments := strings.Split(c.appConfig.StaticIPs, "_")
 	macMap := map[string][]IPEntry{}
 
@@ -203,16 +204,11 @@ func (c *Customize) injectComplementryStaticIPTemplate(templatePath, outputPath 
 			continue
 		}
 
-		ip := ipParts[0]
-		gw := ipParts[1]
-		prefix := ipParts[2]
-		dns := ipParts[3:]
-
 		ipEntry := IPEntry{
-			IP:           ip,
-			Gateway:      gw,
-			PrefixLength: prefix,
-			DNS:          dns,
+			IP:           ipParts[0],
+			Gateway:      ipParts[1],
+			PrefixLength: ipParts[2],
+			DNS:          ipParts[3:],
 		}
 		macMap[mac] = append(macMap[mac], ipEntry)
 	}
@@ -241,50 +237,70 @@ func (c *Customize) injectComplementryStaticIPTemplate(templatePath, outputPath 
 		},
 	}
 
-	tmpl, err := template.New("preserveComplementryStaticIpScript").Funcs(funcMap).Parse(string(tmplContent))
+	return renderTemplate(templatePath, outputPath, configs, funcMap)
+}
+
+func renderTemplate(templatePath, outputPath string, data any, funcMaps ...template.FuncMap) error {
+	tmplContent, err := os.ReadFile(templatePath)
 	if err != nil {
-		return fmt.Errorf("failed to parse template: %w", err)
+		return fmt.Errorf("read template %s: %w", templatePath, err)
+	}
+
+	tmpl := template.New(filepath.Base(templatePath))
+	for _, fm := range funcMaps {
+		tmpl = tmpl.Funcs(fm)
+	}
+	if tmpl, err = tmpl.Parse(string(tmplContent)); err != nil {
+		return fmt.Errorf("parse template %s: %w", templatePath, err)
 	}
 
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, configs); err != nil {
-		return fmt.Errorf("failed to render template: %w", err)
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("render template %s: %w", templatePath, err)
 	}
 
 	if err := os.WriteFile(outputPath, buf.Bytes(), 0644); err != nil {
-		return fmt.Errorf("failed to write output script: %w", err)
+		return fmt.Errorf("write rendered script %s: %w", outputPath, err)
 	}
 
 	return nil
 }
 
+func (c *Customize) injectAdvancedNetworkSettingsTemplate(windowsScriptsPath string) error {
+	settings, err := advancednet.ReadSettingsFile(c.appConfig.Workdir)
+	if err != nil {
+		return fmt.Errorf("read advanced net settings: %w", err)
+	}
+	if settings == nil || !settings.HasNonDefaultSettings() {
+		return ErrNoAdvancedNetSettings
+	}
+
+	settingsJSON, err := json.Marshal(settings)
+	if err != nil {
+		return fmt.Errorf("marshal advanced net settings: %w", err)
+	}
+
+	templatePath := filepath.Join(windowsScriptsPath, "9998-advanced-network-settings.ps1.tmpl")
+	outputPath := filepath.Join(windowsScriptsPath, "9998-advanced-network-settings.ps1")
+
+	if err := renderTemplate(templatePath, outputPath, struct {
+		SettingsJSON string
+	}{
+		SettingsJSON: string(settingsJSON),
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("Advanced network settings script written to %s\n", outputPath)
+	return nil
+}
+
 func (c *Customize) injectStaticIPTemplate(templatePath, outputPath string) error {
-	tmplContent, err := os.ReadFile(templatePath)
-	if err != nil {
-		return fmt.Errorf("failed to read template: %w", err)
-	}
-
-	tmpl, err := template.New("netConfigScript").Parse(string(tmplContent))
-	if err != nil {
-		return fmt.Errorf("failed to parse template: %w", err)
-	}
-
-	data := struct {
+	return renderTemplate(templatePath, outputPath, struct {
 		InputString string
 	}{
 		InputString: c.appConfig.StaticIPs,
-	}
-
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, data); err != nil {
-		return fmt.Errorf("failed to render template: %w", err)
-	}
-
-	if err := os.WriteFile(outputPath, buf.Bytes(), 0644); err != nil {
-		return fmt.Errorf("failed to write output script: %w", err)
-	}
-
-	return nil
+	})
 }
 
 func (c *Customize) runCmd(builder utils.CommandBuilder) error {
@@ -353,8 +369,18 @@ func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) erro
 			uploadPreserveMultipleIpPath = c.formatUpload(preserveMultipleNicsPath, WinFirstbootScriptsPath)
 		}
 	}
+	uploadAdvancedNetPath := ""
+	if err := c.injectAdvancedNetworkSettingsTemplate(windowsScriptsPath); err != nil {
+		if !errors.Is(err, ErrNoAdvancedNetSettings) {
+			return fmt.Errorf("inject advanced network settings: %w", err)
+		}
+	} else {
+		advNetScript := filepath.Join(windowsScriptsPath, "9998-advanced-network-settings.ps1")
+		uploadAdvancedNetPath = c.formatUpload(advNetScript, WinFirstbootScriptsPath)
+	}
+
 	uploadInitPath := c.formatUpload(initPath, WinFirstbootScriptsPath)
-	cmdBuilder.AddArgs(UploadCmd, uploadPreserveIpPath, uploadInitPath, uploadRemoveDuplicatesPath, uploadPreserveMultipleIpPath)
+	cmdBuilder.AddArgs(UploadCmd, uploadAdvancedNetPath, uploadPreserveIpPath, uploadInitPath, uploadRemoveDuplicatesPath, uploadPreserveMultipleIpPath)
 	if c.appConfig.WaitForGuestReboot {
 		signalScript := filepath.Join(windowsScriptsPath, "99999-signal-conversion-done.ps1")
 		cmdBuilder.AddArg(UploadCmd, c.formatUpload(signalScript, filepath.Join(WinFirstbootScriptsPath, "99999-signal-conversion-done.ps1")))

--- a/pkg/virt-v2v/customize/customize_test.go
+++ b/pkg/virt-v2v/customize/customize_test.go
@@ -1,991 +1,170 @@
-// Generated-by: Claude
 package customize
 
 import (
+	"encoding/json"
 	"errors"
-	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
-	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/customize/advancednet"
 )
 
-func TestCustomize(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Customize test suite")
+func TestRenderTemplate(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, "test.ps1.tmpl")
+	outPath := filepath.Join(dir, "test.ps1")
+
+	if err := os.WriteFile(tmplPath, []byte("Hello {{.Name}}, value={{.Value}}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := struct {
+		Name  string
+		Value int
+	}{"world", 42}
+
+	if err := renderTemplate(tmplPath, outPath, data); err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	expected := "Hello world, value=42"
+	if string(got) != expected {
+		t.Errorf("expected %q, got %q", expected, string(got))
+	}
 }
 
-var _ = Describe("Customize", func() {
-	var customize *Customize
-	var mockCtrl *gomock.Controller
-	var mockFileSystem *utils.MockFileSystem
-	var mockCommandBuilder *utils.MockCommandBuilder
-	var mockCommandExecutor *utils.MockCommandExecutor
-	var mockEmbedTool *MockEmbedTool
-	var appConfig *config.AppConfig
-	var expectedFirstBootScripts []string
-	var expectedRunScripts []string
-	var disks []string
-	var firstBootScripts []os.DirEntry
-	var runScripts []os.DirEntry
-
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
-		mockFileSystem = utils.NewMockFileSystem(mockCtrl)
-		mockEmbedTool = NewMockEmbedTool(mockCtrl)
-		mockCommandBuilder = utils.NewMockCommandBuilder(mockCtrl)
-		mockCommandExecutor = utils.NewMockCommandExecutor(mockCtrl)
-
-		appConfig = &config.AppConfig{
-			Workdir: config.V2vOutputDir,
-		}
-		customize = &Customize{
-			appConfig:          appConfig,
-			commandBuilder:     mockCommandBuilder,
-			fileSystem:         mockFileSystem,
-			embeddedFileSystem: mockEmbedTool,
-		}
-
-		expectedFirstBootScripts = []string{
-			"/var/tmp/v2v/scripts/rhel/firstboot/script1.sh",
-			"/var/tmp/v2v/scripts/rhel/firstboot/script2.sh",
-		}
-		expectedRunScripts = []string{
-			"/var/tmp/v2v/scripts/rhel/run/script1.sh",
-			"/var/tmp/v2v/scripts/rhel/run/script2.sh",
-		}
-		firstBootScripts = utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-			{FileName: "script1.sh", FileIsDir: false},
-			{FileName: "script2.sh", FileIsDir: false},
-			{FileName: "script1.ps1", FileIsDir: false},
-			{FileName: "script2.ps1", FileIsDir: false},
-			{FileName: "test-script1.sh", FileIsDir: false},
-			{FileName: "test-script2.sh", FileIsDir: false},
-			{FileName: "test-script1.ps1", FileIsDir: false},
-			{FileName: "test-script2.ps1", FileIsDir: false},
-			{FileName: "dir1", FileIsDir: true},
-			{FileName: "dir2", FileIsDir: true},
-		})
-		runScripts = utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-			{FileName: "script1.sh", FileIsDir: false},
-			{FileName: "script2.sh", FileIsDir: false},
-			{FileName: "script1.ps1", FileIsDir: false},
-			{FileName: "script2.ps1", FileIsDir: false},
-			{FileName: "test-script1.sh", FileIsDir: false},
-			{FileName: "test-script2.sh", FileIsDir: false},
-			{FileName: "dir1", FileIsDir: true},
-			{FileName: "dir2", FileIsDir: true},
-		})
-		disks = []string{
-			"/var/tmp/v2v/new-vm-name-sda",
-			"/var/tmp/v2v/new-vm-name-sdb",
-		}
-	})
-
-	Describe("customizeLinux", func() {
-		It("TestCustomizeRHELWithMock", func() {
-			customize.disks = disks
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			for _, expectedScript := range expectedRunScripts {
-				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, expectedScript := range expectedFirstBootScripts {
-				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(nil)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			mockFileSystem.EXPECT().Stat(gomock.Any()).Return(nil, os.ErrNotExist)
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
-
-			err := customize.customizeLinux()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error when run command fails", func() {
-			customize.disks = disks
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-			for _, expectedScript := range expectedRunScripts {
-				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, expectedScript := range expectedFirstBootScripts {
-				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(errors.New("command failed"))
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			mockFileSystem.EXPECT().Stat(gomock.Any()).Return(nil, os.ErrNotExist)
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
-
-			err := customize.customizeLinux()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to execute domain customization"))
-		})
-	})
-
-	Describe("handleStaticIPConfiguration", func() {
-		It("StaticIPs - It passes", func() {
-			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
-			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n"
-			expectedPath := filepath.Join(appConfig.Workdir, "macToIP")
-			mockFileSystem.EXPECT().WriteFile(expectedPath, []byte(expectedContent), fs.FileMode(0755)).Return(nil)
-			mockCommandBuilder.EXPECT().AddArg("--upload", fmt.Sprintf("%s:/tmp/macToIP", expectedPath)).Times(1)
-			err := customize.handleStaticIPConfiguration(mockCommandBuilder)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("handles multiple static IPs separated by underscore", func() {
-			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100_00:11:22:33:44:56:ip:192.168.1.101"
-			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n00:11:22:33:44:56:ip:192.168.1.101\n"
-			expectedPath := filepath.Join(appConfig.Workdir, "macToIP")
-			mockFileSystem.EXPECT().WriteFile(expectedPath, []byte(expectedContent), fs.FileMode(0755)).Return(nil)
-			mockCommandBuilder.EXPECT().AddArg("--upload", fmt.Sprintf("%s:/tmp/macToIP", expectedPath)).Times(1)
-			err := customize.handleStaticIPConfiguration(mockCommandBuilder)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("does nothing when StaticIPs is empty", func() {
-			appConfig.StaticIPs = ""
-			err := customize.handleStaticIPConfiguration(mockCommandBuilder)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("WriteFileFails - It fails", func() {
-			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
-			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n"
-			expectedPath := filepath.Join(appConfig.Workdir, "macToIP")
-			mockFileSystem.EXPECT().WriteFile(expectedPath, []byte(expectedContent), fs.FileMode(0755)).Return(errors.New("error"))
-			mockCommandBuilder.EXPECT().AddArg("--upload", fmt.Sprintf("%s:/tmp/macToIP", expectedPath)).Times(0)
-			err := customize.handleStaticIPConfiguration(mockCommandBuilder)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("addRhelFirstbootScripts", func() {
-		It("Scripts - It passes", func() {
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
-			for _, expectedScript := range expectedFirstBootScripts {
-				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
-			}
-			err := customize.addRhelFirstbootScripts(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("NoScripts - It does not add", func() {
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(nil, nil)
-			err := customize.addRhelFirstbootScripts(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("ReadDirFails - It fails", func() {
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(nil, errors.New("error"))
-			err := customize.addRhelFirstbootScripts(mockCommandBuilder)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("addRhelRunScripts", func() {
-		It("Scripts - It passes", func() {
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
-			for _, expectedScript := range expectedRunScripts {
-				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
-			}
-			err := customize.addRhelRunScripts(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("NoScripts - It does not add", func() {
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(nil, nil)
-			err := customize.addRhelRunScripts(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("ReadDirFails - It fails", func() {
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(nil, errors.New("error"))
-			err := customize.addRhelRunScripts(mockCommandBuilder)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("addDisksToCustomize", func() {
-		It("adds all disks", func() {
-			customize.disks = disks
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-			customize.addDisksToCustomize(mockCommandBuilder)
-		})
-
-		It("handles empty disks slice", func() {
-			customize.disks = []string{}
-			// No mock expectations - no AddArg calls should be made
-			customize.addDisksToCustomize(mockCommandBuilder)
-		})
-
-		It("handles single disk", func() {
-			customize.disks = []string{"/var/tmp/v2v/single-disk"}
-			mockCommandBuilder.EXPECT().AddArg("--add", "/var/tmp/v2v/single-disk").Return(mockCommandBuilder)
-			customize.addDisksToCustomize(mockCommandBuilder)
-		})
-	})
-
-	Describe("addLuksKeysToCustomize", func() {
-		It("adds clevis key when NbdeClevis is true", func() {
-			appConfig.NbdeClevis = true
-			mockCommandBuilder.EXPECT().AddArgs("--key", "all:clevis").Return(mockCommandBuilder)
-			err := customize.addLuksKeysToCustomize(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("does nothing when Luksdir is empty and NbdeClevis is false", func() {
-			appConfig.Luksdir = ""
-			appConfig.NbdeClevis = false
-			// No mock expectations
-			err := customize.addLuksKeysToCustomize(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("adds LUKS keys from directory", func() {
-			appConfig.Luksdir = "/etc/luks"
-			appConfig.NbdeClevis = false
-
-			files := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "key1", FileIsDir: false},
-				{FileName: "key2", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().Stat("/etc/luks").Return(nil, nil)
-			mockFileSystem.EXPECT().ReadDir("/etc/luks").Return(files, nil)
-			mockCommandBuilder.EXPECT().AddArgs("--key", "all:file:/etc/luks/key1", "all:file:/etc/luks/key2").Return(mockCommandBuilder)
-
-			err := customize.addLuksKeysToCustomize(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error when LUKS directory read fails", func() {
-			appConfig.Luksdir = "/etc/luks"
-			appConfig.NbdeClevis = false
-
-			mockFileSystem.EXPECT().Stat("/etc/luks").Return(nil, nil)
-			mockFileSystem.EXPECT().ReadDir("/etc/luks").Return(nil, errors.New("read error"))
-
-			err := customize.addLuksKeysToCustomize(mockCommandBuilder)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("getScriptsWithSuffix", func() {
-		It("returns scripts with matching suffix", func() {
-			dir := "/test/scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "script1.sh", FileIsDir: false},
-				{FileName: "script2.sh", FileIsDir: false},
-				{FileName: "script3.ps1", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-
-			result, err := customize.getScriptsWithSuffix(dir, ".sh")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(HaveLen(2))
-			Expect(result).To(ContainElement("/test/scripts/script1.sh"))
-			Expect(result).To(ContainElement("/test/scripts/script2.sh"))
-		})
-
-		It("excludes test- prefixed files", func() {
-			dir := "/test/scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "script1.sh", FileIsDir: false},
-				{FileName: "test-script.sh", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-
-			result, err := customize.getScriptsWithSuffix(dir, ".sh")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(HaveLen(1))
-			Expect(result).To(ContainElement("/test/scripts/script1.sh"))
-		})
-
-		It("excludes directories", func() {
-			dir := "/test/scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "script1.sh", FileIsDir: false},
-				{FileName: "subdir.sh", FileIsDir: true},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-
-			result, err := customize.getScriptsWithSuffix(dir, ".sh")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(HaveLen(1))
-		})
-
-		It("returns empty slice for empty directory", func() {
-			dir := "/test/scripts"
-			mockFileSystem.EXPECT().ReadDir(dir).Return([]os.DirEntry{}, nil)
-
-			result, err := customize.getScriptsWithSuffix(dir, ".sh")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(BeEmpty())
-		})
-
-		It("returns error when ReadDir fails", func() {
-			dir := "/test/scripts"
-			mockFileSystem.EXPECT().ReadDir(dir).Return(nil, errors.New("read error"))
-
-			_, err := customize.getScriptsWithSuffix(dir, ".sh")
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("getScriptsWithRegex", func() {
-		It("returns scripts matching regex", func() {
-			dir := "/test/scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "01_linux_run_setup.sh", FileIsDir: false},
-				{FileName: "02_linux_firstboot_config.sh", FileIsDir: false},
-				{FileName: "invalid.sh", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-
-			result, err := customize.getScriptsWithRegex(dir, LinuxDynamicRegex)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(HaveLen(2))
-		})
-
-		It("returns empty for no matches", func() {
-			dir := "/test/scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "invalid.sh", FileIsDir: false},
-				{FileName: "another.txt", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-
-			result, err := customize.getScriptsWithRegex(dir, LinuxDynamicRegex)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(BeEmpty())
-		})
-
-		It("excludes directories", func() {
-			dir := "/test/scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "01_linux_run_setup.sh", FileIsDir: true},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-
-			result, err := customize.getScriptsWithRegex(dir, LinuxDynamicRegex)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(BeEmpty())
-		})
-
-		It("returns error when ReadDir fails", func() {
-			dir := "/test/scripts"
-			mockFileSystem.EXPECT().ReadDir(dir).Return(nil, errors.New("read error"))
-
-			_, err := customize.getScriptsWithRegex(dir, LinuxDynamicRegex)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("addRhelDynamicScripts", func() {
-		It("adds run scripts", func() {
-			dir := "/mnt/dynamic_scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "01_linux_run_setup.sh", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-			mockCommandBuilder.EXPECT().AddArg("--run", filepath.Join(dir, "01_linux_run_setup.sh")).Return(mockCommandBuilder)
-
-			err := customize.addRhelDynamicScripts(mockCommandBuilder, dir)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("adds firstboot scripts", func() {
-			dir := "/mnt/dynamic_scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "01_linux_firstboot_config.sh", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-			mockCommandBuilder.EXPECT().AddArg("--firstboot", filepath.Join(dir, "01_linux_firstboot_config.sh")).Return(mockCommandBuilder)
-
-			err := customize.addRhelDynamicScripts(mockCommandBuilder, dir)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error for invalid action in regex", func() {
-			dir := "/mnt/dynamic_scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "01_linux_invalid_setup.sh", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-
-			// This should not match the regex, so no error
-			err := customize.addRhelDynamicScripts(mockCommandBuilder, dir)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("handles empty directory", func() {
-			dir := "/mnt/dynamic_scripts"
-			mockFileSystem.EXPECT().ReadDir(dir).Return([]os.DirEntry{}, nil)
-
-			err := customize.addRhelDynamicScripts(mockCommandBuilder, dir)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Describe("formatUpload", func() {
-		It("formats upload path correctly", func() {
-			result := customize.formatUpload("/local/path/script.sh", "/remote/path/script.sh")
-			Expect(result).To(Equal("/local/path/script.sh:/remote/path/script.sh"))
-		})
-
-		It("handles paths with spaces", func() {
-			result := customize.formatUpload("/local/path with spaces/script.sh", "/remote/path/script.sh")
-			Expect(result).To(Equal("/local/path with spaces/script.sh:/remote/path/script.sh"))
-		})
-	})
-
-	Describe("formatIPs", func() {
-		It("formats single IP", func() {
-			ips := []IPEntry{{IP: "192.168.1.1"}}
-			result := formatIPs(ips)
-			Expect(result).To(Equal("(\n'192.168.1.1'\n)"))
-		})
-
-		It("formats multiple IPs", func() {
-			ips := []IPEntry{
-				{IP: "192.168.1.1"},
-				{IP: "192.168.1.2"},
-			}
-			result := formatIPs(ips)
-			Expect(result).To(Equal("(\n'192.168.1.1',\n'192.168.1.2'\n)"))
-		})
-
-		It("handles empty IPs", func() {
-			ips := []IPEntry{}
-			result := formatIPs(ips)
-			Expect(result).To(Equal("(\n)"))
-		})
-	})
-
-	Describe("formatDNS", func() {
-		It("formats single DNS", func() {
-			dns := []string{"8.8.8.8"}
-			result := formatDNS(dns)
-			Expect(result).To(Equal("(\n'8.8.8.8'\n)"))
-		})
-
-		It("formats multiple DNS", func() {
-			dns := []string{"8.8.8.8", "8.8.4.4"}
-			result := formatDNS(dns)
-			Expect(result).To(Equal("(\n'8.8.8.8',\n'8.8.4.4'\n)"))
-		})
-
-		It("handles empty DNS", func() {
-			dns := []string{}
-			result := formatDNS(dns)
-			Expect(result).To(Equal("(\n)"))
-		})
-	})
-
-	Describe("NewCustomize", func() {
-		It("creates Customize with correct fields", func() {
-			cfg := &config.AppConfig{
-				Workdir: "/test/workdir",
-			}
-			testDisks := []string{"/disk1", "/disk2"}
-			osInfo := utils.InspectionOS{Name: "Fedora"}
-
-			result := NewCustomize(cfg, testDisks, osInfo)
-
-			Expect(result.appConfig).To(Equal(cfg))
-			Expect(result.disks).To(Equal(testDisks))
-			Expect(result.operatingSystem).To(Equal(osInfo))
-			Expect(result.commandBuilder).ToNot(BeNil())
-			Expect(result.fileSystem).ToNot(BeNil())
-			Expect(result.embeddedFileSystem).ToNot(BeNil())
-		})
-	})
-
-	Describe("Run", func() {
-		It("runs Linux customization for non-Windows OS", func() {
-			customize.disks = disks
-			customize.operatingSystem = utils.InspectionOS{Osinfo: "linux"}
-
-			mockEmbedTool.EXPECT().CreateFilesFromFS(appConfig.Workdir).Return(nil)
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-			for _, expectedScript := range expectedRunScripts {
-				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, expectedScript := range expectedFirstBootScripts {
-				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(nil)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			// Stat is called for DynamicScriptsDir and Luksdir
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
-
-			err := customize.Run()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error when CreateFilesFromFS fails", func() {
-			customize.disks = disks
-			customize.operatingSystem = utils.InspectionOS{Osinfo: "linux"}
-
-			mockEmbedTool.EXPECT().CreateFilesFromFS(appConfig.Workdir).Return(errors.New("embed error"))
-
-			err := customize.Run()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to create files from filesystem"))
-		})
-
-		It("runs Windows customization for Windows OS", func() {
-			customize.disks = disks
-			customize.operatingSystem = utils.InspectionOS{Osinfo: "win10"}
-
-			mockEmbedTool.EXPECT().CreateFilesFromFS(appConfig.Workdir).Return(nil)
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			// DynamicScriptsDir does not exist
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
-
-			// addWinFirstbootScripts
-			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
-
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(nil)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			err := customize.Run()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error when Windows customization fails", func() {
-			customize.disks = disks
-			customize.operatingSystem = utils.InspectionOS{Osinfo: "win10"}
-
-			mockEmbedTool.EXPECT().CreateFilesFromFS(appConfig.Workdir).Return(nil)
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
-			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
-
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(errors.New("windows customization failed"))
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			err := customize.Run()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("windows customization failed"))
-		})
-	})
-
-	Describe("customizeWindows", func() {
-		It("customizes Windows with dynamic scripts", func() {
-			customize.disks = disks
-
-			winScripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "01_win_firstboot_setup.ps1", FileIsDir: false},
-			})
-
-			// DynamicScriptsDir exists
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, nil)
-			mockFileSystem.EXPECT().ReadDir(appConfig.DynamicScriptsDir).Return(winScripts, nil)
-
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			// Dynamic script upload
-			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder)
-
-			// addWinFirstbootScripts
-			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
-
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(nil)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			err := customize.customizeWindows()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error when dynamic scripts read fails", func() {
-			customize.disks = disks
-
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, nil)
-			mockFileSystem.EXPECT().ReadDir(appConfig.DynamicScriptsDir).Return(nil, errors.New("read error"))
-
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			err := customize.customizeWindows()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to read scripts directory"))
-		})
-
-		It("adds vSphere VMware driver removal script uploads", func() {
-			customize.disks = disks
-			appConfig.VsphereVmwareDriverRemoval = true
-			appConfig.Source = config.VSPHERE
-
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
-
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder).Times(5)
-
-			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
-
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(nil)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			err := customize.customizeWindows()
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Describe("addWinDynamicScripts", func() {
-		It("adds Windows dynamic scripts matching regex", func() {
-			dir := "/mnt/dynamic_scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "01_win_firstboot_setup.ps1", FileIsDir: false},
-				{FileName: "02_win_firstboot_config.ps1", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder).Times(2)
-
-			err := customize.addWinDynamicScripts(mockCommandBuilder, dir)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("ignores non-matching files", func() {
-			dir := "/mnt/dynamic_scripts"
-			scripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "invalid_script.ps1", FileIsDir: false},
-				{FileName: "random.txt", FileIsDir: false},
-			})
-
-			mockFileSystem.EXPECT().ReadDir(dir).Return(scripts, nil)
-			// No AddArg calls expected since files don't match regex
-
-			err := customize.addWinDynamicScripts(mockCommandBuilder, dir)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error when ReadDir fails", func() {
-			dir := "/mnt/dynamic_scripts"
-			mockFileSystem.EXPECT().ReadDir(dir).Return(nil, errors.New("read error"))
-
-			err := customize.addWinDynamicScripts(mockCommandBuilder, dir)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("runCmd", func() {
-		It("runs command successfully", func() {
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-			mockCommandExecutor.EXPECT().Run().Return(nil)
-
-			err := customize.runCmd(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error when command fails", func() {
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-			mockCommandExecutor.EXPECT().Run().Return(errors.New("command execution failed"))
-
-			err := customize.runCmd(mockCommandBuilder)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("error executing virt-customize command"))
-		})
-	})
-
-	Describe("customizeLinux with static IPs", func() {
-		It("handles static IP configuration", func() {
-			customize.disks = disks
-			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
-
-			expectedPath := filepath.Join(appConfig.Workdir, "macToIP")
-			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n"
-
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			// Static IP file write
-			mockFileSystem.EXPECT().WriteFile(expectedPath, []byte(expectedContent), fs.FileMode(0755)).Return(nil)
-			mockCommandBuilder.EXPECT().AddArg("--upload", fmt.Sprintf("%s:/tmp/macToIP", expectedPath)).Return(mockCommandBuilder)
-
-			// DynamicScriptsDir does not exist
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
-
-			// Scripts
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
-
-			for _, expectedScript := range expectedRunScripts {
-				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, expectedScript := range expectedFirstBootScripts {
-				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(nil)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			err := customize.customizeLinux()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error when static IP file write fails", func() {
-			customize.disks = disks
-			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
-
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			expectedPath := filepath.Join(appConfig.Workdir, "macToIP")
-			expectedContent := "00:11:22:33:44:55:ip:192.168.1.100\n"
-			mockFileSystem.EXPECT().WriteFile(expectedPath, []byte(expectedContent), fs.FileMode(0755)).Return(errors.New("write error"))
-
-			err := customize.customizeLinux()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to write MAC to IP mapping file"))
-		})
-	})
-
-	Describe("customizeLinux with dynamic scripts", func() {
-		It("adds dynamic scripts when directory exists", func() {
-			customize.disks = disks
-
-			dynamicScripts := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "01_linux_run_custom.sh", FileIsDir: false},
-				{FileName: "02_linux_firstboot_init.sh", FileIsDir: false},
-			})
-
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			// DynamicScriptsDir exists
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, nil)
-			mockFileSystem.EXPECT().ReadDir(appConfig.DynamicScriptsDir).Return(dynamicScripts, nil)
-
-			// Dynamic script commands
-			mockCommandBuilder.EXPECT().AddArg("--run", filepath.Join(appConfig.DynamicScriptsDir, "01_linux_run_custom.sh")).Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--firstboot", filepath.Join(appConfig.DynamicScriptsDir, "02_linux_firstboot_init.sh")).Return(mockCommandBuilder)
-
-			// Regular scripts
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
-
-			for _, expectedScript := range expectedRunScripts {
-				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, expectedScript := range expectedFirstBootScripts {
-				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(nil)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			err := customize.customizeLinux()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error when dynamic scripts read fails", func() {
-			customize.disks = disks
-
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			// DynamicScriptsDir exists but ReadDir fails
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, nil)
-			mockFileSystem.EXPECT().ReadDir(appConfig.DynamicScriptsDir).Return(nil, errors.New("read error"))
-
-			err := customize.customizeLinux()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to read scripts directory"))
-		})
-	})
-
-	Describe("customizeLinux with LUKS keys", func() {
-		It("adds LUKS keys from directory", func() {
-			customize.disks = disks
-			appConfig.Luksdir = "/etc/luks"
-
-			luksFiles := utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
-				{FileName: "key1", FileIsDir: false},
-			})
-
-			mockCommandBuilder.EXPECT().New("virt-customize").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
-			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
-
-			// DynamicScriptsDir does not exist
-			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
-
-			// Scripts
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "run")).Return(runScripts, nil)
-			mockFileSystem.EXPECT().ReadDir(filepath.Join(config.V2vOutputDir, "scripts", "rhel", "firstboot")).Return(firstBootScripts, nil)
-
-			for _, expectedScript := range expectedRunScripts {
-				mockCommandBuilder.EXPECT().AddArg("--run", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, expectedScript := range expectedFirstBootScripts {
-				mockCommandBuilder.EXPECT().AddArg("--firstboot", expectedScript).Return(mockCommandBuilder)
-			}
-			for _, disk := range disks {
-				mockCommandBuilder.EXPECT().AddArg("--add", disk).Return(mockCommandBuilder)
-			}
-
-			// LUKS keys
-			mockFileSystem.EXPECT().Stat("/etc/luks").Return(nil, nil)
-			mockFileSystem.EXPECT().ReadDir("/etc/luks").Return(luksFiles, nil)
-			mockCommandBuilder.EXPECT().AddArgs("--key", "all:file:/etc/luks/key1").Return(mockCommandBuilder)
-
-			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-			mockCommandExecutor.EXPECT().Run().Return(nil)
-			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
-			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-
-			err := customize.customizeLinux()
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Describe("addWinFirstbootScripts path selection", func() {
-		It("no static IPs - only init script uploaded", func() {
-			appConfig.StaticIPs = ""
-			mockCommandBuilder.EXPECT().AddArgs("--upload", "", gomock.Any(), "", "").Return(mockCommandBuilder)
-			err := customize.addWinFirstbootScripts(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("static IPs but neither legacy nor registry - skips network config injection", func() {
-			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
-			appConfig.VirtIoWinLegacyDrivers = ""
-			appConfig.WindowsRegistryNetworkConfig = false
-			mockCommandBuilder.EXPECT().AddArgs("--upload", "", gomock.Any(), gomock.Any(), "").Return(mockCommandBuilder)
-			err := customize.addWinFirstbootScripts(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("legacy init path is selected when VirtIoWinLegacyDrivers is set", func() {
-			appConfig.VirtIoWinLegacyDrivers = "/mnt/virtio.iso"
-			appConfig.StaticIPs = ""
-			var capturedInit string
-			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				Do(func(flag string, values ...string) {
-					capturedInit = values[1]
-				}).Return(mockCommandBuilder)
-			err := customize.addWinFirstbootScripts(mockCommandBuilder)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(capturedInit).To(ContainSubstring("9999-run-mtv-ps-scripts-legacy.bat"))
-		})
-
-		It("static IP with legacy returns error on missing template", func() {
-			appConfig.VirtIoWinLegacyDrivers = "/mnt/virtio.iso"
-			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
-			err := customize.addWinFirstbootScripts(mockCommandBuilder)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("inject static IP template"))
-			Expect(err.Error()).To(ContainSubstring("9999-network-config.ps1.tmpl"))
-		})
-
-		It("static IP with registry returns error referencing registry template", func() {
-			appConfig.WindowsRegistryNetworkConfig = true
-			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
-			err := customize.addWinFirstbootScripts(mockCommandBuilder)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("9999-network-config-registry.ps1.tmpl"))
-		})
-	})
-
-})
+func TestRenderTemplate_MissingTemplate(t *testing.T) {
+	dir := t.TempDir()
+	err := renderTemplate("/nonexistent/template.tmpl", filepath.Join(dir, "out.ps1"), nil)
+	if err == nil {
+		t.Error("expected error for missing template")
+	}
+}
+
+func TestInjectAdvancedNetworkSettings_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	c := &Customize{
+		appConfig: &config.AppConfig{Workdir: dir},
+	}
+	err := c.injectAdvancedNetworkSettingsTemplate(dir)
+	if !errors.Is(err, ErrNoAdvancedNetSettings) {
+		t.Errorf("expected ErrNoAdvancedNetSettings, got %v", err)
+	}
+}
+
+func TestInjectAdvancedNetworkSettings_AllDefaults(t *testing.T) {
+	dir := t.TempDir()
+	settings := &advancednet.AdvancedNetSettings{
+		LanmanServerStart: advancednet.LanmanServerStartAutomatic,
+	}
+	if err := advancednet.WriteSettingsFile(settings, dir); err != nil {
+		t.Fatal(err)
+	}
+	c := &Customize{
+		appConfig: &config.AppConfig{Workdir: dir},
+	}
+	err := c.injectAdvancedNetworkSettingsTemplate(dir)
+	if !errors.Is(err, ErrNoAdvancedNetSettings) {
+		t.Errorf("expected ErrNoAdvancedNetSettings for default settings, got %v", err)
+	}
+}
+
+func TestInjectAdvancedNetworkSettings_RendersJSONScript(t *testing.T) {
+	dir := t.TempDir()
+
+	settings := &advancednet.AdvancedNetSettings{
+		Interfaces: []advancednet.InterfaceSettings{
+			{
+				MAC:                 "00:50:56:BE:56:A1",
+				InterfaceMetric:     25,
+				RegistrationEnabled: 0,
+				NetbiosOptions:      2,
+			},
+		},
+		LanmanServerStart:          4,
+		FilePrinterSharingDisabled: []advancednet.AdapterRef{{GUID: "{TEST}", MAC: "00:50:56:BE:56:A1"}},
+	}
+	if err := advancednet.WriteSettingsFile(settings, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	tmplPath := filepath.Join(dir, "9998-advanced-network-settings.ps1.tmpl")
+	tmplContent := "$settingsJson = '{{.SettingsJSON}}'\n"
+	if err := os.WriteFile(tmplPath, []byte(tmplContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Customize{
+		appConfig: &config.AppConfig{Workdir: dir},
+	}
+	if err := c.injectAdvancedNetworkSettingsTemplate(dir); err != nil {
+		t.Fatalf("injectAdvancedNetworkSettingsTemplate: %v", err)
+	}
+
+	outPath := filepath.Join(dir, "9998-advanced-network-settings.ps1")
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	rendered := string(got)
+
+	prefix := "$settingsJson = '"
+	suffix := "'"
+	start := strings.Index(rendered, prefix)
+	if start == -1 {
+		t.Fatalf("rendered script missing settingsJson assignment:\n%s", rendered)
+	}
+	start += len(prefix)
+	end := strings.Index(rendered[start:], suffix)
+	if end == -1 {
+		t.Fatalf("rendered script missing closing quote:\n%s", rendered)
+	}
+	jsonValue := rendered[start : start+end]
+
+	var roundTrip advancednet.AdvancedNetSettings
+	if err := json.Unmarshal([]byte(jsonValue), &roundTrip); err != nil {
+		t.Fatalf("JSON unmarshal failed: %v\nraw: %s", err, jsonValue)
+	}
+	if len(roundTrip.Interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(roundTrip.Interfaces))
+	}
+	if roundTrip.Interfaces[0].InterfaceMetric != 25 {
+		t.Errorf("InterfaceMetric: expected 25, got %d", roundTrip.Interfaces[0].InterfaceMetric)
+	}
+	if roundTrip.LanmanServerStart != 4 {
+		t.Errorf("LanmanServerStart: expected 4, got %d", roundTrip.LanmanServerStart)
+	}
+	if len(roundTrip.FilePrinterSharingDisabled) != 1 {
+		t.Errorf("FilePrinterSharingDisabled: expected 1, got %d", len(roundTrip.FilePrinterSharingDisabled))
+	}
+}
+
+func TestInjectAdvancedNetworkSettings_RealFailurePropagates(t *testing.T) {
+	dir := t.TempDir()
+
+	settings := &advancednet.AdvancedNetSettings{
+		LanmanServerStart: 4,
+	}
+	if err := advancednet.WriteSettingsFile(settings, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Customize{
+		appConfig: &config.AppConfig{Workdir: dir},
+	}
+	// No template file exists so renderTemplate should fail with a real error
+	err := c.injectAdvancedNetworkSettingsTemplate(dir)
+	if err == nil {
+		t.Fatal("expected error when template file is missing")
+	}
+	if errors.Is(err, ErrNoAdvancedNetSettings) {
+		t.Error("missing template should not return ErrNoAdvancedNetSettings")
+	}
+}

--- a/pkg/virt-v2v/customize/scripts/windows/9998-advanced-network-settings.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9998-advanced-network-settings.ps1.tmpl
@@ -1,0 +1,154 @@
+# Advanced Network Settings — firstboot script (runs before static IP assignment).
+#
+# Script flow:
+#   1. Parse embedded JSON settings (populated at template render time).
+#   2. For each interface entry, find the adapter by MAC (poll up to 30s).
+#   3. Apply per-adapter settings: InterfaceMetric, DNS registration, NetBIOS.
+#   4. Set LanmanServer service startup type globally (if non-default).
+#   5. Unbind "File & Printer Sharing" on adapters that had it disabled on source.
+
+$settingsJson = '{{.SettingsJSON}}'
+$adapterWaitSeconds = 30
+
+Write-Host "=============================================="
+Write-Host "[INFO] MTV Advanced Network Settings Script"
+Write-Host "=============================================="
+
+try {
+    $settings = $settingsJson | ConvertFrom-Json
+} catch {
+    Write-Error "[FAIL] Failed to parse settings JSON: $_"
+    exit 1
+}
+
+function Find-AdapterByMAC($mac) {
+    $startTime = Get-Date
+    $deadline = $startTime.AddSeconds($adapterWaitSeconds)
+
+    while ((Get-Date) -lt $deadline) {
+        $adapters = Get-NetAdapter -Physical -ErrorAction SilentlyContinue
+        foreach ($a in $adapters) {
+            if ($a.MacAddress -and ($a.MacAddress.ToUpper().Replace(":", "-") -eq $mac.ToUpper().Replace(":", "-"))) {
+                $elapsed = ((Get-Date) - $startTime).TotalSeconds
+                Write-Host "[INFO] Found adapter '$($a.Name)' (MAC=$mac) after $([math]::Round($elapsed))s"
+                return $a
+            }
+        }
+        Start-Sleep -Seconds 2
+    }
+    return $null
+}
+
+$adaptersProcessed = 0
+$failCount = 0
+
+# Per-interface settings (only physical adapters with resolved MACs)
+foreach ($iface in $settings.interfaces) {
+    $mac = $iface.mac
+    Write-Host ""
+    Write-Host "--- Interface: $mac ---"
+
+    $adapter = Find-AdapterByMAC $mac
+    if ($adapter -eq $null) {
+        Write-Warning "[FAIL] Adapter $mac not found after waiting ${adapterWaitSeconds}s"
+        $failCount++
+        continue
+    }
+
+    $idx = $adapter.ifIndex
+    $name = $adapter.Name
+
+    # InterfaceMetric
+    if (-not $iface.interfaceMetricAuto -and $iface.interfaceMetric -gt 0) {
+        Write-Host "[INFO] Setting InterfaceMetric=$($iface.interfaceMetric) on '$name'"
+        try {
+            Set-NetIPInterface -InterfaceIndex $idx -InterfaceMetric $iface.interfaceMetric -ErrorAction Stop
+            Write-Host "[OK] InterfaceMetric set"
+        } catch {
+            Write-Warning "[FAIL] InterfaceMetric: $_"
+            $failCount++
+        }
+    }
+
+    # DNS Registration (RegistrationEnabled=0 means disabled)
+    if ($iface.registrationEnabled -eq 0) {
+        Write-Host "[INFO] Disabling DNS registration on '$name'"
+        try {
+            Set-DnsClient -InterfaceIndex $idx -RegisterThisConnectionsAddress $false -ErrorAction Stop
+            Write-Host "[OK] DNS registration disabled"
+        } catch {
+            Write-Warning "[FAIL] DNS registration: $_"
+            $failCount++
+        }
+    }
+
+    # NetBIOS over TCP/IP (registry write — no clean cmdlet)
+    if ($iface.netbiosOptions -eq 1 -or $iface.netbiosOptions -eq 2) {
+        $guid = $adapter.InterfaceGuid
+        $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters\Interfaces\Tcpip_$guid"
+        if (Test-Path $regPath) {
+            Write-Host "[INFO] Setting NetbiosOptions=$($iface.netbiosOptions) on '$name'"
+            try {
+                Set-ItemProperty -Path $regPath -Name "NetbiosOptions" -Value $iface.netbiosOptions -Type DWord -ErrorAction Stop
+                Write-Host "[OK] NetbiosOptions set"
+            } catch {
+                Write-Warning "[FAIL] NetbiosOptions: $_"
+                $failCount++
+            }
+        } else {
+            Write-Warning "[WARN] NetBT registry path not found: $regPath"
+        }
+    }
+
+    $adaptersProcessed++
+}
+
+# Global: LanmanServer start type
+if ($settings.lanmanServerStart -ne 0 -and $settings.lanmanServerStart -ne 2) {
+    $typeMap = @{ 3 = 'Manual'; 4 = 'Disabled' }
+    $startType = $typeMap[[int]$settings.lanmanServerStart]
+    if ($startType) {
+        Write-Host ""
+        Write-Host "[INFO] Setting LanmanServer startup to '$startType'"
+        try {
+            Set-Service -Name LanmanServer -StartupType $startType -ErrorAction Stop
+            Write-Host "[OK] LanmanServer startup set"
+        } catch {
+            Write-Warning "[FAIL] LanmanServer startup: $_"
+            $failCount++
+        }
+    } else {
+        Write-Warning "[WARN] Unexpected lanmanServerStart value: $($settings.lanmanServerStart)"
+    }
+}
+
+# Per-adapter File & Printer Sharing (only adapters with resolved MACs)
+if ($settings.filePrinterSharingDisabledAdapters -and $settings.filePrinterSharingDisabledAdapters.Count -gt 0) {
+    foreach ($entry in $settings.filePrinterSharingDisabledAdapters) {
+        $mac = $entry.mac
+        Write-Host ""
+        Write-Host "[INFO] Disabling File & Printer Sharing on MAC=$mac"
+        $adapter = Find-AdapterByMAC $mac
+        if ($adapter) {
+            try {
+                Disable-NetAdapterBinding -InterfaceAlias $adapter.Name -ComponentID ms_server -ErrorAction Stop
+                Write-Host "[OK] ms_server unbound on '$($adapter.Name)'"
+            } catch {
+                Write-Warning "[FAIL] Disable ms_server binding: $_"
+                $failCount++
+            }
+        } else {
+            Write-Warning "[WARN] Adapter MAC=$mac not found for F&PS disable"
+            $failCount++
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "=============================================="
+Write-Host "[INFO] Advanced network settings complete"
+Write-Host "[INFO] Adapters processed: $adaptersProcessed"
+if ($failCount -gt 0) {
+    Write-Warning "[WARN] Failures: $failCount"
+}
+Write-Host "=============================================="


### PR DESCRIPTION
Add a REGF registry parser to extract per-adapter network settings
from the Windows SYSTEM hive after virt-v2v conversion.
MAC addresses are resolved directly from the registry, eliminating any dependency on
provider-supplied NIC MAC lists.

Settings preserved: 

- InterfaceMetric
- DNS registration,
- NetBIOS over TCP/IP,
- LanmanServer start type, and File & Printer Sharing bindings.

Ref: https://redhat.atlassian.net/browse/MTV-5323
Resolves: MTV-5323