### PR TITLE
MTV-5387 | Set SCSI bus for RDM disks mapped as LUN

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1010,7 +1010,7 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 		}
 		if disk.RDM && r.shouldRDMAsLun(vm) {
 			diskDevice = cnv.DiskDevice{
-				LUN: &cnv.LunTarget{Bus: bus},
+				LUN: &cnv.LunTarget{Bus: cnv.DiskBusSCSI},
 			}
 		}
 		kubevirtDisk := cnv.Disk{


### PR DESCRIPTION
When rdmAsLun is enabled, the LUN disk device was inheriting the default virtio bus instead of using SCSI. KubeVirt requires LUN type disks to use the SCSI interface.
Ref: https://redhat.atlassian.net/browse/MTV-5387
Resolves: MTV-5387