### PR TITLE
MTV-5301 | Fix duplicate default routes in registry network config mode

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
@@ -35,9 +35,12 @@ foreach ($gw in $defaultGateways) {
 # Step 2: Clean up duplicate routes (including default gateways)
 Write-Host "Analyzing routes for duplicates..." -ForegroundColor Yellow
 
-# Group ALL routes for duplicate detection  
+# Group routes by destination/gateway/metric, intentionally excluding InterfaceIndex.
+# After migration, stale persistent routes from the source VM's old adapters (e.g. VMware)
+# remain alongside new routes on the target adapter (e.g. VirtIO). These must be grouped
+# together to detect and remove the stale entries.
 $groupedRoutes = $routes | Group-Object {
-    "$($_.DestinationPrefix)-$($_.NextHop)-$($_.RouteMetric)-$($_.InterfaceIndex)"
+    "$($_.DestinationPrefix)-$($_.NextHop)-$($_.RouteMetric)"
 } | Where-Object { $_.Count -gt 1 }
 
 # Separate default gateway duplicates from other duplicates
@@ -56,6 +59,19 @@ if (-not $groupedRoutes) {
     foreach ($group in $gatewayDuplicates) {
         $routes = $group.Group
         
+        # If all interfaces in this group are active, this is a legitimate multi-homed
+        # configuration (same gateway reachable via multiple NICs) — leave it alone.
+        $activeCount = 0
+        foreach ($r in $routes) {
+            if (Get-NetAdapter | Where-Object { $_.InterfaceIndex -eq $r.InterfaceIndex } -ErrorAction SilentlyContinue) {
+                $activeCount++
+            }
+        }
+        if ($activeCount -eq $routes.Count) {
+            Write-Host "  Skipping group '$($group.Name)': all $activeCount interfaces are active (multi-homed)" -ForegroundColor Gray
+            continue
+        }
+
         # Choose the route with an interface that actually exists
         $toKeep = $null
         foreach ($route in $routes) {
@@ -216,7 +232,22 @@ foreach ($gateway in $currentDefaultGateways) {
         $gwList = @($regGateways)
     }
     if ($gwList -contains $nextHop) {
-        Write-Host "    Interface already has gateway $nextHop in registry" -ForegroundColor Green
+        Write-Host "    Interface already has gateway $nextHop in registry DefaultGateway, removing from PersistentRoutes only" -ForegroundColor Green
+        $persistKey = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\PersistentRoutes"
+        if (Test-Path $persistKey) {
+            $routeKeyPrefix = "0.0.0.0,0.0.0.0,$nextHop,"
+            $props = Get-Item -Path $persistKey | Select-Object -ExpandProperty Property
+            foreach ($p in $props) {
+                if ($p.StartsWith($routeKeyPrefix)) {
+                    try {
+                        Remove-ItemProperty -Path $persistKey -Name $p -ErrorAction Stop
+                        Write-Host "    Removed PersistentRoutes entry: $p" -ForegroundColor Green
+                    } catch {
+                        Write-Host "    Failed to remove PersistentRoutes entry '$p': $($_.Exception.Message)" -ForegroundColor Red
+                    }
+                }
+            }
+        }
         continue
     }
 


### PR DESCRIPTION
When feature_windows_registry_network_config is enabled, the remove_duplicate_persistent_routes-registry script used Remove-NetRoute -PolicyStore PersistentStore to clean up redundant routes. This also cleared the DefaultGateway registry key set by the network-config-registry script, leaving the VM with no gateway after reboot.

Fix: when the gateway already exists in the interface-level DefaultGateway registry key, remove only the PersistentRoutes registry entry directly via Remove-ItemProperty, preserving the DefaultGateway value.

Ref: https://redhat.atlassian.net/browse/MTV-5301
Resolves: MTV-5301