### PR TITLE
chore(automation): Bundle SHA reference update for 2-10

### DIFF
--- a/build/forklift-operator-bundle/Containerfile-downstream
+++ b/build/forklift-operator-bundle/Containerfile-downstream
@@ -35,7 +35,7 @@ ARG CLI_DOWNLOAD_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-
 
 ARG VALIDATION_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-validation-rhel9@sha256:bc987cdc88d68d8cfda810f7eaf6c063e262ad3675ba177ec4a463fdb4e6c23a"
 
-ARG VIRT_V2V_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel10@sha256:b21e6dd37522931db0181312c967c12bc1054924a48eafc95cadc22bb783e9ca"
+ARG VIRT_V2V_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel10@sha256:339c3385bcd3cf2ffcb4e51319e300d3e9f284fccf137694638dafcaff4c047f"
 
 ARG VIRT_V2V_IMAGE_RHEL9="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel9@sha256:cf70ae43a8c82bcdc61fc6443ed4a6247ca2591ab8ea0976083f68a903459297"
 


### PR DESCRIPTION
This PR updates the SHA references in Containerfile-downstream files based on the latest snapshot for version 2-10.

## Changes
- Updated SHA references in all Containerfile-downstream files
- Generated from latest snapshot: forklift-operator-2-10-20260518-193314-000

## Automated Update
This PR was created automatically by the mtv-releng update script.