### PR TITLE
chore(version): bump z-stream version to 5.0.0

### DIFF
--- a/build/release.conf
+++ b/build/release.conf
@@ -1,5 +1,5 @@
 # Global version specifying version for every component and for bundle, format "x.y.z"
-MTV_VERSION=2.12.0
+MTV_VERSION=5.0.0
 
 # Release version, format "vX.Y"
 RELEASE=v2.12


### PR DESCRIPTION
Automated z-stream version bump.

Updates version from `2.12.0` → `5.0.0` in `build/release.conf`.