### PR TITLE
MTV-5555 | Fix Windows firstboot scripts for Constrained Language Mode

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config-registry.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config-registry.ps1.tmpl
@@ -6,16 +6,21 @@
 $inputString = "{{.InputString}}"
 $adapterWaitMinutes = 5
 
+# Lookup table avoids [Convert]::ToInt32() which is blocked in Constrained Language Mode
+$PrefixToMaskTable = @(
+    "0.0.0.0",         "128.0.0.0",       "192.0.0.0",       "224.0.0.0",
+    "240.0.0.0",       "248.0.0.0",       "252.0.0.0",       "254.0.0.0",
+    "255.0.0.0",       "255.128.0.0",     "255.192.0.0",     "255.224.0.0",
+    "255.240.0.0",     "255.248.0.0",     "255.252.0.0",     "255.254.0.0",
+    "255.255.0.0",     "255.255.128.0",   "255.255.192.0",   "255.255.224.0",
+    "255.255.240.0",   "255.255.248.0",   "255.255.252.0",   "255.255.254.0",
+    "255.255.255.0",   "255.255.255.128", "255.255.255.192", "255.255.255.224",
+    "255.255.255.240", "255.255.255.248", "255.255.255.252", "255.255.255.254",
+    "255.255.255.255"
+)
+
 function Convert-PrefixToMask($prefix) {
-    $bin = ("1" * $prefix).PadRight(32, "0")
-    $mask = ""
-    for ($i = 0; $i -lt 32; $i += 8) {
-        $chunk = $bin.Substring($i, 8)
-        $num = [Convert]::ToInt32($chunk, 2)
-        if ($mask -ne "") { $mask = $mask + "." }
-        $mask = $mask + $num
-    }
-    return $mask
+    return $PrefixToMaskTable[[int]$prefix]
 }
 
 function Find-AdapterByMAC($mac) {
@@ -28,7 +33,7 @@ function Find-AdapterByMAC($mac) {
         foreach ($a in $adapters) {
             if ($a.MacAddress -and ($a.MacAddress.ToUpper().Replace(":", "-") -eq $mac)) {
                 $elapsed = ((Get-Date) - $startTime).TotalSeconds
-                Write-Host "[INFO] Found adapter '$($a.Name)' (GUID=$($a.InterfaceGuid)) after $([math]::Round($elapsed))s"
+                Write-Host "[INFO] Found adapter '$($a.Name)' (GUID=$($a.InterfaceGuid)) after $([int]$elapsed)s"
                 return $a
             }
         }

--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
@@ -7,18 +7,21 @@
 $inputString = "{{.InputString}}"
 
 
+# Lookup table avoids [Convert]::ToInt32() which is blocked in Constrained Language Mode
+$PrefixToMaskTable = @(
+    "0.0.0.0",         "128.0.0.0",       "192.0.0.0",       "224.0.0.0",
+    "240.0.0.0",       "248.0.0.0",       "252.0.0.0",       "254.0.0.0",
+    "255.0.0.0",       "255.128.0.0",     "255.192.0.0",     "255.224.0.0",
+    "255.240.0.0",     "255.248.0.0",     "255.252.0.0",     "255.254.0.0",
+    "255.255.0.0",     "255.255.128.0",   "255.255.192.0",   "255.255.224.0",
+    "255.255.240.0",   "255.255.248.0",   "255.255.252.0",   "255.255.254.0",
+    "255.255.255.0",   "255.255.255.128", "255.255.255.192", "255.255.255.224",
+    "255.255.255.240", "255.255.255.248", "255.255.255.252", "255.255.255.254",
+    "255.255.255.255"
+)
+
 function Convert-PrefixToMask($prefix) {
-    $bin = ("1" * $prefix).PadRight(32, "0")
-    $mask = ""
-    for ($i = 0; $i -lt 32; $i += 8) {
-        $chunk = $bin.Substring($i, 8)
-        $num = [Convert]::ToInt32($chunk, 2)
-        if ($mask -ne "") {
-            $mask = $mask + "."
-        }
-        $mask = $mask + $num
-    }
-    return $mask
+    return $PrefixToMaskTable[[int]$prefix]
 }
 
 # Split entries by '_'
@@ -60,19 +63,13 @@ foreach ($entry in $entries) {
         $iface = $adapter.NetConnectionID
         Write-Host "Using interface: $iface`n"
 
-       $cmd = "netsh interface ip set address name=`"$iface`" static $ip $mask $gw"
-       # Use WScript.Shell COM object to run netsh commands:
-       # - The '0' parameter hides the command window (runs silently)
-       # - The '$true' parameter ensures the script waits for the command to finish before continuing
-       $wshell = New-Object -ComObject WScript.Shell
-       $wshell.Run($cmd, 0, $true)
+       # Use cmd /c instead of COM objects (blocked in Constrained Language Mode)
+       cmd /c "netsh interface ip set address name=`"$iface`" static $ip $mask $gw" 2>&1 | Out-Null
 
-       $cmd = "netsh interface ip set dns name=`"$iface`" static $dns1"
-       $wshell.Run($cmd, 0, $true)
+       cmd /c "netsh interface ip set dns name=`"$iface`" static $dns1" 2>&1 | Out-Null
         
         if ($dns2 -ne "") {
-            $cmd = "netsh interface ip add dns name=`"$iface`" $dns2 index=2"
-            $wshell.Run($cmd, 0, $true)
+            cmd /c "netsh interface ip add dns name=`"$iface`" $dns2 index=2" 2>&1 | Out-Null
         } 
         
         Write-Host "IP configuration applied`n"

--- a/pkg/virt-v2v/customize/scripts/windows/9999-preserve_complementry_ips_per_nic-registry.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-preserve_complementry_ips_per_nic-registry.ps1.tmpl
@@ -3,16 +3,21 @@
 
 $adapterWaitMinutes = 5
 
+# Lookup table avoids [Convert]::ToInt32() which is blocked in Constrained Language Mode
+$PrefixToMaskTable = @(
+    "0.0.0.0",         "128.0.0.0",       "192.0.0.0",       "224.0.0.0",
+    "240.0.0.0",       "248.0.0.0",       "252.0.0.0",       "254.0.0.0",
+    "255.0.0.0",       "255.128.0.0",     "255.192.0.0",     "255.224.0.0",
+    "255.240.0.0",     "255.248.0.0",     "255.252.0.0",     "255.254.0.0",
+    "255.255.0.0",     "255.255.128.0",   "255.255.192.0",   "255.255.224.0",
+    "255.255.240.0",   "255.255.248.0",   "255.255.252.0",   "255.255.254.0",
+    "255.255.255.0",   "255.255.255.128", "255.255.255.192", "255.255.255.224",
+    "255.255.255.240", "255.255.255.248", "255.255.255.252", "255.255.255.254",
+    "255.255.255.255"
+)
+
 function Convert-PrefixToMask($prefix) {
-    $bin = ("1" * [int]$prefix).PadRight(32, "0")
-    $mask = ""
-    for ($i = 0; $i -lt 32; $i += 8) {
-        $chunk = $bin.Substring($i, 8)
-        $num = [Convert]::ToInt32($chunk, 2)
-        if ($mask -ne "") { $mask = $mask + "." }
-        $mask = $mask + $num
-    }
-    return $mask
+    return $PrefixToMaskTable[[int]$prefix]
 }
 
 # Wait for the netkvm (virtio-net) driver to become active.
@@ -80,8 +85,8 @@ foreach ($config in $networkConfigs) {
     Write-Host "[INFO] Existing IPs: $($existingIPs -join ', ')"
 
     $mask = Convert-PrefixToMask $config.PrefixLength
-    $allIPs = [System.Collections.ArrayList]@($existingIPs)
-    $allMasks = [System.Collections.ArrayList]@($existingMasks)
+    $allIPs = @() + $existingIPs
+    $allMasks = @() + $existingMasks
 
     foreach ($ip in $config.IPs) {
         if ($allIPs -contains $ip) {
@@ -89,8 +94,8 @@ foreach ($config in $networkConfigs) {
             continue
         }
         Write-Host "[INFO] Adding complementary IP: $ip"
-        $allIPs.Add($ip) | Out-Null
-        $allMasks.Add($mask) | Out-Null
+        $allIPs += $ip
+        $allMasks += $mask
     }
 
     if ($allIPs.Count -eq $existingIPs.Count) {

--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
@@ -2,17 +2,21 @@
 
 Write-Host "Starting persistent route cleanup script..." -ForegroundColor Green
 
-# Function to convert CIDR prefix length to subnet mask
-function Convert-PrefixToMask($prefix) {
-    $bin = ("1" * $prefix).PadRight(32, "0")
-    $octets = @(
-        $bin.Substring(0, 8)
-        $bin.Substring(8, 8)
-        $bin.Substring(16, 8)
-        $bin.Substring(24, 8)
-    ) | ForEach-Object { [Convert]::ToInt32($_, 2) }
+# Lookup table avoids [Convert]::ToInt32() which is blocked in Constrained Language Mode
+$PrefixToMaskTable = @(
+    "0.0.0.0",         "128.0.0.0",       "192.0.0.0",       "224.0.0.0",
+    "240.0.0.0",       "248.0.0.0",       "252.0.0.0",       "254.0.0.0",
+    "255.0.0.0",       "255.128.0.0",     "255.192.0.0",     "255.224.0.0",
+    "255.240.0.0",     "255.248.0.0",     "255.252.0.0",     "255.254.0.0",
+    "255.255.0.0",     "255.255.128.0",   "255.255.192.0",   "255.255.224.0",
+    "255.255.240.0",   "255.255.248.0",   "255.255.252.0",   "255.255.254.0",
+    "255.255.255.0",   "255.255.255.128", "255.255.255.192", "255.255.255.224",
+    "255.255.255.240", "255.255.255.248", "255.255.255.252", "255.255.255.254",
+    "255.255.255.255"
+)
 
-    return ($octets -join ".")
+function Convert-PrefixToMask($prefix) {
+    return $PrefixToMaskTable[[int]$prefix]
 }
 
 # Get persistent routes

--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
@@ -2,17 +2,21 @@
 
 Write-Host "Starting persistent route cleanup script..." -ForegroundColor Green
 
-# Function to convert CIDR prefix length to subnet mask
-function Convert-PrefixToMask($prefix) {
-    $bin = ("1" * $prefix).PadRight(32, "0")
-    $octets = @(
-        $bin.Substring(0, 8)
-        $bin.Substring(8, 8)
-        $bin.Substring(16, 8)
-        $bin.Substring(24, 8)
-    ) | ForEach-Object { [Convert]::ToInt32($_, 2) }
+# Lookup table avoids [Convert]::ToInt32() which is blocked in Constrained Language Mode
+$PrefixToMaskTable = @(
+    "0.0.0.0",         "128.0.0.0",       "192.0.0.0",       "224.0.0.0",
+    "240.0.0.0",       "248.0.0.0",       "252.0.0.0",       "254.0.0.0",
+    "255.0.0.0",       "255.128.0.0",     "255.192.0.0",     "255.224.0.0",
+    "255.240.0.0",     "255.248.0.0",     "255.252.0.0",     "255.254.0.0",
+    "255.255.0.0",     "255.255.128.0",   "255.255.192.0",   "255.255.224.0",
+    "255.255.240.0",   "255.255.248.0",   "255.255.252.0",   "255.255.254.0",
+    "255.255.255.0",   "255.255.255.128", "255.255.255.192", "255.255.255.224",
+    "255.255.255.240", "255.255.255.248", "255.255.255.252", "255.255.255.254",
+    "255.255.255.255"
+)
 
-    return ($octets -join ".")
+function Convert-PrefixToMask($prefix) {
+    return $PrefixToMaskTable[[int]$prefix]
 }
 
 # Get persistent routes


### PR DESCRIPTION
Replace .NET method calls blocked by PowerShell Constrained Language Mode (CLM) with CLM-compatible alternatives:

- Convert-PrefixToMask: replace [Convert]::ToInt32() binary-to-decimal conversion with a static CIDR-to-mask lookup table (all 5 scripts)
- Replace [math]::Round() with [int] cast (network-config-registry)
- Replace New-Object -ComObject WScript.Shell with cmd /c calls (network-config legacy)
- Replace [System.Collections.ArrayList] with plain arrays (preserve-complementary-ips-registry)

Tested on CLM-enabled Windows Server 2019 VM with 2 NICs and multiple static IPs. All scripts complete with exit code 0 and subnet masks are correctly written to the registry.

Ref: https://redhat.atlassian.net/browse/MTV-5555
Resolves: MTV-5555