### PR TITLE
MTV-5523 | ocp: exclude mig ID from deletion label selectors

### DIFF
--- a/pkg/controller/plan/context/labeler.go
+++ b/pkg/controller/plan/context/labeler.go
@@ -30,8 +30,14 @@ func (r *Labeler) MigrationLabels() map[string]string {
 	}
 }
 
-func (r *Labeler) VMLabels(vmRef ref.Ref) map[string]string {
+func (r *Labeler) MigrationVMLabels(vmRef ref.Ref) map[string]string {
 	labels := r.MigrationLabels()
+	labels[LabelVM] = vmRef.ID
+	return labels
+}
+
+func (r *Labeler) PlanVMLabels(vmRef ref.Ref) map[string]string {
+	labels := r.PlanLabels()
 	labels[LabelVM] = vmRef.ID
 	return labels
 }

--- a/pkg/controller/plan/ensurer/ensurer.go
+++ b/pkg/controller/plan/ensurer/ensurer.go
@@ -30,7 +30,7 @@ func (r *Ensurer) VirtualMachine(vm *planapi.VMStatus, target *cnv.VirtualMachin
 		context.TODO(),
 		vms,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
@@ -40,7 +40,7 @@ func (r *Ensurer) VirtualMachine(vm *planapi.VMStatus, target *cnv.VirtualMachin
 	}
 
 	if len(vms.Items) == 0 {
-		r.Labeler.SetLabels(target, r.Labeler.VMLabels(vm.Ref))
+		r.Labeler.SetLabels(target, r.Labeler.MigrationVMLabels(vm.Ref))
 		err = r.Destination.Client.Create(context.TODO(), target)
 		if err != nil {
 			err = liberr.Wrap(err)
@@ -66,7 +66,7 @@ func (r *Ensurer) DataVolumes(vm *planapi.VMStatus, dvs []cdi.DataVolume) (err e
 		context.Background(),
 		list,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		})
 	if err != nil {
@@ -81,7 +81,7 @@ func (r *Ensurer) DataVolumes(vm *planapi.VMStatus, dvs []cdi.DataVolume) (err e
 
 	for _, dv := range dvs {
 		if !exists[dv.Annotations[api.AnnDiskSource]] {
-			r.Labeler.SetLabels(&dv, r.Labeler.VMLabels(vm.Ref))
+			r.Labeler.SetLabels(&dv, r.Labeler.MigrationVMLabels(vm.Ref))
 			err = r.Destination.Client.Create(context.Background(), &dv)
 			if err != nil {
 				err = liberr.Wrap(err)
@@ -107,7 +107,7 @@ func (r *Ensurer) PersistentVolumeClaims(vm *planapi.VMStatus, pvcs []core.Persi
 		context.Background(),
 		list,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		})
 	if err != nil {
@@ -122,7 +122,7 @@ func (r *Ensurer) PersistentVolumeClaims(vm *planapi.VMStatus, pvcs []core.Persi
 
 	for _, pvc := range pvcs {
 		if !exists[pvc.Annotations[api.AnnDiskSource]] {
-			r.Labeler.SetLabels(&pvc, r.Labeler.VMLabels(vm.Ref))
+			r.Labeler.SetLabels(&pvc, r.Labeler.MigrationVMLabels(vm.Ref))
 			err = r.Destination.Client.Create(context.Background(), &pvc)
 			if err != nil {
 				err = liberr.Wrap(err)

--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -778,7 +778,7 @@ func (r *LiveMigrator) GetTargetVM(vm *planapi.VMStatus) (target *cnv.VirtualMac
 		context.TODO(),
 		vms,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Context.Plan.Spec.TargetNamespace,
 		},
 	)
@@ -818,7 +818,7 @@ func (r *LiveMigrator) GetTargetVMIM(vm *planapi.VMStatus) (vmim *cnv.VirtualMac
 		context.TODO(),
 		vmims,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Context.Plan.Spec.TargetNamespace,
 		})
 	if err != nil {
@@ -847,7 +847,7 @@ func (r *LiveMigrator) GetSourceVMIM(vm *planapi.VMStatus) (vmim *cnv.VirtualMac
 		context.TODO(),
 		vmims,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     virtualMachine.Namespace,
 		})
 	if err != nil {
@@ -908,7 +908,7 @@ func (r *LiveMigrator) findKubeVirt(inventory web.Client) (kv *cnv.KubeVirt, err
 	}
 }
 
-// DeleteServiceExports deletes the ServiceExports that were created to expose the sync endpooints on
+// DeleteServiceExports deletes the ServiceExports that were created to expose the sync endpoints on
 // the destination cluster.
 func (r *LiveMigrator) DeleteServiceExports(vm *planapi.VMStatus) (err error) {
 	kv, err := r.GetTargetKubeVirt()
@@ -921,7 +921,7 @@ func (r *LiveMigrator) DeleteServiceExports(vm *planapi.VMStatus) (err error) {
 		&multicluster.ServiceExport{},
 		&client.DeleteAllOfOptions{
 			ListOptions: client.ListOptions{
-				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.PlanVMLabels(vm.Ref)),
 				Namespace:     kv.Namespace,
 			},
 		})
@@ -938,7 +938,7 @@ func (r *LiveMigrator) DeleteDataVolumes(vm *planapi.VMStatus) (err error) {
 		&cdi.DataVolume{},
 		&client.DeleteAllOfOptions{
 			ListOptions: client.ListOptions{
-				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.PlanVMLabels(vm.Ref)),
 				Namespace:     r.Plan.Spec.TargetNamespace,
 			},
 		})
@@ -955,7 +955,7 @@ func (r *LiveMigrator) DeletePersistentVolumeClaims(vm *planapi.VMStatus) (err e
 		&core.PersistentVolumeClaim{},
 		&client.DeleteAllOfOptions{
 			ListOptions: client.ListOptions{
-				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.PlanVMLabels(vm.Ref)),
 				Namespace:     r.Plan.Spec.TargetNamespace,
 			},
 		})
@@ -972,7 +972,7 @@ func (r *LiveMigrator) DeleteVirtualMachine(vm *planapi.VMStatus) (err error) {
 		&cnv.VirtualMachine{},
 		&client.DeleteAllOfOptions{
 			ListOptions: client.ListOptions{
-				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.PlanVMLabels(vm.Ref)),
 				Namespace:     r.Plan.Spec.TargetNamespace,
 			},
 		})
@@ -995,7 +995,7 @@ func (r *LiveMigrator) DeleteSourceVMIM(vm *planapi.VMStatus) (err error) {
 		&cnv.VirtualMachineInstanceMigration{},
 		&client.DeleteAllOfOptions{
 			ListOptions: client.ListOptions{
-				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.PlanVMLabels(vm.Ref)),
 				Namespace:     inventoryVm.Namespace,
 			},
 		})
@@ -1012,7 +1012,7 @@ func (r *LiveMigrator) DeleteTargetVMIM(vm *planapi.VMStatus) (err error) {
 		&cnv.VirtualMachineInstanceMigration{},
 		&client.DeleteAllOfOptions{
 			ListOptions: client.ListOptions{
-				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.PlanVMLabels(vm.Ref)),
 				Namespace:     r.Plan.Spec.TargetNamespace,
 			},
 		})
@@ -1029,7 +1029,7 @@ func (r *LiveMigrator) DeleteJobs(vm *planapi.VMStatus) (err error) {
 		&batch.Job{},
 		&client.DeleteAllOfOptions{
 			ListOptions: client.ListOptions{
-				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+				LabelSelector: k8slabels.SelectorFromSet(r.Labeler.PlanVMLabels(vm.Ref)),
 				Namespace:     r.Plan.Spec.TargetNamespace,
 			},
 		})
@@ -1053,7 +1053,7 @@ func (r *Ensurer) EnsureOwnerReferences(vm *planapi.VMStatus) (err error) {
 		context.TODO(),
 		vms,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
@@ -1071,7 +1071,7 @@ func (r *Ensurer) EnsureOwnerReferences(vm *planapi.VMStatus) (err error) {
 		context.Background(),
 		dvs,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		})
 	if err != nil {
@@ -1096,7 +1096,7 @@ func (r *Ensurer) EnsureOwnerReferences(vm *planapi.VMStatus) (err error) {
 		context.Background(),
 		pvcs,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		})
 	if err != nil {
@@ -1126,7 +1126,7 @@ func (r *Ensurer) EnsureTargetVMIM(vm *planapi.VMStatus, target *cnv.VirtualMach
 		context.TODO(),
 		list,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
@@ -1163,7 +1163,7 @@ func (r *Ensurer) EnsureSourceVMIM(vm *planapi.VMStatus, source *cnv.VirtualMach
 		context.TODO(),
 		list,
 		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.VMLabels(vm.Ref)),
+			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
@@ -1321,9 +1321,9 @@ func (r *Builder) VirtualMachine(vm *planapi.VMStatus) (object *cnv.VirtualMachi
 	object.Name = source.Name
 	object.Namespace = r.Plan.Spec.TargetNamespace
 	r.Labeler.SetLabels(object, source.Object.Labels)
-	r.Labeler.SetLabels(object, r.Labeler.VMLabels(vm.Ref))
+	r.Labeler.SetLabels(object, r.Labeler.MigrationVMLabels(vm.Ref))
 	r.Labeler.SetAnnotations(object, source.Object.Annotations)
-	r.Labeler.SetAnnotations(object, r.Labeler.VMLabels(vm.Ref))
+	r.Labeler.SetAnnotations(object, r.Labeler.MigrationVMLabels(vm.Ref))
 	r.Labeler.SetAnnotation(object, AnnSource, key.String())
 
 	// preserve the original runstrategy so that it can be applied
@@ -1408,8 +1408,8 @@ func (r *Builder) DataVolumes(vm *planapi.VMStatus) (dvs []cdi.DataVolume, err e
 			return
 		}
 		target := r.targetDataVolume(source, pvc, storage)
-		r.Labeler.SetLabels(&target, r.Labeler.VMLabels(vm.Ref))
-		r.Labeler.SetAnnotations(&target, r.Labeler.VMLabels(vm.Ref))
+		r.Labeler.SetLabels(&target, r.Labeler.MigrationVMLabels(vm.Ref))
+		r.Labeler.SetAnnotations(&target, r.Labeler.MigrationVMLabels(vm.Ref))
 		r.Labeler.SetAnnotation(&target, AnnDiskSource, path.Join(pvc.Namespace, pvc.Name))
 		r.Labeler.SetAnnotation(&target, AnnVolumeName, vol.Name)
 		dvs = append(dvs, target)
@@ -1464,8 +1464,8 @@ func (r *Builder) PersistentVolumeClaims(vm *planapi.VMStatus) (pvcs []core.Pers
 			return
 		}
 		target := r.targetPvc(source, storage)
-		r.Labeler.SetLabels(&target, r.Labeler.VMLabels(vm.Ref))
-		r.Labeler.SetAnnotations(&target, r.Labeler.VMLabels(vm.Ref))
+		r.Labeler.SetLabels(&target, r.Labeler.MigrationVMLabels(vm.Ref))
+		r.Labeler.SetAnnotations(&target, r.Labeler.MigrationVMLabels(vm.Ref))
 		r.Labeler.SetAnnotation(&target, AnnDiskSource, path.Join(source.Namespace, source.Name))
 		r.Labeler.SetAnnotation(&target, AnnVolumeName, vol.Name)
 		pvcs = append(pvcs, target)
@@ -1729,7 +1729,7 @@ func (r *Builder) TargetVMIM(vm *planapi.VMStatus) (vmim *cnv.VirtualMachineInst
 	vmim = &cnv.VirtualMachineInstanceMigration{}
 	vmim.GenerateName = "forklift-"
 	vmim.Namespace = r.Context.Plan.Spec.TargetNamespace
-	vmim.Labels = r.Labeler.VMLabels(vm.Ref)
+	vmim.Labels = r.Labeler.MigrationVMLabels(vm.Ref)
 	vmim.Spec.VMIName = inventoryVm.Name
 	vmim.Spec.Receive = &cnv.VirtualMachineInstanceMigrationTarget{
 		MigrationID: r.kubevirtMigrationID(vm),
@@ -1748,7 +1748,7 @@ func (r *Builder) SourceVMIM(vm *planapi.VMStatus, syncAddress string) (vmim *cn
 	vmim = &cnv.VirtualMachineInstanceMigration{}
 	vmim.GenerateName = "forklift-"
 	vmim.Namespace = inventoryVm.Namespace
-	vmim.Labels = r.Labeler.VMLabels(vm.Ref)
+	vmim.Labels = r.Labeler.MigrationVMLabels(vm.Ref)
 	vmim.Spec.VMIName = inventoryVm.Name
 	vmim.Spec.SendTo = &cnv.VirtualMachineInstanceMigrationSource{
 		MigrationID: r.kubevirtMigrationID(vm),

--- a/pkg/provider/ec2/controller/builder/volumes.go
+++ b/pkg/provider/ec2/controller/builder/volumes.go
@@ -206,7 +206,7 @@ func (r *Builder) BuildPersistentVolume(vmRef ref.Ref, volumeInfo *VolumeInfo, p
 	storageClass := r.findStorageMapping(volumeInfo.VolumeType)
 	blockMode := core.PersistentVolumeBlock
 
-	pvLabels := r.Labeler.VMLabels(vmRef)
+	pvLabels := r.Labeler.MigrationVMLabels(vmRef)
 	pvLabels["forklift.konveyor.io/ebs-volume-id"] = volumeInfo.EBSVolumeID
 
 	pv := &core.PersistentVolume{
@@ -274,7 +274,7 @@ func (r *Builder) BuildDirectPVC(vmRef ref.Ref, volumeInfo *VolumeInfo, index in
 	volumeSizeBytes := volumeInfo.SizeGiB * 1024 * 1024 * 1024
 	pvcSize := r.calculatePVCSize(volumeSizeBytes, &blockMode)
 
-	pvcLabels := r.Labeler.VMLabels(vmRef)
+	pvcLabels := r.Labeler.MigrationVMLabels(vmRef)
 	// volume-id label stores the source EC2 volume ID - used by mapDisks in vm.go
 	// to match PVCs to the source instance's BlockDeviceMappings
 	pvcLabels["forklift.konveyor.io/volume-id"] = volumeInfo.OriginalVolumeID

--- a/pkg/provider/ec2/controller/ensurer/volumes.go
+++ b/pkg/provider/ec2/controller/ensurer/volumes.go
@@ -20,7 +20,7 @@ func (r *Ensurer) EnsurePersistentVolumes(ctx context.Context, vm *planapi.VMSta
 
 	// List existing PVs by label
 	existingPVList := &core.PersistentVolumeList{}
-	vmLabels := r.Labeler.VMLabels(vm.Ref)
+	vmLabels := r.Labeler.MigrationVMLabels(vm.Ref)
 	err := r.Client.List(ctx, existingPVList, &client.ListOptions{
 		LabelSelector: k8slabels.SelectorFromSet(vmLabels),
 	})
@@ -98,7 +98,7 @@ func (r *Ensurer) EnsureDirectPVCs(ctx context.Context, vm *planapi.VMStatus, pv
 
 	// List existing PVCs by label
 	existingPVCList := &core.PersistentVolumeClaimList{}
-	vmLabels := r.Labeler.VMLabels(vm.Ref)
+	vmLabels := r.Labeler.MigrationVMLabels(vm.Ref)
 	err := r.Client.List(ctx, existingPVCList, &client.ListOptions{
 		Namespace:     r.Plan.Spec.TargetNamespace,
 		LabelSelector: k8slabels.SelectorFromSet(vmLabels),
@@ -168,7 +168,7 @@ func (r *Ensurer) EnsureDirectPVCs(ctx context.Context, vm *planapi.VMStatus, pv
 func (r *Ensurer) CheckDirectPVCsBound(ctx context.Context, vm *planapi.VMStatus) (allBound bool, err error) {
 	// List existing PVCs by label
 	existingPVCList := &core.PersistentVolumeClaimList{}
-	vmLabels := r.Labeler.VMLabels(vm.Ref)
+	vmLabels := r.Labeler.MigrationVMLabels(vm.Ref)
 	err = r.Client.List(ctx, existingPVCList, &client.ListOptions{
 		Namespace:     r.Plan.Spec.TargetNamespace,
 		LabelSelector: k8slabels.SelectorFromSet(vmLabels),


### PR DESCRIPTION
The OCP Live migrator Delete* methods called when cleaning up after plan execution or when archiving were including the migration ID label as part of the label selector. This is fine during normal cleanup, but when archiving, the plancontext is initialized with an empty migration so the labels will never match.

Fixed by refactoring the Labeler to have a PlanVMLabels method that excludes the migration ID and using it during cleanup. The VMLabels method that includes the migration ID has been renamed to MigrationVMLabels for symmetry.

Resolves: MTV-5523