### PR TITLE
MTV-5328 | ocp: use allocated capacity when creating target volumes for block sources

### DIFF
--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -22,6 +22,7 @@ import (
 	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	cnv "kubevirt.io/api/core/v1"
@@ -1479,7 +1480,11 @@ func (r *Builder) targetPvc(source *model.PersistentVolumeClaim, storage api.Des
 	pvc.Namespace = r.Plan.Spec.TargetNamespace
 	pvc.Name = source.Name
 	pvc.Spec = core.PersistentVolumeClaimSpec{
-		Resources:        source.Object.Spec.Resources,
+		Resources: core.VolumeResourceRequirements{
+			Requests: core.ResourceList{
+				core.ResourceStorage: r.requestSize(source),
+			},
+		},
 		StorageClassName: &storage.StorageClass,
 	}
 	if storage.AccessMode != "" {
@@ -1493,7 +1498,6 @@ func (r *Builder) targetPvc(source *model.PersistentVolumeClaim, storage api.Des
 
 // targetDataVolume creates a target CR based on the source CR.
 func (r *Builder) targetDataVolume(source *model.DataVolume, pvc *model.PersistentVolumeClaim, storage api.DestinationStorage) (dv cdi.DataVolume) {
-	size := pvc.Object.Spec.Resources.Requests["storage"]
 	dv = cdi.DataVolume{}
 	dv.Namespace = r.Plan.Spec.TargetNamespace
 	dv.Name = source.Name
@@ -1508,7 +1512,7 @@ func (r *Builder) targetDataVolume(source *model.DataVolume, pvc *model.Persiste
 		Storage: &cdi.StorageSpec{
 			Resources: core.VolumeResourceRequirements{
 				Requests: core.ResourceList{
-					core.ResourceStorage: size,
+					core.ResourceStorage: r.requestSize(pvc),
 				},
 			},
 			StorageClassName: &storage.StorageClass,
@@ -1529,6 +1533,17 @@ func (r *Builder) targetDataVolume(source *model.DataVolume, pvc *model.Persiste
 		dv.Spec.Storage.VolumeMode = &storage.VolumeMode
 	}
 	return
+}
+
+func (r *Builder) requestSize(pvc *model.PersistentVolumeClaim) resource.Quantity {
+	isBlock := (pvc.Object.Spec.VolumeMode != nil) && (*pvc.Object.Spec.VolumeMode == core.PersistentVolumeBlock)
+	if isBlock {
+		// MTV-5328: some block storage backings may create
+		// the pvc with a capacity that is higher than
+		// the request.
+		return *pvc.Object.Status.Capacity.Storage()
+	}
+	return *pvc.Object.Spec.Resources.Requests.Storage()
 }
 
 // LocalInstanceType builds a copy of a namespace-local InstanceType from the source.

--- a/pkg/controller/plan/migrator/ocp/live_test.go
+++ b/pkg/controller/plan/migrator/ocp/live_test.go
@@ -6,8 +6,11 @@ import (
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/ocp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	cnv "kubevirt.io/api/core/v1"
 )
 
@@ -102,6 +105,100 @@ var _ = Describe("Builder", func() {
 			builder.mapNetworks("source", target)
 			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("target/net-attach-target"))
 		})
+	})
+})
+
+var _ = Describe("requestSize", func() {
+	var builder *Builder
+
+	BeforeEach(func() {
+		builder = &Builder{}
+	})
+
+	It("returns the requested size for filesystem volumes", func() {
+		filesystemMode := core.PersistentVolumeFilesystem
+		pvc := &model.PersistentVolumeClaim{
+			Object: core.PersistentVolumeClaim{
+				Spec: core.PersistentVolumeClaimSpec{
+					VolumeMode: &filesystemMode,
+					Resources: core.VolumeResourceRequirements{
+						Requests: core.ResourceList{
+							core.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{
+					Capacity: core.ResourceList{
+						core.ResourceStorage: resource.MustParse("20Gi"),
+					},
+				},
+			},
+		}
+		size := builder.requestSize(pvc)
+		Expect(size.Equal(resource.MustParse("10Gi"))).To(BeTrue())
+	})
+
+	It("returns the requested size when volume mode is nil", func() {
+		pvc := &model.PersistentVolumeClaim{
+			Object: core.PersistentVolumeClaim{
+				Spec: core.PersistentVolumeClaimSpec{
+					Resources: core.VolumeResourceRequirements{
+						Requests: core.ResourceList{
+							core.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{
+					Capacity: core.ResourceList{
+						core.ResourceStorage: resource.MustParse("20Gi"),
+					},
+				},
+			},
+		}
+		size := builder.requestSize(pvc)
+		Expect(size.Equal(resource.MustParse("10Gi"))).To(BeTrue())
+	})
+
+	It("returns the allocated capacity for block volumes", func() {
+		blockMode := core.PersistentVolumeBlock
+		pvc := &model.PersistentVolumeClaim{
+			Object: core.PersistentVolumeClaim{
+				Spec: core.PersistentVolumeClaimSpec{
+					VolumeMode: &blockMode,
+					Resources: core.VolumeResourceRequirements{
+						Requests: core.ResourceList{
+							core.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{
+					Capacity: core.ResourceList{
+						core.ResourceStorage: resource.MustParse("16Gi"),
+					},
+				},
+			},
+		}
+		size := builder.requestSize(pvc)
+		Expect(size.Equal(resource.MustParse("16Gi"))).To(BeTrue())
+	})
+
+	It("tolerates nil resources", func() {
+		blockMode := core.PersistentVolumeBlock
+		pvc := &model.PersistentVolumeClaim{
+			Object: core.PersistentVolumeClaim{
+				Spec: core.PersistentVolumeClaimSpec{
+					VolumeMode: &blockMode,
+					Resources: core.VolumeResourceRequirements{
+						Requests: core.ResourceList{},
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{
+					Capacity: core.ResourceList{},
+				},
+			},
+		}
+		size := builder.requestSize(pvc)
+		Expect(size.Equal(resource.MustParse("0"))).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION
Some block storage backings might create a volume that is larger than the requested size. (for instance, powerflex creating volumes in 8Gi increments)

To accommodate that, use the source capacity instead of the requested size when creating target volumes for block sources.