### PR TITLE
MTV-5082 | ova: skip unreadable paths when walking appliances

### DIFF
--- a/cmd/provider-common/inventory/scan.go
+++ b/cmd/provider-common/inventory/scan.go
@@ -77,7 +77,13 @@ func findApplianceFiles(directory string) (ovaFiles []string, ovfFiles []string,
 
 	err = filepath.WalkDir(directory, func(path string, info os.DirEntry, err error) error {
 		if err != nil {
-			return err
+			// only fail if the root is unreadable,
+			// otherwise log and move on.
+			if path == directory {
+				return err
+			}
+			log.Printf("Skipping unreadable path %s: %v", path, err)
+			return nil
 		}
 
 		if info.IsDir() {


### PR DESCRIPTION
If the file walker hit an error then the entire scan would be aborted, preventing any appliances from being surfaced in the inventory.

Fixes the problem by only failing if the root of the appliance catalog is unreadable.

Resolves: MTV-5082