### PR TITLE
MTV-5560 | Correctly propagate useConvCR feature flag

### DIFF
--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -202,10 +202,8 @@ spec:
         - name: FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG
           value: "true"
 {% endif %}
-{% if feature_use_conversion_cr|bool %}
         - name: FEATURE_USE_CONVERSION_CR
           value: "{{ feature_use_conversion_cr|bool|lower }}"
-{% endif %}
 {% if ovirt_osmap_configmap_name is defined %}
         - name: OVIRT_OS_MAP
           value: {{ ovirt_osmap_configmap_name }}


### PR DESCRIPTION
Issue: when useConvCR feature flag is set to false, the env var is ignored and the default in settings is true when env var is missing.

Fix: correctly propagate the Fflag

Resolves: MTV-5560