### PR TITLE
[release-2.11] MTV-5548 | Add feature flag to retain populator pods for debugging

### DIFF
--- a/docs/compatibility/forkliftcontroller-settings.md
+++ b/docs/compatibility/forkliftcontroller-settings.md
@@ -62,6 +62,7 @@ Feature gates enable or disable specific Forklift capabilities.
 | `feature_vmware_system_serial_number` | `true` | `FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER` | Use VMware system serial number for migrated VMs |
 | `controller_static_udn_ip_addresses` | `false` | `FEATURE_STATIC_UDN_IP_ADDRESSES` | Enable static IP addresses with User Defined Networks |
 | `controller_retain_precopy_importer_pods` | `false` | `FEATURE_RETAIN_PRECOPY_IMPORTER_PODS` | Retain importer pods during warm migration (debugging) |
+| `controller_retain_populator_pods` | `false` | `FEATURE_RETAIN_POPULATOR_PODS` | Retain populator pods after migration for debugging |
 | `feature_ova_appliance_management` | `false` | `FEATURE_OVF_APPLIANCE_MANAGEMENT` | Enable appliance management for OVF-based providers |
 
 ### Feature Requirements

--- a/docs/enhancements/retain-populator-pods.md
+++ b/docs/enhancements/retain-populator-pods.md
@@ -1,0 +1,210 @@
+---
+title: retain-populator-pods
+authors:
+  - "@yaacov"
+reviewers:
+  - TBD
+approvers:
+  - TBD
+creation-date: 2026-05-18
+last-updated: 2026-05-18
+status: implementable
+---
+
+# Retain Populator Pods for Debugging
+
+## Release Signoff Checklist
+
+- [x] Enhancement is `implementable`
+- [x] Design details are appropriately documented from clear requirements
+- [x] Test plan is defined
+- [ ] User-facing documentation is created
+
+## Summary
+
+A new `FEATURE_RETAIN_POPULATOR_PODS` feature flag (default `false`) prevents
+the migration controller from deleting populator pods during cleanup. When
+enabled, populator pods remain on the cluster after migration completes, fails,
+or is canceled, allowing engineers to inspect logs, exec into containers, and
+examine pod specs for debugging purposes.
+
+## Motivation
+
+Populator-based migrations (oVirt, OpenStack, vSphere copy-offload) create
+short-lived populator pods that transfer data into PVCs. When a migration fails
+or produces unexpected results, the migration controller's `cleanup()` function
+unconditionally deletes these pods before an engineer can investigate. Because
+the pods are gone, the only remaining evidence is whatever the controller
+logged, which is often insufficient to diagnose issues such as:
+
+- Network connectivity failures between the populator and the source
+- Authentication or certificate errors
+- Slow or stalled transfers
+- Unexpected pod restarts or OOM kills
+
+Without the pod, `kubectl logs`, `kubectl exec`, and `kubectl describe pod` are
+unavailable, making root-cause analysis significantly harder.
+
+### Goals
+
+- Allow operators to retain populator pods on demand via a feature flag on the
+  ForkliftController CR.
+- Log a message when the flag is active so it is clear that pods are being
+  intentionally retained.
+- Preserve existing behavior (pods are deleted) when the flag is off.
+
+### Non-Goals
+
+- Retaining PVC' (prime/temporary PVCs) created by the populator machinery.
+- Per-plan or per-VM granularity for the retention flag.
+- Preventing Kubernetes garbage collection when the owning PVC is deleted (see
+  Caveats below).
+
+## Proposal
+
+### User Stories
+
+#### Story 1
+
+As a migration administrator, a populator-based migration from oVirt fails and
+I need to inspect the populator pod's logs and environment to understand why.
+I set `controller_retain_populator_pods: "true"` on the ForkliftController CR
+and `deleteVmOnFailMigration: false` on the Plan (to prevent PVC deletion from
+cascading to the pod via Kubernetes GC). I re-run the migration, and after it
+fails again the populator pod remains so I can run `kubectl logs` and
+`kubectl describe pod` against it.
+
+#### Story 2
+
+As a Forklift developer, I am debugging a new populator implementation and need
+to iterate quickly. I enable the retain flag so that each test run leaves the
+pod around for inspection, then disable it once the issue is resolved.
+
+### Implementation Details
+
+#### Feature Flag
+
+A new constant and struct field in `pkg/settings/features.go`:
+
+```go
+FeatureRetainPopulatorPods = "FEATURE_RETAIN_POPULATOR_PODS"
+```
+
+```go
+RetainPopulatorPods bool
+```
+
+Loaded via `getEnvBool(FeatureRetainPopulatorPods, false)`.
+
+#### Controller Guard
+
+In `pkg/controller/plan/kubevirt.go`, the `DeletePopulatorPods` method
+short-circuits when the flag is enabled:
+
+```go
+func (r *KubeVirt) DeletePopulatorPods(vm *plan.VMStatus) (err error) {
+    if Settings.RetainPopulatorPods {
+        r.Log.Info("Retaining populator pods (feature flag enabled).", "vm", vm.String())
+        return
+    }
+    list, err := r.getPopulatorPods()
+    for _, object := range list {
+        err = r.DeleteObject(&object, vm, "Deleted populator pod.", "pod")
+    }
+    return
+}
+```
+
+#### Operator Wiring
+
+- **Ansible default** (`operator/roles/forkliftcontroller/defaults/main.yml`):
+  `controller_retain_populator_pods: false`
+- **Deployment template** (`deployment-controller.yml.j2`): conditionally sets
+  `FEATURE_RETAIN_POPULATOR_PODS=true` when the Ansible variable is true.
+- **CRD schema** (`forklift.konveyor.io_forkliftcontrollers.yaml`): new string
+  property with enum `["true", "false"]`.
+- **CSV descriptors** (upstream/downstream): hidden spec descriptor for the new
+  field.
+
+#### Caveats
+
+Populator pods are created with an `OwnerReference` pointing to the PVC:
+
+```go
+OwnerReferences: []metav1.OwnerReference{
+    {
+        APIVersion: "v1",
+        Kind:       "PersistentVolumeClaim",
+        Name:       pvc.Name,
+        UID:        pvc.UID,
+    },
+},
+```
+
+If the PVC itself is deleted -- for example, on the failure path when
+`DeleteVmOnFailMigration` is enabled (which is the **default**, `true`) and
+the controller calls `DeletePopulatedPVCs` and `DeleteDataVolumes` --
+Kubernetes garbage collection will delete the populator pod regardless of this
+feature flag. The flag only guards the explicit `DeletePopulatorPods` call in
+`cleanup()`.
+
+**To retain populator pods on the failure path, you must also set
+`deleteVmOnFailMigration: false` on the Plan (or per-VM).** Otherwise the
+default behavior (`deleteVmOnFailMigration: true`) will delete the PVCs,
+which cascades to the populator pods via Kubernetes GC.
+
+Summary of when the flag is effective:
+
+| Scenario | `deleteVmOnFailMigration` | Populator pods retained? |
+|----------|--------------------------|--------------------------|
+| Successful migration | N/A | Yes |
+| Canceled migration | N/A | Yes |
+| Failed migration | `false` | Yes |
+| Failed migration | `true` (default) | **No** -- PVC deletion triggers GC |
+
+### Security, Risks, and Mitigations
+
+**Resource accumulation**: Retained pods consume cluster resources (CPU, memory
+reservations, IP addresses). The flag defaults to `false` and is intended for
+temporary debugging use only. Administrators should disable it after
+investigation is complete.
+
+**No privilege escalation**: The flag only prevents deletion of pods that the
+controller already created. It does not grant new access or capabilities.
+
+## Design Details
+
+### Test Plan
+
+- Unit test verifying that `DeletePopulatorPods` returns immediately without
+  calling `DeleteObject` when `Settings.RetainPopulatorPods` is `true`.
+- Unit test verifying that `DeletePopulatorPods` deletes pods normally when the
+  flag is `false`.
+
+### Upgrade / Downgrade Strategy
+
+No migration of existing resources is required. The flag defaults to `false`,
+preserving the existing behavior where populator pods are always deleted during
+cleanup. Upgrading to a version with this feature has no visible effect unless
+the flag is explicitly enabled.
+
+## Implementation History
+
+- 2026-05-18 - Enhancement proposed and implemented.
+
+## Drawbacks
+
+- Retained pods accumulate if operators forget to disable the flag after
+  debugging.
+- The flag cannot prevent garbage collection of pods whose owning PVC is
+  deleted, limiting its usefulness on certain failure paths.
+
+## Alternatives
+
+1. **Per-plan annotation**: Allow a per-plan annotation to retain pods. More
+   granular but adds API surface and controller complexity.
+2. **TTL-based retention**: Retain pods for a configurable duration, then
+   auto-delete. Avoids accumulation but adds a timer mechanism.
+3. **Remove OwnerReference**: Drop the PVC OwnerReference from populator pods
+   so they survive PVC deletion. This would require manual cleanup in all cases
+   and risks orphaned pods.

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -142,6 +142,13 @@ spec:
               controller_precopy_interval:
                 description: 'Precopy interval in minutes (default: 60)'
                 x-kubernetes-int-or-string: true
+              controller_retain_populator_pods:
+                description: 'Retain populator pods after migration for debugging
+                  (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               controller_retain_precopy_importer_pods:
                 description: 'Retain precopy pods (default: false)'
                 enum:
@@ -8078,6 +8085,12 @@ spec:
       - description: Retain precopy pods (default false)
         displayName: Retain Precopy Importer Pods
         path: controller_retain_precopy_importer_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain populator pods after migration for debugging (default
+          false)
+        displayName: Retain Populator Pods
+        path: controller_retain_populator_pods
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -142,6 +142,13 @@ spec:
               controller_precopy_interval:
                 description: 'Precopy interval in minutes (default: 60)'
                 x-kubernetes-int-or-string: true
+              controller_retain_populator_pods:
+                description: 'Retain populator pods after migration for debugging
+                  (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               controller_retain_precopy_importer_pods:
                 description: 'Retain precopy pods (default: false)'
                 enum:
@@ -8074,6 +8081,12 @@ spec:
       - description: Retain precopy pods (default false)
         displayName: Retain Precopy Importer Pods
         path: controller_retain_precopy_importer_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain populator pods after migration for debugging (default
+          false)
+        displayName: Retain Populator Pods
+        path: controller_retain_populator_pods
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -142,6 +142,13 @@ spec:
               controller_precopy_interval:
                 description: 'Precopy interval in minutes (default: 60)'
                 x-kubernetes-int-or-string: true
+              controller_retain_populator_pods:
+                description: 'Retain populator pods after migration for debugging
+                  (default: false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               controller_retain_precopy_importer_pods:
                 description: 'Retain precopy pods (default: false)'
                 enum:
@@ -8078,6 +8085,12 @@ spec:
       - description: Retain precopy pods (default false)
         displayName: Retain Precopy Importer Pods
         path: controller_retain_precopy_importer_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain populator pods after migration for debugging (default
+          false)
+        displayName: Retain Populator Pods
+        path: controller_retain_populator_pods
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -351,6 +351,10 @@ spec:
                 type: string
                 enum: ["true", "false"]
                 description: "Retain precopy pods (default: false)"
+              controller_retain_populator_pods:
+                type: string
+                enum: ["true", "false"]
+                description: "Retain populator pods after migration for debugging (default: false)"
               controller_static_udn_ip_addresses:
                 type: string
                 enum: ["true", "false"]

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -406,6 +406,11 @@ spec:
         path: controller_retain_precopy_importer_pods
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain populator pods after migration for debugging (default false)
+        displayName: Retain Populator Pods
+        path: controller_retain_populator_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)
         displayName: Static UDN IP Addresses
         path: controller_static_udn_ip_addresses

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -45,6 +45,7 @@ controller_snapshot_removal_check_retries: 20
 controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_retain_precopy_importer_pods: false
+controller_retain_populator_pods: false
 controller_static_udn_ip_addresses: true
 controller_max_vm_inflight: 20
 controller_host_lease_namespace: "openshift-mtv"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -151,6 +151,10 @@ spec:
         - name: FEATURE_RETAIN_PRECOPY_IMPORTER_PODS
           value: "true"
 {% endif %}
+{% if controller_retain_populator_pods|bool %}
+        - name: FEATURE_RETAIN_POPULATOR_PODS
+          value: "true"
+{% endif %}
 {% if feature_ocp_live_migration|bool %}
         - name: FEATURE_OCP_LIVE_MIGRATION
           value: "true"

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -477,6 +477,11 @@ spec:
           path: controller_retain_precopy_importer_pods
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Retain populator pods after migration for debugging (default false)
+          displayName: Retain Populator Pods
+          path: controller_retain_populator_pods
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Enable static udn IP addresses feature (default false)
           displayName: Static UDN IP Addresses
           path: controller_static_udn_ip_addresses

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -481,6 +481,11 @@ spec:
           path: controller_retain_precopy_importer_pods
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Retain populator pods after migration for debugging (default false)
+          displayName: Retain Populator Pods
+          path: controller_retain_populator_pods
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Enable static udn IP addresses feature (default false)
           displayName: Static UDN IP Addresses
           path: controller_static_udn_ip_addresses

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1481,6 +1481,16 @@ func (r *KubeVirt) deletePopulatedPVC(pvc *core.PersistentVolumeClaim, vm *plan.
 
 // Delete any populator pods that belong to a VM's migration.
 func (r *KubeVirt) DeletePopulatorPods(vm *plan.VMStatus) (err error) {
+	if Settings.RetainPopulatorPods {
+		if r.Plan.Spec.DeleteVmOnFailMigration || vm.DeleteVmOnFailMigration {
+			r.Log.Info(
+				"WARNING: FEATURE_RETAIN_POPULATOR_PODS is enabled but DeleteVmOnFailMigration is also set;"+
+					" on failure the PVCs will be deleted and Kubernetes GC will remove the populator pods via OwnerReference.",
+				"vm", vm.String())
+		}
+		r.Log.Info("Retaining populator pods (feature flag enabled).", "vm", vm.String())
+		return
+	}
 	list, err := r.getPopulatorPods()
 	for _, object := range list {
 		err = r.DeleteObject(&object, vm, "Deleted populator pod.", "pod")

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -6,6 +6,7 @@ import (
 
 	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
@@ -385,6 +386,67 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			p.Spec.VirtV2vImage = ""
 			p.Spec.XfsCompatibility = true
 			Expect(getVirtV2vImage(p)).To(Equal(xfsImage))
+		})
+	})
+
+	ginkgo.Describe("DeletePopulatorPods", func() {
+		const migrationUID = "test-migration-uid"
+		const targetNS = "test-ns"
+
+		var savedRetain bool
+
+		ginkgo.BeforeEach(func() {
+			savedRetain = Settings.RetainPopulatorPods
+		})
+		ginkgo.AfterEach(func() {
+			Settings.RetainPopulatorPods = savedRetain
+		})
+
+		createKubeVirtWithPopulatorPod := func() (*KubeVirt, *v1.Pod) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "populate-test-pvc",
+					Namespace: targetNS,
+					Labels: map[string]string{
+						"migration": migrationUID,
+					},
+				},
+			}
+
+			kubevirt := createKubeVirt(pod)
+			kubevirt.Plan.Spec.TargetNamespace = targetNS
+			kubevirt.Plan.Status.Migration.History = []plan.Snapshot{
+				{
+					Migration: plan.SnapshotRef{UID: migrationUID},
+				},
+			}
+			return kubevirt, pod
+		}
+
+		ginkgo.It("should skip deletion when RetainPopulatorPods is true", func() {
+			Settings.RetainPopulatorPods = true
+			kubevirt, _ := createKubeVirtWithPopulatorPod()
+			vm := &plan.VMStatus{}
+
+			err := kubevirt.DeletePopulatorPods(vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			pods, err := kubevirt.getPopulatorPods()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pods).To(HaveLen(1), "populator pod should still exist")
+		})
+
+		ginkgo.It("should delete populator pods when RetainPopulatorPods is false", func() {
+			Settings.RetainPopulatorPods = false
+			kubevirt, _ := createKubeVirtWithPopulatorPod()
+			vm := &plan.VMStatus{}
+
+			err := kubevirt.DeletePopulatorPods(vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			pods, err := kubevirt.getPopulatorPods()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pods).To(BeEmpty(), "populator pod should have been deleted")
 		})
 	})
 

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -18,6 +18,7 @@ const (
 	FeatureOVFApplianceManagement       = "FEATURE_OVF_APPLIANCE_MANAGEMENT"
 	FeatureVsphereVmwareDriverRemoval   = "FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL"
 	FeatureWindowsRegistryNetworkConfig = "FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG"
+	FeatureRetainPopulatorPods          = "FEATURE_RETAIN_POPULATOR_PODS"
 )
 
 // OpenShift version where the FeatureVmwareSystemSerialNumber feature is supported:
@@ -65,6 +66,8 @@ type Features struct {
 	VsphereVmwareDriverRemoval bool
 	// Whether to use registry-based network configuration scripts for Windows static IP setup.
 	WindowsRegistryNetworkConfig bool
+	// Whether populator pods should be retained after migration for debugging.
+	RetainPopulatorPods bool
 }
 
 // isOpenShiftVersionAboveMinimum checks if OpenShift version is above or equal to minimum version using semantic versioning
@@ -103,5 +106,6 @@ func (r *Features) Load() (err error) {
 	r.OVFApplianceManagement = getEnvBool(FeatureOVFApplianceManagement, false)
 	r.VsphereVmwareDriverRemoval = getEnvBool(FeatureVsphereVmwareDriverRemoval, false)
 	r.WindowsRegistryNetworkConfig = getEnvBool(FeatureWindowsRegistryNetworkConfig, false)
+	r.RetainPopulatorPods = getEnvBool(FeatureRetainPopulatorPods, false)
 	return
 }


### PR DESCRIPTION
MANUAL BACKPORT OF https://github.com/kubev2v/forklift/pull/6554

Add FEATURE_RETAIN_POPULATOR_PODS (default false) that skips deletion of populator pods during migration cleanup. When enabled, the controller logs a message and leaves populator pods on the cluster after migration completes, fails, or is canceled, so engineers can inspect logs and pod state.

Changes:
- Feature flag in pkg/settings/features.go
- Early-return guard in DeletePopulatorPods
- Operator wiring: Ansible default, Jinja2 template, CRD, CSV
- Enhancement doc and settings reference update

Note: populator pods have an OwnerReference to the PVC, so Kubernetes GC will still delete them if the PVC itself is removed (e.g. failure path with DeleteVmOnFailMigration enabled).

Ref: https://redhat.atlassian.net/browse/MTV-5548
Resolves: MTV-5548