### PR TITLE
MTV-5437 | DI: orphaned vSphere snapshot after Conversion CR failure

### DIFF
--- a/pkg/controller/conversion/controller.go
+++ b/pkg/controller/conversion/controller.go
@@ -163,6 +163,23 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 			"stage", conversion.Status.Stage)
 	}
 
+	// Safety net: if the pipeline terminates with Phase=Failed and an owned
+	// snapshot is still present (e.g. the failure happened before the divert
+	// logic could redirect to StageRemoveSnapshot, or the snapshotRemoval stage
+	// itself errored and set Phase=Failed internally), submit a best effort
+	// removal task here. If in the primary failure path, the divert in
+	// runDeepInspection clears Status.Snapshot before StageFinished (successful snapshot removal) then this block is a no-op.
+	if conversion.Status.Phase == api.PhaseFailed {
+		ensurer, ensureErr := NewEnsurer(r.Client, r.Log, conversion.Spec)
+		if ensureErr == nil {
+			if _, snapErr := ensurer.RemoveOwnedSnapshot(ctx, conversion); snapErr != nil {
+				r.Log.Error(snapErr, "Failed to trigger snapshot removal for failed Conversion.")
+			}
+		} else {
+			r.Log.Error(ensureErr, "Failed to build Ensurer for snapshot cleanup on failure.")
+		}
+	}
+
 	resolvePhaseConditions(conversion)
 
 	conversion.Status.EndStagingConditions()

--- a/pkg/controller/conversion/ensurer_test.go
+++ b/pkg/controller/conversion/ensurer_test.go
@@ -1,6 +1,7 @@
 package conversion
 
 import (
+	"context"
 	"testing"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -41,6 +42,154 @@ func pvcFilesystem(name, ns string) *core.PersistentVolumeClaim {
 
 func pvcBlock(name, ns string) *core.PersistentVolumeClaim {
 	return pvcWithMode(name, ns, core.PersistentVolumeBlock)
+}
+
+// conversionWithSnapshot builds a minimal DeepInspection Conversion whose
+// controller-owned snapshot has the given MoRef. Pass moref="" to simulate a
+// state where snapshot creation has not yet completed.
+func conversionWithSnapshot(moref string) *api.Conversion {
+	conv := &api.Conversion{
+		ObjectMeta: meta.ObjectMeta{Name: "test-conv", Namespace: "default"},
+		Spec: api.ConversionSpec{
+			Type: api.DeepInspection,
+			// No SNAPSHOT_MOREF in Settings → controller owns the snapshot.
+			Connection: api.Connection{
+				Secret: core.ObjectReference{
+					Name:      "vsphere-secret",
+					Namespace: "default",
+				},
+			},
+		},
+		Status: api.ConversionStatus{
+			Snapshot: &api.SnapshotStatus{
+				Owned: true,
+				Moref: moref,
+			},
+		},
+	}
+	return conv
+}
+
+// TestRemoveOwnedSnapshot_Guards verifies that RemoveOwnedSnapshot returns
+// (true, nil) immediately — without contacting vSphere — for all cases where
+// there is nothing to clean up. This is the guard logic that protects the
+// happy-path (SNAPSHOT_MOREF supplied by caller, non-DeepInspection types, or
+// snapshot not yet created) from triggering an unnecessary removal.
+func TestRemoveOwnedSnapshot_Guards(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		conv     *api.Conversion
+		wantDone bool
+		wantErr  bool
+	}{
+		{
+			name: "non-DeepInspection type is a no-op",
+			conv: &api.Conversion{
+				Spec:   api.ConversionSpec{Type: api.Remote},
+				Status: api.ConversionStatus{Snapshot: &api.SnapshotStatus{Moref: "snapshot-1", Owned: true}},
+			},
+			wantDone: true,
+		},
+		{
+			// SNAPSHOT_MOREF in settings means the caller owns the snapshot;
+			// Status.Snapshot.Owned is false as runPhasePending would set it.
+			name: "snapshot not owned by controller (SNAPSHOT_MOREF was supplied)",
+			conv: &api.Conversion{
+				ObjectMeta: meta.ObjectMeta{Name: "test-conv", Namespace: "default"},
+				Spec: api.ConversionSpec{
+					Type:     api.DeepInspection,
+					Settings: map[string]string{api.SpecSettingsSnapshotMorefKey: "snapshot-2"},
+				},
+				Status: api.ConversionStatus{
+					Snapshot: &api.SnapshotStatus{Owned: false, Moref: "snapshot-2"},
+				},
+			},
+			wantDone: true,
+		},
+		{
+			name:     "snapshot status is nil",
+			conv:     &api.Conversion{Spec: api.ConversionSpec{Type: api.DeepInspection}},
+			wantDone: true,
+		},
+		{
+			name: "snapshot moref is empty (creation not yet completed)",
+			conv: conversionWithSnapshot(""),
+			// moref="" → nothing to remove yet
+			wantDone: true,
+		},
+		{
+			name: "moref set but connection secret name is empty",
+			conv: func() *api.Conversion {
+				c := conversionWithSnapshot("snapshot-3")
+				c.Spec.Connection.Secret.Name = ""
+				return c
+			}(),
+			// must not attempt vSphere; returns error to surface misconfiguration
+			wantDone: false,
+			wantErr:  true,
+		},
+		{
+			name: "moref set but connection secret namespace is empty",
+			conv: func() *api.Conversion {
+				c := conversionWithSnapshot("snapshot-4")
+				c.Spec.Connection.Secret.Namespace = ""
+				return c
+			}(),
+			wantDone: false,
+			wantErr:  true,
+		},
+		{
+			// Secret ref is fully set but the secret does not exist in the cluster.
+			// testEnsurer uses an empty fake client so e.Client.Get returns not-found.
+			name:     "moref set, valid secret ref, but secret not found in cluster",
+			conv:     conversionWithSnapshot("snapshot-5"),
+			wantDone: false,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := testEnsurer(t) // no pre-existing k8s objects needed for guard cases
+			done, err := e.RemoveOwnedSnapshot(ctx, tt.conv)
+
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if done != tt.wantDone {
+				t.Errorf("done = %v, want %v", done, tt.wantDone)
+			}
+		})
+	}
+}
+
+// TestSnapshotOwnedByController checks the predicate that decides whether the
+// controller created (and is responsible for removing) the snapshot.
+func TestSnapshotOwnedByController(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]string
+		want     bool
+	}{
+		{"no settings map", nil, true},
+		{"empty SNAPSHOT_MOREF", map[string]string{api.SpecSettingsSnapshotMorefKey: ""}, true},
+		{"whitespace-only SNAPSHOT_MOREF", map[string]string{api.SpecSettingsSnapshotMorefKey: "   "}, true},
+		{"SNAPSHOT_MOREF provided", map[string]string{api.SpecSettingsSnapshotMorefKey: "snapshot-42"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conv := &api.Conversion{Spec: api.ConversionSpec{Settings: tt.settings}}
+			if got := snapshotOwnedByController(conv); got != tt.want {
+				t.Errorf("snapshotOwnedByController = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestVolumesFromDiskRefs(t *testing.T) {

--- a/pkg/controller/conversion/pipeline.go
+++ b/pkg/controller/conversion/pipeline.go
@@ -211,7 +211,7 @@ func (p *ConversionPipeline) runVirtV2v() (pipelineFinished bool, err error) {
 			p.advanceStage()
 		}
 	case api.StageFinished:
-		return p.podSucceeded()
+		return p.podHandler()
 	default:
 		return false, liberr.New("unknown stage", "stage", p.conv.Status.Stage)
 	}
@@ -246,11 +246,21 @@ func (p *ConversionPipeline) runDeepInspection() (pipelineFinished bool, err err
 	case api.StageWaitForSnapshotRemoval:
 		stageDone, err = p.runStageWaitingForSnapshotRemoval()
 	case api.StageFinished:
-		return p.podSucceeded()
+		return p.podHandler()
 	}
 
 	if err != nil {
 		p.r.Log.Error(err, "Stage failed.", "stage", p.conv.Status.Stage)
+		// When the controller owns the snapshot and it already exists, divert to the snapshot removal stages instead of propagating the error immediately.
+		// This ensures the snapshot is cleaned up via the normal polling path before the pipeline terminates. The pod failure is then detected again at StageFinished by podHandler and pipeline is set as failed.
+		if snapshotOwnedByController(p.conv) &&
+			p.conv.Status.Snapshot != nil &&
+			p.conv.Status.Snapshot.Moref != "" {
+			p.r.Log.Info("Diverting to snapshot removal stage after stage failure.",
+				"stage", p.conv.Status.Stage, "error", err.Error())
+			p.setStage(api.StageRemoveSnapshot)
+			return false, nil
+		}
 		return false, err
 	}
 	if stageDone {
@@ -563,25 +573,28 @@ func (p *ConversionPipeline) fetchInspectionResults(podIP string) (*api.Inspecti
 	return result, nil
 }
 
-// podSucceeded is called by the pipeline runners when StageFinished is reached.
+// podhandler is called by the pipeline runners when StageFinished is reached.
 // Returns (true, nil) when the pod succeeded, (false, err) when it failed, and
 // (false, nil) when it is still running or not yet found.
-func (p *ConversionPipeline) podSucceeded() (podSucceeded bool, err error) {
+//   - Succeeded         - (true, nil)  = pipeline complete
+//   - Failed / Unknown  - (false, err) = propagate failure to the reconciler
+//   - Pending / Running - (false, nil) = keep waiting
+func (p *ConversionPipeline) podHandler() (podSucceeded bool, err error) {
 	ensurer, err := NewEnsurer(p.r.Client, p.r.Log, p.conv.Spec)
 	if err != nil {
-		p.r.Log.Error(err, "Failed to create ensurer in podSucceeded.")
+		p.r.Log.Error(err, "Failed to create ensurer in podHandler.")
 		return false, err
 	}
 	pod, err := ensurer.EnsurePod(p.conv)
 	if err != nil {
-		p.r.Log.Error(err, "EnsurePod failed in podSucceeded.")
+		p.r.Log.Error(err, "EnsurePod failed in podHandler.")
 		return false, err
 	}
 	if pod == nil {
-		p.r.Log.Info("podSucceeded: pod not found.")
+		p.r.Log.Info("podHandler: pod not found.")
 		return false, nil
 	}
-	p.r.Log.Info("podSucceeded: pod phase check.", "pod", pod.Name, "phase", pod.Status.Phase)
+	p.r.Log.Info("podHandler: pod phase check.", "pod", pod.Name, "phase", pod.Status.Phase)
 	switch pod.Status.Phase {
 	case core.PodSucceeded:
 		return true, nil

--- a/pkg/controller/conversion/pipeline.go
+++ b/pkg/controller/conversion/pipeline.go
@@ -253,11 +253,15 @@ func (p *ConversionPipeline) runDeepInspection() (pipelineFinished bool, err err
 		p.r.Log.Error(err, "Stage failed.", "stage", p.conv.Status.Stage)
 		// When the controller owns the snapshot and it already exists, divert to the snapshot removal stages instead of propagating the error immediately.
 		// This ensures the snapshot is cleaned up via the normal polling path before the pipeline terminates. The pod failure is then detected again at StageFinished by podHandler and pipeline is set as failed.
+		// When already in a snapshot removal or waiting for snapshot removal stage, propagate errors out instead of looping forever.
+		currentStage := p.conv.Status.Stage
 		if snapshotOwnedByController(p.conv) &&
 			p.conv.Status.Snapshot != nil &&
-			p.conv.Status.Snapshot.Moref != "" {
+			p.conv.Status.Snapshot.Moref != "" &&
+			currentStage != api.StageRemoveSnapshot &&
+			currentStage != api.StageWaitForSnapshotRemoval {
 			p.r.Log.Info("Diverting to snapshot removal stage after stage failure.",
-				"stage", p.conv.Status.Stage, "error", err.Error())
+				"stage", currentStage, "error", err.Error())
 			p.setStage(api.StageRemoveSnapshot)
 			return false, nil
 		}
@@ -573,7 +577,7 @@ func (p *ConversionPipeline) fetchInspectionResults(podIP string) (*api.Inspecti
 	return result, nil
 }
 
-// podhandler is called by the pipeline runners when StageFinished is reached.
+// podHandler is called by the pipeline runners when StageFinished is reached.
 // Returns (true, nil) when the pod succeeded, (false, err) when it failed, and
 // (false, nil) when it is still running or not yet found.
 //   - Succeeded         - (true, nil)  = pipeline complete


### PR DESCRIPTION
Issue: When a standalone DeepInspection Conversion CR (no plan) is created without SNAPSHOT_MOREF, the controller creates its own snapshot. If the CR fails, the snapshot is not removed from vCenter. This blocks future warm migrations for the same VM with: "VM has pre-existing snapshots which are incompatible with warm migration."

Fix: Add condition for snapshot removal in the DI pipeline state machine