### PR TITLE
MTV-5584 | xfs_repair ignore RHEL 7 AGFL inconsistency

### DIFF
--- a/build/virt-v2v-rhel9/Containerfile
+++ b/build/virt-v2v-rhel9/Containerfile
@@ -75,6 +75,14 @@ COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
 COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 LABEL \

--- a/build/virt-v2v-rhel9/Containerfile-downstream
+++ b/build/virt-v2v-rhel9/Containerfile-downstream
@@ -81,6 +81,14 @@ COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-f
 
 COPY --from=winlegacyiso /usr/share/virtio-win/virtio-win.iso /usr/local/virtio-win-legacy.iso
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 ARG MTV_VERSION

--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -75,6 +75,14 @@ COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
 COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 LABEL \

--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -93,6 +93,14 @@ COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-f
 
 COPY --from=winlegacyiso /usr/share/virtio-win/virtio-win.iso /usr/local/virtio-win-legacy.iso
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 ARG MTV_VERSION

--- a/build/virt-v2v/Containerfile-downstream-fssupport
+++ b/build/virt-v2v/Containerfile-downstream-fssupport
@@ -88,6 +88,14 @@ COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
 COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 ARG MTV_VERSION

--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -47,6 +47,14 @@ RUN mkdir -p /usr/lib64/guestfs/appliance && \
         mv -vf root.qcow2 root && \
         tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 # This prevents libvirt from attempting to create files in the root directory,
 # which would lead to permission errors.
 # Refer to: https://issues.redhat.com/browse/RHEL-105490

--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -45,6 +45,14 @@ RUN mkdir -p /usr/lib64/guestfs/appliance && \
         mv -vf root.qcow2 root && \
         tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 # This prevents libvirt from attempting to create files in the root directory,
 # which would lead to permission errors.
 # Refer to: https://issues.redhat.com/browse/RHEL-105490

--- a/build/virt-v2v/Containerfile-upstream-xfs
+++ b/build/virt-v2v/Containerfile-upstream-xfs
@@ -48,6 +48,14 @@ RUN mkdir -p /usr/lib64/guestfs/appliance && \
         mv -vf root.qcow2 root && \
         tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 # This prevents libvirt from attempting to create files in the root directory,
 # which would lead to permission errors.
 # Refer to: https://issues.redhat.com/browse/RHEL-105490

--- a/build/virt-v2v/xfs_repair_wrapper.sh
+++ b/build/virt-v2v/xfs_repair_wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+if grep -q 'xfs_repair_ignore=1' /proc/cmdline 2>/dev/null; then
+	echo "xfs_repair wrapper: xfs_repair_ignore=1 detected, failures will be suppressed" >&2
+	/usr/sbin/xfs_repair.original "$@"
+	rc=$?
+	echo "xfs_repair wrapper: xfs_repair.original exited with status $rc (ignored)" >&2
+	exit 0
+fi
+exec /usr/sbin/xfs_repair.original "$@"

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3704,6 +3704,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_xfs_repair_ignore:
+                description: 'Ignore xfs_repair exit status during conversion (default:
+                  false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m
@@ -11813,6 +11820,11 @@ spec:
           false)
         displayName: Retain Populator Pods
         path: controller_retain_populator_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ignore xfs_repair exit status during conversion (default false)
+        displayName: XFS Repair Ignore
+        path: feature_xfs_repair_ignore
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3704,6 +3704,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_xfs_repair_ignore:
+                description: 'Ignore xfs_repair exit status during conversion (default:
+                  false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m
@@ -11813,6 +11820,11 @@ spec:
           false)
         displayName: Retain Populator Pods
         path: controller_retain_populator_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ignore xfs_repair exit status during conversion (default false)
+        displayName: XFS Repair Ignore
+        path: feature_xfs_repair_ignore
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -448,6 +448,10 @@ spec:
                 type: string
                 enum: ["true", "false"]
                 description: "Retain populator pods after migration for debugging (default: false)"
+              feature_xfs_repair_ignore:
+                type: string
+                enum: ["true", "false"]
+                description: "Ignore xfs_repair exit status during conversion (default: false)"
               controller_static_udn_ip_addresses:
                 type: string
                 enum: ["true", "false"]

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -451,6 +451,11 @@ spec:
         path: controller_retain_populator_pods
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ignore xfs_repair exit status during conversion (default false)
+        displayName: XFS Repair Ignore
+        path: feature_xfs_repair_ignore
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)
         displayName: Static UDN IP Addresses
         path: controller_static_udn_ip_addresses

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -50,6 +50,7 @@ controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_retain_precopy_importer_pods: false
 controller_retain_populator_pods: false
+feature_xfs_repair_ignore: false
 controller_static_udn_ip_addresses: true
 controller_max_vm_inflight: 20
 controller_host_lease_namespace: "openshift-mtv"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -190,6 +190,10 @@ spec:
         - name: FEATURE_RETAIN_POPULATOR_PODS
           value: "true"
 {% endif %}
+{% if feature_xfs_repair_ignore|bool %}
+        - name: FEATURE_XFS_REPAIR_IGNORE
+          value: "true"
+{% endif %}
 {% if feature_ocp_live_migration|bool %}
         - name: FEATURE_OCP_LIVE_MIGRATION
           value: "true"

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -521,6 +521,11 @@ spec:
           path: controller_retain_populator_pods
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Ignore xfs_repair exit status during conversion (default false)
+          displayName: XFS Repair Ignore
+          path: feature_xfs_repair_ignore
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Enable static udn IP addresses feature (default false)
           displayName: Static UDN IP Addresses
           path: controller_static_udn_ip_addresses

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -525,6 +525,11 @@ spec:
           path: controller_retain_populator_pods
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Ignore xfs_repair exit status during conversion (default false)
+          displayName: XFS Repair Ignore
+          path: feature_xfs_repair_ignore
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Enable static udn IP addresses feature (default false)
           displayName: Static UDN IP Addresses
           path: controller_static_udn_ip_addresses

--- a/pkg/controller/conversion/builder.go
+++ b/pkg/controller/conversion/builder.go
@@ -459,6 +459,13 @@ func (b *Builder) BuildV2vPodEnvironment(env []core.EnvVar, vm *plan.VMStatus) (
 				Value: "true",
 			})
 	}
+	if settings.Settings.XfsRepairIgnore {
+		env = append(env,
+			core.EnvVar{
+				Name:  "V2V_xfsRepairIgnore",
+				Value: "true",
+			})
+	}
 	if settings.Settings.Features.WindowsRegistryNetworkConfig {
 		env = append(env,
 			core.EnvVar{

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -21,6 +21,7 @@ const (
 	FeatureWindowsWaitForReboot         = "FEATURE_WINDOWS_WAIT_FOR_REBOOT"
 	FeatureUseConversionCR              = "FEATURE_USE_CONVERSION_CR"
 	FeatureRetainPopulatorPods          = "FEATURE_RETAIN_POPULATOR_PODS"
+	FeatureXfsRepairIgnore              = "FEATURE_XFS_REPAIR_IGNORE"
 )
 
 // OpenShift version where the FeatureVmwareSystemSerialNumber feature is supported:
@@ -74,6 +75,8 @@ type Features struct {
 	UseConversionCR bool
 	// Whether populator pods should be retained after migration for debugging.
 	RetainPopulatorPods bool
+	// Whether to ignore xfs_repair exit status during conversion.
+	XfsRepairIgnore bool
 }
 
 // isOpenShiftVersionAboveMinimum checks if OpenShift version is above or equal to minimum version using semantic versioning
@@ -115,5 +118,6 @@ func (r *Features) Load() (err error) {
 	r.WindowsWaitForReboot = getEnvBool(FeatureWindowsWaitForReboot, false)
 	r.UseConversionCR = getEnvBool(FeatureUseConversionCR, true)
 	r.RetainPopulatorPods = getEnvBool(FeatureRetainPopulatorPods, false)
+	r.XfsRepairIgnore = getEnvBool(FeatureXfsRepairIgnore, false)
 	return
 }

--- a/pkg/settings/features_test.go
+++ b/pkg/settings/features_test.go
@@ -220,6 +220,36 @@ func TestFeatures_Load_VsphereVmwareDriverRemoval(t *testing.T) {
 	}
 }
 
+func TestFeatures_Load_XfsRepairIgnore(t *testing.T) {
+	tests := []struct {
+		name           string
+		envVal         string
+		unset          bool
+		expectedResult bool
+	}{
+		{name: "default off when unset", unset: true, expectedResult: false},
+		{name: "false when false", envVal: "false", expectedResult: false},
+		{name: "true when true", envVal: "true", expectedResult: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unset {
+				t.Setenv(FeatureXfsRepairIgnore, "")
+			} else {
+				t.Setenv(FeatureXfsRepairIgnore, tt.envVal)
+			}
+			t.Setenv(OpenShiftVersion, "4.20.0")
+			var features Features
+			if err := features.Load(); err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if features.XfsRepairIgnore != tt.expectedResult {
+				t.Errorf("XfsRepairIgnore = %v, want %v", features.XfsRepairIgnore, tt.expectedResult)
+			}
+		})
+	}
+}
+
 func TestFeatures_isOpenShiftVersionAboveMinimum(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -40,6 +40,7 @@ const (
 	EnvWindowsRegistryNetworkConfigName = "V2V_windowsRegistryNetworkConfig"
 	EnvWaitForGuestRebootName           = "V2V_waitForGuestReboot"
 	EnvXfsCompatibilityName             = "V2V_xfsCompatibility"
+	EnvXfsRepairIgnoreName              = "V2V_xfsRepairIgnore"
 )
 
 const (
@@ -174,6 +175,16 @@ func (s *AppConfig) Load() (err error) {
 	flag.Parse()
 
 	s.SupportsNoFstrim = detectNoFstrimSupport("/etc/os-release")
+
+	if s.getEnvBool(EnvXfsRepairIgnoreName, false) {
+		const token = "xfs_repair_ignore=1"
+		if existing := os.Getenv("LIBGUESTFS_APPEND"); existing != "" {
+			_ = os.Setenv("LIBGUESTFS_APPEND", existing+" "+token)
+		} else {
+			_ = os.Setenv("LIBGUESTFS_APPEND", token)
+		}
+		fmt.Fprintf(os.Stderr, "xfs_repair ignore enabled (LIBGUESTFS_APPEND += %s)\n", token)
+	}
 
 	return s.validate()
 }


### PR DESCRIPTION

Relates to [RHEL-178287](https://redhat.atlassian.net/browse/RHEL-178287), there is issue when XFSv5 on RHEL 7 reports corrupted FS even if there is no actuall corrpution.

When feature_xfs_repair_ignore is enabled on the ForkliftController CR,
xfs_repair exit status is suppressed so conversions are not blocked by
minor XFS issues. The flag flows from the operator through the controller
env into LIBGUESTFS_APPEND and is checked by a wrapper script that
replaces xfs_repair inside the appliance.

Resolves: MTV-5584

[RHEL-178287]: https://redhat.atlassian.net/browse/RHEL-178287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ