### PR TITLE
MTV-5558 | Rewrite guest customization as stack-based plugin architecture

### DIFF
--- a/pkg/virt-customization/README.md
+++ b/pkg/virt-customization/README.md
@@ -1,0 +1,221 @@
+# virt-customization
+
+Post-conversion guest disk customization for Forklift/MTV.
+
+This package modifies VM disk images after virt-v2v conversion using a
+four-phase pipeline: **probe, resolve, commit files, commit CLI**. Plugins
+declare what changes they need; the commit layer writes them to the guest.
+
+## Quick start
+
+```go
+customization.Run(customization.Options{
+    Config:     appConfig,
+    Disks:      []string{"/tmp/disk.img"},
+    OpenHandle: guesthandle.DefaultOpenHandle(),
+})
+```
+
+## Pipeline
+
+```
+customize.Run(opts)
+    |
+    +-- Resolve LUKS keys
+    +-- OpenHandle -> GuestHandle (libguestfs Go session)
+    |
+    |   Phase 1 - Probe (GuestHandle API)
+    |     detect.go:  IsDir/IsFile -> OS family, network stacks, cloud-init, SSH, console
+    |     extract.go: Cat/GlobExpand/Ls -> InterfaceInfo, CloudInitInfo, SSHInfo, ConsoleInfo
+    |     -> GuestInfo
+    |
+    |   Resolve applicable plugins (Applicable filter)
+    |   Collect declarative Actions (Apply)
+    |     -> []FileAction + []RegAction + []ExecAction
+    |
+    |   Phase 2 - Files (GuestHandle API)
+    |     commit/files.go: MkdirP + Write/Upload + Chmod
+    |
+    +-- Shutdown + Close (release disk locks)
+    |
+    +-- Phase 3 - Registry (CLI)
+    |   commit/registry.go: virt-win-reg --merge
+    |
+    +-- Phase 4 - Scripts (CLI)
+        commit/scripts.go: virt-customize --firstboot/--run
+```
+
+Phases 1+2 share a single libguestfs session. Phases 3+4 are CLI-based
+and each boot their own appliance only when actions exist.
+
+## Package layout
+
+```
+virt-customization/
+  api/              Core types: GuestInfo, GuestHandle, Plugin, Actions
+  commit/           Materialize actions onto guest disk (files, registry, scripts)
+  guesthandle/      HandleFactory, DefaultOpenHandle, production GuestHandle (libguestfs CGO)
+  plugins/          Modular customization steps
+    example/        Reference plugin (see "Adding a plugin" below)
+  probe/            Read-only guest inspection
+    netcfg/         Network config parsers (ifcfg, NM, NM DHCP leases, dhclient, netplan, interfaces, wicked)
+    cloudinit/      cloud.cfg YAML parser (datasource list, network config disabled)
+    ssh/            sshd_config parser (PermitRootLogin, PasswordAuthentication, Port)
+    console/        GRUB defaults parser (serial console params), serial-getty units
+```
+
+## Design principles
+
+- **Probe-first**: All guest state is extracted read-only before any plugin
+  runs. No in-guest shell scripts for discovery.
+- **Declarative plugins**: Plugins return `Actions` (data), not side effects.
+  This makes them unit-testable with mocked contexts.
+- **Go API for data operations**: Probe and file operations use the
+  GuestHandle interface directly. CLI tools (virt-customize, virt-win-reg)
+  are used only for script execution and registry merges.
+- **Compile-time registry**: Plugins are registered in `resolve.go` in fixed
+  order. No dynamic loading.
+- **Stack detection over distro detection**: Filesystem markers
+  (`/etc/sysconfig/network-scripts`, `/etc/netplan`, etc.) determine which
+  parsers run, not the distro name.
+
+## Plugin interface
+
+```go
+type Plugin interface {
+    Name() string
+    Applicable(ctx *Context) bool
+    Apply(ctx *Context) (*Actions, error)
+}
+```
+
+`Applicable` gates execution based on `ctx.Guest` (OS, network stacks) and
+`ctx.Config` (feature flags). `Apply` returns declarative actions:
+
+| Action type | Written by | Phase |
+|-------------|------------|-------|
+| `FileAction` | `commit/files.go` via GuestHandle | 2 |
+| `RegAction` | `commit/registry.go` via virt-win-reg | 3 |
+| `ExecAction` | `commit/scripts.go` via virt-customize | 4 |
+
+`ExecAction` supports both inline `Content` (commit layer writes to temp
+file) and `ScriptPath` (pre-existing host file).
+
+## Probe
+
+Detection (`probe/detect.go`) uses `GuestHandle.IsDir`/`IsFile` to set
+flags on `GuestInfo`:
+
+| Probe | Path | Flag |
+|-------|------|------|
+| Windows | `/Windows/System32` | `OS.Family=windows` |
+| os-release | `/etc/os-release` | `OS.Family=linux` |
+| ifcfg | `/etc/sysconfig/network-scripts` | `UsesIfcfg` |
+| ifcfg (SUSE) | `/etc/sysconfig/network` | `UsesIfcfgSuse` |
+| NetworkManager | `/etc/NetworkManager/system-connections` | `UsesNetworkManager` |
+| netplan | `/etc/netplan` | `UsesNetplan` |
+| ifquery | `/etc/network/interfaces` | `UsesIfquery` |
+| interfaces.d | `/etc/network/interfaces.d` | `UsesInterfacesD` |
+| wicked | `/etc/wicked` or `/var/lib/wicked` | `UsesWicked` |
+| NM DHCP lease | `/var/lib/NetworkManager` | `UsesNMDhcpLease` |
+| dhclient | `/var/lib/dhclient` | `UsesDhclient` |
+| cloud-init | `/etc/cloud/` or `/usr/bin/cloud-init` | `CloudInit.Present` |
+| cloud.cfg | `/etc/cloud/cloud.cfg` | `CloudInit.HasCloudCfg` |
+| cloud.cfg.d | `/etc/cloud/cloud.cfg.d/` | `CloudInit.HasCloudCfgD` |
+| cloud instance | `/var/lib/cloud/instance/` | `CloudInit.HasInstanceData` |
+| cloud seed | `/var/lib/cloud/seed/` | `CloudInit.HasSeedData` |
+| sshd | `/usr/sbin/sshd` | `SSH.Present` |
+| sshd_config | `/etc/ssh/sshd_config` | `SSH.HasConfig` |
+| SSH host keys | `/etc/ssh/ssh_host_*_key` | `SSH.HasHostKeys` |
+| root authkeys | `/root/.ssh/authorized_keys` | `SSH.HasRootAuthorizedKeys` |
+| GRUB defaults | `/etc/default/grub` | `Console.HasGrubDefaults` |
+
+Extraction (`probe/extract.go`) reads config files via `Cat`/`GlobExpand`
+and feeds them to parsers:
+
+### Network (`probe/netcfg/`)
+
+| Parser | Source paths |
+|--------|-------------|
+| ifcfg | `/etc/sysconfig/network-scripts/ifcfg-*`, `/etc/sysconfig/network/ifcfg-*` |
+| NM | `/etc/NetworkManager/system-connections/*` |
+| NM DHCP lease | `/var/lib/NetworkManager/*.lease` + `timestamps` |
+| dhclient | `/var/lib/dhclient/dhclient-*`, `/var/lib/NetworkManager/dhclient-*` |
+| netplan | `/etc/netplan/*.yaml`, `/etc/netplan/*.yml` |
+| interfaces | `/etc/network/interfaces`, `/etc/network/interfaces.d/*` |
+| wicked | `/var/lib/wicked/lease-*` (XML) |
+
+Each parser produces `[]InterfaceInfo` with interface name, IPs, MAC, and
+DHCP flag. A guest may have multiple stacks active simultaneously.
+
+### Cloud-init (`probe/cloudinit/`)
+
+| Field | Source |
+|-------|--------|
+| `DatasourceList` | `cloud.cfg` + `cloud.cfg.d/*.cfg` YAML |
+| `NetworkConfigDisabled` | `network: {config: disabled}` in cloud.cfg |
+| `ActiveDatasource` | `/var/lib/cloud/instance/datasource` |
+| `InstanceID` | `/var/lib/cloud/instance/instance-id` |
+
+`CloudInitInfo.ManagesNetwork()` returns true when cloud-init is present
+and networking is not explicitly disabled -- plugins use this to decide
+whether to disable cloud-init networking before migration.
+
+### SSH (`probe/ssh/`)
+
+| Field | Source |
+|-------|--------|
+| `PermitRootLogin` | `sshd_config` + `sshd_config.d/*.conf` |
+| `PasswordAuthentication` | same (first-match-wins) |
+| `Port` | same |
+| `HostKeyTypes` | filenames from `/etc/ssh/ssh_host_*_key` glob |
+| `ServiceEnabled` | `sshd.service` or `ssh.service` in `multi-user.target.wants/` |
+
+### Console (`probe/console/`)
+
+| Field | Source |
+|-------|--------|
+| `SerialConsoles` | `console=` params from `GRUB_CMDLINE_LINUX*` in `/etc/default/grub` |
+| `SerialGettyDevices` | `serial-getty@*.service` in `getty.target.wants/` |
+
+`ConsoleInfo.HasSerialConsole()` returns true if either source detected serial access.
+
+## Adding a plugin
+
+The `plugins/example/` directory is a complete reference implementation.
+To create a new plugin:
+
+1. Copy `plugins/example/` to `plugins/<category>/<name>/`.
+2. Rename the package.
+3. Implement `Applicable` with real conditions (OS family, config flags).
+4. Implement `Apply` to return the actions your plugin needs.
+5. Place scripts in `scripts/` and embed with `//go:embed scripts`.
+6. Register in `resolve.go` -> `AllPlugins()` at the correct position.
+7. Add tests in `plugin_test.go`.
+
+Plugin ordering matters: network config before drivers before boot scripts.
+
+Each `plugin.go` should start with a doc comment:
+
+```go
+// <plugin-name> -- Short description.
+//
+// Applicable: <conditions>.
+// Output:     <action types and files>.
+//
+// <Longer explanation.>
+package <pkgname>
+```
+
+## Adding a probe subsystem
+
+**Network parsers:** Create a parser in `probe/netcfg/` (one Go file per
+format), add detection markers in `probe/detect.go`, add extraction logic
+in `probe/extract.go`. Network plugins consume `GuestInfo.Interfaces`
+uniformly.
+
+**Other subsystems** (cloud-init, SSH, console, etc.): Create a sub-package
+under `probe/` with a parser and tests. Add detection flags to the
+corresponding struct in `api/types.go`, wire detection in `detect.go`, and
+extraction in `extract.go`. All extraction is non-fatal (warnings on read
+errors). Windows guests skip Linux-only subsystems.

--- a/pkg/virt-customization/api/types.go
+++ b/pkg/virt-customization/api/types.go
@@ -1,0 +1,230 @@
+package api
+
+import (
+	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
+)
+
+// OSFamily distinguishes the top-level OS type.
+type OSFamily string
+
+const (
+	OSFamilyLinux   OSFamily = "linux"
+	OSFamilyWindows OSFamily = "windows"
+	OSFamilyUnknown OSFamily = "unknown"
+)
+
+// GuestOS holds OS-level information detected from the guest disk.
+type GuestOS struct {
+	Family  OSFamily // linux or windows
+	Distro  string   // "rhel", "ubuntu", "debian", "sles", etc. (empty for Windows)
+	Version string   // "9.2", "22.04" (best-effort from os-release)
+}
+
+func (g *GuestOS) IsWindows() bool { return g.Family == OSFamilyWindows }
+func (g *GuestOS) IsLinux() bool   { return g.Family == OSFamilyLinux }
+
+// InterfaceInfo is populated by probe parsers (ifcfg, NM, NM DHCP leases,
+// dhclient, netplan, interfaces, wicked) and consumed by network plugins to
+// map MAC→interface name for static IP assignment.
+type InterfaceInfo struct {
+	Name   string   // Interface name ("eth0", "ens192")
+	IPv4   []string // IPv4 addresses from config
+	IPv6   []string // IPv6 addresses from config
+	MAC    string   // MAC address if in config (may be empty)
+	DHCP   bool     // True if configured via DHCP (BOOTPROTO=dhcp, method=auto, dhcp4: true)
+	Source string   // "ifcfg", "nm-connection", "nm-dhcp-lease", "dhclient", "netplan", "interfaces", "wicked"
+}
+
+// GuestInfo is the complete probe result -- everything customize needs.
+type GuestInfo struct {
+	OS GuestOS
+
+	// Network stacks detected on disk (multiple can coexist)
+	UsesIfcfg          bool
+	UsesIfcfgSuse      bool // SUSE path: /etc/sysconfig/network/ifcfg-*
+	UsesNetworkManager bool
+	UsesNetplan        bool
+	UsesIfquery        bool
+	UsesInterfacesD    bool // /etc/network/interfaces.d/ directory exists
+	UsesWicked         bool
+	UsesNMDhcpLease    bool // /var/lib/NetworkManager/*.lease files exist
+	UsesDhclient       bool // /var/lib/dhclient/ directory exists
+
+	// Netplan renderer ("networkd" or "NetworkManager"), if detected
+	NetplanRenderer string
+
+	// Pre-extracted interface configs
+	Interfaces []InterfaceInfo
+
+	// Subsystem probes (Linux only)
+	CloudInit CloudInitInfo
+	SSH       SSHInfo
+	Console   ConsoleInfo
+}
+
+// CloudInitInfo holds cloud-init detection and configuration state.
+// Plugins use this to prevent cloud-init from overriding network config
+// after migration (the primary post-migration failure mode).
+type CloudInitInfo struct {
+	Present         bool // /etc/cloud/ dir or /usr/bin/cloud-init exists
+	HasCloudCfg     bool // /etc/cloud/cloud.cfg exists
+	HasCloudCfgD    bool // /etc/cloud/cloud.cfg.d/ dir exists
+	HasInstanceData bool // /var/lib/cloud/instance/ dir exists
+	HasSeedData     bool // /var/lib/cloud/seed/ dir exists
+
+	DatasourceList        []string // from cloud.cfg: datasource_list
+	ActiveDatasource      string   // from /var/lib/cloud/instance/datasource
+	NetworkConfigDisabled bool     // network: {config: disabled} in cloud.cfg
+	InstanceID            string   // from /var/lib/cloud/instance/instance-id
+}
+
+// ManagesNetwork returns true if cloud-init is present and has not been
+// told to leave networking alone. Plugins can use this to decide whether
+// cloud-init networking needs to be disabled before migration.
+func (c *CloudInitInfo) ManagesNetwork() bool {
+	return c.Present && !c.NetworkConfigDisabled
+}
+
+// SSHInfo holds SSH service detection for post-migration login capability.
+type SSHInfo struct {
+	Present               bool // /usr/sbin/sshd exists
+	HasConfig             bool // /etc/ssh/sshd_config exists
+	ServiceEnabled        bool // sshd.service or ssh.service in multi-user.target.wants
+	HasHostKeys           bool // /etc/ssh/ssh_host_*_key glob matched
+	HasRootAuthorizedKeys bool // /root/.ssh/authorized_keys exists
+
+	PermitRootLogin        string // "yes", "no", "prohibit-password", etc.
+	PasswordAuthentication *bool
+	Port                   int      // 0 = unset (default 22)
+	HostKeyTypes           []string // "rsa", "ed25519", etc. (from filenames)
+}
+
+// ConsoleDevice represents a serial console parameter from the kernel cmdline.
+type ConsoleDevice struct {
+	Device string // "ttyS0"
+	Baud   string // "115200" (empty if not specified)
+}
+
+// ConsoleInfo holds serial console detection for virtctl console readiness.
+type ConsoleInfo struct {
+	HasGrubDefaults bool // /etc/default/grub exists
+	HasSerialGetty  bool // serial-getty@*.service in getty.target.wants
+
+	SerialConsoles     []ConsoleDevice // from GRUB_CMDLINE_LINUX console= params
+	SerialGettyDevices []string        // "ttyS0" parsed from unit names
+}
+
+// HasSerialConsole returns true if the guest has serial console configured
+// either via GRUB kernel cmdline or systemd serial-getty units.
+func (c *ConsoleInfo) HasSerialConsole() bool {
+	return len(c.SerialConsoles) > 0 || len(c.SerialGettyDevices) > 0
+}
+
+// InterfaceForIP returns the interface name associated with the given IP,
+// searching both IPv4 and IPv6 addresses.
+func (g *GuestInfo) InterfaceForIP(ip string) string {
+	for _, iface := range g.Interfaces {
+		for _, v := range iface.IPv4 {
+			if v == ip {
+				return iface.Name
+			}
+		}
+		for _, v := range iface.IPv6 {
+			if v == ip {
+				return iface.Name
+			}
+		}
+	}
+	return ""
+}
+
+// HasIPs returns true if the interface has any IPv4 or IPv6 address.
+func (i *InterfaceInfo) HasIPs() bool {
+	return len(i.IPv4) > 0 || len(i.IPv6) > 0
+}
+
+// WinFirstbootScriptsPath is the guest-side directory where Windows firstboot
+// PowerShell and batch scripts are placed for execution after conversion.
+const WinFirstbootScriptsPath = "/Program Files/Guestfs/Firstboot/scripts"
+
+// FileActionType identifies the kind of file operation.
+type FileActionType string
+
+const (
+	ActionUpload FileActionType = "upload"
+	ActionWrite  FileActionType = "write"
+)
+
+// FileAction is a file operation performed by virt-customize (upload or write).
+type FileAction struct {
+	Type        FileActionType
+	LocalPath   string // Source path on host (for Upload)
+	GuestPath   string // Destination path inside guest
+	Content     []byte // Content to write (for Write)
+	Permissions string // e.g., "0644" (optional)
+}
+
+// ExecActionType identifies the kind of virt-customize operation.
+type ExecActionType string
+
+const (
+	ActionFirstboot ExecActionType = "firstboot"
+	ActionRun       ExecActionType = "run"
+)
+
+// ExecAction is a virt-customize operation (script execution).
+//
+// Provide either Content (inline script bytes) or ScriptPath (host-side file).
+// When Content is set the commit layer writes it to a temp file automatically,
+// keeping Apply free of side effects. ScriptPath is for pre-existing host files
+// (e.g., user-supplied scripts from a ConfigMap mount).
+type ExecAction struct {
+	Type       ExecActionType
+	ScriptPath string // host path passed to virt-customize --firstboot or --run
+	Content    []byte // inline script content (commit layer writes to temp file)
+}
+
+// RegAction is a Windows Registry merge operation performed by virt-win-reg.
+type RegAction struct {
+	Content []byte // .reg file content in Windows REGEDIT format
+}
+
+// Actions collects file, registry, and exec operations returned by a plugin.
+type Actions struct {
+	Files []FileAction
+	Regs  []RegAction
+	Execs []ExecAction
+}
+
+// Context carries all shared state that stack plugins need.
+type Context struct {
+	Guest      *GuestInfo
+	Config     *config.AppConfig
+	Disks      []string
+	FileSystem utils.FileSystem
+}
+
+// Plugin is a modular unit handling one aspect of guest customization.
+type Plugin interface {
+	Name() string
+	Applicable(ctx *Context) bool
+	Apply(ctx *Context) (*Actions, error)
+}
+
+// GuestHandle abstracts the libguestfs operations used by probe and commit.
+// Production code uses the CGO-backed implementation; tests use a mock.
+type GuestHandle interface {
+	IsDir(path string) (bool, error)
+	IsFile(path string) (bool, error)
+	Cat(path string) (string, error)
+	GlobExpand(pattern string) ([]string, error)
+	Ls(dir string) ([]string, error)
+	ReadFile(path string) ([]byte, error)
+	MkdirP(path string) error
+	Upload(local, guest string) error
+	Write(path string, content []byte) error
+	Chmod(mode int, path string) error
+	Shutdown() error
+	Close()
+}

--- a/pkg/virt-customization/api/types_test.go
+++ b/pkg/virt-customization/api/types_test.go
@@ -1,0 +1,63 @@
+package api
+
+import "testing"
+
+func TestInterfaceForIP(t *testing.T) {
+	t.Parallel()
+	guest := &GuestInfo{
+		Interfaces: []InterfaceInfo{
+			{Name: "eth0", IPv4: []string{"10.0.0.1"}, IPv6: []string{"fd00::1"}},
+			{Name: "eth1", IPv4: []string{"192.168.1.5"}},
+		},
+	}
+
+	tests := []struct {
+		name string
+		ip   string
+		want string
+	}{
+		{"ipv4 hit", "10.0.0.1", "eth0"},
+		{"ipv6 hit", "fd00::1", "eth0"},
+		{"second iface", "192.168.1.5", "eth1"},
+		{"miss", "172.16.0.1", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := guest.InterfaceForIP(tc.ip); got != tc.want {
+				t.Errorf("InterfaceForIP(%q) = %q, want %q", tc.ip, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInterfaceForIP_Empty(t *testing.T) {
+	t.Parallel()
+	guest := &GuestInfo{}
+	if got := guest.InterfaceForIP("10.0.0.1"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestHasIPs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		info InterfaceInfo
+		want bool
+	}{
+		{"ipv4 only", InterfaceInfo{IPv4: []string{"10.0.0.1"}}, true},
+		{"ipv6 only", InterfaceInfo{IPv6: []string{"fd00::1"}}, true},
+		{"both", InterfaceInfo{IPv4: []string{"10.0.0.1"}, IPv6: []string{"fd00::1"}}, true},
+		{"empty", InterfaceInfo{}, false},
+		{"nil slices", InterfaceInfo{Name: "eth0"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.info.HasIPs(); got != tc.want {
+				t.Errorf("HasIPs() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/virt-customization/commit/files.go
+++ b/pkg/virt-customization/commit/files.go
@@ -1,0 +1,80 @@
+package commit
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+var validOctalMode = regexp.MustCompile(`^[0-7]{3,4}$`)
+
+// Files performs all file operations (uploads and writes) on the guest
+// disk via the GuestHandle.
+//
+// ActionUpload is translated to g.Upload(localpath, guestpath).
+// ActionWrite is translated to g.Write(guestpath, content) directly —
+// no temp file staging is needed.
+// Parent directories are created with g.MkdirP and optional permissions
+// are applied with g.Chmod.
+func Files(g api.GuestHandle, actions []api.FileAction) error {
+	if len(actions) == 0 {
+		return nil
+	}
+
+	for _, action := range actions {
+		if action.Permissions != "" && !validOctalMode.MatchString(action.Permissions) {
+			return fmt.Errorf("invalid permissions %q for %s: must be an octal mode (e.g. 0644)", action.Permissions, action.GuestPath)
+		}
+		if action.Type != api.ActionUpload && action.Type != api.ActionWrite {
+			return fmt.Errorf("unsupported file action type: %v", action.Type)
+		}
+	}
+
+	// Ensure parent directories exist before writing files.
+	// Uses path (not filepath) because guest paths use forward slashes.
+	dirs := map[string]bool{}
+	for _, action := range actions {
+		dir := path.Dir(action.GuestPath)
+		if dir != "" && dir != "." && dir != "/" {
+			dirs[dir] = true
+		}
+	}
+	if len(dirs) > 0 {
+		sorted := make([]string, 0, len(dirs))
+		for d := range dirs {
+			sorted = append(sorted, d)
+		}
+		sort.Strings(sorted)
+		for _, d := range sorted {
+			if err := g.MkdirP(d); err != nil {
+				return fmt.Errorf("mkdir_p %s: %w", d, err)
+			}
+		}
+	}
+
+	for _, action := range actions {
+		switch action.Type {
+		case api.ActionUpload:
+			if err := g.Upload(action.LocalPath, action.GuestPath); err != nil {
+				return fmt.Errorf("upload %s -> %s: %w", action.LocalPath, action.GuestPath, err)
+			}
+		case api.ActionWrite:
+			if err := g.Write(action.GuestPath, action.Content); err != nil {
+				return fmt.Errorf("write %s: %w", action.GuestPath, err)
+			}
+		}
+
+		if action.Permissions != "" {
+			mode, _ := strconv.ParseInt(action.Permissions, 8, 32)
+			if err := g.Chmod(int(mode), action.GuestPath); err != nil {
+				return fmt.Errorf("chmod %s on %s: %w", action.Permissions, action.GuestPath, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/virt-customization/commit/files_test.go
+++ b/pkg/virt-customization/commit/files_test.go
@@ -1,0 +1,346 @@
+package commit
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// mockGuestHandle records file operations for assertions.
+type mockGuestHandle struct {
+	mkdirs  []string
+	uploads []uploadCall
+	writes  []writeCall
+	chmods  []chmodCall
+	failOn  string // method name to fail on (e.g. "MkdirP", "Upload", "Write", "Chmod")
+	failErr error
+}
+
+type uploadCall struct{ local, guest string }
+type writeCall struct {
+	path    string
+	content []byte
+}
+type chmodCall struct {
+	mode int
+	path string
+}
+
+func (m *mockGuestHandle) IsDir(string) (bool, error)          { return false, nil }
+func (m *mockGuestHandle) IsFile(string) (bool, error)         { return false, nil }
+func (m *mockGuestHandle) Cat(string) (string, error)          { return "", nil }
+func (m *mockGuestHandle) GlobExpand(string) ([]string, error) { return nil, nil }
+func (m *mockGuestHandle) Ls(string) ([]string, error)         { return nil, nil }
+func (m *mockGuestHandle) ReadFile(string) ([]byte, error)     { return nil, nil }
+func (m *mockGuestHandle) Shutdown() error                     { return nil }
+func (m *mockGuestHandle) Close()                              {}
+
+func (m *mockGuestHandle) MkdirP(path string) error {
+	if m.failOn == "MkdirP" {
+		return m.failErr
+	}
+	m.mkdirs = append(m.mkdirs, path)
+	return nil
+}
+
+func (m *mockGuestHandle) Upload(local, guest string) error {
+	if m.failOn == "Upload" {
+		return m.failErr
+	}
+	m.uploads = append(m.uploads, uploadCall{local, guest})
+	return nil
+}
+
+func (m *mockGuestHandle) Write(path string, content []byte) error {
+	if m.failOn == "Write" {
+		return m.failErr
+	}
+	m.writes = append(m.writes, writeCall{path, content})
+	return nil
+}
+
+func (m *mockGuestHandle) Chmod(mode int, path string) error {
+	if m.failOn == "Chmod" {
+		return m.failErr
+	}
+	m.chmods = append(m.chmods, chmodCall{mode, path})
+	return nil
+}
+
+var _ api.GuestHandle = (*mockGuestHandle)(nil)
+
+func TestFiles_EmptyActions(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	err := Files(g, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(g.mkdirs) > 0 || len(g.uploads) > 0 || len(g.writes) > 0 {
+		t.Error("expected no operations for empty actions")
+	}
+}
+
+func TestFiles_EmptySlice(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	err := Files(g, []api.FileAction{})
+	if err != nil {
+		t.Fatalf("expected nil error for empty slice, got %v", err)
+	}
+}
+
+func TestFiles_Upload(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	actions := []api.FileAction{
+		{
+			Type:      api.ActionUpload,
+			LocalPath: "/tmp/script.bat",
+			GuestPath: "/Program Files/Guestfs/Firstboot/scripts/script.bat",
+		},
+	}
+	err := Files(g, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.uploads) != 1 {
+		t.Fatalf("expected 1 upload, got %d", len(g.uploads))
+	}
+	if g.uploads[0].local != "/tmp/script.bat" {
+		t.Errorf("upload local = %q", g.uploads[0].local)
+	}
+	if g.uploads[0].guest != "/Program Files/Guestfs/Firstboot/scripts/script.bat" {
+		t.Errorf("upload guest = %q", g.uploads[0].guest)
+	}
+}
+
+func TestFiles_Write(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	content := []byte("SUBSYSTEM==\"net\",ACTION==\"add\"\n")
+	actions := []api.FileAction{
+		{
+			Type:      api.ActionWrite,
+			GuestPath: "/etc/udev/rules.d/70-persistent-net.rules",
+			Content:   content,
+		},
+	}
+	err := Files(g, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.writes) != 1 {
+		t.Fatalf("expected 1 write, got %d", len(g.writes))
+	}
+	if g.writes[0].path != "/etc/udev/rules.d/70-persistent-net.rules" {
+		t.Errorf("write path = %q", g.writes[0].path)
+	}
+	if string(g.writes[0].content) != string(content) {
+		t.Errorf("write content mismatch")
+	}
+}
+
+func TestFiles_Chmod(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	actions := []api.FileAction{
+		{
+			Type:        api.ActionWrite,
+			GuestPath:   "/etc/udev/rules.d/70-persistent-net.rules",
+			Content:     []byte("rule\n"),
+			Permissions: "0644",
+		},
+	}
+	err := Files(g, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.chmods) != 1 {
+		t.Fatalf("expected 1 chmod, got %d", len(g.chmods))
+	}
+	if g.chmods[0].mode != 0644 {
+		t.Errorf("chmod mode = %o, want 0644", g.chmods[0].mode)
+	}
+	if g.chmods[0].path != "/etc/udev/rules.d/70-persistent-net.rules" {
+		t.Errorf("chmod path = %q", g.chmods[0].path)
+	}
+}
+
+func TestFiles_MultipleActions(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	actions := []api.FileAction{
+		{Type: api.ActionUpload, LocalPath: "/a.sh", GuestPath: "/b.sh"},
+		{Type: api.ActionWrite, GuestPath: "/c.txt", Content: []byte("hello")},
+		{Type: api.ActionUpload, LocalPath: "/d.bat", GuestPath: "/e.bat", Permissions: "0755"},
+	}
+	err := Files(g, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.uploads) != 2 {
+		t.Errorf("expected 2 uploads, got %d", len(g.uploads))
+	}
+	if len(g.writes) != 1 {
+		t.Errorf("expected 1 write, got %d", len(g.writes))
+	}
+	if len(g.chmods) != 1 {
+		t.Errorf("expected 1 chmod, got %d", len(g.chmods))
+	}
+	if g.chmods[0].mode != 0755 {
+		t.Errorf("chmod mode = %o, want 0755", g.chmods[0].mode)
+	}
+}
+
+func TestFiles_UnsupportedActionType(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	actions := []api.FileAction{
+		{Type: "bogus", GuestPath: "/etc/test"},
+	}
+	err := Files(g, actions)
+	if err == nil {
+		t.Fatal("expected error for unsupported action type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Errorf("expected error mentioning 'unsupported', got: %v", err)
+	}
+}
+
+func TestFiles_InvalidPermissions(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	actions := []api.FileAction{
+		{Type: api.ActionWrite, GuestPath: "/etc/test", Content: []byte("data"), Permissions: "abc"},
+	}
+	err := Files(g, actions)
+	if err == nil {
+		t.Fatal("expected error for invalid permissions, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid permissions") {
+		t.Errorf("expected error mentioning 'invalid permissions', got: %v", err)
+	}
+}
+
+func TestFiles_MkdirP(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	actions := []api.FileAction{
+		{Type: api.ActionWrite, GuestPath: "/Program Files/Guestfs/Firstboot/scripts/100_config.ps1", Content: []byte("echo hi")},
+		{Type: api.ActionWrite, GuestPath: "/Program Files/Guestfs/Firstboot/scripts/200_restore.ps1", Content: []byte("echo bye")},
+		{Type: api.ActionWrite, GuestPath: "/etc/udev/rules.d/70-persistent-net.rules", Content: []byte("rule")},
+	}
+	err := Files(g, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Deduplicated: only 2 unique dirs
+	if len(g.mkdirs) != 2 {
+		t.Errorf("expected 2 deduplicated mkdirs, got %d: %v", len(g.mkdirs), g.mkdirs)
+	}
+
+	containsDir := func(dir string) bool {
+		for _, d := range g.mkdirs {
+			if d == dir {
+				return true
+			}
+		}
+		return false
+	}
+	if !containsDir("/Program Files/Guestfs/Firstboot/scripts") {
+		t.Errorf("expected mkdir for firstboot scripts dir, got: %v", g.mkdirs)
+	}
+	if !containsDir("/etc/udev/rules.d") {
+		t.Errorf("expected mkdir for udev dir, got: %v", g.mkdirs)
+	}
+}
+
+func TestFiles_MkdirBeforeWrite(t *testing.T) {
+	t.Parallel()
+	// mkdirs are called before writes/uploads since Files does dirs first, then actions
+	g := &mockGuestHandle{}
+	actions := []api.FileAction{
+		{Type: api.ActionUpload, LocalPath: "/a", GuestPath: "/deep/dir/file.txt"},
+	}
+	err := Files(g, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.mkdirs) < 1 {
+		t.Fatal("expected at least one mkdir")
+	}
+	if len(g.uploads) < 1 {
+		t.Fatal("expected at least one upload")
+	}
+}
+
+func TestFiles_UploadWithPermissions(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{}
+	actions := []api.FileAction{
+		{
+			Type:        api.ActionUpload,
+			LocalPath:   "/tmp/myscript.sh",
+			GuestPath:   "/usr/local/bin/myscript.sh",
+			Permissions: "0755",
+		},
+	}
+	err := Files(g, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.uploads) != 1 || g.uploads[0].guest != "/usr/local/bin/myscript.sh" {
+		t.Errorf("unexpected uploads: %v", g.uploads)
+	}
+	if len(g.chmods) != 1 || g.chmods[0].mode != 0755 {
+		t.Errorf("unexpected chmods: %v", g.chmods)
+	}
+}
+
+func TestFiles_UploadError(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{failOn: "Upload", failErr: errors.New("upload failed")}
+	actions := []api.FileAction{
+		{Type: api.ActionUpload, LocalPath: "/a", GuestPath: "/b"},
+	}
+	err := Files(g, actions)
+	if err == nil {
+		t.Fatal("expected error from Upload")
+	}
+	if !strings.Contains(err.Error(), "upload failed") {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+func TestFiles_WriteError(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{failOn: "Write", failErr: errors.New("write failed")}
+	actions := []api.FileAction{
+		{Type: api.ActionWrite, GuestPath: "/etc/test", Content: []byte("data")},
+	}
+	err := Files(g, actions)
+	if err == nil {
+		t.Fatal("expected error from Write")
+	}
+	if !strings.Contains(err.Error(), "write failed") {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+func TestFiles_MkdirError(t *testing.T) {
+	t.Parallel()
+	g := &mockGuestHandle{failOn: "MkdirP", failErr: errors.New("mkdir failed")}
+	actions := []api.FileAction{
+		{Type: api.ActionUpload, LocalPath: "/a", GuestPath: "/deep/dir/file.txt"},
+	}
+	err := Files(g, actions)
+	if err == nil {
+		t.Fatal("expected error from MkdirP")
+	}
+	if !strings.Contains(err.Error(), "mkdir failed") {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}

--- a/pkg/virt-customization/commit/registry.go
+++ b/pkg/virt-customization/commit/registry.go
@@ -1,0 +1,57 @@
+package commit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
+)
+
+// Registry runs virt-win-reg --merge to apply Windows Registry changes
+// to an offline guest disk. Each RegAction's Content is written to a
+// temporary .reg file and merged in order.
+func Registry(cmdBuilder utils.CommandBuilder, disks []string, keys []string, actions []api.RegAction) error {
+	if len(actions) == 0 {
+		return nil
+	}
+	if len(disks) == 0 {
+		return fmt.Errorf("no disks provided for virt-win-reg")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "virt-win-reg-*")
+	if err != nil {
+		return fmt.Errorf("creating temp dir for registry files: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	var regFiles []string
+	for i, action := range actions {
+		name := filepath.Join(tmpDir, fmt.Sprintf("%04d.reg", i+1))
+		if err := os.WriteFile(name, action.Content, 0600); err != nil {
+			return fmt.Errorf("writing temp registry file %s: %w", name, err)
+		}
+		regFiles = append(regFiles, name)
+	}
+
+	cmd := cmdBuilder.New("virt-win-reg")
+	cmd.AddFlag("--merge")
+	for _, disk := range disks {
+		cmd.AddArg("-a", disk)
+	}
+	for _, key := range keys {
+		cmd.AddArg("--key", key)
+	}
+	for _, rf := range regFiles {
+		cmd.AddPositional(rf)
+	}
+
+	builtCmd := cmd.Build()
+	builtCmd.SetStdout(os.Stdout)
+	builtCmd.SetStderr(os.Stderr)
+	if err := builtCmd.Run(); err != nil {
+		return fmt.Errorf("virt-win-reg merge: %w", err)
+	}
+	return nil
+}

--- a/pkg/virt-customization/commit/registry_test.go
+++ b/pkg/virt-customization/commit/registry_test.go
@@ -1,0 +1,106 @@
+package commit
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+func TestRegistry_EmptyActions(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(nil)
+	err := Registry(fb, []string{"/disk1"}, nil, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if fb.newCmd != "" {
+		t.Error("expected no command to be built for empty actions")
+	}
+}
+
+func TestRegistry_EmptyDisks(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(nil)
+	actions := []api.RegAction{{Content: []byte("Windows Registry Editor Version 5.00\n")}}
+	err := Registry(fb, nil, nil, actions)
+	if err == nil {
+		t.Fatal("expected error for empty disks")
+	}
+	if got := err.Error(); got != "no disks provided for virt-win-reg" {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestRegistry_ValidActions(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(nil)
+	actions := []api.RegAction{
+		{Content: []byte("Windows Registry Editor Version 5.00\n\n[HKEY_LOCAL_MACHINE\\SOFTWARE\\Test]\n\"Key\"=\"Value\"\n")},
+	}
+	err := Registry(fb, []string{"/disk1"}, []string{"all:clevis"}, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fb.newCmd != "virt-win-reg" {
+		t.Errorf("expected command virt-win-reg, got %s", fb.newCmd)
+	}
+	for _, want := range []string{"--merge", "-a", "/disk1", "--key", "all:clevis"} {
+		if !fb.contains(want) {
+			t.Errorf("expected args to contain %q, got %v", want, fb.args)
+		}
+	}
+}
+
+func TestRegistry_MultipleDisksAndKeys(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(nil)
+	actions := []api.RegAction{
+		{Content: []byte("Windows Registry Editor Version 5.00\n")},
+	}
+	err := Registry(fb, []string{"/disk1", "/disk2"}, []string{"all:file:/k1", "all:file:/k2"}, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"/disk1", "/disk2", "all:file:/k1", "all:file:/k2"} {
+		if !fb.contains(want) {
+			t.Errorf("expected args to contain %q, got %v", want, fb.args)
+		}
+	}
+}
+
+func TestRegistry_MultipleActions(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(nil)
+	actions := []api.RegAction{
+		{Content: []byte("Windows Registry Editor Version 5.00\n\n[HKEY_LOCAL_MACHINE\\SOFTWARE\\A]\n")},
+		{Content: []byte("Windows Registry Editor Version 5.00\n\n[HKEY_LOCAL_MACHINE\\SOFTWARE\\B]\n")},
+	}
+	err := Registry(fb, []string{"/disk1"}, nil, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	positionalCount := 0
+	for _, a := range fb.args {
+		if len(a) > 0 && a[0] != '-' && a != "/disk1" {
+			positionalCount++
+		}
+	}
+	if positionalCount != 2 {
+		t.Errorf("expected 2 positional .reg file args, got %d (args: %v)", positionalCount, fb.args)
+	}
+}
+
+func TestRegistry_RunError(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(errors.New("merge failed"))
+	actions := []api.RegAction{{Content: []byte("Windows Registry Editor Version 5.00\n")}}
+	err := Registry(fb, []string{"/disk1"}, nil, actions)
+	if err == nil {
+		t.Fatal("expected error from Run")
+	}
+	if !containsSubstr(err.Error(), "merge failed") {
+		t.Errorf("expected wrapped merge error, got %v", err)
+	}
+}

--- a/pkg/virt-customization/commit/scripts.go
+++ b/pkg/virt-customization/commit/scripts.go
@@ -1,0 +1,89 @@
+package commit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
+)
+
+// Scripts runs virt-customize with --firstboot and --run actions.
+// Keys are passed for LUKS encrypted volumes.
+//
+// Actions that carry inline Content are written to temp files automatically;
+// actions with ScriptPath reference pre-existing host files directly.
+func Scripts(cmdBuilder utils.CommandBuilder, disks []string, keys []string, actions []api.ExecAction) error {
+	if len(actions) == 0 {
+		return nil
+	}
+	if len(disks) == 0 {
+		return fmt.Errorf("no disks provided for virt-customize")
+	}
+
+	// Resolve inline Content to temp files so virt-customize can read them.
+	resolved, tmpDir, err := resolveScriptPaths(actions)
+	if err != nil {
+		return err
+	}
+	if tmpDir != "" {
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+	}
+
+	cmd := cmdBuilder.New("virt-customize")
+	cmd.AddFlag("--verbose")
+	cmd.AddArg("--format", "raw")
+	for _, disk := range disks {
+		cmd.AddArg("-a", disk)
+	}
+	for _, key := range keys {
+		cmd.AddArg("--key", key)
+	}
+	for i, action := range resolved {
+		switch action.Type {
+		case api.ActionFirstboot:
+			cmd.AddArg("--firstboot", action.ScriptPath)
+		case api.ActionRun:
+			cmd.AddArg("--run", action.ScriptPath)
+		default:
+			return fmt.Errorf("unsupported exec action type %q at index %d (value=%q)", action.Type, i, action.ScriptPath)
+		}
+	}
+
+	builtCmd := cmd.Build()
+	builtCmd.SetStdout(os.Stdout)
+	builtCmd.SetStderr(os.Stderr)
+	if err := builtCmd.Run(); err != nil {
+		return fmt.Errorf("virt-customize exec: %w", err)
+	}
+	return nil
+}
+
+// resolveScriptPaths returns a copy of actions where any inline Content has
+// been written to a temp file and ScriptPath set accordingly. A single temp
+// directory is created only if needed and returned so the caller can clean up.
+func resolveScriptPaths(actions []api.ExecAction) ([]api.ExecAction, string, error) {
+	var tmpDir string
+	resolved := make([]api.ExecAction, len(actions))
+	copy(resolved, actions)
+
+	for i := range resolved {
+		if len(resolved[i].Content) == 0 {
+			continue
+		}
+		if tmpDir == "" {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "virt-customize-scripts-*")
+			if err != nil {
+				return nil, "", fmt.Errorf("creating temp dir for exec scripts: %w", err)
+			}
+		}
+		name := filepath.Join(tmpDir, fmt.Sprintf("%04d-script", i+1))
+		if err := os.WriteFile(name, resolved[i].Content, 0700); err != nil {
+			return nil, tmpDir, fmt.Errorf("writing temp script %s: %w", name, err)
+		}
+		resolved[i].ScriptPath = name
+	}
+	return resolved, tmpDir, nil
+}

--- a/pkg/virt-customization/commit/scripts_test.go
+++ b/pkg/virt-customization/commit/scripts_test.go
@@ -1,0 +1,159 @@
+package commit
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
+)
+
+// fakeExecutor records SetStdout/SetStderr calls and returns a configurable Run error.
+type fakeExecutor struct {
+	runErr error
+}
+
+func (f *fakeExecutor) Run() error          { return f.runErr }
+func (f *fakeExecutor) Start() error        { return nil }
+func (f *fakeExecutor) Wait() error         { return nil }
+func (f *fakeExecutor) SetStdout(io.Writer) {}
+func (f *fakeExecutor) SetStderr(io.Writer) {}
+func (f *fakeExecutor) SetStdin(io.Reader)  {}
+
+// fakeBuilder records all calls and returns itself for chaining.
+type fakeBuilder struct {
+	newCmd string
+	args   []string
+	exec   *fakeExecutor
+}
+
+func newFakeBuilder(runErr error) *fakeBuilder {
+	return &fakeBuilder{exec: &fakeExecutor{runErr: runErr}}
+}
+
+func (b *fakeBuilder) New(cmd string) utils.CommandBuilder {
+	b.newCmd = cmd
+	b.args = nil
+	return b
+}
+func (b *fakeBuilder) AddArg(flag, value string) utils.CommandBuilder {
+	b.args = append(b.args, flag, value)
+	return b
+}
+func (b *fakeBuilder) AddArgs(flag string, values ...string) utils.CommandBuilder {
+	for _, v := range values {
+		b.args = append(b.args, flag, v)
+	}
+	return b
+}
+func (b *fakeBuilder) AddFlag(flag string) utils.CommandBuilder {
+	b.args = append(b.args, flag)
+	return b
+}
+func (b *fakeBuilder) AddPositional(value string) utils.CommandBuilder {
+	b.args = append(b.args, value)
+	return b
+}
+func (b *fakeBuilder) AddExtraArgs(values ...string) utils.CommandBuilder {
+	b.args = append(b.args, values...)
+	return b
+}
+func (b *fakeBuilder) Build() utils.CommandExecutor { return b.exec }
+
+func (b *fakeBuilder) contains(s string) bool {
+	for _, a := range b.args {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScripts_EmptyActions(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(nil)
+	err := Scripts(fb, []string{"/disk1"}, nil, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if fb.newCmd != "" {
+		t.Error("expected no command to be built for empty actions")
+	}
+}
+
+func TestScripts_EmptyDisks(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(nil)
+	actions := []api.ExecAction{{Type: api.ActionFirstboot, ScriptPath: "/tmp/script.sh"}}
+	err := Scripts(fb, nil, nil, actions)
+	if err == nil {
+		t.Fatal("expected error for empty disks")
+	}
+	if got := err.Error(); got != "no disks provided for virt-customize" {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestScripts_UnsupportedActionType(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(nil)
+	actions := []api.ExecAction{{Type: "unknown", ScriptPath: "foo"}}
+	err := Scripts(fb, []string{"/disk1"}, nil, actions)
+	if err == nil {
+		t.Fatal("expected error for unsupported action type")
+	}
+	errMsg := err.Error()
+	for _, want := range []string{"unsupported", "unknown", "foo"} {
+		if !containsSubstr(errMsg, want) {
+			t.Errorf("error %q should contain %q", errMsg, want)
+		}
+	}
+}
+
+func TestScripts_ValidActions(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(nil)
+	actions := []api.ExecAction{
+		{Type: api.ActionFirstboot, ScriptPath: "/tmp/first.sh"},
+		{Type: api.ActionRun, ScriptPath: "/tmp/run.sh"},
+	}
+	err := Scripts(fb, []string{"/disk1"}, []string{"all:clevis"}, actions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fb.newCmd != "virt-customize" {
+		t.Errorf("expected command virt-customize, got %s", fb.newCmd)
+	}
+	for _, want := range []string{"-a", "/disk1", "--key", "all:clevis", "--firstboot", "/tmp/first.sh", "--run", "/tmp/run.sh"} {
+		if !fb.contains(want) {
+			t.Errorf("expected args to contain %q, got %v", want, fb.args)
+		}
+	}
+}
+
+func TestScripts_RunError(t *testing.T) {
+	t.Parallel()
+	fb := newFakeBuilder(errors.New("exec failed"))
+	actions := []api.ExecAction{{Type: api.ActionFirstboot, ScriptPath: "/tmp/s.sh"}}
+	err := Scripts(fb, []string{"/disk1"}, nil, actions)
+	if err == nil {
+		t.Fatal("expected error from Run")
+	}
+	if !containsSubstr(err.Error(), "exec failed") {
+		t.Errorf("expected wrapped exec error, got %v", err)
+	}
+}
+
+func containsSubstr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsIndex(s, sub))
+}
+
+func containsIndex(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/virt-customization/customize.go
+++ b/pkg/virt-customization/customize.go
@@ -1,0 +1,191 @@
+package customization
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	"github.com/kubev2v/forklift/pkg/virt-customization/commit"
+	"github.com/kubev2v/forklift/pkg/virt-customization/guesthandle"
+	"github.com/kubev2v/forklift/pkg/virt-customization/probe"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
+)
+
+// Options configures a post-conversion run.
+type Options struct {
+	Config *config.AppConfig
+	Disks  []string
+
+	// OpenHandle creates the libguestfs session for probe + file
+	// operations (Phases 1+2). Required in production.
+	OpenHandle guesthandle.HandleFactory
+
+	// CommandBuilder is used only for CLI-based phases (registry + scripts).
+	// Optional — defaults to a real CommandBuilder.
+	CommandBuilder utils.CommandBuilder
+	FileSystem     utils.FileSystem
+
+	// Unexported test hooks — nil means use real implementation.
+	probeGuest     func(api.GuestHandle) (*api.GuestInfo, error)
+	plugins        []api.Plugin
+	commitFiles    func(api.GuestHandle, []api.FileAction) error
+	commitRegistry func(utils.CommandBuilder, []string, []string, []api.RegAction) error
+	commitScripts  func(utils.CommandBuilder, []string, []string, []api.ExecAction) error
+}
+
+// Run is the self-contained entry point for post-conversion processing.
+// It operates in four phases:
+//  1. Probe guest via GuestHandle (detect OS, stacks, interfaces)
+//  2. Apply file operations via GuestHandle (uploads, writes, mkdir, chmod)
+//     Then the GuestHandle session is shut down so CLI tools get exclusive access.
+//  3. Merge Windows Registry entries via virt-win-reg --merge (if any)
+//  4. Execute scripts via virt-customize (only --firstboot/--run if needed)
+//
+// LUKS keys (when configured) are passed to CLI phases so that encrypted
+// volumes can be unlocked.
+func Run(opts Options) error {
+	if opts.Config == nil {
+		return fmt.Errorf("Run: missing Config")
+	}
+	if len(opts.Disks) == 0 {
+		return fmt.Errorf("Run: no Disks provided")
+	}
+	if opts.OpenHandle == nil {
+		return fmt.Errorf("Run: missing OpenHandle factory")
+	}
+
+	applyDefaults(&opts)
+
+	// Resolve LUKS keys — needed for the GuestHandle and CLI phases.
+	keys, err := luksKeys(opts.FileSystem, opts.Config)
+	if err != nil {
+		return fmt.Errorf("resolving LUKS keys: %w", err)
+	}
+
+	// Open the GuestHandle for Phases 1+2.
+	g, err := opts.OpenHandle(opts.Disks, keys, opts.Config.RootDisk)
+	if err != nil {
+		return fmt.Errorf("opening guest handle: %w", err)
+	}
+
+	// Phase 1: Probe guest via GuestHandle
+	doProbe := probe.Guest
+	if opts.probeGuest != nil {
+		doProbe = opts.probeGuest
+	}
+	guest, err := doProbe(g)
+	if err != nil {
+		g.Close()
+		return fmt.Errorf("guest probe: %w", err)
+	}
+
+	ctx := &api.Context{
+		Guest:      guest,
+		Config:     opts.Config,
+		Disks:      opts.Disks,
+		FileSystem: opts.FileSystem,
+	}
+
+	// Resolve and collect all actions
+	plugins := opts.plugins
+	if plugins == nil {
+		plugins = Resolve(ctx)
+	}
+	var allFiles []api.FileAction
+	var allRegs []api.RegAction
+	var allExecs []api.ExecAction
+
+	for _, p := range plugins {
+		fmt.Printf("Collecting actions from plugin: %s\n", p.Name())
+		actions, err := p.Apply(ctx)
+		if err != nil {
+			g.Close()
+			return fmt.Errorf("plugin %s: %w", p.Name(), err)
+		}
+		if actions == nil {
+			continue
+		}
+		allFiles = append(allFiles, actions.Files...)
+		allRegs = append(allRegs, actions.Regs...)
+		allExecs = append(allExecs, actions.Execs...)
+	}
+
+	// Phase 2: Apply file operations via GuestHandle
+	doFiles := commit.Files
+	if opts.commitFiles != nil {
+		doFiles = opts.commitFiles
+	}
+	if len(allFiles) > 0 {
+		if err := doFiles(g, allFiles); err != nil {
+			g.Close()
+			return fmt.Errorf("commit files: %w", err)
+		}
+	}
+
+	// Shut down the GuestHandle before CLI phases to release disk locks.
+	if err := g.Shutdown(); err != nil {
+		fmt.Printf("warning: GuestHandle shutdown: %v\n", err)
+	}
+	g.Close()
+
+	// Phase 3: Merge Windows Registry entries via virt-win-reg (CLI, only if needed)
+	if len(allRegs) > 0 {
+		doRegistry := commit.Registry
+		if opts.commitRegistry != nil {
+			doRegistry = opts.commitRegistry
+		}
+		if err := doRegistry(opts.CommandBuilder, opts.Disks, keys, allRegs); err != nil {
+			return fmt.Errorf("virt-win-reg merge: %w", err)
+		}
+	}
+
+	// Phase 4: Execute scripts via virt-customize (CLI, only if needed)
+	if len(allExecs) > 0 {
+		doScripts := commit.Scripts
+		if opts.commitScripts != nil {
+			doScripts = opts.commitScripts
+		}
+		if err := doScripts(opts.CommandBuilder, opts.Disks, keys, allExecs); err != nil {
+			return fmt.Errorf("virt-customize exec: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// luksKeys computes LUKS key arguments from config, supporting both
+// key files and centralized server (NBDE/Clevis). These are passed to
+// virt-customize and virt-win-reg so encrypted volumes can be accessed.
+func luksKeys(fs utils.FileSystem, cfg *config.AppConfig) ([]string, error) {
+	if cfg.NbdeClevis {
+		return []string{"all:clevis"}, nil
+	}
+	if cfg.Luksdir == "" {
+		return nil, nil
+	}
+	if _, err := fs.Stat(cfg.Luksdir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error accessing LUKS directory: %w", err)
+	}
+	files, err := utils.GetFilesInPath(fs, cfg.Luksdir)
+	if err != nil {
+		return nil, fmt.Errorf("error reading LUKS key files: %w", err)
+	}
+	var keys []string
+	for _, file := range files {
+		keys = append(keys, fmt.Sprintf("all:file:%s", file))
+	}
+	return keys, nil
+}
+
+func applyDefaults(opts *Options) {
+	if opts.CommandBuilder == nil {
+		opts.CommandBuilder = &utils.CommandBuilderImpl{}
+	}
+	if opts.FileSystem == nil {
+		opts.FileSystem = &utils.FileSystemImpl{}
+	}
+}

--- a/pkg/virt-customization/customize_test.go
+++ b/pkg/virt-customization/customize_test.go
@@ -1,0 +1,549 @@
+package customization
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
+)
+
+// --- test helpers ---
+
+type stubFS struct {
+	statFn    func(string) (os.FileInfo, error)
+	readDirFn func(string) ([]os.DirEntry, error)
+}
+
+func (f *stubFS) Symlink(_, _ string) error                         { return nil }
+func (f *stubFS) WriteFile(_ string, _ []byte, _ os.FileMode) error { return nil }
+func (f *stubFS) Stat(name string) (os.FileInfo, error) {
+	if f.statFn != nil {
+		return f.statFn(name)
+	}
+	return nil, os.ErrNotExist
+}
+func (f *stubFS) ReadDir(name string) ([]os.DirEntry, error) {
+	if f.readDirFn != nil {
+		return f.readDirFn(name)
+	}
+	return nil, nil
+}
+
+type stubPlugin struct {
+	name     string
+	actions  *api.Actions
+	applyErr error
+}
+
+func (p *stubPlugin) Name() string                               { return p.name }
+func (p *stubPlugin) Applicable(_ *api.Context) bool             { return true }
+func (p *stubPlugin) Apply(_ *api.Context) (*api.Actions, error) { return p.actions, p.applyErr }
+
+// stubHandle implements api.GuestHandle for tests.
+type stubHandle struct{}
+
+func (s *stubHandle) IsDir(string) (bool, error)          { return false, nil }
+func (s *stubHandle) IsFile(string) (bool, error)         { return false, nil }
+func (s *stubHandle) Cat(string) (string, error)          { return "", nil }
+func (s *stubHandle) GlobExpand(string) ([]string, error) { return nil, nil }
+func (s *stubHandle) Ls(string) ([]string, error)         { return nil, nil }
+func (s *stubHandle) ReadFile(string) ([]byte, error)     { return nil, nil }
+func (s *stubHandle) MkdirP(string) error                 { return nil }
+func (s *stubHandle) Upload(string, string) error         { return nil }
+func (s *stubHandle) Write(string, []byte) error          { return nil }
+func (s *stubHandle) Chmod(int, string) error             { return nil }
+func (s *stubHandle) Shutdown() error                     { return nil }
+func (s *stubHandle) Close()                              {}
+
+var _ api.GuestHandle = (*stubHandle)(nil)
+
+func noopOpenHandle(_ []string, _ []string, _ string) (api.GuestHandle, error) {
+	return &stubHandle{}, nil
+}
+
+func noopProbe(_ api.GuestHandle) (*api.GuestInfo, error) {
+	return &api.GuestInfo{OS: api.GuestOS{Family: api.OSFamilyLinux}}, nil
+}
+
+func noopCommitFiles(_ api.GuestHandle, _ []api.FileAction) error {
+	return nil
+}
+
+func noopCommitRegistry(_ utils.CommandBuilder, _ []string, _ []string, _ []api.RegAction) error {
+	return nil
+}
+
+func noopCommitScripts(_ utils.CommandBuilder, _ []string, _ []string, _ []api.ExecAction) error {
+	return nil
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// --- luksKeys tests ---
+
+func TestLuksKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      *config.AppConfig
+		fs       utils.FileSystem
+		wantKeys []string
+		wantErr  string
+	}{
+		{
+			name:     "NbdeClevis true returns clevis key",
+			cfg:      &config.AppConfig{NbdeClevis: true},
+			fs:       &stubFS{},
+			wantKeys: []string{"all:clevis"},
+		},
+		{
+			name: "empty Luksdir returns nil",
+			cfg:  &config.AppConfig{},
+			fs:   &stubFS{},
+		},
+		{
+			name: "Stat returns os.ErrNotExist returns nil",
+			cfg:  &config.AppConfig{Luksdir: "/etc/luks"},
+			fs: &stubFS{
+				statFn: func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+			},
+		},
+		{
+			name: "Stat returns other error wraps message",
+			cfg:  &config.AppConfig{Luksdir: "/etc/luks"},
+			fs: &stubFS{
+				statFn: func(string) (os.FileInfo, error) {
+					return nil, errors.New("permission denied")
+				},
+			},
+			wantErr: "error accessing LUKS directory",
+		},
+		{
+			name: "GetFilesInPath (ReadDir) error wraps message",
+			cfg:  &config.AppConfig{Luksdir: "/etc/luks"},
+			fs: &stubFS{
+				statFn: func(string) (os.FileInfo, error) {
+					return utils.MockFileInfo{}, nil
+				},
+				readDirFn: func(string) ([]os.DirEntry, error) {
+					return nil, errors.New("i/o timeout")
+				},
+			},
+			wantErr: "error reading LUKS key files",
+		},
+		{
+			name: "successful key list",
+			cfg:  &config.AppConfig{Luksdir: "/etc/luks"},
+			fs: &stubFS{
+				statFn: func(string) (os.FileInfo, error) {
+					return utils.MockFileInfo{}, nil
+				},
+				readDirFn: func(string) ([]os.DirEntry, error) {
+					return utils.ConvertMockDirEntryToOs([]utils.MockDirEntry{
+						{FileName: "key1"},
+						{FileName: "key2"},
+					}), nil
+				},
+			},
+			wantKeys: []string{"all:file:/etc/luks/key1", "all:file:/etc/luks/key2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			keys, err := luksKeys(tc.fs, tc.cfg)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slicesEqual(keys, tc.wantKeys) {
+				t.Errorf("keys = %v, want %v", keys, tc.wantKeys)
+			}
+		})
+	}
+}
+
+// --- Run tests ---
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	noopFS := &stubFS{}
+
+	t.Run("missing Config returns error", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{Disks: []string{"/dev/sda"}, OpenHandle: noopOpenHandle})
+		if err == nil || !strings.Contains(err.Error(), "Run: missing Config") {
+			t.Fatalf("expected 'Run: missing Config', got: %v", err)
+		}
+	})
+
+	t.Run("empty Disks returns error", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{Config: &config.AppConfig{}, OpenHandle: noopOpenHandle})
+		if err == nil || !strings.Contains(err.Error(), "Run: no Disks provided") {
+			t.Fatalf("expected 'Run: no Disks provided', got: %v", err)
+		}
+	})
+
+	t.Run("missing OpenHandle returns error", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{Config: &config.AppConfig{}, Disks: []string{"/dev/sda"}})
+		if err == nil || !strings.Contains(err.Error(), "Run: missing OpenHandle") {
+			t.Fatalf("expected 'Run: missing OpenHandle', got: %v", err)
+		}
+	})
+
+	t.Run("OpenHandle failure propagated", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{
+			Config: &config.AppConfig{},
+			Disks:  []string{"/dev/sda"},
+			OpenHandle: func([]string, []string, string) (api.GuestHandle, error) {
+				return nil, errors.New("appliance failed")
+			},
+			FileSystem: noopFS,
+		})
+		if err == nil || !strings.Contains(err.Error(), "opening guest handle:") {
+			t.Fatalf("expected 'opening guest handle:' wrapper, got: %v", err)
+		}
+	})
+
+	t.Run("probe failure propagated", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{
+			Config:     &config.AppConfig{},
+			Disks:      []string{"/dev/sda"},
+			FileSystem: noopFS,
+			OpenHandle: noopOpenHandle,
+			probeGuest: func(_ api.GuestHandle) (*api.GuestInfo, error) {
+				return nil, errors.New("connection refused")
+			},
+		})
+		if err == nil || !strings.Contains(err.Error(), "guest probe:") {
+			t.Fatalf("expected 'guest probe:' wrapper, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "connection refused") {
+			t.Fatalf("expected original error preserved, got: %v", err)
+		}
+	})
+
+	t.Run("plugin Apply error wrapped with plugin name", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{
+			Config:     &config.AppConfig{},
+			Disks:      []string{"/dev/sda"},
+			FileSystem: noopFS,
+			OpenHandle: noopOpenHandle,
+			probeGuest: noopProbe,
+			plugins: []api.Plugin{
+				&stubPlugin{name: "test/exploder", applyErr: errors.New("boom")},
+			},
+			commitFiles:    noopCommitFiles,
+			commitRegistry: noopCommitRegistry,
+			commitScripts:  noopCommitScripts,
+		})
+		if err == nil || !strings.Contains(err.Error(), "plugin test/exploder:") {
+			t.Fatalf("expected 'plugin test/exploder:' wrapper, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("expected original error preserved, got: %v", err)
+		}
+	})
+
+	t.Run("file actions trigger commitFiles", func(t *testing.T) {
+		t.Parallel()
+		var filesCalled atomic.Bool
+		err := Run(Options{
+			Config:     &config.AppConfig{},
+			Disks:      []string{"/dev/sda"},
+			FileSystem: noopFS,
+			OpenHandle: noopOpenHandle,
+			probeGuest: noopProbe,
+			plugins: []api.Plugin{
+				&stubPlugin{
+					name: "test/writer",
+					actions: &api.Actions{
+						Files: []api.FileAction{{Type: api.ActionWrite, GuestPath: "/etc/test", Content: []byte("data")}},
+					},
+				},
+			},
+			commitFiles: func(_ api.GuestHandle, files []api.FileAction) error {
+				filesCalled.Store(true)
+				if len(files) != 1 {
+					t.Errorf("expected 1 file action, got %d", len(files))
+				}
+				return nil
+			},
+			commitRegistry: noopCommitRegistry,
+			commitScripts:  noopCommitScripts,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !filesCalled.Load() {
+			t.Error("expected commitFiles to be called")
+		}
+	})
+
+	t.Run("commitFiles not called when no file actions", func(t *testing.T) {
+		t.Parallel()
+		var filesCalled atomic.Bool
+		err := Run(Options{
+			Config:     &config.AppConfig{},
+			Disks:      []string{"/dev/sda"},
+			FileSystem: noopFS,
+			OpenHandle: noopOpenHandle,
+			probeGuest: noopProbe,
+			plugins:    []api.Plugin{&stubPlugin{name: "test/noop", actions: &api.Actions{}}},
+			commitFiles: func(_ api.GuestHandle, _ []api.FileAction) error {
+				filesCalled.Store(true)
+				return nil
+			},
+			commitRegistry: noopCommitRegistry,
+			commitScripts:  noopCommitScripts,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if filesCalled.Load() {
+			t.Error("commitFiles should not be called when there are no file actions")
+		}
+	})
+
+	t.Run("exec actions trigger commitScripts", func(t *testing.T) {
+		t.Parallel()
+		var scriptsCalled atomic.Bool
+		err := Run(Options{
+			Config:     &config.AppConfig{},
+			Disks:      []string{"/dev/sda"},
+			FileSystem: noopFS,
+			OpenHandle: noopOpenHandle,
+			probeGuest: noopProbe,
+			plugins: []api.Plugin{
+				&stubPlugin{
+					name: "test/runner",
+					actions: &api.Actions{
+						Execs: []api.ExecAction{{Type: api.ActionFirstboot, ScriptPath: "/tmp/init.sh"}},
+					},
+				},
+			},
+			commitFiles:    noopCommitFiles,
+			commitRegistry: noopCommitRegistry,
+			commitScripts: func(_ utils.CommandBuilder, _ []string, _ []string, execs []api.ExecAction) error {
+				scriptsCalled.Store(true)
+				if len(execs) != 1 {
+					t.Errorf("expected 1 exec action, got %d", len(execs))
+				}
+				return nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !scriptsCalled.Load() {
+			t.Error("expected commitScripts to be called")
+		}
+	})
+
+	t.Run("commitFiles error propagated", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{
+			Config:     &config.AppConfig{},
+			Disks:      []string{"/dev/sda"},
+			FileSystem: noopFS,
+			OpenHandle: noopOpenHandle,
+			probeGuest: noopProbe,
+			plugins: []api.Plugin{
+				&stubPlugin{
+					name: "test/writer",
+					actions: &api.Actions{
+						Files: []api.FileAction{{Type: api.ActionWrite, GuestPath: "/etc/test"}},
+					},
+				},
+			},
+			commitFiles: func(_ api.GuestHandle, _ []api.FileAction) error {
+				return errors.New("disk full")
+			},
+			commitRegistry: noopCommitRegistry,
+			commitScripts:  noopCommitScripts,
+		})
+		if err == nil || !strings.Contains(err.Error(), "commit files:") {
+			t.Fatalf("expected 'commit files:' wrapper, got: %v", err)
+		}
+	})
+
+	t.Run("commitScripts error propagated", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{
+			Config:     &config.AppConfig{},
+			Disks:      []string{"/dev/sda"},
+			FileSystem: noopFS,
+			OpenHandle: noopOpenHandle,
+			probeGuest: noopProbe,
+			plugins: []api.Plugin{
+				&stubPlugin{
+					name: "test/runner",
+					actions: &api.Actions{
+						Execs: []api.ExecAction{{Type: api.ActionRun, ScriptPath: "/tmp/fix.sh"}},
+					},
+				},
+			},
+			commitFiles:    noopCommitFiles,
+			commitRegistry: noopCommitRegistry,
+			commitScripts: func(_ utils.CommandBuilder, _ []string, _ []string, _ []api.ExecAction) error {
+				return errors.New("virt-customize segfault")
+			},
+		})
+		if err == nil || !strings.Contains(err.Error(), "virt-customize exec:") {
+			t.Fatalf("expected 'virt-customize exec:' wrapper, got: %v", err)
+		}
+	})
+
+	t.Run("LUKS key resolution error propagated", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{
+			Config:     &config.AppConfig{Luksdir: "/etc/luks"},
+			Disks:      []string{"/dev/sda"},
+			OpenHandle: noopOpenHandle,
+			FileSystem: &stubFS{
+				statFn: func(string) (os.FileInfo, error) {
+					return nil, errors.New("io error")
+				},
+			},
+		})
+		if err == nil || !strings.Contains(err.Error(), "resolving LUKS keys:") {
+			t.Fatalf("expected 'resolving LUKS keys:' wrapper, got: %v", err)
+		}
+	})
+
+	t.Run("reg actions trigger commitRegistry", func(t *testing.T) {
+		t.Parallel()
+		var registryCalled atomic.Bool
+		err := Run(Options{
+			Config:     &config.AppConfig{},
+			Disks:      []string{"/dev/sda"},
+			FileSystem: noopFS,
+			OpenHandle: noopOpenHandle,
+			probeGuest: noopProbe,
+			plugins: []api.Plugin{
+				&stubPlugin{
+					name: "test/regwriter",
+					actions: &api.Actions{
+						Regs: []api.RegAction{{Content: []byte("Windows Registry Editor Version 5.00\n")}},
+					},
+				},
+			},
+			commitFiles: noopCommitFiles,
+			commitRegistry: func(_ utils.CommandBuilder, _ []string, _ []string, regs []api.RegAction) error {
+				registryCalled.Store(true)
+				if len(regs) != 1 {
+					t.Errorf("expected 1 reg action, got %d", len(regs))
+				}
+				return nil
+			},
+			commitScripts: noopCommitScripts,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !registryCalled.Load() {
+			t.Error("expected commitRegistry to be called")
+		}
+	})
+
+	t.Run("commitRegistry not called when no reg actions", func(t *testing.T) {
+		t.Parallel()
+		var registryCalled atomic.Bool
+		err := Run(Options{
+			Config:      &config.AppConfig{},
+			Disks:       []string{"/dev/sda"},
+			FileSystem:  noopFS,
+			OpenHandle:  noopOpenHandle,
+			probeGuest:  noopProbe,
+			plugins:     []api.Plugin{&stubPlugin{name: "test/noop", actions: &api.Actions{}}},
+			commitFiles: noopCommitFiles,
+			commitRegistry: func(_ utils.CommandBuilder, _ []string, _ []string, _ []api.RegAction) error {
+				registryCalled.Store(true)
+				return nil
+			},
+			commitScripts: noopCommitScripts,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if registryCalled.Load() {
+			t.Error("commitRegistry should not be called when there are no reg actions")
+		}
+	})
+
+	t.Run("commitRegistry error propagated", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{
+			Config:     &config.AppConfig{},
+			Disks:      []string{"/dev/sda"},
+			FileSystem: noopFS,
+			OpenHandle: noopOpenHandle,
+			probeGuest: noopProbe,
+			plugins: []api.Plugin{
+				&stubPlugin{
+					name: "test/regwriter",
+					actions: &api.Actions{
+						Regs: []api.RegAction{{Content: []byte("Windows Registry Editor Version 5.00\n")}},
+					},
+				},
+			},
+			commitFiles: noopCommitFiles,
+			commitRegistry: func(_ utils.CommandBuilder, _ []string, _ []string, _ []api.RegAction) error {
+				return errors.New("registry hive corrupted")
+			},
+			commitScripts: noopCommitScripts,
+		})
+		if err == nil || !strings.Contains(err.Error(), "virt-win-reg merge:") {
+			t.Fatalf("expected 'virt-win-reg merge:' wrapper, got: %v", err)
+		}
+	})
+
+	t.Run("happy path with no plugins produces no error", func(t *testing.T) {
+		t.Parallel()
+		err := Run(Options{
+			Config:         &config.AppConfig{},
+			Disks:          []string{"/dev/sda"},
+			FileSystem:     noopFS,
+			OpenHandle:     noopOpenHandle,
+			probeGuest:     noopProbe,
+			plugins:        []api.Plugin{},
+			commitFiles:    noopCommitFiles,
+			commitRegistry: noopCommitRegistry,
+			commitScripts:  noopCommitScripts,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/pkg/virt-customization/detect_test.go
+++ b/pkg/virt-customization/detect_test.go
@@ -1,0 +1,49 @@
+package customization_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
+	customization "github.com/kubev2v/forklift/pkg/virt-customization"
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fakeFS struct{}
+
+func (f *fakeFS) Symlink(_, _ string) error                         { return nil }
+func (f *fakeFS) Stat(_ string) (os.FileInfo, error)                { return nil, os.ErrNotExist }
+func (f *fakeFS) WriteFile(_ string, _ []byte, _ os.FileMode) error { return nil }
+func (f *fakeFS) ReadDir(_ string) ([]os.DirEntry, error)           { return nil, os.ErrNotExist }
+
+func TestPostprocess(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Customize Suite")
+}
+
+var _ = Describe("AllPlugins", func() {
+	It("returns exactly one plugin (example/hello)", func() {
+		plugins := customization.AllPlugins()
+		Expect(plugins).To(HaveLen(1))
+		Expect(plugins[0].Name()).To(Equal("example/hello"))
+	})
+})
+
+var _ = Describe("Resolve", func() {
+	It("returns empty when no plugins are applicable", func() {
+		ctx := &api.Context{
+			Guest:      &api.GuestInfo{OS: api.GuestOS{Family: api.OSFamilyLinux}},
+			FileSystem: &fakeFS{},
+			Config:     &config.AppConfig{},
+		}
+		plugins := customization.Resolve(ctx)
+		Expect(plugins).To(BeEmpty())
+	})
+
+	It("returns empty for nil context", func() {
+		plugins := customization.Resolve(nil)
+		Expect(plugins).To(BeEmpty())
+	})
+})

--- a/pkg/virt-customization/guesthandle/factory.go
+++ b/pkg/virt-customization/guesthandle/factory.go
@@ -1,0 +1,22 @@
+//go:build !ignore
+
+package guesthandle
+
+import (
+	"fmt"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// HandleFactory creates a GuestHandle for the given disks and LUKS keys.
+// Production callers supply DefaultOpenHandle(); tests supply a function
+// returning a mock.
+type HandleFactory func(disks []string, keys []string, rootDisk string) (api.GuestHandle, error)
+
+// DefaultOpenHandle returns a factory that always fails when the CGO guestfs
+// bindings are not available. Production builds must use the "guestfs" build tag.
+func DefaultOpenHandle() HandleFactory {
+	return func([]string, []string, string) (api.GuestHandle, error) {
+		return nil, fmt.Errorf("libguestfs Go bindings not available (build without guestfs tag)")
+	}
+}

--- a/pkg/virt-customization/guesthandle/factory_guestfs.go
+++ b/pkg/virt-customization/guesthandle/factory_guestfs.go
@@ -1,0 +1,14 @@
+//go:build ignore
+
+package guesthandle
+
+import (
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// DefaultOpenHandle is the production HandleFactory backed by libguestfs CGO bindings.
+func DefaultOpenHandle() HandleFactory {
+	return func(disks []string, keys []string, rootDisk string) (api.GuestHandle, error) {
+		return Open(disks, keys, rootDisk)
+	}
+}

--- a/pkg/virt-customization/guesthandle/handle.go
+++ b/pkg/virt-customization/guesthandle/handle.go
@@ -1,0 +1,130 @@
+// Package guesthandle provides the production GuestHandle backed by
+// the libguestfs Go (CGO) bindings. Build-tagged so that unit tests
+// not needing a real appliance can compile without libguestfs-devel.
+//
+//go:build ignore
+
+package guesthandle
+
+import (
+	"fmt"
+	"sort"
+
+	"libguestfs.org/guestfs"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// Handle wraps a live libguestfs session and implements api.GuestHandle.
+type Handle struct {
+	g *guestfs.Guestfs
+}
+
+// Open creates a new libguestfs session, adds the given disks (raw format),
+// launches the appliance, inspects for an OS root, and mounts all
+// discovered filesystems. The returned Handle is ready for probe and
+// file operations. Callers must call Shutdown + Close when done.
+func Open(disks []string, keys []string, rootDisk string) (api.GuestHandle, error) {
+	if len(disks) == 0 {
+		return nil, fmt.Errorf("guesthandle.Open: no disks provided")
+	}
+
+	g, errno := guestfs.Create()
+	if errno != nil {
+		return nil, fmt.Errorf("guestfs.Create: %w", errno)
+	}
+
+	for _, disk := range disks {
+		optargs := guestfs.OptargsAdd_drive{
+			Format_is_set:   true,
+			Format:          "raw",
+			Readonly_is_set: true,
+			Readonly:        false,
+		}
+		if err := g.Add_drive(disk, &optargs); err != nil {
+			g.Close()
+			return nil, fmt.Errorf("add_drive %s: %w", disk, err)
+		}
+	}
+
+	if err := g.Launch(); err != nil {
+		g.Close()
+		return nil, fmt.Errorf("launch: %w", err)
+	}
+
+	roots, err := g.Inspect_os()
+	if err != nil {
+		g.Close()
+		return nil, fmt.Errorf("inspect_os: %w", err)
+	}
+
+	root := pickRoot(roots, rootDisk)
+	if root == "" {
+		g.Close()
+		return nil, fmt.Errorf("no OS root found (inspected %d candidates)", len(roots))
+	}
+
+	mountpoints, err := g.Inspect_get_mountpoints(root)
+	if err != nil {
+		g.Close()
+		return nil, fmt.Errorf("inspect_get_mountpoints: %w", err)
+	}
+
+	// Mount in path-length order so parents appear before children.
+	mps := sortedMountpoints(mountpoints)
+	for _, mp := range mps {
+		if err := g.Mount(mp.device, mp.mountpoint); err != nil {
+			fmt.Printf("warning: mount %s on %s: %v\n", mp.device, mp.mountpoint, err)
+		}
+	}
+
+	// LUKS keys are handled at the appliance level; placeholder for future support.
+	_ = keys
+
+	return &Handle{g: g}, nil
+}
+
+func (h *Handle) IsDir(path string) (bool, error)            { return h.g.Is_dir(path, nil) }
+func (h *Handle) IsFile(path string) (bool, error)            { return h.g.Is_file(path, nil) }
+func (h *Handle) Cat(path string) (string, error)             { return h.g.Cat(path) }
+func (h *Handle) Ls(dir string) ([]string, error)             { return h.g.Ls(dir) }
+func (h *Handle) MkdirP(path string) error                    { return h.g.Mkdir_p(path) }
+func (h *Handle) Chmod(mode int, path string) error            { return h.g.Chmod(mode, path) }
+func (h *Handle) Write(path string, content []byte) error     { return h.g.Write(path, content) }
+func (h *Handle) Upload(local, guest string) error             { return h.g.Upload(local, guest) }
+func (h *Handle) ReadFile(path string) ([]byte, error)         { return h.g.Read_file(path) }
+func (h *Handle) GlobExpand(pattern string) ([]string, error) { return h.g.Glob_expand(pattern, nil) }
+func (h *Handle) Shutdown() error                              { return h.g.Shutdown() }
+func (h *Handle) Close()                                       { h.g.Close() }
+
+var _ api.GuestHandle = (*Handle)(nil)
+
+func pickRoot(roots []string, rootDisk string) string {
+	if len(roots) == 0 {
+		return ""
+	}
+	if rootDisk != "" {
+		for _, r := range roots {
+			if r == rootDisk {
+				return r
+			}
+		}
+	}
+	return roots[0]
+}
+
+type mountEntry struct {
+	mountpoint string
+	device     string
+}
+
+func sortedMountpoints(mp map[string]string) []mountEntry {
+	entries := make([]mountEntry, 0, len(mp))
+	for mountpoint, device := range mp {
+		entries = append(entries, mountEntry{mountpoint: mountpoint, device: device})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return len(entries[i].mountpoint) < len(entries[j].mountpoint)
+	})
+	return entries
+}

--- a/pkg/virt-customization/plugins/example/plugin.go
+++ b/pkg/virt-customization/plugins/example/plugin.go
@@ -1,0 +1,142 @@
+// example/hello — Reference plugin demonstrating the Plugin interface.
+//
+// Applicable: Never (this is a documentation-only reference).
+// Output:     FileAction{Write}, RegAction, ExecAction{Firstboot} — all illustrative.
+//
+// This plugin exists solely as a template for implementing real plugins.
+// It shows how to:
+//   - Implement the api.Plugin interface (Name, Applicable, Apply).
+//   - Gate execution on guest OS type and config flags via Applicable.
+//   - Return declarative Actions from Apply (files, registry, scripts).
+//   - Embed static scripts using //go:embed.
+//   - Follow the package-level doc header convention.
+//
+// To create a new plugin based on this example:
+//  1. Copy this directory to plugins/<category>/<name>/.
+//  2. Rename the package.
+//  3. Implement Applicable with real conditions (OS family, config flags, etc.).
+//  4. Implement Apply to return the actual actions your plugin needs.
+//  5. Place any scripts in scripts/ and embed them with //go:embed scripts.
+//  6. Register the plugin in resolve.go by adding it to AllPlugins() at the
+//     correct position (ordering matters: network before drivers before boot).
+//  7. Add tests in plugin_test.go covering Applicable and Apply.
+package example
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// Embed the scripts/ directory so its contents are compiled into the binary.
+// Each plugin that writes files to the guest should embed its scripts this way.
+// Access individual files with scriptFS.ReadFile("scripts/<filename>").
+//
+//go:embed scripts
+var scriptFS embed.FS
+
+// readScript returns the content of the named file from the embedded scripts/ dir.
+// Keeping this as a helper avoids repeating the "scripts/" prefix everywhere.
+func readScript(name string) ([]byte, error) {
+	return scriptFS.ReadFile("scripts/" + name)
+}
+
+// Plugin implements api.Plugin. Every plugin must be a struct (even if empty)
+// so it can be registered as a pointer (&example.Plugin{}) in resolve.go.
+type Plugin struct{}
+
+// Name returns a unique, human-readable identifier for this plugin.
+// Convention: "<category>/<name>" (e.g., "network/udev", "boot/windows/firstboot-runner").
+func (p *Plugin) Name() string { return "example/hello" }
+
+// Applicable decides whether this plugin should run for the given guest.
+//
+// Real plugins inspect ctx.Guest (OS family, detected network stacks, interfaces)
+// and ctx.Config (feature flags, paths) to decide. For example:
+//
+//	// Only applies to Windows guests with static IPs configured.
+//	func (p *Plugin) Applicable(ctx *api.Context) bool {
+//	    if ctx == nil || ctx.Guest == nil || ctx.Config == nil {
+//	        return false
+//	    }
+//	    return ctx.Guest.OS.IsWindows() && ctx.Config.StaticIPs != ""
+//	}
+//
+// This example always returns false since it is a reference, not a real plugin.
+func (p *Plugin) Applicable(ctx *api.Context) bool {
+	if ctx == nil || ctx.Guest == nil || ctx.Config == nil {
+		return false
+	}
+	return false
+}
+
+// Apply collects the declarative actions this plugin wants performed on the guest.
+//
+// The returned *api.Actions contains three slices — real plugins populate only the
+// ones they need:
+//
+//   - Files  []FileAction  — written to the guest disk via the GuestHandle (Phase 2).
+//     Use ActionWrite for in-memory content, ActionUpload for host files.
+//
+//   - Regs   []RegAction   — merged into the Windows registry offline via
+//     virt-win-reg --merge (Phase 3). Only relevant for Windows guests.
+//
+//   - Execs  []ExecAction  — executed via virt-customize (Phase 4).
+//     Use ActionFirstboot for scripts that run on next boot,
+//     ActionRun for scripts that run immediately in the offline guest.
+//
+// Plugins must NOT perform side effects here — only return data. The commit
+// layer (commit/files.go, commit/registry.go, commit/scripts.go) materializes
+// the actions onto the guest disk.
+func (p *Plugin) Apply(ctx *api.Context) (*api.Actions, error) {
+	if ctx == nil || ctx.Guest == nil || ctx.Config == nil {
+		return nil, fmt.Errorf("example plugin: nil context, guest, or config")
+	}
+
+	// Read an embedded script. Real plugins embed .ps1, .bat, .sh, or .reg files.
+	content, err := readScript("hello.sh")
+	if err != nil {
+		return nil, fmt.Errorf("read embedded script: %w", err)
+	}
+
+	return &api.Actions{
+		// FileAction — write content directly into the guest filesystem.
+		// The commit layer calls g.MkdirP on parent dirs, then g.Write or g.Upload.
+		// GuestPath is the destination inside the guest disk. For example:
+		//   - Windows firstboot: path.Join(api.WinFirstbootScriptsPath, "myscript.ps1")
+		//   - Linux udev rules:  "/etc/udev/rules.d/70-persistent-net.rules"
+		Files: []api.FileAction{
+			{
+				Type:        api.ActionWrite,
+				GuestPath:   "/usr/local/bin/hello.sh",
+				Content:     content,
+				Permissions: "0755",
+			},
+		},
+
+		// RegAction — offline Windows registry merge via virt-win-reg.
+		// Content must be valid Windows REGEDIT (.reg) format.
+		// Only include this for Windows-specific plugins.
+		Regs: []api.RegAction{
+			{
+				Content: []byte("Windows Registry Editor Version 5.00\n\n" +
+					"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Example]\n" +
+					"\"HelloKey\"=\"HelloValue\"\n"),
+			},
+		},
+
+		// ExecAction — script execution via virt-customize CLI (Phase 4).
+		// Use Content for inline scripts (the commit layer writes them to temp
+		// files automatically). Use ScriptPath for pre-existing host files
+		// (e.g., user-supplied scripts from a ConfigMap mount).
+		// ActionFirstboot: registers the script to run on the guest's next boot.
+		// ActionRun: runs the script immediately in the offline guest.
+		Execs: []api.ExecAction{
+			{
+				Type:    api.ActionFirstboot,
+				Content: content,
+			},
+		},
+	}, nil
+}

--- a/pkg/virt-customization/plugins/example/plugin_test.go
+++ b/pkg/virt-customization/plugins/example/plugin_test.go
@@ -1,0 +1,96 @@
+package example
+
+import (
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
+)
+
+func TestName(t *testing.T) {
+	t.Parallel()
+	p := &Plugin{}
+	if got := p.Name(); got != "example/hello" {
+		t.Errorf("Name() = %q, want %q", got, "example/hello")
+	}
+}
+
+func TestApplicable_NilContext(t *testing.T) {
+	t.Parallel()
+	p := &Plugin{}
+	if p.Applicable(nil) {
+		t.Error("Applicable(nil) should return false")
+	}
+}
+
+func TestApplicable_NilGuest(t *testing.T) {
+	t.Parallel()
+	p := &Plugin{}
+	ctx := &api.Context{Config: &config.AppConfig{}}
+	if p.Applicable(ctx) {
+		t.Error("Applicable with nil Guest should return false")
+	}
+}
+
+func TestApplicable_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	p := &Plugin{}
+	ctx := &api.Context{
+		Guest:  &api.GuestInfo{OS: api.GuestOS{Family: api.OSFamilyLinux}},
+		Config: &config.AppConfig{},
+	}
+	if p.Applicable(ctx) {
+		t.Error("example plugin Applicable should always return false")
+	}
+}
+
+func TestApply_ReturnsAllActionTypes(t *testing.T) {
+	t.Parallel()
+	p := &Plugin{}
+	ctx := &api.Context{
+		Guest:  &api.GuestInfo{OS: api.GuestOS{Family: api.OSFamilyWindows}},
+		Config: &config.AppConfig{},
+	}
+
+	actions, err := p.Apply(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(actions.Files) == 0 {
+		t.Error("expected at least one FileAction")
+	}
+	if len(actions.Regs) == 0 {
+		t.Error("expected at least one RegAction")
+	}
+	if len(actions.Execs) == 0 {
+		t.Error("expected at least one ExecAction")
+	}
+
+	if actions.Files[0].Type != api.ActionWrite {
+		t.Errorf("FileAction type = %q, want %q", actions.Files[0].Type, api.ActionWrite)
+	}
+	if len(actions.Files[0].Content) == 0 {
+		t.Error("FileAction content should not be empty (embedded script)")
+	}
+	if actions.Files[0].Permissions != "0755" {
+		t.Errorf("FileAction permissions = %q, want %q", actions.Files[0].Permissions, "0755")
+	}
+
+	// ExecAction uses inline Content — no host file needed, the commit layer
+	// writes it to a temp file automatically.
+	if actions.Execs[0].Type != api.ActionFirstboot {
+		t.Errorf("ExecAction type = %q, want %q", actions.Execs[0].Type, api.ActionFirstboot)
+	}
+	if len(actions.Execs[0].Content) == 0 {
+		t.Error("ExecAction Content should not be empty")
+	}
+}
+
+func TestApply_NilContext(t *testing.T) {
+	t.Parallel()
+	p := &Plugin{}
+	_, err := p.Apply(nil)
+	if err == nil {
+		t.Error("Apply(nil) should return an error")
+	}
+}

--- a/pkg/virt-customization/plugins/example/scripts/hello.sh
+++ b/pkg/virt-customization/plugins/example/scripts/hello.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Example embedded script — replace with your real script content.
+# This file is compiled into the plugin binary via //go:embed scripts.
+echo "Hello from the example plugin"

--- a/pkg/virt-customization/probe/cloudinit/cloudcfg.go
+++ b/pkg/virt-customization/probe/cloudinit/cloudcfg.go
@@ -1,0 +1,107 @@
+package cloudinit
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+// CloudCfgResult holds the fields extracted from cloud.cfg and cloud.cfg.d.
+type CloudCfgResult struct {
+	DatasourceList        []string
+	NetworkConfigDisabled bool
+}
+
+// cloudCfgDoc is the partial YAML structure we extract from cloud.cfg.
+type cloudCfgDoc struct {
+	DatasourceList []string    `yaml:"datasource_list"`
+	Network        interface{} `yaml:"network"`
+}
+
+// ParseCloudCfg parses concatenated cloud.cfg + cloud.cfg.d/*.cfg YAML
+// documents and extracts the fields needed by migration plugins.
+// Later documents override earlier ones (drop-in semantics).
+func ParseCloudCfg(section string) (CloudCfgResult, error) {
+	var result CloudCfgResult
+	var errs []error
+
+	for i, doc := range splitYAMLDocuments(section) {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var cfg cloudCfgDoc
+		if err := yaml.Unmarshal([]byte(doc), &cfg); err != nil {
+			errs = append(errs, fmt.Errorf("parsing cloud.cfg document %d: %w", i, err))
+			continue
+		}
+
+		if len(cfg.DatasourceList) > 0 {
+			result.DatasourceList = cfg.DatasourceList
+		}
+
+		if cfg.Network != nil {
+			result.NetworkConfigDisabled = isNetworkDisabled(cfg.Network)
+		}
+	}
+
+	return result, errors.Join(errs...)
+}
+
+// isNetworkDisabled checks if the network key is {config: disabled}.
+// cloud-init supports: network: {config: disabled}
+func isNetworkDisabled(network interface{}) bool {
+	m, ok := network.(map[interface{}]interface{})
+	if !ok {
+		return false
+	}
+	val, ok := m["config"]
+	if !ok {
+		return false
+	}
+	s, ok := val.(string)
+	return ok && s == "disabled"
+}
+
+// ParseDatasourceFile reads the /var/lib/cloud/instance/datasource file
+// which contains a line like "DataSourceNoCloud [seed=/dev/sr0]".
+// Returns the datasource name (e.g., "NoCloud").
+func ParseDatasourceFile(content string) string {
+	line := strings.TrimSpace(content)
+	if line == "" {
+		return ""
+	}
+	// Format: "DataSource<Name> [<details>]" or "DataSource<Name>"
+	name := line
+	if idx := strings.IndexByte(name, ' '); idx > 0 {
+		name = name[:idx]
+	}
+	if idx := strings.IndexByte(name, '['); idx > 0 {
+		name = name[:idx]
+	}
+	name = strings.TrimPrefix(name, "DataSource")
+	return name
+}
+
+// splitYAMLDocuments splits concatenated YAML docs on "---" separators.
+func splitYAMLDocuments(input string) []string {
+	var docs []string
+	var current strings.Builder
+
+	for _, line := range strings.Split(input, "\n") {
+		if strings.TrimSpace(line) == "---" {
+			if current.Len() > 0 {
+				docs = append(docs, current.String())
+				current.Reset()
+			}
+			continue
+		}
+		current.WriteString(line)
+		current.WriteByte('\n')
+	}
+	if current.Len() > 0 {
+		docs = append(docs, current.String())
+	}
+	return docs
+}

--- a/pkg/virt-customization/probe/cloudinit/cloudcfg_test.go
+++ b/pkg/virt-customization/probe/cloudinit/cloudcfg_test.go
@@ -1,0 +1,159 @@
+package cloudinit
+
+import "testing"
+
+func TestParseCloudCfg_DatasourceList(t *testing.T) {
+	t.Parallel()
+	cfg := `datasource_list:
+  - NoCloud
+  - ConfigDrive
+  - OpenStack
+`
+	result, err := ParseCloudCfg(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.DatasourceList) != 3 {
+		t.Fatalf("expected 3 datasources, got %d", len(result.DatasourceList))
+	}
+	if result.DatasourceList[0] != "NoCloud" {
+		t.Errorf("expected NoCloud, got %s", result.DatasourceList[0])
+	}
+	if result.DatasourceList[2] != "OpenStack" {
+		t.Errorf("expected OpenStack, got %s", result.DatasourceList[2])
+	}
+}
+
+func TestParseCloudCfg_NetworkDisabled(t *testing.T) {
+	t.Parallel()
+	cfg := `network:
+  config: disabled
+`
+	result, err := ParseCloudCfg(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.NetworkConfigDisabled {
+		t.Error("expected NetworkConfigDisabled to be true")
+	}
+}
+
+func TestParseCloudCfg_NetworkNotDisabled(t *testing.T) {
+	t.Parallel()
+	cfg := `network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+`
+	result, err := ParseCloudCfg(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NetworkConfigDisabled {
+		t.Error("expected NetworkConfigDisabled to be false")
+	}
+}
+
+func TestParseCloudCfg_NoNetworkKey(t *testing.T) {
+	t.Parallel()
+	cfg := `datasource_list:
+  - EC2
+`
+	result, err := ParseCloudCfg(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NetworkConfigDisabled {
+		t.Error("expected NetworkConfigDisabled false when network key absent")
+	}
+}
+
+func TestParseCloudCfg_MultipleDocuments(t *testing.T) {
+	t.Parallel()
+	// Simulates cloud.cfg + cloud.cfg.d/99-datasource.cfg concatenated
+	cfg := `datasource_list:
+  - EC2
+  - None
+---
+datasource_list:
+  - NoCloud
+`
+	result, err := ParseCloudCfg(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Later document overrides
+	if len(result.DatasourceList) != 1 || result.DatasourceList[0] != "NoCloud" {
+		t.Errorf("expected [NoCloud] from override, got %v", result.DatasourceList)
+	}
+}
+
+func TestParseCloudCfg_EmptyInput(t *testing.T) {
+	t.Parallel()
+	result, err := ParseCloudCfg("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.DatasourceList) != 0 {
+		t.Errorf("expected empty DatasourceList, got %v", result.DatasourceList)
+	}
+}
+
+func TestParseCloudCfg_InvalidYAML(t *testing.T) {
+	t.Parallel()
+	_, err := ParseCloudCfg(":\n  bad: [yaml")
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestParseCloudCfg_FullConfig(t *testing.T) {
+	t.Parallel()
+	cfg := `users:
+  - default
+disable_root: true
+datasource_list:
+  - VMware
+  - OVF
+  - None
+network:
+  config: disabled
+ssh_authorized_keys:
+  - ssh-rsa AAAA...
+`
+	result, err := ParseCloudCfg(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.DatasourceList) != 3 {
+		t.Fatalf("expected 3 datasources, got %d", len(result.DatasourceList))
+	}
+	if result.DatasourceList[0] != "VMware" {
+		t.Errorf("expected VMware, got %s", result.DatasourceList[0])
+	}
+	if !result.NetworkConfigDisabled {
+		t.Error("expected NetworkConfigDisabled to be true")
+	}
+}
+
+func TestParseDatasourceFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"DataSourceNoCloud [seed=/dev/sr0][dsmode=net]\n", "NoCloud"},
+		{"DataSourceConfigDrive\n", "ConfigDrive"},
+		{"DataSourceEC2Local\n", "EC2Local"},
+		{"DataSourceOpenStackLocal [ds=OpenStackLocal,ver=2]\n", "OpenStackLocal"},
+		{"", ""},
+		{"\n", ""},
+	}
+	for _, tt := range tests {
+		got := ParseDatasourceFile(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseDatasourceFile(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/pkg/virt-customization/probe/console/grub.go
+++ b/pkg/virt-customization/probe/console/grub.go
@@ -1,0 +1,86 @@
+package console
+
+import (
+	"bufio"
+	"strings"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// ParseGrubDefaults parses /etc/default/grub and extracts console= parameters
+// from GRUB_CMDLINE_LINUX and GRUB_CMDLINE_LINUX_DEFAULT.
+func ParseGrubDefaults(section string) []api.ConsoleDevice {
+	var consoles []api.ConsoleDevice
+
+	scanner := bufio.NewScanner(strings.NewReader(section))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+
+		kv := strings.SplitN(line, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+
+		key := kv[0]
+		if key != "GRUB_CMDLINE_LINUX" && key != "GRUB_CMDLINE_LINUX_DEFAULT" {
+			continue
+		}
+
+		val := stripShellQuotes(kv[1])
+		consoles = append(consoles, parseConsoleParams(val)...)
+	}
+
+	return consoles
+}
+
+// ParseSerialGettyUnits extracts device names from serial-getty unit filenames.
+// Input: directory listing entries like "serial-getty@ttyS0.service".
+// Returns: ["ttyS0"]
+func ParseSerialGettyUnits(entries []string) []string {
+	var devices []string
+	for _, name := range entries {
+		if !strings.HasPrefix(name, "serial-getty@") {
+			continue
+		}
+		dev := strings.TrimPrefix(name, "serial-getty@")
+		dev = strings.TrimSuffix(dev, ".service")
+		if dev != "" {
+			devices = append(devices, dev)
+		}
+	}
+	return devices
+}
+
+// parseConsoleParams extracts console= parameters from a kernel cmdline string.
+// Example: "console=ttyS0,115200n8 console=tty0 quiet"
+// Returns: [{Device:"ttyS0", Baud:"115200n8"}, {Device:"tty0", Baud:""}]
+func parseConsoleParams(cmdline string) []api.ConsoleDevice {
+	var consoles []api.ConsoleDevice
+	for _, token := range strings.Fields(cmdline) {
+		if !strings.HasPrefix(token, "console=") {
+			continue
+		}
+		val := strings.TrimPrefix(token, "console=")
+		parts := strings.SplitN(val, ",", 2)
+		dev := api.ConsoleDevice{Device: parts[0]}
+		if len(parts) > 1 {
+			dev.Baud = parts[1]
+		}
+		consoles = append(consoles, dev)
+	}
+	return consoles
+}
+
+// stripShellQuotes removes surrounding double or single quotes.
+func stripShellQuotes(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/pkg/virt-customization/probe/console/grub_test.go
+++ b/pkg/virt-customization/probe/console/grub_test.go
@@ -1,0 +1,160 @@
+package console
+
+import (
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+func TestParseGrubDefaults_SerialConsole(t *testing.T) {
+	t.Parallel()
+	grub := `GRUB_TIMEOUT=5
+GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 console=tty0 crashkernel=auto"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+`
+	consoles := ParseGrubDefaults(grub)
+	if len(consoles) != 2 {
+		t.Fatalf("expected 2 consoles, got %d", len(consoles))
+	}
+	if consoles[0].Device != "ttyS0" {
+		t.Errorf("expected ttyS0, got %s", consoles[0].Device)
+	}
+	if consoles[0].Baud != "115200n8" {
+		t.Errorf("expected 115200n8, got %s", consoles[0].Baud)
+	}
+	if consoles[1].Device != "tty0" {
+		t.Errorf("expected tty0, got %s", consoles[1].Device)
+	}
+	if consoles[1].Baud != "" {
+		t.Errorf("expected empty baud for tty0, got %s", consoles[1].Baud)
+	}
+}
+
+func TestParseGrubDefaults_NoConsole(t *testing.T) {
+	t.Parallel()
+	grub := `GRUB_TIMEOUT=5
+GRUB_CMDLINE_LINUX="crashkernel=auto rd.lvm.lv=centos/root"
+`
+	consoles := ParseGrubDefaults(grub)
+	if len(consoles) != 0 {
+		t.Errorf("expected 0 consoles, got %d", len(consoles))
+	}
+}
+
+func TestParseGrubDefaults_SingleQuotes(t *testing.T) {
+	t.Parallel()
+	grub := `GRUB_CMDLINE_LINUX='console=ttyS0,9600'
+`
+	consoles := ParseGrubDefaults(grub)
+	if len(consoles) != 1 {
+		t.Fatalf("expected 1 console, got %d", len(consoles))
+	}
+	if consoles[0].Device != "ttyS0" {
+		t.Errorf("expected ttyS0, got %s", consoles[0].Device)
+	}
+	if consoles[0].Baud != "9600" {
+		t.Errorf("expected 9600, got %s", consoles[0].Baud)
+	}
+}
+
+func TestParseGrubDefaults_Comments(t *testing.T) {
+	t.Parallel()
+	grub := `# GRUB_CMDLINE_LINUX="console=ttyS0"
+GRUB_CMDLINE_LINUX="quiet"
+`
+	consoles := ParseGrubDefaults(grub)
+	if len(consoles) != 0 {
+		t.Errorf("expected 0 consoles (commented line), got %d", len(consoles))
+	}
+}
+
+func TestParseGrubDefaults_EmptyInput(t *testing.T) {
+	t.Parallel()
+	consoles := ParseGrubDefaults("")
+	if len(consoles) != 0 {
+		t.Errorf("expected 0 consoles, got %d", len(consoles))
+	}
+}
+
+func TestParseGrubDefaults_DefaultKey(t *testing.T) {
+	t.Parallel()
+	grub := `GRUB_CMDLINE_LINUX=""
+GRUB_CMDLINE_LINUX_DEFAULT="console=ttyAMA0,115200"
+`
+	consoles := ParseGrubDefaults(grub)
+	if len(consoles) != 1 {
+		t.Fatalf("expected 1 console from DEFAULT, got %d", len(consoles))
+	}
+	if consoles[0].Device != "ttyAMA0" {
+		t.Errorf("expected ttyAMA0 (ARM), got %s", consoles[0].Device)
+	}
+}
+
+func TestParseGrubDefaults_OtherKeysIgnored(t *testing.T) {
+	t.Parallel()
+	grub := `GRUB_TIMEOUT=5
+GRUB_DEFAULT=0
+GRUB_TERMINAL="serial console"
+GRUB_SERIAL_COMMAND="serial --speed=115200"
+`
+	consoles := ParseGrubDefaults(grub)
+	if len(consoles) != 0 {
+		t.Errorf("expected 0 consoles (no CMDLINE keys), got %d", len(consoles))
+	}
+}
+
+func TestParseSerialGettyUnits(t *testing.T) {
+	t.Parallel()
+	entries := []string{
+		"getty@tty1.service",
+		"serial-getty@ttyS0.service",
+		"serial-getty@ttyS1.service",
+		"remote-fs.target",
+	}
+	devices := ParseSerialGettyUnits(entries)
+	if len(devices) != 2 {
+		t.Fatalf("expected 2 serial devices, got %d", len(devices))
+	}
+	if devices[0] != "ttyS0" {
+		t.Errorf("expected ttyS0, got %s", devices[0])
+	}
+	if devices[1] != "ttyS1" {
+		t.Errorf("expected ttyS1, got %s", devices[1])
+	}
+}
+
+func TestParseSerialGettyUnits_Empty(t *testing.T) {
+	t.Parallel()
+	devices := ParseSerialGettyUnits(nil)
+	if len(devices) != 0 {
+		t.Errorf("expected 0 devices, got %d", len(devices))
+	}
+}
+
+func TestParseSerialGettyUnits_NoSerialGetty(t *testing.T) {
+	t.Parallel()
+	entries := []string{"getty@tty1.service", "getty@tty2.service"}
+	devices := ParseSerialGettyUnits(entries)
+	if len(devices) != 0 {
+		t.Errorf("expected 0 serial devices, got %d", len(devices))
+	}
+}
+
+func TestConsoleInfo_HasSerialConsole(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		info api.ConsoleInfo
+		want bool
+	}{
+		{"grub console", api.ConsoleInfo{SerialConsoles: []api.ConsoleDevice{{Device: "ttyS0"}}}, true},
+		{"getty unit", api.ConsoleInfo{SerialGettyDevices: []string{"ttyS0"}}, true},
+		{"both", api.ConsoleInfo{SerialConsoles: []api.ConsoleDevice{{Device: "ttyS0"}}, SerialGettyDevices: []string{"ttyS0"}}, true},
+		{"neither", api.ConsoleInfo{}, false},
+	}
+	for _, tt := range tests {
+		if got := tt.info.HasSerialConsole(); got != tt.want {
+			t.Errorf("%s: HasSerialConsole() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/pkg/virt-customization/probe/detect.go
+++ b/pkg/virt-customization/probe/detect.go
@@ -1,0 +1,78 @@
+package probe
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// detect uses direct GuestHandle calls to probe for OS type and network stacks.
+func detect(g api.GuestHandle, guest *api.GuestInfo) error {
+	isWindows, err := g.IsDir("/Windows/System32")
+	if err != nil {
+		return fmt.Errorf("checking /Windows/System32: %w", err)
+	}
+	if isWindows {
+		guest.OS.Family = api.OSFamilyWindows
+		return nil
+	}
+
+	hasOsRelease, err := g.IsFile("/etc/os-release")
+	if err != nil {
+		return fmt.Errorf("checking /etc/os-release: %w", err)
+	}
+	if hasOsRelease {
+		guest.OS.Family = api.OSFamilyLinux
+	} else {
+		guest.OS.Family = api.OSFamilyUnknown
+	}
+
+	guest.UsesIfcfg, _ = g.IsDir("/etc/sysconfig/network-scripts")
+	guest.UsesIfcfgSuse, _ = g.IsDir("/etc/sysconfig/network")
+	guest.UsesNetworkManager, _ = g.IsDir("/etc/NetworkManager/system-connections")
+	guest.UsesNetplan, _ = g.IsDir("/etc/netplan")
+	guest.UsesIfquery, _ = g.IsFile("/etc/network/interfaces")
+	guest.UsesInterfacesD, _ = g.IsDir("/etc/network/interfaces.d")
+	wickedEtc, _ := g.IsDir("/etc/wicked")
+	wickedVar, _ := g.IsDir("/var/lib/wicked")
+	guest.UsesWicked = wickedEtc || wickedVar
+	guest.UsesNMDhcpLease, _ = g.IsDir("/var/lib/NetworkManager")
+	guest.UsesDhclient, _ = g.IsDir("/var/lib/dhclient")
+
+	// Cloud-init
+	hasCloudDir, _ := g.IsDir("/etc/cloud")
+	hasCloudBin, _ := g.IsFile("/usr/bin/cloud-init")
+	guest.CloudInit.Present = hasCloudDir || hasCloudBin
+	guest.CloudInit.HasCloudCfg, _ = g.IsFile("/etc/cloud/cloud.cfg")
+	guest.CloudInit.HasCloudCfgD, _ = g.IsDir("/etc/cloud/cloud.cfg.d")
+	guest.CloudInit.HasInstanceData, _ = g.IsDir("/var/lib/cloud/instance")
+	guest.CloudInit.HasSeedData, _ = g.IsDir("/var/lib/cloud/seed")
+
+	// SSH
+	guest.SSH.Present, _ = g.IsFile("/usr/sbin/sshd")
+	guest.SSH.HasConfig, _ = g.IsFile("/etc/ssh/sshd_config")
+	guest.SSH.HasRootAuthorizedKeys, _ = g.IsFile("/root/.ssh/authorized_keys")
+	hostKeys, _ := g.GlobExpand("/etc/ssh/ssh_host_*_key")
+	guest.SSH.HasHostKeys = len(hostKeys) > 0
+
+	// Console
+	guest.Console.HasGrubDefaults, _ = g.IsFile("/etc/default/grub")
+
+	return nil
+}
+
+// parseOsRelease extracts ID and VERSION_ID from /etc/os-release content.
+func parseOsRelease(content string, guest *api.GuestInfo) error {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "ID=") {
+			guest.OS.Distro = strings.Trim(strings.TrimPrefix(line, "ID="), "\"")
+		} else if strings.HasPrefix(line, "VERSION_ID=") {
+			guest.OS.Version = strings.Trim(strings.TrimPrefix(line, "VERSION_ID="), "\"")
+		}
+	}
+	return scanner.Err()
+}

--- a/pkg/virt-customization/probe/extract.go
+++ b/pkg/virt-customization/probe/extract.go
@@ -1,0 +1,380 @@
+package probe
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	"github.com/kubev2v/forklift/pkg/virt-customization/probe/cloudinit"
+	"github.com/kubev2v/forklift/pkg/virt-customization/probe/console"
+	"github.com/kubev2v/forklift/pkg/virt-customization/probe/netcfg"
+	"github.com/kubev2v/forklift/pkg/virt-customization/probe/ssh"
+)
+
+// extract reads network configuration files from the guest via direct
+// GuestHandle API calls and populates guest.Interfaces.
+func extract(g api.GuestHandle, guest *api.GuestInfo) error {
+	if guest.OS.Family == api.OSFamilyLinux {
+		if err := extractOsRelease(g, guest); err != nil {
+			return fmt.Errorf("os-release: %w", err)
+		}
+	}
+
+	if guest.UsesIfcfg || guest.UsesIfcfgSuse {
+		if err := extractIfcfg(g, guest); err != nil {
+			return fmt.Errorf("ifcfg: %w", err)
+		}
+	}
+	if guest.UsesNetworkManager {
+		if err := extractNM(g, guest); err != nil {
+			return fmt.Errorf("NM: %w", err)
+		}
+	}
+	if guest.UsesNetplan {
+		if err := extractNetplan(g, guest); err != nil {
+			return fmt.Errorf("netplan: %w", err)
+		}
+	}
+	if guest.UsesIfquery || guest.UsesInterfacesD {
+		if err := extractInterfaces(g, guest); err != nil {
+			return fmt.Errorf("interfaces: %w", err)
+		}
+	}
+	if guest.UsesWicked {
+		if err := extractWicked(g, guest); err != nil {
+			return fmt.Errorf("wicked: %w", err)
+		}
+	}
+	if guest.UsesNMDhcpLease {
+		if err := extractNMDhcpLease(g, guest); err != nil {
+			return fmt.Errorf("NM DHCP lease: %w", err)
+		}
+	}
+	if guest.UsesDhclient {
+		if err := extractDhclient(g, guest); err != nil {
+			return fmt.Errorf("dhclient: %w", err)
+		}
+	}
+
+	if guest.CloudInit.Present {
+		if err := extractCloudInit(g, guest); err != nil {
+			return fmt.Errorf("cloud-init: %w", err)
+		}
+	}
+	if guest.SSH.HasConfig {
+		if err := extractSSH(g, guest); err != nil {
+			return fmt.Errorf("SSH: %w", err)
+		}
+	}
+	if guest.Console.HasGrubDefaults {
+		if err := extractConsole(g, guest); err != nil {
+			return fmt.Errorf("console: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func extractOsRelease(g api.GuestHandle, guest *api.GuestInfo) error {
+	content, err := g.Cat("/etc/os-release")
+	if err != nil {
+		return err
+	}
+	return parseOsRelease(content, guest)
+}
+
+func extractIfcfg(g api.GuestHandle, guest *api.GuestInfo) error {
+	var combined strings.Builder
+	if guest.UsesIfcfg {
+		if err := catGlob(g, "/etc/sysconfig/network-scripts/ifcfg-*", &combined); err != nil {
+			return err
+		}
+	}
+	if guest.UsesIfcfgSuse {
+		if err := catGlob(g, "/etc/sysconfig/network/ifcfg-*", &combined); err != nil {
+			return err
+		}
+	}
+	if combined.Len() == 0 {
+		return nil
+	}
+	ifaces, err := netcfg.Ifcfg(combined.String())
+	if err != nil {
+		return err
+	}
+	guest.Interfaces = append(guest.Interfaces, ifaces...)
+	return nil
+}
+
+func extractNM(g api.GuestHandle, guest *api.GuestInfo) error {
+	var combined strings.Builder
+	if err := catGlob(g, "/etc/NetworkManager/system-connections/*", &combined); err != nil {
+		return err
+	}
+	if combined.Len() == 0 {
+		return nil
+	}
+	ifaces, err := netcfg.NM(combined.String())
+	if err != nil {
+		return err
+	}
+	guest.Interfaces = append(guest.Interfaces, ifaces...)
+	return nil
+}
+
+func extractNetplan(g api.GuestHandle, guest *api.GuestInfo) error {
+	var combined strings.Builder
+	if err := catGlob(g, "/etc/netplan/*.yaml", &combined); err != nil {
+		return err
+	}
+	if err := catGlob(g, "/etc/netplan/*.yml", &combined); err != nil {
+		return err
+	}
+	if combined.Len() == 0 {
+		return nil
+	}
+	result, err := netcfg.Netplan(combined.String())
+	if err != nil {
+		return err
+	}
+	guest.Interfaces = append(guest.Interfaces, result.Interfaces...)
+	if result.Renderer != "" {
+		guest.NetplanRenderer = result.Renderer
+	}
+	return nil
+}
+
+func extractInterfaces(g api.GuestHandle, guest *api.GuestInfo) error {
+	var combined strings.Builder
+	if guest.UsesIfquery {
+		content, err := g.Cat("/etc/network/interfaces")
+		if err != nil {
+			fmt.Printf("warning: reading /etc/network/interfaces: %v\n", err)
+		} else {
+			combined.WriteString(content)
+			combined.WriteByte('\n')
+		}
+	}
+	if guest.UsesInterfacesD {
+		if err := catGlob(g, "/etc/network/interfaces.d/*", &combined); err != nil {
+			return err
+		}
+	}
+	if combined.Len() == 0 {
+		return nil
+	}
+	ifaces, err := netcfg.Interfaces(combined.String())
+	if err != nil {
+		return err
+	}
+	guest.Interfaces = append(guest.Interfaces, ifaces...)
+	return nil
+}
+
+func extractWicked(g api.GuestHandle, guest *api.GuestInfo) error {
+	var filesList string
+	files, err := g.Ls("/var/lib/wicked/")
+	if err != nil {
+		fmt.Printf("warning: listing /var/lib/wicked/: %v\n", err)
+	} else {
+		filesList = strings.Join(files, "\n")
+	}
+
+	var xmlContent strings.Builder
+	if err := catGlob(g, "/var/lib/wicked/lease-*", &xmlContent); err != nil {
+		return err
+	}
+
+	if filesList == "" && xmlContent.Len() == 0 {
+		return nil
+	}
+
+	ifaces, err := netcfg.Wicked(filesList, xmlContent.String())
+	if err != nil {
+		return err
+	}
+	guest.Interfaces = append(guest.Interfaces, ifaces...)
+	return nil
+}
+
+func extractNMDhcpLease(g api.GuestHandle, guest *api.GuestInfo) error {
+	var filesList string
+	files, err := g.Ls("/var/lib/NetworkManager/")
+	if err != nil {
+		fmt.Printf("warning: listing /var/lib/NetworkManager/: %v\n", err)
+	} else {
+		filesList = strings.Join(files, "\n")
+	}
+
+	var leaseContent strings.Builder
+	if err := catGlob(g, "/var/lib/NetworkManager/*.lease", &leaseContent); err != nil {
+		return err
+	}
+
+	var timestampsContent string
+	ts, err := g.Cat("/var/lib/NetworkManager/timestamps")
+	if err != nil {
+		fmt.Printf("warning: reading /var/lib/NetworkManager/timestamps: %v\n", err)
+	} else {
+		timestampsContent = ts
+	}
+
+	if filesList == "" && leaseContent.Len() == 0 {
+		return nil
+	}
+
+	ifaces, err := netcfg.NMDhcpLease(filesList, leaseContent.String(), timestampsContent)
+	if err != nil {
+		return err
+	}
+	guest.Interfaces = append(guest.Interfaces, ifaces...)
+	return nil
+}
+
+func extractDhclient(g api.GuestHandle, guest *api.GuestInfo) error {
+	var combined strings.Builder
+	if err := catGlob(g, "/var/lib/dhclient/dhclient-*", &combined); err != nil {
+		return err
+	}
+	// Also check NM dhclient files
+	if guest.UsesNMDhcpLease {
+		if err := catGlob(g, "/var/lib/NetworkManager/dhclient-*", &combined); err != nil {
+			return err
+		}
+	}
+	if combined.Len() == 0 {
+		return nil
+	}
+	ifaces, err := netcfg.Dhclient(combined.String())
+	if err != nil {
+		return err
+	}
+	guest.Interfaces = append(guest.Interfaces, ifaces...)
+	return nil
+}
+
+func extractCloudInit(g api.GuestHandle, guest *api.GuestInfo) error {
+	// Parse cloud.cfg + cloud.cfg.d/*.cfg
+	if guest.CloudInit.HasCloudCfg || guest.CloudInit.HasCloudCfgD {
+		var combined strings.Builder
+		if guest.CloudInit.HasCloudCfg {
+			content, err := g.Cat("/etc/cloud/cloud.cfg")
+			if err != nil {
+				fmt.Printf("warning: reading /etc/cloud/cloud.cfg: %v\n", err)
+			} else {
+				combined.WriteString(content)
+				combined.WriteByte('\n')
+			}
+		}
+		if guest.CloudInit.HasCloudCfgD {
+			if err := catGlob(g, "/etc/cloud/cloud.cfg.d/*.cfg", &combined); err != nil {
+				return err
+			}
+		}
+		if combined.Len() > 0 {
+			result, err := cloudinit.ParseCloudCfg(combined.String())
+			if err != nil {
+				fmt.Printf("warning: parsing cloud.cfg: %v\n", err)
+			}
+			guest.CloudInit.DatasourceList = result.DatasourceList
+			guest.CloudInit.NetworkConfigDisabled = result.NetworkConfigDisabled
+		}
+	}
+
+	// Read active datasource from instance state
+	if guest.CloudInit.HasInstanceData {
+		content, err := g.Cat("/var/lib/cloud/instance/datasource")
+		if err != nil {
+			fmt.Printf("warning: reading cloud-init datasource: %v\n", err)
+		} else {
+			guest.CloudInit.ActiveDatasource = cloudinit.ParseDatasourceFile(content)
+		}
+
+		idContent, err := g.Cat("/var/lib/cloud/instance/instance-id")
+		if err != nil {
+			fmt.Printf("warning: reading cloud-init instance-id: %v\n", err)
+		} else {
+			guest.CloudInit.InstanceID = strings.TrimSpace(idContent)
+		}
+	}
+
+	return nil
+}
+
+func extractSSH(g api.GuestHandle, guest *api.GuestInfo) error {
+	var combined strings.Builder
+	content, err := g.Cat("/etc/ssh/sshd_config")
+	if err != nil {
+		return fmt.Errorf("reading sshd_config: %w", err)
+	}
+	combined.WriteString(content)
+	combined.WriteByte('\n')
+
+	// Include drop-ins (sshd_config.d/*.conf)
+	if err := catGlob(g, "/etc/ssh/sshd_config.d/*.conf", &combined); err != nil {
+		return err
+	}
+
+	result := ssh.ParseSSHDConfig(combined.String())
+	guest.SSH.PermitRootLogin = result.PermitRootLogin
+	guest.SSH.PasswordAuthentication = result.PasswordAuthentication
+	guest.SSH.Port = result.Port
+
+	// Host key types from glob filenames
+	hostKeys, _ := g.GlobExpand("/etc/ssh/ssh_host_*_key")
+	for _, keyPath := range hostKeys {
+		keyType := ssh.HostKeyTypeFromFilename(path.Base(keyPath))
+		if keyType != "" {
+			guest.SSH.HostKeyTypes = append(guest.SSH.HostKeyTypes, keyType)
+		}
+	}
+
+	// Service enabled check via systemd wants directory
+	entries, err := g.Ls("/etc/systemd/system/multi-user.target.wants/")
+	if err == nil {
+		for _, entry := range entries {
+			if entry == "sshd.service" || entry == "ssh.service" {
+				guest.SSH.ServiceEnabled = true
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+func extractConsole(g api.GuestHandle, guest *api.GuestInfo) error {
+	content, err := g.Cat("/etc/default/grub")
+	if err != nil {
+		return fmt.Errorf("reading /etc/default/grub: %w", err)
+	}
+	guest.Console.SerialConsoles = console.ParseGrubDefaults(content)
+
+	// Serial getty units
+	entries, err := g.Ls("/etc/systemd/system/getty.target.wants/")
+	if err != nil {
+		fmt.Printf("warning: listing getty.target.wants: %v\n", err)
+	} else {
+		guest.Console.SerialGettyDevices = console.ParseSerialGettyUnits(entries)
+		guest.Console.HasSerialGetty = len(guest.Console.SerialGettyDevices) > 0
+	}
+
+	return nil
+}
+
+// catGlob expands a guest glob pattern and concatenates the contents
+// of all matching files into dst.
+func catGlob(g api.GuestHandle, pattern string, dst *strings.Builder) error {
+	matches, _ := g.GlobExpand(pattern) // glob failure is non-fatal (directory may exist but be empty)
+	for _, path := range matches {
+		content, err := g.Cat(path)
+		if err != nil {
+			fmt.Printf("warning: reading %s: %v\n", path, err)
+			continue
+		}
+		dst.WriteString(content)
+		dst.WriteByte('\n')
+	}
+	return nil
+}

--- a/pkg/virt-customization/probe/netcfg/dhclient.go
+++ b/pkg/virt-customization/probe/netcfg/dhclient.go
@@ -1,0 +1,129 @@
+package netcfg
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// Dhclient parses dhclient lease files (concatenated contents of all
+// dhclient-* files from /var/lib/dhclient/ and /var/lib/NetworkManager/).
+//
+// Lease blocks have the form:
+//
+//	lease {
+//	  interface "eth0";
+//	  fixed-address 192.168.122.82;
+//	  ...
+//	  expire 3 2025/04/30 17:42:30;
+//	}
+//
+// When multiple blocks share the same interface, the one with the latest
+// expiration is kept. Each unique (interface, latest-IP) pair becomes one
+// InterfaceInfo entry.
+func Dhclient(section string) ([]api.InterfaceInfo, error) {
+	blocks := parseDhclientBlocks(section)
+
+	type best struct {
+		iface  string
+		ip     string
+		expire time.Time
+	}
+	latest := map[string]best{}
+
+	for _, b := range blocks {
+		if b.iface == "" || b.ip == "" {
+			continue
+		}
+		prev, exists := latest[b.iface]
+		if !exists || b.expire.After(prev.expire) {
+			latest[b.iface] = best{iface: b.iface, ip: b.ip, expire: b.expire}
+		}
+	}
+
+	var interfaces []api.InterfaceInfo
+	for _, entry := range latest {
+		iface := api.InterfaceInfo{
+			Name:   entry.iface,
+			DHCP:   true,
+			Source: "dhclient",
+		}
+		if strings.Contains(entry.ip, ":") {
+			iface.IPv6 = []string{entry.ip}
+		} else {
+			iface.IPv4 = []string{entry.ip}
+		}
+		interfaces = append(interfaces, iface)
+	}
+	return interfaces, nil
+}
+
+type dhclientBlock struct {
+	iface  string
+	ip     string
+	expire time.Time
+}
+
+// parseDhclientBlocks splits concatenated dhclient lease content into blocks
+// and extracts interface, fixed-address, and expire from each.
+func parseDhclientBlocks(section string) []dhclientBlock {
+	var blocks []dhclientBlock
+	var current dhclientBlock
+	inBlock := false
+
+	scanner := bufio.NewScanner(strings.NewReader(section))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		line = strings.TrimSuffix(line, ";")
+		line = strings.TrimSpace(line)
+
+		if line == "lease {" {
+			inBlock = true
+			current = dhclientBlock{}
+			continue
+		}
+		if line == "}" && inBlock {
+			blocks = append(blocks, current)
+			inBlock = false
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "interface":
+			current.iface = stripQuotes(fields[1])
+		case "fixed-address":
+			current.ip = fields[1]
+		case "expire":
+			current.expire = parseDhclientExpire(fields[1:])
+		}
+	}
+	return blocks
+}
+
+// stripQuotes removes surrounding double quotes from a string.
+func stripQuotes(s string) string {
+	return strings.Trim(s, `"`)
+}
+
+// parseDhclientExpire parses the expire fields: <dayofweek> <YYYY/MM/DD> <HH:MM:SS>
+func parseDhclientExpire(fields []string) time.Time {
+	if len(fields) < 3 {
+		return time.Time{}
+	}
+	dateStr := fmt.Sprintf("%s %s", fields[1], fields[2])
+	t, err := time.Parse("2006/01/02 15:04:05", dateStr)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/pkg/virt-customization/probe/netcfg/dhclient_test.go
+++ b/pkg/virt-customization/probe/netcfg/dhclient_test.go
@@ -1,0 +1,210 @@
+package netcfg
+
+import "testing"
+
+func TestDhclient(t *testing.T) {
+	t.Parallel()
+	// Two lease blocks for eth0; second has later expire -> wins with IP .82
+	section := `lease {
+  interface "eth0";
+  fixed-address 192.168.122.83;
+  option subnet-mask 255.255.255.0;
+  expire 3 2025/04/30 17:40:05;
+}
+lease {
+  interface "eth0";
+  fixed-address 192.168.122.82;
+  option subnet-mask 255.255.255.0;
+  expire 3 2025/04/30 17:42:30;
+}
+`
+	interfaces, err := Dhclient(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface (same name deduplicated), got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "eth0" {
+		t.Errorf("expected eth0, got %s", interfaces[0].Name)
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.122.82") {
+		t.Errorf("expected IPv4 192.168.122.82 (latest expire), got %v", interfaces[0].IPv4)
+	}
+	if !interfaces[0].DHCP {
+		t.Error("expected DHCP=true")
+	}
+	if interfaces[0].Source != "dhclient" {
+		t.Errorf("expected source dhclient, got %s", interfaces[0].Source)
+	}
+}
+
+func TestDhclient_MultipleInterfaces(t *testing.T) {
+	t.Parallel()
+	section := `lease {
+  interface "eth0";
+  fixed-address 192.168.122.82;
+  expire 3 2025/04/30 17:42:30;
+}
+lease {
+  interface "eth1";
+  fixed-address 192.168.122.83;
+  expire 3 2025/04/30 17:42:30;
+}
+`
+	interfaces, err := Dhclient(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+	found := map[string]bool{}
+	for _, iface := range interfaces {
+		found[iface.Name] = true
+	}
+	if !found["eth0"] || !found["eth1"] {
+		t.Errorf("expected eth0 and eth1, got %v", found)
+	}
+}
+
+func TestDhclient_LatestExpireWins(t *testing.T) {
+	t.Parallel()
+	// eth1 has two blocks: older one has IP .82, newer one has IP .83
+	section := `lease {
+  interface "eth1";
+  fixed-address 192.168.122.82;
+  expire 3 2024/03/14 12:40:05;
+}
+lease {
+  interface "eth1";
+  fixed-address 192.168.122.83;
+  expire 3 2025/04/30 17:42:30;
+}
+`
+	interfaces, err := Dhclient(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.122.83") {
+		t.Errorf("expected 192.168.122.83 (latest), got %v", interfaces[0].IPv4)
+	}
+}
+
+func TestDhclient_EmptyInput(t *testing.T) {
+	t.Parallel()
+	interfaces, err := Dhclient("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 0 {
+		t.Errorf("expected 0 interfaces for empty input, got %d", len(interfaces))
+	}
+}
+
+func TestDhclient_IncompleteBlock(t *testing.T) {
+	t.Parallel()
+	// Block missing fixed-address should be skipped
+	section := `lease {
+  interface "eth0";
+  expire 3 2025/04/30 17:42:30;
+}
+`
+	interfaces, err := Dhclient(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 0 {
+		t.Errorf("expected 0 interfaces (incomplete block), got %d", len(interfaces))
+	}
+}
+
+func TestDhclient_MissingExpire(t *testing.T) {
+	t.Parallel()
+	// Block with no expire should still be usable (zero time)
+	section := `lease {
+  interface "eth0";
+  fixed-address 10.0.0.1;
+}
+`
+	interfaces, err := Dhclient(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if !containsStr(interfaces[0].IPv4, "10.0.0.1") {
+		t.Error("expected IPv4 10.0.0.1")
+	}
+}
+
+func TestParseDhclientBlocks(t *testing.T) {
+	t.Parallel()
+	section := `lease {
+  interface "eth0";
+  fixed-address 192.168.122.82;
+  option subnet-mask 255.255.255.0;
+  option routers 192.168.122.1;
+  expire 3 2025/04/30 17:42:30;
+}
+`
+	blocks := parseDhclientBlocks(section)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].iface != "eth0" {
+		t.Errorf("expected eth0, got %s", blocks[0].iface)
+	}
+	if blocks[0].ip != "192.168.122.82" {
+		t.Errorf("expected 192.168.122.82, got %s", blocks[0].ip)
+	}
+	if blocks[0].expire.IsZero() {
+		t.Error("expected non-zero expire time")
+	}
+}
+
+func TestDhclient_ConcatenatedFiles(t *testing.T) {
+	t.Parallel()
+	// Simulates two files concatenated (as catGlob would produce)
+	section := `lease {
+  interface "eth0";
+  fixed-address 192.168.122.82;
+  expire 3 2025/04/30 17:42:30;
+}
+lease {
+  interface "eth0";
+  fixed-address 192.168.122.83;
+  expire 3 2025/04/30 17:40:05;
+}
+lease {
+  interface "eth1";
+  fixed-address 192.168.122.84;
+  expire 3 2025/04/30 17:42:30;
+}
+`
+	interfaces, err := Dhclient(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+	for _, iface := range interfaces {
+		switch iface.Name {
+		case "eth0":
+			if !containsStr(iface.IPv4, "192.168.122.82") {
+				t.Errorf("expected eth0 to have 192.168.122.82 (later expire), got %v", iface.IPv4)
+			}
+		case "eth1":
+			if !containsStr(iface.IPv4, "192.168.122.84") {
+				t.Errorf("expected eth1 to have 192.168.122.84, got %v", iface.IPv4)
+			}
+		default:
+			t.Errorf("unexpected interface: %s", iface.Name)
+		}
+	}
+}

--- a/pkg/virt-customization/probe/netcfg/ifcfg.go
+++ b/pkg/virt-customization/probe/netcfg/ifcfg.go
@@ -1,0 +1,81 @@
+package netcfg
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// Ifcfg parses RHEL/CentOS/SUSE ifcfg-style configuration output.
+// Supports both bare IPADDR and numbered IPADDR0, IPADDR1, etc.
+// IPv6 addresses are extracted from IPV6ADDR and IPV6ADDR_SECONDARIES.
+// Entries in the concatenated input are split on blank lines or on a new
+// DEVICE= line (whichever comes first), so the parser handles both
+// blank-line-separated and directly concatenated ifcfg files.
+func Ifcfg(section string) ([]api.InterfaceInfo, error) {
+	var interfaces []api.InterfaceInfo
+	var current api.InterfaceInfo
+	current.Source = "ifcfg"
+
+	scanner := bufio.NewScanner(strings.NewReader(section))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			if current.Name != "" || current.HasIPs() {
+				interfaces = append(interfaces, current)
+				current = api.InterfaceInfo{Source: "ifcfg"}
+			}
+			continue
+		}
+		kv := strings.SplitN(line, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := kv[0]
+		val := strings.Trim(kv[1], "\"'")
+		switch key {
+		case "DEVICE":
+			if current.Name != "" || current.HasIPs() {
+				interfaces = append(interfaces, current)
+				current = api.InterfaceInfo{Source: "ifcfg"}
+			}
+			current.Name = val
+		case "HWADDR":
+			current.MAC = strings.ToLower(val)
+		case "NAME":
+			if current.Name == "" {
+				current.Name = val
+			}
+		case "BOOTPROTO":
+			current.DHCP = strings.EqualFold(val, "dhcp")
+		case "IPV6ADDR":
+			if ip := stripPrefix(val); ip != "" {
+				current.IPv6 = append(current.IPv6, ip)
+			}
+		case "IPV6ADDR_SECONDARIES":
+			for _, addr := range strings.Fields(val) {
+				if ip := stripPrefix(addr); ip != "" {
+					current.IPv6 = append(current.IPv6, ip)
+				}
+			}
+		default:
+			if strings.HasPrefix(key, "IPADDR") && val != "" {
+				current.IPv4 = append(current.IPv4, val)
+			}
+		}
+	}
+	if current.Name != "" || current.HasIPs() {
+		interfaces = append(interfaces, current)
+	}
+	if err := scanner.Err(); err != nil {
+		return interfaces, fmt.Errorf("Ifcfg parser: scanner error: %w", err)
+	}
+	return interfaces, nil
+}
+
+// stripPrefix removes a CIDR prefix length ("/64") if present.
+func stripPrefix(addr string) string {
+	return strings.SplitN(addr, "/", 2)[0]
+}

--- a/pkg/virt-customization/probe/netcfg/ifcfg_test.go
+++ b/pkg/virt-customization/probe/netcfg/ifcfg_test.go
@@ -1,0 +1,158 @@
+package netcfg
+
+import "testing"
+
+func TestIfcfg(t *testing.T) {
+	t.Parallel()
+	section := "DEVICE=eth0\nIPADDR=192.168.1.10\nHWADDR=00:11:22:33:44:55\n\nDEVICE=eth1\nIPADDR=10.0.0.5\nHWADDR=aa:bb:cc:dd:ee:ff\n"
+	interfaces, err := Ifcfg(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "eth0" {
+		t.Errorf("expected eth0, got %s", interfaces[0].Name)
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.10") {
+		t.Error("expected IPv4 192.168.1.10")
+	}
+	if interfaces[0].MAC != "00:11:22:33:44:55" {
+		t.Errorf("expected MAC 00:11:22:33:44:55, got %s", interfaces[0].MAC)
+	}
+	if interfaces[0].Source != "ifcfg" {
+		t.Errorf("expected source ifcfg, got %s", interfaces[0].Source)
+	}
+	if interfaces[1].Name != "eth1" {
+		t.Errorf("expected eth1, got %s", interfaces[1].Name)
+	}
+}
+
+func TestIfcfg_DHCP(t *testing.T) {
+	t.Parallel()
+	section := "DEVICE=eth0\nBOOTPROTO=dhcp\nHWADDR=00:11:22:33:44:55\n\nDEVICE=eth1\nBOOTPROTO=static\nIPADDR=10.0.0.5\n"
+	interfaces, err := Ifcfg(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+	if !interfaces[0].DHCP {
+		t.Error("expected eth0 DHCP to be true")
+	}
+	if interfaces[1].DHCP {
+		t.Error("expected eth1 DHCP to be false")
+	}
+}
+
+func TestIfcfg_NumberedIPADDR(t *testing.T) {
+	t.Parallel()
+	section := "DEVICE=eth0\nIPADDR0=192.168.1.10\nIPADDR1=10.0.0.1\nHWADDR=00:11:22:33:44:55\n"
+	interfaces, err := Ifcfg(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.10") {
+		t.Error("expected IPv4 192.168.1.10")
+	}
+	if !containsStr(interfaces[0].IPv4, "10.0.0.1") {
+		t.Error("expected IPv4 10.0.0.1")
+	}
+}
+
+func TestIfcfg_IPv6(t *testing.T) {
+	t.Parallel()
+	section := "DEVICE=eth0\nIPADDR=192.168.1.10\nIPV6ADDR=fd00::1/64\nIPV6ADDR_SECONDARIES=\"fd00::2/64 fd00::3/64\"\n"
+	interfaces, err := Ifcfg(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.10") {
+		t.Error("expected IPv4 192.168.1.10")
+	}
+	if !containsStr(interfaces[0].IPv6, "fd00::1") {
+		t.Error("expected IPv6 fd00::1")
+	}
+	if !containsStr(interfaces[0].IPv6, "fd00::2") {
+		t.Error("expected IPv6 fd00::2")
+	}
+	if !containsStr(interfaces[0].IPv6, "fd00::3") {
+		t.Error("expected IPv6 fd00::3")
+	}
+	if len(interfaces[0].IPv6) != 3 {
+		t.Errorf("expected 3 IPv6 addresses, got %d", len(interfaces[0].IPv6))
+	}
+}
+
+func TestIfcfg_EmptyIPADDR(t *testing.T) {
+	t.Parallel()
+	section := "DEVICE=eth0\nIPADDR=\nHWADDR=00:11:22:33:44:55\n"
+	interfaces, err := Ifcfg(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if len(interfaces[0].IPv4) != 0 {
+		t.Errorf("expected no IPv4 for empty IPADDR, got %v", interfaces[0].IPv4)
+	}
+}
+
+func TestIfcfg_ConcatenatedRecords(t *testing.T) {
+	t.Parallel()
+	section := "DEVICE=eth0\nIPADDR=192.168.1.10\nHWADDR=00:11:22:33:44:55\nDEVICE=eth1\nIPADDR=10.0.0.5\nHWADDR=aa:bb:cc:dd:ee:ff\n"
+	interfaces, err := Ifcfg(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "eth0" {
+		t.Errorf("expected eth0, got %s", interfaces[0].Name)
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.10") {
+		t.Error("expected IPv4 192.168.1.10 on eth0")
+	}
+	if interfaces[0].MAC != "00:11:22:33:44:55" {
+		t.Errorf("expected MAC 00:11:22:33:44:55 on eth0, got %s", interfaces[0].MAC)
+	}
+	if interfaces[1].Name != "eth1" {
+		t.Errorf("expected eth1, got %s", interfaces[1].Name)
+	}
+	if !containsStr(interfaces[1].IPv4, "10.0.0.5") {
+		t.Error("expected IPv4 10.0.0.5 on eth1")
+	}
+	if interfaces[1].MAC != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("expected MAC aa:bb:cc:dd:ee:ff on eth1, got %s", interfaces[1].MAC)
+	}
+}
+
+func TestIfcfg_EmptyInput(t *testing.T) {
+	t.Parallel()
+	interfaces, err := Ifcfg("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 0 {
+		t.Errorf("expected 0 interfaces for empty input, got %d", len(interfaces))
+	}
+}
+
+func containsStr(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/virt-customization/probe/netcfg/interfaces.go
+++ b/pkg/virt-customization/probe/netcfg/interfaces.go
@@ -1,0 +1,59 @@
+package netcfg
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// Interfaces parses Debian /etc/network/interfaces format.
+// Reads iface stanzas and address lines, skipping loopback.
+// Distinguishes inet (IPv4) from inet6 (IPv6) stanzas.
+func Interfaces(section string) ([]api.InterfaceInfo, error) {
+	var interfaces []api.InterfaceInfo
+	var current api.InterfaceInfo
+	current.Source = "interfaces"
+	isV6 := false
+	hasData := false
+
+	scanner := bufio.NewScanner(strings.NewReader(section))
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		// iface <name> inet|inet6 <method>
+		if len(fields) >= 4 && fields[0] == "iface" {
+			if fields[1] == "lo" {
+				if hasData {
+					interfaces = append(interfaces, current)
+				}
+				hasData = false
+				current = api.InterfaceInfo{Source: "interfaces"}
+				continue
+			}
+			if hasData {
+				interfaces = append(interfaces, current)
+				current = api.InterfaceInfo{Source: "interfaces"}
+			}
+			current.Name = fields[1]
+			isV6 = fields[2] == "inet6"
+			current.DHCP = fields[3] == "dhcp"
+			hasData = true
+		} else if len(fields) >= 2 && fields[0] == "address" && hasData {
+			ip := strings.SplitN(fields[1], "/", 2)[0]
+			if isV6 {
+				current.IPv6 = append(current.IPv6, ip)
+			} else {
+				current.IPv4 = append(current.IPv4, ip)
+			}
+		}
+	}
+	if hasData {
+		interfaces = append(interfaces, current)
+	}
+	if err := scanner.Err(); err != nil {
+		return interfaces, fmt.Errorf("Interfaces parser: scanner error: %w", err)
+	}
+	return interfaces, nil
+}

--- a/pkg/virt-customization/probe/netcfg/interfaces_test.go
+++ b/pkg/virt-customization/probe/netcfg/interfaces_test.go
@@ -1,0 +1,54 @@
+package netcfg
+
+import "testing"
+
+func TestInterfaces(t *testing.T) {
+	t.Parallel()
+	section := "auto lo\niface lo inet loopback\n\nauto eth0\niface eth0 inet static\naddress 192.168.1.200\nnetmask 255.255.255.0\n\nauto eth1\niface eth1 inet dhcp\n"
+	interfaces, err := Interfaces(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "eth0" {
+		t.Errorf("expected eth0, got %s", interfaces[0].Name)
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.200") {
+		t.Error("expected IPv4 192.168.1.200")
+	}
+	if interfaces[0].Source != "interfaces" {
+		t.Errorf("expected source interfaces, got %s", interfaces[0].Source)
+	}
+	if interfaces[0].DHCP {
+		t.Error("expected eth0 DHCP to be false")
+	}
+	if !interfaces[1].DHCP {
+		t.Error("expected eth1 DHCP to be true")
+	}
+}
+
+func TestInterfaces_IPv6(t *testing.T) {
+	t.Parallel()
+	section := "auto eth0\niface eth0 inet static\naddress 192.168.1.200\n\niface eth0 inet6 static\naddress fd00::1\n"
+	interfaces, err := Interfaces(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interface stanzas, got %d", len(interfaces))
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.200") {
+		t.Error("expected IPv4 192.168.1.200")
+	}
+	if len(interfaces[0].IPv6) != 0 {
+		t.Errorf("expected no IPv6 on inet stanza, got %v", interfaces[0].IPv6)
+	}
+	if !containsStr(interfaces[1].IPv6, "fd00::1") {
+		t.Error("expected IPv6 fd00::1")
+	}
+	if len(interfaces[1].IPv4) != 0 {
+		t.Errorf("expected no IPv4 on inet6 stanza, got %v", interfaces[1].IPv4)
+	}
+}

--- a/pkg/virt-customization/probe/netcfg/netplan.go
+++ b/pkg/virt-customization/probe/netcfg/netplan.go
@@ -1,0 +1,117 @@
+package netcfg
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	"gopkg.in/yaml.v2"
+)
+
+type netplanConfig struct {
+	Network struct {
+		Renderer  string                   `yaml:"renderer"`
+		Ethernets map[string]netplanDevice `yaml:"ethernets"`
+		Bonds     map[string]netplanDevice `yaml:"bonds"`
+		Bridges   map[string]netplanDevice `yaml:"bridges"`
+		Vlans     map[string]netplanDevice `yaml:"vlans"`
+	} `yaml:"network"`
+}
+
+// NetplanResult holds both parsed interfaces and metadata.
+type NetplanResult struct {
+	Interfaces []api.InterfaceInfo
+	Renderer   string // "networkd", "NetworkManager", or empty
+}
+
+type netplanDevice struct {
+	Addresses []string     `yaml:"addresses"`
+	DHCP4     bool         `yaml:"dhcp4"`
+	DHCP6     bool         `yaml:"dhcp6"`
+	Match     netplanMatch `yaml:"match"`
+}
+
+type netplanMatch struct {
+	MACAddress string `yaml:"macaddress"`
+}
+
+// Netplan parses netplan YAML configuration.
+// The input may contain multiple concatenated YAML documents (one per file).
+func Netplan(section string) (NetplanResult, error) {
+	var result NetplanResult
+	var errs []error
+
+	for i, doc := range splitYAMLDocuments(section) {
+		var cfg netplanConfig
+		if err := yaml.Unmarshal([]byte(doc), &cfg); err != nil {
+			errs = append(errs, fmt.Errorf("parsing netplan document %d: %w", i, err))
+			continue
+		}
+		if cfg.Network.Renderer != "" && result.Renderer == "" {
+			result.Renderer = cfg.Network.Renderer
+		}
+		result.Interfaces = append(result.Interfaces, extractDevices(cfg.Network.Ethernets, "netplan")...)
+		result.Interfaces = append(result.Interfaces, extractDevices(cfg.Network.Bonds, "netplan")...)
+		result.Interfaces = append(result.Interfaces, extractDevices(cfg.Network.Bridges, "netplan")...)
+		result.Interfaces = append(result.Interfaces, extractDevices(cfg.Network.Vlans, "netplan")...)
+	}
+	return result, errors.Join(errs...)
+}
+
+// extractDevices converts a netplan device map into sorted InterfaceInfo entries.
+func extractDevices(devices map[string]netplanDevice, source string) []api.InterfaceInfo {
+	names := make([]string, 0, len(devices))
+	for name := range devices {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var result []api.InterfaceInfo
+	for _, name := range names {
+		dev := devices[name]
+		iface := api.InterfaceInfo{
+			Name:   name,
+			MAC:    strings.ToLower(dev.Match.MACAddress),
+			DHCP:   dev.DHCP4 || dev.DHCP6,
+			Source: source,
+		}
+		for _, addr := range dev.Addresses {
+			ip := strings.SplitN(addr, "/", 2)[0]
+			if ip == "" {
+				continue
+			}
+			if strings.Contains(ip, ":") {
+				iface.IPv6 = append(iface.IPv6, ip)
+			} else {
+				iface.IPv4 = append(iface.IPv4, ip)
+			}
+		}
+		result = append(result, iface)
+	}
+	return result
+}
+
+// splitYAMLDocuments splits concatenated YAML docs on "---" separators.
+// Also treats the entire input as a single doc if no separators exist.
+func splitYAMLDocuments(input string) []string {
+	var docs []string
+	var current strings.Builder
+
+	for _, line := range strings.Split(input, "\n") {
+		if strings.TrimSpace(line) == "---" {
+			if current.Len() > 0 {
+				docs = append(docs, current.String())
+				current.Reset()
+			}
+			continue
+		}
+		current.WriteString(line)
+		current.WriteByte('\n')
+	}
+	if current.Len() > 0 {
+		docs = append(docs, current.String())
+	}
+	return docs
+}

--- a/pkg/virt-customization/probe/netcfg/netplan_test.go
+++ b/pkg/virt-customization/probe/netcfg/netplan_test.go
@@ -1,0 +1,228 @@
+package netcfg
+
+import (
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+func findIface(interfaces []api.InterfaceInfo, name string) *api.InterfaceInfo {
+	for i := range interfaces {
+		if interfaces[i].Name == name {
+			return &interfaces[i]
+		}
+	}
+	return nil
+}
+
+func TestNetplan(t *testing.T) {
+	t.Parallel()
+	section := `network:
+  ethernets:
+    eth0:
+      addresses:
+        - 192.168.1.50/24
+        - 10.0.0.1/8
+    eth1:
+      dhcp4: true
+`
+	result, err := Netplan(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(result.Interfaces))
+	}
+	eth0 := findIface(result.Interfaces, "eth0")
+	if eth0 == nil {
+		t.Fatal("expected to find eth0")
+		return
+	}
+	if !containsStr(eth0.IPv4, "192.168.1.50") {
+		t.Error("expected IPv4 192.168.1.50")
+	}
+	if !containsStr(eth0.IPv4, "10.0.0.1") {
+		t.Error("expected IPv4 10.0.0.1")
+	}
+	if eth0.DHCP {
+		t.Error("expected eth0 DHCP to be false")
+	}
+	eth1 := findIface(result.Interfaces, "eth1")
+	if eth1 == nil {
+		t.Fatal("expected to find eth1")
+		return
+	}
+	if !eth1.DHCP {
+		t.Error("expected eth1 DHCP to be true")
+	}
+}
+
+func TestNetplan_4SpaceIndent(t *testing.T) {
+	t.Parallel()
+	section := `network:
+    ethernets:
+        eth0:
+            addresses:
+                - 192.168.1.50/24
+        eth1:
+            dhcp4: true
+`
+	result, err := Netplan(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(result.Interfaces))
+	}
+	eth0 := findIface(result.Interfaces, "eth0")
+	if eth0 == nil {
+		t.Fatal("expected to find eth0")
+		return
+	}
+	if !containsStr(eth0.IPv4, "192.168.1.50") {
+		t.Error("expected IPv4 192.168.1.50")
+	}
+	if findIface(result.Interfaces, "eth1") == nil {
+		t.Error("expected to find eth1")
+	}
+}
+
+func TestNetplan_MACAddress(t *testing.T) {
+	t.Parallel()
+	section := `network:
+  ethernets:
+    eth0:
+      match:
+        macaddress: "00:11:22:33:44:55"
+      addresses:
+        - 192.168.1.50/24
+`
+	result, err := Netplan(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(result.Interfaces))
+	}
+	if result.Interfaces[0].MAC != "00:11:22:33:44:55" {
+		t.Errorf("expected MAC 00:11:22:33:44:55, got %s", result.Interfaces[0].MAC)
+	}
+}
+
+func TestNetplan_MultipleDocuments(t *testing.T) {
+	t.Parallel()
+	section := `network:
+  ethernets:
+    eth0:
+      addresses:
+        - 192.168.1.50/24
+---
+network:
+  ethernets:
+    eth1:
+      addresses:
+        - 10.0.0.1/8
+`
+	result, err := Netplan(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(result.Interfaces))
+	}
+	if findIface(result.Interfaces, "eth0") == nil {
+		t.Error("expected to find eth0")
+	}
+	if findIface(result.Interfaces, "eth1") == nil {
+		t.Error("expected to find eth1")
+	}
+}
+
+func TestNetplan_Renderer(t *testing.T) {
+	t.Parallel()
+	section := `network:
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: true
+`
+	result, err := Netplan(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Renderer != "networkd" {
+		t.Errorf("expected renderer networkd, got %s", result.Renderer)
+	}
+	if len(result.Interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(result.Interfaces))
+	}
+	if !result.Interfaces[0].DHCP {
+		t.Error("expected DHCP to be true")
+	}
+}
+
+func TestNetplan_IPv6(t *testing.T) {
+	t.Parallel()
+	section := `network:
+  ethernets:
+    eth0:
+      addresses:
+        - 192.168.1.50/24
+        - "fd00::1/64"
+`
+	result, err := Netplan(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(result.Interfaces))
+	}
+	eth0 := findIface(result.Interfaces, "eth0")
+	if eth0 == nil {
+		t.Fatal("expected to find eth0")
+		return
+	}
+	if !containsStr(eth0.IPv4, "192.168.1.50") {
+		t.Error("expected IPv4 192.168.1.50")
+	}
+	if !containsStr(eth0.IPv6, "fd00::1") {
+		t.Error("expected IPv6 fd00::1")
+	}
+}
+
+func TestNetplan_EmptyEthernets(t *testing.T) {
+	t.Parallel()
+	section := `network:
+  ethernets: {}
+`
+	result, err := Netplan(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Interfaces) != 0 {
+		t.Errorf("expected 0 interfaces for empty ethernets, got %d", len(result.Interfaces))
+	}
+}
+
+func TestNetplan_EmptyInput(t *testing.T) {
+	t.Parallel()
+	result, err := Netplan("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Interfaces) != 0 {
+		t.Errorf("expected 0 interfaces for empty input, got %d", len(result.Interfaces))
+	}
+}
+
+func TestNetplan_InvalidYAML(t *testing.T) {
+	t.Parallel()
+	section := "not: valid: yaml: [[[["
+	result, err := Netplan(section)
+	if err == nil {
+		t.Error("expected error for invalid YAML, got nil")
+	}
+	if len(result.Interfaces) != 0 {
+		t.Errorf("expected 0 interfaces for invalid YAML, got %d", len(result.Interfaces))
+	}
+}

--- a/pkg/virt-customization/probe/netcfg/nm.go
+++ b/pkg/virt-customization/probe/netcfg/nm.go
@@ -1,0 +1,70 @@
+package netcfg
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// NM parses NetworkManager keyfile-format connection profiles.
+// Multiple concatenated profiles are split on [connection] boundaries.
+// Addresses under [ipv4] go to IPv4, addresses under [ipv6] go to IPv6.
+func NM(section string) ([]api.InterfaceInfo, error) {
+	var interfaces []api.InterfaceInfo
+	var current api.InterfaceInfo
+	current.Source = "nm-connection"
+	currentSection := ""
+
+	scanner := bufio.NewScanner(strings.NewReader(section))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "[connection]" {
+			if current.Name != "" || current.HasIPs() {
+				interfaces = append(interfaces, current)
+				current = api.InterfaceInfo{Source: "nm-connection"}
+			}
+			currentSection = "connection"
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			currentSection = line[1 : len(line)-1]
+			continue
+		}
+		kv := strings.SplitN(line, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(kv[0])
+		val := strings.TrimSpace(kv[1])
+		switch key {
+		case "interface-name":
+			current.Name = val
+		case "mac-address":
+			current.MAC = strings.ToLower(val)
+		case "method":
+			if (currentSection == "ipv4" || currentSection == "ipv6") && val == "auto" {
+				current.DHCP = true
+			}
+		}
+		if (currentSection == "ipv4" || currentSection == "ipv6") && strings.HasPrefix(key, "address") && strings.Contains(val, "/") {
+			ip := strings.SplitN(val, "/", 2)[0]
+			if ip != "" {
+				switch currentSection {
+				case "ipv6":
+					current.IPv6 = append(current.IPv6, ip)
+				default:
+					current.IPv4 = append(current.IPv4, ip)
+				}
+			}
+		}
+	}
+	if current.Name != "" || current.HasIPs() {
+		interfaces = append(interfaces, current)
+	}
+	if err := scanner.Err(); err != nil {
+		return interfaces, fmt.Errorf("NM parser: scanner error: %w", err)
+	}
+	return interfaces, nil
+}

--- a/pkg/virt-customization/probe/netcfg/nm_dhcp.go
+++ b/pkg/virt-customization/probe/netcfg/nm_dhcp.go
@@ -1,0 +1,130 @@
+package netcfg
+
+import (
+	"bufio"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// uuidRe matches a UUID in a lease filename.
+// Filename format: prefix-<UUID>-<INTERFACE>.lease
+var uuidRe = regexp.MustCompile(`([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-(.+)\.lease$`)
+
+// NMDhcpLease parses NetworkManager DHCP lease files from /var/lib/NetworkManager/.
+// filesSection contains ls output (filenames, one per line).
+// leaseSection contains the concatenated lease file contents (each file has
+// an optional comment line and an ADDRESS=<ip> line).
+// timestampsSection contains the timestamps file (uuid=epoch pairs).
+//
+// For each lease file the parser extracts the IP from ADDRESS=, the UUID and
+// interface name from the filename, and the timestamp from the timestamps file.
+// When multiple leases exist for the same interface, the most recent wins.
+func NMDhcpLease(filesSection, leaseSection, timestampsSection string) ([]api.InterfaceInfo, error) {
+	leaseFiles := parseNMLeaseFilenames(filesSection)
+	addresses := parseNMLeaseAddresses(leaseSection)
+	timestamps := parseTimestamps(timestampsSection)
+
+	type leaseEntry struct {
+		name      string
+		ip        string
+		timestamp int64
+	}
+
+	best := map[string]leaseEntry{}
+	for i, lf := range leaseFiles {
+		ip := ""
+		if i < len(addresses) {
+			ip = addresses[i]
+		}
+		if ip == "" || lf.iface == "" {
+			continue
+		}
+
+		ts := timestamps[lf.uuid]
+
+		prev, exists := best[lf.iface]
+		if !exists || ts > prev.timestamp {
+			best[lf.iface] = leaseEntry{name: lf.iface, ip: ip, timestamp: ts}
+		}
+	}
+
+	var interfaces []api.InterfaceInfo
+	for _, entry := range best {
+		iface := api.InterfaceInfo{
+			Name:   entry.name,
+			DHCP:   true,
+			Source: "nm-dhcp-lease",
+		}
+		if strings.Contains(entry.ip, ":") {
+			iface.IPv6 = []string{entry.ip}
+		} else {
+			iface.IPv4 = []string{entry.ip}
+		}
+		interfaces = append(interfaces, iface)
+	}
+	return interfaces, nil
+}
+
+type nmLeaseFile struct {
+	uuid  string
+	iface string
+}
+
+// parseNMLeaseFilenames extracts UUID and interface name from NM lease filenames.
+func parseNMLeaseFilenames(section string) []nmLeaseFile {
+	var files []nmLeaseFile
+	for _, line := range strings.Split(strings.TrimSpace(section), "\n") {
+		fname := strings.TrimSpace(line)
+		if fname == "" || !strings.HasSuffix(fname, ".lease") {
+			continue
+		}
+		matches := uuidRe.FindStringSubmatch(fname)
+		if matches == nil {
+			continue
+		}
+		files = append(files, nmLeaseFile{uuid: matches[1], iface: matches[2]})
+	}
+	return files
+}
+
+// parseNMLeaseAddresses extracts ADDRESS= values from concatenated lease contents.
+func parseNMLeaseAddresses(section string) []string {
+	var addrs []string
+	scanner := bufio.NewScanner(strings.NewReader(section))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "ADDRESS=") {
+			addrs = append(addrs, strings.TrimPrefix(line, "ADDRESS="))
+		}
+	}
+	return addrs
+}
+
+// parseTimestamps parses the NM timestamps file (uuid=epoch pairs).
+// Lines like "[timestamps]" headers and blank lines are skipped.
+func parseTimestamps(section string) map[string]int64 {
+	ts := map[string]int64{}
+	scanner := bufio.NewScanner(strings.NewReader(section))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "[") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		uuid := strings.TrimSpace(parts[0])
+		epoch, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+		if err != nil {
+			fmt.Printf("warning: bad timestamp for UUID %s: %v\n", uuid, err)
+			continue
+		}
+		ts[uuid] = epoch
+	}
+	return ts
+}

--- a/pkg/virt-customization/probe/netcfg/nm_dhcp_test.go
+++ b/pkg/virt-customization/probe/netcfg/nm_dhcp_test.go
@@ -1,0 +1,164 @@
+package netcfg
+
+import "testing"
+
+func TestNMDhcpLease(t *testing.T) {
+	t.Parallel()
+	files := "internal-6a0608c2-9d57-46d8-84d1-d2bbf6767acc-enp1s0.lease\ninternal-1f2ea111-624b-32f6-8c93-12b2388516a6-enp1s0.lease\n"
+	leases := "# This is private data. Do not parse.\nADDRESS=192.168.122.167\n# This is private data. Do not parse.\nADDRESS=192.168.122.179\n"
+	timestamps := "1f2ea111-624b-32f6-8c93-12b2388516a6=1745269160\n6a0608c2-9d57-46d8-84d1-d2bbf6767acc=1745269159\n"
+
+	interfaces, err := NMDhcpLease(files, leases, timestamps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface (deduplicated by name), got %d", len(interfaces))
+	}
+	iface := interfaces[0]
+	if iface.Name != "enp1s0" {
+		t.Errorf("expected enp1s0, got %s", iface.Name)
+	}
+	// UUID 1f2ea111... has timestamp 1745269160 (newer), ADDRESS=192.168.122.179
+	if !containsStr(iface.IPv4, "192.168.122.179") {
+		t.Errorf("expected IPv4 192.168.122.179 (from newer lease), got %v", iface.IPv4)
+	}
+	if !iface.DHCP {
+		t.Error("expected DHCP=true")
+	}
+	if iface.Source != "nm-dhcp-lease" {
+		t.Errorf("expected source nm-dhcp-lease, got %s", iface.Source)
+	}
+}
+
+func TestNMDhcpLease_MultipleInterfaces(t *testing.T) {
+	t.Parallel()
+	files := "internal-aabbccdd-bbbb-cccc-dddd-eeeeeeeeeeee-eth0.lease\ninternal-11112222-2222-3333-4444-555555555555-eth1.lease\n"
+	leases := "ADDRESS=10.0.0.1\nADDRESS=10.0.0.2\n"
+	timestamps := "aabbccdd-bbbb-cccc-dddd-eeeeeeeeeeee=100\n11112222-2222-3333-4444-555555555555=200\n"
+
+	interfaces, err := NMDhcpLease(files, leases, timestamps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+	found := map[string]bool{}
+	for _, iface := range interfaces {
+		found[iface.Name] = true
+	}
+	if !found["eth0"] || !found["eth1"] {
+		t.Errorf("expected eth0 and eth1, got %v", found)
+	}
+}
+
+func TestNMDhcpLease_NoTimestampsFile(t *testing.T) {
+	t.Parallel()
+	files := "internal-aabbccdd-bbbb-cccc-dddd-eeeeeeeeeeee-eth0.lease\n"
+	leases := "ADDRESS=10.0.0.1\n"
+	timestamps := ""
+
+	interfaces, err := NMDhcpLease(files, leases, timestamps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "eth0" {
+		t.Errorf("expected eth0, got %s", interfaces[0].Name)
+	}
+	if !containsStr(interfaces[0].IPv4, "10.0.0.1") {
+		t.Error("expected IPv4 10.0.0.1")
+	}
+}
+
+func TestNMDhcpLease_TimestampsWithHeader(t *testing.T) {
+	t.Parallel()
+	files := "internal-aabbccdd-bbbb-cccc-dddd-eeeeeeeeeeee-eth0.lease\n"
+	leases := "ADDRESS=10.0.0.1\n"
+	timestamps := "[timestamps]\naabbccdd-bbbb-cccc-dddd-eeeeeeeeeeee=999\n"
+
+	interfaces, err := NMDhcpLease(files, leases, timestamps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+}
+
+func TestNMDhcpLease_EmptyInput(t *testing.T) {
+	t.Parallel()
+	interfaces, err := NMDhcpLease("", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 0 {
+		t.Errorf("expected 0 interfaces for empty input, got %d", len(interfaces))
+	}
+}
+
+func TestNMDhcpLease_NonLeaseFilesIgnored(t *testing.T) {
+	t.Parallel()
+	files := "timestamps\nsecret_key\ninternal-aabbccdd-bbbb-cccc-dddd-eeeeeeeeeeee-eth0.lease\n"
+	leases := "ADDRESS=10.0.0.1\n"
+	timestamps := ""
+
+	interfaces, err := NMDhcpLease(files, leases, timestamps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface (non-.lease files ignored), got %d", len(interfaces))
+	}
+}
+
+func TestParseNMLeaseFilenames(t *testing.T) {
+	t.Parallel()
+	section := "timestamps\ninternal-6a0608c2-9d57-46d8-84d1-d2bbf6767acc-enp1s0.lease\ninternal-1f2ea111-624b-32f6-8c93-12b2388516a6-ens192.lease\n"
+	files := parseNMLeaseFilenames(section)
+	if len(files) != 2 {
+		t.Fatalf("expected 2 lease files, got %d", len(files))
+	}
+	if files[0].uuid != "6a0608c2-9d57-46d8-84d1-d2bbf6767acc" {
+		t.Errorf("unexpected uuid: %s", files[0].uuid)
+	}
+	if files[0].iface != "enp1s0" {
+		t.Errorf("expected enp1s0, got %s", files[0].iface)
+	}
+	if files[1].iface != "ens192" {
+		t.Errorf("expected ens192, got %s", files[1].iface)
+	}
+}
+
+func TestParseTimestamps(t *testing.T) {
+	t.Parallel()
+	section := "[timestamps]\n1f2ea111-624b-32f6-8c93-12b2388516a6=1745269160\n6a0608c2-9d57-46d8-84d1-d2bbf6767acc=1745269159\n\n"
+	ts := parseTimestamps(section)
+	if len(ts) != 2 {
+		t.Fatalf("expected 2 timestamps, got %d", len(ts))
+	}
+	if ts["1f2ea111-624b-32f6-8c93-12b2388516a6"] != 1745269160 {
+		t.Errorf("unexpected timestamp: %d", ts["1f2ea111-624b-32f6-8c93-12b2388516a6"])
+	}
+	if ts["6a0608c2-9d57-46d8-84d1-d2bbf6767acc"] != 1745269159 {
+		t.Errorf("unexpected timestamp: %d", ts["6a0608c2-9d57-46d8-84d1-d2bbf6767acc"])
+	}
+}
+
+func TestParseNMLeaseAddresses(t *testing.T) {
+	t.Parallel()
+	section := "# This is private data. Do not parse.\nADDRESS=192.168.122.167\n# This is private data. Do not parse.\nADDRESS=192.168.122.179\n"
+	addrs := parseNMLeaseAddresses(section)
+	if len(addrs) != 2 {
+		t.Fatalf("expected 2 addresses, got %d", len(addrs))
+	}
+	if addrs[0] != "192.168.122.167" {
+		t.Errorf("expected 192.168.122.167, got %s", addrs[0])
+	}
+	if addrs[1] != "192.168.122.179" {
+		t.Errorf("expected 192.168.122.179, got %s", addrs[1])
+	}
+}

--- a/pkg/virt-customization/probe/netcfg/nm_test.go
+++ b/pkg/virt-customization/probe/netcfg/nm_test.go
@@ -1,0 +1,146 @@
+package netcfg
+
+import "testing"
+
+func TestNM(t *testing.T) {
+	t.Parallel()
+	section := "[connection]\nid=Wired connection 1\ntype=ethernet\ninterface-name=ens192\n\n[ipv4]\naddress1=192.168.1.100/24,192.168.1.1\nmethod=manual\n\n[ethernet]\nmac-address=00:50:56:a1:b2:c3\n"
+	interfaces, err := NM(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "ens192" {
+		t.Errorf("expected ens192, got %s", interfaces[0].Name)
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.100") {
+		t.Error("expected IPv4 192.168.1.100")
+	}
+	if interfaces[0].MAC != "00:50:56:a1:b2:c3" {
+		t.Errorf("expected MAC 00:50:56:a1:b2:c3, got %s", interfaces[0].MAC)
+	}
+	if interfaces[0].DHCP {
+		t.Error("expected DHCP to be false for method=manual")
+	}
+}
+
+func TestNM_DHCP(t *testing.T) {
+	t.Parallel()
+	section := "[connection]\nid=Wired connection 1\ntype=ethernet\ninterface-name=ens192\n\n[ipv4]\nmethod=auto\n"
+	interfaces, err := NM(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if !interfaces[0].DHCP {
+		t.Error("expected DHCP to be true for method=auto")
+	}
+}
+
+func TestNM_MultiProfile(t *testing.T) {
+	t.Parallel()
+	section := "[connection]\nid=Wired connection 1\ntype=ethernet\ninterface-name=ens192\n\n[ipv4]\naddress1=192.168.1.100/24,192.168.1.1\nmethod=manual\n\n[ethernet]\nmac-address=00:50:56:a1:b2:c3\n[connection]\nid=Wired connection 2\ntype=ethernet\ninterface-name=ens224\n\n[ipv4]\naddress1=10.0.0.50/16,10.0.0.1\nmethod=manual\n\n[ethernet]\nmac-address=00:50:56:d4:e5:f6\n"
+	interfaces, err := NM(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "ens192" {
+		t.Errorf("expected ens192, got %s", interfaces[0].Name)
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.100") {
+		t.Error("expected IPv4 192.168.1.100 on first interface")
+	}
+	if interfaces[0].MAC != "00:50:56:a1:b2:c3" {
+		t.Errorf("expected MAC 00:50:56:a1:b2:c3, got %s", interfaces[0].MAC)
+	}
+	if interfaces[1].Name != "ens224" {
+		t.Errorf("expected ens224, got %s", interfaces[1].Name)
+	}
+	if !containsStr(interfaces[1].IPv4, "10.0.0.50") {
+		t.Error("expected IPv4 10.0.0.50 on second interface")
+	}
+	if interfaces[1].MAC != "00:50:56:d4:e5:f6" {
+		t.Errorf("expected MAC 00:50:56:d4:e5:f6, got %s", interfaces[1].MAC)
+	}
+}
+
+func TestNM_IPv6(t *testing.T) {
+	t.Parallel()
+	section := "[connection]\nid=Wired connection 1\ntype=ethernet\ninterface-name=ens192\n\n[ipv4]\naddress1=192.168.1.100/24,192.168.1.1\nmethod=manual\n\n[ipv6]\naddress1=fd00::1/64\nmethod=manual\n"
+	interfaces, err := NM(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.100") {
+		t.Error("expected IPv4 192.168.1.100")
+	}
+	if !containsStr(interfaces[0].IPv6, "fd00::1") {
+		t.Error("expected IPv6 fd00::1")
+	}
+	if len(interfaces[0].IPv4) != 1 {
+		t.Errorf("expected 1 IPv4, got %d", len(interfaces[0].IPv4))
+	}
+	if len(interfaces[0].IPv6) != 1 {
+		t.Errorf("expected 1 IPv6, got %d", len(interfaces[0].IPv6))
+	}
+}
+
+func TestNM_NoConnectionHeader(t *testing.T) {
+	t.Parallel()
+	section := "interface-name=eth0\n\n[ipv4]\naddress1=10.0.0.1/24,10.0.0.254\n"
+	interfaces, err := NM(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "eth0" {
+		t.Errorf("expected eth0, got %s", interfaces[0].Name)
+	}
+}
+
+func TestNM_NonIPSectionsIgnoreAddresses(t *testing.T) {
+	t.Parallel()
+	section := "[connection]\nid=Test\ntype=ethernet\ninterface-name=ens192\n\n[proxy]\nmethod=auto\naddress1=1.2.3.4/24,1.2.3.1\n\n[ipv4]\naddress1=192.168.1.100/24,192.168.1.1\nmethod=manual\n"
+	interfaces, err := NM(section)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "ens192" {
+		t.Errorf("expected ens192, got %s", interfaces[0].Name)
+	}
+	if len(interfaces[0].IPv4) != 1 {
+		t.Errorf("expected 1 IPv4 address, got %d: %v", len(interfaces[0].IPv4), interfaces[0].IPv4)
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.100") {
+		t.Error("expected IPv4 192.168.1.100")
+	}
+	if interfaces[0].DHCP {
+		t.Error("expected DHCP false: method=auto in [proxy] should not set DHCP")
+	}
+}
+
+func TestNM_EmptyInput(t *testing.T) {
+	t.Parallel()
+	interfaces, err := NM("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 0 {
+		t.Errorf("expected 0 interfaces for empty input, got %d", len(interfaces))
+	}
+}

--- a/pkg/virt-customization/probe/netcfg/wicked.go
+++ b/pkg/virt-customization/probe/netcfg/wicked.go
@@ -1,0 +1,140 @@
+package netcfg
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// Wicked parses wicked lease data from /var/lib/wicked/.
+// filesSection contains the `ls` output (filenames, one per line).
+// xmlSection contains the concatenated XML from `glob cat lease-*`.
+// Interface names and address families are extracted from filenames
+// (e.g. "lease-eth0-dhcp-ipv4.xml" → name="eth0", family="ipv4").
+// IP addresses are extracted from <address> elements in the XML.
+func Wicked(filesSection, xmlSection string) ([]api.InterfaceInfo, error) {
+	leases := parseLeaseFilenames(filesSection)
+	addresses, err := parseLeaseXML(xmlSection)
+	if err != nil {
+		return nil, fmt.Errorf("Wicked parser: %w", err)
+	}
+
+	var interfaces []api.InterfaceInfo
+	for i, lease := range leases {
+		if lease.name == "lo" {
+			continue
+		}
+		iface := api.InterfaceInfo{
+			Name:   lease.name,
+			DHCP:   true,
+			Source: "wicked",
+		}
+		if i < len(addresses) && addresses[i] != "" {
+			if lease.family == "ipv6" {
+				iface.IPv6 = []string{addresses[i]}
+			} else {
+				iface.IPv4 = []string{addresses[i]}
+			}
+		}
+		interfaces = append(interfaces, iface)
+	}
+	return interfaces, nil
+}
+
+type leaseFile struct {
+	name   string // interface name (e.g. "eth0")
+	family string // "ipv4" or "ipv6"
+}
+
+// parseLeaseFilenames extracts interface names and address families from
+// wicked lease filenames. Format: lease-{interface}-dhcp-{family}.xml
+func parseLeaseFilenames(section string) []leaseFile {
+	var leases []leaseFile
+	for _, line := range strings.Split(strings.TrimSpace(section), "\n") {
+		fname := strings.TrimSpace(line)
+		if fname == "" || !strings.HasPrefix(fname, "lease-") {
+			continue
+		}
+		fname = strings.TrimPrefix(fname, "lease-")
+		idx := strings.Index(fname, "-dhcp-")
+		if idx <= 0 {
+			continue
+		}
+		name := fname[:idx]
+		rest := fname[idx+len("-dhcp-"):]
+		family := strings.TrimSuffix(rest, ".xml")
+		leases = append(leases, leaseFile{name: name, family: family})
+	}
+	return leases
+}
+
+// parseLeaseXML extracts the <address> from each <lease> document in
+// a concatenated XML stream. Multiple <lease> root elements are handled
+// by decoding sequentially.
+func parseLeaseXML(section string) ([]string, error) {
+	var addresses []string
+	decoder := xml.NewDecoder(strings.NewReader(section))
+	for {
+		addr, err := decodeOneLease(decoder)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return addresses, fmt.Errorf("decoding lease XML: %w", err)
+		}
+		addresses = append(addresses, addr)
+	}
+	return addresses, nil
+}
+
+// decodeOneLease advances the decoder past the next <lease> element and
+// extracts the first <address> found inside it.
+func decodeOneLease(decoder *xml.Decoder) (string, error) {
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			return "", err
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if start.Name.Local == "lease" {
+			return extractAddressFromLease(decoder)
+		}
+	}
+}
+
+// extractAddressFromLease reads tokens inside a <lease> element until
+// it finds <address> or hits </lease>.
+func extractAddressFromLease(decoder *xml.Decoder) (string, error) {
+	var address string
+	depth := 1
+	for depth > 0 {
+		tok, err := decoder.Token()
+		if err == io.EOF {
+			return address, fmt.Errorf("unexpected EOF inside <lease> element (truncated XML?)")
+		}
+		if err != nil {
+			return address, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			depth++
+			if t.Name.Local == "address" {
+				var content string
+				if err := decoder.DecodeElement(&content, &t); err != nil {
+					return address, fmt.Errorf("decoding <address> element: %w", err)
+				}
+				address = strings.SplitN(content, "/", 2)[0]
+				depth--
+			}
+		case xml.EndElement:
+			depth--
+		}
+	}
+	return address, nil
+}

--- a/pkg/virt-customization/probe/netcfg/wicked_test.go
+++ b/pkg/virt-customization/probe/netcfg/wicked_test.go
@@ -1,0 +1,162 @@
+package netcfg
+
+import "testing"
+
+func TestWicked(t *testing.T) {
+	files := "duid.xml\nlease-eth0-dhcp-ipv4.xml\nlease-eth1-dhcp-ipv4.xml\n"
+	xml := `<lease>
+    <family>ipv4</family>
+    <type>dhcp</type>
+    <state>granted</state>
+    <ipv4:dhcp>
+        <address>192.168.122.82</address>
+    </ipv4:dhcp>
+</lease>
+<lease>
+    <family>ipv4</family>
+    <type>dhcp</type>
+    <state>granted</state>
+    <ipv4:dhcp>
+        <address>192.168.122.83</address>
+    </ipv4:dhcp>
+</lease>
+`
+	interfaces, err := Wicked(files, xml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(interfaces))
+	}
+	if interfaces[0].Name != "eth0" {
+		t.Errorf("expected eth0, got %s", interfaces[0].Name)
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.122.82") {
+		t.Error("expected IPv4 192.168.122.82")
+	}
+	if len(interfaces[0].IPv6) != 0 {
+		t.Errorf("expected no IPv6, got %v", interfaces[0].IPv6)
+	}
+	if interfaces[0].Source != "wicked" {
+		t.Errorf("expected source wicked, got %s", interfaces[0].Source)
+	}
+	if interfaces[1].Name != "eth1" {
+		t.Errorf("expected eth1, got %s", interfaces[1].Name)
+	}
+	if !containsStr(interfaces[1].IPv4, "192.168.122.83") {
+		t.Error("expected IPv4 192.168.122.83")
+	}
+}
+
+func TestWicked_IPv6(t *testing.T) {
+	files := "lease-eth0-dhcp-ipv6.xml\n"
+	xml := `<lease>
+    <family>ipv6</family>
+    <type>dhcp</type>
+    <state>granted</state>
+    <ipv6:dhcp>
+        <address>fd00::42</address>
+    </ipv6:dhcp>
+</lease>
+`
+	interfaces, err := Wicked(files, xml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 1 {
+		t.Fatalf("expected 1 interface, got %d", len(interfaces))
+	}
+	if !containsStr(interfaces[0].IPv6, "fd00::42") {
+		t.Error("expected IPv6 fd00::42")
+	}
+	if len(interfaces[0].IPv4) != 0 {
+		t.Errorf("expected no IPv4, got %v", interfaces[0].IPv4)
+	}
+}
+
+func TestWicked_NoLeaseFiles(t *testing.T) {
+	files := "duid.xml\n"
+	xml := ""
+	interfaces, err := Wicked(files, xml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 0 {
+		t.Errorf("expected 0 interfaces, got %d", len(interfaces))
+	}
+}
+
+func TestParseLeaseFilenames(t *testing.T) {
+	section := "duid.xml\nlease-eth0-dhcp-ipv4.xml\nlease-ens192-dhcp-ipv6.xml\n"
+	leases := parseLeaseFilenames(section)
+	if len(leases) != 2 {
+		t.Fatalf("expected 2 leases, got %d", len(leases))
+	}
+	if leases[0].name != "eth0" {
+		t.Errorf("expected eth0, got %s", leases[0].name)
+	}
+	if leases[0].family != "ipv4" {
+		t.Errorf("expected ipv4, got %s", leases[0].family)
+	}
+	if leases[1].name != "ens192" {
+		t.Errorf("expected ens192, got %s", leases[1].name)
+	}
+	if leases[1].family != "ipv6" {
+		t.Errorf("expected ipv6, got %s", leases[1].family)
+	}
+}
+
+func TestWicked_MoreFilesThanXML(t *testing.T) {
+	files := "lease-eth0-dhcp-ipv4.xml\nlease-eth1-dhcp-ipv4.xml\nlease-eth2-dhcp-ipv4.xml\n"
+	xml := `<lease><ipv4:dhcp><address>192.168.1.1</address></ipv4:dhcp></lease>`
+	interfaces, err := Wicked(files, xml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 3 {
+		t.Fatalf("expected 3 interfaces, got %d", len(interfaces))
+	}
+	if !containsStr(interfaces[0].IPv4, "192.168.1.1") {
+		t.Error("expected first interface to have IPv4 192.168.1.1")
+	}
+	if len(interfaces[1].IPv4) != 0 {
+		t.Errorf("expected second interface to have no IPs, got %v", interfaces[1].IPv4)
+	}
+	if len(interfaces[2].IPv4) != 0 {
+		t.Errorf("expected third interface to have no IPs, got %v", interfaces[2].IPv4)
+	}
+}
+
+func TestWicked_EmptyInput(t *testing.T) {
+	interfaces, err := Wicked("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(interfaces) != 0 {
+		t.Errorf("expected 0 interfaces for empty input, got %d", len(interfaces))
+	}
+}
+
+func TestWicked_MalformedXML(t *testing.T) {
+	files := "lease-eth0-dhcp-ipv4.xml\n"
+	xml := "<not-a-lease>broken"
+	_, err := Wicked(files, xml)
+	if err == nil {
+		t.Error("expected error for malformed XML, got nil")
+	}
+}
+
+func TestWicked_TruncatedXML(t *testing.T) {
+	files := "lease-eth0-dhcp-ipv4.xml\n"
+	xmlSection := `<lease>
+    <family>ipv4</family>
+    <type>dhcp</type>
+    <state>granted</state>
+    <ipv4:dhcp>
+        <address>192.168.122.82</address>
+    </ipv4:dhcp>`
+	_, err := Wicked(files, xmlSection)
+	if err == nil {
+		t.Error("expected error for truncated XML (missing </lease>), got nil")
+	}
+}

--- a/pkg/virt-customization/probe/probe.go
+++ b/pkg/virt-customization/probe/probe.go
@@ -1,0 +1,28 @@
+package probe
+
+import (
+	"fmt"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// Guest probes the guest disk via a GuestHandle to detect OS type,
+// network stacks, and extract interface configuration. The handle must
+// already be opened and the guest filesystems mounted.
+func Guest(g api.GuestHandle) (*api.GuestInfo, error) {
+	guest := &api.GuestInfo{}
+
+	if err := detect(g, guest); err != nil {
+		return nil, fmt.Errorf("detection phase: %w", err)
+	}
+
+	if guest.OS.IsWindows() {
+		return guest, nil
+	}
+
+	if err := extract(g, guest); err != nil {
+		return guest, fmt.Errorf("extraction phase: %w", err)
+	}
+
+	return guest, nil
+}

--- a/pkg/virt-customization/probe/probe_test.go
+++ b/pkg/virt-customization/probe/probe_test.go
@@ -1,0 +1,286 @@
+package probe
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+)
+
+// testHandle implements api.GuestHandle for testing.
+type testHandle struct {
+	dirs   map[string]bool
+	files  map[string]string
+	globs  map[string][]string
+	lsData map[string][]string
+}
+
+func newTestHandle() *testHandle {
+	return &testHandle{
+		dirs:   make(map[string]bool),
+		files:  make(map[string]string),
+		globs:  make(map[string][]string),
+		lsData: make(map[string][]string),
+	}
+}
+
+func (h *testHandle) IsDir(path string) (bool, error) { return h.dirs[path], nil }
+func (h *testHandle) IsFile(path string) (bool, error) {
+	_, ok := h.files[path]
+	return ok, nil
+}
+func (h *testHandle) Cat(path string) (string, error) {
+	c, ok := h.files[path]
+	if !ok {
+		return "", fmt.Errorf("file not found: %s", path)
+	}
+	return c, nil
+}
+func (h *testHandle) ReadFile(path string) ([]byte, error) {
+	c, err := h.Cat(path)
+	return []byte(c), err
+}
+func (h *testHandle) GlobExpand(pattern string) ([]string, error) {
+	return h.globs[pattern], nil
+}
+func (h *testHandle) Ls(dir string) ([]string, error) { return h.lsData[dir], nil }
+func (h *testHandle) MkdirP(string) error             { return nil }
+func (h *testHandle) Upload(string, string) error     { return nil }
+func (h *testHandle) Write(string, []byte) error      { return nil }
+func (h *testHandle) Chmod(int, string) error         { return nil }
+func (h *testHandle) Shutdown() error                 { return nil }
+func (h *testHandle) Close()                          {}
+
+var _ api.GuestHandle = (*testHandle)(nil)
+
+// --- Detection tests ---
+
+func TestDetect_Windows(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.dirs["/Windows/System32"] = true
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if guest.OS.Family != api.OSFamilyWindows {
+		t.Errorf("expected Windows, got %s", guest.OS.Family)
+	}
+}
+
+func TestDetect_Linux(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.files["/etc/os-release"] = "ID=rhel\n"
+	h.dirs["/etc/sysconfig/network-scripts"] = true
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if guest.OS.Family != api.OSFamilyLinux {
+		t.Errorf("expected Linux, got %s", guest.OS.Family)
+	}
+	if !guest.UsesIfcfg {
+		t.Error("expected UsesIfcfg to be true")
+	}
+}
+
+func TestDetect_Unknown(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if guest.OS.Family != api.OSFamilyUnknown {
+		t.Errorf("expected Unknown, got %s", guest.OS.Family)
+	}
+}
+
+func TestDetect_IfcfgSuse(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.files["/etc/os-release"] = "ID=sles\n"
+	h.dirs["/etc/sysconfig/network"] = true
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if !guest.UsesIfcfgSuse {
+		t.Error("expected UsesIfcfgSuse to be true")
+	}
+}
+
+func TestDetect_NetworkManager(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.files["/etc/os-release"] = "ID=fedora\n"
+	h.dirs["/etc/NetworkManager/system-connections"] = true
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if !guest.UsesNetworkManager {
+		t.Error("expected UsesNetworkManager to be true")
+	}
+}
+
+func TestDetect_Netplan(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.files["/etc/os-release"] = "ID=ubuntu\n"
+	h.dirs["/etc/netplan"] = true
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if !guest.UsesNetplan {
+		t.Error("expected UsesNetplan to be true")
+	}
+}
+
+func TestDetect_Wicked(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.files["/etc/os-release"] = "ID=sles\n"
+	h.dirs["/etc/wicked"] = true
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if !guest.UsesWicked {
+		t.Error("expected UsesWicked to be true")
+	}
+}
+
+func TestDetect_WickedVar(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.files["/etc/os-release"] = "ID=sles\n"
+	h.dirs["/var/lib/wicked"] = true
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if !guest.UsesWicked {
+		t.Error("expected UsesWicked to be true")
+	}
+}
+
+func TestDetect_Ifquery(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.files["/etc/os-release"] = "ID=debian\n"
+	h.files["/etc/network/interfaces"] = "auto eth0\n"
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if !guest.UsesIfquery {
+		t.Error("expected UsesIfquery to be true")
+	}
+}
+
+func TestDetect_InterfacesD(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.files["/etc/os-release"] = "ID=debian\n"
+	h.dirs["/etc/network/interfaces.d"] = true
+	guest := &api.GuestInfo{}
+	if err := detect(h, guest); err != nil {
+		t.Fatal(err)
+	}
+	if !guest.UsesInterfacesD {
+		t.Error("expected UsesInterfacesD to be true")
+	}
+}
+
+// --- OsRelease parsing tests ---
+
+func TestParseOsRelease_RHEL(t *testing.T) {
+	t.Parallel()
+	content := "NAME=\"Red Hat Enterprise Linux\"\nID=rhel\nVERSION_ID=\"9.2\"\n"
+	guest := &api.GuestInfo{}
+	if err := parseOsRelease(content, guest); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if guest.OS.Distro != "rhel" {
+		t.Errorf("expected rhel, got %s", guest.OS.Distro)
+	}
+	if guest.OS.Version != "9.2" {
+		t.Errorf("expected 9.2, got %s", guest.OS.Version)
+	}
+}
+
+func TestParseOsRelease_Ubuntu(t *testing.T) {
+	t.Parallel()
+	content := "NAME=\"Ubuntu\"\nID=ubuntu\nVERSION_ID=\"22.04\"\n"
+	guest := &api.GuestInfo{}
+	if err := parseOsRelease(content, guest); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if guest.OS.Distro != "ubuntu" {
+		t.Errorf("expected ubuntu, got %s", guest.OS.Distro)
+	}
+	if guest.OS.Version != "22.04" {
+		t.Errorf("expected 22.04, got %s", guest.OS.Version)
+	}
+}
+
+// --- Guest integration tests ---
+
+func TestGuest_Windows(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.dirs["/Windows/System32"] = true
+	guest, err := Guest(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if guest.OS.Family != api.OSFamilyWindows {
+		t.Errorf("expected Windows, got %s", guest.OS.Family)
+	}
+}
+
+func TestGuest_Linux(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.files["/etc/os-release"] = "ID=rhel\nVERSION_ID=\"9.2\"\n"
+	guest, err := Guest(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if guest.OS.Family != api.OSFamilyLinux {
+		t.Errorf("expected Linux, got %s", guest.OS.Family)
+	}
+	if guest.OS.Distro != "rhel" {
+		t.Errorf("expected rhel, got %s", guest.OS.Distro)
+	}
+}
+
+// --- catGlob tests ---
+
+func TestCatGlob(t *testing.T) {
+	t.Parallel()
+	h := newTestHandle()
+	h.globs["/etc/sysconfig/network-scripts/ifcfg-*"] = []string{
+		"/etc/sysconfig/network-scripts/ifcfg-eth0",
+		"/etc/sysconfig/network-scripts/ifcfg-eth1",
+	}
+	h.files["/etc/sysconfig/network-scripts/ifcfg-eth0"] = "DEVICE=eth0\nBOOTPROTO=dhcp\n"
+	h.files["/etc/sysconfig/network-scripts/ifcfg-eth1"] = "DEVICE=eth1\nBOOTPROTO=static\n"
+
+	var sb strings.Builder
+	err := catGlob(h, "/etc/sysconfig/network-scripts/ifcfg-*", &sb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := sb.String()
+	if !strings.Contains(result, "DEVICE=eth0") {
+		t.Error("expected eth0 content")
+	}
+	if !strings.Contains(result, "DEVICE=eth1") {
+		t.Error("expected eth1 content")
+	}
+}

--- a/pkg/virt-customization/probe/ssh/sshd_config.go
+++ b/pkg/virt-customization/probe/ssh/sshd_config.go
@@ -1,0 +1,75 @@
+package ssh
+
+import (
+	"bufio"
+	"strconv"
+	"strings"
+)
+
+// SSHDConfigResult holds the fields extracted from sshd_config.
+type SSHDConfigResult struct {
+	PermitRootLogin        string
+	PasswordAuthentication *bool
+	Port                   int
+}
+
+// ParseSSHDConfig parses concatenated sshd_config + sshd_config.d/*.conf
+// content and extracts the directives needed for login capability detection.
+//
+// sshd_config uses "first match wins" semantics for most directives, but
+// Include'd files are processed inline. Since we concatenate main config
+// first, then drop-ins, the first occurrence of each directive wins.
+func ParseSSHDConfig(section string) SSHDConfigResult {
+	var result SSHDConfigResult
+	gotPermitRoot := false
+	gotPassAuth := false
+	gotPort := false
+
+	scanner := bufio.NewScanner(strings.NewReader(section))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		key := strings.ToLower(fields[0])
+		val := fields[1]
+
+		switch key {
+		case "permitrootlogin":
+			if !gotPermitRoot {
+				result.PermitRootLogin = val
+				gotPermitRoot = true
+			}
+		case "passwordauthentication":
+			if !gotPassAuth {
+				b := strings.EqualFold(val, "yes")
+				result.PasswordAuthentication = &b
+				gotPassAuth = true
+			}
+		case "port":
+			if !gotPort {
+				if p, err := strconv.Atoi(val); err == nil {
+					result.Port = p
+				}
+				gotPort = true
+			}
+		}
+	}
+
+	return result
+}
+
+// HostKeyTypeFromFilename extracts the key type from an SSH host key
+// filename like "ssh_host_ed25519_key" -> "ed25519".
+func HostKeyTypeFromFilename(name string) string {
+	name = strings.TrimPrefix(name, "ssh_host_")
+	name = strings.TrimSuffix(name, "_key")
+	name = strings.TrimSuffix(name, "_key.pub")
+	return name
+}

--- a/pkg/virt-customization/probe/ssh/sshd_config_test.go
+++ b/pkg/virt-customization/probe/ssh/sshd_config_test.go
@@ -1,0 +1,145 @@
+package ssh
+
+import "testing"
+
+func TestParseSSHDConfig_Basic(t *testing.T) {
+	t.Parallel()
+	config := `# SSH config
+Port 2222
+PermitRootLogin prohibit-password
+PasswordAuthentication no
+`
+	result := ParseSSHDConfig(config)
+	if result.Port != 2222 {
+		t.Errorf("expected port 2222, got %d", result.Port)
+	}
+	if result.PermitRootLogin != "prohibit-password" {
+		t.Errorf("expected prohibit-password, got %s", result.PermitRootLogin)
+	}
+	if result.PasswordAuthentication == nil {
+		t.Fatal("expected PasswordAuthentication to be set")
+	}
+	if *result.PasswordAuthentication {
+		t.Error("expected PasswordAuthentication=false")
+	}
+}
+
+func TestParseSSHDConfig_FirstMatchWins(t *testing.T) {
+	t.Parallel()
+	config := `PermitRootLogin yes
+PermitRootLogin no
+Port 22
+Port 2222
+PasswordAuthentication yes
+PasswordAuthentication no
+`
+	result := ParseSSHDConfig(config)
+	if result.PermitRootLogin != "yes" {
+		t.Errorf("expected first match 'yes', got %s", result.PermitRootLogin)
+	}
+	if result.Port != 22 {
+		t.Errorf("expected first match port 22, got %d", result.Port)
+	}
+	if result.PasswordAuthentication == nil || !*result.PasswordAuthentication {
+		t.Error("expected first match PasswordAuthentication=true")
+	}
+}
+
+func TestParseSSHDConfig_DefaultPort(t *testing.T) {
+	t.Parallel()
+	config := `PermitRootLogin yes
+`
+	result := ParseSSHDConfig(config)
+	if result.Port != 0 {
+		t.Errorf("expected port 0 (unset), got %d", result.Port)
+	}
+}
+
+func TestParseSSHDConfig_Comments(t *testing.T) {
+	t.Parallel()
+	config := `# PermitRootLogin yes
+#Port 22
+  # PasswordAuthentication no
+PermitRootLogin no
+`
+	result := ParseSSHDConfig(config)
+	if result.PermitRootLogin != "no" {
+		t.Errorf("expected 'no' (comments skipped), got %s", result.PermitRootLogin)
+	}
+	if result.Port != 0 {
+		t.Errorf("expected port 0 (commented out), got %d", result.Port)
+	}
+}
+
+func TestParseSSHDConfig_EmptyInput(t *testing.T) {
+	t.Parallel()
+	result := ParseSSHDConfig("")
+	if result.PermitRootLogin != "" {
+		t.Errorf("expected empty PermitRootLogin, got %s", result.PermitRootLogin)
+	}
+	if result.PasswordAuthentication != nil {
+		t.Error("expected nil PasswordAuthentication")
+	}
+	if result.Port != 0 {
+		t.Errorf("expected port 0, got %d", result.Port)
+	}
+}
+
+func TestParseSSHDConfig_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	config := `PERMITROOTLOGIN yes
+PASSWORDAUTHENTICATION yes
+PORT 3333
+`
+	result := ParseSSHDConfig(config)
+	if result.PermitRootLogin != "yes" {
+		t.Errorf("expected yes (case insensitive), got %s", result.PermitRootLogin)
+	}
+	if result.Port != 3333 {
+		t.Errorf("expected 3333, got %d", result.Port)
+	}
+	if result.PasswordAuthentication == nil || !*result.PasswordAuthentication {
+		t.Error("expected PasswordAuthentication=true")
+	}
+}
+
+func TestParseSSHDConfig_ConcatenatedWithDropins(t *testing.T) {
+	t.Parallel()
+	// Main config first, then drop-in; first match wins
+	config := `PermitRootLogin yes
+Port 22
+` + `# Drop-in from /etc/ssh/sshd_config.d/50-cloud-init.conf
+PermitRootLogin no
+PasswordAuthentication no
+`
+	result := ParseSSHDConfig(config)
+	if result.PermitRootLogin != "yes" {
+		t.Errorf("expected 'yes' from main config, got %s", result.PermitRootLogin)
+	}
+	if result.Port != 22 {
+		t.Errorf("expected 22, got %d", result.Port)
+	}
+	if result.PasswordAuthentication == nil || *result.PasswordAuthentication {
+		t.Error("expected PasswordAuthentication=false from drop-in (not set in main)")
+	}
+}
+
+func TestHostKeyTypeFromFilename(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"ssh_host_rsa_key", "rsa"},
+		{"ssh_host_ed25519_key", "ed25519"},
+		{"ssh_host_ecdsa_key", "ecdsa"},
+		{"ssh_host_dsa_key", "dsa"},
+		{"ssh_host_rsa_key.pub", "rsa"},
+	}
+	for _, tt := range tests {
+		got := HostKeyTypeFromFilename(tt.input)
+		if got != tt.want {
+			t.Errorf("HostKeyTypeFromFilename(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/pkg/virt-customization/resolve.go
+++ b/pkg/virt-customization/resolve.go
@@ -1,0 +1,42 @@
+package customization
+
+import (
+	"github.com/kubev2v/forklift/pkg/virt-customization/api"
+	"github.com/kubev2v/forklift/pkg/virt-customization/plugins/example"
+)
+
+// AllPlugins returns the ordered set of all known plugins.
+//
+// Ordering matters: network config before drivers before boot scripts, etc.
+// When adding real plugins, insert them at the correct position. For example:
+//
+//	return []api.Plugin{
+//	    &udev.Plugin{},          // 1. Linux network
+//	    &registry.Plugin{},      // 2. Windows network (modern)
+//	    &netsh.Plugin{},         // 3. Windows network (legacy)
+//	    &vmware.Plugin{},        // 4. Driver removal
+//	    &dynamic.Plugin{},       // 5. User-supplied scripts
+//	    &firstboot.Plugin{},     // 6. Boot orchestrator
+//	    &diskrestore.Plugin{},   // 7. Disk restore
+//	    &conversiondone.Plugin{},// 8. Conversion signal
+//	}
+func AllPlugins() []api.Plugin {
+	return []api.Plugin{
+		&example.Plugin{},
+	}
+}
+
+// Resolve filters AllPlugins() by calling Applicable(ctx) on each; order is preserved.
+func Resolve(ctx *api.Context) []api.Plugin {
+	if ctx == nil {
+		return []api.Plugin{}
+	}
+	all := AllPlugins()
+	var applicable []api.Plugin
+	for _, p := range all {
+		if p.Applicable(ctx) {
+			applicable = append(applicable, p)
+		}
+	}
+	return applicable
+}


### PR DESCRIPTION
Replace the monolithic pkg/virt-v2v/customize package with a new pkg/virt-v2v/customization package that uses a three-phase approach:

1. Probe (guestfish --ro): detect OS family, network stacks, and extract interface configuration directly from the guest disk.
2. Apply (guestfish --rw): perform all file operations in a single guestfish session instead of delegating everything to virt-customize.
3. Exec (virt-customize): run only --firstboot and --run scripts that genuinely require in-guest execution.

Each concern (VMware driver removal, udev rules, netsh/registry network config, firstboot scripts, conversion-done signaling) is handled by a focused plugin returning declarative Actions.

Ref: https://redhat.atlassian.net/browse/MTV-5558
Resolves: MTV-5558