### PR TITLE
ECOPROJECT-4296 | Read the appInfo from the extraConfig VM field

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -1,6 +1,7 @@
 package vsphere
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"sort"
@@ -858,6 +859,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 								}
 								v.model.DiskEnableUuid = boolVal
 							}
+						} else if opt.Key == "guestinfo.appInfo" {
+							if s, cast := opt.Value.(string); cast {
+								v.model.GuestApps = parseGuestApps(s)
+							}
 						} else if hasDiskPrefix(opt.Key) && strings.HasSuffix(strings.ToLower(opt.Key), "."+strings.ToLower(CtkEnabledKey)) {
 							if s, cast := opt.Value.(string); cast {
 								boolVal, err := strconv.ParseBool(s)
@@ -1125,6 +1130,28 @@ func extractWindowsDriveLetter(diskPath string) string {
 		return strings.ToLower(string(diskPath[0]))
 	}
 	return ""
+}
+
+// parseGuestApps parses the guestinfo.appInfo JSON string
+// and returns a list of GuestApp.
+func parseGuestApps(s string) []model.GuestApp {
+	var appInfo struct {
+		Applications []struct {
+			A string `json:"a"`
+			V string `json:"v"`
+		} `json:"applications"`
+	}
+	if err := json.Unmarshal([]byte(s), &appInfo); err != nil {
+		return nil
+	}
+	apps := make([]model.GuestApp, 0, len(appInfo.Applications))
+	for _, a := range appInfo.Applications {
+		apps = append(apps, model.GuestApp{
+			Name:    a.A,
+			Version: a.V,
+		})
+	}
+	return apps
 }
 
 // Update virtual disk devices.

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -341,6 +341,7 @@ type VM struct {
 	GuestNetworks            []GuestNetwork     `sql:""`
 	GuestDisks               []DiskMountPoint   `sql:""`
 	GuestIpStacks            []GuestIpStack     `sql:""`
+	GuestApps                []GuestApp         `sql:""`
 	SecureBoot               bool               `sql:""`
 	ToolsStatus              string             `sql:""`
 	ToolsRunningStatus       string             `sql:""`
@@ -355,6 +356,12 @@ type VM struct {
 // Determine if current revision has been validated.
 func (m *VM) Validated() bool {
 	return m.RevisionValidated == m.Revision
+}
+
+// Guest application.
+type GuestApp struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
 }
 
 // Virtual Controller.


### PR DESCRIPTION
In assisted-migration-agent we would like to display running applications in VMs.

Jira: https://redhat.atlassian.net/browse/ECOPROJECT-4296