### PR TITLE
Backport: Optimize PowerMax host lookup and add retry for 503 errors

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/powermax/powermax.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/powermax/powermax.go
@@ -6,14 +6,17 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	gopowermax "github.com/dell/gopowermax/v2"
 	pmxtypes "github.com/dell/gopowermax/v2/types/v100"
 	"github.com/kubev2v/forklift/cmd/vsphere-xcopy-volume-populator/internal/populator"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
 
@@ -114,23 +117,37 @@ func (p *PowermaxClonner) EnsureClonnerIgroup(_ string, clonnerIqn []string) (po
 	// 5. add port group with protocol type that match the cloner IQN type, only if they all online
 	p.storageGroupID = fmt.Sprintf("%s-SG", p.initiatorID)
 	klog.Infof("ensuring storage group %s exists with hosts %v", p.storageGroupID, clonnerIqn)
-	_, err = p.client.GetStorageGroup(ctx, p.symmetrixID, p.storageGroupID)
+	err = retryOnTransient(ctx, "GetStorageGroup", func() error {
+		_, e := p.client.GetStorageGroup(ctx, p.symmetrixID, p.storageGroupID)
+		return e
+	})
 	if err == nil {
 		klog.Infof("group %s exists", p.storageGroupID)
-	}
-	if e, ok := err.(*pmxtypes.Error); ok && e.HTTPStatusCode == 404 {
-		klog.Infof("group %s doesn't exist - create it", p.storageGroupID)
-		_, err := p.client.CreateStorageGroup(ctx, p.symmetrixID, p.storageGroupID, "none", "", true, nil)
-		if err != nil {
-			klog.Errorf("failed to create group %v ", err)
-			return nil, err
+	} else {
+		var pmxErr *pmxtypes.Error
+		if errors.As(err, &pmxErr) && pmxErr.HTTPStatusCode == 404 {
+			klog.Infof("group %s doesn't exist - create it", p.storageGroupID)
+			err = retryOnTransient(ctx, "CreateStorageGroup", func() error {
+				_, e := p.client.CreateStorageGroup(ctx, p.symmetrixID, p.storageGroupID, "none", "", true, nil)
+				return e
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create group: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to check storage group %s: %w", p.storageGroupID, err)
 		}
 	}
 
 	klog.Infof("storage group %s", p.storageGroupID)
 
 	// Fetch port group to determine protocol type
-	portGroup, err := p.client.GetPortGroupByID(ctx, p.symmetrixID, p.portGroup)
+	var portGroup *pmxtypes.PortGroup
+	err = retryOnTransient(ctx, "GetPortGroupByID", func() error {
+		var e error
+		portGroup, e = p.client.GetPortGroupByID(ctx, p.symmetrixID, p.portGroup)
+		return e
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get port group %s: %w", p.portGroup, err)
 	}
@@ -143,24 +160,26 @@ func (p *PowermaxClonner) EnsureClonnerIgroup(_ string, clonnerIqn []string) (po
 	}
 	klog.Infof("filtered initiators for protocol %s: %v", portGroup.PortGroupProtocol, filteredInitiators)
 
-	hosts, err := p.client.GetHostList(ctx, p.symmetrixID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get host list from symmetrix %s: %w", p.symmetrixID, err)
-	}
-h:
-	for _, hostId := range hosts.HostIDs {
-		host, err := p.client.GetHostByID(ctx, p.symmetrixID, hostId)
+	// Direct initiator lookup (1 API call per initiator instead of N+1)
+	for _, filteredInit := range filteredInitiators {
+		lookupID := initiatorToLookupID(filteredInit)
+		var initiator *pmxtypes.Initiator
+		err = retryOnTransient(ctx, "GetInitiatorByID", func() error {
+			var e error
+			initiator, e = p.client.GetInitiatorByID(ctx, p.symmetrixID, lookupID)
+			return e
+		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to look up initiator %s: %w", lookupID, err)
 		}
-		klog.Infof("host ID %s and initiators %v", host.HostID, host.Initiators)
-		for _, initiator := range host.Initiators {
-			for _, filteredInit := range filteredInitiators {
-				if strings.HasSuffix(filteredInit, initiator) {
-					p.hostID = hostId
-					break h
-				}
-			}
+		hostID := initiator.HostID
+		if hostID == "" {
+			hostID = initiator.Host
+		}
+		if hostID != "" {
+			p.hostID = hostID
+			klog.Infof("found matching host %s for initiator %s", p.hostID, lookupID)
+			break
 		}
 	}
 	if p.hostID == "" {
@@ -310,6 +329,40 @@ func generateRandomString(length int) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(bytes), nil
+}
+
+// retryOnTransient retries the given function with exponential backoff when the
+// error is a transient Unisphere 503 Service Unavailable response.
+func retryOnTransient(ctx context.Context, operation string, fn func() error) error {
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    5,
+	}
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+		lastErr = fn()
+		if lastErr == nil {
+			return true, nil
+		}
+		var pmxErr *pmxtypes.Error
+		if errors.As(lastErr, &pmxErr) && pmxErr.HTTPStatusCode == 503 {
+			klog.Infof("transient 503 error during %s, retrying: %v", operation, lastErr)
+			return false, nil
+		}
+		return false, lastErr
+	})
+	if err != nil && lastErr != nil && !errors.Is(err, lastErr) {
+		return fmt.Errorf("%w: %w", err, lastErr)
+	}
+	return err
+}
+
+// initiatorToLookupID strips the "fc." prefix from FC-style initiator identifiers
+// so the raw WWN can be used for PowerMax API lookups (e.g., GetInitiatorByID).
+func initiatorToLookupID(initiator string) string {
+	return strings.TrimPrefix(initiator, "fc.")
 }
 
 // filterInitiatorsByProtocol filters the initiator list based on the port group protocol

--- a/cmd/vsphere-xcopy-volume-populator/internal/powermax/powermax_test.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/powermax/powermax_test.go
@@ -2,6 +2,7 @@ package powermax
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -54,7 +55,7 @@ func TestNewPowermaxClonner(t *testing.T) {
 func TestEnsureClonnerIgroup(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	t.Run("should return a mapping context with the port group id", func(t *testing.T) {
+	t.Run("should find host via direct initiator lookup (iSCSI)", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockClient := NewMockPmax(ctrl)
@@ -70,12 +71,40 @@ func TestEnsureClonnerIgroup(t *testing.T) {
 
 		mockClient.EXPECT().GetStorageGroup(context.TODO(), "123", gomock.Not(gomock.Nil())).Return(&v100.StorageGroup{}, nil)
 		mockClient.EXPECT().GetPortGroupByID(context.TODO(), "123", "456").Return(&v100.PortGroup{PortGroupProtocol: "iSCSI"}, nil)
-		mockClient.EXPECT().GetHostList(context.TODO(), "123").Return(&v100.HostList{HostIDs: []string{"host1"}}, nil)
-		mockClient.EXPECT().GetHostByID(context.TODO(), "123", "host1").Return(&v100.Host{Initiators: []string{"iqn.1994-05.com.redhat:rhv-host"}}, nil)
+		// Direct initiator lookup succeeds and returns the host
+		mockClient.EXPECT().GetInitiatorByID(context.TODO(), "123", "iqn.1994-05.com.redhat:rhv-host").Return(&v100.Initiator{
+			InitiatorID: "iqn.1994-05.com.redhat:rhv-host",
+			Host:        "host1",
+		}, nil)
 
 		mappingContext, err := clonner.EnsureClonnerIgroup(initiatorGroup, clonnerIqn)
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(mappingContext).ToNot(gomega.BeNil())
+		g.Expect(clonner.hostID).To(gomega.Equal("host1"))
+	})
+
+	t.Run("should fail when initiator lookup returns 404", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient := NewMockPmax(ctrl)
+
+		clonner := PowermaxClonner{
+			client:      mockClient,
+			symmetrixID: "123",
+			portGroup:   "456",
+		}
+
+		initiatorGroup := "test-ig"
+		clonnerIqn := []string{"iqn.1994-05.com.redhat:rhv-host"}
+
+		mockClient.EXPECT().GetStorageGroup(context.TODO(), "123", gomock.Not(gomock.Nil())).Return(&v100.StorageGroup{}, nil)
+		mockClient.EXPECT().GetPortGroupByID(context.TODO(), "123", "456").Return(&v100.PortGroup{PortGroupProtocol: "iSCSI"}, nil)
+		mockClient.EXPECT().GetInitiatorByID(context.TODO(), "123", "iqn.1994-05.com.redhat:rhv-host").Return(nil, &v100.Error{HTTPStatusCode: 404, Message: "not found"})
+
+		mappingContext, err := clonner.EnsureClonnerIgroup(initiatorGroup, clonnerIqn)
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("failed to look up initiator"))
+		g.Expect(mappingContext).To(gomega.BeNil())
 	})
 
 	t.Run("should fail when port group protocol is SCSI_FC but only iSCSI initiators are provided", func(t *testing.T) {
@@ -103,7 +132,7 @@ func TestEnsureClonnerIgroup(t *testing.T) {
 		g.Expect(mappingContext).To(gomega.BeNil())
 	})
 
-	t.Run("should succeed when port group protocol is SCSI_FC and FC initiators are provided", func(t *testing.T) {
+	t.Run("should find host via direct initiator lookup (FC)", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockClient := NewMockPmax(ctrl)
@@ -120,11 +149,143 @@ func TestEnsureClonnerIgroup(t *testing.T) {
 
 		mockClient.EXPECT().GetStorageGroup(context.TODO(), "123", gomock.Not(gomock.Nil())).Return(&v100.StorageGroup{}, nil)
 		mockClient.EXPECT().GetPortGroupByID(context.TODO(), "123", "fc-port-group").Return(&v100.PortGroup{PortGroupProtocol: "SCSI_FC"}, nil)
-		mockClient.EXPECT().GetHostList(context.TODO(), "123").Return(&v100.HostList{HostIDs: []string{"host1"}}, nil)
-		mockClient.EXPECT().GetHostByID(context.TODO(), "123", "host1").Return(&v100.Host{Initiators: []string{"10000000c9a12345:10000000c9a12346"}}, nil)
+		// Direct initiator lookup succeeds
+		mockClient.EXPECT().GetInitiatorByID(context.TODO(), "123", "10000000c9a12345:10000000c9a12346").Return(&v100.Initiator{
+			InitiatorID: "10000000c9a12345:10000000c9a12346",
+			Host:        "host1",
+		}, nil)
 
 		mappingContext, err := clonner.EnsureClonnerIgroup(initiatorGroup, clonnerIqn)
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 		g.Expect(mappingContext).ToNot(gomega.BeNil())
+		g.Expect(clonner.hostID).To(gomega.Equal("host1"))
 	})
+
+	t.Run("should strip fc. prefix for direct initiator lookup", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient := NewMockPmax(ctrl)
+
+		clonner := PowermaxClonner{
+			client:      mockClient,
+			symmetrixID: "123",
+			portGroup:   "fc-port-group",
+		}
+
+		initiatorGroup := "test-ig"
+		// FC initiators with fc. prefix (as seen from ESXi)
+		clonnerIqn := []string{"fc.200000109b985703:100000109b985703"}
+
+		mockClient.EXPECT().GetStorageGroup(context.TODO(), "123", gomock.Not(gomock.Nil())).Return(&v100.StorageGroup{}, nil)
+		mockClient.EXPECT().GetPortGroupByID(context.TODO(), "123", "fc-port-group").Return(&v100.PortGroup{PortGroupProtocol: "SCSI_FC"}, nil)
+		// Should look up with stripped prefix
+		mockClient.EXPECT().GetInitiatorByID(context.TODO(), "123", "200000109b985703:100000109b985703").Return(&v100.Initiator{
+			InitiatorID: "200000109b985703:100000109b985703",
+			Host:        "esx-host-42",
+		}, nil)
+
+		mappingContext, err := clonner.EnsureClonnerIgroup(initiatorGroup, clonnerIqn)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(mappingContext).ToNot(gomega.BeNil())
+		g.Expect(clonner.hostID).To(gomega.Equal("esx-host-42"))
+	})
+
+	t.Run("should retry on transient 503 error during direct initiator lookup", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient := NewMockPmax(ctrl)
+
+		clonner := PowermaxClonner{
+			client:      mockClient,
+			symmetrixID: "123",
+			portGroup:   "456",
+		}
+
+		initiatorGroup := "test-ig"
+		clonnerIqn := []string{"iqn.1994-05.com.redhat:rhv-host"}
+
+		mockClient.EXPECT().GetStorageGroup(context.TODO(), "123", gomock.Not(gomock.Nil())).Return(&v100.StorageGroup{}, nil)
+		mockClient.EXPECT().GetPortGroupByID(context.TODO(), "123", "456").Return(&v100.PortGroup{PortGroupProtocol: "iSCSI"}, nil)
+		// First call returns 503, second succeeds
+		gomock.InOrder(
+			mockClient.EXPECT().GetInitiatorByID(context.TODO(), "123", "iqn.1994-05.com.redhat:rhv-host").Return(nil, &v100.Error{HTTPStatusCode: 503, Message: "Service Unavailable"}),
+			mockClient.EXPECT().GetInitiatorByID(context.TODO(), "123", "iqn.1994-05.com.redhat:rhv-host").Return(&v100.Initiator{
+				InitiatorID: "iqn.1994-05.com.redhat:rhv-host",
+				Host:        "host1",
+			}, nil),
+		)
+
+		mappingContext, err := clonner.EnsureClonnerIgroup(initiatorGroup, clonnerIqn)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(mappingContext).ToNot(gomega.BeNil())
+		g.Expect(clonner.hostID).To(gomega.Equal("host1"))
+	})
+}
+
+func TestRetryOnTransient(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := context.Background()
+
+	t.Run("should not retry on non-503 errors", func(t *testing.T) {
+		callCount := 0
+		err := retryOnTransient(ctx, "test", func() error {
+			callCount++
+			return &v100.Error{HTTPStatusCode: 404, Message: "not found"}
+		})
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(callCount).To(gomega.Equal(1))
+	})
+
+	t.Run("should retry on 503 and succeed", func(t *testing.T) {
+		callCount := 0
+		err := retryOnTransient(ctx, "test", func() error {
+			callCount++
+			if callCount < 3 {
+				return &v100.Error{HTTPStatusCode: 503, Message: "Service Unavailable"}
+			}
+			return nil
+		})
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(callCount).To(gomega.Equal(3))
+	})
+
+	t.Run("should pass through non-pmxtypes errors", func(t *testing.T) {
+		callCount := 0
+		err := retryOnTransient(ctx, "test", func() error {
+			callCount++
+			return fmt.Errorf("some other error")
+		})
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("some other error"))
+		g.Expect(callCount).To(gomega.Equal(1))
+	})
+
+	t.Run("should succeed on first try", func(t *testing.T) {
+		callCount := 0
+		err := retryOnTransient(ctx, "test", func() error {
+			callCount++
+			return nil
+		})
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(callCount).To(gomega.Equal(1))
+	})
+
+	t.Run("should preserve last error when retries exhausted", func(t *testing.T) {
+		callCount := 0
+		err := retryOnTransient(ctx, "test", func() error {
+			callCount++
+			return &v100.Error{HTTPStatusCode: 503, Message: "Service Unavailable"}
+		})
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("Service Unavailable"))
+		g.Expect(callCount).To(gomega.Equal(5)) // 5 steps in backoff
+	})
+}
+
+func TestInitiatorToLookupID(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	g.Expect(initiatorToLookupID("fc.200000109b985703:100000109b985703")).To(gomega.Equal("200000109b985703:100000109b985703"))
+	g.Expect(initiatorToLookupID("iqn.1994-05.com.redhat:rhv-host")).To(gomega.Equal("iqn.1994-05.com.redhat:rhv-host"))
+	g.Expect(initiatorToLookupID("10000000c9a12345:10000000c9a12346")).To(gomega.Equal("10000000c9a12345:10000000c9a12346"))
 }


### PR DESCRIPTION
## Summary
- Backport of #6598 to release-2.11
- Replace O(N+1) GetHostList + GetHostByID loop with direct GetInitiatorByID call (1 API call per initiator)
- Add retryOnTransient helper with exponential backoff for HTTP 503 errors
- Add filterInitiatorsByProtocol to match initiators to port group protocol (iSCSI vs FC)

## Test plan
- [ ] Unit tests pass (`go test ./internal/powermax/ -v -count=1`)
- [ ] Test with PowerMax array running bulk migration (200+ pods)

Resolves: MTV-5586

🤖 Generated with [Claude Code](https://claude.com/claude-code)