### PR TITLE
MTV-5555 | Set DefaultGatewayMetric in registry network config script

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config-registry.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config-registry.ps1.tmpl
@@ -115,6 +115,7 @@ foreach ($mac in $adapterConfigs.Keys) {
         Set-ItemProperty -Path $regPath -Name "IPAddress" -Value ([string[]]$config.IPs) -Type MultiString
         Set-ItemProperty -Path $regPath -Name "SubnetMask" -Value ([string[]]$config.Masks) -Type MultiString
         Set-ItemProperty -Path $regPath -Name "DefaultGateway" -Value @($config.Gateway) -Type MultiString
+        Set-ItemProperty -Path $regPath -Name "DefaultGatewayMetric" -Value @("0") -Type MultiString
 
         $dnsServers = $config.DNS1
         if ($config.DNS2 -ne "") { $dnsServers = "$($config.DNS1),$($config.DNS2)" }


### PR DESCRIPTION
Without an explicit DefaultGatewayMetric, Windows assigns a default value of 1 instead of 0 (automatic) when DefaultGateway is written via registry.
This preserves the original auto-metric behavior.

Ref: https://redhat.atlassian.net/browse/MTV-5555
Resolves: MTV-5555