### PR TITLE
MTV-5602 | Fix VSphereXcopyVolumePopulator CR cleanup to filter by VM ID

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/destinationclient.go
+++ b/pkg/controller/plan/adapter/vsphere/destinationclient.go
@@ -22,7 +22,7 @@ type DestinationClient struct {
 func (d *DestinationClient) DeletePopulatorDataSource(vm *plan.VMStatus) error {
 	d.Log.Info("Starting DeletePopulatorDataSource", "vm", vm.String())
 
-	populatorCrList, err := d.getPopulatorCrList()
+	populatorCrList, err := d.getPopulatorCrList(vm.ID)
 	if err != nil {
 		d.Log.Error(err, "Failed to get populator CR list")
 		return liberr.Wrap(err)
@@ -58,8 +58,8 @@ func (r *DestinationClient) SetPopulatorCrOwnership() (err error) {
 	return nil
 }
 
-// Get the VSphereXcopyVolumePopulator CustomResource List.
-func (r *DestinationClient) getPopulatorCrList() (populatorCrList v1beta1.VSphereXcopyVolumePopulatorList, err error) {
+// Get the VSphereXcopyVolumePopulator CustomResource List filtered by migration and VM.
+func (r *DestinationClient) getPopulatorCrList(vmID string) (populatorCrList v1beta1.VSphereXcopyVolumePopulatorList, err error) {
 	snap := r.Plan.Status.Migration.ActiveSnapshot()
 	if snap.Migration.UID == "" {
 		err = liberr.New("no active migration snapshot", "plan", r.Plan.Name)
@@ -69,7 +69,8 @@ func (r *DestinationClient) getPopulatorCrList() (populatorCrList v1beta1.VSpher
 	migUID := string(snap.Migration.UID)
 	r.Log.Info("Getting populator CR list",
 		"namespace", r.Plan.Spec.TargetNamespace,
-		"migrationUID", migUID)
+		"migrationUID", migUID,
+		"vmID", vmID)
 
 	populatorCrList = v1beta1.VSphereXcopyVolumePopulatorList{}
 	err = r.Destination.Client.List(
@@ -77,7 +78,7 @@ func (r *DestinationClient) getPopulatorCrList() (populatorCrList v1beta1.VSpher
 		&populatorCrList,
 		&client.ListOptions{
 			Namespace:     r.Plan.Spec.TargetNamespace,
-			LabelSelector: labels.SelectorFromSet(map[string]string{"migration": migUID}),
+			LabelSelector: labels.SelectorFromSet(map[string]string{"migration": migUID, "vmID": vmID}),
 		})
 
 	if err != nil {

--- a/pkg/controller/plan/adapter/vsphere/destinationclient_test.go
+++ b/pkg/controller/plan/adapter/vsphere/destinationclient_test.go
@@ -5,6 +5,7 @@ import (
 
 	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	ref "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	. "github.com/onsi/ginkgo/v2"
@@ -24,7 +25,7 @@ var destClientLog = logging.WithName("destination-client-test")
 
 var _ = Describe("DestinationClient", func() {
 	Describe("DeletePopulatorDataSource", func() {
-		It("should delete all populator CRs successfully", func() {
+		It("should delete only populator CRs matching the VM", func() {
 			// Setup
 			populator1 := &v1beta1.VSphereXcopyVolumePopulator{
 				ObjectMeta: meta.ObjectMeta{
@@ -32,6 +33,7 @@ var _ = Describe("DestinationClient", func() {
 					Namespace: "test",
 					Labels: map[string]string{
 						"migration": "123",
+						"vmID":      "vm-1",
 					},
 				},
 				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
@@ -44,16 +46,31 @@ var _ = Describe("DestinationClient", func() {
 					Namespace: "test",
 					Labels: map[string]string{
 						"migration": "123",
+						"vmID":      "vm-1",
 					},
 				},
 				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
 					VmdkPath: "/vmdk/path2.vmdk",
 				},
 			}
+			// Another VM's populator — must survive the cleanup
+			populatorOtherVM := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "populator-other-vm",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "123",
+						"vmID":      "vm-2",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/path3.vmdk",
+				},
+			}
 
-			destClient := createDestinationClient(populator1, populator2)
+			destClient := createDestinationClient(populator1, populator2, populatorOtherVM)
 			vmStatus := &planapi.VMStatus{
-				NewName: "test-vm",
+				VM: planapi.VM{Ref: ref.Ref{ID: "vm-1"}},
 			}
 
 			// Execute
@@ -62,11 +79,12 @@ var _ = Describe("DestinationClient", func() {
 			// Assert
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify all populators are deleted
+			// Verify only vm-1 populators are deleted; vm-2 populator survives
 			populatorList := &v1beta1.VSphereXcopyVolumePopulatorList{}
 			err = destClient.Destination.Client.List(context.TODO(), populatorList, client.InNamespace("test"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(populatorList.Items).To(BeEmpty())
+			Expect(populatorList.Items).To(HaveLen(1))
+			Expect(populatorList.Items[0].Name).To(Equal("populator-other-vm"))
 		})
 
 		It("should succeed when no populator CRs exist", func() {
@@ -85,7 +103,7 @@ var _ = Describe("DestinationClient", func() {
 	})
 
 	Describe("getPopulatorCrList", func() {
-		It("should return only CRs matching the migration UID", func() {
+		It("should return only CRs matching the migration UID and VM ID", func() {
 			// Setup
 			populator1 := &v1beta1.VSphereXcopyVolumePopulator{
 				ObjectMeta: meta.ObjectMeta{
@@ -93,6 +111,7 @@ var _ = Describe("DestinationClient", func() {
 					Namespace: "test",
 					Labels: map[string]string{
 						"migration": "123",
+						"vmID":      "vm-1",
 					},
 				},
 				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
@@ -105,35 +124,52 @@ var _ = Describe("DestinationClient", func() {
 					Namespace: "test",
 					Labels: map[string]string{
 						"migration": "123",
+						"vmID":      "vm-1",
 					},
 				},
 				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
 					VmdkPath: "/vmdk/path2.vmdk",
 				},
 			}
-			populatorDifferent := &v1beta1.VSphereXcopyVolumePopulator{
+			// Same migration, different VM — must NOT be returned
+			populatorDifferentVM := &v1beta1.VSphereXcopyVolumePopulator{
 				ObjectMeta: meta.ObjectMeta{
-					Name:      "populator-different-migration",
+					Name:      "populator-different-vm",
 					Namespace: "test",
 					Labels: map[string]string{
-						"migration": "different-uid",
+						"migration": "123",
+						"vmID":      "vm-2",
 					},
 				},
 				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
 					VmdkPath: "/vmdk/path3.vmdk",
 				},
 			}
+			populatorDifferentMig := &v1beta1.VSphereXcopyVolumePopulator{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "populator-different-migration",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "different-uid",
+						"vmID":      "vm-1",
+					},
+				},
+				Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+					VmdkPath: "/vmdk/path4.vmdk",
+				},
+			}
 
-			destClient := createDestinationClient(populator1, populator2, populatorDifferent)
+			destClient := createDestinationClient(populator1, populator2, populatorDifferentVM, populatorDifferentMig)
 
 			// Execute
-			populatorList, err := destClient.getPopulatorCrList()
+			populatorList, err := destClient.getPopulatorCrList("vm-1")
 
 			// Assert
 			Expect(err).NotTo(HaveOccurred())
 			Expect(populatorList.Items).To(HaveLen(2))
 			for _, pop := range populatorList.Items {
 				Expect(pop.Labels["migration"]).To(Equal("123"))
+				Expect(pop.Labels["vmID"]).To(Equal("vm-1"))
 			}
 		})
 
@@ -142,7 +178,7 @@ var _ = Describe("DestinationClient", func() {
 			destClient := createDestinationClient()
 
 			// Execute
-			populatorList, err := destClient.getPopulatorCrList()
+			populatorList, err := destClient.getPopulatorCrList("any-vm")
 
 			// Assert
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

- `getPopulatorCrList()` was filtering populator CRs only by `migration` UID, causing `DeletePopulatorDataSource()` to delete CRs belonging to **all VMs** in a migration whenever any VM's `PhaseStarted` cleanup ran
- Added `vmID` parameter to `getPopulatorCrList()` and included `"vmID": vmID` in the label selector — cleanup is now scoped to the calling VM's CRs only
- Updated tests to verify cross-VM isolation: a VM-2 populator CR must survive when VM-1's cleanup runs

## Root cause

In `builder.go` the `"vmID"` label has always been stamped on every `VSphereXcopyVolumePopulator` CR at creation time (line ~1463). The label was just never used in the List filter, so any VM's cleanup wiped the entire migration's CRs.

## Race condition (how the bug manifests in production)

Mixed disk sizes create a natural race window:
1. Wave N: N VMs start xcopy. Small-disk VMs finish fast → free scheduler slots
2. Wave N+1 VMs start `PhaseStarted` and call `DeletePopulatorDataSource()`
3. Without the fix, this cleanup deletes the still-running large-disk CRs from Wave N, causing those populators to fail

## Test plan
- [x] Unit tests in `destinationclient_test.go` cover the cross-VM isolation (both `DeletePopulatorDataSource` and `getPopulatorCrList`)
- [x] Reproduce bug: deploy populator with 50% VMs sleeping 15 min before xcopy, `MAX_VM_INFLIGHT=5`, 6-VM migration → confirm "CR not found" errors appear in Wave N populator pods
- [x] Confirm fix: deploy patched controller → same scenario shows no cross-VM CR deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)