### PR TITLE
[release-2.11] MTV-5584 | xfs_repair ignore RHEL 7 AGFL inconsistency

### DIFF
--- a/build/virt-v2v-rhel9/Containerfile
+++ b/build/virt-v2v-rhel9/Containerfile
@@ -73,6 +73,14 @@ COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 LABEL \

--- a/build/virt-v2v-rhel9/Containerfile-downstream
+++ b/build/virt-v2v-rhel9/Containerfile-downstream
@@ -78,6 +78,14 @@ COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
 COPY --from=winlegacyiso /usr/share/virtio-win/virtio-win.iso /usr/local/virtio-win-legacy.iso
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 ARG MTV_VERSION

--- a/build/virt-v2v/Containerfile
+++ b/build/virt-v2v/Containerfile
@@ -73,6 +73,14 @@ COPY --from=builder /app/image-converter /usr/local/bin/image-converter
 COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 LABEL \

--- a/build/virt-v2v/Containerfile-downstream
+++ b/build/virt-v2v/Containerfile-downstream
@@ -90,6 +90,14 @@ COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
 COPY --from=winlegacyiso /usr/share/virtio-win/virtio-win.iso /usr/local/virtio-win-legacy.iso
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 ARG MTV_VERSION

--- a/build/virt-v2v/Containerfile-downstream-fssupport
+++ b/build/virt-v2v/Containerfile-downstream-fssupport
@@ -88,6 +88,14 @@ COPY --from=builder /app/virt-v2v-wrapper /usr/bin/virt-v2v-wrapper
 
 COPY --from=builder /app/forklift-wait-for-reboot /usr/local/bin/forklift-wait-for-reboot
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "/usr/bin/virt-v2v-wrapper"]
 
 ARG MTV_VERSION

--- a/build/virt-v2v/Containerfile-upstream
+++ b/build/virt-v2v/Containerfile-upstream
@@ -46,6 +46,14 @@ RUN mkdir -p /usr/lib64/guestfs/appliance && \
         mv -vf root.qcow2 root && \
         tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 # This prevents libvirt from attempting to create files in the root directory,
 # which would lead to permission errors.
 # Refer to: https://issues.redhat.com/browse/RHEL-105490

--- a/build/virt-v2v/Containerfile-upstream-fedora
+++ b/build/virt-v2v/Containerfile-upstream-fedora
@@ -44,6 +44,14 @@ RUN mkdir -p /usr/lib64/guestfs/appliance && \
         mv -vf root.qcow2 root && \
         tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 # This prevents libvirt from attempting to create files in the root directory,
 # which would lead to permission errors.
 # Refer to: https://issues.redhat.com/browse/RHEL-105490

--- a/build/virt-v2v/Containerfile-upstream-xfs
+++ b/build/virt-v2v/Containerfile-upstream-xfs
@@ -47,6 +47,14 @@ RUN mkdir -p /usr/lib64/guestfs/appliance && \
         mv -vf root.qcow2 root && \
         tar -cvf /libguestfs-appliance.tar /usr/lib64/guestfs/appliance
 
+# Replace xfs_repair with a wrapper that can ignore failures; register the
+# original binary in supermin hostfiles so both get copied into the appliance.
+COPY build/virt-v2v/xfs_repair_wrapper.sh /tmp/xfs_repair_wrapper.sh
+RUN cp /usr/sbin/xfs_repair /usr/sbin/xfs_repair.original && \
+    cp /tmp/xfs_repair_wrapper.sh /usr/sbin/xfs_repair && \
+    chmod 755 /usr/sbin/xfs_repair && \
+    echo '/usr/sbin/xfs_repair.original' >> /usr/lib64/guestfs/supermin.d/hostfiles
+
 # This prevents libvirt from attempting to create files in the root directory,
 # which would lead to permission errors.
 # Refer to: https://issues.redhat.com/browse/RHEL-105490

--- a/build/virt-v2v/xfs_repair_wrapper.sh
+++ b/build/virt-v2v/xfs_repair_wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+if grep -q 'xfs_repair_ignore=1' /proc/cmdline 2>/dev/null; then
+	echo "xfs_repair wrapper: xfs_repair_ignore=1 detected, failures will be suppressed" >&2
+	/usr/sbin/xfs_repair.original "$@"
+	rc=$?
+	echo "xfs_repair wrapper: xfs_repair.original exited with status $rc (ignored)" >&2
+	exit 0
+fi
+exec /usr/sbin/xfs_repair.original "$@"

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -256,6 +256,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_xfs_repair_ignore:
+                description: 'Ignore xfs_repair exit status during conversion (default:
+                  false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m
@@ -8091,6 +8098,11 @@ spec:
           false)
         displayName: Retain Populator Pods
         path: controller_retain_populator_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ignore xfs_repair exit status during conversion (default false)
+        displayName: XFS Repair Ignore
+        path: feature_xfs_repair_ignore
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)

--- a/operator/.kustomized_manifests
+++ b/operator/.kustomized_manifests
@@ -256,6 +256,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_xfs_repair_ignore:
+                description: 'Ignore xfs_repair exit status during conversion (default:
+                  false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m
@@ -8087,6 +8094,11 @@ spec:
           false)
         displayName: Retain Populator Pods
         path: controller_retain_populator_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ignore xfs_repair exit status during conversion (default false)
+        displayName: XFS Repair Ignore
+        path: feature_xfs_repair_ignore
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -256,6 +256,13 @@ spec:
                 - "true"
                 - "false"
                 type: string
+              feature_xfs_repair_ignore:
+                description: 'Ignore xfs_repair exit status during conversion (default:
+                  false)'
+                enum:
+                - "true"
+                - "false"
+                type: string
               hooks_container_limits_cpu:
                 description: 'Hooks CPU limit (default: 1000m)'
                 example: 2000m
@@ -8091,6 +8098,11 @@ spec:
           false)
         displayName: Retain Populator Pods
         path: controller_retain_populator_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ignore xfs_repair exit status during conversion (default false)
+        displayName: XFS Repair Ignore
+        path: feature_xfs_repair_ignore
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -355,6 +355,10 @@ spec:
                 type: string
                 enum: ["true", "false"]
                 description: "Retain populator pods after migration for debugging (default: false)"
+              feature_xfs_repair_ignore:
+                type: string
+                enum: ["true", "false"]
+                description: "Ignore xfs_repair exit status during conversion (default: false)"
               controller_static_udn_ip_addresses:
                 type: string
                 enum: ["true", "false"]

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -411,6 +411,11 @@ spec:
         path: controller_retain_populator_pods
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ignore xfs_repair exit status during conversion (default false)
+        displayName: XFS Repair Ignore
+        path: feature_xfs_repair_ignore
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable static udn IP addresses feature (default false)
         displayName: Static UDN IP Addresses
         path: controller_static_udn_ip_addresses

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -46,6 +46,7 @@ controller_vsphere_incremental_backup: true
 controller_ovirt_warm_migration: true
 controller_retain_precopy_importer_pods: false
 controller_retain_populator_pods: false
+feature_xfs_repair_ignore: false
 controller_static_udn_ip_addresses: true
 controller_max_vm_inflight: 20
 controller_host_lease_namespace: "openshift-mtv"

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -155,6 +155,10 @@ spec:
         - name: FEATURE_RETAIN_POPULATOR_PODS
           value: "true"
 {% endif %}
+{% if feature_xfs_repair_ignore|bool %}
+        - name: FEATURE_XFS_REPAIR_IGNORE
+          value: "true"
+{% endif %}
 {% if feature_ocp_live_migration|bool %}
         - name: FEATURE_OCP_LIVE_MIGRATION
           value: "true"

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -482,6 +482,11 @@ spec:
           path: controller_retain_populator_pods
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Ignore xfs_repair exit status during conversion (default false)
+          displayName: XFS Repair Ignore
+          path: feature_xfs_repair_ignore
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Enable static udn IP addresses feature (default false)
           displayName: Static UDN IP Addresses
           path: controller_static_udn_ip_addresses

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -486,6 +486,11 @@ spec:
           path: controller_retain_populator_pods
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Ignore xfs_repair exit status during conversion (default false)
+          displayName: XFS Repair Ignore
+          path: feature_xfs_repair_ignore
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Enable static udn IP addresses feature (default false)
           displayName: Static UDN IP Addresses
           path: controller_static_udn_ip_addresses

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2251,6 +2251,13 @@ func (r *KubeVirt) getVirtV2vPod(vm *plan.VMStatus, vmVolumes []cnv.Volume, vddk
 				Value: "true",
 			})
 	}
+	if settings.Settings.XfsRepairIgnore {
+		environment = append(environment,
+			core.EnvVar{
+				Name:  "V2V_xfsRepairIgnore",
+				Value: "true",
+			})
+	}
 
 	environment = append(environment,
 		core.EnvVar{

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -19,6 +19,7 @@ const (
 	FeatureVsphereVmwareDriverRemoval   = "FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL"
 	FeatureWindowsRegistryNetworkConfig = "FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG"
 	FeatureRetainPopulatorPods          = "FEATURE_RETAIN_POPULATOR_PODS"
+	FeatureXfsRepairIgnore              = "FEATURE_XFS_REPAIR_IGNORE"
 )
 
 // OpenShift version where the FeatureVmwareSystemSerialNumber feature is supported:
@@ -68,6 +69,8 @@ type Features struct {
 	WindowsRegistryNetworkConfig bool
 	// Whether populator pods should be retained after migration for debugging.
 	RetainPopulatorPods bool
+	// Whether to ignore xfs_repair exit status during conversion.
+	XfsRepairIgnore bool
 }
 
 // isOpenShiftVersionAboveMinimum checks if OpenShift version is above or equal to minimum version using semantic versioning
@@ -107,5 +110,6 @@ func (r *Features) Load() (err error) {
 	r.VsphereVmwareDriverRemoval = getEnvBool(FeatureVsphereVmwareDriverRemoval, false)
 	r.WindowsRegistryNetworkConfig = getEnvBool(FeatureWindowsRegistryNetworkConfig, false)
 	r.RetainPopulatorPods = getEnvBool(FeatureRetainPopulatorPods, false)
+	r.XfsRepairIgnore = getEnvBool(FeatureXfsRepairIgnore, false)
 	return
 }

--- a/pkg/settings/features_test.go
+++ b/pkg/settings/features_test.go
@@ -220,6 +220,36 @@ func TestFeatures_Load_VsphereVmwareDriverRemoval(t *testing.T) {
 	}
 }
 
+func TestFeatures_Load_XfsRepairIgnore(t *testing.T) {
+	tests := []struct {
+		name           string
+		envVal         string
+		unset          bool
+		expectedResult bool
+	}{
+		{name: "default off when unset", unset: true, expectedResult: false},
+		{name: "false when false", envVal: "false", expectedResult: false},
+		{name: "true when true", envVal: "true", expectedResult: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unset {
+				t.Setenv(FeatureXfsRepairIgnore, "")
+			} else {
+				t.Setenv(FeatureXfsRepairIgnore, tt.envVal)
+			}
+			t.Setenv(OpenShiftVersion, "4.20.0")
+			var features Features
+			if err := features.Load(); err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if features.XfsRepairIgnore != tt.expectedResult {
+				t.Errorf("XfsRepairIgnore = %v, want %v", features.XfsRepairIgnore, tt.expectedResult)
+			}
+		})
+	}
+}
+
 func TestFeatures_isOpenShiftVersionAboveMinimum(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -38,6 +38,7 @@ const (
 	EnvVsphereVmwareDriverRemovalName   = "V2V_vsphereVmwareDriverRemoval"
 	EnvWindowsRegistryNetworkConfigName = "V2V_windowsRegistryNetworkConfig"
 	EnvXfsCompatibilityName             = "V2V_xfsCompatibility"
+	EnvXfsRepairIgnoreName              = "V2V_xfsRepairIgnore"
 )
 
 const (
@@ -155,6 +156,16 @@ func (s *AppConfig) Load() (err error) {
 	flag.BoolVar(&s.XfsCompatibility, "xfs-compatibility", s.getEnvBool(EnvXfsCompatibilityName, false), "XFS compatibility mode: do not pass --no-fstrim to virt-v2v")
 	s.RemoteInspectionDisks = s.getRemoteInspectionDisks()
 	flag.Parse()
+
+	if s.getEnvBool(EnvXfsRepairIgnoreName, false) {
+		const token = "xfs_repair_ignore=1"
+		if existing := os.Getenv("LIBGUESTFS_APPEND"); existing != "" {
+			_ = os.Setenv("LIBGUESTFS_APPEND", existing+" "+token)
+		} else {
+			_ = os.Setenv("LIBGUESTFS_APPEND", token)
+		}
+		fmt.Fprintf(os.Stderr, "xfs_repair ignore enabled (LIBGUESTFS_APPEND += %s)\n", token)
+	}
 
 	return s.validate()
 }


### PR DESCRIPTION
Backport: https://github.com/kubev2v/forklift/pull/6590

Relates to RHEL-178287, there is issue when XFSv5 on RHEL 7 reports corrupted FS even if there is no actuall corrpution.

When feature_xfs_repair_ignore is enabled on the ForkliftController CR, xfs_repair exit status is suppressed so conversions are not blocked by minor XFS issues. The flag flows from the operator through the controller env into LIBGUESTFS_APPEND and is checked by a wrapper script that replaces xfs_repair inside the appliance.

Resolves: MTV-5584