### PR TITLE
MTV-5604 | Fix slow vSphere tag fetching causing collector to hang

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -8,9 +8,11 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubev2v/forklift/pkg/lib/util"
+	"github.com/kubev2v/forklift/pkg/settings"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/controller/base"
@@ -538,48 +540,127 @@ func (r *Collector) getVMsWithTags(ctx context.Context) (map[string][]model.Tag,
 		return make(map[string][]model.Tag), nil
 	}
 	tagManager := tags.NewManager(r.restClient)
-	allTags, err := tagManager.GetTags(ctx)
+
+	// Step 1: List all tag IDs (single API call).
+	tagIDs, err := tagManager.ListTags(ctx)
 	if err != nil {
-		r.log.Error(err, "Failed to retrieve tags")
+		r.log.Error(err, "Failed to list tags")
 		return nil, err
 	}
 
-	if len(allTags) == 0 {
+	if len(tagIDs) == 0 {
 		return make(map[string][]model.Tag), nil
 	}
 
-	tagIDs := make([]string, len(allTags))
-	for i, tag := range allTags {
-		tagIDs[i] = tag.ID
-	}
-
-	attachedObjectsList, err := tagManager.GetAttachedObjectsOnTags(ctx, tagIDs)
+	// Step 2: Get attached objects in a single batch API call and filter to
+	// only tags that are attached to at least one VirtualMachine.
+	attachedObjectsList, err := tagManager.ListAttachedObjectsOnTags(ctx, tagIDs)
 	if err != nil {
 		r.log.Error(err, "Failed to retrieve attached objects for tags", "tagCount", len(tagIDs))
 		return nil, err
 	}
 
-	vmTagsMap := make(map[string][]model.Tag)
+	type vmAttachment struct {
+		tagID string
+		vmIDs []string
+	}
+	var vmAttachments []vmAttachment
+	vmRelevantTagIDs := make(map[string]struct{})
 
 	for _, attached := range attachedObjectsList {
-		if attached.Tag == nil {
-			r.log.Info("Skipping tag with nil details", "tagID", attached.TagID)
-			continue
-		}
-
-		tagDetails := model.Tag{
-			ID:          attached.Tag.ID,
-			Description: attached.Tag.Description,
-			Name:        attached.Tag.Name,
-			CategoryID:  attached.Tag.CategoryID,
-			UsedBy:      attached.Tag.UsedBy,
-		}
-
+		var vmIDs []string
 		for _, resource := range attached.ObjectIDs {
 			if resource.Reference().Type == VirtualMachine {
-				vmID := resource.Reference().Value
-				vmTagsMap[vmID] = append(vmTagsMap[vmID], tagDetails)
+				vmIDs = append(vmIDs, resource.Reference().Value)
 			}
+		}
+		if len(vmIDs) > 0 {
+			vmAttachments = append(vmAttachments, vmAttachment{tagID: attached.TagID, vmIDs: vmIDs})
+			vmRelevantTagIDs[attached.TagID] = struct{}{}
+		}
+	}
+
+	if len(vmRelevantTagIDs) == 0 {
+		return make(map[string][]model.Tag), nil
+	}
+
+	// Step 3: Fetch tag details only for VM-relevant tags, concurrently.
+	type tagResult struct {
+		tag tags.Tag
+		err error
+	}
+	relevantIDs := make([]string, 0, len(vmRelevantTagIDs))
+	for id := range vmRelevantTagIDs {
+		relevantIDs = append(relevantIDs, id)
+	}
+
+	results := make([]tagResult, len(relevantIDs))
+	concurrency := settings.Settings.VsphereTagFetchConcurrency
+	if concurrency <= 0 {
+		concurrency = settings.DefaultVsphereTagFetchConcurrency
+	}
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	fetchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var firstErr error
+	var firstErrOnce sync.Once
+
+	for i, id := range relevantIDs {
+		wg.Add(1)
+		go func(idx int, tagID string) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-fetchCtx.Done():
+				return
+			}
+			defer func() { <-sem }()
+
+			tag, err := tagManager.GetTag(fetchCtx, tagID)
+			if err != nil {
+				firstErrOnce.Do(func() {
+					firstErr = err
+					cancel()
+				})
+				results[idx] = tagResult{err: err}
+				return
+			}
+			results[idx] = tagResult{tag: *tag}
+		}(i, id)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		r.log.Error(firstErr, "Failed to retrieve tag details")
+		return nil, firstErr
+	}
+
+	tagDetailsMap := make(map[string]tags.Tag, len(relevantIDs))
+	for _, res := range results {
+		if res.tag.ID == "" {
+			continue
+		}
+		tagDetailsMap[res.tag.ID] = res.tag
+	}
+
+	// Step 4: Combine tag details + attachments locally.
+	vmTagsMap := make(map[string][]model.Tag)
+	for _, att := range vmAttachments {
+		tag, ok := tagDetailsMap[att.tagID]
+		if !ok {
+			continue
+		}
+		tagDetails := model.Tag{
+			ID:          tag.ID,
+			Description: tag.Description,
+			Name:        tag.Name,
+			CategoryID:  tag.CategoryID,
+			UsedBy:      tag.UsedBy,
+		}
+		for _, vmID := range att.vmIDs {
+			vmTagsMap[vmID] = append(vmTagsMap[vmID], tagDetails)
 		}
 	}
 

--- a/pkg/controller/provider/container/vsphere/tags_test.go
+++ b/pkg/controller/provider/container/vsphere/tags_test.go
@@ -1,0 +1,280 @@
+package vsphere
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/settings"
+)
+
+var _ = Describe("Tag fetching", func() {
+	var (
+		server     *httptest.Server
+		collector  *Collector
+		restClient *rest.Client
+		ctx        context.Context
+		getTagReqs int32
+	)
+
+	newMockVCenter := func(numTags int, failTagID string) *httptest.Server {
+		tagPrefix := "/rest/com/vmware/cis/tagging/tag"
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			path := r.URL.Path
+
+			switch {
+			case path == "/rest/com/vmware/cis/session":
+				if r.Method == http.MethodDelete {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]string{"value": "fake-session"})
+
+			case path == tagPrefix && r.Method == http.MethodGet:
+				ids := make([]string, numTags)
+				for i := range ids {
+					ids[i] = fmt.Sprintf("urn:vmomi:InventoryServiceTag:tag-%d:GLOBAL", i)
+				}
+				_ = json.NewEncoder(w).Encode(map[string][]string{"value": ids})
+
+			case len(path) > len(tagPrefix)+4 && path[:len(tagPrefix)+4] == tagPrefix+"/id:":
+				atomic.AddInt32(&getTagReqs, 1)
+				tagID := path[len(tagPrefix)+4:]
+				if tagID == failTagID {
+					http.Error(w, "internal error", http.StatusInternalServerError)
+					return
+				}
+				tag := map[string]interface{}{
+					"id":          tagID,
+					"name":        "name-" + tagID,
+					"description": "desc-" + tagID,
+					"category_id": "urn:vmomi:InventoryServiceCategory:cat-1:GLOBAL",
+					"used_by":     []string{},
+				}
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"value": tag})
+
+			case path == "/rest/com/vmware/cis/tagging/tag-association" && r.Method == http.MethodPost:
+				var req struct {
+					TagIDs []string `json:"tag_ids"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&req)
+
+				type attachedObj struct {
+					Type  string `json:"type"`
+					Value string `json:"id"`
+				}
+				type result struct {
+					TagID     string        `json:"tag_id"`
+					ObjectIDs []attachedObj `json:"object_ids"`
+				}
+
+				results := make([]result, 0, len(req.TagIDs))
+				for i, tagID := range req.TagIDs {
+					switch i % 3 {
+					case 0:
+						results = append(results, result{
+							TagID: tagID,
+							ObjectIDs: []attachedObj{
+								{Type: "VirtualMachine", Value: fmt.Sprintf("vm-%d", i%5)},
+							},
+						})
+					case 1:
+						results = append(results, result{
+							TagID: tagID,
+							ObjectIDs: []attachedObj{
+								{Type: "HostSystem", Value: fmt.Sprintf("host-%d", i%3)},
+							},
+						})
+					default:
+						results = append(results, result{
+							TagID: tagID,
+							ObjectIDs: []attachedObj{
+								{Type: "VirtualMachine", Value: fmt.Sprintf("vm-%d", i%5)},
+								{Type: "HostSystem", Value: "host-0"},
+							},
+						})
+					}
+				}
+				_ = json.NewEncoder(w).Encode(map[string][]result{"value": results})
+
+			default:
+				http.NotFound(w, r)
+			}
+		})
+
+		srv := httptest.NewServer(handler)
+		srv.Config.SetKeepAlivesEnabled(false)
+		return srv
+	}
+
+	createCollector := func(serverURL string) *Collector {
+		parsedURL, _ := url.Parse(serverURL)
+		soapClient := soap.NewClient(parsedURL, true)
+		soapClient.DefaultTransport().DisableKeepAlives = true
+		vimClient := &vim25.Client{Client: soapClient}
+		restClient = rest.NewClient(vimClient)
+		userInfo := url.UserPassword("admin", "pass")
+		err := restClient.Login(context.Background(), userInfo)
+		Expect(err).NotTo(HaveOccurred())
+		log := logging.WithName("test")
+
+		return &Collector{
+			restClient: restClient,
+			log:        log,
+		}
+	}
+
+	BeforeEach(func() {
+		atomic.StoreInt32(&getTagReqs, 0)
+		ctx = context.Background()
+		_ = os.Unsetenv(settings.VsphereTagFetchConcurrencyEv)
+		settings.Settings.VsphereTagFetchConcurrency = settings.DefaultVsphereTagFetchConcurrency
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			server.CloseClientConnections()
+			server.Close()
+			server = nil
+		}
+		restClient = nil
+	})
+
+	Describe("env var configuration via settings pkg", func() {
+		AfterEach(func() {
+			_ = os.Unsetenv(settings.VsphereTagFetchConcurrencyEv)
+		})
+
+		It("uses default when env is unset", func() {
+			Expect(os.Unsetenv(settings.VsphereTagFetchConcurrencyEv)).To(Succeed())
+			err := settings.Settings.Providers.Load()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(settings.Settings.VsphereTagFetchConcurrency).To(Equal(settings.DefaultVsphereTagFetchConcurrency))
+		})
+
+		It("parses valid env var", func() {
+			Expect(os.Setenv(settings.VsphereTagFetchConcurrencyEv, "25")).To(Succeed())
+			err := settings.Settings.Providers.Load()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(settings.Settings.VsphereTagFetchConcurrency).To(Equal(25))
+		})
+
+		It("returns error for invalid env var values", func() {
+			for _, val := range []string{"0", "-5", "abc"} {
+				Expect(os.Setenv(settings.VsphereTagFetchConcurrencyEv, val)).To(Succeed())
+				err := settings.Settings.Providers.Load()
+				Expect(err).To(HaveOccurred(), "should fail for value %q", val)
+			}
+		})
+	})
+
+	Describe("non-VM attachment filtering", func() {
+		It("only returns tags attached to VirtualMachine objects", func() {
+			server = newMockVCenter(9, "")
+			collector = createCollector(server.URL)
+
+			result, err := collector.getVMsWithTags(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// With 9 tags: indices 0,3,6 attached to VM only; 2,5,8 attached to VM+Host
+			// Indices 1,4,7 attached to HostSystem only -> filtered out
+			// So 6 tags are VM-relevant
+			totalVMTags := 0
+			for _, tags := range result {
+				totalVMTags += len(tags)
+			}
+			Expect(totalVMTags).To(Equal(6))
+
+			// GetTag should only be called for VM-relevant tags (6), not all 9
+			Expect(int(atomic.LoadInt32(&getTagReqs))).To(Equal(6))
+		})
+
+		It("returns empty map when no tags are attached to VMs", func() {
+			type obj struct {
+				Type  string `json:"type"`
+				Value string `json:"id"`
+			}
+			type res struct {
+				TagID     string `json:"tag_id"`
+				ObjectIDs []obj  `json:"object_ids"`
+			}
+			tag1 := "urn:vmomi:InventoryServiceTag:no-vm-1:GLOBAL"
+			tag2 := "urn:vmomi:InventoryServiceTag:no-vm-2:GLOBAL"
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/rest/com/vmware/cis/session":
+					if r.Method == http.MethodDelete {
+						w.WriteHeader(http.StatusOK)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]string{"value": "s"})
+				case r.URL.Path == "/rest/com/vmware/cis/tagging/tag" && r.Method == http.MethodGet:
+					_ = json.NewEncoder(w).Encode(map[string][]string{"value": {tag1, tag2}})
+				case r.URL.Path == "/rest/com/vmware/cis/tagging/tag-association":
+					results := []res{
+						{TagID: tag1, ObjectIDs: []obj{{Type: "HostSystem", Value: "host-1"}}},
+						{TagID: tag2, ObjectIDs: []obj{{Type: "Datastore", Value: "ds-1"}}},
+					}
+					_ = json.NewEncoder(w).Encode(map[string][]res{"value": results})
+				default:
+					http.NotFound(w, r)
+				}
+			})
+			srv := httptest.NewServer(handler)
+			srv.Config.SetKeepAlivesEnabled(false)
+			server = srv
+			collector = createCollector(server.URL)
+
+			result, err := collector.getVMsWithTags(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+	})
+
+	Describe("GetTag failure handling", func() {
+		It("returns error when a GetTag call fails", func() {
+			server = newMockVCenter(6, "urn:vmomi:InventoryServiceTag:tag-0:GLOBAL")
+			collector = createCollector(server.URL)
+
+			result, err := collector.getVMsWithTags(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("functional correctness", func() {
+		It("maps tags to correct VM IDs", func() {
+			server = newMockVCenter(6, "")
+			collector = createCollector(server.URL)
+
+			result, err := collector.getVMsWithTags(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeEmpty())
+
+			for vmID, vmTags := range result {
+				Expect(vmID).To(HavePrefix("vm-"))
+				for _, tag := range vmTags {
+					Expect(tag.Name).To(HavePrefix("name-urn:"))
+					Expect(tag.ID).To(HavePrefix("urn:vmomi:"))
+					Expect(tag.CategoryID).To(HavePrefix("urn:vmomi:InventoryServiceCategory:"))
+				}
+			}
+		})
+	})
+})
+
+// Ensure model.Tag is properly referenced
+var _ = model.Tag{}

--- a/pkg/settings/providers.go
+++ b/pkg/settings/providers.go
@@ -9,9 +9,10 @@ import (
 
 // Env
 const (
-	OVAProviderServerImage    = "OVA_PROVIDER_SERVER_IMAGE"
-	HyperVProviderServerImage = "HYPERV_PROVIDER_SERVER_IMAGE"
-	ProviderPendingTimeout    = "PROVIDER_PENDING_TIMEOUT_SECONDS"
+	OVAProviderServerImage       = "OVA_PROVIDER_SERVER_IMAGE"
+	HyperVProviderServerImage    = "HYPERV_PROVIDER_SERVER_IMAGE"
+	ProviderPendingTimeout       = "PROVIDER_PENDING_TIMEOUT_SECONDS"
+	VsphereTagFetchConcurrencyEv = "VSPHERE_TAG_FETCH_CONCURRENCY"
 )
 
 // Defaults
@@ -27,6 +28,7 @@ const (
 	DefaultHyperVMemoryRequest = "512Mi"
 
 	DefaultProviderPendingTimeoutSeconds = 120
+	DefaultVsphereTagFetchConcurrency    = 10
 )
 
 // ProviderPodConfig defines common configuration for provider server pods
@@ -48,6 +50,7 @@ type Providers struct {
 	OVA                           ProviderPodConfig
 	HyperV                        ProviderPodConfig
 	ProviderPendingTimeoutSeconds int
+	VsphereTagFetchConcurrency    int
 }
 
 func (r *Providers) Load() error {
@@ -93,6 +96,12 @@ func (r *Providers) Load() error {
 		return fmt.Errorf("invalid provider pending timeout: %w", err)
 	}
 	r.ProviderPendingTimeoutSeconds = timeout
+
+	tagConcurrency, err := getPositiveEnvLimit(VsphereTagFetchConcurrencyEv, DefaultVsphereTagFetchConcurrency)
+	if err != nil {
+		return fmt.Errorf("invalid vsphere tag fetch concurrency: %w", err)
+	}
+	r.VsphereTagFetchConcurrency = tagConcurrency
 
 	return nil
 }


### PR DESCRIPTION
The vSphere collector's getVMsWithTags function suffered from an N+1 API call problem: it called GetTags (which internally does ListTags + N sequential GetTag calls) and GetAttachedObjectsOnTags (which also does N sequential GetTag calls). With hundreds of tags in vCenter, this caused the collector to hang or become unresponsive.

Replace the inefficient govmomi convenience methods with an optimized approach:
1. ListTags - single API call to get all tag IDs
2. ListAttachedObjectsOnTags - single batch call to get attachments
3. Filter to only tags attached to VirtualMachine objects
4. Fetch tag details concurrently (bounded at 10 workers) only for VM-relevant tags

Tested with 1000 tags in vCenter (872 attached to a single VM). Migration of all 872 tags as labels on the destination VM was verified end-to-end.

Ref: https://redhat.atlassian.net/browse/MTV-5604
Resolves: MTV-5604