### PR TITLE
MTV-5555 | Fix persistent route metric lost during route.exe fallback

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
@@ -124,7 +124,7 @@ if (-not $groupedRoutes) {
                 $network = $parts[0]
                 $prefix = [int]$parts[1]
                 $netmask = Convert-PrefixToMask $prefix
-                $metricStr = if ($metric -is [int]) { "METRIC $metric" } else { "" }
+                $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
                 $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
                 Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
                 cmd /c $command
@@ -156,7 +156,7 @@ if (-not $groupedRoutes) {
         $network = $parts[0]
         $prefix = [int]$parts[1]
         $netmask = Convert-PrefixToMask $prefix
-        $metricStr = if ($metric -is [int]) { "METRIC $metric" } else { "" }
+        $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
 
         # Delete all matching routes
         foreach ($route in $group.Group) {

--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
@@ -108,7 +108,7 @@ if (-not $groupedRoutes) {
                 $network = $parts[0]
                 $prefix = [int]$parts[1]
                 $netmask = Convert-PrefixToMask $prefix
-                $metricStr = if ($metric -is [int]) { "METRIC $metric" } else { "" }
+                $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
                 $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
                 Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
                 cmd /c $command
@@ -137,7 +137,7 @@ if (-not $groupedRoutes) {
         $network = $parts[0]
         $prefix = [int]$parts[1]
         $netmask = Convert-PrefixToMask $prefix
-        $metricStr = if ($metric -is [int]) { "METRIC $metric" } else { "" }
+        $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
 
         # Delete all matching routes
         foreach ($route in $group.Group) {


### PR DESCRIPTION
Issue:
Get-NetRoute returns RouteMetric as UInt16, but the type check `$metric -is [int]` only matches Int32, so it always returns false. This causes the route.exe fallback to omit the METRIC argument, which defaults to 1 instead of preserving the original value.

Fix:
Check `$null -ne $metric` and cast explicitly with `[int]$metric`.

Ref: https://redhat.atlassian.net/browse/MTV-5555
Resolves: MTV-5555