### PR TITLE
MTV-5621 | Add per-ESXi-host populator throttling with dedicated MAX_POPULATOR_INFLIGHT

### DIFF
--- a/cmd/populator-controller/populator-controller.go
+++ b/cmd/populator-controller/populator-controller.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -17,11 +18,12 @@ import (
 )
 
 const (
-	prefix     = "forklift.konveyor.io"
-	mountPath  = "/mnt/"
-	devicePath = "/dev/block"
-	groupName  = "forklift.konveyor.io"
-	apiVersion = "v1beta1"
+	prefix                  = "forklift.konveyor.io"
+	mountPath               = "/mnt/"
+	devicePath              = "/dev/block"
+	groupName               = "forklift.konveyor.io"
+	apiVersion              = "v1beta1"
+	maxPopulatorInFlightEnv = "MAX_POPULATOR_INFLIGHT"
 )
 
 type populator struct {
@@ -90,17 +92,28 @@ func main() {
 			klog.Warning("Couldn't find", "imageVar", populator.imageVar)
 			continue
 		}
+		maxInFlight := getEnvInt(maxPopulatorInFlightEnv, 20)
 		gk := schema.GroupKind{Group: groupName, Kind: populator.kind}
 		gvr := schema.GroupVersionResource{Group: groupName, Version: apiVersion, Resource: populator.resource}
 		controllerFunc := populator.controllerFunc
 		metricsEndpoint := populator.metricsEndpoint
 		go func() {
 			populator_machinery.RunController(masterURL, kubeconfig, imageName, metricsEndpoint, metricsPath,
-				prefix, gk, gvr, mountPath, devicePath, controllerFunc, resources)
+				prefix, gk, gvr, mountPath, devicePath, controllerFunc, resources, maxInFlight)
 			<-stop
 		}()
 	}
 	<-stop
+}
+
+func getEnvInt(name string, def int) int {
+	if s, found := os.LookupEnv(name); found {
+		parsed, err := strconv.Atoi(s)
+		if err == nil {
+			return parsed
+		}
+	}
+	return def
 }
 
 func getOvirtPopulatorPodArgs(rawBlock bool, u *unstructured.Unstructured, _ corev1.PersistentVolumeClaim) ([]string, error) {

--- a/docs/compatibility/forkliftcontroller-settings.md
+++ b/docs/compatibility/forkliftcontroller-settings.md
@@ -27,6 +27,7 @@ spec:
 
   # Controller settings
   controller_max_vm_inflight: 20
+  controller_max_populator_inflight: 20
   controller_precopy_interval: 60
   controller_log_level: 3
 
@@ -82,6 +83,7 @@ Feature gates enable or disable specific Forklift capabilities.
 | Setting | Default | Environment Variable | Description |
 |---------|---------|---------------------|-------------|
 | `controller_max_vm_inflight` | `20` | `MAX_VM_INFLIGHT` | Maximum concurrent VM migrations |
+| `controller_max_populator_inflight` | `20` | `MAX_POPULATOR_INFLIGHT` | Maximum concurrent populator pods per ESXi host |
 | `controller_max_concurrent_reconciles` | `10` | `MAX_CONCURRENT_RECONCILES` | Maximum concurrent controller reconciles |
 
 ### Timing Settings
@@ -292,6 +294,7 @@ spec:
 
   # Concurrency
   controller_max_vm_inflight: 30
+  controller_max_populator_inflight: 10
   controller_max_concurrent_reconciles: 15
 
   # Timing

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3538,6 +3538,11 @@ spec:
               controller_max_parent_backing_retries:
                 description: 'Max retries when getting parent disks (default: 10)'
                 x-kubernetes-int-or-string: true
+              controller_max_populator_inflight:
+                description: 'Max concurrent populator pods per ESXi host (default:
+                  20)'
+                example: 10
+                x-kubernetes-int-or-string: true
               controller_max_vm_inflight:
                 description: 'Max concurrent VM migrations (default: 20)'
                 x-kubernetes-int-or-string: true
@@ -11753,6 +11758,11 @@ spec:
       - description: Max concurrent VM migrations (default 20)
         displayName: Max VM Inflight
         path: controller_max_vm_inflight
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent populator pods per ESXi host (default 20)
+        displayName: Max Populator Inflight
+        path: controller_max_populator_inflight
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Precopy interval in minutes (default 60)

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3538,6 +3538,11 @@ spec:
               controller_max_parent_backing_retries:
                 description: 'Max retries when getting parent disks (default: 10)'
                 x-kubernetes-int-or-string: true
+              controller_max_populator_inflight:
+                description: 'Max concurrent populator pods per ESXi host (default:
+                  20)'
+                example: 10
+                x-kubernetes-int-or-string: true
               controller_max_vm_inflight:
                 description: 'Max concurrent VM migrations (default: 20)'
                 x-kubernetes-int-or-string: true
@@ -11753,6 +11758,11 @@ spec:
       - description: Max concurrent VM migrations (default 20)
         displayName: Max VM Inflight
         path: controller_max_vm_inflight
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent populator pods per ESXi host (default 20)
+        displayName: Max Populator Inflight
+        path: controller_max_populator_inflight
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Precopy interval in minutes (default 60)

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -373,6 +373,10 @@ spec:
               controller_max_vm_inflight:
                 x-kubernetes-int-or-string: true
                 description: "Max concurrent VM migrations (default: 20)"
+              controller_max_populator_inflight:
+                x-kubernetes-int-or-string: true
+                description: "Max concurrent populator pods per ESXi host (default: 20)"
+                example: 10
               controller_precopy_interval:
                 x-kubernetes-int-or-string: true
                 description: "Precopy interval in minutes (default: 60)"

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -385,6 +385,11 @@ spec:
         path: controller_max_vm_inflight
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent populator pods per ESXi host (default 20)
+        displayName: Max Populator Inflight
+        path: controller_max_populator_inflight
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Precopy interval in minutes (default 60)
         displayName: Precopy Interval
         path: controller_precopy_interval

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -53,6 +53,7 @@ controller_retain_populator_pods: false
 feature_xfs_repair_ignore: false
 controller_static_udn_ip_addresses: true
 controller_max_vm_inflight: 20
+controller_max_populator_inflight: 20
 controller_host_lease_namespace: "openshift-mtv"
 controller_host_lease_duration_seconds: 10
 controller_filesystem_overhead: 10

--- a/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
@@ -40,6 +40,10 @@ spec:
             value: "{{ controller_host_lease_duration_seconds }}"
 {% endif %}
 {% endif %}
+{% if controller_max_populator_inflight is number %}
+          - name: MAX_POPULATOR_INFLIGHT
+            value: "{{ controller_max_populator_inflight }}"
+{% endif %}
           - name: POPULATOR_CONTAINER_LIMITS_CPU
             value: "{{ populator_container_limits_cpu }}"
           - name: POPULATOR_CONTAINER_LIMITS_MEMORY

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -455,6 +455,11 @@ spec:
           path: controller_max_vm_inflight
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Max concurrent populator pods per ESXi host (default 20)
+          displayName: Max Populator Inflight
+          path: controller_max_populator_inflight
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Precopy interval in minutes (default 60)
           displayName: Precopy Interval
           path: controller_precopy_interval

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -459,6 +459,11 @@ spec:
           path: controller_max_vm_inflight
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Max concurrent populator pods per ESXi host (default 20)
+          displayName: Max Populator Inflight
+          path: controller_max_populator_inflight
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Precopy interval in minutes (default 60)
           displayName: Precopy Interval
           path: controller_precopy_interval

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1389,6 +1389,9 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				if errs := k8svalidation.IsValidLabelValue(naa); len(errs) == 0 {
 					labels[TemplateNAALabel] = naa
 				}
+				if errs := k8svalidation.IsValidLabelValue(vm.Host); vm.Host != "" && len(errs) == 0 {
+					labels["sourceHost"] = vm.Host
+				}
 
 				if disk.Shared {
 					labels[Shareable] = "true"

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -26,8 +26,10 @@ const (
 
 // Steps.
 const (
-	DiskTransfer = "DiskTransfer"
-	NotFound     = "NotFound"
+	DiskTransfer    = "DiskTransfer"
+	DiskTransferV2v = "DiskTransferV2v"
+	DiskAllocation  = "DiskAllocation"
+	NotFound        = "NotFound"
 )
 
 // Package level mutex to ensure that
@@ -206,7 +208,7 @@ func (r *Scheduler) buildPending() (err error) {
 
 func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {
 	useV2vForTransfer, _ := r.Plan.ShouldUseV2vForTransfer(vmStatus.Ref, r.Destination.Client)
-	if useV2vForTransfer {
+	if useV2vForTransfer || r.Plan.IsUsingOffloadPlugin() {
 		switch vmStatus.Phase {
 		case CreateVM, PostHook, Completed:
 			// In these phases we already have the disk transferred and are left only to create the VM
@@ -234,7 +236,8 @@ func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {
 func (r *Scheduler) finishedDisks(vmStatus *plan.VMStatus) int {
 	var resp = 0
 	for _, step := range vmStatus.Pipeline {
-		if step.Name == DiskTransfer {
+		switch step.Name {
+		case DiskTransfer, DiskTransferV2v, DiskAllocation:
 			for _, task := range step.Tasks {
 				if task.Phase == Completed {
 					resp += 1

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -80,6 +81,8 @@ const (
 	AnnPopulatorServiceAccount = "forklift.konveyor.io/serviceAccount"
 
 	qemuGroup = 107
+
+	labelSourceHost = "sourceHost"
 )
 
 type empty struct{}
@@ -143,12 +146,14 @@ type controller struct {
 	recorder          record.EventRecorder
 	httpClient        *http.Client
 	resources         *corev1.ResourceRequirements
+	maxInFlight       int
 }
 
 func RunController(masterURL, kubeconfig, imageName, httpEndpoint, metricsPath, prefix string,
 	gk schema.GroupKind, gvr schema.GroupVersionResource, mountPath, devicePath string,
 	populatorArgs func(bool, *unstructured.Unstructured, corev1.PersistentVolumeClaim) ([]string, error),
 	resources *corev1.ResourceRequirements,
+	maxInFlight int,
 ) {
 	klog.Infof("Starting populator controller for %s", gk)
 
@@ -211,6 +216,7 @@ func RunController(masterURL, kubeconfig, imageName, httpEndpoint, metricsPath, 
 		metrics:           initMetrics(),
 		recorder:          getRecorder(kubeClient, prefix+"-"+controllerNameSuffix),
 		resources:         resources,
+		maxInFlight:       maxInFlight,
 	}
 
 	if gk.Kind == api.VSphereXcopyVolumePopulatorKind {
@@ -604,6 +610,18 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 
 		// If the pod doesn't exist yet, create it
 		if pod == nil {
+			sourceHost, _, _ := unstructured.NestedString(crInstance.Object, "metadata", "labels", labelSourceHost)
+			if c.maxInFlight > 0 && sourceHost != "" {
+				if active := c.countActivePopulatorPodsForHost(sourceHost); active >= c.maxInFlight {
+					klog.V(2).Infof("Max populator pods in-flight reached for host %s (%d/%d), deferring PVC %s/%s",
+						sourceHost, active, c.maxInFlight, pvcNamespace, pvcName)
+					c.recorder.Eventf(pvc, corev1.EventTypeNormal, "PopulatorThrottled",
+						"Waiting for available populator slot on host %s (%d/%d in-flight)", sourceHost, active, c.maxInFlight)
+					c.workqueue.AddAfter(key, 10*time.Second)
+					return nil
+				}
+			}
+
 			transferNetwork, found, err := unstructured.NestedStringMap(crInstance.Object, "spec", "transferNetwork")
 			if err != nil {
 				return err
@@ -620,6 +638,9 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 			labels := map[string]string{"pvcName": pvc.Name}
 			if found {
 				labels["migration"] = migration
+			}
+			if sourceHost != "" {
+				labels[labelSourceHost] = sourceHost
 			}
 
 			// Make the pod
@@ -1098,6 +1119,22 @@ func (c *controller) checkIntreeStorageClass(pvc *corev1.PersistentVolumeClaim, 
 
 	// The SC is in-tree & PVC is not migrated
 	return fmt.Errorf("in-tree volume volume plugin %q cannot use volume populator", sc.Provisioner)
+}
+
+func (c *controller) countActivePopulatorPodsForHost(host string) int {
+	selector := labels.SelectorFromSet(labels.Set{labelSourceHost: host})
+	pods, err := c.podLister.List(selector)
+	if err != nil {
+		klog.V(2).Infof("Failed to list populator pods for host %s: %v", host, err)
+		return 0
+	}
+	count := 0
+	for _, pod := range pods {
+		if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending {
+			count++
+		}
+	}
+	return count
 }
 
 func buildHTTPClient() *http.Client {

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -14,6 +14,7 @@ import (
 // Environment variables.
 const (
 	MaxVmInFlight                          = "MAX_VM_INFLIGHT"
+	MaxPopulatorInFlight                   = "MAX_POPULATOR_INFLIGHT"
 	HookRetry                              = "HOOK_RETRY"
 	ImporterRetry                          = "IMPORTER_RETRY"
 	VirtV2vImage                           = "VIRT_V2V_IMAGE"


### PR DESCRIPTION
Add per-ESXi-host populator throttling via controller_max_populator_inflight

Introduce controller_max_populator_inflight ForkliftController setting
(default 20) to control how many populator pods can run concurrently
per ESXi source host, independent of controller_max_vm_inflight.

The populator controller reads the sourceHost label from the xcopy CR
and propagates it to the populator pod. Before creating a new pod, it
counts active pods for that host and defers if the limit is reached.
This prevents a single busy host from starving transfers on other hosts.

The plan-level scheduler now treats offload-plugin (xcopy) VMs the same
as v2v transfers (cost=1 per VM) since per-disk throttling is handled
by the populator controller.

Example ForkliftController CR:
```
  spec:
    controller_max_populator_inflight: 10
```
Resolves: MTV-5621

Signed-off-by: Martin Necas <mnecas@redhat.com>