### PR TITLE
MTV-5586 | Fix PowerMax retry for 503 and 409 errors

### DIFF
--- a/cmd/vsphere-xcopy-volume-populator/internal/powermax/powermax.go
+++ b/cmd/vsphere-xcopy-volume-populator/internal/powermax/powermax.go
@@ -306,6 +306,18 @@ func (p *PowermaxClonner) Map(_ string, targetLUN populator.LUN, mappingContext 
 		if err != nil {
 			return populator.LUN{}, err
 		}
+		// If mv is still nil after a 409 (treated as success), the masking view
+		// was created by a prior attempt — fetch it.
+		if mv == nil {
+			err = retryOnTransient(ctx, "GetMaskingViewByID", func() error {
+				var e error
+				mv, e = p.client.GetMaskingViewByID(ctx, p.symmetrixID, p.initiatorID)
+				return e
+			})
+			if err != nil {
+				return populator.LUN{}, fmt.Errorf("masking view %s exists (409) but failed to fetch it: %w", p.initiatorID, err)
+			}
+		}
 	}
 
 	klog.Infof("successfully mapped volume %s to %s with masking view %s", targetLUN.ProviderID, p.initiatorID, mv.MaskingViewID)
@@ -436,18 +448,44 @@ func retryOnTransient(ctx context.Context, operation string, fn func() error) er
 		Steps:    5,
 	}
 	var lastErr error
+	attempt := 0
 	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+		attempt++
 		lastErr = fn()
 		if lastErr == nil {
+			if attempt > 1 {
+				klog.Infof("%s succeeded after %d attempts", operation, attempt)
+			}
 			return true, nil
 		}
 		var pmxErr *pmxtypes.Error
-		if errors.As(lastErr, &pmxErr) && pmxErr.HTTPStatusCode == 503 {
-			klog.Infof("transient 503 error during %s, retrying: %v", operation, lastErr)
+		if errors.As(lastErr, &pmxErr) {
+			if pmxErr.HTTPStatusCode == 503 {
+				klog.Infof("transient 503 error during %s (attempt %d/%d), retrying: %v", operation, attempt, backoff.Steps, lastErr)
+				return false, nil
+			}
+			if pmxErr.HTTPStatusCode == 409 {
+				klog.Infof("409 conflict during %s, treating as success (operation likely completed on a prior attempt): %v", operation, lastErr)
+				return true, nil
+			}
+			klog.Warningf("non-retryable PowerMax API error during %s: HTTP %d, message=%q, errorCode=%d, type=%T",
+				operation, pmxErr.HTTPStatusCode, pmxErr.Message, pmxErr.ErrorCode, lastErr)
+		} else if strings.Contains(lastErr.Error(), "Service Unavailable") {
+			// Some SDK methods (e.g. AddVolumesToStorageGroupS) wrap the original
+			// *pmxtypes.Error with fmt.Errorf("%s", ...) which destroys the type.
+			// Fall back to string matching for these cases.
+			klog.Infof("transient Service Unavailable error during %s (attempt %d/%d), retrying: %v (error type: %T)",
+				operation, attempt, backoff.Steps, lastErr, lastErr)
 			return false, nil
+		} else {
+			klog.Warningf("non-retryable error during %s (not a PowerMax API error): type=%T, error=%v",
+				operation, lastErr, lastErr)
 		}
 		return false, lastErr
 	})
+	if wait.Interrupted(err) {
+		klog.Errorf("%s failed after %d attempts, last error: %v", operation, attempt, lastErr)
+	}
 	if err != nil && lastErr != nil && !errors.Is(err, lastErr) {
 		return fmt.Errorf("%w: %w", err, lastErr)
 	}


### PR DESCRIPTION
## Summary
- Fix `AddVolumesToStorageGroupS` 503 errors not being retried because the Dell SDK wraps errors with `fmt.Errorf("%s", ...)`, destroying the `*pmxtypes.Error` type. Added string-based fallback matching for "Service Unavailable".
- Treat HTTP 409 (Conflict) as success in `retryOnTransient` — when a 503 is returned after the operation actually completed server-side, the retry gets a 409 "already exists". For `CreateMaskingView`, fetch the existing masking view after a 409.
- Add detailed retry logging: attempt counts, exhaustion messages, non-retryable error diagnostics with full type info.

## Root Cause
Observed during bulk PowerMax migrations where Unisphere returns transient 503s under load. Three failure modes were identified from production logs:
1. `AddVolumesToStorageGroupS` → SDK wraps 503 as `*errors.errorString` → retry bypassed → Fatal
2. `CreateMaskingView` → 503 (but op succeeded) → retry → 409 Conflict → Fatal  
3. No diagnostic logging to distinguish retryable from non-retryable errors

## Test plan
- [x] Unit tests pass (156/156)
- [x] Image built and pushed: `quay.io/bodnopoz/vsphere-xcopy-volume-populator:fix-fc-lookup-cleanup-v6-amd64-amd64`
- [ ] Deploy to PowerMax cluster and run bulk migration to verify retry behavior under load

Resolves: MTV-5586

🤖 Generated with [Claude Code](https://claude.com/claude-code)