### PR TITLE
fix tekton virt-v2v change detection

### DIFF
--- a/.tekton/virt-v2v-int-2-11-pull-request.yaml
+++ b/.tekton/virt-v2v-int-2-11-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.11" && ( ".tekton/virt-v2v-int-2-11-*.yaml".pathChanged() || ".konflux/virt-v2v/rpms.lock.yaml".pathChanged() || "build/virt-v2v/Containerfile-downstream".pathChanged() || "pkg/virt-v2v/***".pathChanged() || "cmd/virt-v2v/***".pathChanged() || "cmd/virt-v2v-monitor/***".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.11" && ( ".tekton/virt-v2v-int-2-11-*.yaml".pathChanged() || ".konflux/virt-v2v/***".pathChanged() || "build/virt-v2v/Containerfile-downstream".pathChanged() || "pkg/virt-v2v/***".pathChanged() || "cmd/virt-v2v/***".pathChanged() || "cmd/virt-v2v-monitor/***".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: forklift-operator-int-2-11

--- a/.tekton/virt-v2v-int-2-11-push.yaml
+++ b/.tekton/virt-v2v-int-2-11-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.11" && ( ".tekton/virt-v2v-int-2-11-*.yaml".pathChanged() || ".konflux/virt-v2v/rpms.lock.yaml".pathChanged() || "build/virt-v2v/Containerfile-downstream".pathChanged() || "pkg/virt-v2v/***".pathChanged() || "cmd/virt-v2v/***".pathChanged() || "cmd/virt-v2v-monitor/***".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.11" && ( ".tekton/virt-v2v-int-2-11-*.yaml".pathChanged() || ".konflux/virt-v2v/***".pathChanged() || "build/virt-v2v/Containerfile-downstream".pathChanged() || "pkg/virt-v2v/***".pathChanged() || "cmd/virt-v2v/***".pathChanged() || "cmd/virt-v2v-monitor/***".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: forklift-operator-int-2-11


### PR DESCRIPTION
issue: the changes were not triggered as the
.konflux/virt-v2v/rpms.lock.yaml does not exist