### PR TITLE
chore(kubectl-mtv): bump kubectl-mtv to v0.3.11

### DIFF
--- a/cmd/kubectl-mtv/go.mod
+++ b/cmd/kubectl-mtv/go.mod
@@ -2,7 +2,7 @@ module github.com/kubev2v/forklift/cmd/kubectl-mtv
 
 go 1.25.0
 
-require github.com/yaacov/kubectl-mtv v0.3.7
+require github.com/yaacov/kubectl-mtv v0.3.11
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
@@ -39,7 +39,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.6 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/kubev2v/forklift v0.0.0-20260513104241-eaea136684e0 // indirect
+	github.com/kubev2v/forklift v0.0.0-20260519094428-e2d6d4e314b5 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/cmd/kubectl-mtv/go.sum
+++ b/cmd/kubectl-mtv/go.sum
@@ -289,8 +289,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yaacov/karl-interpreter v0.0.1 h1:gq+j69BBBj0Lv6SwOfvWou0fsfySpyfPyl1hJ5h/9Ho=
 github.com/yaacov/karl-interpreter v0.0.1/go.mod h1:5QRw50uhYw3KMQRU38D3ir9IobE7lIpU4DwlHWNXjmI=
-github.com/yaacov/kubectl-mtv v0.3.7 h1:A7pzF9LZp7bLyNoPQt5t7Lh/sR8AzkDr0NX+gI8iaPY=
-github.com/yaacov/kubectl-mtv v0.3.7/go.mod h1:go4aQSamQ4dfO0Yic6ogDK415uVlJk08CkcmTyrX4R8=
+github.com/yaacov/kubectl-mtv v0.3.11 h1:BepD/vBIh+qzbYV1hiNJDpkWrqAwPmohQxvvLnb7VV4=
+github.com/yaacov/kubectl-mtv v0.3.11/go.mod h1:hTPQJ7qTamUFwV64/Pk//vzAVTbraYN2zc/1gDVnhfc=
 github.com/yaacov/tree-search-language/v6 v6.0.10 h1:DOI0agE6VmTKLq03guXnGrWRxnGYb0KxN9mhWyCBVD0=
 github.com/yaacov/tree-search-language/v6 v6.0.10/go.mod h1:ZXSpcgyyUZswjeC/OOYBnrvUWhhENumaV4+Xeg59NFk=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/cmd/kubectl-mtv/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/doc.go
+++ b/cmd/kubectl-mtv/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/doc.go
@@ -74,6 +74,7 @@ const (
 	PhaseCreateInitialSnapshot             = "CreateInitialSnapshot"
 	PhaseCreateSnapshot                    = "CreateSnapshot"
 	PhaseCreateVM                          = "CreateVM"
+	PhaseWaitForGuestReboots               = "WaitForGuestReboots"
 	PhaseFinalize                          = "Finalize"
 	PhasePreflightInspection               = "PreflightInspection"
 	PhasePowerOffSource                    = "PowerOffSource"

--- a/cmd/kubectl-mtv/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/mapping.go
+++ b/cmd/kubectl-mtv/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/mapping.go
@@ -227,6 +227,43 @@ func (r *NetworkMap) FindNetworkByNameAndNamespace(namespace, name string) (pair
 	return
 }
 
+// FindAllNetworks returns all network map entries matching the given source ID.
+func (r *NetworkMap) FindAllNetworks(networkID string) []NetworkPair {
+	var pairs []NetworkPair
+	for _, pair := range r.Spec.Map {
+		if pair.Source.ID == networkID {
+			pairs = append(pairs, pair)
+		}
+	}
+	return pairs
+}
+
+// FindAllNetworksByType returns all network map entries matching the given source type.
+func (r *NetworkMap) FindAllNetworksByType(networkType string) []NetworkPair {
+	var pairs []NetworkPair
+	for _, pair := range r.Spec.Map {
+		if pair.Source.Type == networkType {
+			pairs = append(pairs, pair)
+		}
+	}
+	return pairs
+}
+
+// FindAllNetworksByNameAndNamespace returns all network map entries matching the given source namespace and name.
+func (r *NetworkMap) FindAllNetworksByNameAndNamespace(namespace, name string) []NetworkPair {
+	var pairs []NetworkPair
+	for _, pair := range r.Spec.Map {
+		if pair.Source.Namespace != "" {
+			if pair.Source.Namespace == namespace && pair.Source.Name == name {
+				pairs = append(pairs, pair)
+			}
+		} else if pair.Source.Name == fmt.Sprintf("%s/%s", namespace, name) {
+			pairs = append(pairs, pair)
+		}
+	}
+	return pairs
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type NetworkMapList struct {
 	meta.TypeMeta `json:",inline"`

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/cmd/settings/set.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/cmd/settings/set.go
@@ -15,16 +15,19 @@ import (
 
 // NewSetCmd creates the 'settings set' subcommand.
 func NewSetCmd(kubeConfigFlags *genericclioptions.ConfigFlags, globalConfig GlobalConfigGetter) *cobra.Command {
-	var settingName string
-	var settingValue string
+	var settingNames []string
+	var settingValues []string
 
 	cmd := &cobra.Command{
 		Use:   "set",
-		Short: "Set a ForkliftController setting value",
-		Long: `Set a ForkliftController setting value.
+		Short: "Set one or more ForkliftController setting values",
+		Long: `Set one or more ForkliftController setting values.
 
 The setting name must be one of the supported settings. Use 'kubectl mtv settings'
 to see all available settings and their current values.
+
+Multiple --setting/--value pairs can be specified to update several settings in a
+single Kubernetes patch operation, avoiding multiple reconciliation cycles.
 
 Value types are automatically validated:
   - Boolean settings accept: true, false, yes, no, 1, 0
@@ -44,38 +47,45 @@ Examples:
   # Increase virt-v2v memory limit for large VMs
   kubectl mtv settings set --setting virt_v2v_container_limits_memory --value 16Gi
 
+  # Set multiple settings at once (single reconciliation cycle)
+  kubectl mtv settings set --setting feature_mcp_server --value true \
+                           --setting mcp_server_lightspeed_set_mcp_gate --value true
+
   # Set a value starting with -- (use -- to stop flag parsing)
   kubectl mtv settings set --setting virt_v2v_extra_args --value --machine-readable`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(settingNames) != len(settingValues) {
+				return fmt.Errorf("number of --setting flags (%d) must match number of --value flags (%d)", len(settingNames), len(settingValues))
+			}
+
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
 
-			opts := settings.SetSettingOptions{
+			opts := settings.SetSettingsOptions{
 				ConfigFlags: kubeConfigFlags,
-				Name:        settingName,
-				Value:       settingValue,
+				Names:       settingNames,
+				Values:      settingValues,
 				Verbosity:   globalConfig.GetVerbosity(),
 			}
 
-			if err := settings.SetSetting(ctx, opts); err != nil {
+			if err := settings.SetSettings(ctx, opts); err != nil {
 				return err
 			}
 
-			fmt.Printf("Setting '%s' updated to '%s'\n", settingName, settingValue)
+			for i, name := range settingNames {
+				fmt.Printf("Setting '%s' updated to '%s'\n", name, settingValues[i])
+			}
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&settingName, "setting", "", "Setting name")
-	cmd.Flags().StringVar(&settingValue, "value", "", "Setting value")
-	if err := cmd.MarkFlagRequired("setting"); err != nil {
-		_ = err
-	}
-	if err := cmd.MarkFlagRequired("value"); err != nil {
-		_ = err
-	}
+	cmd.Flags().StringArrayVar(&settingNames, "setting", nil, "Setting name (can be specified multiple times)")
+	cmd.Flags().StringArrayVar(&settingValues, "value", nil, "Setting value (can be specified multiple times)")
+
+	_ = cmd.MarkFlagRequired("setting")
+	_ = cmd.MarkFlagRequired("value")
 
 	_ = cmd.RegisterFlagCompletionFunc("setting", setSettingCompletion)
 	_ = cmd.RegisterFlagCompletionFunc("value", setValueCompletion)
@@ -97,8 +107,13 @@ func setSettingCompletion(cmd *cobra.Command, args []string, toComplete string) 
 
 // setValueCompletion provides completion for the --value flag based on the --setting flag.
 func setValueCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	settingName, _ := cmd.Flags().GetString("setting")
-	def := settings.GetSettingDefinition(settingName)
+	settingNameList, _ := cmd.Flags().GetStringArray("setting")
+	if len(settingNameList) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	// Use the last --setting value for context-sensitive completion
+	lastSettingName := settingNameList[len(settingNameList)-1]
+	def := settings.GetSettingDefinition(lastSettingName)
 	if def == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload/offload.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload/offload.go
@@ -1,0 +1,190 @@
+// Package offload provides reusable helpers for creating and managing
+// offload-plugin Kubernetes Secrets.  The functions are decoupled from any
+// particular command-options struct so that both the "mapping" and "storage"
+// packages can share the same logic.
+package offload
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+)
+
+// SecretOptions holds the fields needed to build an offload Secret.
+type SecretOptions struct {
+	DefaultOffloadSecret string
+	VSphereUsername       string
+	VSpherePassword      string
+	VSphereURL           string
+	StorageUsername       string
+	StoragePassword      string
+	StorageEndpoint      string
+	CACert               string
+	InsecureSkipTLS      bool
+}
+
+// BuildSecret constructs the offload Secret object without persisting it.
+// For dry-run a deterministic Name is used; for live create GenerateName is used.
+func BuildSecret(namespace, baseName string, opts SecretOptions, dryRun bool) (*corev1.Secret, error) {
+	// Process CA certificate file if specified with @filename
+	cacert := opts.CACert
+	if strings.HasPrefix(cacert, "@") {
+		filePath := cacert[1:]
+		fileContent, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate file %s: %v", filePath, err)
+		}
+		cacert = string(fileContent)
+	}
+
+	secretData := map[string][]byte{}
+
+	if opts.VSphereUsername != "" {
+		secretData["user"] = []byte(opts.VSphereUsername)
+	}
+	if opts.VSpherePassword != "" {
+		secretData["password"] = []byte(opts.VSpherePassword)
+	}
+	if opts.VSphereURL != "" {
+		secretData["url"] = []byte(opts.VSphereURL)
+	}
+	if opts.StorageUsername != "" {
+		secretData["storageUser"] = []byte(opts.StorageUsername)
+	}
+	if opts.StoragePassword != "" {
+		secretData["storagePassword"] = []byte(opts.StoragePassword)
+	}
+	if opts.StorageEndpoint != "" {
+		secretData["storageEndpoint"] = []byte(opts.StorageEndpoint)
+	}
+	if opts.InsecureSkipTLS {
+		secretData["insecureSkipVerify"] = []byte("true")
+	}
+	if cacert != "" {
+		secretData["cacert"] = []byte(cacert)
+	}
+
+	if len(secretData) == 0 {
+		return nil, fmt.Errorf("no offload secret fields provided")
+	}
+
+	meta := metav1.ObjectMeta{
+		Namespace: namespace,
+		Labels: map[string]string{
+			"createdForResourceType": "offload",
+			"createdForMapping":      baseName,
+		},
+	}
+	if dryRun {
+		meta.Name = fmt.Sprintf("%s-offload", baseName)
+	} else {
+		meta.GenerateName = fmt.Sprintf("%s-offload-", baseName)
+	}
+
+	return &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: meta,
+		Data:       secretData,
+		Type:       corev1.SecretTypeOpaque,
+	}, nil
+}
+
+// CreateSecret creates an offload Secret on the cluster and returns it.
+func CreateSecret(configFlags *genericclioptions.ConfigFlags, namespace, baseName string, opts SecretOptions) (*corev1.Secret, error) {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	secret, err := BuildSecret(namespace, baseName, opts, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+}
+
+// ValidateSecretFields validates that when any offload-secret fields are
+// provided, all required fields are present.
+func ValidateSecretFields(opts SecretOptions) error {
+	hasInlineFields := opts.VSphereUsername != "" ||
+		opts.VSpherePassword != "" ||
+		opts.VSphereURL != "" ||
+		opts.StorageUsername != "" ||
+		opts.StoragePassword != "" ||
+		opts.StorageEndpoint != "" ||
+		opts.CACert != "" ||
+		opts.InsecureSkipTLS
+
+	// Conflict: user supplied both an existing secret name and inline credentials.
+	if opts.DefaultOffloadSecret != "" && hasInlineFields {
+		return fmt.Errorf("cannot specify both --default-offload-secret and inline offload credentials (--offload-vsphere-username, etc.); use one or the other")
+	}
+
+	if !hasInlineFields {
+		return nil // No validation needed if no fields provided
+	}
+
+	// If any offload fields are provided, validate required combinations
+	var missingFields []string
+
+	// vSphere credentials are required
+	if opts.VSphereUsername == "" {
+		missingFields = append(missingFields, "--offload-vsphere-username")
+	}
+	if opts.VSpherePassword == "" {
+		missingFields = append(missingFields, "--offload-vsphere-password")
+	}
+	if opts.VSphereURL == "" {
+		missingFields = append(missingFields, "--offload-vsphere-url")
+	}
+
+	// Storage credentials are required
+	if opts.StorageUsername == "" {
+		missingFields = append(missingFields, "--offload-storage-username")
+	}
+	if opts.StoragePassword == "" {
+		missingFields = append(missingFields, "--offload-storage-password")
+	}
+	if opts.StorageEndpoint == "" {
+		missingFields = append(missingFields, "--offload-storage-endpoint")
+	}
+
+	if len(missingFields) > 0 {
+		return fmt.Errorf("when creating offload secrets inline, all required fields must be provided. Missing: %s", strings.Join(missingFields, ", "))
+	}
+
+	return nil
+}
+
+// NeedsSecret returns true when the caller should create a new offload secret
+// (no existing secret name provided AND at least one credential field is set).
+func NeedsSecret(opts SecretOptions) bool {
+	return opts.DefaultOffloadSecret == "" &&
+		(opts.VSphereUsername != "" ||
+			opts.VSpherePassword != "" ||
+			opts.VSphereURL != "" ||
+			opts.StorageUsername != "" ||
+			opts.StoragePassword != "" ||
+			opts.StorageEndpoint != "" ||
+			opts.CACert != "" ||
+			opts.InsecureSkipTLS)
+}
+
+// CleanupSecret removes a previously created offload secret (typically on
+// rollback after a downstream failure).
+func CleanupSecret(configFlags *genericclioptions.ConfigFlags, namespace, secretName string) error {
+	k8sClient, err := client.GetKubernetesClientset(configFlags)
+	if err != nil {
+		return fmt.Errorf("failed to get kubernetes client: %v", err)
+	}
+
+	return k8sClient.CoreV1().Secrets(namespace).Delete(context.Background(), secretName, metav1.DeleteOptions{})
+}

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload_secrets.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload_secrets.go
@@ -1,159 +1,45 @@
 package mapping
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/yaacov/kubectl-mtv/pkg/util/client"
+	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload"
 )
+
+// toSecretOptions converts the offload-related fields of StorageCreateOptions
+// into the shared offload.SecretOptions.
+func toSecretOptions(opts StorageCreateOptions) offload.SecretOptions {
+	return offload.SecretOptions{
+		DefaultOffloadSecret: opts.DefaultOffloadSecret,
+		VSphereUsername:      opts.OffloadVSphereUsername,
+		VSpherePassword:      opts.OffloadVSpherePassword,
+		VSphereURL:           opts.OffloadVSphereURL,
+		StorageUsername:      opts.OffloadStorageUsername,
+		StoragePassword:      opts.OffloadStoragePassword,
+		StorageEndpoint:      opts.OffloadStorageEndpoint,
+		CACert:               opts.OffloadCACert,
+		InsecureSkipTLS:      opts.OffloadInsecureSkipTLS,
+	}
+}
 
 // buildOffloadSecret constructs the offload Secret object without persisting it.
 // For dry-run a deterministic Name is used; for live create GenerateName is used.
 func buildOffloadSecret(namespace, baseName string, opts StorageCreateOptions, dryRun bool) (*corev1.Secret, error) {
-	// Process CA certificate file if specified with @filename
-	cacert := opts.OffloadCACert
-	if strings.HasPrefix(cacert, "@") {
-		filePath := cacert[1:]
-		fileContent, err := os.ReadFile(filePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CA certificate file %s: %v", filePath, err)
-		}
-		cacert = string(fileContent)
-	}
-
-	secretData := map[string][]byte{}
-
-	if opts.OffloadVSphereUsername != "" {
-		secretData["user"] = []byte(opts.OffloadVSphereUsername)
-	}
-	if opts.OffloadVSpherePassword != "" {
-		secretData["password"] = []byte(opts.OffloadVSpherePassword)
-	}
-	if opts.OffloadVSphereURL != "" {
-		secretData["url"] = []byte(opts.OffloadVSphereURL)
-	}
-	if opts.OffloadStorageUsername != "" {
-		secretData["storageUser"] = []byte(opts.OffloadStorageUsername)
-	}
-	if opts.OffloadStoragePassword != "" {
-		secretData["storagePassword"] = []byte(opts.OffloadStoragePassword)
-	}
-	if opts.OffloadStorageEndpoint != "" {
-		secretData["storageEndpoint"] = []byte(opts.OffloadStorageEndpoint)
-	}
-	if opts.OffloadInsecureSkipTLS {
-		secretData["insecureSkipVerify"] = []byte("true")
-	}
-	if cacert != "" {
-		secretData["cacert"] = []byte(cacert)
-	}
-
-	if len(secretData) == 0 {
-		return nil, fmt.Errorf("no offload secret fields provided")
-	}
-
-	meta := metav1.ObjectMeta{
-		Namespace: namespace,
-		Labels: map[string]string{
-			"createdForResourceType": "offload",
-			"createdForMapping":      baseName,
-		},
-	}
-	if dryRun {
-		meta.Name = fmt.Sprintf("%s-offload", baseName)
-	} else {
-		meta.GenerateName = fmt.Sprintf("%s-offload-", baseName)
-	}
-
-	return &corev1.Secret{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
-		ObjectMeta: meta,
-		Data:       secretData,
-		Type:       corev1.SecretTypeOpaque,
-	}, nil
+	return offload.BuildSecret(namespace, baseName, toSecretOptions(opts), dryRun)
 }
 
 // createOffloadSecret creates a secret for offload plugin authentication
 func createOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, baseName string, opts StorageCreateOptions) (*corev1.Secret, error) {
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
-	}
-
-	secret, err := buildOffloadSecret(namespace, baseName, opts, false)
-	if err != nil {
-		return nil, err
-	}
-
-	return k8sClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	return offload.CreateSecret(configFlags, namespace, baseName, toSecretOptions(opts))
 }
 
 // validateOffloadSecretFields validates that required fields are present for offload secret creation
 func validateOffloadSecretFields(opts StorageCreateOptions) error {
-	// Check if any offload secret creation fields are provided
-	hasOffloadFields := opts.OffloadVSphereUsername != "" ||
-		opts.OffloadVSpherePassword != "" ||
-		opts.OffloadVSphereURL != "" ||
-		opts.OffloadStorageUsername != "" ||
-		opts.OffloadStoragePassword != "" ||
-		opts.OffloadStorageEndpoint != "" ||
-		opts.OffloadCACert != "" ||
-		opts.OffloadInsecureSkipTLS
-
-	if !hasOffloadFields {
-		return nil // No validation needed if no fields provided
-	}
-
-	// If any offload fields are provided, validate required combinations
-	var missingFields []string
-
-	// vSphere credentials are required
-	if opts.OffloadVSphereUsername == "" {
-		missingFields = append(missingFields, "--offload-vsphere-username")
-	}
-	if opts.OffloadVSpherePassword == "" {
-		missingFields = append(missingFields, "--offload-vsphere-password")
-	}
-	if opts.OffloadVSphereURL == "" {
-		missingFields = append(missingFields, "--offload-vsphere-url")
-	}
-
-	// Storage credentials are required
-	if opts.OffloadStorageUsername == "" {
-		missingFields = append(missingFields, "--offload-storage-username")
-	}
-	if opts.OffloadStoragePassword == "" {
-		missingFields = append(missingFields, "--offload-storage-password")
-	}
-	if opts.OffloadStorageEndpoint == "" {
-		missingFields = append(missingFields, "--offload-storage-endpoint")
-	}
-
-	if len(missingFields) > 0 {
-		return fmt.Errorf("when creating offload secrets inline, all required fields must be provided. Missing: %s", strings.Join(missingFields, ", "))
-	}
-
-	return nil
+	return offload.ValidateSecretFields(toSecretOptions(opts))
 }
 
 // needsOffloadSecret determines if we should create an offload secret
 func needsOffloadSecret(opts StorageCreateOptions) bool {
-	// Only create a secret if:
-	// 1. No existing secret name is provided AND
-	// 2. Some offload secret creation fields are provided
-	return opts.DefaultOffloadSecret == "" &&
-		(opts.OffloadVSphereUsername != "" ||
-			opts.OffloadVSpherePassword != "" ||
-			opts.OffloadVSphereURL != "" ||
-			opts.OffloadStorageUsername != "" ||
-			opts.OffloadStoragePassword != "" ||
-			opts.OffloadStorageEndpoint != "" ||
-			opts.OffloadCACert != "" ||
-			opts.OffloadInsecureSkipTLS)
+	return offload.NeedsSecret(toSecretOptions(opts))
 }

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/storage.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/storage.go
@@ -14,6 +14,7 @@ import (
 
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
+	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload"
 	"github.com/yaacov/kubectl-mtv/pkg/util/client"
 	"github.com/yaacov/kubectl-mtv/pkg/util/output"
 )
@@ -354,10 +355,5 @@ func createStorageMappingWithOptionsAndSecret(ctx context.Context, opts StorageC
 
 // cleanupOffloadSecret removes a created offload secret on failure
 func cleanupOffloadSecret(configFlags *genericclioptions.ConfigFlags, namespace, secretName string) error {
-	k8sClient, err := client.GetKubernetesClientset(configFlags)
-	if err != nil {
-		return fmt.Errorf("failed to get kubernetes client: %v", err)
-	}
-
-	return k8sClient.CoreV1().Secrets(namespace).Delete(context.Background(), secretName, metav1.DeleteOptions{})
+	return offload.CleanupSecret(configFlags, namespace, secretName)
 }

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/plan.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/plan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
 	mapping "github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping"
+	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/network"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/provider/defaultprovider"
@@ -128,6 +129,7 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 	// Track which maps we create for cleanup if needed
 	createdNetworkMap := false
 	createdStorageMap := false
+	var createdOffloadSecretName string
 
 	// Extract VM names from the plan
 	var planVMNames []string
@@ -250,7 +252,8 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 			}
 		} else {
 			// Create default storage mapping using existing logic
-			storageMapName, err := storage.CreateStorageMap(ctx, storage.StorageMapperOptions{
+			var storageMapName string
+			storageMapName, createdOffloadSecretName, err = storage.CreateStorageMap(ctx, storage.StorageMapperOptions{
 				Name:                      opts.Name,
 				Namespace:                 opts.Namespace,
 				SourceProvider:            opts.SourceProvider,
@@ -264,6 +267,19 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 				DefaultTargetStorageClass: opts.DefaultTargetStorageClass,
 				DryRun:                    opts.DryRun,
 				OutputFormat:              opts.OutputFormat,
+				DefaultVolumeMode:         opts.DefaultVolumeMode,
+				DefaultAccessMode:         opts.DefaultAccessMode,
+				DefaultOffloadPlugin:      opts.DefaultOffloadPlugin,
+				DefaultOffloadSecret:      opts.DefaultOffloadSecret,
+				DefaultOffloadVendor:      opts.DefaultOffloadVendor,
+				OffloadVSphereUsername:    opts.OffloadVSphereUsername,
+				OffloadVSpherePassword:    opts.OffloadVSpherePassword,
+				OffloadVSphereURL:         opts.OffloadVSphereURL,
+				OffloadStorageUsername:    opts.OffloadStorageUsername,
+				OffloadStoragePassword:    opts.OffloadStoragePassword,
+				OffloadStorageEndpoint:    opts.OffloadStorageEndpoint,
+				OffloadCACert:             opts.OffloadCACert,
+				OffloadInsecureSkipTLS:    opts.OffloadInsecureSkipTLS,
 			})
 			if err != nil {
 				// Clean up the network map if we created it
@@ -346,6 +362,11 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 				fmt.Printf("Warning: failed to delete storage map: %v\n", delErr)
 			}
 		}
+		if createdOffloadSecretName != "" {
+			if delErr := offload.CleanupSecret(opts.ConfigFlags, opts.Namespace, createdOffloadSecretName); delErr != nil {
+				fmt.Printf("Warning: failed to clean up offload secret '%s': %v\n", createdOffloadSecretName, delErr)
+			}
+		}
 		return fmt.Errorf("failed to convert Plan to Unstructured: %v", err)
 	}
 	planUnstructured := &unstructured.Unstructured{Object: unstructuredPlan}
@@ -362,6 +383,11 @@ func Create(ctx context.Context, opts CreatePlanOptions) error {
 		if createdStorageMap {
 			if delErr := deleteMap(opts.ConfigFlags, client.StorageMapGVR, opts.StorageMapping, opts.Namespace); delErr != nil {
 				fmt.Printf("Warning: failed to delete storage map: %v\n", delErr)
+			}
+		}
+		if createdOffloadSecretName != "" {
+			if delErr := offload.CleanupSecret(opts.ConfigFlags, opts.Namespace, createdOffloadSecretName); delErr != nil {
+				fmt.Printf("Warning: failed to clean up offload secret '%s': %v\n", createdOffloadSecretName, delErr)
 			}
 		}
 		return fmt.Errorf("failed to create plan: %v", err)

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/factory.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/factory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 
+	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload"
 	"github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/fetchers"
 	ec2Fetcher "github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/fetchers/ec2"
 	hypervFetcher "github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/fetchers/hyperv"
@@ -63,10 +64,30 @@ type StorageMapperOptions struct {
 	DefaultTargetStorageClass string
 	DryRun                    bool
 	OutputFormat              string
+
+	// Storage enhancement options
+	DefaultVolumeMode    string
+	DefaultAccessMode    string
+	DefaultOffloadPlugin string
+	DefaultOffloadSecret string
+	DefaultOffloadVendor string
+
+	// Offload secret creation fields
+	OffloadVSphereUsername string
+	OffloadVSpherePassword string
+	OffloadVSphereURL      string
+	OffloadStorageUsername  string
+	OffloadStoragePassword string
+	OffloadStorageEndpoint string
+	OffloadCACert          string
+	OffloadInsecureSkipTLS bool
 }
 
-// CreateStorageMap creates a storage map using the new fetcher-based architecture
-func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, error) {
+// CreateStorageMap creates a storage map using the new fetcher-based architecture.
+// It returns the storage map name, the name of any offload secret that was created
+// (empty if none), and an error. The caller is responsible for cleaning up the
+// returned secret if later operations fail.
+func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (storageMapName string, createdSecretName string, err error) {
 	klog.V(4).Infof("DEBUG: Creating storage map - Source: %s, Target: %s, DefaultTargetStorageClass: '%s'",
 		opts.SourceProvider, opts.TargetProvider, opts.DefaultTargetStorageClass)
 
@@ -74,7 +95,7 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 	sourceProviderNamespace := client.GetProviderNamespace(opts.SourceProviderNamespace, opts.Namespace)
 	sourceFetcher, err := GetSourceStorageFetcher(ctx, opts.ConfigFlags, opts.SourceProvider, sourceProviderNamespace, opts.InventoryInsecureSkipTLS)
 	if err != nil {
-		return "", fmt.Errorf("failed to get source storage fetcher: %v", err)
+		return "", "", fmt.Errorf("failed to get source storage fetcher: %v", err)
 	}
 	klog.V(4).Infof("DEBUG: Source storage fetcher created for provider: %s", opts.SourceProvider)
 
@@ -82,14 +103,14 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 	targetProviderNamespace := client.GetProviderNamespace(opts.TargetProviderNamespace, opts.Namespace)
 	targetFetcher, err := GetTargetStorageFetcher(ctx, opts.ConfigFlags, opts.TargetProvider, targetProviderNamespace, opts.InventoryInsecureSkipTLS)
 	if err != nil {
-		return "", fmt.Errorf("failed to get target storage fetcher: %v", err)
+		return "", "", fmt.Errorf("failed to get target storage fetcher: %v", err)
 	}
 	klog.V(4).Infof("DEBUG: Target storage fetcher created for provider: %s", opts.TargetProvider)
 
 	// Fetch source storages
 	sourceStorages, err := sourceFetcher.FetchSourceStorages(ctx, opts.ConfigFlags, opts.SourceProvider, sourceProviderNamespace, opts.InventoryURL, opts.PlanVMNames, opts.InventoryInsecureSkipTLS)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch source storages: %v", err)
+		return "", "", fmt.Errorf("failed to fetch source storages: %v", err)
 	}
 	klog.V(4).Infof("DEBUG: Fetched %d source storages", len(sourceStorages))
 
@@ -99,7 +120,7 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 		klog.V(4).Infof("DEBUG: Fetching target storages from target provider: %s", opts.TargetProvider)
 		targetStorages, err = targetFetcher.FetchTargetStorages(ctx, opts.ConfigFlags, opts.TargetProvider, targetProviderNamespace, opts.InventoryURL, opts.InventoryInsecureSkipTLS)
 		if err != nil {
-			return "", fmt.Errorf("failed to fetch target storages: %v", err)
+			return "", "", fmt.Errorf("failed to fetch target storages: %v", err)
 		}
 		klog.V(4).Infof("DEBUG: Fetched %d target storages", len(targetStorages))
 	} else {
@@ -109,7 +130,46 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 	// Get provider-specific storage mapper
 	storageMapper, sourceProviderType, targetProviderType, err := GetStorageMapper(ctx, opts.ConfigFlags, opts.SourceProvider, sourceProviderNamespace, opts.TargetProvider, targetProviderNamespace, opts.InventoryInsecureSkipTLS)
 	if err != nil {
-		return "", fmt.Errorf("failed to get storage mapper: %v", err)
+		return "", "", fmt.Errorf("failed to get storage mapper: %v", err)
+	}
+
+	// Handle offload secret creation
+	secretOpts := offload.SecretOptions{
+		DefaultOffloadSecret: opts.DefaultOffloadSecret,
+		VSphereUsername:      opts.OffloadVSphereUsername,
+		VSpherePassword:     opts.OffloadVSpherePassword,
+		VSphereURL:          opts.OffloadVSphereURL,
+		StorageUsername:      opts.OffloadStorageUsername,
+		StoragePassword:     opts.OffloadStoragePassword,
+		StorageEndpoint:     opts.OffloadStorageEndpoint,
+		CACert:              opts.OffloadCACert,
+		InsecureSkipTLS:     opts.OffloadInsecureSkipTLS,
+	}
+
+	if err := offload.ValidateSecretFields(secretOpts); err != nil {
+		return "", "", err
+	}
+
+	storageMapName = opts.Name + "-storage-map"
+	if opts.DryRun && offload.NeedsSecret(secretOpts) {
+		sec, err := offload.BuildSecret(opts.Namespace, storageMapName, secretOpts, true)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to build offload secret for dry-run: %v", err)
+		}
+		if err := output.OutputResource(sec, opts.OutputFormat); err != nil {
+			return "", "", err
+		}
+		opts.DefaultOffloadSecret = sec.Name
+	} else if !opts.DryRun && offload.NeedsSecret(secretOpts) {
+		fmt.Printf("Creating offload secret for storage mapping '%s'\n", storageMapName)
+
+		createdSecret, err := offload.CreateSecret(opts.ConfigFlags, opts.Namespace, storageMapName, secretOpts)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to create offload secret: %v", err)
+		}
+		opts.DefaultOffloadSecret = createdSecret.Name
+		createdSecretName = createdSecret.Name
+		fmt.Printf("Created offload secret '%s' for storage mapping authentication\n", createdSecret.Name)
 	}
 
 	// Create storage pairs using provider-specific mapping logic
@@ -117,25 +177,44 @@ func CreateStorageMap(ctx context.Context, opts StorageMapperOptions) (string, e
 		DefaultTargetStorageClass: opts.DefaultTargetStorageClass,
 		SourceProviderType:        sourceProviderType,
 		TargetProviderType:        targetProviderType,
+		DefaultVolumeMode:         opts.DefaultVolumeMode,
+		DefaultAccessMode:         opts.DefaultAccessMode,
+		DefaultOffloadPlugin:      opts.DefaultOffloadPlugin,
+		DefaultOffloadSecret:      opts.DefaultOffloadSecret,
+		DefaultOffloadVendor:      opts.DefaultOffloadVendor,
 	}
 	storagePairs, err := storageMapper.CreateStoragePairs(sourceStorages, targetStorages, mappingOpts)
 	if err != nil {
-		return "", fmt.Errorf("failed to create storage pairs: %v", err)
+		if createdSecretName != "" {
+			if delErr := offload.CleanupSecret(opts.ConfigFlags, opts.Namespace, createdSecretName); delErr != nil {
+				fmt.Printf("Warning: failed to clean up offload secret '%s': %v\n", createdSecretName, delErr)
+			}
+		}
+		return "", "", fmt.Errorf("failed to create storage pairs: %v", err)
 	}
 
 	if opts.DryRun {
-		storageMap, storageMapName, err := buildStorageMapObject(opts, storagePairs)
+		storageMap, dryRunMapName, err := buildStorageMapObject(opts, storagePairs)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		if err := output.OutputResource(storageMap, opts.OutputFormat); err != nil {
-			return "", err
+			return "", "", err
 		}
-		return storageMapName, nil
+		return dryRunMapName, "", nil
 	}
 
 	// Create the storage map using the existing infrastructure
-	return createStorageMap(opts, storagePairs)
+	storageMapResult, err := createStorageMap(opts, storagePairs)
+	if err != nil {
+		if createdSecretName != "" {
+			if delErr := offload.CleanupSecret(opts.ConfigFlags, opts.Namespace, createdSecretName); delErr != nil {
+				fmt.Printf("Warning: failed to clean up offload secret '%s': %v\n", createdSecretName, delErr)
+			}
+		}
+		return "", "", err
+	}
+	return storageMapResult, createdSecretName, nil
 }
 
 // buildStorageMapObject builds a typed StorageMap (no API call).

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/ec2/mapper.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/ec2/mapper.go
@@ -140,6 +140,9 @@ func (m *EC2StorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targetSt
 			})
 		}
 		klog.V(4).Infof("DEBUG: EC2 storage mapper - Created %d storage pairs (user default)", len(storagePairs))
+
+		storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 		return storagePairs, nil
 	}
 
@@ -179,5 +182,8 @@ func (m *EC2StorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targetSt
 	}
 
 	klog.V(4).Infof("DEBUG: EC2 storage mapper - Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/hyperv/mapper.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/hyperv/mapper.go
@@ -41,6 +41,9 @@ func (m *HyperVStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targe
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/interfaces.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/interfaces.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	forkliftv1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // StorageMappingOptions contains options for storage mapping
@@ -10,9 +11,42 @@ type StorageMappingOptions struct {
 	DefaultTargetStorageClass string
 	SourceProviderType        string
 	TargetProviderType        string
+	DefaultVolumeMode         string
+	DefaultAccessMode         string
+	DefaultOffloadPlugin      string
+	DefaultOffloadSecret      string
+	DefaultOffloadVendor      string
 }
 
 // StorageMapper defines the interface for storage mapping operations
 type StorageMapper interface {
 	CreateStoragePairs(sourceStorages []ref.Ref, targetStorages []forkliftv1beta1.DestinationStorage, opts StorageMappingOptions) ([]forkliftv1beta1.StoragePair, error)
+}
+
+// ApplyOffloadToPairs applies default volume mode, access mode, and offload
+// plugin settings from opts to every pair that does not already have them set.
+func ApplyOffloadToPairs(pairs []forkliftv1beta1.StoragePair, opts StorageMappingOptions) []forkliftv1beta1.StoragePair {
+	for i := range pairs {
+		if opts.DefaultVolumeMode != "" && pairs[i].Destination.VolumeMode == "" {
+			pairs[i].Destination.VolumeMode = corev1.PersistentVolumeMode(opts.DefaultVolumeMode)
+		}
+
+		if opts.DefaultAccessMode != "" && pairs[i].Destination.AccessMode == "" {
+			pairs[i].Destination.AccessMode = corev1.PersistentVolumeAccessMode(opts.DefaultAccessMode)
+		}
+
+		if opts.DefaultOffloadPlugin != "" && opts.DefaultOffloadVendor != "" && pairs[i].OffloadPlugin == nil {
+			switch opts.DefaultOffloadPlugin {
+			case "vsphere":
+				pairs[i].OffloadPlugin = &forkliftv1beta1.OffloadPlugin{
+					VSphereXcopyPluginConfig: &forkliftv1beta1.VSphereXcopyPluginConfig{
+						SecretRef:            opts.DefaultOffloadSecret,
+						StorageVendorProduct: forkliftv1beta1.StorageVendorProduct(opts.DefaultOffloadVendor),
+					},
+				}
+			}
+		}
+	}
+
+	return pairs
 }

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/openshift/mapper.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/openshift/mapper.go
@@ -36,7 +36,12 @@ func (m *OpenShiftStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, ta
 
 	// (a) User specified a default SC — map every source to it.
 	if opts.DefaultTargetStorageClass != "" {
-		return createDefaultStoragePairs(sourceStorages, opts.DefaultTargetStorageClass)
+		pairs, err := createDefaultStoragePairs(sourceStorages, opts.DefaultTargetStorageClass)
+		if err != nil {
+			return nil, err
+		}
+		pairs = mapper.ApplyOffloadToPairs(pairs, opts)
+		return pairs, nil
 	}
 
 	// Resolve the default SC for gap-filling (best SC selected by the target fetcher).
@@ -45,11 +50,21 @@ func (m *OpenShiftStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, ta
 	// (b) + (c) For OCP-to-OCP: same-name matching with gap-fill.
 	if opts.TargetProviderType == "openshift" {
 		klog.V(4).Infof("DEBUG: OCP-to-OCP migration detected, attempting same-name matching with gap-fill")
-		return createSameNameWithFallback(sourceStorages, targetStorages, defaultSC)
+		pairs, err := createSameNameWithFallback(sourceStorages, targetStorages, defaultSC)
+		if err != nil {
+			return nil, err
+		}
+		pairs = mapper.ApplyOffloadToPairs(pairs, opts)
+		return pairs, nil
 	}
 
 	// Non-OCP target: map all sources to the default SC.
-	return createAllToDefaultPairs(sourceStorages, defaultSC)
+	pairs, err := createAllToDefaultPairs(sourceStorages, defaultSC)
+	if err != nil {
+		return nil, err
+	}
+	pairs = mapper.ApplyOffloadToPairs(pairs, opts)
+	return pairs, nil
 }
 
 // createDefaultStoragePairs maps every source to the user-specified SC.

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/openstack/mapper.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/openstack/mapper.go
@@ -41,6 +41,9 @@ func (m *OpenStackStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, ta
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/ova/mapper.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/ova/mapper.go
@@ -41,6 +41,9 @@ func (m *OVAStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targetSt
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/ovirt/mapper.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/ovirt/mapper.go
@@ -41,6 +41,9 @@ func (m *OvirtStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, target
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/vsphere/mapper.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/storage/mapper/vsphere/mapper.go
@@ -41,6 +41,9 @@ func (m *VSphereStorageMapper) CreateStoragePairs(sourceStorages []ref.Ref, targ
 	}
 
 	klog.V(4).Infof("DEBUG: Created %d storage pairs", len(storagePairs))
+
+	storagePairs = mapper.ApplyOffloadToPairs(storagePairs, opts)
+
 	return storagePairs, nil
 }
 

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/health/description.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/health/description.go
@@ -84,7 +84,7 @@ func (r *HealthReport) buildControllerSection(b *describe.Builder) {
 	if len(ctrl.CustomImages) > 0 {
 		b.Field("Custom Images", fmt.Sprintf("%d overrides", len(ctrl.CustomImages)))
 		for _, img := range ctrl.CustomImages {
-			b.FieldC(img.Field, img.Image, output.Blue)
+			b.FieldC(img.Field, img.Image, output.ColorizeImage)
 		}
 	} else {
 		b.Field("Custom Images", "None")
@@ -121,7 +121,6 @@ func (r *HealthReport) buildPodsSection(b *describe.Builder) {
 
 	headers := []describe.TableColumn{
 		{Display: "NAME", Key: "name"},
-		{Display: "IMAGE", Key: "image"},
 		{Display: "STATUS", Key: "status", ColorFunc: output.ColorizeStatus},
 		{Display: "RESTARTS", Key: "restarts"},
 		{Display: "ISSUES", Key: "issues"},
@@ -133,9 +132,19 @@ func (r *HealthReport) buildPodsSection(b *describe.Builder) {
 		if len(pod.Issues) > 0 {
 			issues = strings.Join(pod.Issues, ", ")
 		}
+		indentedImages := strings.Join(
+			func() []string {
+				lines := strings.Split(pod.Image, "\n")
+				out := make([]string, len(lines))
+				for i, l := range lines {
+					out[i] = "  " + output.ColorizeImage(l)
+				}
+				return out
+			}(),
+			"\n",
+		)
 		rows = append(rows, map[string]string{
-			"name":     pod.Name,
-			"image":    pod.Image,
+			"name":     pod.Name + "\n" + indentedImages,
 			"status":   pod.Status,
 			"restarts": fmt.Sprintf("%d", pod.Restarts),
 			"issues":   issues,

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/health/pods.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/health/pods.go
@@ -158,13 +158,26 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// getContainerImages returns a comma-separated list of container images for a pod
+// formatImage truncates a container image string to a max length,
+// placing an ellipsis near the end if needed.
+func formatImage(image string) string {
+	const maxLen = 64
+	if len(image) <= maxLen {
+		return image
+	}
+	usable := maxLen - 3
+	front := usable*3/4 + 4
+	back := usable - front
+	return image[:front] + "..." + image[len(image)-back:]
+}
+
+// getContainerImages returns a newline-separated list of container images for a pod
 func getContainerImages(pod *corev1.Pod) string {
 	images := make([]string, 0, len(pod.Spec.Containers))
 	for _, c := range pod.Spec.Containers {
-		images = append(images, c.Image)
+		images = append(images, formatImage(c.Image))
 	}
-	return strings.Join(images, ", ")
+	return strings.Join(images, "\n")
 }
 
 // getTotalRestarts returns the total restart count across all containers

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/settings/settings.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/settings/settings.go
@@ -32,6 +32,14 @@ type SetSettingOptions struct {
 	Verbosity   int
 }
 
+// SetSettingsOptions contains options for setting multiple values in a single patch.
+type SetSettingsOptions struct {
+	ConfigFlags *genericclioptions.ConfigFlags
+	Names       []string
+	Values      []string
+	Verbosity   int
+}
+
 // UnsetSettingOptions contains options for unsetting a value.
 type UnsetSettingOptions struct {
 	ConfigFlags *genericclioptions.ConfigFlags
@@ -201,18 +209,45 @@ func extractSettingValue(spec map[string]interface{}, def SettingDefinition) Set
 }
 
 // SetSetting updates a ForkliftController setting.
+// It delegates to SetSettings to avoid duplicating patch logic.
 func SetSetting(ctx context.Context, opts SetSettingOptions) error {
-	// Validate setting name against all known settings
-	allSettings := GetAllSettings()
-	def, ok := allSettings[opts.Name]
-	if !ok {
-		return fmt.Errorf("unknown setting: %s\nUse 'kubectl mtv settings --all' to see available settings", opts.Name)
+	return SetSettings(ctx, SetSettingsOptions{
+		ConfigFlags: opts.ConfigFlags,
+		Names:       []string{opts.Name},
+		Values:      []string{opts.Value},
+		Verbosity:   opts.Verbosity,
+	})
+}
+
+// SetSettings updates multiple ForkliftController settings in a single patch operation.
+// This avoids multiple reconciliation cycles by merging all settings into one API call.
+func SetSettings(ctx context.Context, opts SetSettingsOptions) error {
+	if len(opts.Names) != len(opts.Values) {
+		return fmt.Errorf("number of --setting flags (%d) must match number of --value flags (%d)", len(opts.Names), len(opts.Values))
 	}
 
-	// Validate and convert the value
-	patchValue, err := validateAndConvertValue(opts.Value, def)
-	if err != nil {
-		return fmt.Errorf("invalid value for %s: %w", opts.Name, err)
+	seen := make(map[string]bool, len(opts.Names))
+	for _, name := range opts.Names {
+		if seen[name] {
+			return fmt.Errorf("duplicate setting: %s (each setting can only be specified once)", name)
+		}
+		seen[name] = true
+	}
+
+	// Validate all setting names and values upfront before making any changes
+	allSettings := GetAllSettings()
+	patchValues := make([]interface{}, len(opts.Names))
+	for i, name := range opts.Names {
+		def, ok := allSettings[name]
+		if !ok {
+			return fmt.Errorf("unknown setting: %s\nUse 'kubectl mtv settings --all' to see available settings", name)
+		}
+
+		patchValue, err := validateAndConvertValue(opts.Values[i], def)
+		if err != nil {
+			return fmt.Errorf("invalid value for setting '%s': %w", name, err)
+		}
+		patchValues[i] = patchValue
 	}
 
 	// Get the MTV operator namespace
@@ -241,12 +276,12 @@ func SetSetting(ctx context.Context, opts SetSettingOptions) error {
 	controller := controllerList.Items[0]
 	controllerName := controller.GetName()
 
-	// Create the patch data
-	patchMap := map[string]interface{}{
-		"spec": map[string]interface{}{
-			opts.Name: patchValue,
-		},
+	// Build one merged patch with all settings
+	specMap := map[string]interface{}{}
+	for i, name := range opts.Names {
+		specMap[name] = patchValues[i]
 	}
+	patchMap := map[string]interface{}{"spec": specMap}
 
 	patchData, err := json.Marshal(patchMap)
 	if err != nil {
@@ -257,7 +292,7 @@ func SetSetting(ctx context.Context, opts SetSettingOptions) error {
 		fmt.Printf("Patching ForkliftController '%s': %s\n", controllerName, string(patchData))
 	}
 
-	// Apply the patch
+	// Apply the single patch
 	_, err = dynamicClient.Resource(client.ForkliftControllersGVR).Namespace(operatorNamespace).Patch(
 		ctx,
 		controllerName,
@@ -266,7 +301,7 @@ func SetSetting(ctx context.Context, opts SetSettingOptions) error {
 		metav1.PatchOptions{},
 	)
 	if err != nil {
-		return wrapClusterError(err, "failed to update setting")
+		return wrapClusterError(err, "failed to update settings")
 	}
 
 	return nil

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/settings/types.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/cmd/settings/types.go
@@ -193,7 +193,7 @@ var SupportedSettings = map[string]SettingDefinition{
 		Name:        "controller_retain_populator_pods",
 		Type:        TypeBool,
 		Default:     false,
-		Description: "Retain populator pods after migration for debugging",
+		Description: "Retain populator pods after migration (debugging)",
 		Category:    CategoryFeature,
 	},
 	"feature_ova_appliance_management": {

--- a/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/util/output/style.go
+++ b/cmd/kubectl-mtv/vendor/github.com/yaacov/kubectl-mtv/pkg/util/output/style.go
@@ -204,6 +204,18 @@ func ColorizeConcerns(val string) string {
 	return Green(val)
 }
 
+// ColorizeImage returns a colored image string based on its container registry.
+func ColorizeImage(image string) string {
+	switch {
+	case strings.HasPrefix(image, "quay.io/"):
+		return Cyan(image)
+	case strings.HasPrefix(image, "registry.redhat.io/"):
+		return Green(image)
+	default:
+		return Yellow(image)
+	}
+}
+
 // ColorizeProgress returns a colored string based on percentage thresholds.
 func ColorizeProgress(progress string) string {
 	trimmed := strings.TrimSpace(progress)

--- a/cmd/kubectl-mtv/vendor/modules.txt
+++ b/cmd/kubectl-mtv/vendor/modules.txt
@@ -117,7 +117,7 @@ github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8
 # github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 ## explicit
 github.com/kballard/go-shellquote
-# github.com/kubev2v/forklift v0.0.0-20260513104241-eaea136684e0 => ../../
+# github.com/kubev2v/forklift v0.0.0-20260519094428-e2d6d4e314b5 => ../../
 ## explicit; go 1.25.0
 github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1
 github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan
@@ -226,7 +226,7 @@ github.com/xo/terminfo
 # github.com/yaacov/karl-interpreter v0.0.1
 ## explicit; go 1.21
 github.com/yaacov/karl-interpreter/pkg/karl
-# github.com/yaacov/kubectl-mtv v0.3.7
+# github.com/yaacov/kubectl-mtv v0.3.11
 ## explicit; go 1.25.0
 github.com/yaacov/kubectl-mtv/cmd
 github.com/yaacov/kubectl-mtv/cmd/archive
@@ -249,6 +249,7 @@ github.com/yaacov/kubectl-mtv/pkg/cmd/cancel/plan
 github.com/yaacov/kubectl-mtv/pkg/cmd/create/hook
 github.com/yaacov/kubectl-mtv/pkg/cmd/create/host
 github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping
+github.com/yaacov/kubectl-mtv/pkg/cmd/create/mapping/offload
 github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan
 github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/network
 github.com/yaacov/kubectl-mtv/pkg/cmd/create/plan/network/fetchers


### PR DESCRIPTION
Update the vendored github.com/yaacov/kubectl-mtv dependency from v0.3.7 to v0.3.11 and re-vendor to pick up changes.

Highlights in v0.3.11:
- settings set command supports multiple --setting/--value pairs in a single patch operation
- offload-secret logic extracted into a reusable package
- storage mapper interfaces updated for all providers

Resolves: none