### PR TITLE
MTV-3505 | Fix VMware serial number feature flag not disabling from CR

### DIFF
--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -198,10 +198,8 @@ spec:
         - name: FEATURE_OCP_LIVE_MIGRATION
           value: "true"
 {% endif %}
-{% if feature_vmware_system_serial_number|bool %}
         - name: FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER
-          value: "true"
-{% endif %}
+          value: "{{ feature_vmware_system_serial_number|bool|lower }}"
 {% if feature_vsphere_vmware_driver_removal|bool %}
         - name: FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL
           value: "true"


### PR DESCRIPTION
The Jinja2 template only emitted FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER when the CR value was true, omitting the env var entirely when false. Since the Go code defaults to true when the env var is absent, setting feature_vmware_system_serial_number: "false" in the ForkliftController CR had no effect.

Replace the conditional block with an unconditional emit using |bool|lower, matching the pattern already used for FEATURE_USE_CONVERSION_CR.

Bash test plan added to Jira ticket.

Ref: https://redhat.atlassian.net/browse/MTV-3505
Resolves: MTV-3505