### PR TITLE
MTV-5586 | Handle PowerMax API transient 503 and 409 responses

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
@@ -319,6 +319,18 @@ func (p *PowermaxClonner) Map(_ string, targetLUN populator.LUN, mappingContext 
 		if err != nil {
 			return populator.LUN{}, err
 		}
+		// If mv is still nil after a 409 (treated as success), the masking view
+		// was created by a prior attempt — fetch it.
+		if mv == nil {
+			err = retryOnTransient(ctx, p.log, "GetMaskingViewByID", func() error {
+				var e error
+				mv, e = p.client.GetMaskingViewByID(ctx, p.symmetrixID, p.initiatorID)
+				return e
+			})
+			if err != nil {
+				return populator.LUN{}, fmt.Errorf("masking view %s exists (409) but failed to fetch it: %w", p.initiatorID, err)
+			}
+		}
 	}
 
 	p.log.Info("volume mapped successfully", "volume", targetLUN.ProviderID, "masking_view", mv.MaskingViewID)
@@ -487,18 +499,41 @@ func retryOnTransient(ctx context.Context, log klog.Logger, operation string, fn
 		Steps:    5,
 	}
 	var lastErr error
+	attempt := 0
 	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+		attempt++
 		lastErr = fn()
 		if lastErr == nil {
+			if attempt > 1 {
+				log.Info("operation succeeded after retries", "operation", operation, "attempts", attempt)
+			}
 			return true, nil
 		}
 		var pmxErr *pmxtypes.Error
-		if errors.As(lastErr, &pmxErr) && pmxErr.HTTPStatusCode == 503 {
-			log.Info("transient 503 error, retrying", "operation", operation, "err", lastErr)
+		if errors.As(lastErr, &pmxErr) {
+			if pmxErr.HTTPStatusCode == 503 {
+				log.Info("transient 503 error, retrying", "operation", operation, "attempt", attempt, "maxAttempts", backoff.Steps, "err", lastErr)
+				return false, nil
+			}
+			if pmxErr.HTTPStatusCode == 409 {
+				log.Info("409 conflict, treating as success", "operation", operation, "err", lastErr)
+				return true, nil
+			}
+			log.Info("non-retryable PowerMax API error", "operation", operation, "httpStatus", pmxErr.HTTPStatusCode, "message", pmxErr.Message, "errorCode", pmxErr.ErrorCode)
+		} else if strings.Contains(lastErr.Error(), "Service Unavailable") {
+			// Some SDK methods (e.g. AddVolumesToStorageGroupS) wrap the original
+			// *pmxtypes.Error with fmt.Errorf("%s", ...) which destroys the type.
+			// Fall back to string matching for these cases.
+			log.Info("transient Service Unavailable error, retrying", "operation", operation, "attempt", attempt, "maxAttempts", backoff.Steps, "err", lastErr)
 			return false, nil
+		} else {
+			log.Info("non-retryable error", "operation", operation, "errType", fmt.Sprintf("%T", lastErr), "err", lastErr)
 		}
 		return false, lastErr
 	})
+	if wait.Interrupted(err) {
+		log.Error(lastErr, "operation failed after retries", "operation", operation, "attempts", attempt)
+	}
 	if err != nil && lastErr != nil && !errors.Is(err, lastErr) {
 		return fmt.Errorf("%w: %w", err, lastErr)
 	}


### PR DESCRIPTION
## Summary
- Backport of #6739 to main
- Handle 503 errors from PowerMax API methods that wrap errors in unexpected formats (string-based fallback)
- Treat 409 (Conflict) as success since the operation may have completed before the 503 was returned
- Add diagnostic logging for retry attempts and non-retryable errors

Resolves: MTV-5586

🤖 Generated with [Claude Code](https://claude.com/claude-code)