### PR TITLE
MTV-5644 | Add overlay to the virt-v2v-in-place so we write changes only if conversion passes

### DIFF
--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -46,25 +46,23 @@ func main() {
 			// - If LibvirtUrl is set: fetch domain XML from libvirt and use -i libvirtxml mode
 			// - Otherwise: use -i disk mode directly on the mounted disks (e.g., EC2)
 			if convert.LibvirtUrl != "" {
-				// fetch xml description of the guest from libvirt to help virt-v2v make the conversion
 				err = func() error {
 					domainXML, err := convert.GetDomainXML()
 					if err != nil {
 						return fmt.Errorf("failed to get domain XML: %v", err)
 					}
-
-					err = os.WriteFile(convert.LibvirtDomainFile, []byte(domainXML), 0644)
-					if err != nil {
+					if err := os.WriteFile(convert.LibvirtDomainFile, []byte(domainXML), 0644); err != nil {
 						return fmt.Errorf("failed to write domain XML file: %v", err)
 					}
 					return nil
 				}()
 				if err == nil {
-					err = convert.RunVirtV2vInPlace()
+					// Run in-place conversion using libvirtxml input mode
+					err = convert.RunInPlaceWithOverlay(convert.RunVirtV2vInPlace)
 				}
 			} else {
-				// No libvirt URL - use disk mode directly on mounted disks
-				err = convert.RunVirtV2vInPlaceDisk()
+				// No libvirt URL - Run in-place conversion directly on mounted disks
+				err = convert.RunInPlaceWithOverlay(convert.RunVirtV2vInPlaceDisk)
 			}
 		} else {
 			err = convert.RunVirtV2v()

--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -57,12 +57,18 @@ func main() {
 					return nil
 				}()
 				if err == nil {
-					// Run in-place conversion using libvirtxml input mode
-					err = convert.RunInPlaceWithOverlay(convert.RunVirtV2vInPlace)
+					if convert.OverlayEnabled {
+						err = convert.RunInPlaceWithOverlay(convert.RunVirtV2vInPlace)
+					} else {
+						err = convert.RunVirtV2vInPlace()
+					}
 				}
 			} else {
-				// No libvirt URL - Run in-place conversion directly on mounted disks
-				err = convert.RunInPlaceWithOverlay(convert.RunVirtV2vInPlaceDisk)
+				if convert.OverlayEnabled {
+					err = convert.RunInPlaceWithOverlay(convert.RunVirtV2vInPlaceDisk)
+				} else {
+					err = convert.RunVirtV2vInPlaceDisk()
+				}
 			}
 		} else {
 			err = convert.RunVirtV2v()

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -41,6 +41,7 @@ const (
 	EnvWaitForGuestRebootName           = "V2V_waitForGuestReboot"
 	EnvXfsCompatibilityName             = "V2V_xfsCompatibility"
 	EnvXfsRepairIgnoreName              = "V2V_xfsRepairIgnore"
+	EnvOverlayEnabledName               = "V2V_overlayEnabled"
 )
 
 const (
@@ -124,6 +125,8 @@ type AppConfig struct {
 	// SupportsNoFstrim is true when the virt-v2v binary supports --no-fstrim
 	// (RHEL-only downstream patch. upstream CentOS/Fedora builds lack this flag)
 	SupportsNoFstrim bool
+	// V2V_overlayEnabled — use qcow2 overlay for in-place conversions (default true)
+	OverlayEnabled bool
 
 	// V2V_multipleIPsPerNic
 	MultipleIpsPerNicName string
@@ -143,6 +146,7 @@ func (s *AppConfig) Load() (err error) {
 	s.InspectorExtraArgs = s.getInspectorExtraArgs()
 	flag.BoolVar(&s.IsLocalMigration, "local-migration", s.getEnvBool(EnvLocalMigrationName, true), "Migration is in local or remote cluster")
 	flag.BoolVar(&s.IsInPlace, "in-place", s.getEnvBool(EnvInPlaceName, false), "Run virt-v2v-in-place on already populated disks")
+	flag.BoolVar(&s.OverlayEnabled, "overlay-enabled", s.getEnvBool(EnvOverlayEnabledName, true), "Use qcow2 overlay for in-place conversions")
 	flag.BoolVar(&s.NbdeClevis, "nbde-clevis", s.getEnvBool(EnvNbdeClevis, false), "virt-v2v should unencrypt the disks via clevis client")
 	flag.StringVar(&s.Source, "source", os.Getenv(EnvSourceName), "Source of VM ['ova','vSphere']")
 	flag.StringVar(&s.LibvirtUrl, "libvirt-url", os.Getenv(EnvLibvirtUrlName), "Libvirt domain to the vSphere")

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -486,7 +486,7 @@ func (c *Conversion) updateDiskPaths(domainXML string) (string, error) {
 		if updated := updateDiskSource(&disk, newPath); updated {
 			disk.Driver = &libvirtxml.DomainDiskDriver{
 				Name: "qemu",
-				Type: "raw",
+				Type: "qcow2",
 			}
 			updatedDisks = append(updatedDisks, disk)
 		}

--- a/pkg/virt-v2v/conversion/conversion_test.go
+++ b/pkg/virt-v2v/conversion/conversion_test.go
@@ -697,7 +697,7 @@ var _ = Describe("Conversion", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sda"))
 				Expect(result).ToNot(ContainSubstring("/original/path/disk.vmdk"))
-				Expect(result).To(ContainSubstring(`<driver name="qemu" type="raw"`))
+				Expect(result).To(ContainSubstring(`<driver name="qemu" type="qcow2"`))
 			},
 		)
 
@@ -721,7 +721,7 @@ var _ = Describe("Conversion", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sda"))
 				Expect(result).ToNot(ContainSubstring("/dev/original-block"))
-				Expect(result).To(ContainSubstring(`<driver name="qemu" type="raw"`))
+				Expect(result).To(ContainSubstring(`<driver name="qemu" type="qcow2"`))
 			},
 		)
 
@@ -984,6 +984,56 @@ var _ = Describe("Conversion", func() {
 				Expect(result).ToNot(ContainSubstring(".iso"))
 			},
 		)
+
+		It("uses qcow2 driver type for disk", func() {
+			conversion.Disks = []*Disk{
+				{Link: "/var/tmp/v2v/vm-sda"},
+			}
+
+			domainXML := `<domain type='kvm'>
+  <name>test-vm</name>
+  <devices>
+    <disk type='file' device='disk'>
+      <source file='/original/path/disk.vmdk'/>
+      <target dev='sda' bus='scsi'/>
+    </disk>
+  </devices>
+</domain>`
+
+			result, err := conversion.updateDiskPaths(domainXML)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sda"))
+			Expect(result).To(ContainSubstring(`type="qcow2"`))
+			Expect(result).ToNot(ContainSubstring(`type="raw"`))
+		})
+
+		It("uses qcow2 driver type for multiple disks", func() {
+			conversion.Disks = []*Disk{
+				{Link: "/var/tmp/v2v/vm-sda"},
+				{Link: "/var/tmp/v2v/vm-sdb"},
+			}
+
+			domainXML := `<domain type='kvm'>
+  <name>test-vm</name>
+  <devices>
+    <disk type='file' device='disk'>
+      <source file='/original/path/disk1.vmdk'/>
+      <target dev='sda' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <source file='/original/path/disk2.vmdk'/>
+      <target dev='sdb' bus='scsi'/>
+    </disk>
+  </devices>
+</domain>`
+
+			result, err := conversion.updateDiskPaths(domainXML)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sda"))
+			Expect(result).To(ContainSubstring("/var/tmp/v2v/vm-sdb"))
+			Expect(result).To(ContainSubstring(`type="qcow2"`))
+			Expect(result).ToNot(ContainSubstring(`type="raw"`))
+		})
 
 		It("handles more XML disks than available when cdroms are present",
 			func() {

--- a/pkg/virt-v2v/conversion/overlay.go
+++ b/pkg/virt-v2v/conversion/overlay.go
@@ -1,8 +1,6 @@
 package conversion
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,56 +17,28 @@ type Overlay struct {
 	OriginalLink string
 }
 
-func (c *Conversion) detectDiskFormat(path string) (string, error) {
-	var stdout bytes.Buffer
-	cmd := c.CommandBuilder.New("qemu-img").
-		AddPositional("info").
-		AddArg("--output", "json").
-		AddPositional(path).
-		Build()
-	cmd.SetStdout(&stdout)
-	cmd.SetStderr(os.Stderr)
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("qemu-img info failed for %s: %w", path, err)
-	}
-	var info struct {
-		Format string `json:"format"`
-	}
-	if err := json.Unmarshal(stdout.Bytes(), &info); err != nil {
-		return "", fmt.Errorf("failed to parse qemu-img info output for %s: %w", path, err)
-	}
-	if info.Format == "" {
-		fmt.Fprintf(os.Stderr, "WARNING: qemu-img info returned empty format for %s, assuming raw\n", path)
-		return "raw", nil
-	}
-	return info.Format, nil
-}
-
+// CreateOverlays creates a qcow2 overlay for each disk, rewires the
+// disk.Link symlink to point at the overlay, and updates disk.Path to
+// the overlay path. The original device path is preserved in Overlay.BackingPath
+// so restoreLinks can revert both the symlink and the struct on cleanup.
 func (c *Conversion) CreateOverlays() ([]*Overlay, error) {
 	var overlays []*Overlay
 	for _, disk := range c.Disks {
 		overlayPath := disk.Link + ".qcow2"
 
-		// Detect the backing disk format instead of assuming raw
-		backingFmt, err := c.detectDiskFormat(disk.Path)
-		if err != nil {
-			c.rollbackOverlays(overlays)
-			return nil, fmt.Errorf("failed to detect format for %s: %w", disk.Path, err)
-		}
-
-		// Step 1: Create qcow2 overlay file backed by the original disk
+		// Step 1: Create qcow2 overlay file backed by the original disk (always raw)
 		cmd := c.CommandBuilder.New("qemu-img").
 			AddPositional("create").
 			AddArg("-f", "qcow2").
 			AddArg("-b", disk.Path).
-			AddArg("-F", backingFmt).
+			AddArg("-F", "raw").
 			AddPositional(overlayPath).
 			Build()
 		cmd.SetStdout(os.Stdout)
 		cmd.SetStderr(os.Stderr)
 		if err := cmd.Run(); err != nil {
 			_ = os.Remove(overlayPath)
-			c.rollbackOverlays(overlays)
+			c.DiscardOverlays(overlays)
 			return nil, fmt.Errorf("failed to create overlay for %s: %w", disk.Path, err)
 		}
 
@@ -76,12 +46,12 @@ func (c *Conversion) CreateOverlays() ([]*Overlay, error) {
 		originalLink, err := os.Readlink(disk.Link)
 		if err != nil {
 			_ = os.Remove(overlayPath)
-			c.rollbackOverlays(overlays)
+			c.DiscardOverlays(overlays)
 			return nil, fmt.Errorf("failed to read symlink %s: %w", disk.Link, err)
 		}
 		if err := os.Remove(disk.Link); err != nil && !os.IsNotExist(err) {
 			_ = os.Remove(overlayPath)
-			c.rollbackOverlays(overlays)
+			c.DiscardOverlays(overlays)
 			return nil, fmt.Errorf("failed to remove old symlink %s: %w", disk.Link, err)
 		}
 
@@ -89,7 +59,7 @@ func (c *Conversion) CreateOverlays() ([]*Overlay, error) {
 		if err := os.Symlink(overlayPath, disk.Link); err != nil {
 			_ = os.Remove(overlayPath)
 			_ = os.Symlink(originalLink, disk.Link)
-			c.rollbackOverlays(overlays)
+			c.DiscardOverlays(overlays)
 			return nil, fmt.Errorf("failed to create overlay symlink %s -> %s: %w", disk.Link, overlayPath, err)
 		}
 
@@ -100,17 +70,9 @@ func (c *Conversion) CreateOverlays() ([]*Overlay, error) {
 			OriginalLink: originalLink,
 		})
 		fmt.Printf("Created overlay %s backed by %s\n", filepath.Base(overlayPath), disk.Path)
+		disk.Path = overlayPath
 	}
 	return overlays, nil
-}
-
-// rollbackOverlays removes overlay files and restores symlinks for
-// partially-created overlays during a failed CreateOverlays call.
-func (c *Conversion) rollbackOverlays(overlays []*Overlay) {
-	for _, o := range overlays {
-		_ = os.Remove(o.Path)
-	}
-	c.restoreLinks(overlays)
 }
 
 // CommitOverlays merges each overlay back into its backing disk, then removes the overlay file.
@@ -128,7 +90,7 @@ func (c *Conversion) CommitOverlays(overlays []*Overlay) error {
 		cmd.SetStdout(os.Stdout)
 		cmd.SetStderr(os.Stderr)
 		if err := cmd.Run(); err != nil {
-			c.rollbackOverlays(overlays)
+			c.DiscardOverlays(overlays)
 			if len(committed) > 0 {
 				return fmt.Errorf("partial commit: disks %v already committed, failed on %s — VM may be in inconsistent state: %w",
 					committed, filepath.Base(o.Path), err)
@@ -162,6 +124,7 @@ func (c *Conversion) DiscardOverlays(overlays []*Overlay) {
 
 func (c *Conversion) restoreLinks(overlays []*Overlay) {
 	for _, o := range overlays {
+		o.Disk.Path = o.BackingPath
 		if err := os.Remove(o.Disk.Link); err != nil && !os.IsNotExist(err) {
 			fmt.Fprintf(os.Stderr, "WARNING: failed to remove symlink %s during restore: %v\n", o.Disk.Link, err)
 			continue

--- a/pkg/virt-v2v/conversion/overlay.go
+++ b/pkg/virt-v2v/conversion/overlay.go
@@ -1,0 +1,204 @@
+package conversion
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type Overlay struct {
+	// Path to the qcow2 overlay file (e.g. /var/tmp/v2v/vm-sda.qcow2)
+	Path string
+	// Path to the original backing disk (e.g. /dev/block0 or /mnt/disks/disk0/disk.img)
+	BackingPath string
+	// The Disk whose Link symlink was rewired to point to the overlay
+	Disk *Disk
+	// Original symlink target before rewire
+	OriginalLink string
+}
+
+func (c *Conversion) detectDiskFormat(path string) (string, error) {
+	var stdout bytes.Buffer
+	cmd := c.CommandBuilder.New("qemu-img").
+		AddPositional("info").
+		AddArg("--output", "json").
+		AddPositional(path).
+		Build()
+	cmd.SetStdout(&stdout)
+	cmd.SetStderr(os.Stderr)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("qemu-img info failed for %s: %w", path, err)
+	}
+	var info struct {
+		Format string `json:"format"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &info); err != nil {
+		return "", fmt.Errorf("failed to parse qemu-img info output for %s: %w", path, err)
+	}
+	if info.Format == "" {
+		fmt.Fprintf(os.Stderr, "WARNING: qemu-img info returned empty format for %s, assuming raw\n", path)
+		return "raw", nil
+	}
+	return info.Format, nil
+}
+
+func (c *Conversion) CreateOverlays() ([]*Overlay, error) {
+	var overlays []*Overlay
+	for _, disk := range c.Disks {
+		overlayPath := disk.Link + ".qcow2"
+
+		// Detect the backing disk format instead of assuming raw
+		backingFmt, err := c.detectDiskFormat(disk.Path)
+		if err != nil {
+			c.rollbackOverlays(overlays)
+			return nil, fmt.Errorf("failed to detect format for %s: %w", disk.Path, err)
+		}
+
+		// Step 1: Create qcow2 overlay file backed by the original disk
+		cmd := c.CommandBuilder.New("qemu-img").
+			AddPositional("create").
+			AddArg("-f", "qcow2").
+			AddArg("-b", disk.Path).
+			AddArg("-F", backingFmt).
+			AddPositional(overlayPath).
+			Build()
+		cmd.SetStdout(os.Stdout)
+		cmd.SetStderr(os.Stderr)
+		if err := cmd.Run(); err != nil {
+			_ = os.Remove(overlayPath)
+			c.rollbackOverlays(overlays)
+			return nil, fmt.Errorf("failed to create overlay for %s: %w", disk.Path, err)
+		}
+
+		// Step 2: Read and remove old symlink (pointed at base disk)
+		originalLink, err := os.Readlink(disk.Link)
+		if err != nil {
+			_ = os.Remove(overlayPath)
+			c.rollbackOverlays(overlays)
+			return nil, fmt.Errorf("failed to read symlink %s: %w", disk.Link, err)
+		}
+		if err := os.Remove(disk.Link); err != nil && !os.IsNotExist(err) {
+			_ = os.Remove(overlayPath)
+			c.rollbackOverlays(overlays)
+			return nil, fmt.Errorf("failed to remove old symlink %s: %w", disk.Link, err)
+		}
+
+		// Step 3: Create new symlink pointing at the overlay
+		if err := os.Symlink(overlayPath, disk.Link); err != nil {
+			_ = os.Remove(overlayPath)
+			_ = os.Symlink(originalLink, disk.Link)
+			c.rollbackOverlays(overlays)
+			return nil, fmt.Errorf("failed to create overlay symlink %s -> %s: %w", disk.Link, overlayPath, err)
+		}
+
+		overlays = append(overlays, &Overlay{
+			Path:         overlayPath,
+			BackingPath:  disk.Path,
+			Disk:         disk,
+			OriginalLink: originalLink,
+		})
+		fmt.Printf("Created overlay %s backed by %s\n", filepath.Base(overlayPath), disk.Path)
+	}
+	return overlays, nil
+}
+
+// rollbackOverlays removes overlay files and restores symlinks for
+// partially-created overlays during a failed CreateOverlays call.
+func (c *Conversion) rollbackOverlays(overlays []*Overlay) {
+	for _, o := range overlays {
+		_ = os.Remove(o.Path)
+	}
+	c.restoreLinks(overlays)
+}
+
+// CommitOverlays merges each overlay back into its backing disk, then removes the overlay file.
+// Note: commits are not transactional across disks — if commit fails for a later disk,
+// earlier disks will already have their changes persisted - qemu-img commit is irreversible
+// and each disk remains individually consistent.
+func (c *Conversion) CommitOverlays(overlays []*Overlay) error {
+	var committed []string
+	for _, o := range overlays {
+		// Merge dirty clusters from overlay into the base disk
+		cmd := c.CommandBuilder.New("qemu-img").
+			AddPositional("commit").
+			AddPositional(o.Path).
+			Build()
+		cmd.SetStdout(os.Stdout)
+		cmd.SetStderr(os.Stderr)
+		if err := cmd.Run(); err != nil {
+			c.rollbackOverlays(overlays)
+			if len(committed) > 0 {
+				return fmt.Errorf("partial commit: disks %v already committed, failed on %s — VM may be in inconsistent state: %w",
+					committed, filepath.Base(o.Path), err)
+			}
+			return fmt.Errorf("failed to commit overlay %s: %w", o.Path, err)
+		}
+		committed = append(committed, filepath.Base(o.Path))
+		// Remove the now-redundant overlay file
+		if err := os.Remove(o.Path); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "WARNING: committed overlay %s but failed to remove file: %v\n", filepath.Base(o.Path), err)
+		} else {
+			fmt.Printf("Committed and removed overlay %s\n", filepath.Base(o.Path))
+		}
+	}
+	// Restore symlinks to point back at base disks
+	c.restoreLinks(overlays)
+	return nil
+}
+
+// DiscardOverlays removes overlay files without committing; base disks are untouched.
+func (c *Conversion) DiscardOverlays(overlays []*Overlay) {
+	for _, o := range overlays {
+		if err := os.Remove(o.Path); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "WARNING: failed to remove overlay %s: %v\n", o.Path, err)
+		} else {
+			fmt.Printf("Discarded overlay %s (base disk unchanged)\n", filepath.Base(o.Path))
+		}
+	}
+	c.restoreLinks(overlays)
+}
+
+func (c *Conversion) restoreLinks(overlays []*Overlay) {
+	for _, o := range overlays {
+		if err := os.Remove(o.Disk.Link); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "WARNING: failed to remove symlink %s during restore: %v\n", o.Disk.Link, err)
+			continue
+		}
+		if err := os.Symlink(o.OriginalLink, o.Disk.Link); err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: failed to restore symlink %s -> %s: %v\n", o.Disk.Link, o.OriginalLink, err)
+		}
+	}
+}
+
+func (c *Conversion) RunInPlaceWithOverlay(runConversion func() error) error {
+	// Create overlay per disk and redirect symlinks to overlays
+	overlays, err := c.CreateOverlays()
+	if err != nil {
+		return fmt.Errorf("overlay setup failed: %w", err)
+	}
+
+	completed := false
+	defer func() {
+		if !completed {
+			fmt.Println("Unexpected exit — discarding overlays as safety cleanup")
+			c.DiscardOverlays(overlays)
+		}
+	}()
+
+	// Run the actual conversion (writes go to overlays, not base disks)
+	convErr := runConversion()
+
+	if convErr != nil {
+		fmt.Println("Conversion failed — discarding overlays, base disks unchanged")
+		c.DiscardOverlays(overlays)
+		completed = true
+		return convErr
+	}
+
+	fmt.Println("Conversion succeeded — committing overlays to base disks")
+	commitErr := c.CommitOverlays(overlays)
+	completed = true
+	return commitErr
+}

--- a/pkg/virt-v2v/conversion/overlay_test.go
+++ b/pkg/virt-v2v/conversion/overlay_test.go
@@ -2,7 +2,6 @@ package conversion
 
 import (
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -57,21 +56,7 @@ var _ = Describe("Overlay", func() {
 		return linkA, linkB
 	}
 
-	expectQemuImgInfo := func(diskPath, format string) {
-		mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
-		mockCommandBuilder.EXPECT().AddPositional("info").Return(mockCommandBuilder)
-		mockCommandBuilder.EXPECT().AddArg("--output", "json").Return(mockCommandBuilder)
-		mockCommandBuilder.EXPECT().AddPositional(diskPath).Return(mockCommandBuilder)
-		mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
-		mockCommandExecutor.EXPECT().SetStdout(gomock.Any()).Do(func(w io.Writer) {
-			_, _ = w.Write([]byte(`{"format":"` + format + `"}`))
-		})
-		mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
-		mockCommandExecutor.EXPECT().Run().Return(nil)
-	}
-
 	expectQemuImgCreate := func(diskPath, overlayPath string) {
-		expectQemuImgInfo(diskPath, "raw")
 		mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
 		mockCommandBuilder.EXPECT().AddPositional("create").Return(mockCommandBuilder)
 		mockCommandBuilder.EXPECT().AddArg("-f", "qcow2").Return(mockCommandBuilder)
@@ -129,8 +114,7 @@ var _ = Describe("Overlay", func() {
 
 			expectQemuImgCreate("/dev/block0", linkA+".qcow2")
 
-			// Second disk: info succeeds but create fails
-			expectQemuImgInfo("/dev/block1", "raw")
+			// Second disk: create fails
 			mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddPositional("create").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-f", "qcow2").Return(mockCommandBuilder)
@@ -287,8 +271,7 @@ var _ = Describe("Overlay", func() {
 			linkPath := setupSingleDisk()
 			overlayPath := linkPath + ".qcow2"
 
-			// info succeeds but qemu-img create fails
-			expectQemuImgInfo("/dev/block0", "raw")
+			// qemu-img create fails
 			mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddPositional("create").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-f", "qcow2").Return(mockCommandBuilder)

--- a/pkg/virt-v2v/conversion/overlay_test.go
+++ b/pkg/virt-v2v/conversion/overlay_test.go
@@ -1,0 +1,314 @@
+package conversion
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
+	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("Overlay", func() {
+	var conversion *Conversion
+	var mockCtrl *gomock.Controller
+	var mockCommandExecutor *utils.MockCommandExecutor
+	var mockCommandBuilder *utils.MockCommandBuilder
+	var appConfig *config.AppConfig
+	var workdir string
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockCommandExecutor = utils.NewMockCommandExecutor(mockCtrl)
+		mockCommandBuilder = utils.NewMockCommandBuilder(mockCtrl)
+
+		workdir = GinkgoT().TempDir()
+		appConfig = &config.AppConfig{
+			Workdir: workdir,
+		}
+		conversion = &Conversion{
+			AppConfig:      appConfig,
+			CommandBuilder: mockCommandBuilder,
+		}
+	})
+
+	setupSingleDisk := func() string {
+		linkPath := filepath.Join(workdir, "vm-sda")
+		Expect(os.Symlink("/dev/block0", linkPath)).To(Succeed())
+		conversion.Disks = []*Disk{
+			{Path: "/dev/block0", Link: linkPath},
+		}
+		return linkPath
+	}
+
+	setupTwoDisks := func() (string, string) {
+		linkA := filepath.Join(workdir, "vm-sda")
+		linkB := filepath.Join(workdir, "vm-sdb")
+		Expect(os.Symlink("/dev/block0", linkA)).To(Succeed())
+		Expect(os.Symlink("/dev/block1", linkB)).To(Succeed())
+		conversion.Disks = []*Disk{
+			{Path: "/dev/block0", Link: linkA},
+			{Path: "/dev/block1", Link: linkB},
+		}
+		return linkA, linkB
+	}
+
+	expectQemuImgInfo := func(diskPath, format string) {
+		mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddPositional("info").Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddArg("--output", "json").Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddPositional(diskPath).Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+		mockCommandExecutor.EXPECT().SetStdout(gomock.Any()).Do(func(w io.Writer) {
+			_, _ = w.Write([]byte(`{"format":"` + format + `"}`))
+		})
+		mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+		mockCommandExecutor.EXPECT().Run().Return(nil)
+	}
+
+	expectQemuImgCreate := func(diskPath, overlayPath string) {
+		expectQemuImgInfo(diskPath, "raw")
+		mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddPositional("create").Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddArg("-f", "qcow2").Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddArg("-b", diskPath).Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddArg("-F", "raw").Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddPositional(overlayPath).Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+		mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+		mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+		mockCommandExecutor.EXPECT().Run().Return(nil)
+	}
+
+	expectQemuImgCommit := func(overlayPath string) {
+		mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddPositional("commit").Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().AddPositional(overlayPath).Return(mockCommandBuilder)
+		mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+		mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+		mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+		mockCommandExecutor.EXPECT().Run().Return(nil)
+	}
+
+	Describe("CreateOverlays", func() {
+		It("creates overlay and rewires symlink for a single disk", func() {
+			linkPath := setupSingleDisk()
+			overlayPath := linkPath + ".qcow2"
+
+			expectQemuImgCreate("/dev/block0", overlayPath)
+
+			overlays, err := conversion.CreateOverlays()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overlays).To(HaveLen(1))
+			Expect(overlays[0].Path).To(Equal(overlayPath))
+			Expect(overlays[0].BackingPath).To(Equal("/dev/block0"))
+			Expect(overlays[0].OriginalLink).To(Equal("/dev/block0"))
+
+			target, err := os.Readlink(linkPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target).To(Equal(overlayPath))
+		})
+
+		It("creates overlays for multiple disks", func() {
+			linkA, linkB := setupTwoDisks()
+
+			expectQemuImgCreate("/dev/block0", linkA+".qcow2")
+			expectQemuImgCreate("/dev/block1", linkB+".qcow2")
+
+			overlays, err := conversion.CreateOverlays()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overlays).To(HaveLen(2))
+		})
+
+		It("cleans up earlier overlays when a later create fails", func() {
+			linkA, linkB := setupTwoDisks()
+
+			expectQemuImgCreate("/dev/block0", linkA+".qcow2")
+
+			// Second disk: info succeeds but create fails
+			expectQemuImgInfo("/dev/block1", "raw")
+			mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("create").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-f", "qcow2").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-b", "/dev/block1").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-F", "raw").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional(linkB + ".qcow2").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run().Return(errors.New("qemu-img failed"))
+
+			_, err := conversion.CreateOverlays()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create overlay for /dev/block1"))
+		})
+
+		It("handles empty disk list", func() {
+			conversion.Disks = []*Disk{}
+
+			overlays, err := conversion.CreateOverlays()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overlays).To(BeEmpty())
+		})
+	})
+
+	Describe("CommitOverlays", func() {
+		It("commits overlay and restores symlink", func() {
+			linkPath := setupSingleDisk()
+			overlayPath := linkPath + ".qcow2"
+
+			// Create a dummy overlay file so Remove can find it
+			Expect(os.WriteFile(overlayPath, []byte("fake"), 0644)).To(Succeed())
+
+			// Rewire the symlink as CreateOverlays would
+			Expect(os.Remove(linkPath)).To(Succeed())
+			Expect(os.Symlink(overlayPath, linkPath)).To(Succeed())
+
+			overlays := []*Overlay{{
+				Path:         overlayPath,
+				BackingPath:  "/dev/block0",
+				Disk:         conversion.Disks[0],
+				OriginalLink: "/dev/block0",
+			}}
+
+			expectQemuImgCommit(overlayPath)
+
+			err := conversion.CommitOverlays(overlays)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Overlay file should be removed
+			_, err = os.Stat(overlayPath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+
+			// Symlink should be restored to original
+			target, err := os.Readlink(linkPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target).To(Equal("/dev/block0"))
+		})
+
+		It("returns error when qemu-img commit fails", func() {
+			linkPath := setupSingleDisk()
+			overlayPath := linkPath + ".qcow2"
+
+			overlays := []*Overlay{{
+				Path:         overlayPath,
+				BackingPath:  "/dev/block0",
+				Disk:         conversion.Disks[0],
+				OriginalLink: "/dev/block0",
+			}}
+
+			mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("commit").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional(overlayPath).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run().Return(errors.New("commit failed"))
+
+			err := conversion.CommitOverlays(overlays)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to commit overlay"))
+		})
+	})
+
+	Describe("DiscardOverlays", func() {
+		It("removes overlay files and restores symlinks", func() {
+			linkPath := setupSingleDisk()
+			overlayPath := linkPath + ".qcow2"
+
+			Expect(os.WriteFile(overlayPath, []byte("fake"), 0644)).To(Succeed())
+
+			// Rewire symlink as CreateOverlays would
+			Expect(os.Remove(linkPath)).To(Succeed())
+			Expect(os.Symlink(overlayPath, linkPath)).To(Succeed())
+
+			overlays := []*Overlay{{
+				Path:         overlayPath,
+				BackingPath:  "/dev/block0",
+				Disk:         conversion.Disks[0],
+				OriginalLink: "/dev/block0",
+			}}
+
+			conversion.DiscardOverlays(overlays)
+
+			// Overlay file should be removed
+			_, err := os.Stat(overlayPath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+
+			// Symlink should be restored to original
+			target, err := os.Readlink(linkPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target).To(Equal("/dev/block0"))
+		})
+	})
+
+	Describe("RunInPlaceWithOverlay", func() {
+		It("commits overlays on successful conversion", func() {
+			linkPath := setupSingleDisk()
+			overlayPath := linkPath + ".qcow2"
+
+			expectQemuImgCreate("/dev/block0", overlayPath)
+			expectQemuImgCommit(overlayPath)
+
+			called := false
+			err := conversion.RunInPlaceWithOverlay(func() error {
+				called = true
+				return nil
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(called).To(BeTrue())
+		})
+
+		It("discards overlays on conversion failure", func() {
+			linkPath := setupSingleDisk()
+			overlayPath := linkPath + ".qcow2"
+
+			expectQemuImgCreate("/dev/block0", overlayPath)
+
+			convErr := errors.New("simulated virt-v2v failure")
+			err := conversion.RunInPlaceWithOverlay(func() error {
+				return convErr
+			})
+
+			Expect(err).To(Equal(convErr))
+
+			// Verify symlink was restored to original target
+			target, err := os.Readlink(linkPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(target).To(Equal("/dev/block0"))
+		})
+
+		It("returns error when overlay setup fails", func() {
+			linkPath := setupSingleDisk()
+			overlayPath := linkPath + ".qcow2"
+
+			// info succeeds but qemu-img create fails
+			expectQemuImgInfo("/dev/block0", "raw")
+			mockCommandBuilder.EXPECT().New("qemu-img").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("create").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-f", "qcow2").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-b", "/dev/block0").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-F", "raw").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional(overlayPath).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
+			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
+			mockCommandExecutor.EXPECT().SetStderr(os.Stderr)
+			mockCommandExecutor.EXPECT().Run().Return(errors.New("no space"))
+
+			called := false
+			err := conversion.RunInPlaceWithOverlay(func() error {
+				called = true
+				return nil
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("overlay setup failed"))
+			Expect(called).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Before running virt-v2v-in-place, create a qcow2 overlay per disk backed by the original. The conversion writes only to the overlay. On success, qemu-img commit merges changes back to the base disk. On failure, the overlay is discarded and the base disk is untouched, enabling safe retry.

The overlay is always active for in-place conversions (no opt-out flag). The domain XML driver type is set to qcow2 to match the overlay format.

Ref: https://redhat.atlassian.net/browse/MTV-5644
Resolves: MTV-5644