### PR TITLE
MTV-4498 | Allow controller to read CSIStorageCapacity

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -10554,6 +10554,7 @@ rules:
   resources:
   - storageclasses
   - csidrivers
+  - csistoragecapacities
   verbs:
   - get
   - list

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -10554,6 +10554,7 @@ rules:
   resources:
   - storageclasses
   - csidrivers
+  - csistoragecapacities
   verbs:
   - get
   - list

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -79,6 +79,7 @@ rules:
   resources:
   - storageclasses
   - csidrivers
+  - csistoragecapacities
   verbs:
   - get
   - list


### PR DESCRIPTION
## Summary
- Add RBAC for `csistoragecapacities.storage.k8s.io` to the forklift-controller ClusterRole so temp storage capacity validation can run without RBAC forbidden errors.

## Test plan
- `go test ./pkg/controller/plan -count=1`

Ref: https://redhat.atlassian.net/browse/MTV-4498
Resolves: MTV-4498

Made with [Cursor](https://cursor.com)