### PR TITLE
MTV-5529 | Rework reusing of DI conversion CRs

### DIFF
--- a/docs/conversion-cr.md
+++ b/docs/conversion-cr.md
@@ -48,12 +48,10 @@ The conversion controller communicates with the deep-inspection pod over a plain
 
 ### Endpoints
 
-
 | Endpoint   | Method | Description                                                                                                                       |
 | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | `/ready`   | GET    | Returns `200 OK` when detection is complete and results are ready to serve. Returns non-200 otherwise.                            |
 | `/results` | GET    | Returns `200 OK` + JSON body with the full inspection result. Returns `503 Service Unavailable` while detection is still running. |
-
 
 ### Communication flow
 
@@ -169,25 +167,73 @@ The Plan controller creates `Inspection`, `InPlace`, and `Remote` Conversion CRs
 
 ### 2. Plan + DeepInspection path (warm migration preflight)
 
-When `UseConversionCR` is enabled and the plan is a warm vSphere migration, the Plan controller creates a `DeepInspection` Conversion CR during the `PreflightInspection` step. The controller:
+When `UseConversionCR` is enabled and the plan is a warm vSphere migration, the Plan controller drives the `PreflightInspection` step through a **two phase lookup** that can reuse a compatible standalone CR before falling back to a plan owned one.
 
-1. Copies the source provider credentials + URL into a connection secret in `TargetNamespace`.
-2. Optionally copies the LUKS passphrase secret into `TargetNamespace`.
-3. Creates the Conversion CR pointing at the warm snapshot MoRef via `spec.settings.SNAPSHOT_MOREF`.
-4. Waits for `PhaseSucceeded`, propagates `InspectionResult.Concerns` to the migration step.
+#### Compatibility check
 
-On failure one automatic retry is attempted. The `retryAllowed` label on the CR controls this:
+Before a standalone CR can be reused, it must have been built with settings that produce equivalent inspection results. Two fields are checked:
 
+| Field                   | Why it matters                                                                                        |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| `spec.diskEncryption.type` | Must match what the plan would configure (`LUKS`, `Clevis`, or none). A mismatch means the pod cannot read the disk and the results are from an incompatible access path. |
+| `spec.xfsCompatibility` | Selects a different container image (`DeepInspectionImageXFS` vs. the standard image). Results from a non-XFS image cannot substitute for an XFS-compat run, or vice versa. |
 
-| Label value        | Behaviour on failure                               |
-| ------------------ | -------------------------------------------------- |
-| absent or `"true"` | CR deleted and recreated with `retryAllowed=false` |
-| `"false"`          | Step is immediately failed                         |
+CRs that fail either check are silently skipped, they will not be deleted or modified.
 
+#### Phase 1 - plan-owned CR (plan UID label set)
+
+The controller first checks for a CR that already has `plan=<planUID>`. This CR is present when the plan previously started a DI run for this VM (either directly created in Phase 3, or promoted from a failed standalone in Phase 2).
+
+| CR state            | Action                                                                                        |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `Succeeded`         | Propagate `InspectionResult.Concerns` to the migration step. Advance on no critical concerns. |
+| `Running`/`Pending` | Wait, requeue.                                                                                |
+| `Failed`/`Canceled` | Fail the migration step immediately. No further retries.                                      |
+| None found          | Fall through to Phase 2.                                                                      |
+
+#### Phase 2 - standalone CR (no plan label, compatible settings)
+
+If no plan owned CR exists, the controller searches for `DeepInspection` CRs that have **no** `plan` label and whose `diskEncryption.type` and `xfsCompatibility` match the plan. If more than one exists, the most actionable is chosen: Succeeded > Running/Pending > Failed.
+
+| CR state            | Action                                                                                        |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `Succeeded`         | Propagate `InspectionResult.Concerns` to the migration step. Advance on no critical concerns. |
+| `Running`/`Pending` | Wait; requeue.                                                                                |
+| `Failed`/`Canceled` | Delete the standalone CR, then fall through to Phase 3 to create the plan owned CR.          |
+| None found          | Fall through to Phase 3.                                                                      |
+
+The standalone CR is deleted before Phase 3 creates the replacement because `ensureConversion` performs a plan label-agnostic lookup: without deletion it would update the `Failed` CR in place, leaving the conversion controller with no reason to re-run its pipeline.
+
+#### Phase 3 - create plan-owned CR
+
+No existing CR of either kind was found. The controller creates the first plan owned CR (copies credentials, optionally the LUKS passphrase secret, sets `SNAPSHOT_MOREF`) and requeues. Phase 1 handles the CR from the next reconcile onward.
+
+#### Full decision flow
+
+```
+PhasePreflightInspection
+│
+├─ Phase 1: find plan owned CR (plan=<UID>, compatible settings)
+│   ├─ Succeeded  ──► propagate concerns - advance (or fail on critical)
+│   ├─ Running    ──► wait
+│   ├─ Failed     ──► fail migration step (no retry)
+│   └─ none found ──► Phase 2
+│
+├─ Phase 2: find standalone CR (no plan label, compatible settings)
+│   ├─ Succeeded  ──► propagate concerns - advance (or fail on critical)
+│   ├─ Running    ──► wait
+│   ├─ Failed     ──► delete standalone CR ──► Phase 3
+│   └─ none found ──► Phase 3
+│
+└─ Phase 3: create plan owned CR
+    └─ wait (Phase 1 handles Succeeded / Running / Failed next reconcile)
+```
 
 ### 3. Standalone path
 
 Any `Conversion` CR created directly (without a Plan) is reconciled identically. The user is responsible for providing all required fields.
+
+A standalone `DeepInspection` CR created before a plan runs can be **reused by the plan** provided it has no `plan` label and its `spec.diskEncryption.type` and `spec.xfsCompatibility` match what the plan would create. See Phase 2 above.
 
 ---
 
@@ -195,16 +241,13 @@ Any `Conversion` CR created directly (without a Plan) is reconciled identically.
 
 ### Required fields (all types)
 
-
 | Field                    | Description                                              |
 | ------------------------ | -------------------------------------------------------- |
 | `spec.type`              | `DeepInspection`, `Inspection`, `InPlace`, or `Remote`   |
 | `spec.vm.id`             | vSphere managed object ID of the source VM               |
 | `spec.connection.secret` | Reference to the credentials secret (see per-type notes) |
 
-
 ### Optional fields
-
 
 | Field                                         | Description                                                                                                                                                                                                                 |
 | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -222,7 +265,6 @@ Any `Conversion` CR created directly (without a Plan) is reconciled identically.
 | `spec.podSettings.affinity`                   | Pod affinity/anti-affinity rules.                                                                                                                                                                                           |
 | `spec.podSettings.transferNetworkAnnotations` | Network annotations copied to the pod.                                                                                                                                                                                      |
 
-
 ---
 
 ## Resource placement
@@ -231,31 +273,25 @@ Every resource associated with a Conversion CR has a specific namespace and clus
 
 ### Conversion CR
 
-
 | Resource      | Namespace                                                | Cluster            |
 | ------------- | -------------------------------------------------------- | ------------------ |
 | Conversion CR | `Plan.Namespace` (plan path) or user-chosen (standalone) | management cluster |
-
 
 The Conversion CR lives on the **management cluster** alongside the Plan. The controller that reconciles it also runs there.
 
 ### Conversion pod
 
-
 | Resource       | Namespace                                         | Cluster                                                                    |
 | -------------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
 | Conversion pod | `spec.targetNamespace` (defaults to CR namespace) | destination cluster (`spec.destination`, or management cluster if omitted) |
-
 
 The pod is scheduled on the **destination cluster** in `spec.targetNamespace`. When `spec.destination` is empty the management cluster is used as destination.
 
 ### Connection secret
 
-
 | Resource          | Namespace                                       | Cluster             |
 | ----------------- | ----------------------------------------------- | ------------------- |
 | Connection secret | same as conversion pod (`spec.targetNamespace`) | destination cluster |
-
 
 The connection secret is mounted at `/etc/secret` inside the pod. Because a pod can only mount secrets from its **own namespace on its own cluster**, the secret must live in `spec.targetNamespace` on the destination cluster.
 
@@ -263,22 +299,18 @@ In the plan path the controller copies the source-provider credentials (includin
 
 ### LUKS passphrase secret
 
-
 | Resource             | Namespace                               | Cluster             |
 | -------------------- | --------------------------------------- | ------------------- |
 | LUKS secret (source) | `vm.LUKS.Namespace` or `Plan.Namespace` | management cluster  |
 | LUKS secret (copy)   | `spec.targetNamespace`                  | destination cluster |
 
-
 The original LUKS secret lives on the management cluster in the plan namespace. Because the conversion pod cannot reach across clusters or namespaces to mount a secret, the plan controller **copies** the secret into `spec.targetNamespace` on the destination cluster. `spec.diskEncryption.secret` always references this copy; the copy is mounted at `/etc/luks` inside the pod.
 
 ### PVCs (InPlace / Remote)
 
-
 | Resource | Namespace              | Cluster             |
 | -------- | ---------------------- | ------------------- |
 | PVCs     | `spec.targetNamespace` | destination cluster |
-
 
 Disks are represented as PVCs on the destination cluster. `spec.disks` entries reference them by name and namespace; the controller mounts them as block devices or filesystem volumes into the conversion pod.
 
@@ -299,7 +331,6 @@ Source LUKS secret ──copy──►          LUKS secret copy  (spec.targetNa
 
 The secret referenced by `spec.connection.secret` is mounted at `/etc/secret` inside the pod and also injected as `V2V_`-prefixed environment variables.
 
-
 | Key                  | Required by                             | Description                         |
 | -------------------- | --------------------------------------- | ----------------------------------- |
 | `user`               | all                                     | Source username                     |
@@ -307,7 +338,6 @@ The secret referenced by `spec.connection.secret` is mounted at `/etc/secret` in
 | `url`                | `DeepInspection`                        | vSphere SDK endpoint URL            |
 | `fingerprint`        | `DeepInspection` (insecure skip-verify) | TLS fingerprint of the vSphere host |
 | `insecureSkipVerify` | optional                                | Skip TLS certificate verification   |
-
 
 For virt-v2v types the Plan controller supplies the secret; for standalone `DeepInspection` the user must populate all keys.
 
@@ -507,7 +537,6 @@ spec:
 
 ## Status fields
 
-
 | Field                     | Description                                                                    |
 | ------------------------- | ------------------------------------------------------------------------------ |
 | `status.phase`            | `Pending`, `Running`, `Succeeded`, `Failed`, `Canceled`                        |
@@ -518,7 +547,6 @@ spec:
 | `status.snapshot`         | vSphere snapshot tracking (MoRef, task IDs, ownership flag)                    |
 | `status.inspectionResult` | Deep-inspection outcome: `passed`, OS info, concerns, filesystems, mountpoints |
 | `status.conditions`       | Standard Kubernetes conditions set by validation and the pipeline              |
-
 
 ### Inspection concerns
 
@@ -542,4 +570,3 @@ status:
         label: Non-migrateable fstab entries
         message: "Fstab contains /dev/disk/by-path/ entries which are not migrateable. Found device: /dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:1:0-part1 mounted at: /home/..."
 ```
-

--- a/pkg/controller/conversion/builder.go
+++ b/pkg/controller/conversion/builder.go
@@ -182,7 +182,7 @@ func (b *Builder) GetVirtV2vPodSpec(vm *plan.VMStatus, volumes []core.Volume, vo
 			Containers: []core.Container{
 				{
 					Env:             nil, // set by type-specific builder
-					ImagePullPolicy: core.PullAlways,
+					ImagePullPolicy: core.PullIfNotPresent,
 					Resources: core.ResourceRequirements{
 						Requests: core.ResourceList{
 							core.ResourceCPU:    resource.MustParse(Settings.Migration.VirtV2vContainerRequestsCpu),
@@ -354,7 +354,7 @@ func (b *Builder) GetDeepInspectionPodSpec(volumes []core.Volume, volumeMounts [
 				{
 					Name:            "deep-inspection",
 					Image:           img,
-					ImagePullPolicy: core.PullAlways,
+					ImagePullPolicy: core.PullIfNotPresent,
 					Resources: core.ResourceRequirements{
 						Requests: core.ResourceList{
 							core.ResourceCPU:    resource.MustParse("100m"),

--- a/pkg/controller/conversion/context/doc.go
+++ b/pkg/controller/conversion/context/doc.go
@@ -27,11 +27,6 @@ const (
 	LabelPlanNamespace  = "plan-namespace"
 	LabelMigration      = "migration"
 	LabelVM             = "vmID"
-	// LabelRetryAllowed controls whether a failed/canceled DeepInspection Conversion CR may be retried during preflight inspection.
-	// "true": one retry is allowed, the replacement CR will be stamped "false".
-	// "false": no further retries, the step is immediately failed.
-	// absent: treated the same as "true" (one retry allowed).
-	LabelRetryAllowed = "retryAllowed"
 )
 
 // VddkVolumeName is the volume name used for the VDDK library scratch space.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -582,20 +582,11 @@ func (r *KubeVirt) buildConversion(planName, vmID string, labels map[string]stri
 }
 
 // ensureConversion creates or updates the Conversion CR on the cluster.
-// An existing CR is found by matching all labels except LabelPlan (which
-// changes when a plan is re-created). When found its Spec and Labels are
-// refreshed; otherwise the provided CR is created verbatim.
 func (r *KubeVirt) ensureConversion(cr *api.Conversion) (*api.Conversion, error) {
-	lookupLabels := make(map[string]string, len(cr.Labels))
-	for k, v := range cr.Labels {
-		if k != convctx.LabelPlan {
-			lookupLabels[k] = v
-		}
-	}
 	list := &api.ConversionList{}
 	if err := r.Client.List(context.TODO(), list,
 		client.InNamespace(cr.Namespace),
-		client.MatchingLabels(lookupLabels),
+		client.MatchingLabels(cr.Labels),
 	); err != nil {
 		return nil, liberr.Wrap(err)
 	}
@@ -697,7 +688,7 @@ func (r *KubeVirt) GetStandaloneDeepInspectionConversion(vm *plan.VMStatus) (*ap
 	}
 
 	// Filter to CRs whose settings are compatible with what the plan would create,
-	// then return the most actionable one by phase.
+	// then return the most actionable one by phase priority (e.g. Success>Running>Failed...).
 	var matching []api.Conversion
 	for i := range list.Items {
 		if deepInspectionMatchesPlan(&list.Items[i], vm, r.Plan.Spec.XfsCompatibility) {
@@ -773,13 +764,9 @@ func bestConversionByPhase(items []api.Conversion) *api.Conversion {
 	}
 }
 
-// CreateDeepInspectionConversion creates a new DeepInspection Conversion CR and
-// returns it. retryAllowed controls the value of the LabelRetryAllowed label
-// stamped on the new CR: "true" permits one future retry on failure; "false"
-// makes the next failure permanent.
-func (r *KubeVirt) CreateDeepInspectionConversion(
-	vm *plan.VMStatus, snapshotMoref, planName, planID string,
-) (*api.Conversion, error) {
+// CreateDeepInspectionConversion creates a new DeepInspection Conversion CR
+// owned by the given plan and returns it.
+func (r *KubeVirt) CreateDeepInspectionConversion(vm *plan.VMStatus, snapshotMoref, planName, planID string) (*api.Conversion, error) {
 	// Connection secret goes to Plan.Namespace on the management cluster
 	// (DeepInspection pods run there, not on the destination cluster).
 	connSecretData := r.buildDeepInspectionConnectionSecretData()
@@ -833,7 +820,6 @@ func (r *KubeVirt) CreateDeepInspectionConversion(
 		}
 	}
 
-	// Empty Destination → resolveDestinationClient returns localClient →
 	// pod is created on the management cluster in Plan.Namespace.
 	crLabels := r.getConversionLabels(api.DeepInspection, vm.ID, planID, nil)
 	spec := api.ConversionSpec{

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -680,7 +680,7 @@ func (r *KubeVirt) GetStandaloneDeepInspectionConversion(vm *plan.VMStatus) (*ap
 	sel := k8slabels.NewSelector().Add(*vmReq, *typeReq, *noPlanReq)
 
 	list := &api.ConversionList{}
-	if err = r.Client.List(context.TODO(), list,
+	if err = r.List(context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabelsSelector{Selector: sel},
 	); err != nil {

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -659,6 +659,37 @@ func (r *KubeVirt) ensureConversionSecret(cl client.Client, secret *core.Secret)
 	return secret, nil
 }
 
+// GetGuestConversion returns the guest-conversion (Remote or InPlace) Conversion CR
+// for the given VM on this plan, or nil when none exists.
+func (r *KubeVirt) GetGuestConversion(vm *plan.VMStatus) (*api.Conversion, error) {
+	typeReq, err := k8slabels.NewRequirement(
+		convctx.LabelConversionType,
+		selection.In,
+		[]string{string(api.Remote), string(api.InPlace)},
+	)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+
+	selector := k8slabels.SelectorFromSet(map[string]string{
+		convctx.LabelPlan: string(r.Plan.UID),
+		convctx.LabelVM:   vm.ID,
+	}).Add(*typeReq)
+
+	list := &api.ConversionList{}
+	if err = r.List(context.TODO(), list,
+		client.InNamespace(r.Plan.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
+	}
+
+	return nil, nil //nolint:nilnil
+}
+
 // GetStandaloneDeepInspectionConversion returns the most relevant DeepInspection
 // Conversion CR for the given VM that has no plan label (created outside any plan)
 // and whose settings are compatible with what this plan would create

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -668,42 +668,6 @@ func (r *KubeVirt) ensureConversionSecret(cl client.Client, secret *core.Secret)
 	return secret, nil
 }
 
-// GetGuestConversion returns the guest-conversion (Remote or InPlace) Conversion CR
-// for the given VM on this plan, or nil when none exists.
-func (r *KubeVirt) GetGuestConversion(vm *plan.VMStatus) (*api.Conversion, error) {
-	typeReq, err := k8slabels.NewRequirement(
-		convctx.LabelConversionType,
-		selection.In,
-		[]string{string(api.Remote), string(api.InPlace)},
-	)
-	if err != nil {
-		return nil, liberr.Wrap(err)
-	}
-	selector := k8slabels.SelectorFromSet(map[string]string{
-		convctx.LabelPlan: string(r.Plan.UID),
-		convctx.LabelVM:   vm.ID,
-	}).Add(*typeReq)
-
-	list := &api.ConversionList{}
-	if err := r.List(context.TODO(), list,
-		client.InNamespace(r.Plan.Namespace),
-		client.MatchingLabelsSelector{Selector: selector},
-	); err != nil {
-		return nil, liberr.Wrap(err)
-	}
-	if len(list.Items) > 0 {
-		return &list.Items[0], nil
-	}
-	return nil, nil //nolint:nilnil
-}
-
-// GetDeepInspectionConversion returns the DeepInspection Conversion CR for the
-// given VM, or nil when none exists.
-func (r *KubeVirt) GetDeepInspectionConversion(vm *plan.VMStatus) (*api.Conversion, error) {
-	labels := r.getConversionLabels(api.DeepInspection, vm.ID, "", nil)
-	return r.getConversion(labels)
-}
-
 // GetStandaloneDeepInspectionConversion returns the most relevant DeepInspection
 // Conversion CR for the given VM that has no plan label (created outside any plan)
 // and whose settings are compatible with what this plan would create
@@ -763,7 +727,7 @@ func vmDiskEncType(vm *plan.VMStatus) api.DiskEncryptionType {
 
 // deepInspectionMatchesPlan reports whether the Conversion CR is compatible with
 // what the plan would create for the given VM. Two fields affect this:
-//   - DiskEncryption.Type: a CR without dsik encryption can't be used for CR with disk encryption set and vice versa,
+//   - DiskEncryption.Type: a CR without disk encryption can't be used for CR with disk encryption set and vice versa,
 //     e.g. the pod would fail to access the disk.
 //   - XfsCompatibility: selects the XFS compatible deep-inspection image variant,
 //     e.g. CR built without XFS compat cannot substitute for one that needs it.
@@ -814,13 +778,8 @@ func bestConversionByPhase(items []api.Conversion) *api.Conversion {
 // stamped on the new CR: "true" permits one future retry on failure; "false"
 // makes the next failure permanent.
 func (r *KubeVirt) CreateDeepInspectionConversion(
-	vm *plan.VMStatus, snapshotMoref, planName, planID string, retryAllowed bool,
+	vm *plan.VMStatus, snapshotMoref, planName, planID string,
 ) (*api.Conversion, error) {
-	retryValue := "false"
-	if retryAllowed {
-		retryValue = "true"
-	}
-
 	// Connection secret goes to Plan.Namespace on the management cluster
 	// (DeepInspection pods run there, not on the destination cluster).
 	connSecretData := r.buildDeepInspectionConnectionSecretData()
@@ -876,8 +835,7 @@ func (r *KubeVirt) CreateDeepInspectionConversion(
 
 	// Empty Destination → resolveDestinationClient returns localClient →
 	// pod is created on the management cluster in Plan.Namespace.
-	crLabels := r.getConversionLabels(api.DeepInspection, vm.ID, planID,
-		map[string]string{convctx.LabelRetryAllowed: retryValue})
+	crLabels := r.getConversionLabels(api.DeepInspection, vm.ID, planID, nil)
 	spec := api.ConversionSpec{
 		Type:            api.DeepInspection,
 		TargetNamespace: r.Plan.Namespace,

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -704,6 +704,111 @@ func (r *KubeVirt) GetDeepInspectionConversion(vm *plan.VMStatus) (*api.Conversi
 	return r.getConversion(labels)
 }
 
+// GetStandaloneDeepInspectionConversion returns the most relevant DeepInspection
+// Conversion CR for the given VM that has no plan label (created outside any plan)
+// and whose settings are compatible with what this plan would create
+// (e.g. same disk encryption type). Phase priority: Succeeded > Running/Pending > Failed.
+// Returns nil when no matching CR exists.
+func (r *KubeVirt) GetStandaloneDeepInspectionConversion(vm *plan.VMStatus) (*api.Conversion, error) {
+	vmReq, err := k8slabels.NewRequirement(convctx.LabelVM, selection.Equals, []string{vm.ID})
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	typeReq, err := k8slabels.NewRequirement(convctx.LabelConversionType, selection.Equals, []string{string(api.DeepInspection)})
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	noPlanReq, err := k8slabels.NewRequirement(convctx.LabelPlan, selection.DoesNotExist, nil)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	sel := k8slabels.NewSelector().Add(*vmReq, *typeReq, *noPlanReq)
+
+	list := &api.ConversionList{}
+	if err = r.Client.List(context.TODO(), list,
+		client.InNamespace(r.Plan.Namespace),
+		client.MatchingLabelsSelector{Selector: sel},
+	); err != nil {
+		return nil, liberr.Wrap(err)
+	}
+
+	// Filter to CRs whose settings are compatible with what the plan would create,
+	// then return the most actionable one by phase.
+	var matching []api.Conversion
+	for i := range list.Items {
+		if deepInspectionMatchesPlan(&list.Items[i], vm, r.Plan.Spec.XfsCompatibility) {
+			matching = append(matching, list.Items[i])
+		}
+	}
+	return bestConversionByPhase(matching), nil
+}
+
+// GetPlanDeepInspectionConversion returns the DeepInspection Conversion CR owned
+// by this specific plan for a specific VM. Returns nil when none exists.
+func (r *KubeVirt) GetPlanDeepInspectionConversion(vm *plan.VMStatus) (*api.Conversion, error) {
+	labels := r.getConversionLabels(api.DeepInspection, vm.ID, string(r.Plan.UID), nil)
+	return r.getConversion(labels)
+}
+
+// helper for conversionCR matching rules
+func vmDiskEncType(vm *plan.VMStatus) api.DiskEncryptionType {
+	if vm.NbdeClevis {
+		return api.DiskEncryptionTypeClevis
+	}
+	if vm.LUKS.Name != "" {
+		return api.DiskEncryptionTypeLUKS
+	}
+	return ""
+}
+
+// deepInspectionMatchesPlan reports whether the Conversion CR is compatible with
+// what the plan would create for the given VM. Two fields affect this:
+//   - DiskEncryption.Type: a CR without dsik encryption can't be used for CR with disk encryption set and vice versa,
+//     e.g. the pod would fail to access the disk.
+//   - XfsCompatibility: selects the XFS compatible deep-inspection image variant,
+//     e.g. CR built without XFS compat cannot substitute for one that needs it.
+func deepInspectionMatchesPlan(cr *api.Conversion, vm *plan.VMStatus, xfsCompatibility bool) bool {
+	expected := vmDiskEncType(vm)
+	actual := api.DiskEncryptionType("")
+	if cr.Spec.DiskEncryption != nil {
+		actual = cr.Spec.DiskEncryption.Type
+	}
+	if actual != expected {
+		return false
+	}
+	return cr.Spec.XfsCompatibility == xfsCompatibility
+}
+
+// bestConversionByPhase returns the Conversion from items with prio:
+// Succeeded > Running/Pending > Failed/Canceled/other. Returns nil for empty input.
+func bestConversionByPhase(items []api.Conversion) *api.Conversion {
+	var succeeded, running, other *api.Conversion
+	for i := range items {
+		switch items[i].Status.Phase {
+		case api.PhaseSucceeded:
+			if succeeded == nil {
+				succeeded = &items[i]
+			}
+		case api.PhaseRunning, api.PhasePending:
+			if running == nil {
+				running = &items[i]
+			}
+		default:
+			if other == nil {
+				other = &items[i]
+			}
+		}
+	}
+	switch {
+	case succeeded != nil:
+		return succeeded
+	case running != nil:
+		return running
+	default:
+		return other
+	}
+}
+
 // CreateDeepInspectionConversion creates a new DeepInspection Conversion CR and
 // returns it. retryAllowed controls the value of the LabelRetryAllowed label
 // stamped on the new CR: "true" permits one future retry on failure; "false"

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1665,6 +1665,7 @@ func (r *Migration) handleDeepInspectionCR(vm *plan.VMStatus, step *plan.Step, c
 			if _, err := r.kubevirt.CreateDeepInspectionConversion(
 				vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID),
 			); err != nil {
+				r.Log.Error(err, "Failed to create a new deep inspection conversion CR")
 				step.AddError(err.Error())
 				return
 			}
@@ -1686,6 +1687,7 @@ func (r *Migration) handleDeepInspectionCR(vm *plan.VMStatus, step *plan.Step, c
 			if _, err := r.kubevirt.CreateDeepInspectionConversion(
 				vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID),
 			); err != nil {
+				r.Log.Error(err, "Failed to create a new deep inspection conversion CR")
 				step.AddError(err.Error())
 				return
 			}
@@ -1696,6 +1698,7 @@ func (r *Migration) handleDeepInspectionCR(vm *plan.VMStatus, step *plan.Step, c
 			r.Log.Info("Plan owned deep inspection CR was canceled, deleting",
 				"conversion", cr.Name, "vm", vm.String())
 			if err := r.kubevirt.DeleteConversion(cr); err != nil {
+				r.Log.Error(err, "Failed to create a new deep inspection conversion CR")
 				step.AddError(err.Error())
 				return
 			}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -16,7 +16,6 @@ import (
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
-	convctx "github.com/kubev2v/forklift/pkg/controller/conversion/context"
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter"
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
@@ -1445,73 +1444,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			step.Phase = api.StepRunning
 
 			if settings.Settings.UseConversionCR {
-				snapshotMoref := vm.Warm.Precopies[0].Snapshot
-
-				var cr *api.Conversion
-				cr, err = r.kubevirt.GetDeepInspectionConversion(vm)
-				if err != nil {
-					step.AddError(err.Error())
-					err = nil
-					break
-				}
-
-				if cr == nil {
-					// No CR yet, first attempt
-					// retryAllowed=false means if this one fails it will not be retried automatically.
-					_, err = r.kubevirt.CreateDeepInspectionConversion(
-						vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID), false)
-					if err != nil {
-						step.AddError(err.Error())
-						err = nil
-					}
-					return
-				}
-
-				switch cr.Status.Phase {
-				case api.PhaseSucceeded:
-					// Propagate concerns and advance, failing on blockers.
-					if blockers := r.propagateInspectionConcerns(vm, cr.Status.InspectionResult); len(blockers) > 0 {
-						step.Error = &plan.Error{
-							Reasons: append([]string{"VM deep inspection found critical concerns"}, blockers...),
-							Phase:   step.Phase,
-						}
-						break
-					}
-					r.NextPhase(vm)
-
-				case api.PhaseFailed, api.PhaseCanceled:
-					r.Log.Info("Deep inspection CR failed.",
-						"conversion", cr.Name,
-						"phase", cr.Status.Phase,
-						"vm", vm.String())
-					retryLabel, hasLabel := cr.Labels[convctx.LabelRetryAllowed]
-					// Label present and explicitly false, no more retries.
-					if hasLabel && retryLabel == "false" {
-						step.AddError("Deep inspection failed after retry.")
-						break
-					}
-					// Label missing or set to "true", one retry allowed.
-					// Delete the failed CR and recreate it with retryAllowed=false so
-					// the replacement cannot trigger another retry.
-					if err = r.kubevirt.DeleteConversion(cr); err != nil {
-						step.AddError(err.Error())
-						err = nil
-						break
-					}
-					_, err = r.kubevirt.CreateDeepInspectionConversion(
-						vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID), false)
-					if err != nil {
-						step.AddError(err.Error())
-						err = nil
-					}
-					return
-
-				default:
-					// Pending/Running, still in progress.
-					r.Log.Info("Deep inspection CR is still in progress.",
-						"conversion", cr.Name,
-						"phase", cr.Status.Phase,
-						"vm", vm.String())
+				if r.runPreflightDeepInspection(vm, step) {
 					return
 				}
 				break
@@ -1622,6 +1555,121 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			})
 	}
 
+	return
+}
+
+// runPreflightDeepInspection drives the UseConversionCR path of
+// PhasePreflightInspection through three phases:
+//
+//	Phase 1 - look up an existing plan owned CR.
+//	          Found - jump straight to Phase 3.
+//	          Not found - fall through to Phase 2.
+//	Phase 2 - look for a compatible standalone CR (no plan label).
+//	          Succeeded - propagate concerns and advance the step.
+//	          Failed/Canceled - delete the CR, then create a plan owned one and requeue.
+//	          Running/Pending - wait (requeue).
+//	          Not found - create a plan owned CR and requeue.
+//	Phase 3 - evaluate the plan owned CR.
+//	          Succeeded - propagate concerns and advance the step.
+//	          Failed/Canceled - fail the migration step (no retry).
+//	          Running/Pending - wait (requeue).
+//
+// Returns true when the reconcile should requeue (CR still in progress or just
+// created). Returns false when the step has been settled - either advanced to
+// the next phase via NextPhase or failed via step.AddError.
+// All errors are consumed internally and recorded on the step, the caller never
+// receives a non-nil error from this method.
+func (r *Migration) runPreflightDeepInspection(vm *plan.VMStatus, step *plan.Step) (requeue bool) {
+	snapshotMoref := vm.Warm.Precopies[0].Snapshot
+
+	// phase 1: look up an existing plan owned CR (created by a previous
+	// reconcile or promoted from a failed standalone)
+	planCR, err := r.kubevirt.GetPlanDeepInspectionConversion(vm)
+	if err != nil {
+		step.AddError(err.Error())
+		return
+	}
+	if planCR != nil {
+		// Plan owned CR already exists, skip Phase 2 and evaluate it di CR
+		return r.handlePlanDeepInspectionCR(vm, step, planCR)
+	}
+
+	// Phase 2: no plan owned CR so look for a compatible standalone CR (no plan label, matching disk encryption type and XFS compatibility).
+	// Mismatched CRs are silently skipped.
+	standaloneCR, err := r.kubevirt.GetStandaloneDeepInspectionConversion(vm)
+	if err != nil {
+		step.AddError(err.Error())
+		return
+	}
+	if standaloneCR != nil {
+		switch standaloneCR.Status.Phase {
+		case api.PhaseSucceeded:
+			r.Log.Info("Reusing succeeded standalone deep inspection CR.",
+				"conversion", standaloneCR.Name, "vm", vm.String())
+			if blockers := r.propagateInspectionConcerns(vm, standaloneCR.Status.InspectionResult); len(blockers) > 0 {
+				step.Error = &plan.Error{
+					Reasons: append([]string{"VM deep inspection found critical concerns"}, blockers...),
+					Phase:   step.Phase,
+				}
+				return
+			}
+			r.NextPhase(vm)
+			return
+		case api.PhaseFailed, api.PhaseCanceled:
+			// Delete the standalone CR so the plan owned CR created below
+			// starts fresh rather than updating the failed resource.
+			// After it's deleted, continue to create a plan owned CR.
+			r.Log.Info("Found failed standalone deep inspection CR, retrying with plan owned inspection CR.",
+				"conversion", standaloneCR.Name, "phase", standaloneCR.Status.Phase, "vm", vm.String())
+			if err = r.kubevirt.DeleteConversion(standaloneCR); err != nil {
+				step.AddError(err.Error())
+				return
+			}
+		default:
+			r.Log.Info("Standalone deep inspection CR still in progress.",
+				"conversion", standaloneCR.Name, "phase", standaloneCR.Status.Phase, "vm", vm.String())
+			requeue = true
+			return
+		}
+	}
+
+	// Create a plan owned CR (no standalone CR found, or CR was just
+	// deleted). Phase 1 will find it and route to Phase 3 on next reconcile.
+	if _, err = r.kubevirt.CreateDeepInspectionConversion(
+		vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID), false,
+	); err != nil {
+		step.AddError(err.Error())
+		return
+	}
+	requeue = true
+	return
+}
+
+// handlePlanDeepInspectionCR evaluates an existing plan owned deep inspection
+// CR and settles the migration step accordingly (Phase 3).
+func (r *Migration) handlePlanDeepInspectionCR(vm *plan.VMStatus, step *plan.Step, planCR *api.Conversion) (requeue bool) {
+	switch planCR.Status.Phase {
+	case api.PhaseSucceeded:
+		r.Log.Info("Plan owned deep inspection CR succeeded.",
+			"conversion", planCR.Name, "vm", vm.String())
+		if blockers := r.propagateInspectionConcerns(vm, planCR.Status.InspectionResult); len(blockers) > 0 {
+			step.Error = &plan.Error{
+				Reasons: append([]string{"VM deep inspection found critical concerns"}, blockers...),
+				Phase:   step.Phase,
+			}
+			return
+		}
+		r.NextPhase(vm)
+	case api.PhaseFailed, api.PhaseCanceled:
+		r.Log.Info("Plan owned deep inspection CR failed.",
+			"conversion", planCR.Name, "phase", planCR.Status.Phase, "vm", vm.String())
+		step.AddError(fmt.Sprintf("deep inspection failed: conversion %s/%s phase %s",
+			planCR.Namespace, planCR.Name, planCR.Status.Phase))
+	default:
+		r.Log.Info("Plan owned deep inspection CR still in progress.",
+			"conversion", planCR.Name, "phase", planCR.Status.Phase, "vm", vm.String())
+		requeue = true
+	}
 	return
 }
 

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -16,6 +16,7 @@ import (
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	convctx "github.com/kubev2v/forklift/pkg/controller/conversion/context"
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter"
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
@@ -1561,80 +1562,60 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 // runPreflightDeepInspection drives the UseConversionCR path of
 // PhasePreflightInspection through three phases:
 //
-//	Phase 1 - look up an existing plan owned CR.
-//	          Found - jump straight to Phase 3.
-//	          Not found - fall through to Phase 2.
-//	Phase 2 - look for a compatible standalone CR (no plan label).
-//	          Succeeded - propagate concerns and advance the step.
-//	          Failed/Canceled - delete the CR, then create a plan owned one and requeue.
-//	          Running/Pending - wait (requeue).
-//	          Not found - create a plan owned CR and requeue.
-//	Phase 3 - evaluate the plan owned CR.
-//	          Succeeded - propagate concerns and advance the step.
-//	          Failed/Canceled - fail the migration step (no retry).
-//	          Running/Pending - wait (requeue).
+//	Phase 1 - look up an existing plan owned DI CR (labels: DeepInspection, vmID, planID)
+//	    Found - go to Phase 3
+//	    Not found - go to Phase 2
+//	Phase 2 - look for a compatible standalone DI CR (labels: DeepInspection, vmID, no planID),
+//	          compatible means the CR settings (disk encryption type, XFS compatibility, ...) match
+//	          what the plan would create, mismatched CRs are considered as "not found" e.g. are skipped
+//	    Found - go to Phase 3
+//	    Not found - create a plan owned DI CR and requeue
+//	Phase 3 - evaluate the found CR:
+//	    Succeeded - propagate inspection concerns, advance or fail the step
+//	    Failed - if standalone: create a plan owned CR and requeue
+//	             if plan owned: fail the migration step (no retry)
+//	    Canceled - if standalone: skip (don't delete), create a plan owned CR and requeue
+//	               if plan owned: delete the CR and requeue for a fresh attempt
+//	    Running/Pending - wait (requeue)
 //
 // Returns true when the reconcile should requeue (CR still in progress or just
-// created). Returns false when the step has been settled - either advanced to
+// created). Returns false when the step has finished, either advanced to
 // the next phase via NextPhase or failed via step.AddError.
 // All errors are consumed internally and recorded on the step, the caller never
-// receives a non-nil error from this method.
+// receives a non-nil error from this method, e.g. no err return.
 func (r *Migration) runPreflightDeepInspection(vm *plan.VMStatus, step *plan.Step) (requeue bool) {
+	// fail when initial snapshot doesn't exist, when this happened something went terribly wrong before preflight step
+	if vm.Warm.Precopies == nil {
+		step.AddError("Preflight inspection failed: no snapshot found for warm migration")
+		return
+	}
 	snapshotMoref := vm.Warm.Precopies[0].Snapshot
 
-	// phase 1: look up an existing plan owned CR (created by a previous
-	// reconcile or promoted from a failed standalone)
+	// Phase 1: look up an existing plan owned CR (created by a previous reconcile)
 	planCR, err := r.kubevirt.GetPlanDeepInspectionConversion(vm)
 	if err != nil {
 		step.AddError(err.Error())
 		return
 	}
 	if planCR != nil {
-		// Plan owned CR already exists, skip Phase 2 and evaluate it
-		return r.handlePlanDeepInspectionCR(vm, step, planCR)
+		// phase 3
+		return r.handleDeepInspectionCR(vm, step, planCR)
 	}
 
-	// Phase 2: no plan owned CR so look for a compatible standalone CR (no plan label, matching disk encryption type and XFS compatibility).
-	// Mismatched CRs are silently skipped.
+	// Phase 2: no plan owned CR, look for a compatible standalone CR
+	// (no plan label, matching disk encryption type and XFS compatibility).
 	standaloneCR, err := r.kubevirt.GetStandaloneDeepInspectionConversion(vm)
 	if err != nil {
 		step.AddError(err.Error())
 		return
 	}
 	if standaloneCR != nil {
-		switch standaloneCR.Status.Phase {
-		case api.PhaseSucceeded:
-			r.Log.Info("Reusing succeeded standalone deep inspection CR.",
-				"conversion", standaloneCR.Name, "vm", vm.String())
-			if blockers := r.propagateInspectionConcerns(vm, standaloneCR.Status.InspectionResult); len(blockers) > 0 {
-				step.Error = &plan.Error{
-					Reasons: append([]string{"VM deep inspection found critical concerns"}, blockers...),
-					Phase:   step.Phase,
-				}
-				return
-			}
-			r.NextPhase(vm)
-			return
-		case api.PhaseFailed, api.PhaseCanceled:
-			// Delete the standalone CR so the plan owned CR created below
-			// starts fresh rather than updating the failed resource.
-			// After it's deleted, continue to create a plan owned CR.
-			r.Log.Info("Found failed standalone deep inspection CR, retrying with plan owned inspection CR.",
-				"conversion", standaloneCR.Name, "phase", standaloneCR.Status.Phase, "vm", vm.String())
-			if err = r.kubevirt.DeleteConversion(standaloneCR); err != nil {
-				step.AddError(err.Error())
-				return
-			}
-		default:
-			r.Log.Info("Standalone deep inspection CR still in progress.",
-				"conversion", standaloneCR.Name, "phase", standaloneCR.Status.Phase, "vm", vm.String())
-			requeue = true
-			return
-		}
+		// phase 3
+		return r.handleDeepInspectionCR(vm, step, standaloneCR)
 	}
 
-	// Create a plan owned CR (no standalone CR found, or CR was just
-	// deleted). Phase 1 will find it and route to Phase 3 on next reconcile.
+	// Plan owned and standalone CR not found so create a new plan owned CR
+	// Phase 1 will find it and go to Phase 3 on the next reconcile.
 	if _, err = r.kubevirt.CreateDeepInspectionConversion(
 		vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID),
 	); err != nil {
@@ -1645,14 +1626,21 @@ func (r *Migration) runPreflightDeepInspection(vm *plan.VMStatus, step *plan.Ste
 	return
 }
 
-// handlePlanDeepInspectionCR evaluates an existing plan owned deep inspection
-// CR and settles the migration step accordingly (Phase 3).
-func (r *Migration) handlePlanDeepInspectionCR(vm *plan.VMStatus, step *plan.Step, planCR *api.Conversion) (requeue bool) {
-	switch planCR.Status.Phase {
+// handleDeepInspectionCR evaluates a deep inspection CR (plan owned or standalone)
+// and processes the migration step (Phase 3):
+//   - Succeeded: propagate concerns and advance or fail the step if critical/error concerns found
+//   - Failed: if standalone (no planID label): create plan owned CR and requeue,
+//     if plan owned: fail the migration step
+//   - Canceled: if standalone: we do not own it so skip it and create a plan owned CR
+//     and requeue so Phase 1 finds the new CR next reconcile,
+//     if plan owned: delete the canceled CR and requeue
+//   - Running/Pending: wait e.g. requeue
+func (r *Migration) handleDeepInspectionCR(vm *plan.VMStatus, step *plan.Step, cr *api.Conversion) (requeue bool) {
+	switch cr.Status.Phase {
 	case api.PhaseSucceeded:
-		r.Log.Info("Plan owned deep inspection CR succeeded.",
-			"conversion", planCR.Name, "vm", vm.String())
-		if blockers := r.propagateInspectionConcerns(vm, planCR.Status.InspectionResult); len(blockers) > 0 {
+		r.Log.Info("Deep inspection CR succeeded.",
+			"conversion", cr.Name, "vm", vm.String())
+		if blockers := r.propagateInspectionConcerns(vm, cr.Status.InspectionResult); len(blockers) > 0 {
 			step.Error = &plan.Error{
 				Reasons: append([]string{"VM deep inspection found critical concerns"}, blockers...),
 				Phase:   step.Phase,
@@ -1660,14 +1648,56 @@ func (r *Migration) handlePlanDeepInspectionCR(vm *plan.VMStatus, step *plan.Ste
 			return
 		}
 		r.NextPhase(vm)
-	case api.PhaseFailed, api.PhaseCanceled:
-		r.Log.Info("Plan owned deep inspection CR failed.",
-			"conversion", planCR.Name, "phase", planCR.Status.Phase, "vm", vm.String())
-		step.AddError(fmt.Sprintf("deep inspection failed: conversion %s/%s phase %s",
-			planCR.Namespace, planCR.Name, planCR.Status.Phase))
+	case api.PhaseFailed:
+		if _, hasPlanLabel := cr.Labels[convctx.LabelPlan]; !hasPlanLabel {
+			// Standalone CR failed, create a plan owned CR so the retry is
+			// isolated to this plan. Phase 1 will pick it up on the next reconcile.
+			r.Log.Info("Standalone deep inspection CR failed, creating plan owned CR to retry.",
+				"conversion", cr.Name, "vm", vm.String())
+			// no need to check for nil here as it was done in runPreflightDeepInspection
+			snapshotMoref := vm.Warm.Precopies[0].Snapshot
+			if _, err := r.kubevirt.CreateDeepInspectionConversion(
+				vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID),
+			); err != nil {
+				step.AddError(err.Error())
+				return
+			}
+			requeue = true
+		} else {
+			r.Log.Info("Plan owned deep inspection CR failed.",
+				"conversion", cr.Name, "vm", vm.String())
+			step.AddError(fmt.Sprintf("deep inspection failed: conversion %s/%s phase %s",
+				cr.Namespace, cr.Name, cr.Status.Phase))
+		}
+	case api.PhaseCanceled:
+		if _, hasPlanLabel := cr.Labels[convctx.LabelPlan]; !hasPlanLabel {
+			// Standalone canceled CR - we don't own it so we don't delete it
+			// Create a plan owned CR instead and Phase 1 will find it next reconcile and
+			// go to Phase 3, bypassing the standalone entirely.
+			r.Log.Info("Standalone deep inspection CR was canceled, creating plan owned CR.",
+				"conversion", cr.Name, "vm", vm.String())
+			snapshotMoref := vm.Warm.Precopies[0].Snapshot
+			if _, err := r.kubevirt.CreateDeepInspectionConversion(
+				vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID),
+			); err != nil {
+				step.AddError(err.Error())
+				return
+			}
+		} else {
+			// Plan owned CR was canceled, delete it so the next reconcile can
+			// create a fresh plan owned CR, this won't loop as the lookup is done only in preflight
+			// inspection step while plan is running, if a plan is canceled, the step is exited
+			r.Log.Info("Plan owned deep inspection CR was canceled, deleting",
+				"conversion", cr.Name, "vm", vm.String())
+			if err := r.kubevirt.DeleteConversion(cr); err != nil {
+				step.AddError(err.Error())
+				return
+			}
+		}
+		requeue = true
 	default:
-		r.Log.Info("Plan owned deep inspection CR still in progress.",
-			"conversion", planCR.Name, "phase", planCR.Status.Phase, "vm", vm.String())
+		r.Log.Info("Deep inspection CR still in progress.",
+			"conversion", cr.Name, "phase", cr.Status.Phase, "vm", vm.String())
 		requeue = true
 	}
 	return

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1590,7 +1590,7 @@ func (r *Migration) runPreflightDeepInspection(vm *plan.VMStatus, step *plan.Ste
 		return
 	}
 	if planCR != nil {
-		// Plan owned CR already exists, skip Phase 2 and evaluate it di CR
+		// Plan owned CR already exists, skip Phase 2 and evaluate it
 		return r.handlePlanDeepInspectionCR(vm, step, planCR)
 	}
 
@@ -1636,7 +1636,7 @@ func (r *Migration) runPreflightDeepInspection(vm *plan.VMStatus, step *plan.Ste
 	// Create a plan owned CR (no standalone CR found, or CR was just
 	// deleted). Phase 1 will find it and route to Phase 3 on next reconcile.
 	if _, err = r.kubevirt.CreateDeepInspectionConversion(
-		vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID), false,
+		vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID),
 	); err != nil {
 		step.AddError(err.Error())
 		return

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1585,7 +1585,13 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 // receives a non-nil error from this method, e.g. no err return.
 func (r *Migration) runPreflightDeepInspection(vm *plan.VMStatus, step *plan.Step) (requeue bool) {
 	// fail when initial snapshot doesn't exist, when this happened something went terribly wrong before preflight step
-	if vm.Warm.Precopies == nil {
+	if vm.Warm == nil {
+		r.Log.Error(nil, "runPreflightDeepInspection: vm.Warm is nil", "vm", vm.ID)
+		step.AddError("Preflight inspection failed: warm migration state is nil")
+		return
+	}
+	if len(vm.Warm.Precopies) == 0 {
+		r.Log.Error(nil, "runPreflightDeepInspection: no precopies found for warm migration", "vm", vm.ID)
 		step.AddError("Preflight inspection failed: no snapshot found for warm migration")
 		return
 	}


### PR DESCRIPTION
Issue: When a plan tries to reuse a deep inspection CR, it doesn't scope it's search to the plan owned/standalone and is reusing old/wring CRs.

Fix: change the search mechanism to first look for plan DI CRs, if not found then look for standalone CRs (with excluding other plans CRs), and if not found create a new plan owned one.

Resolves: MTV-5529
Ref: https://redhat.atlassian.net/browse/MTV-5529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep inspection conversion resource reuse and lifecycle management during preflight checks.

* **Performance**
  * Optimized container image fetching by changing pull policy to fetch images only when not already present locally.

* **Documentation**
  * Updated Conversion CR documentation with clearer API endpoint descriptions and warm-migration preflight workflow details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->