### PR TITLE
fix(build): fix missing logger arg in retryOnTransient call

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powermax/powermax.go
@@ -322,7 +322,7 @@ func (p *PowermaxClonner) Map(_ string, targetLUN populator.LUN, mappingContext 
 		// If mv is still nil after a 409 (treated as success), the masking view
 		// was created by a prior attempt — fetch it.
 		if mv == nil {
-			err = retryOnTransient(ctx, "GetMaskingViewByID", func() error {
+			err = retryOnTransient(ctx, p.log, "GetMaskingViewByID", func() error {
 				var e error
 				mv, e = p.client.GetMaskingViewByID(ctx, p.symmetrixID, p.initiatorID)
 				return e


### PR DESCRIPTION
## Summary
- The backport of `46b92c836` (MTV-5586 409 handling) dropped `p.log` from a `retryOnTransient` call on line 325, causing a compilation failure on `release-2.12`.
- Adds the missing `p.log` argument. `main` already has this correct.

## Test plan
- [ ] `vsphere-copy-offload-populator-2-12` build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)