### PR TITLE
MTV-5548 | Guard populator-controller PVC deletion with retain flag

### DIFF
--- a/cmd/populator-controller/populator-controller.go
+++ b/cmd/populator-controller/populator-controller.go
@@ -73,6 +73,10 @@ func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 
+	if err := settings.Settings.Features.Load(); err != nil {
+		klog.Fatalf("Failed to load feature settings: %v", err)
+	}
+
 	resources, err := getResources()
 	if err != nil {
 		klog.Fatalf("Failed to parse resources: %v", err)

--- a/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/populator/deployment-populator-controller.yml.j2
@@ -44,6 +44,10 @@ spec:
           - name: MAX_POPULATOR_INFLIGHT
             value: "{{ controller_max_populator_inflight }}"
 {% endif %}
+{% if controller_retain_populator_pods|bool %}
+          - name: FEATURE_RETAIN_POPULATOR_PODS
+            value: "true"
+{% endif %}
           - name: POPULATOR_CONTAINER_LIMITS_CPU
             value: "{{ populator_container_limits_cpu }}"
           - name: POPULATOR_CONTAINER_LIMITS_MEMORY

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/settings"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -120,33 +121,34 @@ type populatorResource struct {
 }
 
 type controller struct {
-	populatedFromAnno string
-	kubeClient        kubernetes.Interface
-	dynamicClient     dynamic.Interface
-	imageName         string
-	devicePath        string
-	mountPath         string
-	pvcLister         corelisters.PersistentVolumeClaimLister
-	pvcSynced         cache.InformerSynced
-	pvLister          corelisters.PersistentVolumeLister
-	pvSynced          cache.InformerSynced
-	podLister         corelisters.PodLister
-	podSynced         cache.InformerSynced
-	scLister          storagelisters.StorageClassLister
-	scSynced          cache.InformerSynced
-	unstLister        dynamiclister.Lister
-	unstSynced        cache.InformerSynced
-	mu                sync.Mutex
-	notifyMap         map[string]*stringSet
-	cleanupMap        map[string]*stringSet
-	workqueue         workqueue.TypedRateLimitingInterface[string]
-	populatorArgs     func(bool, *unstructured.Unstructured, corev1.PersistentVolumeClaim) ([]string, error)
-	gk                schema.GroupKind
-	metrics           *metricsManager
-	recorder          record.EventRecorder
-	httpClient        *http.Client
-	resources         *corev1.ResourceRequirements
-	maxInFlight       int
+	populatedFromAnno   string
+	kubeClient          kubernetes.Interface
+	dynamicClient       dynamic.Interface
+	imageName           string
+	devicePath          string
+	mountPath           string
+	pvcLister           corelisters.PersistentVolumeClaimLister
+	pvcSynced           cache.InformerSynced
+	pvLister            corelisters.PersistentVolumeLister
+	pvSynced            cache.InformerSynced
+	podLister           corelisters.PodLister
+	podSynced           cache.InformerSynced
+	scLister            storagelisters.StorageClassLister
+	scSynced            cache.InformerSynced
+	unstLister          dynamiclister.Lister
+	unstSynced          cache.InformerSynced
+	mu                  sync.Mutex
+	notifyMap           map[string]*stringSet
+	cleanupMap          map[string]*stringSet
+	workqueue           workqueue.TypedRateLimitingInterface[string]
+	populatorArgs       func(bool, *unstructured.Unstructured, corev1.PersistentVolumeClaim) ([]string, error)
+	gk                  schema.GroupKind
+	metrics             *metricsManager
+	recorder            record.EventRecorder
+	httpClient          *http.Client
+	resources           *corev1.ResourceRequirements
+	maxInFlight         int
+	retainPopulatorPods bool
 }
 
 func RunController(masterURL, kubeconfig, imageName, httpEndpoint, metricsPath, prefix string,
@@ -192,31 +194,36 @@ func RunController(masterURL, kubeconfig, imageName, httpEndpoint, metricsPath, 
 	unstInformer := dynInformerFactory.ForResource(gvr).Informer()
 
 	c := &controller{
-		kubeClient:        kubeClient,
-		dynamicClient:     dynClient,
-		imageName:         imageName,
-		devicePath:        devicePath,
-		mountPath:         mountPath,
-		populatedFromAnno: prefix + "/" + populatedFromAnnoSuffix,
-		pvcLister:         pvcInformer.Lister(),
-		pvcSynced:         pvcInformer.Informer().HasSynced,
-		pvLister:          pvInformer.Lister(),
-		pvSynced:          pvInformer.Informer().HasSynced,
-		podLister:         podInformer.Lister(),
-		podSynced:         podInformer.Informer().HasSynced,
-		scLister:          scInformer.Lister(),
-		scSynced:          scInformer.Informer().HasSynced,
-		unstLister:        dynamiclister.New(unstInformer.GetIndexer(), gvr),
-		unstSynced:        unstInformer.HasSynced,
-		notifyMap:         make(map[string]*stringSet),
-		cleanupMap:        make(map[string]*stringSet),
-		workqueue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
-		populatorArgs:     populatorArgs,
-		gk:                gk,
-		metrics:           initMetrics(),
-		recorder:          getRecorder(kubeClient, prefix+"-"+controllerNameSuffix),
-		resources:         resources,
-		maxInFlight:       maxInFlight,
+		kubeClient:          kubeClient,
+		dynamicClient:       dynClient,
+		imageName:           imageName,
+		devicePath:          devicePath,
+		mountPath:           mountPath,
+		populatedFromAnno:   prefix + "/" + populatedFromAnnoSuffix,
+		pvcLister:           pvcInformer.Lister(),
+		pvcSynced:           pvcInformer.Informer().HasSynced,
+		pvLister:            pvInformer.Lister(),
+		pvSynced:            pvInformer.Informer().HasSynced,
+		podLister:           podInformer.Lister(),
+		podSynced:           podInformer.Informer().HasSynced,
+		scLister:            scInformer.Lister(),
+		scSynced:            scInformer.Informer().HasSynced,
+		unstLister:          dynamiclister.New(unstInformer.GetIndexer(), gvr),
+		unstSynced:          unstInformer.HasSynced,
+		notifyMap:           make(map[string]*stringSet),
+		cleanupMap:          make(map[string]*stringSet),
+		workqueue:           workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		populatorArgs:       populatorArgs,
+		gk:                  gk,
+		metrics:             initMetrics(),
+		recorder:            getRecorder(kubeClient, prefix+"-"+controllerNameSuffix),
+		resources:           resources,
+		maxInFlight:         maxInFlight,
+		retainPopulatorPods: settings.Settings.RetainPopulatorPods,
+	}
+
+	if c.retainPopulatorPods {
+		klog.Infof("FEATURE_RETAIN_POPULATOR_PODS is enabled for %s; failed PVCs will NOT be deleted on populator failure", gk)
 	}
 
 	if gk.Kind == api.VSphereXcopyVolumePopulatorKind {
@@ -773,6 +780,11 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 					vendor, _, _ := unstructured.NestedString(crInstance.Object, "spec", "storageVendorProduct")
 					c.metrics.recordCompletionFromScrape(pvc.UID, "failure", migration, string(pvc.UID), vendor, "", "", "", 0, 0, 0)
 					c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPodFailed, "VSphere xcopy populator failed (no retry): Please check the logs of the populator pod, %s/%s", populatorNamespace, pod.Name)
+					if c.retainPopulatorPods {
+						klog.Infof("Retaining failed populator pod %s/%s and PVC %s/%s (FEATURE_RETAIN_POPULATOR_PODS enabled)",
+							populatorNamespace, pod.Name, pvc.Namespace, pvc.Name)
+						return nil
+					}
 					return c.deleteFailedPVC(ctx, pvc)
 				}
 
@@ -788,6 +800,11 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 					return c.retryFailedPopulator(ctx, pvc, populatorNamespace, pod.Name, restartsInteger+1)
 				}
 				c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPodFailed, "Populator failed after few (3) attempts: Please check the logs of the populator pod, %s/%s", populatorNamespace, pod.Name)
+				if c.retainPopulatorPods {
+					klog.Infof("Retaining failed populator pod %s/%s and PVC %s/%s (FEATURE_RETAIN_POPULATOR_PODS enabled)",
+						populatorNamespace, pod.Name, pvc.Namespace, pvc.Name)
+					return nil
+				}
 				return c.deleteFailedPVC(ctx, pvc)
 			}
 			// We'll get called again later when the pod succeeds

--- a/pkg/lib-volume-populator/populator-machinery/controller_test.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller_test.go
@@ -1,0 +1,220 @@
+package populator_machinery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic/dynamiclister"
+	"k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	testGroup = "forklift.konveyor.io"
+)
+
+// newTestController builds a minimal controller wired to fake clients and
+// in-memory listers so that syncPvc can be called end-to-end.
+func newTestController(
+	t *testing.T,
+	gk schema.GroupKind,
+	retain bool,
+	pvc *corev1.PersistentVolumeClaim,
+	pod *corev1.Pod,
+	cr *unstructured.Unstructured,
+	populatorNs string,
+) (*controller, *fake.Clientset) {
+	t.Helper()
+
+	kubeClient := fake.NewSimpleClientset(pvc)
+
+	pvcIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := pvcIndexer.Add(pvc); err != nil {
+		t.Fatal(err)
+	}
+
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := podIndexer.Add(pod); err != nil {
+		t.Fatal(err)
+	}
+
+	unstIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := unstIndexer.Add(cr); err != nil {
+		t.Fatal(err)
+	}
+
+	gvr := schema.GroupVersionResource{Group: gk.Group, Version: "v1beta1", Resource: "testresource"}
+
+	m := initMetrics()
+	if gk.Kind == api.VSphereXcopyVolumePopulatorKind {
+		m.initCompletionMetrics()
+	}
+
+	c := &controller{
+		kubeClient:          kubeClient,
+		retainPopulatorPods: retain,
+		gk:                  gk,
+		populatedFromAnno:   testGroup + "/" + populatedFromAnnoSuffix,
+		pvcLister:           corelisters.NewPersistentVolumeClaimLister(pvcIndexer),
+		podLister:           corelisters.NewPodLister(podIndexer),
+		unstLister:          dynamiclister.New(unstIndexer, gvr),
+		notifyMap:           make(map[string]*stringSet),
+		cleanupMap:          make(map[string]*stringSet),
+		populatorArgs: func(_ bool, _ *unstructured.Unstructured, _ corev1.PersistentVolumeClaim) ([]string, error) {
+			return []string{"--cr-namespace=" + populatorNs}, nil
+		},
+		metrics:  m,
+		recorder: record.NewFakeRecorder(100),
+	}
+	return c, kubeClient
+}
+
+func makeTestPVC(name, ns string, uid types.UID, kind string, annotations map[string]string) *corev1.PersistentVolumeClaim {
+	apiGroup := testGroup
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			UID:         uid,
+			Annotations: annotations,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     kind,
+				Name:     "test-cr",
+			},
+		},
+	}
+	return pvc
+}
+
+func makeFailedPod(pvcUID types.UID, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", populatorPodPrefix, pvcUID),
+			Namespace: namespace,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+		},
+	}
+}
+
+func makeTestCR(name, namespace, kind string) *unstructured.Unstructured {
+	cr := &unstructured.Unstructured{}
+	cr.SetName(name)
+	cr.SetNamespace(namespace)
+	cr.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   testGroup,
+		Version: "v1beta1",
+		Kind:    kind,
+	})
+	return cr
+}
+
+func TestDeleteFailedPVC_RetainDisabled(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "test-ns",
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(pvc)
+
+	c := &controller{
+		kubeClient:          kubeClient,
+		retainPopulatorPods: false,
+	}
+
+	err := c.deleteFailedPVC(context.Background(), pvc)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	_, err = kubeClient.CoreV1().PersistentVolumeClaims("test-ns").Get(context.Background(), "test-pvc", metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected PVC to be deleted, but it still exists")
+	}
+}
+
+func TestSyncPvc_RetainEnabled_XcopyFailure(t *testing.T) {
+	const (
+		pvcNs       = "test-ns"
+		pvcName     = "test-pvc"
+		populatorNs = "populator-ns"
+		pvcUID      = types.UID("xcopy-uid-001")
+	)
+	kind := api.VSphereXcopyVolumePopulatorKind
+	gk := schema.GroupKind{Group: testGroup, Kind: kind}
+
+	pvc := makeTestPVC(pvcName, pvcNs, pvcUID, kind, nil)
+	pod := makeFailedPod(pvcUID, populatorNs)
+	cr := makeTestCR("test-cr", pvcNs, kind)
+
+	c, kubeClient := newTestController(t, gk, true, pvc, pod, cr, populatorNs)
+
+	key := pvcNs + "/" + pvcName
+	err := c.syncPvc(context.Background(), key, pvcNs, pvcName)
+	if err != nil {
+		t.Fatalf("syncPvc should return nil when retain is enabled, got: %v", err)
+	}
+
+	_, err = kubeClient.CoreV1().PersistentVolumeClaims(pvcNs).Get(context.Background(), pvcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("PVC should still exist when retain is enabled, got: %v", err)
+	}
+}
+
+func TestSyncPvc_RetainEnabled_GenericFailureAfterRetries(t *testing.T) {
+	const (
+		pvcNs       = "test-ns"
+		pvcName     = "generic-pvc"
+		populatorNs = "populator-ns"
+		pvcUID      = types.UID("generic-uid-002")
+	)
+	kind := api.OvirtVolumePopulatorKind
+	gk := schema.GroupKind{Group: testGroup, Kind: kind}
+
+	pvc := makeTestPVC(pvcName, pvcNs, pvcUID, kind, map[string]string{
+		AnnPopulatorReCreations: "3",
+	})
+	pod := makeFailedPod(pvcUID, populatorNs)
+	cr := makeTestCR("test-cr", pvcNs, kind)
+
+	c, kubeClient := newTestController(t, gk, true, pvc, pod, cr, populatorNs)
+
+	key := pvcNs + "/" + pvcName
+	err := c.syncPvc(context.Background(), key, pvcNs, pvcName)
+	if err != nil {
+		t.Fatalf("syncPvc should return nil when retain is enabled after retries exhausted, got: %v", err)
+	}
+
+	_, err = kubeClient.CoreV1().PersistentVolumeClaims(pvcNs).Get(context.Background(), pvcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("PVC should still exist when retain is enabled, got: %v", err)
+	}
+}
+
+func TestRetainPopulatorPods_FieldSetCorrectly(t *testing.T) {
+	c := &controller{
+		retainPopulatorPods: true,
+	}
+	if !c.retainPopulatorPods {
+		t.Fatal("retainPopulatorPods should be true")
+	}
+
+	c.retainPopulatorPods = false
+	if c.retainPopulatorPods {
+		t.Fatal("retainPopulatorPods should be false")
+	}
+}


### PR DESCRIPTION
The previous commit (81ce8b79) only guarded explicit pod deletion in the Forklift plan controller's cleanup(). However, during an active migration failure the populator-controller independently detects PodFailed and calls deleteFailedPVC(), which deletes the target PVC. Since the populator pod has an OwnerReference on that PVC, Kubernetes GC cascades the deletion to the pod — defeating the retain flag.

This fix reads FEATURE_RETAIN_POPULATOR_PODS in the populator- controller and skips deleteFailedPVC() on permanent failure when the flag is set. The operator template is updated to propagate the env var to the populator-controller deployment. Retry-path pod deletion (oVirt/OpenStack, up to 3 attempts) is intentionally left unchanged since those pods are immediately recreated.

Ref: https://redhat.atlassian.net/browse/MTV-5548
Resolves: MTV-5548