### PR TITLE
MTV-5674 | Add per-network guestIPConfig to NetworkMap

### DIFF
--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/mapping.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/mapping.go
@@ -54,12 +54,29 @@ type NetworkSourceRef struct {
 	Vlan string `json:"vlan,omitempty"`
 }
 
+// NetworkIPMode defines the guest OS network configuration behavior
+// for interfaces mapped through this network pair.
+// +kubebuilder:validation:Enum=preserve;dhcp;none
+type NetworkIPMode string
+
+const (
+	// NetworkIPModePreserve migrates static IP configuration from the source VM.
+	NetworkIPModePreserve NetworkIPMode = "preserve"
+	// NetworkIPModeDHCP signals the NIC should use DHCP on the target.
+	NetworkIPModeDHCP NetworkIPMode = "dhcp"
+	// NetworkIPModeNone leaves the NIC untouched — no IP configuration is applied.
+	NetworkIPModeNone NetworkIPMode = "none"
+)
+
 // Mapped network.
 type NetworkPair struct {
 	// Source network.
 	Source NetworkSourceRef `json:"source"`
 	// Destination network.
 	Destination DestinationNetwork `json:"destination"`
+	// Network IP mode for this network, overrides plan-level preserveStaticIPs.
+	// +optional
+	NetworkIPMode NetworkIPMode `json:"networkIPMode,omitempty"`
 }
 
 // OffloadPlugin is a storage plugin that acts on the storage allocation and copying

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -5650,6 +5650,14 @@ spec:
                       required:
                       - type
                       type: object
+                    networkIPMode:
+                      description: Network IP mode for this network, overrides plan-level
+                        preserveStaticIPs.
+                      enum:
+                      - preserve
+                      - dhcp
+                      - none
+                      type: string
                     source:
                       description: Source network.
                       properties:

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -5728,6 +5728,14 @@ spec:
                       required:
                       - type
                       type: object
+                    networkIPMode:
+                      description: Network IP mode for this network, overrides plan-level
+                        preserveStaticIPs.
+                      enum:
+                      - preserve
+                      - dhcp
+                      - none
+                      type: string
                     source:
                       description: Source network.
                       properties:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -5650,6 +5650,14 @@ spec:
                       required:
                       - type
                       type: object
+                    networkIPMode:
+                      description: Network IP mode for this network, overrides plan-level
+                        preserveStaticIPs.
+                      enum:
+                      - preserve
+                      - dhcp
+                      - none
+                      type: string
                     source:
                       description: Source network.
                       properties:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -5728,6 +5728,14 @@ spec:
                       required:
                       - type
                       type: object
+                    networkIPMode:
+                      description: Network IP mode for this network, overrides plan-level
+                        preserveStaticIPs.
+                      enum:
+                      - preserve
+                      - dhcp
+                      - none
+                      type: string
                     source:
                       description: Source network.
                       properties:

--- a/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_networkmaps.yaml
@@ -74,6 +74,14 @@ spec:
                       required:
                       - type
                       type: object
+                    networkIPMode:
+                      description: Network IP mode for this network, overrides plan-level
+                        preserveStaticIPs.
+                      enum:
+                      - preserve
+                      - dhcp
+                      - none
+                      type: string
                     source:
                       description: Source network.
                       properties:

--- a/pkg/apis/forklift/v1beta1/mapping.go
+++ b/pkg/apis/forklift/v1beta1/mapping.go
@@ -54,12 +54,29 @@ type NetworkSourceRef struct {
 	Vlan string `json:"vlan,omitempty"`
 }
 
+// NetworkIPMode defines the guest OS network configuration behavior
+// for interfaces mapped through this network pair.
+// +kubebuilder:validation:Enum=preserve;dhcp;none
+type NetworkIPMode string
+
+const (
+	// NetworkIPModePreserve migrates static IP configuration from the source VM.
+	NetworkIPModePreserve NetworkIPMode = "preserve"
+	// NetworkIPModeDHCP signals the NIC should use DHCP on the target.
+	NetworkIPModeDHCP NetworkIPMode = "dhcp"
+	// NetworkIPModeNone leaves the NIC untouched — no IP configuration is applied.
+	NetworkIPModeNone NetworkIPMode = "none"
+)
+
 // Mapped network.
 type NetworkPair struct {
 	// Source network.
 	Source NetworkSourceRef `json:"source"`
 	// Destination network.
 	Destination DestinationNetwork `json:"destination"`
+	// Network IP mode for this network, overrides plan-level preserveStaticIPs.
+	// +optional
+	NetworkIPMode NetworkIPMode `json:"networkIPMode,omitempty"`
 }
 
 // OffloadPlugin is a storage plugin that acts on the storage allocation and copying

--- a/pkg/controller/map/network/network_test.go
+++ b/pkg/controller/map/network/network_test.go
@@ -254,6 +254,202 @@ var _ = Describe("NetworkMap Methods", func() {
 	})
 })
 
+// These tests verify the condition-setting logic in isolation (not via the reconciler)
+// so they can run without a full envtest cluster. If validateDestination changes,
+// update the inline logic here accordingly.
+var _ = Describe("NetworkIPMode validation", func() {
+	Describe("networkIPMode on ignored destinations", func() {
+		It("should set NetworkIPModeNotValid when networkIPMode is set on ignored destination", func() {
+			nm := &api.NetworkMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-network-map",
+					Namespace: "default",
+				},
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							Source:        api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}},
+							Destination:   api.DestinationNetwork{Type: Ignored},
+							NetworkIPMode: api.NetworkIPModePreserve,
+						},
+					},
+				},
+			}
+			// Simulate what validateDestination does for the networkIPMode check
+			var networkIPModeOnIgnored []string
+			for _, entry := range nm.Spec.Map {
+				if entry.Destination.Type == Ignored && entry.NetworkIPMode != "" {
+					networkIPModeOnIgnored = append(networkIPModeOnIgnored, entry.Source.String())
+				}
+			}
+			Expect(networkIPModeOnIgnored).To(HaveLen(1))
+
+			if len(networkIPModeOnIgnored) > 0 {
+				nm.Status.SetCondition(libcnd.Condition{
+					Type:     NetworkIPModeNotValid,
+					Status:   True,
+					Reason:   NotValidForDestination,
+					Category: Critical,
+					Message:  "networkIPMode is not valid for the destination type (ignored or pod network).",
+					Items:    networkIPModeOnIgnored,
+				})
+			}
+			Expect(nm.Status.HasCondition(NetworkIPModeNotValid)).To(BeTrue())
+			Expect(nm.Status.HasBlockerCondition()).To(BeTrue())
+		})
+
+		It("should NOT set NetworkIPModeNotValid when networkIPMode is empty on ignored destination", func() {
+			nm := &api.NetworkMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-network-map",
+					Namespace: "default",
+				},
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							Source:      api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}},
+							Destination: api.DestinationNetwork{Type: Ignored},
+						},
+					},
+				},
+			}
+			var networkIPModeOnIgnored []string
+			for _, entry := range nm.Spec.Map {
+				if entry.Destination.Type == Ignored && entry.NetworkIPMode != "" {
+					networkIPModeOnIgnored = append(networkIPModeOnIgnored, entry.Source.String())
+				}
+			}
+			Expect(networkIPModeOnIgnored).To(BeEmpty())
+			Expect(nm.Status.HasCondition(NetworkIPModeNotValid)).To(BeFalse())
+		})
+
+		It("should allow networkIPMode on pod destinations", func() {
+			nm := &api.NetworkMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-network-map",
+					Namespace: "default",
+				},
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							Source:        api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}},
+							Destination:   api.DestinationNetwork{Type: Pod},
+							NetworkIPMode: api.NetworkIPModeDHCP,
+						},
+					},
+				},
+			}
+			var networkIPModeOnIgnored []string
+			for _, entry := range nm.Spec.Map {
+				if entry.Destination.Type == Ignored && entry.NetworkIPMode != "" {
+					networkIPModeOnIgnored = append(networkIPModeOnIgnored, entry.Source.String())
+				}
+			}
+			Expect(networkIPModeOnIgnored).To(BeEmpty())
+		})
+
+		It("should allow networkIPMode on multus destinations", func() {
+			nm := &api.NetworkMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-network-map",
+					Namespace: "default",
+				},
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							Source:        api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}},
+							Destination:   api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-1"},
+							NetworkIPMode: api.NetworkIPModeNone,
+						},
+					},
+				},
+			}
+			var networkIPModeOnIgnored []string
+			for _, entry := range nm.Spec.Map {
+				if entry.Destination.Type == Ignored && entry.NetworkIPMode != "" {
+					networkIPModeOnIgnored = append(networkIPModeOnIgnored, entry.Source.String())
+				}
+			}
+			Expect(networkIPModeOnIgnored).To(BeEmpty())
+		})
+
+		It("should collect multiple offending entries", func() {
+			nm := &api.NetworkMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "test-network-map",
+					Namespace: "default",
+				},
+				Spec: api.NetworkMapSpec{
+					Map: []api.NetworkPair{
+						{
+							Source:        api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}},
+							Destination:   api.DestinationNetwork{Type: Ignored},
+							NetworkIPMode: api.NetworkIPModePreserve,
+						},
+						{
+							Source:      api.NetworkSourceRef{Ref: ref.Ref{ID: "net-2"}},
+							Destination: api.DestinationNetwork{Type: Pod},
+						},
+						{
+							Source:        api.NetworkSourceRef{Ref: ref.Ref{ID: "net-3"}},
+							Destination:   api.DestinationNetwork{Type: Ignored},
+							NetworkIPMode: api.NetworkIPModeNone,
+						},
+					},
+				},
+			}
+			var networkIPModeOnIgnored []string
+			for _, entry := range nm.Spec.Map {
+				if entry.Destination.Type == Ignored && entry.NetworkIPMode != "" {
+					networkIPModeOnIgnored = append(networkIPModeOnIgnored, entry.Source.String())
+				}
+			}
+			Expect(networkIPModeOnIgnored).To(HaveLen(2))
+		})
+	})
+})
+
+var _ = Describe("FindAllNetworks with NetworkIPMode", func() {
+	It("should return pairs with NetworkIPMode field preserved", func() {
+		nm := &api.NetworkMap{
+			Spec: api.NetworkMapSpec{
+				Map: []api.NetworkPair{
+					{
+						Source:        api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}},
+						Destination:   api.DestinationNetwork{Type: Pod},
+						NetworkIPMode: api.NetworkIPModePreserve,
+					},
+					{
+						Source:        api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}},
+						Destination:   api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-1"},
+						NetworkIPMode: api.NetworkIPModeDHCP,
+					},
+				},
+			},
+		}
+		pairs := nm.FindAllNetworks("net-1")
+		Expect(pairs).To(HaveLen(2))
+		Expect(pairs[0].NetworkIPMode).To(Equal(api.NetworkIPModePreserve))
+		Expect(pairs[1].NetworkIPMode).To(Equal(api.NetworkIPModeDHCP))
+	})
+
+	It("should return pairs with empty NetworkIPMode when unset", func() {
+		nm := &api.NetworkMap{
+			Spec: api.NetworkMapSpec{
+				Map: []api.NetworkPair{
+					{
+						Source:      api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}},
+						Destination: api.DestinationNetwork{Type: Pod},
+					},
+				},
+			},
+		}
+		pairs := nm.FindAllNetworks("net-1")
+		Expect(pairs).To(HaveLen(1))
+		Expect(pairs[0].NetworkIPMode).To(Equal(api.NetworkIPMode("")))
+	})
+})
+
 var _ = Describe("MapPredicate", func() {
 	var predicate MapPredicate
 

--- a/pkg/controller/map/network/validation.go
+++ b/pkg/controller/map/network/validation.go
@@ -15,6 +15,7 @@ import (
 const (
 	SourceNetworkNotValid      = "SourceNetworkNotValid"
 	DestinationNetworkNotValid = "DestinationNetworkNotValid"
+	NetworkIPModeNotValid      = "NetworkIPModeNotValid"
 )
 
 // Categories
@@ -28,9 +29,10 @@ const (
 
 // Reasons
 const (
-	NotSet    = "NotSet"
-	NotFound  = "NotFound"
-	Ambiguous = "Ambiguous"
+	NotSet                 = "NotSet"
+	NotFound               = "NotFound"
+	Ambiguous              = "Ambiguous"
+	NotValidForDestination = "NotValidForDestination"
 )
 
 // Statuses
@@ -151,8 +153,17 @@ func (r *Reconciler) validateDestination(mp *api.NetworkMap) (err error) {
 	list := mp.Spec.Map
 	notFound := []string{}
 	ambiguous := []string{}
+	networkIPModeInvalid := []string{}
+	networkIPModeHasCritical := false
 next:
 	for _, entry := range list {
+		if entry.Destination.Type == Ignored && entry.NetworkIPMode != "" {
+			networkIPModeInvalid = append(networkIPModeInvalid, entry.Source.String())
+			networkIPModeHasCritical = true
+		}
+		if entry.Destination.Type == Pod && entry.NetworkIPMode == api.NetworkIPModePreserve {
+			networkIPModeInvalid = append(networkIPModeInvalid, entry.Source.String())
+		}
 		switch entry.Destination.Type {
 		case Ignored, Pod:
 			continue next
@@ -201,6 +212,20 @@ next:
 			Category: Critical,
 			Message:  "Destination network (NAD) namespace required.",
 			Items:    ambiguous,
+		})
+	}
+	if len(networkIPModeInvalid) > 0 {
+		category := Warn
+		if networkIPModeHasCritical {
+			category = Critical
+		}
+		mp.Status.SetCondition(libcnd.Condition{
+			Type:     NetworkIPModeNotValid,
+			Status:   True,
+			Reason:   NotValidForDestination,
+			Category: category,
+			Message:  "networkIPMode is not valid for the destination type (ignored or pod network).",
+			Items:    networkIPModeInvalid,
 		})
 	}
 

--- a/pkg/controller/plan/adapter/base/network.go
+++ b/pkg/controller/plan/adapter/base/network.go
@@ -5,6 +5,70 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 )
 
+type NICRef struct {
+	MAC       string
+	NetworkID string
+}
+
+// NICRefsFrom converts a slice of any NIC type to []NICRef using the provided accessor.
+func NICRefsFrom[N any](nics []N, toRef func(N) NICRef) []NICRef {
+	refs := make([]NICRef, len(nics))
+	for i := range nics {
+		refs[i] = toRef(nics[i])
+	}
+	return refs
+}
+
+// ResolveNICModes returns a MAC->mode map based on NetworkMap pairs and NADPool allocation.
+func ResolveNICModes(nics []NICRef, networkMap *api.NetworkMap, preserveStaticIPs bool) map[string]string {
+	modes := map[string]string{}
+	if networkMap == nil {
+		// No NetworkMap available — fall back to plan-level preserveStaticIPs for all NICs.
+		if preserveStaticIPs {
+			for _, nic := range nics {
+				modes[nic.MAC] = string(api.NetworkIPModePreserve)
+			}
+		}
+		return modes
+	}
+	pool := NewNADPool()
+	for _, nic := range nics {
+		pairs := networkMap.FindAllNetworks(nic.NetworkID)
+		if len(pairs) == 0 {
+			continue
+		}
+		pair, allocated := AllocateNetwork(pool, pairs)
+		if !allocated {
+			// Example: net-1 is mapped to [nad-a, nad-b] but the VM has 3 NICs on net-1.
+			// The first two NICs claim nad-a and nad-b, the third NIC has no NAD left.
+			// It won't appear in the mode map, so mapMacStaticIps includes it in static
+			// IPs by default (backward compat). ValidateNetworkDuplicates warns about this.
+			continue
+		}
+		mode := string(pair.NetworkIPMode)
+		if pair.Destination.Type == Ignored {
+			mode = string(api.NetworkIPModeNone)
+		} else if mode == "" {
+			if preserveStaticIPs {
+				mode = string(api.NetworkIPModePreserve)
+			} else {
+				mode = string(api.NetworkIPModeNone)
+			}
+		}
+		modes[nic.MAC] = mode
+	}
+	return modes
+}
+
+func HasPreserveMode(modes map[string]string) bool {
+	for _, mode := range modes {
+		if mode == string(api.NetworkIPModePreserve) {
+			return true
+		}
+	}
+	return false
+}
+
 // Network destination types.
 const (
 	Pod     = "pod"
@@ -67,6 +131,7 @@ func (p *NADPool) Allocate(pairsForSource []api.NetworkPair) (api.NetworkPair, b
 func AllocateNetwork(pool *NADPool, pairsForSource []api.NetworkPair) (api.NetworkPair, bool) {
 	var nadPairs []api.NetworkPair
 	for _, pair := range pairsForSource {
+		// Only Multus NADs need deduplication via the pool.
 		if pair.Destination.Type != Multus {
 			return pair, true
 		}

--- a/pkg/controller/plan/adapter/base/network.go
+++ b/pkg/controller/plan/adapter/base/network.go
@@ -37,6 +37,71 @@ func HasMultipleIPsPerMAC(macs []string) bool {
 	return false
 }
 
+type NICRef struct {
+	MAC       string
+	NetworkID string
+}
+
+// NICRefsFrom converts a slice of any NIC type to []NICRef using the provided accessor.
+func NICRefsFrom[N any](nics []N, toRef func(N) NICRef) []NICRef {
+	refs := make([]NICRef, len(nics))
+	for i := range nics {
+		refs[i] = toRef(nics[i])
+	}
+	return refs
+}
+
+// ResolveNICModes returns a MAC->mode map based on NetworkMap pairs and NADPool allocation.
+func ResolveNICModes(nics []NICRef, networkMap *api.NetworkMap, preserveStaticIPs bool) map[string]string {
+	modes := map[string]string{}
+	if networkMap == nil {
+		for _, nic := range nics {
+			if preserveStaticIPs {
+				modes[nic.MAC] = string(api.NetworkIPModePreserve)
+			} else {
+				modes[nic.MAC] = string(api.NetworkIPModeNone)
+			}
+		}
+		return modes
+	}
+	pool := NewNADPool()
+	for _, nic := range nics {
+		pairs := networkMap.FindAllNetworks(nic.NetworkID)
+		if len(pairs) == 0 {
+			continue
+		}
+		pair, allocated := AllocateNetwork(pool, pairs)
+		if !allocated {
+			// Example: net-1 is mapped to [nad-a, nad-b] but the VM has 3 NICs on net-1.
+			// The first two NICs claim nad-a and nad-b, the third NIC has no NAD left.
+			// It won't appear in the mode map, so mapMacStaticIps includes it in static
+			// IPs by default (backward compat). ValidateNetworkDuplicates warns about this.
+			continue
+		}
+		mode := string(pair.NetworkIPMode)
+		if pair.Destination.Type == Ignored {
+			mode = string(api.NetworkIPModeNone)
+		} else if mode == "" {
+			if preserveStaticIPs {
+				mode = string(api.NetworkIPModePreserve)
+			} else {
+				mode = string(api.NetworkIPModeNone)
+			}
+		}
+		modes[nic.MAC] = mode
+	}
+	return modes
+}
+
+func HasPreserveMode(modes map[string]string) bool {
+	for _, mode := range modes {
+		if mode == string(api.NetworkIPModePreserve) {
+			return true
+		}
+	}
+	return false
+}
+
 // Network destination types.
 const (
 	Pod     = "pod"
@@ -86,14 +151,6 @@ func nadKey(dest api.DestinationNetwork) string {
 // name), so every pair shares the same source. Only pass Multus pairs;
 // for mixed-type routing use AllocateNetwork.
 func (p *NADPool) Allocate(pairsForSource []api.NetworkPair) (api.NetworkPair, bool) {
-	if len(pairsForSource) == 0 {
-		return api.NetworkPair{}, false
-	}
-
-	if len(pairsForSource) == 1 {
-		return pairsForSource[0], true
-	}
-
 	for _, pair := range pairsForSource {
 		key := nadKey(pair.Destination)
 		if !p.used[key] {
@@ -111,12 +168,43 @@ func (p *NADPool) Allocate(pairsForSource []api.NetworkPair) (api.NetworkPair, b
 func AllocateNetwork(pool *NADPool, pairsForSource []api.NetworkPair) (api.NetworkPair, bool) {
 	var nadPairs []api.NetworkPair
 	for _, pair := range pairsForSource {
+		// Only Multus NADs need deduplication via the pool.
 		if pair.Destination.Type != Multus {
 			return pair, true
 		}
 		nadPairs = append(nadPairs, pair)
 	}
 	return pool.Allocate(nadPairs)
+}
+
+// ValidateNetworkDuplicates checks whether more than one NIC resolves to the
+// pod network or more than one NIC resolves to the same Multus NAD name.
+// With NAD pool mapping, duplicate NADs are only flagged when the pool for a
+// source network is exhausted (NIC count exceeds available NADs).
+func ValidateNetworkDuplicates(nicRefs []ref.Ref, networkMap *api.NetworkMap) (foundNadDup bool, foundPodDup bool) {
+	if networkMap == nil {
+		return
+	}
+
+	pool := NewNADPool()
+	podCount := 0
+
+	for _, nicRef := range nicRefs {
+		pairsForSource := FindAllMappingsForNICRef(nicRef, networkMap)
+		pair, allocated := AllocateNetwork(pool, pairsForSource)
+		if !allocated {
+			if len(pairsForSource) > 0 {
+				foundNadDup = true
+			}
+			continue
+		}
+		if pair.Destination.Type == Pod {
+			podCount++
+		}
+	}
+
+	foundPodDup = podCount > 1
+	return
 }
 
 // ValidatePodNetworkDuplicates reports whether more than one NIC resolves

--- a/pkg/controller/plan/adapter/base/network_test.go
+++ b/pkg/controller/plan/adapter/base/network_test.go
@@ -280,6 +280,210 @@ func TestValidateNetworkDuplicates_1toN_MixedNetworks(t *testing.T) {
 	}
 }
 
+// --- ResolveNICModes ---
+
+func TestResolveNICModes_NilNetworkMap_PreserveTrue(t *testing.T) {
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nil, true)
+	if modes["aa:bb:cc:dd:ee:01"] != "preserve" {
+		t.Errorf("nil network map with preserveStaticIPs=true should fallback to preserve, got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_NilNetworkMap_PreserveFalse(t *testing.T) {
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nil, false)
+	if len(modes) != 0 {
+		t.Errorf("nil network map with preserveStaticIPs=false should return empty, got %v", modes)
+	}
+}
+
+func TestResolveNICModes_EmptyNetworkIPMode_PreserveTrue(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
+	}}}
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["aa:bb:cc:dd:ee:01"] != "preserve" {
+		t.Errorf("expected 'preserve', got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_EmptyNetworkIPMode_PreserveFalse(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
+	}}}
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nm, false)
+	if modes["aa:bb:cc:dd:ee:01"] != "none" {
+		t.Errorf("expected 'none', got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_NetworkIPModeOverridesPlanLevel(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}, NetworkIPMode: api.NetworkIPModeDHCP},
+	}}}
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["aa:bb:cc:dd:ee:01"] != "dhcp" {
+		t.Errorf("networkIPMode should override plan-level, expected 'dhcp', got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_PreserveOverridesPreserveFalse(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}, NetworkIPMode: api.NetworkIPModePreserve},
+	}}}
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nm, false)
+	if modes["aa:bb:cc:dd:ee:01"] != "preserve" {
+		t.Errorf("networkIPMode=preserve should override preserveStaticIPs=false, got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_UnmappedNICSkipped(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
+	}}}
+	nics := []NICRef{
+		{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"},
+		{MAC: "aa:bb:cc:dd:ee:02", NetworkID: "net-unmapped"},
+	}
+	modes := ResolveNICModes(nics, nm, true)
+	if len(modes) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(modes))
+	}
+	if _, ok := modes["aa:bb:cc:dd:ee:02"]; ok {
+		t.Error("unmapped NIC should not appear in modes map")
+	}
+}
+
+func TestResolveNICModes_MixedModes(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}, NetworkIPMode: api.NetworkIPModePreserve},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-2"}}, Destination: api.DestinationNetwork{Type: Multus, Name: "br0", Namespace: "ns"}, NetworkIPMode: api.NetworkIPModeDHCP},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-3"}}, Destination: api.DestinationNetwork{Type: Multus, Name: "br1", Namespace: "ns"}, NetworkIPMode: api.NetworkIPModeNone},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-4"}}, Destination: api.DestinationNetwork{Type: Pod}},
+	}}}
+	nics := []NICRef{
+		{MAC: "mac-1", NetworkID: "net-1"},
+		{MAC: "mac-2", NetworkID: "net-2"},
+		{MAC: "mac-3", NetworkID: "net-3"},
+		{MAC: "mac-4", NetworkID: "net-4"},
+	}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["mac-1"] != "preserve" {
+		t.Errorf("mac-1: expected 'preserve', got %q", modes["mac-1"])
+	}
+	if modes["mac-2"] != "dhcp" {
+		t.Errorf("mac-2: expected 'dhcp', got %q", modes["mac-2"])
+	}
+	if modes["mac-3"] != "none" {
+		t.Errorf("mac-3: expected 'none', got %q", modes["mac-3"])
+	}
+	if modes["mac-4"] != "preserve" {
+		t.Errorf("mac-4: expected 'preserve' (plan-level fallback), got %q", modes["mac-4"])
+	}
+}
+
+// --- ResolveNICModes 1:N allocation ---
+
+func TestResolveNICModes_1toN_DifferentNetworkIPMode(t *testing.T) {
+	// Two NICs on the same source network, mapped to two different NADs
+	// with different networkIPMode values. Each NIC should get its own pair's mode.
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}, NetworkIPMode: api.NetworkIPModePreserve},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}, NetworkIPMode: api.NetworkIPModeNone},
+	}}}
+	nics := []NICRef{
+		{MAC: "mac-1", NetworkID: "net-1"},
+		{MAC: "mac-2", NetworkID: "net-1"},
+	}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["mac-1"] != "preserve" {
+		t.Errorf("mac-1: expected 'preserve' (from row 0), got %q", modes["mac-1"])
+	}
+	if modes["mac-2"] != "none" {
+		t.Errorf("mac-2: expected 'none' (from row 1), got %q", modes["mac-2"])
+	}
+}
+
+func TestResolveNICModes_1toN_PoolExhausted(t *testing.T) {
+	// 3 NICs on the same source network but only 2 NAD rows — third NIC should be skipped.
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}, NetworkIPMode: api.NetworkIPModePreserve},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}, NetworkIPMode: api.NetworkIPModeDHCP},
+	}}}
+	nics := []NICRef{
+		{MAC: "mac-1", NetworkID: "net-1"},
+		{MAC: "mac-2", NetworkID: "net-1"},
+		{MAC: "mac-3", NetworkID: "net-1"},
+	}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["mac-1"] != "preserve" {
+		t.Errorf("mac-1: expected 'preserve', got %q", modes["mac-1"])
+	}
+	if modes["mac-2"] != "dhcp" {
+		t.Errorf("mac-2: expected 'dhcp', got %q", modes["mac-2"])
+	}
+	if _, exists := modes["mac-3"]; exists {
+		t.Errorf("mac-3: expected not allocated (pool exhausted), got %q", modes["mac-3"])
+	}
+}
+
+func TestResolveNICModes_1toN_MixedNetworks(t *testing.T) {
+	// Two NICs on net-1 (1:N) and one NIC on net-2 (1:1).
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}, NetworkIPMode: api.NetworkIPModePreserve},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}, NetworkIPMode: api.NetworkIPModeNone},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-2"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-c"}, NetworkIPMode: api.NetworkIPModeDHCP},
+	}}}
+	nics := []NICRef{
+		{MAC: "mac-1", NetworkID: "net-1"},
+		{MAC: "mac-2", NetworkID: "net-1"},
+		{MAC: "mac-3", NetworkID: "net-2"},
+	}
+	modes := ResolveNICModes(nics, nm, false)
+	if modes["mac-1"] != "preserve" {
+		t.Errorf("mac-1: expected 'preserve', got %q", modes["mac-1"])
+	}
+	if modes["mac-2"] != "none" {
+		t.Errorf("mac-2: expected 'none', got %q", modes["mac-2"])
+	}
+	if modes["mac-3"] != "dhcp" {
+		t.Errorf("mac-3: expected 'dhcp', got %q", modes["mac-3"])
+	}
+}
+
+// --- HasPreserveMode ---
+
+func TestHasPreserveMode_True(t *testing.T) {
+	modes := map[string]string{"mac-1": "none", "mac-2": "preserve"}
+	if !HasPreserveMode(modes) {
+		t.Error("expected true when at least one NIC is preserve")
+	}
+}
+
+func TestHasPreserveMode_False(t *testing.T) {
+	modes := map[string]string{"mac-1": "none", "mac-2": "dhcp"}
+	if HasPreserveMode(modes) {
+		t.Error("expected false when no NIC is preserve")
+	}
+}
+
+func TestHasPreserveMode_Empty(t *testing.T) {
+	if HasPreserveMode(map[string]string{}) {
+		t.Error("expected false for empty map")
+	}
+}
+
+func TestHasPreserveMode_Nil(t *testing.T) {
+	if HasPreserveMode(nil) {
+		t.Error("expected false for nil map")
+	}
+}
+
 func TestValidateNetworkDuplicates_BackwardCompat_SingleRow(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},

--- a/pkg/controller/plan/adapter/base/network_test.go
+++ b/pkg/controller/plan/adapter/base/network_test.go
@@ -161,20 +161,23 @@ func TestNADPool_Allocate_DistinctNADs(t *testing.T) {
 	}
 }
 
-func TestNADPool_Allocate_SameNADReused(t *testing.T) {
+func TestNADPool_Allocate_SingleNADExhausted(t *testing.T) {
 	pairsForSource := []api.NetworkPair{
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
 	}
 	pool := NewNADPool()
 
 	pair1, allocated1 := pool.Allocate(pairsForSource)
-	pair2, allocated2 := pool.Allocate(pairsForSource)
+	_, allocated2 := pool.Allocate(pairsForSource)
 
-	if !allocated1 || !allocated2 {
-		t.Fatal("both allocations should succeed when reusing the same NAD")
+	if !allocated1 {
+		t.Fatal("first allocation should succeed")
 	}
-	if pair1.Destination.Name != "nad-a" || pair2.Destination.Name != "nad-a" {
-		t.Errorf("expected same NAD nad-a, got %s and %s", pair1.Destination.Name, pair2.Destination.Name)
+	if pair1.Destination.Name != "nad-a" {
+		t.Errorf("expected nad-a, got %s", pair1.Destination.Name)
+	}
+	if allocated2 {
+		t.Error("second allocation should fail when the single NAD is already used")
 	}
 }
 
@@ -254,5 +257,262 @@ func TestNADPool_Allocate_IndependentNetworks(t *testing.T) {
 	}
 	if pair1.Destination.Name != "nad-a" || pair2.Destination.Name != "nad-b" {
 		t.Errorf("unexpected assignments: %s, %s", pair1.Destination.Name, pair2.Destination.Name)
+	}
+}
+
+// --- ValidateNetworkDuplicates with NAD pool ---
+
+func TestValidateNetworkDuplicates_1toN_NoDuplicate(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+	}}}
+	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}}
+	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
+	if foundNadDup {
+		t.Error("with 2 NADs for 2 NICs, should not flag duplicate")
+	}
+	if foundPodDup {
+		t.Error("no pod mapping, should not flag pod duplicate")
+	}
+}
+
+func TestValidateNetworkDuplicates_1toN_PoolExhausted(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+	}}}
+	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}, {ID: "net-1"}}
+	foundNadDup, _ := ValidateNetworkDuplicates(nicRefs, nm)
+	if !foundNadDup {
+		t.Error("3 NICs with only 2 NADs should flag duplicate")
+	}
+}
+
+func TestValidateNetworkDuplicates_1toN_MixedNetworks(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-2"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-c"}},
+	}}}
+	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}, {ID: "net-2"}}
+	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
+	if foundNadDup || foundPodDup {
+		t.Errorf("sufficient NADs for all NICs, should find no duplicates, got (%v, %v)", foundNadDup, foundPodDup)
+	}
+}
+
+// --- ResolveNICModes ---
+
+func TestResolveNICModes_NilNetworkMap_PreserveTrue(t *testing.T) {
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nil, true)
+	if modes["aa:bb:cc:dd:ee:01"] != "preserve" {
+		t.Errorf("nil network map with preserveStaticIPs=true should fallback to preserve, got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_NilNetworkMap_PreserveFalse(t *testing.T) {
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nil, false)
+	if modes["aa:bb:cc:dd:ee:01"] != "none" {
+		t.Errorf("nil network map with preserveStaticIPs=false should set 'none', got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_EmptyNetworkIPMode_PreserveTrue(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
+	}}}
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["aa:bb:cc:dd:ee:01"] != "preserve" {
+		t.Errorf("expected 'preserve', got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_EmptyNetworkIPMode_PreserveFalse(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
+	}}}
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nm, false)
+	if modes["aa:bb:cc:dd:ee:01"] != "none" {
+		t.Errorf("expected 'none', got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_NetworkIPModeOverridesPlanLevel(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}, NetworkIPMode: api.NetworkIPModeDHCP},
+	}}}
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["aa:bb:cc:dd:ee:01"] != "dhcp" {
+		t.Errorf("networkIPMode should override plan-level, expected 'dhcp', got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_PreserveOverridesPreserveFalse(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}, NetworkIPMode: api.NetworkIPModePreserve},
+	}}}
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
+	modes := ResolveNICModes(nics, nm, false)
+	if modes["aa:bb:cc:dd:ee:01"] != "preserve" {
+		t.Errorf("networkIPMode=preserve should override preserveStaticIPs=false, got %q", modes["aa:bb:cc:dd:ee:01"])
+	}
+}
+
+func TestResolveNICModes_UnmappedNICSkipped(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
+	}}}
+	nics := []NICRef{
+		{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"},
+		{MAC: "aa:bb:cc:dd:ee:02", NetworkID: "net-unmapped"},
+	}
+	modes := ResolveNICModes(nics, nm, true)
+	if len(modes) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(modes))
+	}
+	if _, ok := modes["aa:bb:cc:dd:ee:02"]; ok {
+		t.Error("unmapped NIC should not appear in modes map")
+	}
+}
+
+func TestResolveNICModes_MixedModes(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}, NetworkIPMode: api.NetworkIPModePreserve},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-2"}}, Destination: api.DestinationNetwork{Type: Multus, Name: "br0", Namespace: "ns"}, NetworkIPMode: api.NetworkIPModeDHCP},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-3"}}, Destination: api.DestinationNetwork{Type: Multus, Name: "br1", Namespace: "ns"}, NetworkIPMode: api.NetworkIPModeNone},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-4"}}, Destination: api.DestinationNetwork{Type: Pod}},
+	}}}
+	nics := []NICRef{
+		{MAC: "mac-1", NetworkID: "net-1"},
+		{MAC: "mac-2", NetworkID: "net-2"},
+		{MAC: "mac-3", NetworkID: "net-3"},
+		{MAC: "mac-4", NetworkID: "net-4"},
+	}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["mac-1"] != "preserve" {
+		t.Errorf("mac-1: expected 'preserve', got %q", modes["mac-1"])
+	}
+	if modes["mac-2"] != "dhcp" {
+		t.Errorf("mac-2: expected 'dhcp', got %q", modes["mac-2"])
+	}
+	if modes["mac-3"] != "none" {
+		t.Errorf("mac-3: expected 'none', got %q", modes["mac-3"])
+	}
+	if modes["mac-4"] != "preserve" {
+		t.Errorf("mac-4: expected 'preserve' (plan-level fallback), got %q", modes["mac-4"])
+	}
+}
+
+// --- ResolveNICModes 1:N allocation ---
+
+func TestResolveNICModes_1toN_DifferentNetworkIPMode(t *testing.T) {
+	// Two NICs on the same source network, mapped to two different NADs
+	// with different networkIPMode values. Each NIC should get its own pair's mode.
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}, NetworkIPMode: api.NetworkIPModePreserve},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}, NetworkIPMode: api.NetworkIPModeNone},
+	}}}
+	nics := []NICRef{
+		{MAC: "mac-1", NetworkID: "net-1"},
+		{MAC: "mac-2", NetworkID: "net-1"},
+	}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["mac-1"] != "preserve" {
+		t.Errorf("mac-1: expected 'preserve' (from row 0), got %q", modes["mac-1"])
+	}
+	if modes["mac-2"] != "none" {
+		t.Errorf("mac-2: expected 'none' (from row 1), got %q", modes["mac-2"])
+	}
+}
+
+func TestResolveNICModes_1toN_PoolExhausted(t *testing.T) {
+	// 3 NICs on the same source network but only 2 NAD rows — third NIC should be skipped.
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}, NetworkIPMode: api.NetworkIPModePreserve},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}, NetworkIPMode: api.NetworkIPModeDHCP},
+	}}}
+	nics := []NICRef{
+		{MAC: "mac-1", NetworkID: "net-1"},
+		{MAC: "mac-2", NetworkID: "net-1"},
+		{MAC: "mac-3", NetworkID: "net-1"},
+	}
+	modes := ResolveNICModes(nics, nm, true)
+	if modes["mac-1"] != "preserve" {
+		t.Errorf("mac-1: expected 'preserve', got %q", modes["mac-1"])
+	}
+	if modes["mac-2"] != "dhcp" {
+		t.Errorf("mac-2: expected 'dhcp', got %q", modes["mac-2"])
+	}
+	if _, exists := modes["mac-3"]; exists {
+		t.Errorf("mac-3: expected not allocated (pool exhausted), got %q", modes["mac-3"])
+	}
+}
+
+func TestResolveNICModes_1toN_MixedNetworks(t *testing.T) {
+	// Two NICs on net-1 (1:N) and one NIC on net-2 (1:1).
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}, NetworkIPMode: api.NetworkIPModePreserve},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}, NetworkIPMode: api.NetworkIPModeNone},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-2"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-c"}, NetworkIPMode: api.NetworkIPModeDHCP},
+	}}}
+	nics := []NICRef{
+		{MAC: "mac-1", NetworkID: "net-1"},
+		{MAC: "mac-2", NetworkID: "net-1"},
+		{MAC: "mac-3", NetworkID: "net-2"},
+	}
+	modes := ResolveNICModes(nics, nm, false)
+	if modes["mac-1"] != "preserve" {
+		t.Errorf("mac-1: expected 'preserve', got %q", modes["mac-1"])
+	}
+	if modes["mac-2"] != "none" {
+		t.Errorf("mac-2: expected 'none', got %q", modes["mac-2"])
+	}
+	if modes["mac-3"] != "dhcp" {
+		t.Errorf("mac-3: expected 'dhcp', got %q", modes["mac-3"])
+	}
+}
+
+// --- HasPreserveMode ---
+
+func TestHasPreserveMode_True(t *testing.T) {
+	modes := map[string]string{"mac-1": "none", "mac-2": "preserve"}
+	if !HasPreserveMode(modes) {
+		t.Error("expected true when at least one NIC is preserve")
+	}
+}
+
+func TestHasPreserveMode_False(t *testing.T) {
+	modes := map[string]string{"mac-1": "none", "mac-2": "dhcp"}
+	if HasPreserveMode(modes) {
+		t.Error("expected false when no NIC is preserve")
+	}
+}
+
+func TestHasPreserveMode_Empty(t *testing.T) {
+	if HasPreserveMode(map[string]string{}) {
+		t.Error("expected false for empty map")
+	}
+}
+
+func TestHasPreserveMode_Nil(t *testing.T) {
+	if HasPreserveMode(nil) {
+		t.Error("expected false for nil map")
+	}
+}
+
+func TestValidateNetworkDuplicates_BackwardCompat_SingleRow(t *testing.T) {
+	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+	}}}
+	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}}
+	foundNadDup, _ := ValidateNetworkDuplicates(nicRefs, nm)
+	if !foundNadDup {
+		t.Error("single-row map with 2 NICs should still flag duplicate (backward compatible)")
 	}
 }

--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -396,6 +396,12 @@ func (r *Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVol
 	return pvc.Name
 }
 
+func nicRefsFromVM(vm *model.VM) []planbase.NICRef {
+	return planbase.NICRefsFrom(vm.NICs, func(n hyperv.NIC) planbase.NICRef {
+		return planbase.NICRef{MAC: n.MAC, NetworkID: n.Network.ID}
+	})
+}
+
 func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env []core.EnvVar, err error) {
 	vm := &model.VM{}
 	err = r.Source.Inventory.Find(vm, vmRef)
@@ -417,14 +423,15 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		core.EnvVar{Name: "V2V_diskPath", Value: strings.Join(diskPaths, ",")},
 	)
 
-	if r.Plan.Spec.PreserveStaticIPs {
-		macsToIps := r.mapMacStaticIps(vm)
+	modeByMAC := planbase.ResolveNICModes(nicRefsFromVM(vm), r.Map.Network, r.Plan.Spec.PreserveStaticIPs)
+	if planbase.HasPreserveMode(modeByMAC) {
+		macsToIps := r.mapMacStaticIps(vm, modeByMAC)
 		if macsToIps != "" {
 			env = append(env,
 				core.EnvVar{Name: "V2V_staticIPs", Value: macsToIps},
 			)
 		}
-		if hasMultipleStaticIPsPerNIC(vm) {
+		if hasMultipleStaticIPsPerNIC(vm, modeByMAC) {
 			env = append(env, core.EnvVar{
 				Name:  "V2V_multipleIPsPerNic",
 				Value: "true",
@@ -439,12 +446,17 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 	return
 }
 
-func hasMultipleStaticIPsPerNIC(vm *model.VM) bool {
+func hasMultipleStaticIPsPerNIC(vm *model.VM, modeByMAC map[string]string) bool {
 	if !isWindows(vm) {
 		return false
 	}
 	macIPCount := make(map[string]int)
 	for _, gn := range vm.GuestNetworks {
+		// Only count NICs that are in "preserve" mode, since non-preserve
+		// NICs are excluded from V2V_staticIPs.
+		if mode, ok := modeByMAC[gn.MAC]; ok && mode != string(api.NetworkIPModePreserve) {
+			continue
+		}
 		if gn.Origin == hyperv.OriginManual && net.ParseIP(gn.IP).To4() != nil {
 			macIPCount[gn.MAC]++
 		}
@@ -457,11 +469,18 @@ func hasMultipleStaticIPsPerNIC(vm *model.VM) bool {
 	return false
 }
 
-func (r *Builder) mapMacStaticIps(vm *model.VM) string {
+func (r *Builder) mapMacStaticIps(vm *model.VM, modeByMAC map[string]string) string {
 	isWin := isWindows(vm)
 
 	var configurations []string
 	for _, gn := range vm.GuestNetworks {
+		// Skip this NIC if its resolved mode is not "preserve".
+		// Even though we're inside the "preserve" path, individual NICs marked
+		// as "dhcp" or "none" on their NetworkPair are excluded here.
+		if mode, ok := modeByMAC[gn.MAC]; ok && mode != string(api.NetworkIPModePreserve) {
+			continue
+		}
+
 		if !isWin || gn.Origin == hyperv.OriginManual {
 			ip := net.ParseIP(gn.IP)
 			if ip == nil {

--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -483,6 +483,12 @@ func (r *Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVol
 	return pvc.Name
 }
 
+func nicRefsFromVM(vm *model.VM) []planbase.NICRef {
+	return planbase.NICRefsFrom(vm.NICs, func(n hyperv.NIC) planbase.NICRef {
+		return planbase.NICRef{MAC: n.MAC, NetworkID: n.Network.ID}
+	})
+}
+
 func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env []core.EnvVar, err error) {
 	vm := &model.VM{}
 	err = r.Source.Inventory.Find(vm, vmRef)
@@ -504,14 +510,15 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		core.EnvVar{Name: "V2V_diskPath", Value: strings.Join(diskPaths, ",")},
 	)
 
-	if r.Plan.Spec.PreserveStaticIPs {
-		macsToIps := r.mapMacStaticIps(vm)
+	modeByMAC := planbase.ResolveNICModes(nicRefsFromVM(vm), r.Map.Network, r.Plan.Spec.PreserveStaticIPs)
+	if planbase.HasPreserveMode(modeByMAC) {
+		macsToIps := r.mapMacStaticIps(vm, modeByMAC)
 		if macsToIps != "" {
 			env = append(env,
 				core.EnvVar{Name: "V2V_staticIPs", Value: macsToIps},
 			)
 		}
-		if hasMultipleStaticIPsPerNIC(vm) {
+		if hasMultipleStaticIPsPerNIC(vm, modeByMAC) {
 			env = append(env, core.EnvVar{
 				Name:  "V2V_multipleIPsPerNic",
 				Value: "true",
@@ -526,12 +533,15 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 	return
 }
 
-func hasMultipleStaticIPsPerNIC(vm *model.VM) bool {
+func hasMultipleStaticIPsPerNIC(vm *model.VM, modeByMAC map[string]string) bool {
 	if !isWindows(vm) {
 		return false
 	}
 	var manualMACs []string
 	for _, gn := range vm.GuestNetworks {
+		if mode, ok := modeByMAC[gn.MAC]; ok && mode != string(api.NetworkIPModePreserve) {
+			continue
+		}
 		if gn.Origin == hyperv.OriginManual {
 			manualMACs = append(manualMACs, gn.MAC)
 		}
@@ -539,12 +549,15 @@ func hasMultipleStaticIPsPerNIC(vm *model.VM) bool {
 	return planbase.HasMultipleIPsPerMAC(manualMACs)
 }
 
-func (r *Builder) mapMacStaticIps(vm *model.VM) string {
+func (r *Builder) mapMacStaticIps(vm *model.VM, modeByMAC map[string]string) string {
 	isWin := isWindows(vm)
 	networks := planbase.SortedIPv4First(vm.GuestNetworks, func(gn hyperv.GuestNetwork) string { return gn.IP })
 
 	var configurations []string
 	for _, gn := range networks {
+		if mode, ok := modeByMAC[gn.MAC]; ok && mode != string(api.NetworkIPModePreserve) {
+			continue
+		}
 		if !isWin || gn.Origin == hyperv.OriginManual {
 			ip := net.ParseIP(gn.IP)
 			if ip == nil {

--- a/pkg/controller/plan/adapter/hyperv/builder_test.go
+++ b/pkg/controller/plan/adapter/hyperv/builder_test.go
@@ -3,7 +3,14 @@ package hyperv
 import (
 	"testing"
 
-	hyperv "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestBuildNICKeys(t *testing.T) {
@@ -125,5 +132,107 @@ func TestBuildPairKey(t *testing.T) {
 					tc.networkID, tc.vlan, key, tc.expected)
 			}
 		})
+	}
+}
+
+var builderLog = logging.WithName("hyperv-builder-test")
+
+var _ = Describe("HyperV builder", func() {
+	Context("mapMacStaticIps with networkIPMode filtering", func() {
+		It("should skip NICs with mode 'none'", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+					{MAC: "00:15:5D:01:02:04", IP: "172.29.3.194", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			modeByMAC := map[string]string{
+				"00:15:5D:01:02:03": "preserve",
+				"00:15:5D:01:02:04": "none",
+			}
+			result := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:03"))
+			Expect(result).NotTo(ContainSubstring("00:15:5D:01:02:04"))
+		})
+
+		It("should skip NICs with mode 'dhcp'", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			modeByMAC := map[string]string{
+				"00:15:5D:01:02:03": "dhcp",
+			}
+			result := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should include NICs not in modeByMAC (backward compat)", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			modeByMAC := map[string]string{}
+			result := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:03"))
+		})
+
+		It("should include all NICs when modeByMAC is nil", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+					{MAC: "00:15:5D:01:02:04", IP: "172.29.3.194", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			result := b.mapMacStaticIps(vm, nil)
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:03"))
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:04"))
+		})
+
+		It("should preserve only marked NICs in a mixed-mode map", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+					{MAC: "00:15:5D:01:02:04", IP: "172.29.3.194", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+					{MAC: "00:15:5D:01:02:05", IP: "172.29.3.195", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			modeByMAC := map[string]string{
+				"00:15:5D:01:02:03": "preserve",
+				"00:15:5D:01:02:04": "dhcp",
+				"00:15:5D:01:02:05": "none",
+			}
+			result := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:03"))
+			Expect(result).NotTo(ContainSubstring("00:15:5D:01:02:04"))
+			Expect(result).NotTo(ContainSubstring("00:15:5D:01:02:05"))
+		})
+	})
+
+})
+
+func createBuilder() *Builder {
+	return &Builder{
+		Context: &plancontext.Context{
+			Plan: &v1beta1.Plan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plan",
+					Namespace: "test",
+				},
+			},
+			Log: builderLog,
+		},
 	}
 }

--- a/pkg/controller/plan/adapter/hyperv/builder_test.go
+++ b/pkg/controller/plan/adapter/hyperv/builder_test.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	hyperv "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cnv "kubevirt.io/api/core/v1"
 )
 
@@ -247,5 +253,107 @@ func TestMapHypervGuestOS_TemplateLabels(t *testing.T) {
 		if labels[k] != v {
 			t.Errorf("label %q = %q, want %q", k, labels[k], v)
 		}
+	}
+}
+
+var builderLog = logging.WithName("hyperv-builder-test")
+
+var _ = Describe("HyperV builder", func() {
+	Context("mapMacStaticIps with networkIPMode filtering", func() {
+		It("should skip NICs with mode 'none'", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+					{MAC: "00:15:5D:01:02:04", IP: "172.29.3.194", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			modeByMAC := map[string]string{
+				"00:15:5D:01:02:03": "preserve",
+				"00:15:5D:01:02:04": "none",
+			}
+			result := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:03"))
+			Expect(result).NotTo(ContainSubstring("00:15:5D:01:02:04"))
+		})
+
+		It("should skip NICs with mode 'dhcp'", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			modeByMAC := map[string]string{
+				"00:15:5D:01:02:03": "dhcp",
+			}
+			result := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should include NICs not in modeByMAC (backward compat)", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			modeByMAC := map[string]string{}
+			result := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:03"))
+		})
+
+		It("should include all NICs when modeByMAC is nil", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+					{MAC: "00:15:5D:01:02:04", IP: "172.29.3.194", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			result := b.mapMacStaticIps(vm, nil)
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:03"))
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:04"))
+		})
+
+		It("should preserve only marked NICs in a mixed-mode map", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestOS: "Windows Server 2019",
+				GuestNetworks: []hyperv.GuestNetwork{
+					{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+					{MAC: "00:15:5D:01:02:04", IP: "172.29.3.194", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+					{MAC: "00:15:5D:01:02:05", IP: "172.29.3.195", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				},
+			}
+			modeByMAC := map[string]string{
+				"00:15:5D:01:02:03": "preserve",
+				"00:15:5D:01:02:04": "dhcp",
+				"00:15:5D:01:02:05": "none",
+			}
+			result := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(result).To(ContainSubstring("00:15:5D:01:02:03"))
+			Expect(result).NotTo(ContainSubstring("00:15:5D:01:02:04"))
+			Expect(result).NotTo(ContainSubstring("00:15:5D:01:02:05"))
+		})
+	})
+
+})
+
+func createBuilder() *Builder {
+	return &Builder{
+		Context: &plancontext.Context{
+			Plan: &v1beta1.Plan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plan",
+					Namespace: "test",
+				},
+			},
+			Log: builderLog,
+		},
 	}
 }

--- a/pkg/controller/plan/adapter/hyperv/hyperv_suite_test.go
+++ b/pkg/controller/plan/adapter/hyperv/hyperv_suite_test.go
@@ -1,0 +1,13 @@
+package hyperv
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHyperv(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HyperV Suite")
+}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -209,8 +209,9 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		vm.RemoveSharedDisks()
 	}
 	macsToIps := ""
-	if r.Plan.Spec.PreserveStaticIPs {
-		macsToIps, err = r.mapMacStaticIps(vm)
+	modeByMAC := planbase.ResolveNICModes(nicRefsFromVM(vm), r.Map.Network, r.Plan.Spec.PreserveStaticIPs)
+	if planbase.HasPreserveMode(modeByMAC) {
+		macsToIps, err = r.mapMacStaticIps(vm, modeByMAC)
 		if err != nil {
 			return
 		}
@@ -234,9 +235,14 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 			Value: "/usr/local/virtio-win-legacy.iso",
 		})
 	} else if isWindows(vm) { // We check for multiple IPs per NIC only on Windows VMs
+		// Only count multi-IP NICs that are actually in "preserve" mode,
+		// since non-preserve NICs are excluded from V2V_staticIPs.
 		macIPCount := make(map[string]int)
 
 		for _, gn := range vm.GuestNetworks {
+			if mode, ok := modeByMAC[gn.MAC]; ok && mode != string(api.NetworkIPModePreserve) {
+				continue
+			}
 			// IS ipv4
 			if gn.Origin == string(types.NetIpConfigInfoIpAddressOriginManual) && net.IP.To4(net.ParseIP(gn.IP)) != nil {
 				macIPCount[gn.MAC]++
@@ -311,13 +317,26 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 	return
 }
 
-func (r *Builder) mapMacStaticIps(vm *model.VM) (ipMap string, err error) {
+func nicRefsFromVM(vm *model.VM) []planbase.NICRef {
+	return planbase.NICRefsFrom(vm.NICs, func(n vsphere.NIC) planbase.NICRef {
+		return planbase.NICRef{MAC: n.MAC, NetworkID: n.Network.ID}
+	})
+}
+
+func (r *Builder) mapMacStaticIps(vm *model.VM, modeByMAC map[string]string) (ipMap string, err error) {
 	// on windows machines we check if the interface origin is manual
 	// on linux we collect all networks.
 	isWindowsFlag := isWindows(vm)
 
 	var configurations []string
 	for _, guestNetwork := range vm.GuestNetworks {
+		// Skip this NIC if its resolved mode is not "preserve".
+		// Even though we're inside the "preserve" path, individual NICs marked
+		// as "dhcp" or "none" on their NetworkPair are excluded here.
+		if mode, ok := modeByMAC[guestNetwork.MAC]; ok && mode != string(api.NetworkIPModePreserve) {
+			continue
+		}
+
 		if !isWindowsFlag || guestNetwork.Origin == string(types.NetIpConfigInfoIpAddressOriginManual) {
 			gateway := ""
 			isIpv4 := net.IP.To4(net.ParseIP(guestNetwork.IP)) != nil

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -210,8 +210,9 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		vm.RemoveSharedDisks()
 	}
 	macsToIps := ""
-	if r.Plan.Spec.PreserveStaticIPs {
-		macsToIps, err = r.mapMacStaticIps(vm)
+	modeByMAC := planbase.ResolveNICModes(nicRefsFromVM(vm), r.Map.Network, r.Plan.Spec.PreserveStaticIPs)
+	if planbase.HasPreserveMode(modeByMAC) {
+		macsToIps, err = r.mapMacStaticIps(vm, modeByMAC)
 		if err != nil {
 			return
 		}
@@ -237,6 +238,9 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 	} else if isWindows(vm) {
 		var manualMACs []string
 		for _, gn := range vm.GuestNetworks {
+			if mode, ok := modeByMAC[gn.MAC]; ok && mode != string(api.NetworkIPModePreserve) {
+				continue
+			}
 			if gn.Origin == string(types.NetIpConfigInfoIpAddressOriginManual) {
 				manualMACs = append(manualMACs, gn.MAC)
 			}
@@ -414,12 +418,21 @@ func formatNetworkConfig(network vsphere.GuestNetwork, gateway string) string {
 	return strings.TrimSuffix(config, ",")
 }
 
-func (r *Builder) mapMacStaticIps(vm *model.VM) (ipMap string, err error) {
+func nicRefsFromVM(vm *model.VM) []planbase.NICRef {
+	return planbase.NICRefsFrom(vm.NICs, func(n vsphere.NIC) planbase.NICRef {
+		return planbase.NICRef{MAC: n.MAC, NetworkID: n.Network.ID}
+	})
+}
+
+func (r *Builder) mapMacStaticIps(vm *model.VM, modeByMAC map[string]string) (ipMap string, err error) {
 	isWindowsFlag := isWindows(vm)
 	sortedNetworks := planbase.SortedIPv4First(vm.GuestNetworks, func(gn vsphere.GuestNetwork) string { return gn.IP })
 
 	var configurations []string
 	for _, guestNetwork := range sortedNetworks {
+		if mode, ok := modeByMAC[guestNetwork.MAC]; ok && mode != string(api.NetworkIPModePreserve) {
+			continue
+		}
 		if !shouldIncludeNetwork(guestNetwork, isWindowsFlag) {
 			continue
 		}

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -710,7 +710,7 @@ var _ = Describe("vSphere builder", func() {
 
 	builder := createBuilder()
 	DescribeTable("should", func(vm *model.VM, outputMap string) {
-		Expect(builder.mapMacStaticIps(vm)).Should(Equal(outputMap))
+		Expect(builder.mapMacStaticIps(vm, nil)).Should(Equal(outputMap))
 	},
 		Entry("no static ips", &model.VM{GuestID: "windows9Guest"}, ""),
 		Entry("single static ip", &model.VM{
@@ -868,6 +868,99 @@ var _ = Describe("vSphere builder", func() {
 				}},
 		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.1,24,8.8.8.8"),
 	)
+
+	Context("mapMacStaticIps with networkIPMode filtering", func() {
+		It("should skip NICs with mode 'none'", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+					{MAC: "00:50:56:83:25:48", IP: "172.29.3.194", Origin: ManualOrigin, PrefixLength: 16},
+				},
+				GuestIpStacks: []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}},
+			}
+			modeByMAC := map[string]string{
+				"00:50:56:83:25:47": "preserve",
+				"00:50:56:83:25:48": "none",
+			}
+			result, err := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring("00:50:56:83:25:47"))
+			Expect(result).NotTo(ContainSubstring("00:50:56:83:25:48"))
+		})
+
+		It("should skip NICs with mode 'dhcp'", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+				},
+			}
+			modeByMAC := map[string]string{
+				"00:50:56:83:25:47": "dhcp",
+			}
+			result, err := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should include NICs not in modeByMAC (backward compat)", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+				},
+				GuestIpStacks: []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}},
+			}
+			// NIC not in the map at all — should proceed
+			modeByMAC := map[string]string{}
+			result, err := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring("00:50:56:83:25:47"))
+		})
+
+		It("should include all NICs when modeByMAC is nil", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+					{MAC: "00:50:56:83:25:48", IP: "172.29.3.194", Origin: ManualOrigin, PrefixLength: 16},
+				},
+				GuestIpStacks: []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}},
+			}
+			result, err := b.mapMacStaticIps(vm, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring("00:50:56:83:25:47"))
+			Expect(result).To(ContainSubstring("00:50:56:83:25:48"))
+		})
+
+		It("should preserve only marked NICs in a mixed-mode map", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+					{MAC: "00:50:56:83:25:48", IP: "172.29.3.194", Origin: ManualOrigin, PrefixLength: 16},
+					{MAC: "00:50:56:83:25:49", IP: "172.29.3.195", Origin: ManualOrigin, PrefixLength: 16},
+				},
+				GuestIpStacks: []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}},
+			}
+			modeByMAC := map[string]string{
+				"00:50:56:83:25:47": "preserve",
+				"00:50:56:83:25:48": "dhcp",
+				"00:50:56:83:25:49": "none",
+			}
+			result, err := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring("00:50:56:83:25:47"))
+			Expect(result).NotTo(ContainSubstring("00:50:56:83:25:48"))
+			Expect(result).NotTo(ContainSubstring("00:50:56:83:25:49"))
+		})
+	})
 
 	DescribeTable("should", func(disks []vsphere.Disk, output []vsphere.Disk) {
 		vm := &model.VM1{}

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -761,7 +761,7 @@ var _ = Describe("vSphere builder", func() {
 
 	builder := createBuilder()
 	DescribeTable("should", func(vm *model.VM, outputMap string) {
-		Expect(builder.mapMacStaticIps(vm)).Should(Equal(outputMap))
+		Expect(builder.mapMacStaticIps(vm, nil)).Should(Equal(outputMap))
 	},
 		Entry("no static ips", &model.VM{GuestID: "windows9Guest"}, ""),
 		Entry("single static ip", &model.VM{
@@ -872,6 +872,99 @@ var _ = Describe("vSphere builder", func() {
 			},
 		}, "00:50:56:83:25:47:ip:172.29.3.193,172.29.3.2,16,8.8.8.8_00:50:56:83:25:48:ip:172.29.3.192,172.29.3.1,24,4.4.4.4_00:50:56:83:25:47:ip:2620:52:9:162e::97,2620:52:9:162e::98,64,2620:52:9:162e::1,2620:52:9:162e::2,2620:52:9:162e::3_00:50:56:83:25:48:ip:2620:52:9:162e::90,2620:52:9:162e::95,32,2620:52:9:162e::4,2620:52:9:162e::5,2620:52:9:162e::6"),
 	)
+
+	Context("mapMacStaticIps with networkIPMode filtering", func() {
+		It("should skip NICs with mode 'none'", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+					{MAC: "00:50:56:83:25:48", IP: "172.29.3.194", Origin: ManualOrigin, PrefixLength: 16},
+				},
+				GuestIpStacks: []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}},
+			}
+			modeByMAC := map[string]string{
+				"00:50:56:83:25:47": "preserve",
+				"00:50:56:83:25:48": "none",
+			}
+			result, err := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring("00:50:56:83:25:47"))
+			Expect(result).NotTo(ContainSubstring("00:50:56:83:25:48"))
+		})
+
+		It("should skip NICs with mode 'dhcp'", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+				},
+			}
+			modeByMAC := map[string]string{
+				"00:50:56:83:25:47": "dhcp",
+			}
+			result, err := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should include NICs not in modeByMAC (backward compat)", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+				},
+				GuestIpStacks: []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}},
+			}
+			// NIC not in the map at all — should proceed
+			modeByMAC := map[string]string{}
+			result, err := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring("00:50:56:83:25:47"))
+		})
+
+		It("should include all NICs when modeByMAC is nil", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+					{MAC: "00:50:56:83:25:48", IP: "172.29.3.194", Origin: ManualOrigin, PrefixLength: 16},
+				},
+				GuestIpStacks: []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}},
+			}
+			result, err := b.mapMacStaticIps(vm, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring("00:50:56:83:25:47"))
+			Expect(result).To(ContainSubstring("00:50:56:83:25:48"))
+		})
+
+		It("should preserve only marked NICs in a mixed-mode map", func() {
+			b := createBuilder()
+			vm := &model.VM{
+				GuestID: "windows9Guest",
+				GuestNetworks: []vsphere.GuestNetwork{
+					{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+					{MAC: "00:50:56:83:25:48", IP: "172.29.3.194", Origin: ManualOrigin, PrefixLength: 16},
+					{MAC: "00:50:56:83:25:49", IP: "172.29.3.195", Origin: ManualOrigin, PrefixLength: 16},
+				},
+				GuestIpStacks: []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}},
+			}
+			modeByMAC := map[string]string{
+				"00:50:56:83:25:47": "preserve",
+				"00:50:56:83:25:48": "dhcp",
+				"00:50:56:83:25:49": "none",
+			}
+			result, err := b.mapMacStaticIps(vm, modeByMAC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring("00:50:56:83:25:47"))
+			Expect(result).NotTo(ContainSubstring("00:50:56:83:25:48"))
+			Expect(result).NotTo(ContainSubstring("00:50:56:83:25:49"))
+		})
+	})
 
 	DescribeTable("should", func(disks []vsphere.Disk, output []vsphere.Disk) {
 		vm := &model.VM1{}


### PR DESCRIPTION
Introduce a guestIPConfig field (preserve/dhcp/none) on NetworkPair entries in the NetworkMap CRD, allowing per-NIC control over whether static IPs are preserved during migration. This overrides the plan-level preserveStaticIPs flag on a per-network basis.

Changes:
- Add GuestIPConfig type and field to NetworkPair in mapping.go
- Add validation rejecting guestIPConfig on ignored destinations
- Add ResolveNICModes() and HasPreserveMode() helpers in base package
- Modify vSphere and HyperV builders to filter mapMacStaticIps by mode

Ref: https://redhat.atlassian.net/browse/MTV-5674
Resolves: MTV-5674