### PR TITLE
MTV-5655 | Fix populator pod cleanup and prevent PVC cascade deletion

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1556,6 +1556,11 @@ func (r *Builder) PopulatorTransferredBytes(pvc *core.PersistentVolumeClaim) (tr
 		return
 	}
 
+	if populatorCr.Status.Progress == "" {
+		transferredBytes = 0
+		return
+	}
+
 	progressPercentage, err := strconv.ParseInt(populatorCr.Status.Progress, 10, 64)
 	if err != nil {
 		r.Log.Error(err, "Couldn't parse the progress percentage.", "pvcName", pvc.Name, "progressPercentage", progressPercentage)

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -391,6 +391,12 @@ func (r *KubeVirt) DeleteDataVolumes(vm *plan.VMStatus) (err error) {
 		return
 	}
 	for _, dv := range dvs {
+		r.Log.Info(
+			"Deleting DataVolume.",
+			"dv",
+			path.Join(dv.Namespace, dv.Name),
+			"vm",
+			vm.String())
 		err = r.Destination.Client.Delete(context.TODO(), dv.DataVolume)
 		if err != nil {
 			return
@@ -447,6 +453,7 @@ func (r *KubeVirt) DeleteJobs(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found jobs to delete.", "count", len(list.Items), "vm", vm.String())
 
 	jobNames := []string{}
 	for _, job := range list.Items {
@@ -584,6 +591,7 @@ func (r *KubeVirt) DeleteSecret(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found secrets to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err = r.DeleteObject(&object, vm, "Deleted secret.", "secret")
 		if err != nil {
@@ -609,6 +617,7 @@ func (r *KubeVirt) DeleteConfigMap(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found config maps to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err = r.DeleteObject(&object, vm, "Deleted configMap.", "configMap")
 		if err != nil {
@@ -634,6 +643,7 @@ func (r *KubeVirt) DeleteVM(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found VMs to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		foreground := meta.DeletePropagationForeground
 		opts := &client.DeleteOptions{PropagationPolicy: &foreground}
@@ -1322,6 +1332,7 @@ func (r *KubeVirt) DeletePVCConsumerPod(vm *plan.VMStatus) (err error) {
 	if err != nil {
 		return err
 	}
+	r.Log.Info("Found PVC consumer pods to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err = r.DeleteObject(&object, vm, "Deleted PVC consumer pod.", "pod")
 		if err != nil {
@@ -1337,6 +1348,7 @@ func (r *KubeVirt) DeletePreflightInspectionPod(vm *plan.VMStatus) (err error) {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	r.Log.Info("Found preflight inspection pods to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err := r.DeleteObject(&object, vm, "Deleted preflight inspection pod.", "pod")
 		if err != nil {
@@ -1352,6 +1364,7 @@ func (r *KubeVirt) DeleteGuestConversionPod(vm *plan.VMStatus) (err error) {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	r.Log.Info("Found guest conversion pods to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err := r.DeleteObject(&object, vm, "Deleted guest conversion pod.", "pod")
 		if err != nil {
@@ -1422,6 +1435,7 @@ func (r *KubeVirt) DeleteHookJobs(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found hook jobs to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err = r.DeleteObject(&object, vm, "Deleted hook job.", "job")
 		if err != nil {
@@ -1437,6 +1451,7 @@ func (r *KubeVirt) DeletePopulatedPVCs(vm *plan.VMStatus) error {
 	if err != nil {
 		return err
 	}
+	r.Log.Info("Found populated PVCs to delete.", "count", len(pvcs), "vm", vm.String())
 	for _, pvc := range pvcs {
 		if err = r.deleteCorrespondingPrimePVC(pvc, vm); err != nil {
 			return err
@@ -1491,16 +1506,24 @@ func (r *KubeVirt) DeletePopulatorPods(vm *plan.VMStatus) (err error) {
 		r.Log.Info("Retaining populator pods (feature flag enabled).", "vm", vm.String())
 		return
 	}
-	list, err := r.getPopulatorPods()
+	list, err := r.getPopulatorPods(vm.ID)
+	if err != nil {
+		return
+	}
+	r.Log.Info("Found populator pods to delete.", "count", len(list), "vm", vm.String())
 	for _, object := range list {
 		err = r.DeleteObject(&object, vm, "Deleted populator pod.", "pod")
 	}
 	return
 }
 
-// Get populator pods that belong to a VM's migration.
-func (r *KubeVirt) getPopulatorPods() (pods []core.Pod, err error) {
-	migrationPods, err := r.GetPodsWithLabels(map[string]string{kMigration: string(r.Plan.Status.Migration.ActiveSnapshot().Migration.UID)})
+// Get populator pods that belong to a specific VM in a migration.
+func (r *KubeVirt) getPopulatorPods(vmID string) (pods []core.Pod, err error) {
+	labelSelector := map[string]string{kMigration: string(r.Plan.Status.Migration.ActiveSnapshot().Migration.UID)}
+	if vmID != "" {
+		labelSelector[kVM] = vmID
+	}
+	migrationPods, err := r.GetPodsWithLabels(labelSelector)
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -402,6 +402,8 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			Settings.RetainPopulatorPods = savedRetain
 		})
 
+		const testVmID = "vm-123"
+
 		createKubeVirtWithPopulatorPod := func() (*KubeVirt, *v1.Pod) {
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -409,6 +411,7 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 					Namespace: targetNS,
 					Labels: map[string]string{
 						"migration": migrationUID,
+						"vmID":      testVmID,
 					},
 				},
 			}
@@ -427,11 +430,12 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			Settings.RetainPopulatorPods = true
 			kubevirt, _ := createKubeVirtWithPopulatorPod()
 			vm := &plan.VMStatus{}
+			vm.ID = testVmID
 
 			err := kubevirt.DeletePopulatorPods(vm)
 			Expect(err).ToNot(HaveOccurred())
 
-			pods, err := kubevirt.getPopulatorPods()
+			pods, err := kubevirt.getPopulatorPods(testVmID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pods).To(HaveLen(1), "populator pod should still exist")
 		})
@@ -440,11 +444,12 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			Settings.RetainPopulatorPods = false
 			kubevirt, _ := createKubeVirtWithPopulatorPod()
 			vm := &plan.VMStatus{}
+			vm.ID = testVmID
 
 			err := kubevirt.DeletePopulatorPods(vm)
 			Expect(err).ToNot(HaveOccurred())
 
-			pods, err := kubevirt.getPopulatorPods()
+			pods, err := kubevirt.getPopulatorPods(testVmID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pods).To(BeEmpty(), "populator pod should have been deleted")
 		})

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -306,7 +306,7 @@ func (r *Migration) Archive() {
 			}
 			return false
 		}
-		_ = r.cleanup(vm, dontFailOnError)
+		_ = r.cleanup(vm, dontFailOnError, true)
 		r.migrator.Complete(vm)
 	}
 }
@@ -364,7 +364,7 @@ func (r *Migration) Cancel() error {
 				}
 				return false
 			}
-			_ = r.cleanup(vm, dontFailOnError)
+			_ = r.cleanup(vm, dontFailOnError, true)
 			if vm.RestorePowerState == plan.VMPowerStateOn {
 				if err := r.provider.PowerOn(vm.Ref); err != nil {
 					r.Log.Error(err,
@@ -405,7 +405,7 @@ func (r *Migration) deletePopulatorPVCs(vm *plan.VMStatus) (err error) {
 }
 
 // Delete left over migration resources associated with a VM.
-func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool) error {
+func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, forceDeleteGuestConversionPod bool) error {
 	r.Log.Info("Starting cleanup of migration resources.", "vm", vm.String())
 
 	// If the migration fails and the DeleteVmOnFailMigration is enabled, clean up the VM.
@@ -433,7 +433,7 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool) error
 	if err := r.kubevirt.DeletePVCConsumerPod(vm); failOnErr(err) {
 		return err
 	}
-	if r.Plan.Spec.DeleteGuestConversionPod {
+	if r.Plan.Spec.DeleteGuestConversionPod || forceDeleteGuestConversionPod {
 		r.Log.Info("Deleting guest conversion pod.", "vm", vm.String())
 		if err := r.kubevirt.DeleteGuestConversionPod(vm); failOnErr(err) {
 			return err
@@ -716,7 +716,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			vm.MarkStarted()
 			step.MarkStarted()
 			step.Phase = api.StepRunning
-			err = r.cleanup(vm, func(err error) bool { return err != nil })
+			err = r.cleanup(vm, func(err error) bool { return err != nil }, true)
 			if err != nil {
 				step.AddError(err.Error())
 				err = nil
@@ -1391,7 +1391,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				r.Log.Error(err, "Cleanup after successful VM migration.", "vm", vm.String())
 			}
 			return false
-		})
+		}, false)
 
 	} else if vm.Error != nil {
 		vm.Phase = api.PhaseCompleted

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -281,13 +281,16 @@ func (r *Migration) Archive() {
 
 	switch r.Plan.Provider.Source.Type() {
 	case api.Ova, api.HyperV:
+		r.Log.Info("Deleting provider storage PVCs and PVs.", "provider", r.Plan.Provider.Source.Type())
 		if err := r.deleteProviderStorage(); err != nil {
 			r.Log.Error(err, "Failed to clean up the PVC and PV for the provider storage")
 		}
 	case api.VSphere:
+		r.Log.Info("Deleting validate-VDDK job(s).")
 		if err := r.deleteValidateVddkJob(); err != nil {
 			r.Log.Error(err, "Failed to clean up validate-VDDK job(s)")
 		}
+		r.Log.Info("Deleting VDDK config map.")
 		if err := r.deleteConfigMap(); err != nil {
 			r.Log.Error(err, "Failed to clean up vddk configmap")
 		}
@@ -403,55 +406,73 @@ func (r *Migration) deletePopulatorPVCs(vm *plan.VMStatus) (err error) {
 
 // Delete left over migration resources associated with a VM.
 func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool) error {
+	r.Log.Info("Starting cleanup of migration resources.", "vm", vm.String())
+
 	// If the migration fails and the DeleteVmOnFailMigration is enabled, clean up the VM.
 	// When DeleteVmOnFailMigration is disabled, VM resources are preserved on failure.
 	if !vm.HasCondition(api.ConditionSucceeded) && (r.Plan.Spec.DeleteVmOnFailMigration || vm.DeleteVmOnFailMigration) {
+		r.Log.Info("Deleting VM (failed migration with deleteVmOnFailMigration enabled).", "vm", vm.String())
 		if err := r.kubevirt.DeleteVM(vm); failOnErr(err) {
 			return err
 		}
+		r.Log.Info("Deleting populated PVCs.", "vm", vm.String())
 		if err := r.deletePopulatorPVCs(vm); failOnErr(err) {
 			return err
 		}
+		r.Log.Info("Deleting DataVolumes.", "vm", vm.String())
 		if err := r.kubevirt.DeleteDataVolumes(vm); failOnErr(err) {
 			return err
 		}
 	}
 
+	r.Log.Info("Deleting importer pods.", "vm", vm.String())
 	if err := r.deleteImporterPods(vm); failOnErr(err) {
 		return err
 	}
+	r.Log.Info("Deleting PVC consumer pod.", "vm", vm.String())
 	if err := r.kubevirt.DeletePVCConsumerPod(vm); failOnErr(err) {
 		return err
 	}
-	if err := r.kubevirt.DeleteGuestConversionPod(vm); failOnErr(err) {
-		return err
+	if r.Plan.Spec.DeleteGuestConversionPod {
+		r.Log.Info("Deleting guest conversion pod.", "vm", vm.String())
+		if err := r.kubevirt.DeleteGuestConversionPod(vm); failOnErr(err) {
+			return err
+		}
 	}
+	r.Log.Info("Deleting preflight inspection pod.", "vm", vm.String())
 	if err := r.kubevirt.DeletePreflightInspectionPod(vm); failOnErr(err) {
 		return err
 	}
+	r.Log.Info("Deleting secrets.", "vm", vm.String())
 	if err := r.kubevirt.DeleteSecret(vm); failOnErr(err) {
 		return err
 	}
+	r.Log.Info("Deleting config maps.", "vm", vm.String())
 	if err := r.kubevirt.DeleteConfigMap(vm); failOnErr(err) {
 		return err
 	}
+	r.Log.Info("Deleting hook jobs.", "vm", vm.String())
 	if err := r.kubevirt.DeleteHookJobs(vm); failOnErr(err) {
 		return err
 	}
 	if r.Plan.Provider.Destination.IsHost() {
+		r.Log.Info("Deleting populator data source.", "vm", vm.String())
 		if err := r.destinationClient.DeletePopulatorDataSource(vm); failOnErr(err) {
 			return err
 		}
 	}
+	r.Log.Info("Deleting populator pods.", "vm", vm.String())
 	if err := r.kubevirt.DeletePopulatorPods(vm); failOnErr(err) {
 		return err
 	}
+	r.Log.Info("Deleting migration jobs.", "vm", vm.String())
 	if err := r.kubevirt.DeleteJobs(vm); failOnErr(err) {
 		return err
 	}
 
 	r.removeLastWarmSnapshot(vm)
 
+	r.Log.Info("Cleanup of migration resources completed.", "vm", vm.String())
 	return nil
 }
 
@@ -464,6 +485,7 @@ func (r *Migration) removeLastWarmSnapshot(vm *plan.VMStatus) {
 		return
 	}
 	snapshot := vm.Warm.Precopies[n-1].Snapshot
+	r.Log.Info("Removing warm migration snapshot.", "vm", vm.String(), "snapshot", snapshot)
 	if _, err := r.provider.RemoveSnapshot(vm.Ref, snapshot, r.kubevirt.loadHosts); err != nil {
 		r.Log.Error(
 			err,
@@ -1356,20 +1378,6 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			err = nil
 			return
 		}
-		// Delete pod if user specified that they want to remove it after successful migration.
-		if r.Plan.Spec.DeleteGuestConversionPod {
-			r.Log.Info("Removing guest conversion pod for finished VM.", "vm", vm.String())
-			err = r.kubevirt.DeleteGuestConversionPod(vm)
-			if err != nil {
-				r.Log.Error(
-					err,
-					"Could not remove guest conversion pod for finished VM.",
-					"vm",
-					vm.String(),
-				)
-				err = nil
-			}
-		}
 		vm.SetCondition(
 			libcnd.Condition{
 				Type:     api.ConditionSucceeded,
@@ -1378,6 +1386,12 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				Message:  "The VM migration has SUCCEEDED.",
 				Durable:  true,
 			})
+		_ = r.cleanup(vm, func(err error) bool {
+			if err != nil {
+				r.Log.Error(err, "Cleanup after successful VM migration.", "vm", vm.String())
+			}
+			return false
+		})
 
 	} else if vm.Error != nil {
 		vm.Phase = api.PhaseCompleted
@@ -1910,7 +1924,7 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 		newProgress := int64(percent * float64(task.Progress.Total))
 		if newProgress == task.Progress.Completed {
 			pvcId := string(pvc.UID)
-			populatorFailed := r.isPopulatorPodFailed(pvcId)
+			populatorFailed := r.isPopulatorPodFailed(pvcId, vm.ID)
 			if populatorFailed {
 				return fmt.Errorf("populator pod failed for PVC %s. Please check the pod logs", pvcId)
 			}
@@ -1932,8 +1946,8 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 }
 
 // Checks if the populator pod failed when the progress didn't change
-func (r *Migration) isPopulatorPodFailed(givenPvcId string) bool {
-	populatorPods, err := r.kubevirt.getPopulatorPods()
+func (r *Migration) isPopulatorPodFailed(givenPvcId string, vmID string) bool {
+	populatorPods, err := r.kubevirt.getPopulatorPods(vmID)
 	if err != nil {
 		r.Log.Error(err, "couldn't get the populator pods")
 		return false

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -636,6 +636,9 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 			if found {
 				labels["migration"] = migration
 			}
+			if vmID, ok, _ := unstructured.NestedString(crInstance.Object, "metadata", "labels", "vmID"); ok && vmID != "" {
+				labels["vmID"] = vmID
+			}
 			if sourceHost != "" {
 				labels[labelSourceHost] = sourceHost
 			}
@@ -766,7 +769,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 				// Skip retry logic for VSphere xcopy populator - let it fail immediately
 				if c.gk.Kind == api.VSphereXcopyVolumePopulatorKind {
 					c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPodFailed, "VSphere xcopy populator failed (no retry): Please check the logs of the populator pod, %s/%s", populatorNamespace, pod.Name)
-					return c.deleteFailedPVC(ctx, pvc)
+					return nil
 				}
 
 				restarts, ok := pvc.Annotations[AnnPopulatorReCreations]
@@ -781,7 +784,6 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 					return c.retryFailedPopulator(ctx, pvc, populatorNamespace, pod.Name, restartsInteger+1)
 				}
 				c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPodFailed, "Populator failed after few (3) attempts: Please check the logs of the populator pod, %s/%s", populatorNamespace, pod.Name)
-				return c.deleteFailedPVC(ctx, pvc)
 			}
 			// We'll get called again later when the pod succeeds
 			return nil
@@ -867,14 +869,6 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 	// Stop progress monitoring
 	delete(monitoredPVCs, string(pvc.UID))
 
-	return nil
-}
-
-func (c *controller) deleteFailedPVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
-	klog.V(2).Infof("Deleting PVC %s/%s after permanent populator failure", pvc.Namespace, pvc.Name)
-	if err := c.kubeClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- **Fix populator pod cleanup deleting pods of other VMs**: Add `vmID` label filtering to `getPopulatorPods()` and `DeletePopulatorPods()` so that cleanup for one VM does not kill populator pods belonging to other actively-migrating VMs. Mirrors the fix already applied to `getPopulatorCrList` in PR #6628.
- **Remove `deleteFailedPVC` from populator controller**: Stop deleting target PVCs on populator failure. Combined with OwnerReferences (MTV-3353), deleting the PVC cascades via Kubernetes GC to delete the populator pod, prime PVC, and triggers cleanup of all remaining PVCs for the VM. The forklift controller now handles cleanup during archive instead.
- **Cleanup on successful VM migration**: Call `cleanup()` after setting the Succeeded condition so resources (populator pods, PVCs, etc.) are released on success. Gate `DeleteGuestConversionPod` behind the plan spec flag in `cleanup()`.

## Test plan
- [ ] Run concurrent VM migration (multiple VMs, multiple disks) with copy offload
- [ ] Verify that a single disk failure does NOT cascade-delete PVCs of other disks in the same or different VMs
- [ ] Verify failed VMs report "populator pod failed for PVC" instead of "PVC is missing"
- [ ] Verify successful VM migrations clean up resources properly
- [ ] Verify guest conversion pod is only deleted when `DeleteGuestConversionPod` is set in plan spec

Ref: https://issues.redhat.com/browse/MTV-5655

🤖 Generated with [Claude Code](https://claude.com/claude-code)