### PR TITLE
MTV-5652 | Propagate detailed SCC error for guest conversion pod failure

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3266,6 +3266,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              message:
+                description: |-
+                  Message is a human-readable explanation of the current phase, populated
+                  by the conversion controller on every reconcile.
+                type: string
               observedGeneration:
                 description: |-
                   The most recent generation observed by the controller.

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3266,6 +3266,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              message:
+                description: |-
+                  Message is a human-readable explanation of the current phase, populated
+                  by the conversion controller on every reconcile.
+                type: string
               observedGeneration:
                 description: |-
                   The most recent generation observed by the controller.

--- a/operator/config/crd/bases/forklift.konveyor.io_conversions.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_conversions.yaml
@@ -3260,6 +3260,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              message:
+                description: |-
+                  Message is a human-readable explanation of the current phase, populated
+                  by the conversion controller on every reconcile.
+                type: string
               observedGeneration:
                 description: |-
                   The most recent generation observed by the controller.

--- a/pkg/apis/forklift/v1beta1/conversion.go
+++ b/pkg/apis/forklift/v1beta1/conversion.go
@@ -37,6 +37,12 @@ const (
 	PhaseCanceled  ConversionPhase = "Canceled"
 )
 
+// Condition types set on Conversion status.
+const (
+	ConversionFailed   = "ConversionFailed"
+	ConversionCanceled = "ConversionCanceled"
+)
+
 // ConversionStage is the fine-grained pipeline position within the Running phase.
 type ConversionStage string
 
@@ -301,6 +307,10 @@ type ConversionStatus struct {
 	// +optional
 	// +kubebuilder:validation:Enum=CreatingPod;PodRunning;CreatingSnapshot;WaitingForSnapshot;RemovingSnapshot;WaitingForSnapshotRemoval;FetchingResults;Finished
 	Stage ConversionStage `json:"stage,omitempty"`
+	// Message is a human-readable explanation of the current phase, populated
+	// by the conversion controller on every reconcile.
+	// +optional
+	Message string `json:"message,omitempty"`
 	// Reference to the managed conversion pod.
 	// +optional
 	Pod core.ObjectReference `json:"pod,omitempty"`

--- a/pkg/controller/conversion/controller.go
+++ b/pkg/controller/conversion/controller.go
@@ -2,6 +2,7 @@ package conversion
 
 import (
 	"context"
+	"fmt"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/controller/base"
@@ -127,7 +128,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		} else {
 			r.Log.Error(ensureErr, "Failed to build Ensurer for canceled Conversion.")
 		}
-		resolvePhaseConditions(conversion)
+		resolvePhaseConditions(conversion, nil)
 		conversion.Status.EndStagingConditions()
 		r.Record(conversion, conversion.Status.Conditions)
 		conversion.Status.ObservedGeneration = conversion.Generation
@@ -145,9 +146,9 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	}
 
 	pipe := NewConversionPipeline(ctx, &r, conversion)
-	succeeded, err := pipe.Run()
-	if err != nil {
-		r.Log.Error(err, "Conversion pipeline failed.",
+	succeeded, pipelineErr := pipe.Run()
+	if pipelineErr != nil {
+		r.Log.Error(pipelineErr, "Conversion pipeline failed.",
 			"type", conversion.Spec.Type,
 			"phase", conversion.Status.Phase,
 			"stage", conversion.Status.Stage)
@@ -180,7 +181,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		}
 	}
 
-	resolvePhaseConditions(conversion)
+	resolvePhaseConditions(conversion, pipelineErr)
 
 	conversion.Status.EndStagingConditions()
 
@@ -198,41 +199,54 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 }
 
 // resolvePhaseConditions sets the Ready condition on conversion based on the current phase.
-func resolvePhaseConditions(conversion *api.Conversion) {
+// When pipelineErr is non-nil and Phase is Failed, the error detail is included
+// in the ConversionFailed condition so the plan controller can surface it.
+func resolvePhaseConditions(conversion *api.Conversion, pipelineErr error) {
 	switch conversion.Status.Phase {
 	case api.PhaseSucceeded:
 		now := meta.Now()
 		conversion.Status.CompletionTime = &now
+		msg := "The conversion has completed successfully."
+		conversion.Status.Message = msg
 		conversion.Status.SetCondition(libcnd.Condition{
 			Type:     libcnd.Ready,
 			Status:   True,
 			Category: Required,
-			Message:  "The conversion has completed successfully.",
+			Message:  msg,
 		})
 	case api.PhaseFailed:
 		now := meta.Now()
 		conversion.Status.CompletionTime = &now
+		msg := "The conversion has failed."
+		if pipelineErr != nil {
+			msg = fmt.Sprintf("The conversion has failed: %s", pipelineErr.Error())
+		}
+		conversion.Status.Message = msg
 		conversion.Status.SetCondition(libcnd.Condition{
-			Type:     "ConversionFailed",
+			Type:     api.ConversionFailed,
 			Status:   True,
 			Category: Critical,
-			Message:  "The conversion has failed.",
+			Message:  msg,
 		})
 	case api.PhaseCanceled:
 		now := meta.Now()
 		conversion.Status.CompletionTime = &now
+		msg := "The conversion has been canceled."
+		conversion.Status.Message = msg
 		conversion.Status.SetCondition(libcnd.Condition{
-			Type:     "ConversionCanceled",
+			Type:     api.ConversionCanceled,
 			Status:   True,
 			Category: Advisory,
-			Message:  "The conversion has been canceled.",
+			Message:  msg,
 		})
 	case api.PhasePending:
+		msg := "The conversion is pending."
+		conversion.Status.Message = msg
 		conversion.Status.SetCondition(libcnd.Condition{
 			Type:     libcnd.Ready,
 			Status:   False,
 			Category: Required,
-			Message:  "The conversion is pending.",
+			Message:  msg,
 		})
 	case api.PhaseRunning:
 		resolveStageConditions(conversion)
@@ -263,6 +277,7 @@ func resolveStageConditions(conversion *api.Conversion) {
 	default:
 		msg = "The conversion is running."
 	}
+	conversion.Status.Message = msg
 	conversion.Status.SetCondition(libcnd.Condition{
 		Type:     libcnd.Advisory,
 		Status:   True,

--- a/pkg/controller/conversion/controller_test.go
+++ b/pkg/controller/conversion/controller_test.go
@@ -1,0 +1,95 @@
+package conversion
+
+import (
+	"fmt"
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestResolvePhaseConditions_FailedWithError(t *testing.T) {
+	conv := &api.Conversion{
+		ObjectMeta: meta.ObjectMeta{Name: "test-conv", Namespace: "default"},
+		Status:     api.ConversionStatus{Phase: api.PhaseFailed},
+	}
+	sccErr := fmt.Errorf(`pods "plan1-vm-9265-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount]`)
+
+	resolvePhaseConditions(conv, sccErr)
+
+	cnd := conv.Status.FindCondition(api.ConversionFailed)
+	if cnd == nil {
+		t.Fatal("expected ConversionFailed condition to be set")
+	}
+	if cnd.Status != True {
+		t.Errorf("expected condition status %q, got %q", True, cnd.Status)
+	}
+	expected := "The conversion has failed: " + sccErr.Error()
+	if cnd.Message != expected {
+		t.Errorf("expected condition message:\n  %s\ngot:\n  %s", expected, cnd.Message)
+	}
+	if conv.Status.Message != expected {
+		t.Errorf("expected status.message:\n  %s\ngot:\n  %s", expected, conv.Status.Message)
+	}
+}
+
+func TestResolvePhaseConditions_FailedWithoutError(t *testing.T) {
+	conv := &api.Conversion{
+		ObjectMeta: meta.ObjectMeta{Name: "test-conv", Namespace: "default"},
+		Status:     api.ConversionStatus{Phase: api.PhaseFailed},
+	}
+
+	resolvePhaseConditions(conv, nil)
+
+	cnd := conv.Status.FindCondition(api.ConversionFailed)
+	if cnd == nil {
+		t.Fatal("expected ConversionFailed condition to be set")
+	}
+	if cnd.Message != "The conversion has failed." {
+		t.Errorf("expected generic condition message, got %q", cnd.Message)
+	}
+	if conv.Status.Message != "The conversion has failed." {
+		t.Errorf("expected generic status.message, got %q", conv.Status.Message)
+	}
+}
+
+func TestResolvePhaseConditions_Succeeded(t *testing.T) {
+	conv := &api.Conversion{
+		ObjectMeta: meta.ObjectMeta{Name: "test-conv", Namespace: "default"},
+		Status:     api.ConversionStatus{Phase: api.PhaseSucceeded},
+	}
+
+	resolvePhaseConditions(conv, nil)
+
+	cnd := conv.Status.FindCondition(libcnd.Ready)
+	if cnd == nil {
+		t.Fatal("expected Ready condition to be set")
+	}
+	if cnd.Message != "The conversion has completed successfully." {
+		t.Errorf("unexpected message: %q", cnd.Message)
+	}
+}
+
+func TestResolvePhaseConditions_Canceled(t *testing.T) {
+	conv := &api.Conversion{
+		ObjectMeta: meta.ObjectMeta{Name: "test-conv", Namespace: "default"},
+		Status:     api.ConversionStatus{Phase: api.PhaseCanceled},
+	}
+
+	resolvePhaseConditions(conv, nil)
+
+	cnd := conv.Status.FindCondition(api.ConversionCanceled)
+	if cnd == nil {
+		t.Fatal("expected ConversionCanceled condition to be set")
+	}
+	if cnd.Message != "The conversion has been canceled." {
+		t.Errorf("unexpected condition message: %q", cnd.Message)
+	}
+	if conv.Status.Message != "The conversion has been canceled." {
+		t.Errorf("unexpected status.message: %q", conv.Status.Message)
+	}
+	if conv.Status.CompletionTime == nil {
+		t.Error("expected CompletionTime to be set")
+	}
+}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	cnv "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
@@ -662,6 +663,35 @@ func (r *KubeVirt) ensureConversionSecret(cl client.Client, secret *core.Secret)
 	r.Log.V(1).Info("Conversion secret created.",
 		"secret", path.Join(secret.Namespace, secret.Name))
 	return secret, nil
+}
+
+// GetGuestConversion returns the guest-conversion (Remote or InPlace) Conversion CR
+// for the given VM on this plan, or nil when none exists.
+func (r *KubeVirt) GetGuestConversion(vm *plan.VMStatus) (*api.Conversion, error) {
+	typeReq, err := k8slabels.NewRequirement(
+		convctx.LabelConversionType,
+		selection.In,
+		[]string{string(api.Remote), string(api.InPlace)},
+	)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	selector := k8slabels.SelectorFromSet(map[string]string{
+		convctx.LabelPlan: string(r.Plan.UID),
+		convctx.LabelVM:   vm.ID,
+	}).Add(*typeReq)
+
+	list := &api.ConversionList{}
+	if err := r.List(context.TODO(), list,
+		client.InNamespace(r.Plan.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
+	}
+	return nil, nil //nolint:nilnil
 }
 
 // GetDeepInspectionConversion returns the DeepInspection Conversion CR for the

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1883,6 +1883,42 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 	case err != nil:
 		return liberr.Wrap(err)
 	case pod == nil:
+		if settings.Settings.UseConversionCR {
+			conv, convErr := r.kubevirt.GetGuestConversion(vm)
+			if convErr != nil {
+				r.Log.Error(convErr, "Failed to get guest Conversion CR", "vm", vm.String())
+				return nil
+			}
+			if conv == nil {
+				return nil
+			}
+			switch conv.Status.Phase {
+			case api.PhaseSucceeded:
+				step.MarkCompleted()
+				step.Progress.Completed = step.Progress.Total
+				return nil
+			case api.PhaseFailed:
+				step.MarkCompleted()
+				if conv.Status.Message != "" {
+					step.AddError(conv.Status.Message)
+				} else {
+					step.AddError("Guest conversion failed.")
+				}
+				return nil
+			case api.PhaseCanceled:
+				step.MarkCompleted()
+				if conv.Status.Message != "" {
+					step.AddError(conv.Status.Message)
+				} else {
+					step.AddError("Guest conversion was canceled.")
+				}
+				return nil
+			case api.PhaseRunning, api.PhasePending:
+				return nil
+			default:
+				return nil
+			}
+		}
 		step.MarkCompleted()
 		step.AddError("Guest conversion pod not found")
 		return nil


### PR DESCRIPTION
When UseConversionCR is enabled (default in 2.12), pod creation errors such as SCC validation failures were lost. The Conversion CR condition only stored a generic "The conversion has failed." message, and the plan controller reported "Guest conversion pod not found" without checking the CR for details.

Store the pipeline error in the ConversionFailed condition message so it includes the actual API rejection reason. In the plan controller, read the Conversion CR status when the pod is missing and surface the detailed error in the migration step reasons.

Ref: https://redhat.atlassian.net/browse/MTV-5652
Resolves: MTV-5652