### PR TITLE
MTV-4498 | Allow controller to read CSIStorageCapacity (release-2.12)

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -10554,6 +10554,7 @@ rules:
   resources:
   - storageclasses
   - csidrivers
+  - csistoragecapacities
   verbs:
   - get
   - list

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -10554,6 +10554,7 @@ rules:
   resources:
   - storageclasses
   - csidrivers
+  - csistoragecapacities
   verbs:
   - get
   - list

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -79,6 +79,7 @@ rules:
   resources:
   - storageclasses
   - csidrivers
+  - csistoragecapacities
   verbs:
   - get
   - list


### PR DESCRIPTION
## Summary

Backport of #6844 to `release-2.12`.

Grants forklift-controller ClusterRole read access to `csistoragecapacities` so `conversionTempStorageSize` capacity validation does not fail with RBAC forbidden errors. Regenerates upstream/downstream operator manifests.

## Test plan

- [ ] `verify-manifests` passes
- [ ] QA: conversion temp storage capacity check succeeds without `csistoragecapacities.storage.k8s.io is forbidden`

Ref: https://redhat.atlassian.net/browse/MTV-4498
Resolves: MTV-4498

Made with [Cursor](https://cursor.com)