### PR TITLE
MTV-5344 | Use dedicated RBAC for wait-for-reboot pod

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -10671,6 +10671,8 @@ rules:
   - list
   - watch
   - create
+  - delete
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -10682,6 +10684,8 @@ rules:
   - get
   - patch
   - create
+  - delete
+  - update
 - apiGroups:
   - build.openshift.io
   resources:

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -10583,6 +10583,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/console
+  verbs:
+  - get
+- apiGroups:
   - cdi.kubevirt.io
   resources:
   - datavolumes
@@ -10789,6 +10795,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/console
+  verbs:
+  - get
 - apiGroups:
   - cdi.kubevirt.io
   resources:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -10671,6 +10671,8 @@ rules:
   - list
   - watch
   - create
+  - delete
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -10682,6 +10684,8 @@ rules:
   - get
   - patch
   - create
+  - delete
+  - update
 - apiGroups:
   - build.openshift.io
   resources:

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -10583,6 +10583,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/console
+  verbs:
+  - get
+- apiGroups:
   - cdi.kubevirt.io
   resources:
   - datavolumes
@@ -10789,6 +10795,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/console
+  verbs:
+  - get
 - apiGroups:
   - cdi.kubevirt.io
   resources:

--- a/operator/config/rbac/forklift-controller_migrator_role.yml
+++ b/operator/config/rbac/forklift-controller_migrator_role.yml
@@ -81,6 +81,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/console
+  verbs:
+  - get
+- apiGroups:
   - cdi.kubevirt.io
   resources:
   - datavolumes

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -108,6 +108,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/console
+  verbs:
+  - get
+- apiGroups:
   - cdi.kubevirt.io
   resources:
   - datavolumes

--- a/operator/config/rbac/forklift-controller_role.yaml
+++ b/operator/config/rbac/forklift-controller_role.yaml
@@ -196,6 +196,8 @@ rules:
   - list
   - watch
   - create
+  - delete
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -207,6 +209,8 @@ rules:
   - get
   - patch
   - create
+  - delete
+  - update
 - apiGroups:
     - build.openshift.io
   resources:

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -45,6 +45,7 @@ import (
 	"github.com/openshift/library-go/pkg/template/templateprocessing"
 	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1004,6 +1005,10 @@ func (r *KubeVirt) EnsureWaitForRebootPod(vm *plan.VMStatus) (err error) {
 		return nil
 	}
 
+	if err = r.ensureWaitForRebootRBAC(r.Plan.Spec.TargetNamespace); err != nil {
+		return
+	}
+
 	activeDeadline := int64(settings.Settings.WindowsRebootTimeout + 600)
 	pod := &core.Pod{
 		ObjectMeta: meta.ObjectMeta{
@@ -1013,7 +1018,7 @@ func (r *KubeVirt) EnsureWaitForRebootPod(vm *plan.VMStatus) (err error) {
 		},
 		Spec: core.PodSpec{
 			RestartPolicy:         core.RestartPolicyNever,
-			ServiceAccountName:    resolveServiceAccount(r.Plan),
+			ServiceAccountName:    waitForRebootSAName,
 			ActiveDeadlineSeconds: &activeDeadline,
 			Containers: []core.Container{
 				{
@@ -1036,6 +1041,62 @@ func (r *KubeVirt) EnsureWaitForRebootPod(vm *plan.VMStatus) (err error) {
 		return
 	}
 	r.Log.Info("Created Windows wait-for-reboot pod.", "podNamespace", pod.Namespace, "podName", pod.Name, "vm", vm.String())
+	return nil
+}
+
+const waitForRebootSAName = "forklift-wait-reboot"
+
+// ensureWaitForRebootRBAC creates a dedicated ServiceAccount, Role, and RoleBinding
+// in the target namespace granting only VMI serial console access.
+func (r *KubeVirt) ensureWaitForRebootRBAC(namespace string) error {
+	sa := &core.ServiceAccount{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      waitForRebootSAName,
+			Namespace: namespace,
+		},
+	}
+	if err := r.Destination.Create(context.TODO(), sa); err != nil && !k8serr.IsAlreadyExists(err) {
+		return liberr.Wrap(err)
+	}
+
+	role := &rbacv1.Role{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      waitForRebootSAName,
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"subresources.kubevirt.io"},
+				Resources: []string{"virtualmachineinstances/console"},
+				Verbs:     []string{"get"},
+			},
+		},
+	}
+	if err := r.Destination.Create(context.TODO(), role); err != nil && !k8serr.IsAlreadyExists(err) {
+		return liberr.Wrap(err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      waitForRebootSAName + "-binding",
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      waitForRebootSAName,
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     waitForRebootSAName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+	if err := r.Destination.Create(context.TODO(), binding); err != nil && !k8serr.IsAlreadyExists(err) {
+		return liberr.Wrap(err)
+	}
 	return nil
 }
 

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1059,48 +1060,85 @@ func (r *KubeVirt) ensureWaitForRebootRBAC(namespace string) error {
 		return liberr.Wrap(err)
 	}
 
+	// rules for the wait-for-reboot pod
+	desiredRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"subresources.kubevirt.io"},
+			Resources: []string{"virtualmachineinstances/console"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"kubevirt.io"},
+			Resources: []string{"virtualmachineinstances"},
+			Verbs:     []string{"get"},
+		},
+	}
+
 	role := &rbacv1.Role{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      waitForRebootSAName,
 			Namespace: namespace,
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"subresources.kubevirt.io"},
-				Resources: []string{"virtualmachineinstances/console"},
-				Verbs:     []string{"get"},
-			},
-			{
-				APIGroups: []string{"kubevirt.io"},
-				Resources: []string{"virtualmachineinstances"},
-				Verbs:     []string{"get"},
-			},
-		},
+		Rules: desiredRules,
 	}
-	if err := r.Destination.Create(context.TODO(), role); err != nil && !k8serr.IsAlreadyExists(err) {
-		return liberr.Wrap(err)
+	if err := r.Destination.Create(context.TODO(), role); err != nil {
+		if !k8serr.IsAlreadyExists(err) {
+			return liberr.Wrap(err)
+		}
+		existing := &rbacv1.Role{}
+		if err = r.Destination.Client.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: waitForRebootSAName}, existing); err != nil {
+			return liberr.Wrap(err)
+		}
+		if !reflect.DeepEqual(existing.Rules, desiredRules) {
+			existing.Rules = desiredRules
+			if err = r.Destination.Client.Update(context.TODO(), existing); err != nil {
+				return liberr.Wrap(err)
+			}
+		}
 	}
 
+	desiredSubjects := []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      waitForRebootSAName,
+			Namespace: namespace,
+		},
+	}
 	binding := &rbacv1.RoleBinding{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      waitForRebootSAName + "-binding",
 			Namespace: namespace,
 		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      waitForRebootSAName,
-				Namespace: namespace,
-			},
-		},
+		Subjects: desiredSubjects,
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "Role",
 			Name:     waitForRebootSAName,
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 	}
-	if err := r.Destination.Create(context.TODO(), binding); err != nil && !k8serr.IsAlreadyExists(err) {
-		return liberr.Wrap(err)
+	if err := r.Destination.Create(context.TODO(), binding); err != nil {
+		if !k8serr.IsAlreadyExists(err) {
+			return liberr.Wrap(err)
+		}
+		existing := &rbacv1.RoleBinding{}
+		if err = r.Destination.Client.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: waitForRebootSAName + "-binding"}, existing); err != nil {
+			return liberr.Wrap(err)
+		}
+		// roleRef is immutable, the binding must be replaced entirely if it's different
+		// subjects diff can be fixed with a plain update
+		if !reflect.DeepEqual(existing.RoleRef, binding.RoleRef) {
+			if err = r.Destination.Client.Delete(context.TODO(), existing); err != nil {
+				return liberr.Wrap(err)
+			}
+			if err = r.Destination.Client.Create(context.TODO(), binding); err != nil {
+				return liberr.Wrap(err)
+			}
+		} else if !reflect.DeepEqual(existing.Subjects, desiredSubjects) {
+			existing.Subjects = desiredSubjects
+			if err = r.Destination.Client.Update(context.TODO(), existing); err != nil {
+				return liberr.Wrap(err)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1070,6 +1070,11 @@ func (r *KubeVirt) ensureWaitForRebootRBAC(namespace string) error {
 				Resources: []string{"virtualmachineinstances/console"},
 				Verbs:     []string{"get"},
 			},
+			{
+				APIGroups: []string{"kubevirt.io"},
+				Resources: []string{"virtualmachineinstances"},
+				Verbs:     []string{"get"},
+			},
 		},
 	}
 	if err := r.Destination.Create(context.TODO(), role); err != nil && !k8serr.IsAlreadyExists(err) {

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1011,6 +1011,7 @@ func (r *KubeVirt) EnsureWaitForRebootPod(vm *plan.VMStatus) (err error) {
 	}
 
 	activeDeadline := int64(settings.Settings.WindowsRebootTimeout + 600)
+	automount := true
 	pod := &core.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			GenerateName: "forklift-wait-reboot-",
@@ -1018,9 +1019,10 @@ func (r *KubeVirt) EnsureWaitForRebootPod(vm *plan.VMStatus) (err error) {
 			Labels:       r.waitForRebootLabels(vm.Ref),
 		},
 		Spec: core.PodSpec{
-			RestartPolicy:         core.RestartPolicyNever,
-			ServiceAccountName:    waitForRebootSAName,
-			ActiveDeadlineSeconds: &activeDeadline,
+			RestartPolicy:                core.RestartPolicyNever,
+			ServiceAccountName:           waitForRebootSAName,
+			AutomountServiceAccountToken: &automount,
+			ActiveDeadlineSeconds:        &activeDeadline,
 			Containers: []core.Container{
 				{
 					Name:    "forklift-wait-for-reboot",

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1088,12 +1088,12 @@ func (r *KubeVirt) ensureWaitForRebootRBAC(namespace string) error {
 			return liberr.Wrap(err)
 		}
 		existing := &rbacv1.Role{}
-		if err = r.Destination.Client.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: waitForRebootSAName}, existing); err != nil {
+		if err = r.Destination.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: waitForRebootSAName}, existing); err != nil {
 			return liberr.Wrap(err)
 		}
 		if !reflect.DeepEqual(existing.Rules, desiredRules) {
 			existing.Rules = desiredRules
-			if err = r.Destination.Client.Update(context.TODO(), existing); err != nil {
+			if err = r.Destination.Update(context.TODO(), existing); err != nil {
 				return liberr.Wrap(err)
 			}
 		}
@@ -1123,21 +1123,21 @@ func (r *KubeVirt) ensureWaitForRebootRBAC(namespace string) error {
 			return liberr.Wrap(err)
 		}
 		existing := &rbacv1.RoleBinding{}
-		if err = r.Destination.Client.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: waitForRebootSAName + "-binding"}, existing); err != nil {
+		if err = r.Destination.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: waitForRebootSAName + "-binding"}, existing); err != nil {
 			return liberr.Wrap(err)
 		}
 		// roleRef is immutable, the binding must be replaced entirely if it's different
 		// subjects diff can be fixed with a plain update
 		if !reflect.DeepEqual(existing.RoleRef, binding.RoleRef) {
-			if err = r.Destination.Client.Delete(context.TODO(), existing); err != nil {
+			if err = r.Destination.Delete(context.TODO(), existing); err != nil {
 				return liberr.Wrap(err)
 			}
-			if err = r.Destination.Client.Create(context.TODO(), binding); err != nil {
+			if err = r.Destination.Create(context.TODO(), binding); err != nil {
 				return liberr.Wrap(err)
 			}
 		} else if !reflect.DeepEqual(existing.Subjects, desiredSubjects) {
 			existing.Subjects = desiredSubjects
-			if err = r.Destination.Client.Update(context.TODO(), existing); err != nil {
+			if err = r.Destination.Update(context.TODO(), existing); err != nil {
 				return liberr.Wrap(err)
 			}
 		}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1584,11 +1584,6 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				err = nil
 			}
 		}
-		if vm.HasCondition("WaitForGuestReboots") {
-			r.Log.Info("Retaining failed Windows wait-for-reboot pod for debugging.", "vm", vm.String())
-		} else if ierr := r.kubevirt.DeleteWaitForRebootPod(vm); ierr != nil {
-			r.Log.Error(ierr, "Could not remove Windows wait-for-reboot pod for finished VM.", "vm", vm.String())
-		}
 		vm.SetCondition(
 			libcnd.Condition{
 				Type:     api.ConditionSucceeded,

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1049,19 +1049,38 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				_ = r.kubevirt.DeleteWaitForRebootPod(vm)
 				r.NextPhase(vm)
 			case core.PodFailed:
-				r.Log.Info(
-					"Windows wait-for-reboot watcher ended without success; continuing migration.",
+				logFields := []interface{}{
 					"vm", vm.String(),
 					"podNamespace", pod.Namespace,
-					"podName", pod.Name)
+					"podName", pod.Name,
+					"podMessage", pod.Status.Message,
+					"podReason", pod.Status.Reason,
+				}
+				if len(pod.Status.ContainerStatuses) > 0 {
+					cs := pod.Status.ContainerStatuses[0]
+					if cs.State.Terminated != nil {
+						logFields = append(logFields,
+							"exitCode", cs.State.Terminated.ExitCode,
+							"terminationReason", cs.State.Terminated.Reason,
+							"terminationMessage", cs.State.Terminated.Message,
+						)
+					}
+				}
+				r.Log.Info("Windows wait-for-reboot pod failed; retaining pod for debugging.", logFields...)
+				condMsg := "Windows guest reboot wait did not complete successfully; migration continues. Pod retained for debugging."
+				if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].State.Terminated != nil {
+					t := pod.Status.ContainerStatuses[0].State.Terminated
+					if t.Message != "" {
+						condMsg = fmt.Sprintf("%s Reason: %s", condMsg, t.Message)
+					}
+				}
 				vm.SetCondition(libcnd.Condition{
 					Type:     "WaitForGuestReboots",
 					Status:   libcnd.True,
 					Category: api.CategoryWarn,
-					Message:  "Windows guest reboot wait did not complete successfully; migration continues.",
+					Message:  condMsg,
 					Durable:  true,
 				})
-				_ = r.kubevirt.DeleteWaitForRebootPod(vm)
 				r.NextPhase(vm)
 			default:
 				// Pending or Running — wait for next reconcile.
@@ -1565,7 +1584,9 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				err = nil
 			}
 		}
-		if ierr := r.kubevirt.DeleteWaitForRebootPod(vm); ierr != nil {
+		if vm.HasCondition("WaitForGuestReboots") {
+			r.Log.Info("Retaining failed Windows wait-for-reboot pod for debugging.", "vm", vm.String())
+		} else if ierr := r.kubevirt.DeleteWaitForRebootPod(vm); ierr != nil {
 			r.Log.Error(ierr, "Could not remove Windows wait-for-reboot pod for finished VM.", "vm", vm.String())
 		}
 		vm.SetCondition(

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -115,7 +115,7 @@ func (r *Features) Load() (err error) {
 	r.OVFApplianceManagement = getEnvBool(FeatureOVFApplianceManagement, false)
 	r.VsphereVmwareDriverRemoval = getEnvBool(FeatureVsphereVmwareDriverRemoval, false)
 	r.WindowsRegistryNetworkConfig = getEnvBool(FeatureWindowsRegistryNetworkConfig, false)
-	r.WindowsWaitForReboot = getEnvBool(FeatureWindowsWaitForReboot, false)
+	r.WindowsWaitForReboot = getEnvBool(FeatureWindowsWaitForReboot, true)
 	r.UseConversionCR = getEnvBool(FeatureUseConversionCR, true)
 	r.RetainPopulatorPods = getEnvBool(FeatureRetainPopulatorPods, false)
 	r.XfsRepairIgnore = getEnvBool(FeatureXfsRepairIgnore, false)


### PR DESCRIPTION
Issue: Limit permission scope for the wait-for-reboot pod to only necessary RBAC

Fix: Only VMI/console GET and VMI GET are needed so only use those.

Ref: https://redhat.atlassian.net/browse/MTV-5344