### PR TITLE
MTV-4165 | Detect boot disk for in-place warm guest conversion

### DIFF
--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -96,13 +96,28 @@ func main() {
 				Message: warningMsg,
 			})
 		}
+		// For in-place conversions, detect the boot disk from the converted
+		// disk images so the controller can set the correct boot order on the
+		// target VM. Regular (non-in-place) conversions get this from the
+		// KubeVirt YAML that virt-v2v produces.
+		var bootDiskIndex *int
+		if env.IsInPlace {
+			if idx, detectErr := convert.DetectBootDiskIndex(); detectErr != nil {
+				fmt.Printf("WARNING: Failed to detect boot disk index: %v\n", detectErr)
+			} else {
+				bootDiskIndex = &idx
+				fmt.Printf("Detected boot disk index: %d\n", idx)
+			}
+		}
+
 		// In the remote migrations we can not connect to the conversion pod from the controller.
 		// This connection is needed for to get the additional configuration which is gathered either form virt-v2v or
 		// virt-v2v-inspector. We expose those parameters via server in this pod and once the controller gets the config
 		// the controller sends the request to terminate the pod.
 		if convert.IsLocalMigration {
 			s := server.Server{
-				AppConfig: env,
+				AppConfig:     env,
+				BootDiskIndex: bootDiskIndex,
 			}
 			err = s.Start()
 			if err != nil {

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -961,7 +961,7 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 		}
 	}
 
-	var bootDisk int
+	bootDisk := -1
 	for _, vmConf := range r.Plan.Spec.VMs {
 		if vmConf.ID == vmRef.ID {
 			if vmConf.RootDisk != "" {
@@ -1052,12 +1052,12 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 			r.Log.Info("Available PVC mapping", "diskKey", key, "pvcName", pvc.Name)
 		}
 		return fmt.Errorf("no disks were successfully mapped for VM %s", vm.Name)
-	} else if bootDisk < len(kDisks) {
-		// For multiboot VMs, if the selected boot device is the current disk,
-		// set it as the first in the boot order.
+	} else if bootDisk >= 0 && bootDisk < len(kDisks) {
 		kDisks[bootDisk].BootOrder = ptr.To(uint(1))
-	} else {
+	} else if bootDisk >= len(kDisks) {
 		r.Log.Info("Boot disk index out of range", "bootDisk", bootDisk, "diskCount", len(kDisks), "vm", vm.Name)
+	} else {
+		r.Log.Info("Boot disk not detected, skipping bootOrder assignment", "vm", vm.Name)
 	}
 
 	object.Template.Spec.Volumes = kVolumes

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2101,6 +2101,53 @@ func (r *KubeVirt) GetGuestConversionPod(vm *plan.VMStatus) (pod *core.Pod, err 
 	return
 }
 
+// detectBootDiskFromPod fetches the boot disk index from the conversion pod's
+// /bootdisk endpoint, used for in-place conversions where virt-v2v does not
+// produce a KubeVirt YAML with boot order information.
+func (r *KubeVirt) detectBootDiskFromPod(vm *plan.VMStatus, pod *core.Pod) {
+	vm.DetectedBootDisk = nil
+
+	bootNotDetected := libcnd.Condition{
+		Type:     BootDiskNotDetected,
+		Status:   True,
+		Category: "Warning",
+		Reason:   BootDiskNotDetected,
+		Message:  "Boot disk could not be detected from in-place conversion; boot order was not set.",
+	}
+
+	bootDiskURL := fmt.Sprintf("http://%s:8080/bootdisk", pod.Status.PodIP)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bootDiskURL, nil)
+	if err != nil {
+		r.Log.Error(err, "Failed to create boot disk request", "vmId", vm.ID)
+		vm.SetCondition(bootNotDetected)
+		return
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		r.Log.Error(err, "Failed to fetch boot disk index from conversion pod", "vmId", vm.ID)
+		vm.SetCondition(bootNotDetected)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		r.Log.Info("Boot disk endpoint returned non-OK status", "status", resp.StatusCode, "vmId", vm.ID)
+		vm.SetCondition(bootNotDetected)
+		return
+	}
+	var result struct {
+		BootDiskIndex int `json:"bootDiskIndex"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		r.Log.Error(err, "Failed to decode boot disk response", "vmId", vm.ID)
+		vm.SetCondition(bootNotDetected)
+		return
+	}
+	vm.DetectedBootDisk = &result.BootDiskIndex
+	r.Log.Info("Detected boot disk from in-place conversion", "bootDiskIndex", result.BootDiskIndex, "vmId", vm.ID)
+}
+
 func (r *KubeVirt) getInspectionXml(pod *core.Pod) (string, error) {
 	if pod == nil {
 		return "", liberr.New("no pod found to get the inspection")
@@ -2120,11 +2167,10 @@ func (r *KubeVirt) getInspectionXml(pod *core.Pod) (string, error) {
 
 func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, step *plan.Step) error {
 	if pod == nil || pod.Status.PodIP == "" {
-		// we need the IP for fetching the configuration of the convered VM.
 		return nil
 	}
 
-	url := fmt.Sprintf("http://%s:8080/vm", pod.Status.PodIP)
+	vmURL := fmt.Sprintf("http://%s:8080/vm", pod.Status.PodIP)
 
 	/* Due to the virt-v2v operation, the ovf file is only available after the command's execution,
 	meaning it appears following the copydisks phase.
@@ -2133,7 +2179,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 	Once the VM server is running, we can make a single call to obtain the OVF configuration,
 	followed by a shutdown request. This will complete the pod process, allowing us to move to the next phase.
 	*/
-	resp, err := http.Get(url)
+	resp, err := http.Get(vmURL)
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return nil
@@ -2142,15 +2188,21 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 	}
 	defer resp.Body.Close()
 
-	vmConf, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return liberr.Wrap(err)
+	inPlaceConversion := resp.StatusCode == http.StatusNoContent
+	var vmConf []byte
+	if !inPlaceConversion {
+		vmConf, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
 	}
 
 	switch r.Source.Provider.Type() {
 	case api.Ova, api.HyperV:
-		if vm.Firmware, err = util.GetFirmwareFromYaml(vmConf); err != nil {
-			return liberr.Wrap(err)
+		if !inPlaceConversion {
+			if vm.Firmware, err = util.GetFirmwareFromYaml(vmConf); err != nil {
+				return liberr.Wrap(err)
+			}
 		}
 	case api.VSphere:
 		inspectionXML, err := r.getInspectionXml(pod)
@@ -2163,11 +2215,15 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 		r.Log.Info("Setting the vm OS ", vm.OperatingSystem, "vmId", vm.ID)
 	}
 
-	if bootDiskIndex, bootOrderErr := util.GetDiskBootOrderFromYaml(vmConf); bootOrderErr != nil {
-		r.Log.Error(bootOrderErr, "Failed to extract boot order from virt-v2v output", "vmId", vm.ID)
-	} else if bootDiskIndex >= 0 {
-		vm.DetectedBootDisk = &bootDiskIndex
-		r.Log.Info("Detected boot disk from virt-v2v output", "bootDiskIndex", bootDiskIndex, "vmId", vm.ID)
+	if inPlaceConversion {
+		r.detectBootDiskFromPod(vm, pod)
+	} else {
+		if bootDiskIndex, bootOrderErr := util.GetDiskBootOrderFromYaml(vmConf); bootOrderErr != nil {
+			r.Log.Error(bootOrderErr, "Failed to extract boot order from virt-v2v output", "vmId", vm.ID)
+		} else if bootDiskIndex >= 0 {
+			vm.DetectedBootDisk = &bootDiskIndex
+			r.Log.Info("Detected boot disk from virt-v2v output", "bootDiskIndex", bootDiskIndex, "vmId", vm.ID)
+		}
 	}
 
 	// Fetch warnings before shutting down

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -83,6 +83,7 @@ const (
 	Failed                          = "Failed"
 	Canceled                        = "Canceled"
 	ConversionHasWarnings           = "ConversionHasWarnings"
+	BootDiskNotDetected             = "BootDiskNotDetected"
 	InspectionHasConcerns           = "InspectionHasConcerns"
 	Deleted                         = "Deleted"
 	Paused                          = "Paused"

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -1,12 +1,18 @@
 package conversion
 
 import (
+	"bytes"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
@@ -53,6 +59,7 @@ func (c *Conversion) getDisk() ([]*Disk, error) {
 		return nil, err
 	}
 	diskPaths = append(diskPaths, disksBlock...)
+	sortDiskMountPaths(diskPaths)
 	for _, path := range diskPaths {
 		disk, err := NewDisk(c.AppConfig, path)
 		if err != nil {
@@ -462,6 +469,142 @@ func updateDiskSource(disk *libvirtxml.DomainDisk, path string) bool {
 		return false
 	}
 	return true
+}
+
+func (c *Conversion) DetectBootDiskIndex() (int, error) {
+	if len(c.Disks) == 0 {
+		return -1, fmt.Errorf("no disks available for boot disk detection")
+	}
+	if len(c.Disks) == 1 {
+		return 0, nil
+	}
+	return detectBootDiskIndexFromPaths(diskLinks(c.Disks))
+}
+
+func diskLinks(disks []*Disk) []string {
+	links := make([]string, len(disks))
+	for i, d := range disks {
+		links[i] = d.Link
+	}
+	return links
+}
+
+var diskMountIndexRe = regexp.MustCompile(`\d+`)
+
+// sortDiskMountPaths orders mount paths by their numeric disk index.
+func sortDiskMountPaths(paths []string) {
+	sort.SliceStable(paths, func(i, j int) bool {
+		return diskMountIndex(paths[i]) < diskMountIndex(paths[j])
+	})
+}
+
+func diskMountIndex(path string) int {
+	s := diskMountIndexRe.FindString(filepath.Base(path))
+	if s == "" {
+		return 0
+	}
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+// detectBootDiskIndexFromPaths runs virt-inspector to inspect the disks and
+// determine which one contains the boot partition. virt-inspector produces
+// structured XML in a single call, eliminating the need for multiple
+// guestfish sessions and fragile output parsing.
+func detectBootDiskIndexFromPaths(diskPaths []string) (int, error) {
+	var args []string
+	for _, p := range diskPaths {
+		args = append(args, "--format=raw", "-a", p)
+	}
+
+	out, err := execVirtInspector(args)
+	if err != nil {
+		return -1, fmt.Errorf("virt-inspector failed: %v", err)
+	}
+
+	return parseBootDiskFromInspectorXML(out, len(diskPaths))
+}
+
+// inspectorXML mirrors the virt-inspector XML schema (only the fields we need).
+type inspectorXML struct {
+	OS []inspectorOS `xml:"operatingsystem"`
+}
+
+type inspectorOS struct {
+	Root        string               `xml:"root"`
+	Mountpoints inspectorMountpoints `xml:"mountpoints"`
+}
+
+type inspectorMountpoints struct {
+	Mountpoint []inspectorMountpoint `xml:"mountpoint"`
+}
+
+type inspectorMountpoint struct {
+	Device     string `xml:"dev,attr"`
+	MountPoint string `xml:",chardata"`
+}
+
+// parseBootDiskFromInspectorXML extracts the boot disk index from
+// virt-inspector XML output.
+func parseBootDiskFromInspectorXML(xmlData string, numDisks int) (int, error) {
+	var doc inspectorXML
+	if err := xml.Unmarshal([]byte(xmlData), &doc); err != nil {
+		return -1, fmt.Errorf("failed to parse virt-inspector XML: %v", err)
+	}
+	if len(doc.OS) == 0 {
+		return -1, fmt.Errorf("virt-inspector found no operating systems")
+	}
+
+	os := doc.OS[0]
+	mountpoints := make(map[string]string)
+	for _, mp := range os.Mountpoints.Mountpoint {
+		mountpoints[mp.MountPoint] = mp.Device
+	}
+
+	// Prefer /boot/efi (EFI), then /boot (BIOS), then root device
+	for _, mp := range []string{"/boot/efi", "/boot"} {
+		if dev, ok := mountpoints[mp]; ok {
+			if idx := deviceToDiskIndex(dev); idx >= 0 {
+				return idx, nil
+			}
+		}
+	}
+	if idx := deviceToDiskIndex(os.Root); idx >= 0 {
+		return idx, nil
+	}
+	return -1, fmt.Errorf("could not determine boot disk from virt-inspector output")
+}
+
+// execVirtInspector runs virt-inspector with the given arguments and returns
+// the XML output from stdout.
+var execVirtInspector = func(args []string) (string, error) {
+	cmd := execCommand("virt-inspector", args...)
+	var stdout strings.Builder
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "virt-inspector stderr: %s\n", stderr.String())
+	}
+	return stdout.String(), err
+}
+
+var execCommand = exec.Command
+
+// deviceToDiskIndex extracts the 0-based disk index from a device path
+// like /dev/sdc1 or /dev/sdc. Libguestfs names disks /dev/sda…/dev/sdz
+// for up to 26 disks; multi-letter names (/dev/sdaa, etc.) are not handled.
+func deviceToDiskIndex(dev string) int {
+	const prefix = "/dev/sd"
+	if !strings.HasPrefix(dev, prefix) || len(dev) <= len(prefix) {
+		return -1
+	}
+	letter := dev[len(prefix)]
+	if letter >= 'a' && letter <= 'z' {
+		return int(letter - 'a')
+	}
+	return -1
 }
 
 // modify the domain XML to use the local disk paths for in-place conversions

--- a/pkg/virt-v2v/conversion/conversion_test.go
+++ b/pkg/virt-v2v/conversion/conversion_test.go
@@ -3,6 +3,7 @@ package conversion
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -1292,4 +1293,168 @@ var _ = Describe("Conversion", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Describe("sortDiskMountPaths", func() {
+		It("sorts disk mount paths numerically", func() {
+			paths := []string{
+				"/mnt/disks/disk10",
+				"/mnt/disks/disk2",
+				"/mnt/disks/disk0",
+				"/dev/block1",
+			}
+			sortDiskMountPaths(paths)
+			Expect(paths).To(Equal([]string{
+				"/mnt/disks/disk0",
+				"/dev/block1",
+				"/mnt/disks/disk2",
+				"/mnt/disks/disk10",
+			}))
+		})
+	})
+
+	Describe("detectBootDiskIndexFromPaths", func() {
+		var origExecVirtInspector func([]string) (string, error)
+
+		BeforeEach(func() {
+			origExecVirtInspector = execVirtInspector
+		})
+
+		AfterEach(func() {
+			execVirtInspector = origExecVirtInspector
+		})
+
+		It("detects boot disk via mocked virt-inspector", func() {
+			execVirtInspector = func(args []string) (string, error) {
+				Expect(args).To(ContainElement("-a"))
+				return `<operatingsystems>
+  <operatingsystem>
+    <root>/dev/sdc2</root>
+    <mountpoints>
+      <mountpoint dev="/dev/sdc2">/</mountpoint>
+      <mountpoint dev="/dev/sdc1">/boot</mountpoint>
+    </mountpoints>
+  </operatingsystem>
+</operatingsystems>`, nil
+			}
+
+			idx, err := detectBootDiskIndexFromPaths([]string{
+				"/var/tmp/v2v/vm-sda",
+				"/var/tmp/v2v/vm-sdb",
+				"/var/tmp/v2v/vm-sdc",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(idx).To(Equal(2))
+		})
+
+		It("returns error when virt-inspector fails", func() {
+			execVirtInspector = func(_ []string) (string, error) {
+				return "", errors.New("virt-inspector unavailable")
+			}
+
+			_, err := detectBootDiskIndexFromPaths([]string{"/var/tmp/v2v/vm-sda", "/var/tmp/v2v/vm-sdb"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("virt-inspector failed"))
+		})
+	})
+
+	Describe("parseBootDiskFromInspectorXML", func() {
+		makeXML := func(root string, mountpoints map[string]string) string {
+			var mps string
+			for mp, dev := range mountpoints {
+				mps += fmt.Sprintf(`<mountpoint dev="%s">%s</mountpoint>`, dev, mp)
+			}
+			return fmt.Sprintf(`<operatingsystems><operatingsystem><root>%s</root><mountpoints>%s</mountpoints></operatingsystem></operatingsystems>`, root, mps)
+		}
+
+		It("detects boot disk from /boot mountpoint (BIOS/LVM)", func() {
+			xml := makeXML("/dev/rhel/root", map[string]string{
+				"/":     "/dev/rhel/root",
+				"/boot": "/dev/sdc1",
+			})
+			idx, err := parseBootDiskFromInspectorXML(xml, 3)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(idx).To(Equal(2))
+		})
+
+		It("detects boot disk from /boot/efi mountpoint (EFI)", func() {
+			xml := makeXML("/dev/sda2", map[string]string{
+				"/":         "/dev/sda2",
+				"/boot/efi": "/dev/sdb1",
+			})
+			idx, err := parseBootDiskFromInspectorXML(xml, 2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(idx).To(Equal(1))
+		})
+
+		It("prefers /boot/efi over /boot when both present", func() {
+			xml := makeXML("/dev/sdb2", map[string]string{
+				"/boot/efi": "/dev/sda1",
+				"/":         "/dev/sdb2",
+				"/boot":     "/dev/sdb1",
+			})
+			idx, err := parseBootDiskFromInspectorXML(xml, 2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(idx).To(Equal(0))
+		})
+
+		It("falls back to root device for simple partition scheme", func() {
+			xml := makeXML("/dev/sdb2", map[string]string{
+				"/": "/dev/sdb2",
+			})
+			idx, err := parseBootDiskFromInspectorXML(xml, 2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(idx).To(Equal(1))
+		})
+
+		It("returns error when root is LVM and no /boot found", func() {
+			xml := makeXML("/dev/rhel/root", map[string]string{
+				"/": "/dev/rhel/root",
+			})
+			_, err := parseBootDiskFromInspectorXML(xml, 1)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("handles first disk (sda) correctly", func() {
+			xml := makeXML("/dev/sda2", map[string]string{
+				"/boot": "/dev/sda1",
+				"/":     "/dev/sda2",
+			})
+			idx, err := parseBootDiskFromInspectorXML(xml, 1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(idx).To(Equal(0))
+		})
+
+		It("returns error for invalid XML", func() {
+			_, err := parseBootDiskFromInspectorXML("<not valid xml", 1)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns error when no OS found", func() {
+			_, err := parseBootDiskFromInspectorXML("<operatingsystems></operatingsystems>", 1)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no operating systems"))
+		})
+	})
+
+	Describe("deviceToDiskIndex", func() {
+		It("maps /dev/sda to 0", func() {
+			Expect(deviceToDiskIndex("/dev/sda")).To(Equal(0))
+		})
+		It("maps /dev/sda1 to 0", func() {
+			Expect(deviceToDiskIndex("/dev/sda1")).To(Equal(0))
+		})
+		It("maps /dev/sdc to 2", func() {
+			Expect(deviceToDiskIndex("/dev/sdc")).To(Equal(2))
+		})
+		It("maps /dev/sdc2 to 2", func() {
+			Expect(deviceToDiskIndex("/dev/sdc2")).To(Equal(2))
+		})
+		It("returns -1 for LVM device", func() {
+			Expect(deviceToDiskIndex("/dev/rhel/root")).To(Equal(-1))
+		})
+		It("returns -1 for empty string", func() {
+			Expect(deviceToDiskIndex("")).To(Equal(-1))
+		})
+	})
+
 })

--- a/pkg/virt-v2v/server/server.go
+++ b/pkg/virt-v2v/server/server.go
@@ -24,7 +24,8 @@ type Warning struct {
 }
 
 type Server struct {
-	AppConfig *config.AppConfig
+	AppConfig     *config.AppConfig
+	BootDiskIndex *int
 }
 
 // AddWarning adds a warning that will be exposed via the /warnings endpoint
@@ -39,6 +40,7 @@ func AddWarning(warning Warning) {
 func (s Server) Start() error {
 	http.HandleFunc("/vm", s.vmHandler)
 	http.HandleFunc("/inspection", s.inspectorHandler)
+	http.HandleFunc("/bootdisk", s.bootDiskHandler)
 	http.HandleFunc("/warnings", s.warningsHandler)
 	http.HandleFunc("/shutdown", s.shutdownHandler)
 	server = &http.Server{Addr: ":8080"}
@@ -100,6 +102,18 @@ func (s Server) inspectorHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		fmt.Printf("Error writing response: %v\n", err)
 		http.Error(w, "Error writing response", http.StatusInternalServerError)
+	}
+}
+
+func (s Server) bootDiskHandler(w http.ResponseWriter, r *http.Request) {
+	if s.BootDiskIndex == nil {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(map[string]int{"bootDiskIndex": *s.BootDiskIndex}); err != nil {
+		fmt.Printf("Error encoding boot disk response: %v\n", err)
 	}
 }
 

--- a/pkg/virt-v2v/server/server_test.go
+++ b/pkg/virt-v2v/server/server_test.go
@@ -229,6 +229,37 @@ metadata:
 		})
 	})
 
+	Describe("bootDiskHandler", func() {
+		It("returns 204 when BootDiskIndex is nil", func() {
+			s.BootDiskIndex = nil
+			req := httptest.NewRequest("GET", "/bootdisk", nil)
+			w := httptest.NewRecorder()
+			s.bootDiskHandler(w, req)
+			Expect(w.Code).To(Equal(http.StatusNoContent))
+		})
+
+		It("returns 200 with JSON when BootDiskIndex is set", func() {
+			idx := 2
+			s.BootDiskIndex = &idx
+			req := httptest.NewRequest("GET", "/bootdisk", nil)
+			w := httptest.NewRecorder()
+			s.bootDiskHandler(w, req)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Header().Get("Content-Type")).To(Equal("application/json"))
+			Expect(w.Body.String()).To(ContainSubstring(`"bootDiskIndex":2`))
+		})
+
+		It("returns 200 with index 0", func() {
+			idx := 0
+			s.BootDiskIndex = &idx
+			req := httptest.NewRequest("GET", "/bootdisk", nil)
+			w := httptest.NewRecorder()
+			s.bootDiskHandler(w, req)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Body.String()).To(ContainSubstring(`"bootDiskIndex":0`))
+		})
+	})
+
 	Describe("AddWarning", func() {
 		It("adds warning to global warnings slice", func() {
 			warnings = nil // Reset


### PR DESCRIPTION
In-place virt-v2v does not produce KubeVirt YAML with bootOrder, so warm migrations left DetectedBootDisk unset and the vSphere builder defaulted bootOrder to the first disk. Detect the boot disk with guestfish after in-place conversion, expose it on a /bootdisk endpoint, and have the plan controller consume it when /vm returns 204.

- Add guestfish-based DetectBootDiskIndex and sort mount paths numerically
- Expose boot disk index from the virt-v2v pod HTTP server
- Set vm.DetectedBootDisk from /bootdisk during in-place conversion
- Initialize vSphere bootDisk to -1 to avoid wrong bootOrder on failure
- Surface BootDiskNotDetected on the VM when detection is unavailable
- Add unit tests for parsing, guestfish flow, and /bootdisk handler

Ref: https://redhat.atlassian.net/browse/MTV-4165
Resolves: MTV-4165