### PR TITLE
MTV-5702 | Copy customizationScripts ConfigMap to target namespace

### DIFF
--- a/pkg/controller/conversion/controller_test.go
+++ b/pkg/controller/conversion/controller_test.go
@@ -2,10 +2,13 @@ package conversion
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
+	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -91,5 +94,121 @@ func TestResolvePhaseConditions_Canceled(t *testing.T) {
 	}
 	if conv.Status.CompletionTime == nil {
 		t.Error("expected CompletionTime to be set")
+	}
+}
+
+func TestCheckPendingPodTimeout_NoTimeout(t *testing.T) {
+	Settings.ConversionPodPendingTimeout = 5
+	p := &ConversionPipeline{}
+	pod := &core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name:              "test-pod",
+			CreationTimestamp: meta.NewTime(time.Now().Add(-1 * time.Minute)),
+		},
+		Status: core.PodStatus{Phase: core.PodPending},
+	}
+	err := p.checkPendingPodTimeout(pod)
+	if err != nil {
+		t.Errorf("expected no error for pod pending < timeout, got: %v", err)
+	}
+}
+
+func TestCheckPendingPodTimeout_Exceeded(t *testing.T) {
+	Settings.ConversionPodPendingTimeout = 5
+	p := &ConversionPipeline{}
+	pod := &core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name:              "test-pod",
+			CreationTimestamp: meta.NewTime(time.Now().Add(-6 * time.Minute)),
+		},
+		Status: core.PodStatus{Phase: core.PodPending},
+	}
+	err := p.checkPendingPodTimeout(pod)
+	if err == nil {
+		t.Fatal("expected error for pod pending > timeout")
+	}
+	if !strings.Contains(err.Error(), "stuck in Pending") {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestCheckPendingPodTimeout_ZeroTimestamp(t *testing.T) {
+	Settings.ConversionPodPendingTimeout = 5
+	p := &ConversionPipeline{}
+	pod := &core.Pod{
+		ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+		Status:     core.PodStatus{Phase: core.PodPending},
+	}
+	err := p.checkPendingPodTimeout(pod)
+	if err != nil {
+		t.Errorf("expected no error for zero timestamp, got: %v", err)
+	}
+}
+
+func TestCheckPendingPodTimeout_Disabled(t *testing.T) {
+	Settings.ConversionPodPendingTimeout = 0
+	p := &ConversionPipeline{}
+	pod := &core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name:              "test-pod",
+			CreationTimestamp: meta.NewTime(time.Now().Add(-60 * time.Minute)),
+		},
+		Status: core.PodStatus{Phase: core.PodPending},
+	}
+	err := p.checkPendingPodTimeout(pod)
+	if err != nil {
+		t.Errorf("expected no error when timeout is disabled (0), got: %v", err)
+	}
+}
+
+func TestPendingPodReason_Unschedulable(t *testing.T) {
+	pod := &core.Pod{
+		Status: core.PodStatus{
+			Conditions: []core.PodCondition{
+				{
+					Type:    core.PodScheduled,
+					Status:  core.ConditionFalse,
+					Message: "0/3 nodes are available",
+				},
+			},
+		},
+	}
+	reason := pendingPodReason(pod)
+	if !strings.Contains(reason, "Unschedulable") {
+		t.Errorf("expected Unschedulable reason, got: %s", reason)
+	}
+}
+
+func TestPendingPodReason_ContainerWaiting(t *testing.T) {
+	pod := &core.Pod{
+		Status: core.PodStatus{
+			ContainerStatuses: []core.ContainerStatus{
+				{
+					State: core.ContainerState{
+						Waiting: &core.ContainerStateWaiting{
+							Reason:  "ContainerCreating",
+							Message: "configmap \"my-scripts\" not found",
+						},
+					},
+				},
+			},
+		},
+	}
+	reason := pendingPodReason(pod)
+	if !strings.Contains(reason, "ContainerCreating") {
+		t.Errorf("expected ContainerCreating reason, got: %s", reason)
+	}
+	if !strings.Contains(reason, "my-scripts") {
+		t.Errorf("expected configmap name in reason, got: %s", reason)
+	}
+}
+
+func TestPendingPodReason_Fallback(t *testing.T) {
+	pod := &core.Pod{
+		Status: core.PodStatus{},
+	}
+	reason := pendingPodReason(pod)
+	if reason != "check pod events for mount/scheduling failures" {
+		t.Errorf("expected fallback reason, got: %s", reason)
 	}
 }

--- a/pkg/controller/conversion/pipeline.go
+++ b/pkg/controller/conversion/pipeline.go
@@ -55,6 +55,16 @@ var DeepInspectionPipelineStages = []PipelineStage{
 // inspectionResultPort is the port the deep-inspection pod's HTTP server listens on.
 const inspectionResultPort = 8080
 
+// pendingPodTimeout returns the configured timeout for conversion pods stuck in
+// Pending. Returns 0 (no timeout) when the setting is 0.
+func pendingPodTimeout() time.Duration {
+	minutes := Settings.ConversionPodPendingTimeout
+	if minutes <= 0 {
+		return 0
+	}
+	return time.Duration(minutes) * time.Minute
+}
+
 // ConversionPipeline drives reconciliation for a single Conversion CR.
 type ConversionPipeline struct {
 	ctx    context.Context
@@ -360,6 +370,9 @@ func (p *ConversionPipeline) runStageEnsurePod() (stageDone bool, err error) {
 
 	switch pod.Status.Phase {
 	case core.PodPending:
+		if err = p.checkPendingPodTimeout(pod); err != nil {
+			return stageDone, err
+		}
 		p.setStage(api.StageCreatePod)
 		return stageDone, nil
 	case core.PodRunning:
@@ -397,6 +410,9 @@ func (p *ConversionPipeline) runStageDeepInspectionPod() (stageDone bool, err er
 
 	switch pod.Status.Phase {
 	case core.PodPending:
+		if err = p.checkPendingPodTimeout(pod); err != nil {
+			return
+		}
 		p.setStage(api.StageCreatePod)
 		return
 	case core.PodRunning:
@@ -606,8 +622,12 @@ func (p *ConversionPipeline) podHandler() (podSucceeded bool, err error) {
 		return false, liberr.New("conversion pod failed", "pod", pod.Name, "phase", pod.Status.Phase)
 	case core.PodUnknown:
 		return false, liberr.New("conversion pod in unknown state", "pod", pod.Name)
+	case core.PodPending:
+		if err = p.checkPendingPodTimeout(pod); err != nil {
+			return false, err
+		}
+		return false, nil
 	default:
-		// PodPending/PodRunning, still in progress
 		return false, nil
 	}
 }
@@ -656,6 +676,38 @@ func (p *ConversionPipeline) runStageWaitingForSnapshotRemoval() (stageDone bool
 	}
 	p.conv.Status.Snapshot = nil
 	return true, nil
+}
+
+func (p *ConversionPipeline) checkPendingPodTimeout(pod *core.Pod) error {
+	timeout := pendingPodTimeout()
+	if timeout == 0 {
+		return nil
+	}
+	if pod.CreationTimestamp.IsZero() {
+		return nil
+	}
+	elapsed := time.Since(pod.CreationTimestamp.Time)
+	if elapsed < timeout {
+		return nil
+	}
+	reason := pendingPodReason(pod)
+	return liberr.New(
+		fmt.Sprintf("conversion pod %s stuck in Pending for %s (reason: %s)",
+			pod.Name, elapsed.Truncate(time.Second), reason))
+}
+
+func pendingPodReason(pod *core.Pod) string {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == core.PodScheduled && cond.Status == core.ConditionFalse {
+			return fmt.Sprintf("Unschedulable: %s", cond.Message)
+		}
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+			return fmt.Sprintf("%s: %s", cs.State.Waiting.Reason, cs.State.Waiting.Message)
+		}
+	}
+	return "check pod events for mount/scheduling failures"
 }
 
 // loadConnectionSecret returns the Secret referenced by conv.Spec.Connection.Secret.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -162,8 +162,9 @@ const (
 
 // Vddk v2v conf
 const (
-	ExtraV2vConf = "extra-v2v-conf"
-	VddkConf     = "vddk-conf"
+	ExtraV2vConf         = "extra-v2v-conf"
+	VddkConf             = "vddk-conf"
+	CustomizationScripts = "customization-scripts"
 
 	VddkAioBufSizeDefault  = "16"
 	VddkAioBufCountDefault = "4"
@@ -1295,6 +1296,48 @@ func genExtraV2vConfConfigMapName(plan *api.Plan) string {
 
 func genVddkConfConfigMapName(plan *api.Plan) string {
 	return fmt.Sprintf("%s-%s-", plan.Name, VddkConf)
+}
+
+func genCustomizationScriptsConfigMapName(plan *api.Plan) string {
+	return fmt.Sprintf("%s-%s", plan.Name, CustomizationScripts)
+}
+
+// Ensure the ConfigMap referenced by CustomizationScripts exists in TargetNamespace.
+// If the ConfigMap lives in a different namespace, it is copied to the target.
+func (r *KubeVirt) EnsureCustomizationScriptsConfigMap() error {
+	if r.Plan.Spec.CustomizationScripts == nil {
+		return nil
+	}
+
+	configMapNamespace := r.Plan.Spec.CustomizationScripts.Namespace
+	if configMapNamespace == "" {
+		configMapNamespace = r.Plan.Namespace
+	}
+	if configMapNamespace == r.Plan.Spec.TargetNamespace {
+		return nil
+	}
+
+	configMap := &core.ConfigMap{}
+	err := r.Get(
+		context.TODO(),
+		client.ObjectKey{
+			Name:      r.Plan.Spec.CustomizationScripts.Name,
+			Namespace: configMapNamespace,
+		},
+		configMap,
+	)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+
+	err = ensureConfigMap(configMap, genCustomizationScriptsConfigMapName, r.Plan, r.Destination.Client)
+	if err == nil {
+		r.Log.V(4).Info(
+			"Ensured ConfigMap for customization scripts in target namespace.",
+			"configMap namespace", configMapNamespace,
+			"target namespace", r.Plan.Spec.TargetNamespace)
+	}
+	return err
 }
 
 // Get the importer pod for a PersistentVolumeClaim.
@@ -3302,11 +3345,17 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 		configMapName := r.Plan.Spec.CustomizationScripts.Name
 		configMapNamespace := r.Plan.Spec.CustomizationScripts.Namespace
 		if configMapNamespace == "" {
-			configMapNamespace = r.Plan.Spec.TargetNamespace
+			configMapNamespace = r.Plan.Namespace
+		}
+
+		// When the CM was copied to TargetNamespace, use the generated name
+		volumeConfigMapName := configMapName
+		if configMapNamespace != r.Plan.Spec.TargetNamespace {
+			volumeConfigMapName = genCustomizationScriptsConfigMapName(r.Plan)
 		}
 
 		var exists bool
-		_, exists, err = r.findConfigMapInNamespace(configMapName, configMapNamespace)
+		_, exists, err = r.findConfigMapInNamespace(volumeConfigMapName, r.Plan.Spec.TargetNamespace)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -3314,7 +3363,7 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 		if !exists {
 			err = liberr.New(
 				fmt.Sprintf("CustomizationScripts ConfigMap %s not found in namespace %s",
-					configMapName, configMapNamespace))
+					volumeConfigMapName, r.Plan.Spec.TargetNamespace))
 			return
 		}
 		scriptsVol := core.Volume{
@@ -3322,7 +3371,7 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 			VolumeSource: core.VolumeSource{
 				ConfigMap: &core.ConfigMapVolumeSource{
 					LocalObjectReference: core.LocalObjectReference{
-						Name: configMapName,
+						Name: volumeConfigMapName,
 					},
 				},
 			},

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -553,7 +553,8 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			}
 			kubevirt = createKubeVirtWithProvider(v1beta1.VSphere, cm)
 			kubevirt.Plan.Spec.CustomizationScripts = &v1.ObjectReference{
-				Name: "my-scripts",
+				Name:      "my-scripts",
+				Namespace: "target-ns",
 			}
 
 			vmVolumes := []cnv.Volume{}
@@ -605,12 +606,14 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			Expect(foundExtraMount).To(BeTrue(), "scripts mount not found in extraMounts")
 		})
 
-		ginkgo.It("should use explicit namespace from CustomizationScripts when set", func() {
-			cm := &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-scripts", Namespace: "other-ns"},
+		ginkgo.It("should use generated name when CustomizationScripts namespace differs from target", func() {
+			// Simulate the CM already copied to target-ns with the generated name
+			// (EnsureCustomizationScriptsConfigMap would have done this before podVolumeMounts)
+			copiedCM := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-plan-customization-scripts", Namespace: "target-ns"},
 				Data:       map[string]string{"01_linux_run_test.sh": "#!/bin/sh\necho test"},
 			}
-			kubevirt = createKubeVirtWithProvider(v1beta1.VSphere, cm)
+			kubevirt = createKubeVirtWithProvider(v1beta1.VSphere, copiedCM)
 			kubevirt.Plan.Spec.CustomizationScripts = &v1.ObjectReference{
 				Name:      "my-scripts",
 				Namespace: "other-ns",
@@ -623,15 +626,19 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			var found bool
 			for _, vol := range extraVolumes {
 				if vol.Name == DynamicScriptsVolumeName {
+					Expect(vol.ConfigMap).ToNot(BeNil())
+					Expect(vol.ConfigMap.Name).To(Equal("test-plan-customization-scripts"))
 					found = true
 				}
 			}
-			Expect(found).To(BeTrue(), "scripts volume should be found when using explicit namespace")
+			Expect(found).To(BeTrue(), "scripts volume should be found with generated name")
 		})
 
 		ginkgo.It("should return error when CustomizationScripts ConfigMap does not exist", func() {
+			kubevirt = createKubeVirtWithProvider(v1beta1.VSphere)
 			kubevirt.Plan.Spec.CustomizationScripts = &v1.ObjectReference{
-				Name: "nonexistent-scripts",
+				Name:      "nonexistent-scripts",
+				Namespace: "target-ns",
 			}
 
 			vm := &plan.VMStatus{}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -219,6 +219,11 @@ func (r *Migration) begin() (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	err = r.kubevirt.EnsureCustomizationScriptsConfigMap()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
 	//
 	// Delete
 	kept := []*plan.VMStatus{}
@@ -760,11 +765,11 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				configMapName := r.Plan.Spec.CustomizationScripts.Name
 				configMapNamespace := r.Plan.Spec.CustomizationScripts.Namespace
 				if configMapNamespace == "" {
-					configMapNamespace = r.Plan.Spec.TargetNamespace
+					configMapNamespace = r.Plan.Namespace
 				}
 
 				configMap := &core.ConfigMap{}
-				err = r.Destination.Client.Get(
+				err = r.Get(
 					context.TODO(),
 					client.ObjectKey{
 						Namespace: configMapNamespace,

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -78,6 +78,7 @@ const (
 	AAPInsecureSkipVerify                  = "AAP_INSECURE_SKIP_VERIFY"
 	AAPCASecretName                        = "AAP_CA_SECRET_NAME"
 	WaitForFinalSnapshotConsolidation      = "WAIT_FOR_FINAL_SNAPSHOT_CONSOLIDATION"
+	ConversionPodPendingTimeout            = "CONVERSION_POD_PENDING_TIMEOUT"
 )
 
 // Default values for populator container resources
@@ -87,6 +88,10 @@ var (
 	DefaultPopulatorContainerRequestsCpu    = resource.NewQuantity(100, resource.DecimalSI)
 	DefaultPopulatorContainerRequestsMemory = resource.NewQuantity(512, resource.BinarySI)
 )
+
+// DefaultPendingPodTimeoutMinutes is the default number of minutes a
+// conversion pod may stay in Pending before the controller fails it.
+const DefaultPendingPodTimeoutMinutes = 5
 
 // Migration settings
 type Migration struct {
@@ -191,6 +196,9 @@ type Migration struct {
 	AAPCASecretName string
 	// Whether or not to wait for final snapshot removal and consolidation before finishing Plan.
 	WaitForFinalSnapshotConsolidation bool
+	// ConversionPodPendingTimeout is how long (in minutes) a conversion pod may stay
+	// in Pending phase before the controller fails it. 0 means no timeout.
+	ConversionPodPendingTimeout int
 }
 
 // Load settings.
@@ -446,5 +454,8 @@ func (r *Migration) Load() (err error) {
 		r.DeepInspectionImageXFS = strings.TrimSpace(val)
 	}
 	r.WaitForFinalSnapshotConsolidation = getEnvBool(WaitForFinalSnapshotConsolidation, true)
+	if r.ConversionPodPendingTimeout, err = getEnvLimit(ConversionPodPendingTimeout, DefaultPendingPodTimeoutMinutes, 0); err != nil {
+		return liberr.Wrap(err)
+	}
 	return
 }


### PR DESCRIPTION
When CustomizationScripts references a ConfigMap in a namespace different from TargetNamespace, the conversion pod fails to mount it because ConfigMap volumes are namespace-local. The pod stays in Pending forever, causing the migration to hang.

Fix:
- Add EnsureCustomizationScriptsConfigMap() that copies the ConfigMap from the source (plan) namespace to TargetNamespace before migration.
- Update podVolumeMounts() to use the generated copy name when the source namespace differs from target.
- Add a configurable pending pod timeout (CONVERSION_POD_PENDING_TIMEOUT env var, default 5 minutes) in the conversion pipeline so that stuck pods fail with a clear error instead of hanging indefinitely.

Ref: https://redhat.atlassian.net/browse/MTV-5702
Resolves: MTV-5702