### PR TITLE
MTV-5437 | Fix snapshot consolidate param in DI removal

### DIFF
--- a/pkg/controller/conversion/client.go
+++ b/pkg/controller/conversion/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	core "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -127,7 +128,7 @@ func (r *Client) RemoveSnapshot(snapshot string) (taskID string, err error) {
 		"snapshot", snapshot,
 		"children", false)
 
-	task, err := vm.RemoveSnapshot(context.TODO(), snapshot, false, nil)
+	task, err := vm.RemoveSnapshot(context.TODO(), snapshot, false, ptr.To(true))
 	if err != nil {
 		return "", liberr.Wrap(err)
 	}


### PR DESCRIPTION
Ref: https://redhat.atlassian.net/browse/MTV-5437

## Problem
Follow-up to #6586 (@solenoci) — the snapshot divert logic works correctly, but `RemoveSnapshot()` in `pkg/controller/conversion/client.go` passes `consolidate=nil` instead of `ptr.To(true)`. The vCenter task reports success but the snapshot remains on disk.

The plan path (`pkg/controller/plan/adapter/vsphere/client.go`) already uses `ptr.To(true)`.

## Fix
Pass `ptr.To(true)` instead of `nil` — one-line change.

## Verification
Built custom controller image, deployed to cluster (MTV 2.12.0), triggered DI via "Inspect VMs" on LUKS-encrypted VM. Snapshot is now properly cleaned up after DI failure.

Resolves: MTV-5437