### PR TITLE
Add missing labels to forklift resource

### DIFF
--- a/pkg/controller/plan/adapter/converter.go
+++ b/pkg/controller/plan/adapter/converter.go
@@ -288,6 +288,12 @@ func makeScratchDV(pvc *v1.PersistentVolumeClaim) *cdi.DataVolume {
 		"migration":                     migration,
 		planbase.AnnConversionSourcePVC: pvc.Name,
 	}
+	if plan, ok := pvc.Labels["plan"]; ok {
+		labels["plan"] = plan
+	}
+	if vmID, ok := pvc.Labels["vmID"]; ok {
+		labels["vmID"] = vmID
+	}
 
 	return &cdi.DataVolume{
 		ObjectMeta: meta.ObjectMeta{

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -1065,6 +1065,7 @@ func (r *Builder) createVolumePopulatorCR(image model.Image, secretName, vmId st
 			Labels: map[string]string{
 				"vmID":      vmId,
 				"migration": getMigrationID(r.Context),
+				"plan":      string(r.Plan.GetUID()),
 				"imageID":   image.ID,
 			},
 		},
@@ -1237,6 +1238,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image,
 			Annotations:  annotations,
 			Labels: map[string]string{
 				"migration": getMigrationID(r.Context),
+				"plan":      string(r.Plan.GetUID()),
 				"imageID":   image.ID,
 				"vmID":      vmID,
 			},
@@ -1360,6 +1362,7 @@ func (r *Builder) setPopulatorLabels(populatorCr api.OpenstackVolumePopulator, v
 	}
 	populatorCr.Labels["vmID"] = vmId
 	populatorCr.Labels["migration"] = migrationId
+	populatorCr.Labels["plan"] = string(r.Plan.GetUID())
 	patch := client.MergeFrom(populatorCrCopy)
 	err = r.Destination.Client.Patch(context.TODO(), &populatorCr, patch)
 	return

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -844,6 +844,7 @@ func (r *Builder) createVolumePopulatorCR(diskAttachment model.XDiskAttachment, 
 			Labels: map[string]string{
 				"vmID":      vmId,
 				"migration": migrationId,
+				"plan":      string(r.Plan.GetUID()),
 				"diskID":    diskAttachment.Disk.ID,
 			},
 		},
@@ -915,6 +916,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(diskAttachment model.XDiskA
 			Annotations:  annotations,
 			Labels: map[string]string{
 				"migration": string(r.Migration.UID),
+				"plan":      string(r.Plan.GetUID()),
 				"vmID":      vmID,
 				"diskID":    diskAttachment.Disk.ID,
 			},
@@ -1007,6 +1009,7 @@ func (r *Builder) setOvirtPopulatorLabels(populatorCr api.OvirtVolumePopulator, 
 	}
 	populatorCr.Labels["vmID"] = vmId
 	populatorCr.Labels["migration"] = migrationId
+	populatorCr.Labels["plan"] = string(r.Plan.GetUID())
 	patch := client.MergeFrom(populatorCrCopy)
 	err = r.Destination.Client.Patch(context.TODO(), &populatorCr, patch)
 	return

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1381,6 +1381,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				namespace := r.Plan.Spec.TargetNamespace
 				labels := map[string]string{
 					"migration": string(r.Migration.UID),
+					"plan":      string(r.Plan.GetUID()),
 					// we need uniqness and a value which is less than 64 chars, hence using vmRef.id + disk.key
 					"vmdkKey": fmt.Sprint(disk.Key),
 					"vmID":    vmRef.ID,
@@ -1965,6 +1966,11 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      diskSecretName,
 			Namespace: migrationSecretNS,
+			Labels: map[string]string{
+				"migration": string(r.Migration.UID),
+				"plan":      string(r.Plan.GetUID()),
+				"vmID":      pvc.Labels["vmID"],
+			},
 		},
 		Data: make(map[string][]byte),
 	}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -3838,6 +3838,7 @@ func (r *KubeVirt) setPopulatorPodLabels(pod core.Pod, migrationId string) (err 
 		pod.Labels = make(map[string]string)
 	}
 	pod.Labels[kMigration] = migrationId
+	pod.Labels[kPlan] = string(r.Plan.GetUID())
 	patch := client.MergeFrom(podCopy)
 	err = r.Destination.Client.Patch(context.TODO(), &pod, patch)
 	return

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -639,6 +639,12 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 			if found {
 				labels["migration"] = migration
 			}
+			if vmID, ok, _ := unstructured.NestedString(crInstance.Object, "metadata", "labels", "vmID"); ok && vmID != "" {
+				labels["vmID"] = vmID
+			}
+			if plan, ok, _ := unstructured.NestedString(crInstance.Object, "metadata", "labels", "plan"); ok && plan != "" {
+				labels["plan"] = plan
+			}
 			if sourceHost != "" {
 				labels[labelSourceHost] = sourceHost
 			}
@@ -701,10 +707,17 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 
 			// If PVC' doesn't exist yet, create it
 			if pvcPrime == nil {
+				pvcPrimeLabels := make(map[string]string)
+				for _, key := range []string{"migration", "plan", "vmID"} {
+					if val, ok := pvc.Labels[key]; ok {
+						pvcPrimeLabels[key] = val
+					}
+				}
 				pvcPrime = &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      pvcPrimeName,
 						Namespace: populatorNamespace,
+						Labels:    pvcPrimeLabels,
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion: "v1",


### PR DESCRIPTION
Issue: The console plugin shows the list of reousrces created by migration plan. It shows all resources with specific lables, and some of the resources are missing those labels.