### PR TITLE
MTV-5546 | Set migration context before archiving plan

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -352,6 +352,14 @@ func (r *Reconciler) archive(plan *api.Plan) {
 	if err != nil {
 		r.Log.Error(err, "Couldn't construct plan context while archiving plan.")
 	} else {
+		snapshot := plan.Status.Migration.ActiveSnapshot()
+		if snapshot.Migration.UID != "" {
+			migration := &api.Migration{}
+			migration.UID = snapshot.Migration.UID
+			migration.Name = snapshot.Migration.Name
+			migration.Namespace = snapshot.Migration.Namespace
+			ctx.SetMigration(migration)
+		}
 		runner := Migration{Context: ctx}
 		runner.Archive()
 	}


### PR DESCRIPTION
When archiving a plan, the cleanup code uses the Labeler to find resources by migration UID label. Without setting the migration on the context, the UID is empty and label selectors fail to match any resources, causing archive cleanup to silently skip deletion of populator pods, VMIMs, and other migration artifacts.

Populate the migration context from the plan's active snapshot before calling Archive(), so that the Labeler can construct correct selectors.