### PR TITLE
Don't reconcile archived/finished plan

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -480,7 +480,6 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	if migration == nil {
 		r.Log.Info("No pending migrations found.")
 		plan.Status.DeleteCondition(Executing)
-		reQ = base.SlowReQ
 		return
 	}
 

--- a/pkg/controller/plan/handler/ocp/handler.go
+++ b/pkg/controller/plan/handler/ocp/handler.go
@@ -65,6 +65,12 @@ func (r *Handler) generateEvents() {
 	}
 	for i := range list.Items {
 		plan := &list.Items[i]
+		if plan.Spec.Archived {
+			continue
+		}
+		if plan.Status.HasAnyCondition("Succeeded", "Failed", "Canceled") {
+			continue
+		}
 		if r.MatchProvider(plan.Spec.Provider.Source) || r.MatchProvider(plan.Spec.Provider.Destination) {
 			r.Enqueue(event.GenericEvent{
 				Object: plan,

--- a/pkg/controller/plan/handler/openstack/handler.go
+++ b/pkg/controller/plan/handler/openstack/handler.go
@@ -86,7 +86,7 @@ func (r *Handler) changed(models ...*openstack.VM) {
 	for i := range list.Items {
 		plan := &list.Items[i]
 		ref := plan.Spec.Provider.Source
-		if plan.Spec.Archived || !r.MatchProvider(ref) {
+		if plan.Spec.Archived || plan.Status.HasAnyCondition("Succeeded", "Failed", "Canceled") || !r.MatchProvider(ref) {
 			continue
 		}
 		referenced := false

--- a/pkg/controller/plan/handler/ova/handler.go
+++ b/pkg/controller/plan/handler/ova/handler.go
@@ -86,7 +86,7 @@ func (r *Handler) changed(models ...*ova.VM) {
 	for i := range list.Items {
 		plan := &list.Items[i]
 		ref := plan.Spec.Provider.Source
-		if plan.Spec.Archived || !r.MatchProvider(ref) {
+		if plan.Spec.Archived || plan.Status.HasAnyCondition("Succeeded", "Failed", "Canceled") || !r.MatchProvider(ref) {
 			continue
 		}
 		referenced := false

--- a/pkg/controller/plan/handler/ovirt/handler.go
+++ b/pkg/controller/plan/handler/ovirt/handler.go
@@ -86,7 +86,7 @@ func (r *Handler) changed(models ...*ovirt.VM) {
 	for i := range list.Items {
 		plan := &list.Items[i]
 		ref := plan.Spec.Provider.Source
-		if plan.Spec.Archived || !r.MatchProvider(ref) {
+		if plan.Spec.Archived || plan.Status.HasAnyCondition("Succeeded", "Failed", "Canceled") || !r.MatchProvider(ref) {
 			continue
 		}
 		referenced := false

--- a/pkg/controller/plan/handler/vsphere/handler.go
+++ b/pkg/controller/plan/handler/vsphere/handler.go
@@ -86,7 +86,7 @@ func (r *Handler) changed(models ...*vsphere.VM) {
 	for i := range list.Items {
 		plan := &list.Items[i]
 		ref := plan.Spec.Provider.Source
-		if plan.Spec.Archived || !r.MatchProvider(ref) {
+		if plan.Spec.Archived || plan.Status.HasAnyCondition("Succeeded", "Failed", "Canceled") || !r.MatchProvider(ref) {
 			continue
 		}
 		referenced := false


### PR DESCRIPTION
Issue: In large scale enviromnet with 1000+ migraiton plans, I have seen forklift-controller to reconcile archive or finished plans. Because of still reconciling the finished plans it took long time before the active plans got into qeueu.