### PR TITLE
MTV-5723 | Delete copied ConfigMaps from target namespace after migration

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1446,6 +1446,51 @@ func (r *KubeVirt) EnsureCustomizationScriptsConfigMap() error {
 	return err
 }
 
+// CleanupCopiedConfigMaps deletes the extra-v2v-conf, customization-scripts,
+// and vddk-conf ConfigMaps that were copied to the plan's TargetNamespace at
+// migration start. Safe to call regardless of migration outcome.
+func (r *KubeVirt) CleanupCopiedConfigMaps() {
+	ns := r.Plan.Spec.TargetNamespace
+	cl := r.Destination.Client
+
+	// extra-v2v-conf and customization-scripts use deterministic names (delete by name).
+	for _, name := range []string{
+		genExtraV2vConfConfigMapName(r.Plan),
+		genCustomizationScriptsConfigMapName(r.Plan),
+	} {
+		cm := &core.ConfigMap{}
+		cm.Name = name
+		cm.Namespace = ns
+		if err := cl.Delete(context.TODO(), cm); err != nil && !k8serr.IsNotFound(err) {
+			r.Log.Error(err, "Failed to delete copied ConfigMap.", "name", name, "namespace", ns)
+		} else if err == nil {
+			r.Log.Info("Deleted copied ConfigMap.", "name", name, "namespace", ns)
+		}
+	}
+
+	// vddk-conf uses GenerateName so must be found by label selector.
+	list := &core.ConfigMapList{}
+	err := cl.List(
+		context.TODO(),
+		list,
+		&client.ListOptions{
+			LabelSelector: k8slabels.SelectorFromSet(r.vddkLabels()),
+			Namespace:     ns,
+		},
+	)
+	if err != nil {
+		r.Log.Error(err, "Failed to list vddk-conf ConfigMaps for cleanup.", "namespace", ns)
+		return
+	}
+	for i := range list.Items {
+		if err := cl.Delete(context.TODO(), &list.Items[i]); err != nil && !k8serr.IsNotFound(err) {
+			r.Log.Error(err, "Failed to delete vddk-conf ConfigMap.", "name", list.Items[i].Name, "namespace", ns)
+		} else if err == nil {
+			r.Log.Info("Deleted vddk-conf ConfigMap.", "name", list.Items[i].Name, "namespace", ns)
+		}
+	}
+}
+
 // Get the importer pod for a PersistentVolumeClaim.
 func (r *KubeVirt) GetImporterPod(pvc core.PersistentVolumeClaim) (pod *core.Pod, found bool, err error) {
 	pod = &core.Pod{}

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -2,6 +2,7 @@
 package plan
 
 import (
+	"context"
 	"encoding/json"
 
 	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -13,9 +14,11 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	cnv "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -531,6 +534,104 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 
 			result := kubevirt.determineRunStrategy(vm)
 			Expect(result).To(Equal(cnv.RunStrategyHalted))
+		})
+	})
+
+	ginkgo.Describe("CleanupCopiedConfigMaps", func() {
+		ginkgo.It("should delete extra-v2v-conf and customization-scripts ConfigMaps by name", func() {
+			extraCM := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plan-extra-v2v-conf",
+					Namespace: "target-ns",
+				},
+				Data: map[string]string{"key": "val"},
+			}
+			custCM := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plan-customization-scripts",
+					Namespace: "target-ns",
+				},
+				Data: map[string]string{"key": "val"},
+			}
+			kubevirt := createKubeVirtWithProvider(v1beta1.VSphere, extraCM, custCM)
+
+			kubevirt.CleanupCopiedConfigMaps()
+
+			// Both should be gone
+			result := &v1.ConfigMap{}
+			err := kubevirt.Destination.Get(context.TODO(),
+				client.ObjectKey{Name: extraCM.Name, Namespace: "target-ns"}, result)
+			Expect(k8serr.IsNotFound(err)).To(BeTrue(), "extra-v2v-conf should be deleted")
+
+			err = kubevirt.Destination.Get(context.TODO(),
+				client.ObjectKey{Name: custCM.Name, Namespace: "target-ns"}, result)
+			Expect(k8serr.IsNotFound(err)).To(BeTrue(), "customization-scripts should be deleted")
+		})
+
+		ginkgo.It("should delete vddk-conf ConfigMaps by label selector", func() {
+			vddkCM := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plan-vddk-conf-abc12",
+					Namespace: "target-ns",
+					Labels: map[string]string{
+						kMigration:     "test",
+						kPlan:          "plan-uid",
+						kPlanName:      "test-plan",
+						kPlanNamespace: "test",
+						kUse:           VddkConf,
+						kResource:      ResourceVDDKConfig,
+					},
+				},
+				Data: map[string]string{"key": "val"},
+			}
+			kubevirt := createKubeVirtWithProvider(v1beta1.VSphere, vddkCM)
+
+			kubevirt.CleanupCopiedConfigMaps()
+
+			result := &v1.ConfigMap{}
+			err := kubevirt.Destination.Get(context.TODO(),
+				client.ObjectKey{Name: vddkCM.Name, Namespace: "target-ns"}, result)
+			Expect(k8serr.IsNotFound(err)).To(BeTrue(), "vddk-conf should be deleted")
+		})
+
+		ginkgo.It("should delete multiple vddk-conf ConfigMaps from retries", func() {
+			labels := map[string]string{
+				kMigration:     "test",
+				kPlan:          "plan-uid",
+				kPlanName:      "test-plan",
+				kPlanNamespace: "test",
+				kUse:           VddkConf,
+				kResource:      ResourceVDDKConfig,
+			}
+			vddkCM1 := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-plan-vddk-conf-aaa11", Namespace: "target-ns", Labels: labels,
+				},
+				Data: map[string]string{"key": "val1"},
+			}
+			vddkCM2 := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-plan-vddk-conf-bbb22", Namespace: "target-ns", Labels: labels,
+				},
+				Data: map[string]string{"key": "val2"},
+			}
+			kubevirt := createKubeVirtWithProvider(v1beta1.VSphere, vddkCM1, vddkCM2)
+
+			kubevirt.CleanupCopiedConfigMaps()
+
+			result := &v1.ConfigMap{}
+			err := kubevirt.Destination.Get(context.TODO(),
+				client.ObjectKey{Name: vddkCM1.Name, Namespace: "target-ns"}, result)
+			Expect(k8serr.IsNotFound(err)).To(BeTrue(), "first vddk-conf should be deleted")
+
+			err = kubevirt.Destination.Get(context.TODO(),
+				client.ObjectKey{Name: vddkCM2.Name, Namespace: "target-ns"}, result)
+			Expect(k8serr.IsNotFound(err)).To(BeTrue(), "second vddk-conf should be deleted")
+		})
+
+		ginkgo.It("should not error when no copied ConfigMaps exist", func() {
+			kubevirt := createKubeVirtWithProvider(v1beta1.VSphere)
+			Expect(func() { kubevirt.CleanupCopiedConfigMaps() }).ToNot(Panic())
 		})
 	})
 

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -309,6 +309,8 @@ func (r *Migration) Archive() {
 		}
 	}
 
+	r.kubevirt.CleanupCopiedConfigMaps()
+
 	for _, vm := range r.Plan.Status.Migration.VMs {
 		dontFailOnError := func(err error) bool {
 			if err != nil {
@@ -1668,6 +1670,7 @@ func (r *Migration) end() (completed bool, err error) {
 	} else if succeeded > 0 {
 		// if the migration didn't fail and at least one VM succeeded,
 		// then the migration succeeded.
+		r.kubevirt.CleanupCopiedConfigMaps()
 		r.Log.Info("Migration [SUCCEEDED]")
 		snapshot.SetCondition(
 			libcnd.Condition{


### PR DESCRIPTION
Add CleanupCopiedConfigMaps() to remove extra-v2v-conf, customization-scripts, and vddk-conf ConfigMaps that were copied to TargetNamespace during migration.
The cleanup runs in the migration end() path regardless of outcome. Deterministic-name CMs are deleted by name, vddk-conf CMs (which use GenerateName) are found by label selector.

Ref: https://redhat.atlassian.net/browse/MTV-5723
Resolves: MTV-5723