### PR TITLE
MTV-5655 | Fix populator pod cleanup and prevent PVC

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1572,6 +1572,11 @@ func (r *Builder) PopulatorTransferredBytes(pvc *core.PersistentVolumeClaim) (tr
 		return
 	}
 
+	if populatorCr.Status.Progress == "" {
+		transferredBytes = 0
+		return
+	}
+
 	progressPercentage, err := strconv.ParseInt(populatorCr.Status.Progress, 10, 64)
 	if err != nil {
 		r.Log.Error(err, "Couldn't parse the progress percentage.", "pvcName", pvc.Name, "progressPercentage", progressPercentage)

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1510,6 +1510,12 @@ func (r *KubeVirt) DeleteDataVolumes(vm *plan.VMStatus) (err error) {
 		return
 	}
 	for _, dv := range dvs {
+		r.Log.Info(
+			"Deleting DataVolume.",
+			"dv",
+			path.Join(dv.Namespace, dv.Name),
+			"vm",
+			vm.String())
 		err = r.Destination.Client.Delete(context.TODO(), dv.DataVolume)
 		if err != nil {
 			return
@@ -1566,6 +1572,7 @@ func (r *KubeVirt) DeleteJobs(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found jobs to delete.", "count", len(list.Items), "vm", vm.String())
 
 	jobNames := []string{}
 	for _, job := range list.Items {
@@ -1703,6 +1710,7 @@ func (r *KubeVirt) DeleteSecret(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found secrets to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err = r.DeleteObject(&object, vm, "Deleted secret.", "secret")
 		if err != nil {
@@ -1728,6 +1736,7 @@ func (r *KubeVirt) DeleteConfigMap(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found config maps to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err = r.DeleteObject(&object, vm, "Deleted configMap.", "configMap")
 		if err != nil {
@@ -1753,6 +1762,7 @@ func (r *KubeVirt) DeleteVM(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found VMs to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		foreground := meta.DeletePropagationForeground
 		opts := &client.DeleteOptions{PropagationPolicy: &foreground}
@@ -2432,6 +2442,7 @@ func (r *KubeVirt) DeletePVCConsumerPod(vm *plan.VMStatus) (err error) {
 	if err != nil {
 		return err
 	}
+	r.Log.Info("Found PVC consumer pods to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err = r.DeleteObject(&object, vm, "Deleted PVC consumer pod.", "pod")
 		if err != nil {
@@ -2447,6 +2458,7 @@ func (r *KubeVirt) DeletePreflightInspectionPod(vm *plan.VMStatus) (err error) {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	r.Log.Info("Found preflight inspection pods to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err := r.DeleteObject(&object, vm, "Deleted preflight inspection pod.", "pod")
 		if err != nil {
@@ -2462,6 +2474,7 @@ func (r *KubeVirt) DeleteGuestConversionPod(vm *plan.VMStatus) (err error) {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	r.Log.Info("Found guest conversion pods to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err := r.DeleteObject(&object, vm, "Deleted guest conversion pod.", "pod")
 		if err != nil {
@@ -2538,6 +2551,7 @@ func (r *KubeVirt) DeleteHookJobs(vm *plan.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	r.Log.Info("Found hook jobs to delete.", "count", len(list.Items), "vm", vm.String())
 	for _, object := range list.Items {
 		err = r.DeleteObject(&object, vm, "Deleted hook job.", "job",
 			client.PropagationPolicy(meta.DeletePropagationForeground))
@@ -2554,6 +2568,7 @@ func (r *KubeVirt) DeletePopulatedPVCs(vm *plan.VMStatus) error {
 	if err != nil {
 		return err
 	}
+	r.Log.Info("Found populated PVCs to delete.", "count", len(pvcs), "vm", vm.String())
 	for _, pvc := range pvcs {
 		if err = r.deleteCorrespondingPrimePVC(pvc, vm); err != nil {
 			return err
@@ -2608,16 +2623,24 @@ func (r *KubeVirt) DeletePopulatorPods(vm *plan.VMStatus) (err error) {
 		r.Log.Info("Retaining populator pods (feature flag enabled).", "vm", vm.String())
 		return
 	}
-	list, err := r.getPopulatorPods()
+	list, err := r.getPopulatorPods(vm.ID)
+	if err != nil {
+		return
+	}
+	r.Log.Info("Found populator pods to delete.", "count", len(list), "vm", vm.String())
 	for _, object := range list {
 		err = r.DeleteObject(&object, vm, "Deleted populator pod.", "pod")
 	}
 	return
 }
 
-// Get populator pods that belong to a VM's migration.
-func (r *KubeVirt) getPopulatorPods() (pods []core.Pod, err error) {
-	migrationPods, err := r.GetPodsWithLabels(map[string]string{kMigration: string(r.Plan.Status.Migration.ActiveSnapshot().Migration.UID)})
+// Get populator pods that belong to a specific VM in a migration.
+func (r *KubeVirt) getPopulatorPods(vmID string) (pods []core.Pod, err error) {
+	labelSelector := map[string]string{kMigration: string(r.Plan.Status.Migration.ActiveSnapshot().Migration.UID)}
+	if vmID != "" {
+		labelSelector[kVM] = vmID
+	}
+	migrationPods, err := r.GetPodsWithLabels(labelSelector)
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -403,6 +403,8 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			Settings.RetainPopulatorPods = savedRetain
 		})
 
+		const testVmID = "vm-123"
+
 		createKubeVirtWithPopulatorPod := func() (*KubeVirt, *v1.Pod) {
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -410,6 +412,7 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 					Namespace: targetNS,
 					Labels: map[string]string{
 						"migration": migrationUID,
+						"vmID":      testVmID,
 					},
 				},
 			}
@@ -428,11 +431,12 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			Settings.RetainPopulatorPods = true
 			kubevirt, _ := createKubeVirtWithPopulatorPod()
 			vm := &plan.VMStatus{}
+			vm.ID = testVmID
 
 			err := kubevirt.DeletePopulatorPods(vm)
 			Expect(err).ToNot(HaveOccurred())
 
-			pods, err := kubevirt.getPopulatorPods()
+			pods, err := kubevirt.getPopulatorPods(testVmID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pods).To(HaveLen(1), "populator pod should still exist")
 		})
@@ -441,11 +445,12 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			Settings.RetainPopulatorPods = false
 			kubevirt, _ := createKubeVirtWithPopulatorPod()
 			vm := &plan.VMStatus{}
+			vm.ID = testVmID
 
 			err := kubevirt.DeletePopulatorPods(vm)
 			Expect(err).ToNot(HaveOccurred())
 
-			pods, err := kubevirt.getPopulatorPods()
+			pods, err := kubevirt.getPopulatorPods(testVmID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pods).To(BeEmpty(), "populator pod should have been deleted")
 		})

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -294,13 +294,16 @@ func (r *Migration) Archive() {
 
 	switch r.Plan.Provider.Source.Type() {
 	case api.Ova, api.HyperV:
+		r.Log.Info("Deleting provider storage PVCs and PVs.", "provider", r.Plan.Provider.Source.Type())
 		if err := r.deleteProviderStorage(); err != nil {
 			r.Log.Error(err, "Failed to clean up the PVC and PV for the provider storage")
 		}
 	case api.VSphere:
+		r.Log.Info("Deleting validate-VDDK job(s).")
 		if err := r.deleteValidateVddkJob(); err != nil {
 			r.Log.Error(err, "Failed to clean up validate-VDDK job(s)")
 		}
+		r.Log.Info("Deleting VDDK config map.")
 		if err := r.deleteConfigMap(); err != nil {
 			r.Log.Error(err, "Failed to clean up vddk configmap")
 		}
@@ -316,7 +319,7 @@ func (r *Migration) Archive() {
 			}
 			return false
 		}
-		_ = r.cleanup(vm, dontFailOnError)
+		_ = r.cleanup(vm, dontFailOnError, true)
 		r.migrator.Complete(vm)
 	}
 }
@@ -413,50 +416,54 @@ func markStartedStepsCompleted(vm *plan.VMStatus) {
 func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, cancelConversions ...bool) error {
 	isCancelOnly := len(cancelConversions) > 0 && cancelConversions[0]
 
+// Delete left over migration resources associated with a VM.
+func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, forceDeleteGuestConversionPod bool) error {
+	r.Log.Info("Starting cleanup of migration resources.", "vm", vm.String())
+
 	// If the migration fails and the DeleteVmOnFailMigration is enabled, clean up the VM.
 	// When DeleteVmOnFailMigration is disabled, VM resources are preserved on failure.
 	if !vm.HasCondition(api.ConditionSucceeded) && (r.Plan.Spec.DeleteVmOnFailMigration || vm.DeleteVmOnFailMigration) {
+		r.Log.Info("Deleting VM (failed migration with deleteVmOnFailMigration enabled).", "vm", vm.String())
 		if err := r.kubevirt.DeleteVM(vm); failOnErr(err) {
 			return err
 		}
-		if err := r.kubevirt.DeletePopulatedPVCs(vm); failOnErr(err) {
+		r.Log.Info("Deleting populated PVCs.", "vm", vm.String())
+		if err := r.deletePopulatorPVCs(vm); failOnErr(err) {
 			return err
 		}
+		r.Log.Info("Deleting DataVolumes.", "vm", vm.String())
 		if err := r.kubevirt.DeleteDataVolumes(vm); failOnErr(err) {
 			return err
 		}
 	}
 
+	r.Log.Info("Deleting importer pods.", "vm", vm.String())
 	if err := r.deleteImporterPods(vm); failOnErr(err) {
 		return err
 	}
+	r.Log.Info("Deleting PVC consumer pod.", "vm", vm.String())
 	if err := r.kubevirt.DeletePVCConsumerPod(vm); failOnErr(err) {
 		return err
 	}
-	if err := r.kubevirt.DeleteGuestConversionPod(vm); failOnErr(err) {
-		return err
-	}
-	if settings.Settings.UseConversionCR {
-		if isCancelOnly {
-			if err := r.kubevirt.CancelConversion(vm); failOnErr(err) {
-				return err
-			}
-		} else {
-			if err := r.kubevirt.DeleteAllConversions(vm); failOnErr(err) {
-				return err
-			}
-		}
-	} else {
-		if err := r.kubevirt.DeleteSecret(vm); failOnErr(err) {
+	if r.Plan.Spec.DeleteGuestConversionPod || forceDeleteGuestConversionPod {
+		r.Log.Info("Deleting guest conversion pod.", "vm", vm.String())
+		if err := r.kubevirt.DeleteGuestConversionPod(vm); failOnErr(err) {
 			return err
 		}
 	}
+	r.Log.Info("Deleting preflight inspection pod.", "vm", vm.String())
 	if err := r.kubevirt.DeletePreflightInspectionPod(vm); failOnErr(err) {
 		return err
 	}
+	r.Log.Info("Deleting secrets.", "vm", vm.String())
+	if err := r.kubevirt.DeleteSecret(vm); failOnErr(err) {
+		return err
+	}
+	r.Log.Info("Deleting config maps.", "vm", vm.String())
 	if err := r.kubevirt.DeleteConfigMap(vm); failOnErr(err) {
 		return err
 	}
+	r.Log.Info("Deleting hook jobs.", "vm", vm.String())
 	if err := r.kubevirt.DeleteHookJobs(vm); failOnErr(err) {
 		return err
 	}
@@ -464,19 +471,23 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, cance
 		return err
 	}
 	if r.Plan.Provider.Destination.IsHost() {
+		r.Log.Info("Deleting populator data source.", "vm", vm.String())
 		if err := r.destinationClient.DeletePopulatorDataSource(vm); failOnErr(err) {
 			return err
 		}
 	}
+	r.Log.Info("Deleting populator pods.", "vm", vm.String())
 	if err := r.kubevirt.DeletePopulatorPods(vm); failOnErr(err) {
 		return err
 	}
+	r.Log.Info("Deleting migration jobs.", "vm", vm.String())
 	if err := r.kubevirt.DeleteJobs(vm); failOnErr(err) {
 		return err
 	}
 
 	r.removeLastWarmSnapshot(vm)
 
+	r.Log.Info("Cleanup of migration resources completed.", "vm", vm.String())
 	return nil
 }
 
@@ -489,6 +500,7 @@ func (r *Migration) removeLastWarmSnapshot(vm *plan.VMStatus) {
 		return
 	}
 	snapshot := vm.Warm.Precopies[n-1].Snapshot
+	r.Log.Info("Removing warm migration snapshot.", "vm", vm.String(), "snapshot", snapshot)
 	if _, err := r.provider.RemoveSnapshot(vm.Ref, snapshot, r.kubevirt.loadHosts); err != nil {
 		r.Log.Error(
 			err,
@@ -719,7 +731,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			vm.MarkStarted()
 			step.MarkStarted()
 			step.Phase = api.StepRunning
-			err = r.cleanup(vm, func(err error) bool { return err != nil })
+			err = r.cleanup(vm, func(err error) bool { return err != nil }, true)
 			if err != nil {
 				step.AddError(err.Error())
 				err = nil
@@ -1597,6 +1609,12 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				Message:  "The VM migration has SUCCEEDED.",
 				Durable:  true,
 			})
+		_ = r.cleanup(vm, func(err error) bool {
+			if err != nil {
+				r.Log.Error(err, "Cleanup after successful VM migration.", "vm", vm.String())
+			}
+			return false
+		}, false)
 
 	} else if vm.Error != nil {
 		vm.Phase = api.PhaseCompleted
@@ -2098,7 +2116,7 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 		newProgress := int64(percent * float64(task.Progress.Total))
 		if newProgress == task.Progress.Completed {
 			pvcId := string(pvc.UID)
-			populatorFailed := r.isPopulatorPodFailed(pvcId)
+			populatorFailed := r.isPopulatorPodFailed(pvcId, vm.ID)
 			if populatorFailed {
 				return fmt.Errorf("populator pod failed for PVC %s. Please check the pod logs", pvcId)
 			}
@@ -2120,8 +2138,8 @@ func (r *Migration) updatePopulatorCopyProgress(vm *plan.VMStatus, step *plan.St
 }
 
 // Checks if the populator pod failed when the progress didn't change
-func (r *Migration) isPopulatorPodFailed(givenPvcId string) bool {
-	populatorPods, err := r.kubevirt.getPopulatorPods()
+func (r *Migration) isPopulatorPodFailed(givenPvcId string, vmID string) bool {
+	populatorPods, err := r.kubevirt.getPopulatorPods(vmID)
 	if err != nil {
 		r.Log.Error(err, "couldn't get the populator pods")
 		return false

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -786,7 +786,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 					vendor, _, _ := unstructured.NestedString(crInstance.Object, "spec", "storageVendorProduct")
 					c.metrics.recordCompletionFromScrape(pvc.UID, "failure", migration, string(pvc.UID), vendor, "", "", "", 0, 0, 0)
 					c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPodFailed, "VSphere xcopy populator failed (no retry): Please check the logs of the populator pod, %s/%s", populatorNamespace, pod.Name)
-					return c.deleteFailedPVC(ctx, pvc)
+					return nil
 				}
 
 				restarts, ok := pvc.Annotations[AnnPopulatorReCreations]
@@ -801,7 +801,6 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 					return c.retryFailedPopulator(ctx, pvc, populatorNamespace, pod.Name, restartsInteger+1)
 				}
 				c.recorder.Eventf(pvc, corev1.EventTypeWarning, reasonPodFailed, "Populator failed after few (3) attempts: Please check the logs of the populator pod, %s/%s", populatorNamespace, pod.Name)
-				return c.deleteFailedPVC(ctx, pvc)
 			}
 			// We'll get called again later when the pod succeeds
 			return nil
@@ -888,14 +887,6 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 	// Stop progress monitoring
 	delete(monitoredPVCs, string(pvc.UID))
 
-	return nil
-}
-
-func (c *controller) deleteFailedPVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
-	klog.V(2).Infof("Deleting PVC %s/%s after permanent populator failure", pvc.Namespace, pvc.Name)
-	if err := c.kubeClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
…ascade deletion (#6966)

**Backport:** https://github.com/kubev2v/forklift/pull/6920

- **Fix populator pod cleanup deleting pods of other VMs**: Add `vmID` label filtering to `getPopulatorPods()` and `DeletePopulatorPods()` so that cleanup for one VM does not kill populator pods belonging to other actively-migrating VMs. Mirrors the fix already applied to `getPopulatorCrList` in PR #6628.
- **Remove `deleteFailedPVC` from populator controller**: Stop deleting target PVCs on populator failure. Combined with OwnerReferences (MTV-3353), deleting the PVC cascades via Kubernetes GC to delete the populator pod, prime PVC, and triggers cleanup of all remaining PVCs for the VM. The forklift controller now handles cleanup during archive instead.
- **Cleanup on successful VM migration**: Call `cleanup()` after setting the Succeeded condition so resources (populator pods, PVCs, etc.) are released on success. Gate `DeleteGuestConversionPod` behind the plan spec flag in `cleanup()`.

- [ ] Run concurrent VM migration (multiple VMs, multiple disks) with copy offload
- [ ] Verify that a single disk failure does NOT cascade-delete PVCs of other disks in the same or different VMs
- [ ] Verify failed VMs report "populator pod failed for PVC" instead of "PVC is missing"
- [ ] Verify successful VM migrations clean up resources properly
- [ ] Verify guest conversion pod is only deleted when `DeleteGuestConversionPod` is set in plan spec

Ref: https://issues.redhat.com/browse/MTV-5655

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------