### PR TITLE
MTV-5529 | Remove the retry/reusing of DI conversion CRs

### DIFF
--- a/pkg/controller/conversion/context/doc.go
+++ b/pkg/controller/conversion/context/doc.go
@@ -27,11 +27,6 @@ const (
 	LabelPlanNamespace  = "plan-namespace"
 	LabelMigration      = "migration"
 	LabelVM             = "vmID"
-	// LabelRetryAllowed controls whether a failed/canceled DeepInspection Conversion CR may be retried during preflight inspection.
-	// "true": one retry is allowed, the replacement CR will be stamped "false".
-	// "false": no further retries, the step is immediately failed.
-	// absent: treated the same as "true" (one retry allowed).
-	LabelRetryAllowed = "retryAllowed"
 )
 
 // VddkVolumeName is the volume name used for the VDDK library scratch space.

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -582,27 +582,19 @@ func (r *KubeVirt) buildConversion(planName, vmID string, labels map[string]stri
 }
 
 // ensureConversion creates or updates the Conversion CR on the cluster.
-// An existing CR is found by matching all labels except LabelPlan (which
-// changes when a plan is re-created). When found its Spec and Labels are
-// refreshed; otherwise the provided CR is created verbatim.
+// An existing CR is found by matching all labels (including LabelPlan). When
+// found its Spec is refreshed; otherwise the provided CR is created verbatim.
 func (r *KubeVirt) ensureConversion(cr *api.Conversion) (*api.Conversion, error) {
-	lookupLabels := make(map[string]string, len(cr.Labels))
-	for k, v := range cr.Labels {
-		if k != convctx.LabelPlan {
-			lookupLabels[k] = v
-		}
-	}
 	list := &api.ConversionList{}
 	if err := r.Client.List(context.TODO(), list,
 		client.InNamespace(cr.Namespace),
-		client.MatchingLabels(lookupLabels),
+		client.MatchingLabels(cr.Labels),
 	); err != nil {
 		return nil, liberr.Wrap(err)
 	}
 	if len(list.Items) > 0 {
 		existing := &list.Items[0]
 		existing.Spec = cr.Spec
-		existing.Labels = cr.Labels
 		if err := r.Client.Update(context.TODO(), existing); err != nil {
 			return nil, liberr.Wrap(err)
 		}
@@ -698,24 +690,17 @@ func (r *KubeVirt) GetGuestConversion(vm *plan.VMStatus) (*api.Conversion, error
 }
 
 // GetDeepInspectionConversion returns the DeepInspection Conversion CR for the
-// given VM, or nil when none exists.
+// given VM on this plan, or nil when none exists.
 func (r *KubeVirt) GetDeepInspectionConversion(vm *plan.VMStatus) (*api.Conversion, error) {
-	labels := r.getConversionLabels(api.DeepInspection, vm.ID, "", nil)
+	labels := r.getConversionLabels(api.DeepInspection, vm.ID, string(r.Plan.UID), nil)
 	return r.getConversion(labels)
 }
 
 // CreateDeepInspectionConversion creates a new DeepInspection Conversion CR and
-// returns it. retryAllowed controls the value of the LabelRetryAllowed label
-// stamped on the new CR: "true" permits one future retry on failure; "false"
-// makes the next failure permanent.
+// returns it.
 func (r *KubeVirt) CreateDeepInspectionConversion(
-	vm *plan.VMStatus, snapshotMoref, planName, planID string, retryAllowed bool,
+	vm *plan.VMStatus, snapshotMoref, planName, planID string,
 ) (*api.Conversion, error) {
-	retryValue := "false"
-	if retryAllowed {
-		retryValue = "true"
-	}
-
 	// Connection secret goes to Plan.Namespace on the management cluster
 	// (DeepInspection pods run there, not on the destination cluster).
 	connSecretData := r.buildDeepInspectionConnectionSecretData()
@@ -771,8 +756,7 @@ func (r *KubeVirt) CreateDeepInspectionConversion(
 
 	// Empty Destination → resolveDestinationClient returns localClient →
 	// pod is created on the management cluster in Plan.Namespace.
-	crLabels := r.getConversionLabels(api.DeepInspection, vm.ID, planID,
-		map[string]string{convctx.LabelRetryAllowed: retryValue})
+	crLabels := r.getConversionLabels(api.DeepInspection, vm.ID, planID, nil)
 	spec := api.ConversionSpec{
 		Type:            api.DeepInspection,
 		TargetNamespace: r.Plan.Namespace,

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -8,6 +8,7 @@ import (
 	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	convctx "github.com/kubev2v/forklift/pkg/controller/conversion/context"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -665,6 +666,44 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			for _, vol := range extraVolumes {
 				Expect(vol.Name).ToNot(Equal(DynamicScriptsVolumeName))
 			}
+		})
+	})
+
+	ginkgo.Describe("GetDeepInspectionConversion", func() {
+		ginkgo.It("returns nil when a Conversion CR for the same VM exists under a different plan UID", func() {
+			const (
+				vmID           = "vm-abc-123"
+				planNamespace  = "test-ns"
+				otherPlanUID   = "other-plan-uid"
+				currentPlanUID = "current-plan-uid"
+			)
+
+			// A DeepInspection CR that belongs to a *different* plan but the same VM.
+			existingCR := &v1beta1.Conversion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "di-conversion-other-plan",
+					Namespace: planNamespace,
+					Labels: map[string]string{
+						convctx.LabelVM:             vmID,
+						convctx.LabelConversionType: string(v1beta1.DeepInspection),
+						convctx.LabelPlan:           otherPlanUID,
+					},
+				},
+			}
+
+			kubevirt := createKubeVirt(existingCR)
+			kubevirt.Plan.ObjectMeta = metav1.ObjectMeta{
+				Name:      "current-plan",
+				Namespace: planNamespace,
+				UID:       currentPlanUID,
+			}
+
+			vm := &plan.VMStatus{}
+			vm.ID = vmID
+
+			cr, err := kubevirt.GetDeepInspectionConversion(vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cr).To(BeNil())
 		})
 	})
 })

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -16,7 +16,6 @@ import (
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
-	convctx "github.com/kubev2v/forklift/pkg/controller/conversion/context"
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter"
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
@@ -1456,10 +1455,8 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				}
 
 				if cr == nil {
-					// No CR yet, first attempt
-					// retryAllowed=false means if this one fails it will not be retried automatically.
 					_, err = r.kubevirt.CreateDeepInspectionConversion(
-						vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID), false)
+						vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID))
 					if err != nil {
 						step.AddError(err.Error())
 						err = nil
@@ -1479,31 +1476,22 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 					}
 					r.NextPhase(vm)
 
-				case api.PhaseFailed, api.PhaseCanceled:
+				case api.PhaseFailed:
 					r.Log.Info("Deep inspection CR failed.",
 						"conversion", cr.Name,
-						"phase", cr.Status.Phase,
 						"vm", vm.String())
-					retryLabel, hasLabel := cr.Labels[convctx.LabelRetryAllowed]
-					// Label present and explicitly false, no more retries.
-					if hasLabel && retryLabel == "false" {
-						step.AddError("Deep inspection failed after retry.")
-						break
-					}
-					// Label missing or set to "true", one retry allowed.
-					// Delete the failed CR and recreate it with retryAllowed=false so
-					// the replacement cannot trigger another retry.
+					step.AddError("Deep inspection failed.")
+
+				case api.PhaseCanceled:
+					r.Log.Info("Deep inspection CR was canceled, deleting.",
+						"conversion", cr.Name,
+						"vm", vm.String())
 					if err = r.kubevirt.DeleteConversion(cr); err != nil {
 						step.AddError(err.Error())
 						err = nil
 						break
 					}
-					_, err = r.kubevirt.CreateDeepInspectionConversion(
-						vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID), false)
-					if err != nil {
-						step.AddError(err.Error())
-						err = nil
-					}
+
 					return
 
 				default:


### PR DESCRIPTION
Issue: DI conversion CR reusing has a bug where it is reusing wrong conversions from a different plan. The fix could to properly reuse the conversions with a defined flow.
https://github.com/kubev2v/forklift/pull/6846 However that fix is complicated and could introduce more bugs.

Fix: Instead of implementing the proper reusing of resources https://github.com/kubev2v/forklift/pull/6846 simplify the logic to not reuse DI conversions at all for now. Later we can add the proper method defined in the other PR.

Resolves: MTV-5529