### PR TITLE
fix(regression): add removing of conversions back to cleanup

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2468,6 +2468,32 @@ func (r *KubeVirt) DeletePreflightInspectionPod(vm *plan.VMStatus) (err error) {
 	return
 }
 
+// DeleteDeepInspectionPods deletes any deep inspection pods for the given VM
+// that live on the management cluster.
+func (r *KubeVirt) DeleteDeepInspectionPods(vm *plan.VMStatus) error {
+	matchLabels := map[string]string{
+		convctx.LabelPlan:           string(r.Plan.UID),
+		convctx.LabelVM:             vm.ID,
+		convctx.LabelConversionType: string(api.DeepInspection),
+	}
+	list := &core.PodList{}
+	if err := r.List(context.TODO(), list,
+		client.InNamespace(r.Plan.Namespace),
+		client.MatchingLabels(matchLabels),
+	); err != nil {
+		return liberr.Wrap(err)
+	}
+	r.Log.Info("Found deep inspection pods to delete.", "count", len(list.Items), "vm", vm.String())
+	for i := range list.Items {
+		pod := &list.Items[i]
+		if err := r.Delete(context.TODO(), pod); err != nil && !k8serr.IsNotFound(err) {
+			return liberr.Wrap(err)
+		}
+		r.Log.Info("Deleted deep inspection pod.", "pod", pod.Name, "vm", vm.String())
+	}
+	return nil
+}
+
 // Delete the guest conversion pod on the destination cluster.
 func (r *KubeVirt) DeleteGuestConversionPod(vm *plan.VMStatus) (err error) {
 	list, err := r.GetPodsWithLabels(r.conversionLabels(vm.Ref, true))

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -445,16 +445,40 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, force
 			return err
 		}
 	}
+	if settings.Settings.UseConversionCR {
+		r.Log.Info("Deleting deep inspection conversion CR.", "vm", vm.String())
+		if diConv, diErr := r.kubevirt.GetDeepInspectionConversion(vm); diErr != nil {
+			if failOnErr(diErr) {
+				return diErr
+			}
+		} else if diConv != nil {
+			if err := r.kubevirt.DeleteConversion(diConv); failOnErr(err) {
+				return err
+			}
+		}
+		r.Log.Info("Deleting deep inspection pods.", "vm", vm.String())
+		if err := r.kubevirt.DeleteDeepInspectionPods(vm); failOnErr(err) {
+			return err
+		}
+		if r.Plan.Spec.DeleteGuestConversionPod || forceDeleteGuestConversionPod {
+			r.Log.Info("Deleting guest conversion CR.", "vm", vm.String())
+			if gConv, gErr := r.kubevirt.GetGuestConversion(vm); gErr != nil {
+				if failOnErr(gErr) {
+					return gErr
+				}
+			} else if gConv != nil {
+				if err := r.kubevirt.DeleteConversion(gConv); failOnErr(err) {
+					return err
+				}
+			}
+		}
+	}
 	r.Log.Info("Deleting preflight inspection pod.", "vm", vm.String())
 	if err := r.kubevirt.DeletePreflightInspectionPod(vm); failOnErr(err) {
 		return err
 	}
 	r.Log.Info("Deleting secrets.", "vm", vm.String())
 	if err := r.kubevirt.DeleteSecret(vm); failOnErr(err) {
-		return err
-	}
-	r.Log.Info("Deleting preflight inspection pod.", "vm", vm.String())
-	if err := r.kubevirt.DeletePreflightInspectionPod(vm); failOnErr(err) {
 		return err
 	}
 	r.Log.Info("Deleting config maps.", "vm", vm.String())


### PR DESCRIPTION
Issue: https://github.com/kubev2v/forklift/pull/6870 caused the conversions to be left on the cluster.

Fix: delete conversions and deep inspection pods