### PR TITLE
MTV-5737 | Filter prime PVCs from getPVCs to fix OpenStack cold migration

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2023,11 +2023,12 @@ func (r *KubeVirt) getPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, e
 		return
 	}
 
-	pvcs = make([]*core.PersistentVolumeClaim, len(pvcsList.Items))
-	for i, pvc := range pvcsList.Items {
-		// loopvar
-		pvc := pvc
-		pvcs[i] = &pvc
+	for i := range pvcsList.Items {
+		pvc := &pvcsList.Items[i]
+		if strings.HasPrefix(pvc.Name, "prime-") || !hasDiskIdentity(pvc) {
+			continue
+		}
+		pvcs = append(pvcs, pvc)
 	}
 
 	// Sort the pvcs slice by disk index
@@ -2038,6 +2039,16 @@ func (r *KubeVirt) getPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, e
 	})
 
 	return
+}
+
+// hasDiskIdentity reports whether the PVC carries the AnnDiskSource annotation
+// that every adapter sets on real disk PVCs.
+func hasDiskIdentity(pvc *core.PersistentVolumeClaim) bool {
+	if pvc.Annotations == nil {
+		return false
+	}
+	source, ok := pvc.Annotations[planbase.AnnDiskSource]
+	return ok && strings.TrimSpace(source) != ""
 }
 
 // Creates the PVs and PVCs for LUN disks.

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -32,6 +32,9 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 					"migration": "test",
 					"vmID":      "test",
 				},
+				Annotations: map[string]string{
+					"forklift.konveyor.io/disk-source": "test-disk",
+				},
 			},
 		}
 
@@ -40,6 +43,69 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			pvcs, err := kubevirt.getPVCs(ref.Ref{ID: "test"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pvcs).To(HaveLen(1))
+		})
+
+		ginkgo.It("should exclude prime PVCs created by the volume populator", func() {
+			realPVC := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "9ba19d87-0d7f-43be-9ffe-d7dd3a552188-ggcw8",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "test",
+						"vmID":      "test",
+						"imageID":   "9ba19d87",
+					},
+					Annotations: map[string]string{
+						"forklift.konveyor.io/disk-source": "9ba19d87",
+					},
+				},
+			}
+			primePVC := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-222bcc84-8e35-4afb-a607-39605ff0397a",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "test",
+						"vmID":      "test",
+					},
+				},
+			}
+			kubevirt := createKubeVirt(realPVC, primePVC)
+			pvcs, err := kubevirt.getPVCs(ref.Ref{ID: "test"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvcs).To(HaveLen(1))
+			Expect(pvcs[0].Name).To(Equal(realPVC.Name))
+		})
+
+		ginkgo.It("should exclude PVCs without disk-source annotation", func() {
+			realPVC := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "real-disk-pvc",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "test",
+						"vmID":      "test",
+					},
+					Annotations: map[string]string{
+						"forklift.konveyor.io/disk-source": "disk-001",
+					},
+				},
+			}
+			noIdentityPVC := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stray-pvc-no-annotations",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "test",
+						"vmID":      "test",
+					},
+				},
+			}
+			kubevirt := createKubeVirt(realPVC, noIdentityPVC)
+			pvcs, err := kubevirt.getPVCs(ref.Ref{ID: "test"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvcs).To(HaveLen(1))
+			Expect(pvcs[0].Name).To(Equal(realPVC.Name))
 		})
 	})
 


### PR DESCRIPTION
Prime PVCs gained migration/vmID labels, making getPVCs() return them alongside real disk PVCs. Since they lack the disk-source annotation, mapDisks() produced empty duplicate disk names rejected by KubeVirt. Skip PVCs with a "prime-" name prefix or missing AnnDiskSource.

Ref: https://redhat.atlassian.net/browse/MTV-5737
Resolves: MTV-5737