### PR TITLE
MTV-5746 | fix Ansible default for feature_windows_wait_for_reboot to match Go

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -3709,7 +3709,7 @@ spec:
                 type: string
               feature_windows_wait_for_reboot:
                 description: 'Enable automatic wait-for-reboot step for Windows VM
-                  migrations (default: false)'
+                  migrations (default: true)'
                 enum:
                 - "true"
                 - "false"

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -3709,7 +3709,7 @@ spec:
                 type: string
               feature_windows_wait_for_reboot:
                 description: 'Enable automatic wait-for-reboot step for Windows VM
-                  migrations (default: false)'
+                  migrations (default: true)'
                 enum:
                 - "true"
                 - "false"

--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -94,7 +94,7 @@ spec:
               feature_windows_wait_for_reboot:
                 type: string
                 enum: ["true", "false"]
-                description: "Enable automatic wait-for-reboot step for Windows VM migrations (default: false)"
+                description: "Enable automatic wait-for-reboot step for Windows VM migrations (default: true)"
               feature_use_conversion_cr:
                 type: string
                 enum: ["true", "false"]

--- a/operator/roles/forkliftcontroller/defaults/main.yml
+++ b/operator/roles/forkliftcontroller/defaults/main.yml
@@ -11,7 +11,7 @@ feature_ocp_live_migration: true
 feature_vmware_system_serial_number: true
 feature_vsphere_vmware_driver_removal: false
 feature_windows_registry_network_config: false
-feature_windows_wait_for_reboot: false
+feature_windows_wait_for_reboot: true
 feature_use_conversion_cr: true
 feature_cli_download: true
 feature_mcp_server: false

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -208,10 +208,8 @@ spec:
         - name: FEATURE_WINDOWS_REGISTRY_NETWORK_CONFIG
           value: "true"
 {% endif %}
-{% if feature_windows_wait_for_reboot|bool %}
         - name: FEATURE_WINDOWS_WAIT_FOR_REBOOT
-          value: "true"
-{% endif %}
+          value: "{{ feature_windows_wait_for_reboot|bool|lower }}"
         - name: FEATURE_USE_CONVERSION_CR
           value: "{{ feature_use_conversion_cr|bool|lower }}"
 {% if ovirt_osmap_configmap_name is defined %}


### PR DESCRIPTION
The Go controller defaults FEATURE_WINDOWS_WAIT_FOR_REBOOT to true
  via getEnvBool(..., true). The Ansible operator default was false,
  so the Jinja2 template never set the env var on the controller
  deployment. The Go fallback made the feature always true at runtime,
  but silently, without the env var being present.

  This also means users cannot disable the feature via the CR, since
  the template only emits the env var when true (no else branch).

  Ref: https://redhat.atlassian.net/browse/MTV-5746
  Resolves: MTV-5746