### PR TITLE
MTV-5740 | Consider snapshot presence in CheckSnapshotRemove.

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	liburl "net/url"
+	"strings"
 
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
@@ -318,10 +319,27 @@ func (r *Client) CheckSnapshotRemove(vmRef ref.Ref, precopy planapi.Precopy, hos
 	r.Log.Info("Check Snapshot Remove", "vmRef", vmRef, "precopy", precopy)
 
 	taskInfo, err := r.getTaskById(vmRef, precopy.RemoveTaskId, hosts)
-	if err != nil {
+	if err == nil {
+		return r.checkTaskStatus(taskInfo)
+	}
+
+	notFound := strings.Contains(err.Error(), fmt.Sprintf("task %s not found", precopy.RemoveTaskId))
+	alreadyDeleted := strings.Contains(err.Error(), "has already been deleted")
+	if !notFound && !alreadyDeleted {
 		return false, liberr.Wrap(err)
 	}
-	return r.checkTaskStatus(taskInfo)
+
+	// If the task is done and gone, make sure the snapshot itself is gone
+	r.Log.Info("Snapshot removal task not found, checking for existing snapshot", "vmRef", vmRef, "precopy", precopy)
+	vm := &model.VM{}
+	if err := r.Source.Inventory.Find(vm, vmRef); err != nil {
+		return false, liberr.Wrap(err)
+	}
+	if vm.Snapshot.ID == "" {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // Check if a snapshot is ready to transfer.

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -2,9 +2,9 @@ package vsphere
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	liburl "net/url"
-	"strings"
 
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
@@ -15,6 +15,7 @@ import (
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/fault"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/session"
@@ -35,6 +36,10 @@ const (
 	createSnapshotTaskName = "vim.VirtualMachine.createSnapshot"
 	removeSnapshotTaskName = "vim.vm.Snapshot.remove"
 )
+
+var ErrTaskNotFound = errors.New("not found")
+var ErrTaskNotFoundPropSet = errors.New("not found property set")
+var ErrTaskValueNotFound = errors.New("no task value found for task")
 
 // vSphere VM Client
 type Client struct {
@@ -323,8 +328,8 @@ func (r *Client) CheckSnapshotRemove(vmRef ref.Ref, precopy planapi.Precopy, hos
 		return r.checkTaskStatus(taskInfo)
 	}
 
-	notFound := strings.Contains(err.Error(), fmt.Sprintf("task %s not found", precopy.RemoveTaskId))
-	alreadyDeleted := strings.Contains(err.Error(), "has already been deleted")
+	notFound := errors.Is(err, ErrTaskNotFound)
+	alreadyDeleted := fault.Is(err, &types.ManagedObjectNotFound{})
 	if !notFound && !alreadyDeleted {
 		return false, liberr.Wrap(err)
 	}
@@ -413,13 +418,13 @@ func (r *Client) getTaskById(vmRef ref.Ref, taskId string, hosts util.HostsFunc)
 		return nil, err
 	}
 	if len(content) == 0 {
-		return nil, fmt.Errorf("task %s not found", taskId)
+		return nil, fmt.Errorf("task %s %w", taskId, ErrTaskNotFound)
 	}
 	if len(content[0].PropSet) == 0 {
-		return nil, fmt.Errorf("task %s not found property set", taskId)
+		return nil, fmt.Errorf("task %s %w", taskId, ErrTaskNotFoundPropSet)
 	}
 	if content[0].PropSet[0].Val == nil {
-		return nil, fmt.Errorf("no task value found for task %s", taskId)
+		return nil, fmt.Errorf("%w %s", ErrTaskValueNotFound, taskId)
 	}
 	task := content[0].PropSet[0].Val.(types.TaskInfo)
 	return &task, nil


### PR DESCRIPTION
Issue: if the final snapshot is deleted before the WaitForFinalSnapshotRemoval phase, the plan fails even though all the work is actually done. For VMware this happens becase the removal task ID is no longer present, so checking the task status returns an error.

Fix: in CheckSnapshotRemove, if task status returns "not found", also check the inventory to see if there's a snapshot present. Wait until the snapshot is removed from the inventory before considering the snapshot removed. 

Reference:[MTV-5740]( https://redhat.atlassian.net/browse/MTV-5740)

Resolves: MTV-5740

[MTV-5740]: https://redhat.atlassian.net/browse/MTV-5740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ