### PR TITLE
MTV-5363 | Quote VMDK paths in esxcli clone for names with spaces

### DIFF
--- a/cmd/vsphere-copy-offload-populator/vmkfstools-wrapper/esxcli-vmkfstools.xml
+++ b/cmd/vsphere-copy-offload-populator/vmkfstools-wrapper/esxcli-vmkfstools.xml
@@ -28,7 +28,7 @@
          <format-parameters>
             <formatter>simple</formatter>
          </format-parameters>
-         <execute>/opt/redhat/vmkfstools-wrapper --clone -s $val{source-vmdk} -t $val{target-lun} </execute>
+         <execute>/opt/redhat/vmkfstools-wrapper --clone -s '$val{source-vmdk}' -t '$val{target-lun}' </execute>
       </command>
       <command path="vmkfstools.taskGet">
          <description>Get a clone task status</description>

--- a/cmd/vsphere-copy-offload-populator/vmkfstools-wrapper/version.mk
+++ b/cmd/vsphere-copy-offload-populator/vmkfstools-wrapper/version.mk
@@ -1,1 +1,1 @@
-VIB_VERSION := 0.3.1
+VIB_VERSION := 0.3.2

--- a/cmd/vsphere-copy-offload-populator/vmkfstools-wrapper/vmkfstools_wrapper_test.sh
+++ b/cmd/vsphere-copy-offload-populator/vmkfstools-wrapper/vmkfstools_wrapper_test.sh
@@ -819,6 +819,24 @@ test_argument_parsing() {
     # Test task-get with --task-id
     output=$(sh "${WRAPPER_SCRIPT}" --task-get --task-id "test-id-2" 2>&1)
     assert_contains 'test-id-2' "${output}" "Task-get with --task-id parses task ID"
+
+    # MTV-5363: paths with spaces must not be split into standalone dashes
+    local source_path="/vmfs/volumes/eco-iscsi-ds3/vm10disks - cloned/vm10disks - cloned_1.vmdk"
+    local target_path="/vmfs/devices/disks/naa.600a0980383139544924583130374851"
+    output=$(sh "${WRAPPER_SCRIPT}" --clone -s "${source_path}" -t "${target_path}" 2>&1)
+    assert_not_contains "Unknown option: -" "${output}" "Clone with spaces in path does not treat dash as option"
+}
+
+test_esxcli_xml_path_quoting() {
+    echo ""
+    echo "=== Testing esxcli XML Path Quoting (MTV-5363) ==="
+
+    local xml_file="${SCRIPT_DIR}/esxcli-vmkfstools.xml"
+    local xml_content
+    xml_content=$(cat "${xml_file}")
+
+    assert_contains "'\$val{source-vmdk}'" "${xml_content}" "Clone source path is quoted in esxcli XML"
+    assert_contains "'\$val{target-lun}'" "${xml_content}" "Clone target path is quoted in esxcli XML"
 }
 
 # ============================================================================
@@ -1298,8 +1316,8 @@ main() {
     test_version_output_simple
     test_version_output_xml
     test_argument_parsing
-    
-    
+    test_esxcli_xml_path_quoting
+
     # GROUP 2: Path Validation and Security
     test_path_validation
     


### PR DESCRIPTION
## Summary

Fixes VIB clone failures when source VMDK paths contain spaces (e.g. VM names with spaces). The esxcli plugin was invoking the wrapper via an unquoted shell command, causing the path to be split on whitespace and producing `Unknown option: -`.

- Quote `source-vmdk` and `target-lun` in `esxcli-vmkfstools.xml` execute line
- Bump `vmkfstools-wrapper` VIB version to **0.3.2**
- Add regression tests for spaced paths and XML quoting

**Deployment note:** ESXi hosts must install the rebuilt VIB (`vmkfstools-wrapper` 0.3.2). Patching the populator image alone does not update the esxcli plugin on the host.

## Test plan

- [x] `vmkfstools_wrapper_test.sh` — clone with spaces in path, XML quoting assertions
- [x] Manual migration on `ocp-edge97-0` with VM `polina test vib` (VIB method, xcopy offload, clone 100%)

Ref: https://redhat.atlassian.net/browse/MTV-5363
Resolves: MTV-5363