### PR TITLE
MTV-4165 | Detect boot disk for warm migrations from inspection XML

### DIFF
--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -74,12 +74,16 @@ func main() {
 			os.Exit(1)
 		}
 
-		// virt-v2v-inspector
-		err = convert.RunVirtV2VInspection()
-		if err != nil {
-			fmt.Println("Failed to inspect the disk", err)
-			os.Exit(1)
+		// For non-in-place conversions, run virt-v2v-inspector separately.
+		// For in-place, the -O flag on virt-v2v-in-place already produced the inspection XML.
+		if !convert.IsInPlace {
+			err = convert.RunVirtV2VInspection()
+			if err != nil {
+				fmt.Println("Failed to inspect the disk", err)
+				os.Exit(1)
+			}
 		}
+
 		inspection, err := utils.GetInspectionV2vFromFile(convert.InspectionOutputFile)
 		if err != nil {
 			fmt.Println("Failed to get inspection file", err)

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -961,7 +961,7 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 		}
 	}
 
-	var bootDisk int
+	bootDisk := -1
 	for _, vmConf := range r.Plan.Spec.VMs {
 		if vmConf.ID == vmRef.ID {
 			if vmConf.RootDisk != "" {
@@ -971,6 +971,21 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 				bootDisk = *vmStatus.DetectedBootDisk
 			}
 			break
+		}
+	}
+
+	// Boot disk indices from inspection/virt-v2v/user RootDisk are in libvirt
+	// order. When the final VM uses VMware order, translate to the correct index.
+	if !sortByLibvirt && bootDisk >= 0 {
+		translated := vm.TranslateDiskIndexFromLibvirt(bootDisk, disks)
+		if translated < 0 {
+			r.Log.Info("Failed to translate boot disk index from libvirt to target disk order",
+				"libvirtIndex", bootDisk, "vm", vm.Name)
+			bootDisk = -1
+		} else {
+			r.Log.V(1).Info("Translated boot disk index from libvirt to VMware order",
+				"libvirtIndex", bootDisk, "targetIndex", translated, "vm", vm.Name)
+			bootDisk = translated
 		}
 	}
 
@@ -1052,11 +1067,9 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 			r.Log.Info("Available PVC mapping", "diskKey", key, "pvcName", pvc.Name)
 		}
 		return fmt.Errorf("no disks were successfully mapped for VM %s", vm.Name)
-	} else if bootDisk < len(kDisks) {
-		// For multiboot VMs, if the selected boot device is the current disk,
-		// set it as the first in the boot order.
+	} else if bootDisk >= 0 && bootDisk < len(kDisks) {
 		kDisks[bootDisk].BootOrder = ptr.To(uint(1))
-	} else {
+	} else if bootDisk >= len(kDisks) {
 		r.Log.Info("Boot disk index out of range", "bootDisk", bootDisk, "diskCount", len(kDisks), "vm", vm.Name)
 	}
 

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -898,6 +898,56 @@ var _ = Describe("vSphere builder", func() {
 			},
 		),
 	)
+
+	DescribeTable("TranslateDiskIndexFromLibvirt", func(disks []vsphere.Disk, libvirtIndex int, expectedTargetIndex int) {
+		vm := &model.VM1{}
+		vm.Disks = disks
+		targetOrder := vm.SortedDisksAsVmware()
+		Expect(vm.TranslateDiskIndexFromLibvirt(libvirtIndex, targetOrder)).Should(Equal(expectedTargetIndex))
+	},
+		Entry("translates libvirt boot index to vmware order (boot on SATA, data on SCSI)",
+			[]vsphere.Disk{
+				{Key: 100, Bus: vsphere.SCSI, File: "data.vmdk"},
+				{Key: 200, Bus: vsphere.SATA, File: "boot.vmdk"},
+			},
+			1,  // libvirt index: SCSI first → SATA boot is index 1
+			0,  // vmware index: SATA first → SATA boot is index 0
+		),
+		Entry("same index when single bus (all SCSI)",
+			[]vsphere.Disk{
+				{Key: 100, Bus: vsphere.SCSI, File: "disk0.vmdk"},
+				{Key: 200, Bus: vsphere.SCSI, File: "disk1.vmdk"},
+				{Key: 300, Bus: vsphere.SCSI, File: "disk2.vmdk"},
+			},
+			0,
+			0,
+		),
+		Entry("returns -1 when libvirt index out of range",
+			[]vsphere.Disk{
+				{Key: 100, Bus: vsphere.SCSI, File: "disk0.vmdk"},
+			},
+			5,
+			-1,
+		),
+		Entry("passes through negative index unchanged",
+			[]vsphere.Disk{
+				{Key: 100, Bus: vsphere.SCSI, File: "disk0.vmdk"},
+			},
+			-1,
+			-1,
+		),
+		Entry("translates correctly with multiple buses (IDE boot, SCSI data, SATA extra)",
+			[]vsphere.Disk{
+				{Key: 300, Bus: vsphere.IDE, File: "boot.vmdk"},
+				{Key: 100, Bus: vsphere.SCSI, File: "data.vmdk"},
+				{Key: 200, Bus: vsphere.SATA, File: "extra.vmdk"},
+			},
+			// Libvirt order: SCSI(100), SATA(200), IDE(300) → IDE boot is index 2
+			// VMware order:  SATA(200), IDE(300), SCSI(100) → IDE boot is index 1
+			2,
+			1,
+		),
+	)
 })
 
 //nolint:errcheck

--- a/pkg/controller/plan/adapter/vsphere/inspectionparser.go
+++ b/pkg/controller/plan/adapter/vsphere/inspectionparser.go
@@ -66,11 +66,18 @@ var osV2VMap = map[string]string{
 	"win2k25": "windows2022srvNext_64Guest",
 }
 
+type Mountpoint struct {
+	Dev  string `xml:"dev,attr"`
+	Path string `xml:",chardata"`
+}
+
 type InspectionOS struct {
-	Name   string `xml:"name"`
-	Distro string `xml:"distro"`
-	Osinfo string `xml:"osinfo"`
-	Arch   string `xml:"arch"`
+	Name        string       `xml:"name"`
+	Distro      string       `xml:"distro"`
+	Osinfo      string       `xml:"osinfo"`
+	Arch        string       `xml:"arch"`
+	Root        string       `xml:"root"`
+	Mountpoints []Mountpoint `xml:"mountpoints>mountpoint"`
 }
 
 type InspectionV2V struct {
@@ -84,6 +91,63 @@ func ParseInspectionFromString(xmlData string) (InspectionV2V, error) {
 		return InspectionV2V{}, fmt.Errorf("Error unmarshalling XML: %v\n", err)
 	}
 	return xmlConf, nil
+}
+
+func GetBootDiskFromInspectionXML(vmConfigXML string) int {
+	inspection, err := ParseInspectionFromString(vmConfigXML)
+	if err != nil {
+		return -1
+	}
+
+	// Priority: /boot/efi > /boot > root device
+	var bootDev, efiDev, rootDev string
+	for _, mp := range inspection.OS.Mountpoints {
+		switch mp.Path {
+		case "/boot/efi":
+			efiDev = mp.Dev
+		case "/boot":
+			bootDev = mp.Dev
+		}
+	}
+
+	if inspection.OS.Root != "" {
+		rootDev = inspection.OS.Root
+	}
+
+	dev := efiDev
+	if dev == "" {
+		dev = bootDev
+	}
+	if dev == "" {
+		dev = rootDev
+	}
+	if dev == "" {
+		return -1
+	}
+
+	return deviceToDiskIndex(dev)
+}
+
+// deviceToDiskIndex extracts the 0-based disk index from a device path.
+func deviceToDiskIndex(dev string) int {
+	if strings.HasPrefix(dev, "btrfsvol:") {
+		dev = strings.TrimPrefix(dev, "btrfsvol:")
+		parts := strings.SplitN(dev, "/", 4)
+		if len(parts) >= 3 {
+			dev = "/" + parts[1] + "/" + parts[2]
+		}
+	}
+
+	for _, prefix := range []string{"/dev/sd", "/dev/vd", "/dev/hd"} {
+		if strings.HasPrefix(dev, prefix) {
+			remainder := dev[len(prefix):]
+			if len(remainder) > 0 && remainder[0] >= 'a' && remainder[0] <= 'z' {
+				return int(remainder[0] - 'a')
+			}
+		}
+	}
+
+	return -1
 }
 
 func GetOperationSystemFromConfig(vmConfigXML string) (string, error) {

--- a/pkg/controller/plan/adapter/vsphere/inspectionparser_test.go
+++ b/pkg/controller/plan/adapter/vsphere/inspectionparser_test.go
@@ -1,0 +1,129 @@
+package vsphere
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetBootDiskFromInspectionXML", func() {
+	DescribeTable("detects boot disk from inspection XML",
+		func(xml string, expected int) {
+			Expect(GetBootDiskFromInspectionXML(xml)).To(Equal(expected))
+		},
+		Entry("prefers /boot/efi on sda", `
+<v2v-inspection>
+  <operatingsystem>
+    <root>btrfsvol:/dev/sda4/root</root>
+    <mountpoints>
+      <mountpoint dev='btrfsvol:/dev/sda4/root'>/</mountpoint>
+      <mountpoint dev='/dev/sda3'>/boot</mountpoint>
+      <mountpoint dev='/dev/sda2'>/boot/efi</mountpoint>
+    </mountpoints>
+  </operatingsystem>
+</v2v-inspection>`, 0),
+
+		Entry("prefers /boot/efi on second disk", `
+<v2v-inspection>
+  <operatingsystem>
+    <root>/dev/sda2</root>
+    <mountpoints>
+      <mountpoint dev='/dev/sda2'>/</mountpoint>
+      <mountpoint dev='/dev/sdb1'>/boot/efi</mountpoint>
+    </mountpoints>
+  </operatingsystem>
+</v2v-inspection>`, 1),
+
+		Entry("falls back to /boot when no /boot/efi", `
+<v2v-inspection>
+  <operatingsystem>
+    <root>/dev/sda2</root>
+    <mountpoints>
+      <mountpoint dev='/dev/sda2'>/</mountpoint>
+      <mountpoint dev='/dev/sdb1'>/boot</mountpoint>
+    </mountpoints>
+  </operatingsystem>
+</v2v-inspection>`, 1),
+
+		Entry("falls back to root device when no /boot mounts", `
+<v2v-inspection>
+  <operatingsystem>
+    <root>/dev/sdb2</root>
+    <mountpoints>
+      <mountpoint dev='/dev/sdb2'>/</mountpoint>
+    </mountpoints>
+  </operatingsystem>
+</v2v-inspection>`, 1),
+
+		Entry("handles btrfs root device", `
+<v2v-inspection>
+  <operatingsystem>
+    <root>btrfsvol:/dev/sdc1/root</root>
+    <mountpoints>
+      <mountpoint dev='btrfsvol:/dev/sdc1/root'>/</mountpoint>
+    </mountpoints>
+  </operatingsystem>
+</v2v-inspection>`, 2),
+
+		Entry("handles single-disk VM (sda)", `
+<v2v-inspection>
+  <operatingsystem>
+    <root>/dev/sda1</root>
+    <mountpoints>
+      <mountpoint dev='/dev/sda1'>/</mountpoint>
+      <mountpoint dev='/dev/sda2'>/boot</mountpoint>
+    </mountpoints>
+  </operatingsystem>
+</v2v-inspection>`, 0),
+
+		Entry("returns -1 for empty XML", `
+<v2v-inspection>
+  <operatingsystem>
+  </operatingsystem>
+</v2v-inspection>`, -1),
+
+		Entry("returns -1 for invalid XML", `not valid xml`, -1),
+
+		Entry("returns -1 for unsupported device naming", `
+<v2v-inspection>
+  <operatingsystem>
+    <root>/dev/nvme0n1p2</root>
+    <mountpoints>
+      <mountpoint dev='/dev/nvme0n1p2'>/</mountpoint>
+    </mountpoints>
+  </operatingsystem>
+</v2v-inspection>`, -1),
+
+		Entry("handles virtio device vda", `
+<v2v-inspection>
+  <operatingsystem>
+    <root>/dev/vda2</root>
+    <mountpoints>
+      <mountpoint dev='/dev/vda2'>/</mountpoint>
+      <mountpoint dev='/dev/vda1'>/boot</mountpoint>
+    </mountpoints>
+  </operatingsystem>
+</v2v-inspection>`, 0),
+	)
+})
+
+var _ = Describe("deviceToDiskIndex", func() {
+	DescribeTable("maps device paths to disk index",
+		func(dev string, expected int) {
+			Expect(deviceToDiskIndex(dev)).To(Equal(expected))
+		},
+		Entry("/dev/sda", "/dev/sda", 0),
+		Entry("/dev/sda1", "/dev/sda1", 0),
+		Entry("/dev/sdb", "/dev/sdb", 1),
+		Entry("/dev/sdb3", "/dev/sdb3", 1),
+		Entry("/dev/sdc1", "/dev/sdc1", 2),
+		Entry("/dev/sdz", "/dev/sdz", 25),
+		Entry("/dev/vda1", "/dev/vda1", 0),
+		Entry("/dev/vdb2", "/dev/vdb2", 1),
+		Entry("/dev/hda", "/dev/hda", 0),
+		Entry("btrfsvol:/dev/sda4/root", "btrfsvol:/dev/sda4/root", 0),
+		Entry("btrfsvol:/dev/sdb1/home", "btrfsvol:/dev/sdb1/home", 1),
+		Entry("/dev/nvme0n0p1 unsupported", "/dev/nvme0n0p1", -1),
+		Entry("unknown device", "/dev/xda1", -1),
+		Entry("empty string", "", -1),
+	)
+})

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2358,13 +2358,14 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 		return liberr.Wrap(err)
 	}
 
+	var inspectionXML string
 	switch r.Source.Provider.Type() {
 	case api.Ova, api.HyperV:
 		if vm.Firmware, err = util.GetFirmwareFromYaml(vmConf); err != nil {
 			return liberr.Wrap(err)
 		}
 	case api.VSphere:
-		inspectionXML, err := r.getInspectionXml(pod)
+		inspectionXML, err = r.getInspectionXml(pod)
 		if err != nil {
 			return liberr.Wrap(err)
 		}
@@ -2374,11 +2375,29 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 		r.Log.Info("Setting the vm OS ", vm.OperatingSystem, "vmId", vm.ID)
 	}
 
-	if bootDiskIndex, bootOrderErr := util.GetDiskBootOrderFromYaml(vmConf); bootOrderErr != nil {
+	bootDiskIndex, bootOrderErr := util.GetDiskBootOrderFromYaml(vmConf)
+	if bootOrderErr != nil {
 		r.Log.Error(bootOrderErr, "Failed to extract boot order from virt-v2v output", "vmId", vm.ID)
-	} else if bootDiskIndex >= 0 {
+	}
+	if bootOrderErr == nil && bootDiskIndex >= 0 {
 		vm.DetectedBootDisk = &bootDiskIndex
 		r.Log.Info("Detected boot disk from virt-v2v output", "bootDiskIndex", bootDiskIndex, "vmId", vm.ID)
+	} else if inspectionXML != "" {
+		if idx := inspectionparser.GetBootDiskFromInspectionXML(inspectionXML); idx >= 0 {
+			vm.DetectedBootDisk = &idx
+			r.Log.Info("Detected boot disk from inspection XML", "bootDiskIndex", idx, "vmId", vm.ID)
+		}
+	}
+
+	if vm.DetectedBootDisk == nil && r.Source.Provider.Type() == api.VSphere {
+		vm.SetCondition(libcnd.Condition{
+			Type:     BootDiskNotDetected,
+			Status:   True,
+			Category: "Warning",
+			Reason:   BootDiskNotDetected,
+			Message:  "Boot disk could not be determined from conversion output; no bootOrder will be set.",
+		})
+		r.Log.Info("Boot disk not detected, no bootOrder will be set", "vmId", vm.ID)
 	}
 
 	// Fetch warnings before shutting down

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -83,6 +83,7 @@ const (
 	Failed                          = "Failed"
 	Canceled                        = "Canceled"
 	ConversionHasWarnings           = "ConversionHasWarnings"
+	BootDiskNotDetected             = "BootDiskNotDetected"
 	InspectionHasConcerns           = "InspectionHasConcerns"
 	Deleted                         = "Deleted"
 	Paused                          = "Paused"

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -261,6 +261,23 @@ func (r *VM1) SortedDisksAsVmware() []model.Disk {
 	return r.sortedDisksByBusses(r.Disks, buses)
 }
 
+func (r *VM1) TranslateDiskIndexFromLibvirt(libvirtIndex int, targetOrder []model.Disk) int {
+	if libvirtIndex < 0 {
+		return libvirtIndex
+	}
+	libvirtDisks := r.SortedDisksAsLibvirt()
+	if libvirtIndex >= len(libvirtDisks) {
+		return -1
+	}
+	targetKey := libvirtDisks[libvirtIndex].Key
+	for i, disk := range targetOrder {
+		if disk.Key == targetKey {
+			return i
+		}
+	}
+	return -1
+}
+
 // VM full detail.
 type VM struct {
 	VM1

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -147,7 +147,8 @@ func (c *Conversion) RunVirtV2vInPlace() error {
 	v2vCmdBuilder := c.CommandBuilder.New("virt-v2v-in-place").
 		AddFlag("-v").
 		AddFlag("-x").
-		AddArg("-i", "libvirtxml")
+		AddArg("-i", "libvirtxml").
+		AddArg("-O", c.InspectionOutputFile)
 	err := c.addCommonArgs(v2vCmdBuilder)
 	if err != nil {
 		return err
@@ -172,7 +173,8 @@ func (c *Conversion) RunVirtV2vInPlaceDisk() error {
 	v2vCmdBuilder := c.CommandBuilder.New("virt-v2v-in-place").
 		AddFlag("-v").
 		AddFlag("-x").
-		AddArg("-i", "disk")
+		AddArg("-i", "disk").
+		AddArg("-O", c.InspectionOutputFile)
 
 	err := c.addCommonArgs(v2vCmdBuilder)
 	if err != nil {
@@ -181,7 +183,6 @@ func (c *Conversion) RunVirtV2vInPlaceDisk() error {
 	c.addNoFstrimUnlessXfsCompat(v2vCmdBuilder)
 	c.addConversionExtraArgs(v2vCmdBuilder)
 
-	// Add all disks as positional arguments
 	for _, disk := range c.Disks {
 		v2vCmdBuilder.AddPositional(disk.Link)
 	}

--- a/pkg/virt-v2v/conversion/conversion_test.go
+++ b/pkg/virt-v2v/conversion/conversion_test.go
@@ -137,12 +137,14 @@ var _ = Describe("Conversion", func() {
 		It("passes virt-v2v-in-place with libvirtxml",
 			func() {
 				appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+				appConfig.InspectionOutputFile = config.InspectionOutputFile
 
 				mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("--no-fstrim").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
 
@@ -161,12 +163,14 @@ var _ = Describe("Conversion", func() {
 			func() {
 				appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
 				appConfig.ExtraArgs = []string{"--debug", "--verbose"}
+				appConfig.InspectionOutputFile = config.InspectionOutputFile
 
 				mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("--no-fstrim").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddExtraArgs("--debug", "--verbose").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
@@ -185,12 +189,14 @@ var _ = Describe("Conversion", func() {
 		It("returns error when command fails",
 			func() {
 				appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+				appConfig.InspectionOutputFile = config.InspectionOutputFile
 
 				mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("--no-fstrim").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
 
@@ -210,6 +216,7 @@ var _ = Describe("Conversion", func() {
 	Describe("RunVirtV2vInPlaceDisk", func() {
 		It("runs virt-v2v-in-place with disk mode",
 			func() {
+				appConfig.InspectionOutputFile = config.InspectionOutputFile
 				conversion.Disks = []*Disk{
 					{Link: "/var/tmp/v2v/vm-sda"},
 					{Link: "/var/tmp/v2v/vm-sdb"},
@@ -219,6 +226,7 @@ var _ = Describe("Conversion", func() {
 				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("--no-fstrim").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
@@ -248,6 +256,7 @@ var _ = Describe("Conversion", func() {
 		It("runs virt-v2v-in-place disk mode with extra args",
 			func() {
 				appConfig.ExtraArgs = []string{"--custom-flag"}
+				appConfig.InspectionOutputFile = config.InspectionOutputFile
 				conversion.Disks = []*Disk{
 					{Link: "/var/tmp/v2v/vm-sda"},
 				}
@@ -256,6 +265,7 @@ var _ = Describe("Conversion", func() {
 				mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddFlag("--no-fstrim").Return(mockCommandBuilder)
 				mockCommandBuilder.EXPECT().AddExtraArgs("--custom-flag").Return(mockCommandBuilder)
@@ -445,6 +455,7 @@ var _ = Describe("Conversion", func() {
 
 	Describe("RunVirtV2vInPlaceDisk error cases", func() {
 		It("returns error when command fails", func() {
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
 			conversion.Disks = []*Disk{
 				{Link: "/var/tmp/v2v/vm-sda"},
 			}
@@ -453,6 +464,7 @@ var _ = Describe("Conversion", func() {
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("--no-fstrim").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
@@ -471,6 +483,7 @@ var _ = Describe("Conversion", func() {
 		It("returns error when addCommonArgs fails", func() {
 			luksDir := "/etc/luks"
 			appConfig.Luksdir = luksDir
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
 			conversion.Disks = []*Disk{
 				{Link: "/var/tmp/v2v/vm-sda"},
 			}
@@ -479,6 +492,7 @@ var _ = Describe("Conversion", func() {
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 
 			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
@@ -523,11 +537,13 @@ var _ = Describe("Conversion", func() {
 		It("passes static IP arguments", func() {
 			appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
 			appConfig.StaticIPs = "00:11:22:33:44:55:ip:192.168.1.100"
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
 
 			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--mac", "00:11:22:33:44:55:ip:192.168.1.100").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("--no-fstrim").Return(mockCommandBuilder)
@@ -545,6 +561,7 @@ var _ = Describe("Conversion", func() {
 
 		It("returns error when addCommonArgs fails", func() {
 			appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
 			luksDir := "/etc/luks"
 			appConfig.Luksdir = luksDir
 
@@ -552,6 +569,7 @@ var _ = Describe("Conversion", func() {
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 
 			mockFileSystem.EXPECT().Stat(luksDir).Return(nil, nil)
@@ -1195,12 +1213,14 @@ var _ = Describe("Conversion", func() {
 		It("omits --no-fstrim for RunVirtV2vInPlace", func() {
 			appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
 			appConfig.XfsCompatibility = true
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
 
 			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
 			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
@@ -1213,12 +1233,14 @@ var _ = Describe("Conversion", func() {
 
 		It("omits --no-fstrim for RunVirtV2vInPlaceDisk", func() {
 			appConfig.XfsCompatibility = true
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
 			conversion.Disks = []*Disk{{Link: "/var/tmp/v2v/vm-sda"}}
 
 			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
@@ -1257,12 +1279,14 @@ var _ = Describe("Conversion", func() {
 		It("omits --no-fstrim for RunVirtV2vInPlace on upstream images", func() {
 			appConfig.LibvirtDomainFile = config.V2vInPlaceLibvirtDomain
 			appConfig.SupportsNoFstrim = false
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
 
 			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "libvirtxml").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddPositional(config.V2vInPlaceLibvirtDomain).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)
 			mockCommandExecutor.EXPECT().SetStdout(os.Stdout)
@@ -1275,12 +1299,14 @@ var _ = Describe("Conversion", func() {
 
 		It("omits --no-fstrim for RunVirtV2vInPlaceDisk on upstream images", func() {
 			appConfig.SupportsNoFstrim = false
+			appConfig.InspectionOutputFile = config.InspectionOutputFile
 			conversion.Disks = []*Disk{{Link: "/var/tmp/v2v/vm-sda"}}
 
 			mockCommandBuilder.EXPECT().New("virt-v2v-in-place").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "disk").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-O", config.InspectionOutputFile).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddPositional("/var/tmp/v2v/vm-sda").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().Build().Return(mockCommandExecutor)


### PR DESCRIPTION
Use virt-v2v-in-place's -O flag to produce inspection XML during in-place conversion, then parse the root device and mountpoints to determine the boot disk index.

When the /vm endpoint returns 204 (in-place, no KubeVirt YAML), fall back to inspection XML for boot disk detection. If detection fails, emit a BootDiskNotDetected warning and skip bootOrder assignment instead of defaulting to disk 0.

Translate libvirt-order boot disk indices to VMware disk order in mapDisks so bootOrder is applied on the correct volume for both warm and cold migrations on mixed-bus VMs.

Ref: https://redhat.atlassian.net/browse/MTV-4165
Resolves: MTV-4165