### PR TITLE
MTV-4369 | Check for Hosts redirection in storage offload warm migrations

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -500,25 +500,12 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 	if !r.shouldMigrateSharedDisks(vm) {
 		vm.RemoveSharedDisks()
 	}
+
 	url := r.Source.Provider.Spec.URL
 	thumbprint := r.Source.Provider.Status.Fingerprint
-	hostID, err := r.hostID(vmRef)
+	url, thumbprint, err = r.applyHostsConfig(vmRef, url, thumbprint)
 	if err != nil {
 		return
-	}
-	if hostDef, found := r.hosts[hostID]; found {
-		hostURL := liburl.URL{
-			Scheme: "https",
-			Host:   formatHostAddress(hostDef.Spec.IpAddress),
-			Path:   vim25.Path,
-		}
-		url = hostURL.String()
-		h, nErr := r.host(hostID)
-		if nErr != nil {
-			err = nErr
-			return
-		}
-		thumbprint = h.Thumbprint
 	}
 
 	// Build datastore map for more efficient lookups
@@ -659,6 +646,29 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 	}
 
 	return
+}
+
+func (r *Builder) applyHostsConfig(vmRef ref.Ref, url, thumbprint string) (string, string, error) {
+	hostID, err := r.hostID(vmRef)
+	if err != nil {
+		return "", "", liberr.Wrap(err)
+	}
+	if hostDef, found := r.hosts[hostID]; found {
+		hostURL := liburl.URL{
+			Scheme: "https",
+			Host:   formatHostAddress(hostDef.Spec.IpAddress),
+			Path:   vim25.Path,
+		}
+		url = hostURL.String()
+		h, nErr := r.host(hostID)
+		if nErr != nil {
+			err = nErr
+			return "", "", liberr.Wrap(err)
+		}
+		thumbprint = h.Thumbprint
+	}
+
+	return url, thumbprint, nil
 }
 
 // Create the destination Kubevirt VM.
@@ -1489,10 +1499,17 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				// For warm migration, add annotations to jump-start the DataVolume
 				v := r.getPlanVMStatus(vm)
 				if v != nil && v.Warm != nil {
-					pvc.Annotations[planbase.AnnEndpoint] = r.Source.Provider.Spec.URL
+					url := r.Source.Provider.Spec.URL
+					thumbprint := r.Source.Provider.Status.Fingerprint
+					url, thumbprint, err = r.applyHostsConfig(vmRef, url, thumbprint)
+					if err != nil {
+						return nil, err
+					}
+
+					pvc.Annotations[planbase.AnnEndpoint] = url
 					pvc.Annotations[planbase.AnnImportBackingFile] = baseVolume(disk.File, r.Plan.IsWarm())
 					pvc.Annotations[planbase.AnnUUID] = vm.UUID
-					pvc.Annotations[planbase.AnnThumbprint] = r.Source.Provider.Status.Fingerprint
+					pvc.Annotations[planbase.AnnThumbprint] = thumbprint
 					pvc.Annotations[planbase.AnnVddkInitImageURL] = settings.GetVDDKImage(r.Source.Provider.Spec.Settings)
 					pvc.Annotations[planbase.AnnPodPhase] = "Succeeded"
 					pvc.Annotations[planbase.AnnSource] = "vddk"

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -2091,6 +2091,15 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 		}
 	}
 
+	if r.Plan.IsWarm() {
+		hostsSecret := &core.Secret{}
+		if err := r.Secret(ref.Ref{ID: pvc.Labels["vmID"]}, dst, hostsSecret); err != nil {
+			return fmt.Errorf("failed to get hosts configuration for secret: %w", err)
+		}
+		dst.Data["accessKeyId"] = hostsSecret.Data["accessKeyId"]
+		dst.Data["secretKey"] = hostsSecret.Data["secretKey"]
+	}
+
 	// Always derive GOVMOMI_HOSTNAME from the provider spec, which is the
 	// authoritative source for the vCenter URL.
 	providerURL := r.Source.Provider.Spec.URL


### PR DESCRIPTION
Issue: with a Host entry configured, warm migrations with storage offload set the original URL on the populator PVC instead of the redirected one. This resulted in an ESX-formatted snapshot lookup on a vCenter endpoint, failing the import of the first delta copy.

Fix: check for Host configuration when adding warm migration annotations to the populator PVC, and also make sure to use the right set of credentials.

Resolves: MTV-4369

Reference: https://redhat.atlassian.net/browse/MTV-4369