### PR TITLE
chore(inventory): skip ghost VMs in vSphere inventory API

### DIFF
--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -80,6 +80,10 @@ func (h VMHandler) List(ctx *gin.Context) {
 				"isTemplate", m.IsTemplate)
 			continue
 		}
+		if m.UUID == "" && m.InstanceUUID == "" && m.Host == "" {
+			log.Info("Skipping ghost VM", "vmID", m.ID)
+			continue
+		}
 		r := &VM{}
 		r.With(&m)
 		r.Link(h.Provider)


### PR DESCRIPTION
During VM clone operations, vSphere can create transient placeholder VM objects that get picked up by the PropertyCollector with an enter event but never receive modify or leave events. These ghost VMs have no UUID, no InstanceUUID, and no host association, making them invalid migration candidates. They cause confusing duplicate entries in the inventory and misleading critical concerns about permissions.

Filter out these ghost VMs in the REST API List handler alongside the existing IsTemplate filter.