### PR TITLE
MTV-5740 | More thorough check for missing snapshot removal task.

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -328,7 +328,7 @@ func (r *Client) CheckSnapshotRemove(vmRef ref.Ref, precopy planapi.Precopy, hos
 		return r.checkTaskStatus(taskInfo)
 	}
 
-	notFound := errors.Is(err, ErrTaskNotFound)
+	notFound := errors.Is(err, ErrTaskNotFound) || errors.Is(err, ErrTaskNotFoundPropSet) || errors.Is(err, ErrTaskValueNotFound)
 	alreadyDeleted := fault.Is(err, &types.ManagedObjectNotFound{})
 	if !notFound && !alreadyDeleted {
 		return false, liberr.Wrap(err)


### PR DESCRIPTION
Issue: last-minute refactor of #7060 missed checking some error results from getTaskById.

Fix: check all new error types from getTaskById.

Reference: [MTV-5740](https://redhat.atlassian.net/browse/MTV-5740) re-opened

Resolves: MTV-5740

[MTV-5740]: https://redhat.atlassian.net/browse/MTV-5740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ