### PR TITLE
MTV-1878 | Proactive vSphere privilege check on provider validation

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -297,6 +297,9 @@ type Collector struct {
 	cancel func()
 	// has parity.
 	parity bool
+	// Cached missing privileges from the last check.
+	missingPrivs   *privilegeCheckResult
+	missingPrivsMu *sync.RWMutex
 }
 
 // New collector.
@@ -307,11 +310,12 @@ func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) *Collector
 			provider.GetNamespace(),
 			provider.GetName()))
 	return &Collector{
-		url:      provider.Spec.URL,
-		provider: provider,
-		secret:   secret,
-		db:       db,
-		log:      nlog,
+		url:            provider.Spec.URL,
+		provider:       provider,
+		secret:         secret,
+		db:             db,
+		log:            nlog,
+		missingPrivsMu: &sync.RWMutex{},
 	}
 }
 
@@ -343,6 +347,17 @@ func (r *Collector) Reset() {
 // Reset.
 func (r *Collector) HasParity() bool {
 	return r.parity
+}
+
+// MissingPrivileges returns the cached privilege check results.
+// The bool indicates whether the check has completed.
+func (r *Collector) MissingPrivileges() ([]MissingPrivileges, bool) {
+	r.missingPrivsMu.RLock()
+	defer r.missingPrivsMu.RUnlock()
+	if r.missingPrivs == nil {
+		return nil, false
+	}
+	return r.missingPrivs.missing, true
 }
 
 // Follow
@@ -431,6 +446,24 @@ func (r *Collector) getUpdates(ctx context.Context) error {
 		return err
 	}
 	defer r.close()
+	r.checkAndCachePermissions(ctx)
+
+	permCtx, cancelPerm := context.WithCancel(ctx)
+	defer cancelPerm()
+
+	go func() {
+		ticker := time.NewTicker(PrivilegeCheckInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-permCtx.Done():
+				return
+			case <-ticker.C:
+				r.checkAndCachePermissions(permCtx)
+			}
+		}
+	}()
+
 	about := r.client.ServiceContent.About
 	err = r.db.Insert(
 		&model.About{

--- a/pkg/controller/provider/container/vsphere/permissions.go
+++ b/pkg/controller/provider/container/vsphere/permissions.go
@@ -1,0 +1,208 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+const PrivilegeCheckInterval = 10 * time.Minute
+
+type privilegeGroup struct {
+	Description string
+	Privileges  []string
+}
+
+// MissingPrivileges groups missing privilege IDs by their functional description.
+type MissingPrivileges struct {
+	Group      string
+	Privileges []string
+}
+
+type privilegeCheckResult struct {
+	missing []MissingPrivileges
+}
+
+// requiredPrivileges defines the vSphere privileges MTV needs for migration,
+// grouped by functional area. Derived from the govmomi operations in
+// pkg/controller/plan/adapter/vsphere/client.go and
+// pkg/controller/conversion/client.go.
+var requiredPrivileges = []privilegeGroup{
+	{
+		Description: "Virtual Machine Snapshot Operations",
+		Privileges: []string{
+			"VirtualMachine.State.CreateSnapshot",
+			"VirtualMachine.State.RemoveSnapshot",
+		},
+	},
+	{
+		Description: "Virtual Machine Power Management",
+		Privileges: []string{
+			"VirtualMachine.Interact.PowerOn",
+			"VirtualMachine.Interact.PowerOff",
+		},
+	},
+	{
+		Description: "Virtual Machine Disk Access (VDDK)",
+		Privileges: []string{
+			"VirtualMachine.Provisioning.DiskRandomRead",
+			"VirtualMachine.Provisioning.GetVmFiles",
+			"VirtualMachine.Config.ChangeTracking",
+		},
+	},
+	{
+		Description: "Datastore Access",
+		Privileges: []string{
+			"Datastore.Browse",
+			"Datastore.FileManagement",
+		},
+	},
+}
+
+// pruneToAvailablePrivileges intersects required privilege groups against the
+// set of privileges the vCenter actually supports. This prevents false positives
+// on older vCenter versions that lack certain privilege IDs.
+func pruneToAvailablePrivileges(required []privilegeGroup, available map[string]bool) []privilegeGroup {
+	var pruned []privilegeGroup
+	for _, group := range required {
+		var kept []string
+		for _, priv := range group.Privileges {
+			if available[priv] {
+				kept = append(kept, priv)
+			}
+		}
+		if len(kept) > 0 {
+			pruned = append(pruned, privilegeGroup{
+				Description: group.Description,
+				Privileges:  kept,
+			})
+		}
+	}
+	return pruned
+}
+
+// flattenPrivileges extracts all privilege IDs from a slice of privilege groups
+// into a single flat list, preserving order.
+func flattenPrivileges(groups []privilegeGroup) []string {
+	var flat []string
+	for _, g := range groups {
+		flat = append(flat, g.Privileges...)
+	}
+	return flat
+}
+
+// comparePrivileges checks which required privileges are missing given the
+// granted booleans (aligned 1:1 with the flat privilege ID list).
+func comparePrivileges(groups []privilegeGroup, granted map[string]bool) []MissingPrivileges {
+	var result []MissingPrivileges
+	for _, group := range groups {
+		var missing []string
+		for _, priv := range group.Privileges {
+			if !granted[priv] {
+				missing = append(missing, priv)
+			}
+		}
+		if len(missing) > 0 {
+			result = append(result, MissingPrivileges{
+				Group:      group.Description,
+				Privileges: missing,
+			})
+		}
+	}
+	return result
+}
+
+// FormatMissing produces a human-readable summary of missing privileges
+// suitable for a condition Suggestion field.
+func FormatMissing(missing []MissingPrivileges) string {
+	var sb strings.Builder
+	sb.WriteString("MISSING VSPHERE PRIVILEGES:\n\n")
+	for _, m := range missing {
+		fmt.Fprintf(&sb, "%s:\n", m.Group)
+		for _, p := range m.Privileges {
+			fmt.Fprintf(&sb, "  - %s\n", p)
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("RESOLUTION:\n")
+	sb.WriteString("Assign a vSphere role with these privileges to the service account\n")
+	sb.WriteString("on the vCenter root folder with propagation enabled.\n")
+	sb.WriteString("See: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#vmware-prerequisites_mtv\n")
+	return sb.String()
+}
+
+// checkPermissionsWithClient checks whether the service account has the
+// privileges required for migration using the provided govmomi client.
+// Returns nil, nil if all privileges are granted.
+func checkPermissionsWithClient(ctx context.Context, client *govmomi.Client) ([]MissingPrivileges, error) {
+	authManager := object.NewAuthorizationManager(client.Client)
+
+	var moAuthMgr mo.AuthorizationManager
+	err := authManager.Properties(ctx, authManager.Reference(), []string{"privilegeList"}, &moAuthMgr)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+
+	available := make(map[string]bool, len(moAuthMgr.PrivilegeList))
+	for _, priv := range moAuthMgr.PrivilegeList {
+		available[priv.PrivId] = true
+	}
+
+	pruned := pruneToAvailablePrivileges(requiredPrivileges, available)
+	if len(pruned) == 0 {
+		return nil, nil
+	}
+
+	flatPrivIDs := flattenPrivileges(pruned)
+
+	sessionMgr := session.NewManager(client.Client)
+	userSession, err := sessionMgr.UserSession(ctx)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+
+	rootFolder := client.ServiceContent.RootFolder
+	results, err := authManager.HasPrivilegeOnEntity(ctx, rootFolder, userSession.Key, flatPrivIDs)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+
+	granted := make(map[string]bool, len(flatPrivIDs))
+	for i, privID := range flatPrivIDs {
+		if i < len(results) {
+			granted[privID] = results[i]
+		}
+	}
+
+	return comparePrivileges(pruned, granted), nil
+}
+
+// checkAndCachePermissions runs the privilege check using the collector's
+// already-open client and caches the result. Called from getUpdates() after
+// the client connects, before parity is achieved.
+func (r *Collector) checkAndCachePermissions(ctx context.Context) {
+	if r.provider.Spec.Settings[api.SDK] == api.ESXI {
+		r.missingPrivsMu.Lock()
+		r.missingPrivs = &privilegeCheckResult{}
+		r.missingPrivsMu.Unlock()
+		return
+	}
+
+	missing, err := checkPermissionsWithClient(ctx, r.client)
+	if err != nil {
+		r.log.Error(err, "Privilege check failed.")
+		return
+	}
+
+	r.missingPrivsMu.Lock()
+	r.missingPrivs = &privilegeCheckResult{missing: missing}
+	r.missingPrivsMu.Unlock()
+}

--- a/pkg/controller/provider/container/vsphere/permissions_test.go
+++ b/pkg/controller/provider/container/vsphere/permissions_test.go
@@ -1,0 +1,204 @@
+package vsphere
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("vSphere permissions", func() {
+	Describe("pruneToAvailablePrivileges", func() {
+		input := []privilegeGroup{
+			{
+				Description: "Group A",
+				Privileges:  []string{"Priv.A1", "Priv.A2"},
+			},
+			{
+				Description: "Group B",
+				Privileges:  []string{"Priv.B1", "Priv.B2", "Priv.B3"},
+			},
+		}
+
+		It("should keep all privileges when all are available", func() {
+			available := map[string]bool{
+				"Priv.A1": true, "Priv.A2": true,
+				"Priv.B1": true, "Priv.B2": true, "Priv.B3": true,
+			}
+			result := pruneToAvailablePrivileges(input, available)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Privileges).To(Equal([]string{"Priv.A1", "Priv.A2"}))
+			Expect(result[1].Privileges).To(Equal([]string{"Priv.B1", "Priv.B2", "Priv.B3"}))
+		})
+
+		It("should remove unavailable privileges from a group", func() {
+			available := map[string]bool{
+				"Priv.A1": true, "Priv.A2": true,
+				"Priv.B1": true,
+			}
+			result := pruneToAvailablePrivileges(input, available)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Privileges).To(Equal([]string{"Priv.A1", "Priv.A2"}))
+			Expect(result[1].Privileges).To(Equal([]string{"Priv.B1"}))
+		})
+
+		It("should drop a group entirely when none of its privileges are available", func() {
+			available := map[string]bool{
+				"Priv.A1": true, "Priv.A2": true,
+			}
+			result := pruneToAvailablePrivileges(input, available)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Description).To(Equal("Group A"))
+		})
+
+		It("should return nil for empty input", func() {
+			result := pruneToAvailablePrivileges(nil, map[string]bool{"Priv.X": true})
+			Expect(result).To(BeNil())
+		})
+
+		It("should return nil when no privileges are available", func() {
+			result := pruneToAvailablePrivileges(input, map[string]bool{})
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("comparePrivileges", func() {
+		groups := []privilegeGroup{
+			{
+				Description: "Snapshots",
+				Privileges:  []string{"VM.Snap.Create", "VM.Snap.Remove"},
+			},
+			{
+				Description: "Power",
+				Privileges:  []string{"VM.PowerOn", "VM.PowerOff"},
+			},
+		}
+
+		It("should return nil when all privileges are granted", func() {
+			granted := map[string]bool{
+				"VM.Snap.Create": true, "VM.Snap.Remove": true,
+				"VM.PowerOn": true, "VM.PowerOff": true,
+			}
+			result := comparePrivileges(groups, granted)
+			Expect(result).To(BeNil())
+		})
+
+		It("should report missing privileges from one group", func() {
+			granted := map[string]bool{
+				"VM.Snap.Create": true, "VM.Snap.Remove": true,
+				"VM.PowerOn": true, "VM.PowerOff": false,
+			}
+			result := comparePrivileges(groups, granted)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Group).To(Equal("Power"))
+			Expect(result[0].Privileges).To(Equal([]string{"VM.PowerOff"}))
+		})
+
+		It("should report missing privileges across multiple groups", func() {
+			granted := map[string]bool{
+				"VM.Snap.Create": true, "VM.Snap.Remove": false,
+				"VM.PowerOn": false, "VM.PowerOff": true,
+			}
+			result := comparePrivileges(groups, granted)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Group).To(Equal("Snapshots"))
+			Expect(result[0].Privileges).To(Equal([]string{"VM.Snap.Remove"}))
+			Expect(result[1].Group).To(Equal("Power"))
+			Expect(result[1].Privileges).To(Equal([]string{"VM.PowerOn"}))
+		})
+
+		It("should report all privileges when none are granted", func() {
+			granted := map[string]bool{}
+			result := comparePrivileges(groups, granted)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Privileges).To(Equal([]string{"VM.Snap.Create", "VM.Snap.Remove"}))
+			Expect(result[1].Privileges).To(Equal([]string{"VM.PowerOn", "VM.PowerOff"}))
+		})
+	})
+
+	Describe("flattenPrivileges", func() {
+		It("should flatten all privilege IDs preserving order", func() {
+			groups := []privilegeGroup{
+				{Description: "A", Privileges: []string{"A.1", "A.2"}},
+				{Description: "B", Privileges: []string{"B.1"}},
+			}
+			result := flattenPrivileges(groups)
+			Expect(result).To(Equal([]string{"A.1", "A.2", "B.1"}))
+		})
+
+		It("should return nil for empty input", func() {
+			result := flattenPrivileges(nil)
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("requiredPrivileges", func() {
+		It("should have no duplicate privilege IDs", func() {
+			seen := make(map[string]bool)
+			for _, group := range requiredPrivileges {
+				for _, priv := range group.Privileges {
+					Expect(seen[priv]).To(BeFalse(), "duplicate privilege: %s", priv)
+					seen[priv] = true
+				}
+			}
+		})
+
+		It("should have non-empty descriptions and privileges", func() {
+			for _, group := range requiredPrivileges {
+				Expect(group.Description).ToNot(BeEmpty())
+				Expect(group.Privileges).ToNot(BeEmpty())
+			}
+		})
+	})
+
+	Describe("FormatMissing", func() {
+		It("should produce readable output", func() {
+			missing := []MissingPrivileges{
+				{Group: "Snapshots", Privileges: []string{"VM.Snap.Create"}},
+				{Group: "Power", Privileges: []string{"VM.PowerOn", "VM.PowerOff"}},
+			}
+			result := FormatMissing(missing)
+			Expect(result).To(ContainSubstring("MISSING VSPHERE PRIVILEGES"))
+			Expect(result).To(ContainSubstring("Snapshots:"))
+			Expect(result).To(ContainSubstring("  - VM.Snap.Create"))
+			Expect(result).To(ContainSubstring("Power:"))
+			Expect(result).To(ContainSubstring("  - VM.PowerOn"))
+			Expect(result).To(ContainSubstring("RESOLUTION"))
+		})
+	})
+
+	Describe("MissingPrivileges accessor", func() {
+		It("should return not-checked before any check runs", func() {
+			c := &Collector{missingPrivsMu: &sync.RWMutex{}}
+			missing, checked := c.MissingPrivileges()
+			Expect(checked).To(BeFalse())
+			Expect(missing).To(BeNil())
+		})
+
+		It("should return cached results after setting them", func() {
+			c := &Collector{missingPrivsMu: &sync.RWMutex{}}
+			expected := []MissingPrivileges{
+				{Group: "Snapshots", Privileges: []string{"VM.Snap.Create"}},
+			}
+			c.missingPrivsMu.Lock()
+			c.missingPrivs = &privilegeCheckResult{missing: expected}
+			c.missingPrivsMu.Unlock()
+
+			missing, checked := c.MissingPrivileges()
+			Expect(checked).To(BeTrue())
+			Expect(missing).To(HaveLen(1))
+			Expect(missing[0].Group).To(Equal("Snapshots"))
+		})
+
+		It("should return checked with nil missing when all privileges are granted", func() {
+			c := &Collector{missingPrivsMu: &sync.RWMutex{}}
+			c.missingPrivsMu.Lock()
+			c.missingPrivs = &privilegeCheckResult{}
+			c.missingPrivsMu.Unlock()
+
+			missing, checked := c.MissingPrivileges()
+			Expect(checked).To(BeTrue())
+			Expect(missing).To(BeNil())
+		})
+	})
+})

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -16,6 +16,7 @@ import (
 	hvutil "github.com/kubev2v/forklift/pkg/controller/hyperv"
 	"github.com/kubev2v/forklift/pkg/controller/ova"
 	"github.com/kubev2v/forklift/pkg/controller/provider/container"
+	vsphereCollector "github.com/kubev2v/forklift/pkg/controller/provider/container/vsphere"
 	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
@@ -47,6 +48,7 @@ const (
 	ConnectionInsecure      = "ConnectionInsecure"
 	SSHReady                = "SSHReady"
 	SSHNotReady             = "SSHNotReady"
+	InsufficientPrivileges  = "InsufficientPrivileges"
 	SMBCSIDriverNotReady    = "SMBCSIDriverNotReady"
 	SMBMountFailed          = "SMBMountFailed"
 	WaitingForService       = "WaitingForService"
@@ -118,6 +120,10 @@ func (r *Reconciler) validate(provider *api.Provider) error {
 		return liberr.Wrap(err)
 	}
 	err = r.testConnection(provider, secret)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	err = r.validateVSpherePrivileges(provider)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -496,6 +502,64 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 					err.Error()),
 			})
 	}
+
+	return nil
+}
+
+// Validate vSphere service account privileges.
+func (r *Reconciler) validateVSpherePrivileges(provider *api.Provider) error {
+	if provider.Type() != api.VSphere {
+		return nil
+	}
+	if provider.Status.HasBlockerCondition() {
+		return nil
+	}
+
+	log.Info(
+		"Validating vSphere privileges.",
+		"name", provider.Name,
+		"namespace", provider.Namespace,
+	)
+
+	collector, found := r.container.Get(provider)
+	if !found {
+		return nil
+	}
+	vsphColl, ok := collector.(*vsphereCollector.Collector)
+	if !ok {
+		return nil
+	}
+
+	missing, checked := vsphColl.MissingPrivileges()
+	if !checked {
+		return nil
+	}
+
+	if len(missing) == 0 {
+		provider.Status.DeleteCondition(InsufficientPrivileges)
+		return nil
+	}
+
+	totalMissing := 0
+	var items []string
+	for _, m := range missing {
+		totalMissing += len(m.Privileges)
+		items = append(items, m.Privileges...)
+	}
+
+	provider.Status.SetCondition(
+		libcnd.Condition{
+			Type:     InsufficientPrivileges,
+			Status:   True,
+			Reason:   "PrivilegesNotGranted",
+			Category: Warn,
+			Message: fmt.Sprintf(
+				"The vSphere service account is missing %d privilege(s) required for migration. "+
+					"See the suggestion field in the Provider's YAML for details.",
+				totalMissing),
+			Suggestion: vsphereCollector.FormatMissing(missing),
+			Items:      items,
+		})
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds a proactive vSphere privilege check during provider validation. When a VMware provider is created, the system checks whether the service account has the required vSphere privileges for migration and reports any missing privileges as a **non-blocking warning** condition (`InsufficientPrivileges`).

## Approach

- Uses `AuthorizationManager.HasPrivilegeOnEntity()` with the session key to check privileges on the vCenter root folder
- Required privileges are derived from the actual govmomi operations MTV performs (snapshot, power, disk access, datastore)
- Privileges are pruned against the vCenter's reported `privilegeList` to avoid false positives on older vCenter versions
- ESXi direct connections skip the check (different privilege model)
- **Reuses the inventory collector's already-open govmomi client** rather than opening a disposable connection — the privilege check runs in `getUpdates()` right after the client connects and caches results thread-safely for the reconciler to read via `MissingPrivileges()`, following the `hasParity` pattern

## Files Changed

| File | Change |
|------|--------|
| `pkg/controller/provider/container/vsphere/permissions.go` | Privilege definitions, pruning, comparison helpers, `checkPermissionsWithClient()`, and `checkAndCachePermissions()` |
| `pkg/controller/provider/container/vsphere/permissions_test.go` | Ginkgo tests for pure functions + `MissingPrivileges()` accessor |
| `pkg/controller/provider/container/vsphere/collector.go` | Added cached privilege state fields, `MissingPrivileges()` accessor, call to `checkAndCachePermissions()` in `getUpdates()` |
| `pkg/controller/provider/validation.go` | `validateVSpherePrivileges()` reads cached state from the collector via type assertion |

## Test Plan

- [x] Unit tests for `pruneToAvailablePrivileges`, `comparePrivileges`, `flattenPrivileges`, `FormatMissing`
- [x] Unit tests for `requiredPrivileges` integrity (no duplicates, non-empty)
- [x] Unit tests for `MissingPrivileges()` accessor (not-checked, cached results, all-granted)
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] Full test suite passes (51 packages)
- [ ] Manual integration test: create a vSphere provider with limited permissions and verify warning appears

## CodeRabbit review suggestions not implemented

1. **Unit tests for `CheckPermissions` method** — requires mocking the govmomi client (`AuthorizationManager`, `SessionManager`, property collector). Low value given the pure-function tests already cover the logic.
2. **Unit tests for `validateVSpherePrivileges` branches** — requires mocking the `Reconciler` and `container`. The function is now a thin read from cached state.

Resolves: https://github.com/kubev2v/forklift/issues/7131

🤖 Generated with [Claude Code](https://claude.com/claude-code)