### PR TITLE
MTV-5782 | Add QEMU Guest Agent install script to Windows firstboot

### DIFF
--- a/pkg/virt-v2v/customize/customize.go
+++ b/pkg/virt-v2v/customize/customize.go
@@ -35,6 +35,8 @@ var vsphereVmwareDriverRemovalScriptNames = []string{
 	"9105_remove_vmware_registry.bat",
 }
 
+const qemuGAInstallScript = "5001_win_firstboot_qemu_ga_install.ps1"
+
 //go:embed scripts
 var scriptFS embed.FS
 
@@ -353,6 +355,10 @@ func (c *Customize) addWinFirstbootScripts(cmdBuilder utils.CommandBuilder) erro
 			uploadPreserveMultipleIpPath = c.formatUpload(preserveMultipleNicsPath, WinFirstbootScriptsPath)
 		}
 	}
+	// TODO: Remove once https://redhat.atlassian.net/browse/RHEL-184971 is resolved.
+	qemuGAPath := filepath.Join(windowsScriptsPath, qemuGAInstallScript)
+	cmdBuilder.AddArg(UploadCmd, c.formatUpload(qemuGAPath, filepath.Join(WinFirstbootScriptsPath, qemuGAInstallScript)))
+
 	uploadInitPath := c.formatUpload(initPath, WinFirstbootScriptsPath)
 	cmdBuilder.AddArgs(UploadCmd, uploadPreserveIpPath, uploadInitPath, uploadRemoveDuplicatesPath, uploadPreserveMultipleIpPath)
 	if c.appConfig.WaitForGuestReboot {

--- a/pkg/virt-v2v/customize/customize_test.go
+++ b/pkg/virt-v2v/customize/customize_test.go
@@ -591,7 +591,8 @@ var _ = Describe("Customize", func() {
 			// DynamicScriptsDir does not exist
 			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
 
-			// addWinFirstbootScripts
+			// addWinFirstbootScripts - QEMU GA upload + batch upload
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
 
 			for _, disk := range disks {
@@ -617,6 +618,7 @@ var _ = Describe("Customize", func() {
 			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
 
 			mockFileSystem.EXPECT().Stat(appConfig.DynamicScriptsDir).Return(nil, os.ErrNotExist)
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
 
 			for _, disk := range disks {
@@ -650,8 +652,8 @@ var _ = Describe("Customize", func() {
 			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
 
-			// Dynamic script upload
-			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder)
+			// Dynamic script upload + QEMU GA upload
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder).Times(2)
 
 			// addWinFirstbootScripts
 			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
@@ -695,7 +697,8 @@ var _ = Describe("Customize", func() {
 			mockCommandBuilder.EXPECT().AddFlag("--verbose").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("--format", "raw").Return(mockCommandBuilder)
 
-			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder).Times(5)
+			// VMware driver removal uploads (5) + QEMU GA upload (1)
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder).Times(6)
 
 			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockCommandBuilder)
 
@@ -943,6 +946,7 @@ var _ = Describe("Customize", func() {
 	Describe("addWinFirstbootScripts path selection", func() {
 		It("no static IPs - only init script uploaded", func() {
 			appConfig.StaticIPs = ""
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArgs("--upload", "", gomock.Any(), "", "").Return(mockCommandBuilder)
 			err := customize.addWinFirstbootScripts(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
@@ -952,6 +956,7 @@ var _ = Describe("Customize", func() {
 			appConfig.StaticIPs = "00:11:22:33:44:55:ip:10.0.0.1,10.0.0.254,24,8.8.8.8,"
 			appConfig.VirtIoWinLegacyDrivers = ""
 			appConfig.WindowsRegistryNetworkConfig = false
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArgs("--upload", "", gomock.Any(), gomock.Any(), "").Return(mockCommandBuilder)
 			err := customize.addWinFirstbootScripts(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
@@ -961,6 +966,7 @@ var _ = Describe("Customize", func() {
 			appConfig.VirtIoWinLegacyDrivers = "/mnt/virtio.iso"
 			appConfig.StaticIPs = ""
 			var capturedInit string
+			mockCommandBuilder.EXPECT().AddArg("--upload", gomock.Any()).Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArgs("--upload", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(flag string, values ...string) {
 					capturedInit = values[1]

--- a/pkg/virt-v2v/customize/scripts/windows/5001_win_firstboot_qemu_ga_install.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/5001_win_firstboot_qemu_ga_install.ps1
@@ -1,0 +1,24 @@
+# Uncomment this line for lots of debug output.
+# Set-PSDebug -Trace 2
+Write-Host Installing QEMU Guest Agent
+$msi = "C:\Program Files\Guestfs\Firstboot\Temp\qemu-ga-x86_64.msi"
+$logfile = "$msi.log"
+$maxAttempts = 10
+$retryDelay = 60
+for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+    Write-Host "Attempt $attempt of $maxAttempts"
+    Write-Host "Writing log to $logfile"
+    $proc = Start-Process -Wait -PassThru -FilePath "$msi" -ArgumentList "/norestart","/qn","/l+*vx","`"$logfile`""
+    $exitCode = $proc.ExitCode
+    Write-Host "Exit code: $exitCode"
+    if ($exitCode -eq 0) {
+        Write-Host "QEMU Guest Agent installed successfully"
+        break
+    }
+    if ($attempt -lt $maxAttempts) {
+        Write-Host "Install failed, retrying in $retryDelay seconds..."
+        Start-Sleep -Seconds $retryDelay
+    } else {
+        Write-Host "Install failed after $maxAttempts attempts"
+    }
+}


### PR DESCRIPTION
Add a PowerShell firstboot script that installs the QEMU Guest Agent MSI with retry logic (up to 10 attempts, 60s delay). The script is uploaded unconditionally during Windows customization so the guest agent is available after migration.

Ref: https://redhat.atlassian.net/browse/MTV-5782
Resolves: MTV-5782