### PR TITLE
MTV-5784 | Fix nil pointer panic in SupportsVolumePopulators for conversion plans

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1293,6 +1293,9 @@ func (r *Builder) SupportsVolumePopulators() bool {
 	if !settings.Settings.Features.CopyOffload {
 		return false
 	}
+	if r.Context.Map.Storage == nil {
+		return false
+	}
 	dsMapIn := r.Context.Map.Storage.Spec.Map
 	for _, m := range dsMapIn {
 		ref := m.Source


### PR DESCRIPTION
Conversion plans (spec.type: conversion) don't require a storage map, so Context.Map.Storage is legitimately nil. SupportsVolumePopulators dereferences it unconditionally, causing a panic when a conversion plan is canceled during cleanup.

Add a nil guard for Map.Storage before accessing its spec.

Resolves: MTV-5784