### PR TITLE
MTV-4706 | Optimize shared disk detection in inventory API

### DIFF
--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -388,6 +388,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 		_ = tx.End()
 	}()
 	validatedIDs := map[string]bool{}
+	diskFiles := map[string]bool{}
 	for _, task := range batch {
 		if task.Error != nil {
 			r.log.Error(
@@ -420,6 +421,9 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 			continue
 		}
 		validatedIDs[latest.ID] = true
+		for _, disk := range latest.Disks {
+			diskFiles[disk.File] = true
+		}
 		if task.Error == nil {
 			r.log.V(3).Info(
 				"VM validated.",
@@ -431,7 +435,7 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 				task.Duration())
 		}
 	}
-	r.triggerSharedDiskRevalidation(tx, validatedIDs)
+	r.triggerSharedDiskRevalidation(tx, validatedIDs, diskFiles)
 	err = tx.Commit()
 	if err != nil {
 		r.log.Error(err, "Tx commit failed.")
@@ -442,23 +446,14 @@ func (r *VMEventHandler) validated(batch []*policy.Task) {
 // triggerSharedDiskRevalidation triggers revalidation of VMs that share
 // disks with the just-validated VMs, so they also pick up or drop the
 // shared disk concern.
-func (r *VMEventHandler) triggerSharedDiskRevalidation(tx *libmodel.Tx, validatedIDs map[string]bool) {
+func (r *VMEventHandler) triggerSharedDiskRevalidation(tx *libmodel.Tx, validatedIDs, diskFiles map[string]bool) {
+	if len(diskFiles) == 0 {
+		return
+	}
 	var allVMs []model.VM
 	err := tx.List(&allVMs, model.ListOptions{Detail: model.MaxDetail})
 	if err != nil {
 		r.log.Error(err, "List VMs for shared disk revalidation failed.")
-		return
-	}
-	diskFiles := map[string]bool{}
-	for i := range allVMs {
-		if !validatedIDs[allVMs[i].ID] {
-			continue
-		}
-		for _, disk := range allVMs[i].Disks {
-			diskFiles[disk.File] = true
-		}
-	}
-	if len(diskFiles) == 0 {
 		return
 	}
 	for i := range allVMs {

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -66,6 +66,7 @@ func (h VMHandler) List(ctx *gin.Context) {
 	if err != nil {
 		return
 	}
+	markSharedDisks(list, buildDiskFileCount(list))
 	content := []interface{}{}
 	err = h.filter(ctx, &list)
 	if err != nil {
@@ -121,6 +122,20 @@ func (h VMHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
+	var allVMs []model.VM
+	err = db.List(&allVMs, model.ListOptions{Detail: model.MaxDetail})
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	fileCount := buildDiskFileCount(allVMs)
+	vms := []model.VM{*m}
+	markSharedDisks(vms, fileCount)
+	*m = vms[0]
 	pb := PathBuilder{DB: db}
 	r := &VM{}
 	r.With(m)
@@ -420,4 +435,29 @@ func (r *VM) RemoveDisk(removeDisk model.Disk) {
 		}
 	}
 	r.Disks = disks
+}
+
+// buildDiskFileCount builds a map from disk file path to the number of
+// VMs that reference that file. Used to detect disks shared by multiple
+// VMs even when vSphere does not report multi-writer sharing.
+func buildDiskFileCount(vms []model.VM) map[string]int {
+	m := map[string]int{}
+	for i := range vms {
+		for _, disk := range vms[i].Disks {
+			m[disk.File]++
+		}
+	}
+	return m
+}
+
+// markSharedDisks sets Shared=true on disks whose backing file is used
+// by more than one VM according to the provided file count map.
+func markSharedDisks(vms []model.VM, fileCount map[string]int) {
+	for i := range vms {
+		for j := range vms[i].Disks {
+			if fileCount[vms[i].Disks[j].File] > 1 {
+				vms[i].Disks[j].Shared = true
+			}
+		}
+	}
 }


### PR DESCRIPTION
Mark non-multiwriter shared disks in the vSphere inventory API by counting disk file references across VMs. The List handler reuses the already-loaded VM slice instead of querying the DB twice, and the Get handler loads all VMs once to build the file count map.

In the validation watcher, collect disk files during the batch loop to avoid a redundant full-table scan in triggerSharedDiskRevalidation, and skip the expensive DB list entirely when no disk files are present.

Ref: https://redhat.atlassian.net/browse/MTV-4706
Resolves: MTV-4706