### PR TITLE
MTV-5802 | Fix VVol/RDM populator silent success after panic

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/populator/rdm_populator.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/rdm_populator.go
@@ -34,6 +34,8 @@ func (p *RDMPopulator) Populate(vmId string, sourceVMDKFile string, pv Persisten
 		r := recover()
 		if r != nil {
 			log.Info("recovered from panic", "panic", r)
+			quit <- fmt.Errorf("recovered failure: %v", r)
+			return
 		}
 		log.Info("RDM copy exiting", "err", errFinal)
 		quit <- errFinal

--- a/cmd/vsphere-copy-offload-populator/internal/populator/vvol_populator.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/vvol_populator.go
@@ -31,6 +31,8 @@ func (p *VvolPopulator) Populate(vmId string, sourceVMDKFile string, pv Persiste
 		r := recover()
 		if r != nil {
 			log.Info("recovered from panic", "panic", r)
+			quit <- fmt.Errorf("recovered failure: %v", r)
+			return
 		}
 		log.Info("VVol copy exiting", "err", errFinal)
 		quit <- errFinal


### PR DESCRIPTION
## Summary

When `RDMCopy()` or `VvolCopy()` panics (e.g., nil pointer from an expired storage API session),
the `defer/recover` block in `RDMPopulator.Populate()` and `VvolPopulator.Populate()` catches
the panic but sends `nil` to the quit channel. The controller interprets this as a successful
copy and advances to conversion on empty disks.

The VMDK/Xcopy populator (`RemoteEsxcliPopulator`) already handles this correctly — this change
applies the same two-line pattern to the VVol and RDM populators.

## Reproduction

Reproduced on `ocp-edge114-0` with HPE Primera/3PAR RDM migration:

1. Injected a nil pointer dereference in `RDMCopy` (simulating expired API session)
2. Factory detected RDM disk → selected `RDMPopulator`
3. Populator pod logs:
   ```
   RDM Populator: recovered from panic: runtime error: invalid memory address or nil pointer dereference
   RDM Populator: exiting with final error: <nil>   ← BUG: should be non-nil
   ```
4. Pod exited 0 → DiskAllocation marked Completed → ConvertGuest failed on empty disk

## Fix

Two lines per file — send the recovered error to quit and return early, matching `RemoteEsxcliPopulator`:

```go
quit <- fmt.Errorf("recovered failure: %v", r)
return
```

## Test plan

- [ ] Unit tests verify panic recovery sends non-nil error to quit channel
- [ ] Existing `RemoteEsxcliPopulator` tests continue to pass (no changes to that path)

Resolves: MTV-5802

🤖 Generated with [Claude Code](https://claude.com/claude-code)