### PR TITLE
chore(automation): Bundle SHA reference update for 2-12

### DIFF
--- a/build/forklift-operator-bundle/Containerfile-downstream
+++ b/build/forklift-operator-bundle/Containerfile-downstream
@@ -41,7 +41,7 @@ ARG UI_PLUGIN_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-con
 
 ARG VALIDATION_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-validation-rhel9@sha256:dff419b560dd8f0d0a3dbc49f7dd7514d506c6d60a0581d85813db3e0f6fa03b"
 
-ARG VIRT_V2V_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel10@sha256:22439f3b9f760c15251667e97a81e325025188cf009fa5b19d7686aea18104c1"
+ARG VIRT_V2V_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel10@sha256:ee8f1ccd0e2c6f4384dfa460b4fe01323a377a5aa2917fe26ccc15f5d08ff55e"
 
 ARG VIRT_V2V_IMAGE_RHEL9="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel9@sha256:5883f365d86c33a63e986824ceac4a364bd98bd3e09c01eb44d20815b7f9797c"
 


### PR DESCRIPTION
This PR updates the SHA references in Containerfile-downstream files based on the latest snapshot for version 2-12.

## Changes
- Updated SHA references in all Containerfile-downstream files
- Generated from latest snapshot: forklift-operator-2-12-20260618-115507-000

## Automated Update
This PR was created automatically by the mtv-releng update script.