### PR TITLE
MTV-5781 | Fix cmd.exe parse error in 9100_cleanup_vmware.bat

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.bat
+++ b/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.bat
@@ -510,7 +510,7 @@ if "!VAL_NAME!"=="" (
     ) else (
         reg delete "!REG_PATH!" /f >nul 2>&1
         if !errorlevel! equ 0 (
-            echo [DEL KEY] !REG_PATH! (fallback)
+            echo [DEL KEY] !REG_PATH! ^(fallback^)
             set "RESULT=DELETED"
         ) else (
             set "RESULT=ERROR"
@@ -522,7 +522,8 @@ for %%R in ("!RESULT!") do (
     endlocal
     if "%%~R"=="DELETED" (
         set /a REG_DELETED+=1
-    ) else if "%%~R"=="ERROR" (
+    )
+    if "%%~R"=="ERROR" (
         set /a REG_ERRORS+=1
     )
 )


### PR DESCRIPTION
cmd.exe produces "else was unexpected at this time" at Phase 4 (VMware Registry Entries) of the 9100_cleanup_vmware.bat firstboot script.

Root cause: two cmd.exe parser issues in the :DeleteRegistryEntry subroutine:

1. Unescaped literal parentheses in `echo [DEL KEY] !REG_PATH! (fallback)` inside a nested `if` block. cmd.exe treats `(` as a block delimiter, miscounting parentheses and leaving a stray `else`.

2. `else if` construct inside a `for %%R ... do (...)` block combined with `endlocal`. This is a known cmd.exe parser limitation where `else if` is not reliably parsed inside `for` blocks.

These constructs were introduced when the five predecessor cleanup scripts (9101–9105) were combined into a single 9100_cleanup_vmware.bat firstboot script in this same MTV-5781 work. The predecessor scripts used simple, linear control flow that did not trigger these cmd.exe parser limitations.

Fix:
- Escape the parentheses: `^(fallback^)`
- Replace `else if` with two separate `if` statements

Resolves: MTV-5781