### PR TITLE
MTV-5867 | fix OpenStack client to use GetCACert() for ca.crt support

### DIFF
--- a/pkg/lib/client/openstack/client.go
+++ b/pkg/lib/client/openstack/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/lib/util"
 	core "k8s.io/api/core/v1"
 )
 
@@ -72,6 +73,7 @@ type Client struct {
 	URL                 string
 	Options             map[string]string
 	Log                 logging.LevelLogger
+	secret              *core.Secret
 	provider            *gophercloud.ProviderClient
 	identityService     *gophercloud.ServiceClient
 	computeService      *gophercloud.ServiceClient
@@ -81,6 +83,7 @@ type Client struct {
 }
 
 func (c *Client) LoadOptionsFromSecret(secret *core.Secret) {
+	c.secret = secret
 	c.Options = make(map[string]string)
 	for key, value := range secret.Data {
 		c.Options[key] = string(value)
@@ -179,8 +182,12 @@ func (c *Client) getTLSConfig() (tlsConfig *tls.Config, err error) {
 		if c.getBoolFromOptions(InsecureSkipVerify) {
 			tlsConfig = &tls.Config{InsecureSkipVerify: true}
 		} else {
-			cacert := []byte(c.getStringFromOptions(CACert))
-			if len(cacert) == 0 {
+			var cacert []byte
+			var hasCACert bool
+			if c.secret != nil {
+				cacert, hasCACert = util.GetCACert(c.secret)
+			}
+			if !hasCACert {
 				c.Log.Info("CA certificate was not provided,system CA cert pool is used")
 			} else {
 				roots := x509.NewCertPool()


### PR DESCRIPTION
The OpenStack client was reading CA certificates directly from the
'cacert' secret field, bypassing the GetCACert() helper introduced
in PR #5549 (MTV-4561). This caused the standard Kubernetes ca.crt
field to be ignored, falling back to the system CA pool.

The RHV and OpenShift clients were updated in PR #5549 to use
util.GetCACert(), but the OpenStack client was missed.

Ref: https://redhat.atlassian.net/browse/MTV-5867
Resolves: MTV-5867