### PR TITLE
chore(powermax): Fix test assertions after retryOnTransient changes

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/powermax/powermax_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/powermax/powermax_test.go
@@ -316,7 +316,7 @@ func TestRetryOnTransient(t *testing.T) {
 		})
 		g.Expect(err).To(gomega.HaveOccurred())
 		g.Expect(err.Error()).To(gomega.ContainSubstring("Service Unavailable"))
-		g.Expect(callCount).To(gomega.Equal(5)) // 5 steps in backoff
+		g.Expect(callCount).To(gomega.Equal(7)) // 7 steps in backoff
 	})
 }
 
@@ -648,7 +648,7 @@ func TestMap(t *testing.T) {
 			initiatorID:    "mv-xcopy",
 		}
 
-		mvErr := &v100.Error{HTTPStatusCode: 500, Message: "internal server error"}
+		mvErr := &v100.Error{HTTPStatusCode: 400, Message: "bad request"}
 		gomock.InOrder(
 			mockClient.EXPECT().GetVolumeIDListInStorageGroup(context.TODO(), "sym123", "sg-xcopy").Return([]string{}, nil),
 			mockClient.EXPECT().AddVolumesToStorageGroupS(context.TODO(), "sym123", "sg-xcopy", false, "vol-001").Return(nil),


### PR DESCRIPTION
## Summary
- Update `TestRetryOnTransient/should_preserve_last_error_when_retries_exhausted` to expect 7 retries instead of 5, matching the `Steps: 7` change in #7178
- Change `TestMap/returns_error_when_GetMaskingViewByID_returns_non-404_error` to use HTTP 400 instead of 500, since 500 is now retryable after #7178

## Test plan
- [x] `go test ./internal/powermax/ -run "TestRetryOnTransient|TestMap" -v -count=1` — all subtests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)