### PR TITLE
MTV-5879 | don't cleanup populated pvcs on only migration

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -417,7 +417,7 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, force
 
 	// If the migration fails and the DeleteVmOnFailMigration is enabled, clean up the VM.
 	// When DeleteVmOnFailMigration is disabled, VM resources are preserved on failure.
-	if !vm.HasCondition(api.ConditionSucceeded) && (r.Plan.Spec.DeleteVmOnFailMigration || vm.DeleteVmOnFailMigration) {
+	if !vm.HasCondition(api.ConditionSucceeded) && (r.Plan.Spec.DeleteVmOnFailMigration || vm.DeleteVmOnFailMigration) && r.Plan.Spec.Type != api.MigrationOnlyConversion {
 		r.Log.Info("Deleting VM (failed migration with deleteVmOnFailMigration enabled).", "vm", vm.String())
 		if err := r.kubevirt.DeleteVM(vm); failOnErr(err) {
 			return err


### PR DESCRIPTION
Issue:
when VM fails in middle of warm migration on guest conversion we can retry the conversion by specifying the migration `type: conversion`. However we do cleanup before the next migration run so we remove the old VM PVCs. 

Fix:
ignore cleanup when type is conversion