### PR TITLE
MTV-5883 | Schedule shared-disk creator VMs before consumers

### DIFF
--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -182,8 +182,19 @@ func (r *Scheduler) buildInFlight() (err error) {
 }
 
 // Build the map of pending VMs belonging to each host.
+//
+// Shared-disk VMs are ordered to ensure shareable PVCs are created before
+// they are consumed:
+//   - VMs that create shareable PVCs (migrateSharedDisks=true) run first.
+//   - VMs that reuse PVCs (migrateSharedDisks=false) run after all creators finish.
+//   - VMs without shared disks run any time.
 func (r *Scheduler) buildPending() (err error) {
 	r.pending = make(map[string][]*pendingVM)
+
+	hasActiveCreators, err := r.hasActiveSharedDiskCreators()
+	if err != nil {
+		return
+	}
 
 	for _, vmStatus := range r.Plan.Status.Migration.VMs {
 		if vmStatus.HasCondition(Canceled) {
@@ -194,16 +205,46 @@ func (r *Scheduler) buildPending() (err error) {
 		if err != nil {
 			return
 		}
-
-		if !vmStatus.MarkedStarted() && !vmStatus.MarkedCompleted() {
-			pending := &pendingVM{
-				status: vmStatus,
-				cost:   r.cost(vm, vmStatus),
-			}
-			r.pending[vm.Host] = append(r.pending[vm.Host], pending)
+		if vmStatus.MarkedStarted() || vmStatus.MarkedCompleted() {
+			continue
 		}
+		if hasActiveCreators && vm.HasSharedDisk() && !r.migratesSharedDisks(vmStatus) {
+			continue
+		}
+		r.pending[vm.Host] = append(r.pending[vm.Host], &pendingVM{
+			status: vmStatus,
+			cost:   r.cost(vm, vmStatus),
+		})
 	}
 	return
+}
+
+// hasActiveSharedDiskCreators reports whether any VM that creates
+// shareable PVCs (shared disk + migrateSharedDisks=true) has not
+// yet completed.
+func (r *Scheduler) hasActiveSharedDiskCreators() (bool, error) {
+	for _, vmStatus := range r.Plan.Status.Migration.VMs {
+		if vmStatus.HasCondition(Canceled) || vmStatus.MarkedCompleted() {
+			continue
+		}
+		vm := &model.VM{}
+		if err := r.Source.Inventory.Find(vm, vmStatus.Ref); err != nil {
+			return false, err
+		}
+		if vm.HasSharedDisk() && r.migratesSharedDisks(vmStatus) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// migratesSharedDisks resolves the effective migrateSharedDisks setting,
+// checking the per-VM override first, then the plan-level default.
+func (r *Scheduler) migratesSharedDisks(vmStatus *plan.VMStatus) bool {
+	if specVM, found := r.Plan.Spec.FindVM(vmStatus.Ref); found && specVM.MigrateSharedDisks != nil {
+		return *specVM.MigrateSharedDisks
+	}
+	return r.Plan.Spec.MigrateSharedDisks
 }
 
 func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {

--- a/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"testing"
 
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/onsi/gomega"
 )
 
@@ -101,4 +102,112 @@ func TestScheduler(t *testing.T) {
 		},
 	}
 	g.Expect(scheduler.schedulable()).To(gomega.Equal(expectedSchedule))
+}
+
+func newVMStatus(id string) *plan.VMStatus {
+	s := &plan.VMStatus{}
+	s.ID = id
+	return s
+}
+
+// buildPendingFiltered mirrors the logic from Scheduler.buildPending()
+// without requiring a real inventory or plan context.
+func buildPendingFiltered(all []testVM) map[string][]*pendingVM {
+	hasActiveCreators := false
+	for _, v := range all {
+		if v.hasShared && v.migratesShared && !v.status.MarkedCompleted() {
+			hasActiveCreators = true
+			break
+		}
+	}
+
+	pending := make(map[string][]*pendingVM)
+	for _, v := range all {
+		if v.status.MarkedStarted() || v.status.MarkedCompleted() {
+			continue
+		}
+		if hasActiveCreators && v.hasShared && !v.migratesShared {
+			continue
+		}
+		pending[v.host] = append(pending[v.host], &pendingVM{status: v.status, cost: 1})
+	}
+	return pending
+}
+
+type testVM struct {
+	status         *plan.VMStatus
+	host           string
+	hasShared      bool
+	migratesShared bool
+}
+
+func TestSharedDiskPriority(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("creator blocks consumer but not non-shared", func(_ *testing.T) {
+		pending := buildPendingFiltered([]testVM{
+			{status: newVMStatus("consumer"), host: "h1", hasShared: true, migratesShared: false},
+			{status: newVMStatus("creator"), host: "h1", hasShared: true, migratesShared: true},
+			{status: newVMStatus("normal"), host: "h1", hasShared: false},
+		})
+		g.Expect(pending["h1"]).To(gomega.HaveLen(2))
+		g.Expect(pending["h1"][0].status.ID).To(gomega.Equal("creator"))
+		g.Expect(pending["h1"][1].status.ID).To(gomega.Equal("normal"))
+	})
+
+	t.Run("completed creator unblocks consumer", func(_ *testing.T) {
+		done := newVMStatus("creator-done")
+		done.MarkStarted()
+		done.MarkCompleted()
+
+		pending := buildPendingFiltered([]testVM{
+			{status: done, host: "h1", hasShared: true, migratesShared: true},
+			{status: newVMStatus("consumer"), host: "h1", hasShared: true, migratesShared: false},
+			{status: newVMStatus("normal"), host: "h1", hasShared: false},
+		})
+		g.Expect(pending["h1"]).To(gomega.HaveLen(2))
+		g.Expect(pending["h1"][0].status.ID).To(gomega.Equal("consumer"))
+		g.Expect(pending["h1"][1].status.ID).To(gomega.Equal("normal"))
+	})
+
+	t.Run("no shared-disk VMs allows all", func(_ *testing.T) {
+		pending := buildPendingFiltered([]testVM{
+			{status: newVMStatus("a"), host: "h1", hasShared: false},
+			{status: newVMStatus("b"), host: "h1", hasShared: false},
+		})
+		g.Expect(pending["h1"]).To(gomega.HaveLen(2))
+	})
+
+	t.Run("running creator still blocks consumer", func(_ *testing.T) {
+		running := newVMStatus("creator-running")
+		running.MarkStarted()
+
+		pending := buildPendingFiltered([]testVM{
+			{status: running, host: "h1", hasShared: true, migratesShared: true},
+			{status: newVMStatus("consumer"), host: "h1", hasShared: true, migratesShared: false},
+		})
+		g.Expect(pending["h1"]).To(gomega.BeEmpty())
+	})
+
+	t.Run("cross-host creators both scheduled alongside non-shared", func(_ *testing.T) {
+		pending := buildPendingFiltered([]testVM{
+			{status: newVMStatus("creator-h1"), host: "h1", hasShared: true, migratesShared: true},
+			{status: newVMStatus("creator-h2"), host: "h2", hasShared: true, migratesShared: true},
+			{status: newVMStatus("normal"), host: "h1", hasShared: false},
+		})
+		g.Expect(pending["h1"]).To(gomega.HaveLen(2))
+		g.Expect(pending["h1"][0].status.ID).To(gomega.Equal("creator-h1"))
+		g.Expect(pending["h1"][1].status.ID).To(gomega.Equal("normal"))
+		g.Expect(pending["h2"]).To(gomega.HaveLen(1))
+		g.Expect(pending["h2"][0].status.ID).To(gomega.Equal("creator-h2"))
+	})
+
+	t.Run("user scenario: consumer listed first but creator runs first", func(_ *testing.T) {
+		pending := buildPendingFiltered([]testVM{
+			{status: newVMStatus("vm-3025"), host: "h1", hasShared: true, migratesShared: false},
+			{status: newVMStatus("vm-2998"), host: "h1", hasShared: true, migratesShared: true},
+		})
+		g.Expect(pending["h1"]).To(gomega.HaveLen(1))
+		g.Expect(pending["h1"][0].status.ID).To(gomega.Equal("vm-2998"))
+	})
 }


### PR DESCRIPTION
Hold back consumer VMs (shared disk + migrateSharedDisks=false) from
the pending queue while any creator VM (shared disk +
migrateSharedDisks=true) has not yet completed. Non-shared VMs are
unaffected.

Ref: https://redhat.atlassian.net/browse/MTV-5883
Resolves: MTV-5883
Signed-off-by: Martin Necas <mnecas@redhat.com>
