### PR TITLE
MTV-5753 | Collect PCI slot numbers from vSphere and compute PCI addresses

### DIFF
--- a/docs/enhancements/pci-address-preservation.md
+++ b/docs/enhancements/pci-address-preservation.md
@@ -1,0 +1,177 @@
+---
+title: pci-address-preservation
+authors:
+  - "@yaacov"
+reviewers:
+  - TBD
+approvers:
+  - TBD
+creation-date: 2026-06-14
+last-updated: 2026-06-23
+status: implementable
+see-also:
+  - "https://redhat.atlassian.net/browse/MTV-5753"
+---
+
+# PCI Address Preservation
+
+## Release Signoff Checklist
+
+- [x] Enhancement is `implementable`
+- [x] Design details are appropriately documented from clear requirements
+- [x] Test plan is defined
+- [ ] User-facing documentation is created
+
+## Summary
+
+MTV collects PCI slot information from source vSphere VMs and converts it to
+standard PCI addresses at inventory time. This enables downstream consumers
+(plan builder, CLI, UI) to preserve PCI topology when migrating VMs to KubeVirt.
+
+## Motivation
+
+KubeVirt supports setting PCI addresses on NIC interfaces. By collecting and
+converting PCI slot numbers from the source VM, MTV can preserve the original
+PCI topology across migration.
+
+### Goals
+
+* Collect PCI slot numbers from vSphere VM device configuration.
+* Collect PCI bridge topology from `config.extraConfig`.
+* Convert slot numbers to standard PCI addresses at inventory time using
+  the bridge-aware algorithm.
+* Store the PCI address on the `NIC` struct for downstream use.
+* Store the raw PCI slot number and device key on the `Device` struct to
+  mirror vSphere's data model.
+
+### Non-Goals
+
+* Builder/migration integration (setting `pciAddress` on target KubeVirt VMI
+  interfaces) is a follow-up enhancement.
+* Support for providers other than vSphere.
+
+## Design
+
+### Data Model
+
+**`Device` struct** — one entry per virtual hardware device (NIC, disk controller,
+etc.):
+
+| Field           | Type    | Description                               |
+|:----------------|:--------|:------------------------------------------|
+| `Key`           | `int`   | vSphere device key (e.g. 4000)            |
+| `Kind`          | `string`| Device type (e.g. `VirtualVmxnet3`)       |
+| `PciSlotNumber` | `int32` | Raw vSphere PCI slot number               |
+
+**`NIC` struct** — one entry per network adapter:
+
+| Field       | Type     | Description                                     |
+|:------------|:---------|:------------------------------------------------|
+| `DeviceKey` | `int`    | Links to the corresponding `Device.Key`         |
+| `MAC`       | `string` | MAC address                                     |
+| `PciAddress`| `string` | Computed PCI address (`DDDD:BB:DD.F`)           |
+| `Network`   | `Ref`    | Reference to the network                        |
+| `Order`     | `int`    | NIC order on the VM                             |
+
+**`PciBridge` struct** — one entry per PCI bridge parsed from `config.extraConfig`:
+
+| Field        | Type    | Description                                    |
+|:-------------|:--------|:-----------------------------------------------|
+| `Number`     | `int`   | Bridge index (e.g. 0, 4, 5, 6, 7)             |
+| `SlotNumber` | `int32` | Bridge's own PCI slot on bus 0                 |
+| `Functions`  | `int`   | Number of root-port functions (buses provided) |
+
+### vSphere PCI Slot Number Encoding
+
+vSphere assigns each virtual device a **PCI slot number** — a persistent integer
+stored at `config.hardware.device[].SlotInfo.PciSlotNumber`. The slot number is
+a packed bitmap with the layout `FFF.BBBBB.DDDDD` (Broadcom KB 311606):
+
+```
+DDDDD = slot & 0x1F          (bits 0–4)   device on the secondary bus
+BBBBB = (slot >> 5) & 0x1F   (bits 5–9)   bridge index: 0 = primary, N = pciBridge[N-1]
+FFF   = (slot >> 10) & 0x7   (bits 10–12) root-port function within the bridge device
+```
+
+All PCIe devices (VMXNET3, PVSCSI, e1000e) have `BBBBB != 0` — they sit behind
+PCIe root ports. Legacy PCI devices (e1000, lsilogic) have `BBBBB == 1`
+(behind pciBridge0, the legacy PCI-to-PCI bridge).
+
+### Bridge Topology
+
+The PCI bridge configuration is stored in the VM's `config.extraConfig`:
+
+```
+pciBridge0.pciSlotNumber = "17"     (legacy PCI bridge, 1 bus)
+pciBridge4.pciSlotNumber = "21"     (PCIe root port)
+pciBridge4.functions = "8"          (8 root-port functions = 8 buses)
+pciBridge5.pciSlotNumber = "22"
+pciBridge5.functions = "8"
+pciBridge6.pciSlotNumber = "23"
+pciBridge6.functions = "8"
+pciBridge7.pciSlotNumber = "24"
+pciBridge7.functions = "8"
+```
+
+Bridges without an explicit `functions` entry default to 1 function (1 bus).
+
+### Conversion Algorithm
+
+1. Parse all `pciBridgeN.pciSlotNumber` and `pciBridgeN.functions` entries from
+   `config.extraConfig`.
+2. Sort bridges by their device number on bus 0 (`bridgeSlot & 0x1F`).
+3. Assign bus numbers sequentially starting from `pciBusBaseOffset = 2`
+   (bus 0 = root complex, bus 1 = AGP bridge in the I440BX chipset):
+   - pciBridge0 (legacy PCI, 1 function): bus 2
+   - pciBridge4 (PCIe, 8 functions): buses 3–10
+   - pciBridge5 (PCIe, 8 functions): buses 11–18
+   - pciBridge6 (PCIe, 8 functions): buses 19–26
+   - pciBridge7 (PCIe, 8 functions): buses 27–34
+4. For a device with slot S:
+   - If `BBBBB == 0`: device is on bus 0 → `0000:00:DDDDD.0`
+   - Otherwise: find pciBridge[BBBBB-1], compute `bus = bridge.baseBus + FFF`,
+     `dev = DDDDD` → `0000:bus:dev.0`
+
+If the bridge topology is not available in `config.extraConfig`, `pciAddress`
+is left empty.
+
+**Chipset assumption:** `pciBusBaseOffset = 2` assumes the I440BX virtual chipset
+where bus 1 is the AGP bridge at `00:01.0`. All VMware hardware versions
+(vmx-04 through vmx-21, ESXi 2.x–8.x) use I440BX for both BIOS and EFI firmware.
+
+### Worked Examples
+
+Verified against `lspci` output inside the guest OS:
+
+| vSphere Slot | FFF | BBBBB | DDDDD | Bridge     | Guest Bus | PCI Address  |
+|:------------:|:---:|:-----:|:-----:|:----------:|:---------:|:------------:|
+| 33           | 0   | 1     | 1     | pciBridge0 | 2         | 0000:02:01.0 |
+| 160          | 0   | 5     | 0     | pciBridge4 | 3         | 0000:03:00.0 |
+| 192          | 0   | 6     | 0     | pciBridge5 | 11        | 0000:0b:00.0 |
+| 224          | 0   | 7     | 0     | pciBridge6 | 19        | 0000:13:00.0 |
+| 256          | 0   | 8     | 0     | pciBridge7 | 27        | 0000:1b:00.0 |
+| 1184         | 1   | 5     | 0     | pciBridge4 | 4         | 0000:04:00.0 |
+
+### Collection Flow
+
+1. The vSphere inventory collector fetches `config.hardware.device` and
+   `config.extraConfig` via the govmomi property collector.
+2. `config.extraConfig` entries matching `pciBridgeN.*` are parsed into
+   `PciBridge` structs and stored on the `VM` model.
+3. Each device's `PciSlotNumber` and `Key` are stored in the `Device` list.
+4. For each NIC, the collector matches the NIC's backing device key to a
+   `Device`, calls `computePciAddress(slot, bridges)` to derive the PCI
+   address, and stores it on the `NIC` struct.
+
+## Alternatives
+
+**Alternative 1: Store only the raw slot number, convert at use-time.**
+
+This avoids storing a derived value but pushes conversion logic into every
+consumer (builder, CLI, UI). Storing the pre-converted address is simpler for
+downstream consumers.
+
+**Alternative 2: Store only the PCI address, not the raw slot.**
+
+This loses the original vSphere value, making it harder to debug mismatches or
+handle future edge cases. Storing both preserves full fidelity.

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -25,6 +25,59 @@ const (
 // CtkEnabledKey is the VMware ExtraConfig key for Changed Block Tracking (canonical form).
 const CtkEnabledKey = "ctkEnabled"
 
+// VMware persistent PCI slot number encoding (Broadcom KB 311606).
+// The slot is a packed integer with bitmap FFF.BBBBB.DDDDD:
+//
+//	DDDDD  (bits 0-4)   device number on the secondary bus
+//	BBBBB  (bits 5-9)   bridge index: 0 = primary bus, N = pciBridge[N-1]
+//	FFF    (bits 10-12)  root-port function number within the bridge device
+const (
+	pciSlotMaskDevice  = 0x1F
+	pciSlotShiftBridge = 5
+	pciSlotMaskBridge  = 0x1F
+	pciSlotShiftFunc   = 10
+	pciSlotMaskFunc    = 0x7
+
+	// pciBusBaseOffset is the first bus number available for pciBridge devices
+	// in the VMware I440BX virtual chipset. Bus 0 is the root complex and bus 1
+	// is always the AGP bridge at 00:01.0. All VMware hardware versions (vmx-04
+	// through vmx-21, ESXi 2.x–8.x) use I440BX for both BIOS and EFI firmware.
+	pciBusBaseOffset = 2
+
+	// pciLegacyBridgeFunctions is the number of secondary buses consumed by a
+	// legacy PCI-to-PCI bridge (pciBridge0). Unlike PCIe root ports that reserve
+	// one bus per function, the legacy bridge provides a single shared secondary bus.
+	pciLegacyBridgeFunctions = 1
+)
+
+// computePciAddress converts a VMware persistent PCI slot number to the
+// guest-visible PCI address using the VM's pciBridge topology. Returns an
+// empty string when the bridge topology is unavailable or the slot is zero.
+func computePciAddress(slot int32, bridges []model.PciBridge) string {
+	if slot <= 0 {
+		return ""
+	}
+	dev := slot & pciSlotMaskDevice
+	bridgeIdx := (slot >> pciSlotShiftBridge) & pciSlotMaskBridge
+	bridgeFunc := (slot >> pciSlotShiftFunc) & pciSlotMaskFunc
+	// Primary bus devices don't need bridge topology.
+	if bridgeIdx == 0 {
+		return fmt.Sprintf("0000:00:%02x.0", dev)
+	}
+	if len(bridges) == 0 {
+		return ""
+	}
+	bridgeNum := int(bridgeIdx) - 1
+	bus := int32(pciBusBaseOffset)
+	for _, b := range bridges {
+		if b.Number == bridgeNum {
+			return fmt.Sprintf("0000:%02x:%02x.0", bus+bridgeFunc, dev)
+		}
+		bus += int32(b.Functions)
+	}
+	return ""
+}
+
 // Model adapter.
 // Each adapter provides provider-specific management of a model.
 type Adapter interface {
@@ -836,8 +889,15 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				v.model.Networks = v.RefList(p.Val)
 			case fExtraConfig:
 				if options, cast := p.Val.(types.ArrayOfOptionValue); cast {
+					pciBridgeSlots := map[int]int32{}
+					pciBridgeFuncs := map[int]int{}
 					for _, val := range options.OptionValue {
 						opt := val.GetOptionValue()
+
+						if strings.HasPrefix(opt.Key, "pciBridge") {
+							parsePciBridgeOption(opt.Key, opt.Value, pciBridgeSlots, pciBridgeFuncs)
+							continue
+						}
 
 						if opt.Key == "numa.nodeAffinity" {
 							if s, cast := opt.Value.(string); cast {
@@ -877,6 +937,9 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 							}
 						}
 					}
+
+					v.model.PciBridges = buildPciBridges(pciBridgeSlots, pciBridgeFuncs)
+					refreshNICPciAddresses(&v.model)
 
 					//In case of ExtraConfig update, on initial state model.Disks is not ready yet
 					if len(v.model.Disks) > 0 {
@@ -978,70 +1041,8 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				}
 			case fDevices:
 				if devArray, cast := p.Val.(types.ArrayOfVirtualDevice); cast {
-					devList := []model.Device{}
-					nicList := []model.NIC{}
-					nicsIndex := 0
-					for _, dev := range devArray.VirtualDevice {
-						var nic *types.VirtualEthernetCard
-						switch device := dev.(type) {
-						case *types.VirtualSriovEthernetCard,
-							*types.VirtualPCIPassthrough,
-							*types.VirtualSCSIPassthrough,
-							*types.VirtualUSBController:
-							devList = append(
-								devList,
-								model.Device{
-									Kind: libref.ToKind(dev),
-								})
-						case *types.VirtualE1000:
-							nic = &device.VirtualEthernetCard
-						case *types.VirtualE1000e:
-							nic = &device.VirtualEthernetCard
-						case *types.VirtualVmxnet:
-							nic = &device.VirtualEthernetCard
-						case *types.VirtualVmxnet2:
-							nic = &device.VirtualEthernetCard
-						case *types.VirtualVmxnet3:
-							nic = &device.VirtualEthernetCard
-						case *types.VirtualPCNet32:
-							nic = &device.VirtualEthernetCard
-						}
-
-						if nic != nil && nic.Backing != nil {
-							var network string
-							switch backing := dev.GetVirtualDevice().Backing.(type) {
-							case *types.VirtualEthernetCardNetworkBackingInfo:
-								if backing.Network != nil {
-									network = backing.Network.Value
-								}
-							case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
-								network = backing.Port.PortgroupKey
-							case *types.VirtualEthernetCardOpaqueNetworkBackingInfo:
-								network = backing.OpaqueNetworkId
-							}
-
-							devList = append(
-								devList,
-								model.Device{
-									Kind: libref.ToKind(dev),
-								})
-
-							nicList = append(
-								nicList,
-								model.NIC{
-									MAC:       strings.ToLower(nic.MacAddress),
-									Index:     nicsIndex,
-									DeviceKey: nic.Key,
-									Network: model.Ref{
-										Kind: model.NetKind,
-										ID:   network,
-									},
-								})
-							nicsIndex++
-						}
-					}
-					v.model.Devices = devList
-					v.model.NICs = nicList
+					v.model.Devices = v.collectDevices(devArray)
+					v.model.NICs = v.collectNICs(devArray)
 					v.updateControllers(&devArray)
 					v.updateDisks(&devArray)
 
@@ -1156,6 +1157,167 @@ func parseGuestApps(s string) []model.GuestApp {
 		})
 	}
 	return apps
+}
+
+// parsePciBridgeOption extracts pciBridge slot numbers and function counts
+// from config.extraConfig entries like "pciBridge4.pciSlotNumber" and
+// "pciBridge4.functions".
+func parsePciBridgeOption(key string, value interface{}, slots map[int]int32, funcs map[int]int) {
+	rest := strings.TrimPrefix(key, "pciBridge")
+	dot := strings.IndexByte(rest, '.')
+	if dot < 1 {
+		return
+	}
+	bridgeNum, err := strconv.Atoi(rest[:dot])
+	if err != nil {
+		return
+	}
+	prop := rest[dot+1:]
+	s, ok := value.(string)
+	if !ok {
+		return
+	}
+	switch prop {
+	case "pciSlotNumber":
+		if n, err := strconv.ParseInt(s, 10, 32); err == nil {
+			slots[bridgeNum] = int32(n)
+		}
+	case "functions":
+		if n, err := strconv.Atoi(s); err == nil {
+			funcs[bridgeNum] = n
+		}
+	}
+}
+
+// buildPciBridges assembles PciBridge structs from the parsed extraConfig maps.
+func buildPciBridges(slots map[int]int32, funcs map[int]int) []model.PciBridge {
+	if len(slots) == 0 {
+		return nil
+	}
+	bridges := make([]model.PciBridge, 0, len(slots))
+	for num, slot := range slots {
+		f := funcs[num]
+		if f == 0 {
+			f = pciLegacyBridgeFunctions
+		}
+		bridges = append(bridges, model.PciBridge{
+			Number:     num,
+			SlotNumber: slot,
+			Functions:  f,
+		})
+	}
+	sort.Slice(bridges, func(i, j int) bool {
+		devI := bridges[i].SlotNumber & pciSlotMaskDevice
+		devJ := bridges[j].SlotNumber & pciSlotMaskDevice
+		return devI < devJ
+	})
+	return bridges
+}
+
+// refreshNICPciAddresses recomputes PciAddress on every NIC using the current
+// Devices and PciBridges. Call after PciBridges changes to keep NICs in sync.
+func refreshNICPciAddresses(m *model.VM) {
+	slotByKey := make(map[int32]int32, len(m.Devices))
+	for _, d := range m.Devices {
+		slotByKey[d.Key] = d.PciSlotNumber
+	}
+	for i := range m.NICs {
+		m.NICs[i].PciAddress = computePciAddress(slotByKey[m.NICs[i].DeviceKey], m.PciBridges)
+	}
+}
+
+// pciSlotNumber extracts the PCI slot number from a virtual device's SlotInfo.
+// Returns 0 if the device has no PCI slot assigned.
+func pciSlotNumber(vd *types.VirtualDevice) int32 {
+	if vd.SlotInfo == nil {
+		return 0
+	}
+	if pciInfo, ok := vd.SlotInfo.(*types.VirtualDevicePciBusSlotInfo); ok {
+		return pciInfo.PciSlotNumber
+	}
+	return 0
+}
+
+// isPassthroughOrController reports whether the device is a passthrough or
+// controller type that is always tracked in the device inventory.
+func isPassthroughOrController(dev types.BaseVirtualDevice) bool {
+	switch dev.(type) {
+	case *types.VirtualSriovEthernetCard,
+		*types.VirtualPCIPassthrough,
+		*types.VirtualSCSIPassthrough,
+		*types.VirtualUSBController:
+		return true
+	}
+	return false
+}
+
+// isConnectedNIC reports whether the device is a regular virtual ethernet card
+// with a backing (i.e. connected to a network). SR-IOV NICs are excluded
+// because they are passthrough devices that require matching physical hardware.
+func isConnectedNIC(dev types.BaseVirtualDevice) bool {
+	if _, sriov := dev.(*types.VirtualSriovEthernetCard); sriov {
+		return false
+	}
+	ethCard, ok := dev.(types.BaseVirtualEthernetCard)
+	return ok && ethCard.GetVirtualEthernetCard().Backing != nil
+}
+
+// collectDevices builds the list of tracked virtual devices (passthrough,
+// controllers, and NICs with backing) from the VirtualDevice array.
+func (v *VmAdapter) collectDevices(devArray types.ArrayOfVirtualDevice) []model.Device {
+	var devList []model.Device
+	for _, dev := range devArray.VirtualDevice {
+		// Skip device types we don't track (e.g. disks, SCSI controllers).
+		if !isPassthroughOrController(dev) && !isConnectedNIC(dev) {
+			continue
+		}
+
+		vd := dev.GetVirtualDevice()
+		devList = append(devList, model.Device{
+			Kind:          libref.ToKind(dev),
+			Key:           vd.Key,
+			PciSlotNumber: pciSlotNumber(vd),
+		})
+	}
+	return devList
+}
+
+// collectNICs builds the list of NICs with their network and PCI address info
+// from the VirtualDevice array.
+func (v *VmAdapter) collectNICs(devArray types.ArrayOfVirtualDevice) []model.NIC {
+	var nicList []model.NIC
+	for _, dev := range devArray.VirtualDevice {
+		if !isConnectedNIC(dev) {
+			continue
+		}
+
+		vd := dev.GetVirtualDevice()
+		nic := dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+
+		var network string
+		switch backing := vd.Backing.(type) {
+		case *types.VirtualEthernetCardNetworkBackingInfo:
+			if backing.Network != nil {
+				network = backing.Network.Value
+			}
+		case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
+			network = backing.Port.PortgroupKey
+		case *types.VirtualEthernetCardOpaqueNetworkBackingInfo:
+			network = backing.OpaqueNetworkId
+		}
+
+		nicList = append(nicList, model.NIC{
+			MAC:        strings.ToLower(nic.MacAddress),
+			Index:      len(nicList),
+			DeviceKey:  nic.Key,
+			PciAddress: computePciAddress(pciSlotNumber(vd), v.model.PciBridges),
+			Network: model.Ref{
+				Kind: model.NetKind,
+				ID:   network,
+			},
+		})
+	}
+	return nicList
 }
 
 // Update virtual disk devices.

--- a/pkg/controller/provider/container/vsphere/model_test.go
+++ b/pkg/controller/provider/container/vsphere/model_test.go
@@ -8,6 +8,385 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+// --- helpers for building packed PCI slot numbers ---
+func makeSlot(dev, bridge, fn int32) int32 {
+	return (dev & pciSlotMaskDevice) |
+		((bridge & pciSlotMaskBridge) << pciSlotShiftBridge) |
+		((fn & pciSlotMaskFunc) << pciSlotShiftFunc)
+}
+
+// --- helpers for building govmomi virtual devices ---
+func makeVmxnet3(key int32, slot int32, backing types.BaseVirtualDeviceBackingInfo, mac string) *types.VirtualVmxnet3 {
+	return &types.VirtualVmxnet3{
+		VirtualVmxnet: types.VirtualVmxnet{
+			VirtualEthernetCard: types.VirtualEthernetCard{
+				VirtualDevice: types.VirtualDevice{
+					Key:      key,
+					SlotInfo: &types.VirtualDevicePciBusSlotInfo{PciSlotNumber: slot},
+					Backing:  backing,
+				},
+				MacAddress: mac,
+			},
+		},
+	}
+}
+
+func makeE1000(key int32, backing types.BaseVirtualDeviceBackingInfo) *types.VirtualE1000 {
+	return &types.VirtualE1000{
+		VirtualEthernetCard: types.VirtualEthernetCard{
+			VirtualDevice: types.VirtualDevice{Key: key, Backing: backing},
+		},
+	}
+}
+
+func makeSriov(key int32, backing types.BaseVirtualDeviceBackingInfo) *types.VirtualSriovEthernetCard {
+	return &types.VirtualSriovEthernetCard{
+		VirtualEthernetCard: types.VirtualEthernetCard{
+			VirtualDevice: types.VirtualDevice{Key: key, Backing: backing},
+		},
+	}
+}
+
+func makePCIPassthrough(key int32) *types.VirtualPCIPassthrough {
+	return &types.VirtualPCIPassthrough{
+		VirtualDevice: types.VirtualDevice{Key: key},
+	}
+}
+
+func makeUSBController(key int32) *types.VirtualUSBController {
+	return &types.VirtualUSBController{
+		VirtualController: types.VirtualController{
+			VirtualDevice: types.VirtualDevice{Key: key},
+		},
+	}
+}
+
+func makeDisk(key int32) *types.VirtualDisk {
+	return &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{Key: key},
+	}
+}
+
+func netBacking(networkID string) *types.VirtualEthernetCardNetworkBackingInfo {
+	return &types.VirtualEthernetCardNetworkBackingInfo{
+		Network: &types.ManagedObjectReference{Value: networkID},
+	}
+}
+
+// --- computePciAddress tests ---
+
+func TestComputePciAddress(t *testing.T) {
+	bridges := []model.PciBridge{
+		{Number: 0, SlotNumber: 17, Functions: 1},
+		{Number: 4, SlotNumber: 21, Functions: 8},
+		{Number: 5, SlotNumber: 22, Functions: 8},
+	}
+
+	tests := []struct {
+		name     string
+		slot     int32
+		bridges  []model.PciBridge
+		expected string
+	}{
+		{
+			name:     "zero slot returns empty",
+			slot:     0,
+			bridges:  bridges,
+			expected: "",
+		},
+		{
+			name:     "negative slot returns empty",
+			slot:     -1,
+			bridges:  bridges,
+			expected: "",
+		},
+		{
+			name:     "primary bus device (bridgeIdx=0)",
+			slot:     makeSlot(0x11, 0, 0),
+			bridges:  bridges,
+			expected: "0000:00:11.0",
+		},
+		{
+			name:     "primary bus device with empty bridges",
+			slot:     makeSlot(0x11, 0, 0),
+			bridges:  nil,
+			expected: "0000:00:11.0",
+		},
+		{
+			name:     "device on pciBridge0 (bridgeIdx=1, bridgeNum=0)",
+			slot:     makeSlot(0x00, 1, 0),
+			bridges:  bridges,
+			expected: "0000:02:00.0",
+		},
+		{
+			name:     "device on pciBridge4 func 0 (bridgeIdx=5, bridgeNum=4)",
+			slot:     makeSlot(0x00, 5, 0),
+			bridges:  bridges,
+			expected: "0000:03:00.0",
+		},
+		{
+			name:     "device on pciBridge4 func 2",
+			slot:     makeSlot(0x00, 5, 2),
+			bridges:  bridges,
+			expected: "0000:05:00.0",
+		},
+		{
+			name:     "device on pciBridge5 func 0",
+			slot:     makeSlot(0x00, 6, 0),
+			bridges:  bridges,
+			expected: "0000:0b:00.0",
+		},
+		{
+			name:     "non-primary bus with empty bridges returns empty",
+			slot:     makeSlot(0x00, 5, 0),
+			bridges:  nil,
+			expected: "",
+		},
+		{
+			name:     "bridge not found returns empty",
+			slot:     makeSlot(0x00, 10, 0),
+			bridges:  bridges,
+			expected: "",
+		},
+		{
+			name:     "real slot 192 matches test VM NIC",
+			slot:     192,
+			bridges:  bridges,
+			expected: "0000:0b:00.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computePciAddress(tt.slot, tt.bridges)
+			if got != tt.expected {
+				t.Errorf("computePciAddress(%d, bridges) = %q, want %q", tt.slot, got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- isPassthroughOrController tests ---
+
+func TestIsPassthroughOrController(t *testing.T) {
+	tests := []struct {
+		name     string
+		dev      types.BaseVirtualDevice
+		expected bool
+	}{
+		{"VirtualSriovEthernetCard", makeSriov(1, nil), true},
+		{"VirtualPCIPassthrough", makePCIPassthrough(2), true},
+		{"VirtualUSBController", makeUSBController(3), true},
+		{"VirtualVmxnet3", makeVmxnet3(4, 0, netBacking("net-1"), ""), false},
+		{"VirtualE1000", makeE1000(5, netBacking("net-1")), false},
+		{"VirtualDisk", makeDisk(6), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPassthroughOrController(tt.dev)
+			if got != tt.expected {
+				t.Errorf("isPassthroughOrController(%s) = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- isConnectedNIC tests ---
+
+func TestIsConnectedNIC(t *testing.T) {
+	tests := []struct {
+		name     string
+		dev      types.BaseVirtualDevice
+		expected bool
+	}{
+		{"vmxnet3 with backing", makeVmxnet3(1, 0, netBacking("net-1"), ""), true},
+		{"e1000 with backing", makeE1000(2, netBacking("net-1")), true},
+		{"vmxnet3 nil backing", makeVmxnet3(3, 0, nil, ""), false},
+		{"SR-IOV with backing", makeSriov(4, netBacking("net-1")), false},
+		{"SR-IOV nil backing", makeSriov(5, nil), false},
+		{"PCI passthrough", makePCIPassthrough(6), false},
+		{"USB controller", makeUSBController(7), false},
+		{"virtual disk", makeDisk(8), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isConnectedNIC(tt.dev)
+			if got != tt.expected {
+				t.Errorf("isConnectedNIC(%s) = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- refreshNICPciAddresses tests ---
+
+func TestRefreshNICPciAddresses(t *testing.T) {
+	bridges := []model.PciBridge{
+		{Number: 0, SlotNumber: 17, Functions: 1},
+		{Number: 4, SlotNumber: 21, Functions: 8},
+	}
+
+	vm := &model.VM{
+		PciBridges: bridges,
+		Devices: []model.Device{
+			{Key: 4000, PciSlotNumber: 192},
+			{Key: 4001, PciSlotNumber: 224},
+		},
+		NICs: []model.NIC{
+			{DeviceKey: 4000, PciAddress: "stale"},
+			{DeviceKey: 4001, PciAddress: "stale"},
+		},
+	}
+
+	refreshNICPciAddresses(vm)
+
+	expected0 := computePciAddress(192, bridges)
+	expected1 := computePciAddress(224, bridges)
+
+	if vm.NICs[0].PciAddress != expected0 {
+		t.Errorf("NIC[0].PciAddress = %q, want %q", vm.NICs[0].PciAddress, expected0)
+	}
+	if vm.NICs[1].PciAddress != expected1 {
+		t.Errorf("NIC[1].PciAddress = %q, want %q", vm.NICs[1].PciAddress, expected1)
+	}
+}
+
+func TestRefreshNICPciAddresses_MissingDevice(t *testing.T) {
+	vm := &model.VM{
+		PciBridges: []model.PciBridge{{Number: 4, SlotNumber: 21, Functions: 8}},
+		Devices:    []model.Device{},
+		NICs: []model.NIC{
+			{DeviceKey: 9999, PciAddress: "old"},
+		},
+	}
+
+	refreshNICPciAddresses(vm)
+
+	if vm.NICs[0].PciAddress != "" {
+		t.Errorf("NIC with missing device should get empty PciAddress, got %q", vm.NICs[0].PciAddress)
+	}
+}
+
+// --- collectDevices tests ---
+
+func TestCollectDevices(t *testing.T) {
+	v := &VmAdapter{}
+
+	devArray := types.ArrayOfVirtualDevice{
+		VirtualDevice: []types.BaseVirtualDevice{
+			makeVmxnet3(4000, 192, netBacking("net-1"), "aa:bb:cc:dd:ee:01"),
+			makePCIPassthrough(100),
+			makeUSBController(200),
+			makeDisk(2000),
+			makeVmxnet3(4001, 224, nil, "aa:bb:cc:dd:ee:02"),
+			makeSriov(300, netBacking("net-2")),
+		},
+	}
+
+	devList := v.collectDevices(devArray)
+
+	expectedKeys := []int32{4000, 100, 200, 300}
+	if len(devList) != len(expectedKeys) {
+		t.Fatalf("collectDevices returned %d devices, want %d", len(devList), len(expectedKeys))
+	}
+	for i, key := range expectedKeys {
+		if devList[i].Key != key {
+			t.Errorf("devList[%d].Key = %d, want %d", i, devList[i].Key, key)
+		}
+	}
+
+	if devList[0].PciSlotNumber != 192 {
+		t.Errorf("devList[0].PciSlotNumber = %d, want 192", devList[0].PciSlotNumber)
+	}
+}
+
+func TestCollectDevices_SkipsUnconnectedNIC(t *testing.T) {
+	v := &VmAdapter{}
+
+	devArray := types.ArrayOfVirtualDevice{
+		VirtualDevice: []types.BaseVirtualDevice{
+			makeVmxnet3(4000, 0, nil, ""),
+		},
+	}
+
+	devList := v.collectDevices(devArray)
+	if len(devList) != 0 {
+		t.Errorf("collectDevices should skip NIC without backing, got %d devices", len(devList))
+	}
+}
+
+// --- collectNICs tests ---
+
+func TestCollectNICs(t *testing.T) {
+	bridges := []model.PciBridge{
+		{Number: 0, SlotNumber: 17, Functions: 1},
+		{Number: 4, SlotNumber: 21, Functions: 8},
+		{Number: 5, SlotNumber: 22, Functions: 8},
+	}
+
+	slot0 := makeSlot(0x00, 5, 0) // on pciBridge4
+	slot1 := makeSlot(0x00, 6, 0) // on pciBridge5
+
+	v := &VmAdapter{model: model.VM{PciBridges: bridges}}
+
+	devArray := types.ArrayOfVirtualDevice{
+		VirtualDevice: []types.BaseVirtualDevice{
+			makeVmxnet3(4000, slot0, netBacking("net-10"), "AA:BB:CC:DD:EE:01"),
+			makeVmxnet3(4001, slot1, netBacking("net-20"), "AA:BB:CC:DD:EE:02"),
+			makePCIPassthrough(100),
+			makeDisk(2000),
+			makeSriov(300, netBacking("net-30")),
+			makeVmxnet3(4002, 0, nil, "AA:BB:CC:DD:EE:03"),
+		},
+	}
+
+	nicList := v.collectNICs(devArray)
+
+	if len(nicList) != 2 {
+		t.Fatalf("collectNICs returned %d NICs, want 2", len(nicList))
+	}
+
+	if nicList[0].MAC != "aa:bb:cc:dd:ee:01" {
+		t.Errorf("NIC[0].MAC = %q, want lowercase", nicList[0].MAC)
+	}
+	if nicList[0].DeviceKey != 4000 {
+		t.Errorf("NIC[0].DeviceKey = %d, want 4000", nicList[0].DeviceKey)
+	}
+	if nicList[0].Index != 0 {
+		t.Errorf("NIC[0].Index = %d, want 0", nicList[0].Index)
+	}
+	if nicList[0].Network.ID != "net-10" {
+		t.Errorf("NIC[0].Network.ID = %q, want net-10", nicList[0].Network.ID)
+	}
+	if nicList[0].PciAddress == "" {
+		t.Error("NIC[0].PciAddress should not be empty")
+	}
+
+	if nicList[1].Index != 1 {
+		t.Errorf("NIC[1].Index = %d, want 1", nicList[1].Index)
+	}
+	if nicList[1].DeviceKey != 4001 {
+		t.Errorf("NIC[1].DeviceKey = %d, want 4001", nicList[1].DeviceKey)
+	}
+}
+
+func TestCollectNICs_ExcludesSRIOV(t *testing.T) {
+	v := &VmAdapter{}
+
+	devArray := types.ArrayOfVirtualDevice{
+		VirtualDevice: []types.BaseVirtualDevice{
+			makeSriov(300, netBacking("net-1")),
+		},
+	}
+
+	nicList := v.collectNICs(devArray)
+	if len(nicList) != 0 {
+		t.Errorf("collectNICs should exclude SR-IOV NICs, got %d", len(nicList))
+	}
+}
+
 // Test getDiskGuestInfo method
 func TestVmAdapter_getDiskGuestInfo(t *testing.T) {
 	tests := []struct {

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -333,6 +333,7 @@ type VM struct {
 	ChangeTrackingEnabled    bool               `sql:""`
 	TpmEnabled               bool               `sql:""`
 	Devices                  []Device           `sql:""`
+	PciBridges               []PciBridge        `sql:""`
 	NICs                     []NIC              `sql:""`
 	Disks                    []Disk             `sql:""`
 	Controllers              []Controller       `sql:""`
@@ -394,15 +395,26 @@ type Disk struct {
 
 // Virtual Device.
 type Device struct {
-	Kind string `json:"kind"`
+	Kind          string `json:"kind"`
+	Key           int32  `json:"key"`
+	PciSlotNumber int32  `json:"pciSlotNumber"`
+}
+
+// PciBridge represents a virtual PCI bridge from the VM's extraConfig.
+// Used to compute guest-visible PCI addresses from persistent slot numbers.
+type PciBridge struct {
+	Number     int   `json:"number"`
+	SlotNumber int32 `json:"slotNumber"`
+	Functions  int   `json:"functions"`
 }
 
 // Virtual ethernet card.
 type NIC struct {
-	Network   Ref    `json:"network"`
-	MAC       string `json:"mac"`
-	Index     int    `json:"order"`
-	DeviceKey int32  `json:"deviceKey"`
+	Network    Ref    `json:"network"`
+	MAC        string `json:"mac"`
+	Index      int    `json:"order"`
+	DeviceKey  int32  `json:"deviceKey"`
+	PciAddress string `json:"pciAddress"`
 }
 
 // Guest network.


### PR DESCRIPTION
Add bridge-aware PCI address computation to the vSphere inventory
collector. Each virtual device's PciSlotNumber and Key are stored on the
Device struct, and the corresponding guest-visible PCI address
(0000:BB:DD.F) is computed and stored on the NIC struct.

The slot number is a packed bitmap (FFF.BBBBB.DDDDD) that encodes the
bridge index and root-port function. The collector parses pciBridge
topology from config.extraConfig and sequentially assigns bus numbers to
resolve each device's guest-visible address.

New model types:
  - PciBridge struct to hold bridge slot, number, and function count
  - PciBridges field on the VM struct
  - Key field on the Device struct for NIC-to-device matching
  - DeviceKey and PciAddress fields on the NIC struct

Test case and logs in the Jira ticket.

Example:

```bash
oc mtv get inventory vm \
  --provider vsphere-test -n mtv-5753-test \
  --query "where name = 'mtv-function-rhel7-9-staticips'" \
  --output json | jq '.[0] | {name, devices, nics}'
```

Expected output (4 NICs, all with `pciAddress` populated):

```json
{
  "name": "mtv-function-rhel7-9-staticips",
  "devices": [
    { "key": 4000, "kind": "VirtualVmxnet3", "pciSlotNumber": 192 },
    { "key": 4001, "kind": "VirtualVmxnet3", "pciSlotNumber": 224 },
    { "key": 4002, "kind": "VirtualVmxnet3", "pciSlotNumber": 256 },
    { "key": 4003, "kind": "VirtualVmxnet3", "pciSlotNumber": 1184 }
  ],
  "nics": [
    { "deviceKey": 4003, "mac": "00:50:56:be:3a:07", "pciAddress": "0000:04:00.0", "order": 3 },
    { "deviceKey": 4000, "mac": "00:50:56:1c:1c:7d", "pciAddress": "0000:0b:00.0", "order": 0 },
    { "deviceKey": 4001, "mac": "00:50:56:1c:8c:8d", "pciAddress": "0000:13:00.0", "order": 1 },
    { "deviceKey": 4002, "mac": "00:50:56:be:c3:3a", "pciAddress": "0000:1b:00.0", "order": 2 }
  ]
}
```

Ref: https://redhat.atlassian.net/browse/MTV-5753
Resolves: MTV-5753