### PR TITLE
MTV-5753 | Preserve PCI addresses from source VM during vSphere migration

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -808,6 +808,11 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 		if !hasUDN || settings.Settings.UdnSupportsMac {
 			kInterface.MacAddress = nic.MAC
 		}
+
+		if nic.PciAddress != "" {
+			kInterface.PciAddress = nic.PciAddress
+		}
+
 		switch mapped.Destination.Type {
 		case Pod:
 			kNetwork.Pod = &cnv.PodNetwork{}


### PR DESCRIPTION
Set the pciAddress field on target KubeVirt VM interfaces using the PCI address already computed and stored in the vSphere inventory NIC model.

Ref: https://redhat.atlassian.net/browse/MTV-5753
Resolves: MTV-5753