### PR TITLE
MTV-5636 | fix vSphere provider to validate server cert against user-provided CA

### DIFF
--- a/pkg/controller/base/controller.go
+++ b/pkg/controller/base/controller.go
@@ -133,7 +133,6 @@ func VerifyTLSConnection(rawURL string, secret *core.Secret) (*x509.Certificate,
 		return nil, fmt.Errorf("invalid URL: %w", err)
 	}
 
-	// Attempt to get certificate
 	cert, err := util.GetTlsCertificate(parsedURL, secret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get TLS certificate: %w", err)
@@ -142,19 +141,26 @@ func VerifyTLSConnection(rawURL string, secret *core.Secret) (*x509.Certificate,
 		return nil, fmt.Errorf("received nil certificate from GetTlsCertificate")
 	}
 
-	// Create cert pool
 	tlsConfig := &tls.Config{
 		RootCAs: x509.NewCertPool(),
 	}
-	tlsConfig.RootCAs.AddCert(cert)
+	if cacert, ok := util.GetCACert(secret); ok {
+		if !tlsConfig.RootCAs.AppendCertsFromPEM(cacert) {
+			return nil, fmt.Errorf("failed to parse the CA certificate from secret")
+		}
+	} else {
+		systemPool, poolErr := x509.SystemCertPool()
+		if poolErr != nil {
+			return nil, fmt.Errorf("failed to load system cert pool: %w", poolErr)
+		}
+		tlsConfig.RootCAs = systemPool
+	}
 
-	// Ensure host:port
 	host := parsedURL.Host
 	if _, _, err := net.SplitHostPort(parsedURL.Host); err != nil {
 		host = parsedURL.Host + ":443"
 	}
 
-	// Dial TLS
 	conn, err := tls.Dial("tcp", host, tlsConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a secure TLS connection: %w", err)

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -337,6 +337,13 @@ func (r *Reconciler) updateContainer(provider *api.Provider) (err error) {
 	}
 	secretChanged := secret.ResourceVersion != provider.Status.SecretResourceVersion
 
+	if provider.Status.HasBlockerCondition() ||
+		!provider.Status.HasCondition(ConnectionTestSucceeded) {
+		r.Log.V(1).Info(
+			"Provider not ready, postponing.")
+		return
+	}
+
 	if !secretChanged {
 		if _, found := r.container.Get(provider); found {
 			// Don't update if provider hasn't changed
@@ -346,15 +353,6 @@ func (r *Reconciler) updateContainer(provider *api.Provider) (err error) {
 				return
 			}
 		}
-
-		// Only build a new collector if connection test succeeded
-		if provider.Status.HasBlockerCondition() ||
-			!provider.Status.HasCondition(ConnectionTestSucceeded) {
-			r.Log.V(1).Info(
-				"Provider not ready, postponing.")
-			return
-		}
-
 	} else {
 		r.Log.V(1).Info(
 			"Detected Secret change.",

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -253,6 +253,7 @@ func (r *Reconciler) validateTLSConnection(provider *api.Provider, secret *core.
 
 	_, err := base.VerifyTLSConnection(tlsURL, secret)
 	if err != nil {
+		provider.Status.Phase = ConnectionFailed
 		provider.Status.SetCondition(libcnd.Condition{
 			Type:     ConnectionTestFailed,
 			Status:   True,


### PR DESCRIPTION
VerifyTLSConnection() was fetching the server's own certificate with
InsecureSkipVerify=true, adding it to a new cert pool, and validating
against itself — circular self-trust. The user-provided ca.crt was
never used for validation, so any valid PEM was accepted regardless
of whether it matched the vCenter server's actual certificate chain.

This fix uses the ca.crt from the provider secret as the trust anchor
instead of the server's own certificate. If no ca.crt is provided,
it falls back to the system cert pool.

Additionally, the collector blocker check is moved before the
secretChanged branch so the inventory collector is never started
when the connection test fails, and the provider phase is set to
ConnectionFailed instead of remaining stuck at Staging.

Ref: https://redhat.atlassian.net/browse/MTV-5636
Resolves: MTV-5636