### PR TITLE
MTV-5631 | Cache FlashSystem auth token in populator secret

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
+++ b/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -102,11 +103,15 @@ type FlashSystemAPIClient struct {
 	authToken    string // Session token from /auth
 	username     string // Store for re-authentication
 	password     string // Store for re-authentication
+	tokenCache   TokenCache
 	log          klog.Logger
 }
 
 // NewFlashSystemAPIClient creates and authenticates a new API client.
-func NewFlashSystemAPIClient(managementIP, username, password string, sslSkipVerify bool) (*FlashSystemAPIClient, error) {
+// If tokenCache is provided, the client will try to use a cached token before authenticating,
+// and will save new tokens to the cache after authentication. This prevents token invalidation
+// storms when multiple populator pods start concurrently (IBM allows only one valid token per user).
+func NewFlashSystemAPIClient(managementIP, username, password string, sslSkipVerify bool, tokenCache TokenCache) (*FlashSystemAPIClient, error) {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: sslSkipVerify},
 	}
@@ -117,25 +122,57 @@ func NewFlashSystemAPIClient(managementIP, username, password string, sslSkipVer
 		httpClient:   httpClient,
 		username:     username,
 		password:     password,
+		tokenCache:   tokenCache,
 		log:          logger.New("flashsystem"),
 	}
 
-	// Initial authentication
-	if err := client.authenticate(); err != nil {
+	// Try cached token first to avoid auth call (prevents 429 when many pods start at once)
+	if tokenCache != nil {
+		if cached, err := tokenCache.ReadToken(); err == nil && cached != "" {
+			client.log.Info("using cached FlashSystem auth token from secret")
+			client.authToken = cached
+			return client, nil
+		}
+	}
+
+	if err := client.authenticateAndCache(); err != nil {
 		return nil, fmt.Errorf("initial authentication failed: %w", err)
 	}
 
 	return client, nil
 }
 
-// authenticate handles the authentication process using v1 API best practices
+// authenticate handles the authentication process using v1 API best practices.
+// Retries on 429 (Too Many Requests) with exponential backoff + jitter, since
+// concurrent populator pods can overwhelm the FlashSystem auth endpoint.
 func (c *FlashSystemAPIClient) authenticate() error {
+	var lastStatus int
+	var lastErr error
+	for attempt := 0; attempt <= 3; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(1<<uint(attempt-1))*time.Second + time.Duration(rand.Intn(500))*time.Millisecond
+			c.log.Info("auth rate limited (429), retrying", "attempt", attempt, "backoff", backoff)
+			time.Sleep(backoff)
+		}
+
+		lastStatus, lastErr = c.doAuthenticate()
+		if lastErr == nil {
+			return nil
+		}
+		if lastStatus != http.StatusTooManyRequests {
+			return lastErr
+		}
+	}
+	return lastErr
+}
+
+// doAuthenticate performs a single authentication attempt, returning the HTTP status code and any error.
+func (c *FlashSystemAPIClient) doAuthenticate() (int, error) {
 	authURL := fmt.Sprintf("https://%s:7443/rest/v1/auth", c.ManagementIP)
 
-	// FlashSystem expects username and password via HTTP headers, not JSON body
 	req, err := http.NewRequest("POST", authURL, bytes.NewBuffer([]byte{}))
 	if err != nil {
-		return fmt.Errorf("failed to create auth request: %w", err)
+		return 0, fmt.Errorf("failed to create auth request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -146,46 +183,89 @@ func (c *FlashSystemAPIClient) authenticate() error {
 	c.log.V(2).Info("authenticating with FlashSystem", "host", c.ManagementIP)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to send auth request to FlashSystem: %w", err)
+		return 0, fmt.Errorf("failed to send auth request to FlashSystem: %w", err)
 	}
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read auth response body: %w", err)
+		return resp.StatusCode, fmt.Errorf("failed to read auth response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("FlashSystem authentication failed. Status: %s, Body: %s", resp.Status, string(bodyBytes))
+		return resp.StatusCode, fmt.Errorf("FlashSystem authentication failed. Status: %s, Body: %s", resp.Status, string(bodyBytes))
 	}
 
 	var authResp AuthResponse
 	if err := json.Unmarshal(bodyBytes, &authResp); err != nil {
-		return fmt.Errorf("failed to unmarshal auth token response: %w. Body: %s", err, string(bodyBytes))
+		return resp.StatusCode, fmt.Errorf("failed to unmarshal auth token response: %w. Body: %s", err, string(bodyBytes))
 	}
 
 	if authResp.Token == "" {
-		return fmt.Errorf("FlashSystem authentication successful but no token found in response")
+		return resp.StatusCode, fmt.Errorf("FlashSystem authentication successful but no token found in response")
 	}
 
 	c.authToken = authResp.Token
 
 	c.log.V(2).Info("Successfully authenticated with FlashSystem and obtained session token.")
+	return resp.StatusCode, nil
+}
+
+// authenticateAndCache authenticates and writes the new token to the cache.
+func (c *FlashSystemAPIClient) authenticateAndCache() error {
+	if err := c.authenticate(); err != nil {
+		return err
+	}
+	if c.tokenCache != nil {
+		if err := c.tokenCache.WriteToken(c.authToken); err != nil {
+			c.log.Info("failed to cache auth token in secret (non-fatal)", "error", err)
+		}
+	}
 	return nil
+}
+
+// refreshToken tries to get a fresh token without hitting the auth endpoint.
+// First checks the cache (another pod may have already refreshed). If the cached
+// token is different from ours, uses it. Otherwise authenticates with jitter to
+// avoid multiple pods re-authenticating simultaneously.
+func (c *FlashSystemAPIClient) refreshToken() error {
+	if c.tokenCache == nil {
+		return c.authenticateAndCache()
+	}
+
+	if cached, err := c.tokenCache.ReadToken(); err == nil && cached != "" && cached != c.authToken {
+		c.log.Info("using refreshed token from secret (another pod already re-authenticated)")
+		c.authToken = cached
+		return nil
+	}
+
+	// Jitter before authenticating to spread concurrent re-auth attempts.
+	// If another pod authenticates during our jitter window, we'll pick up
+	// its token from the cache instead of making a redundant auth call.
+	jitter := time.Duration(100+rand.Intn(900)) * time.Millisecond
+	c.log.Info("waiting before re-authentication", "jitter", jitter)
+	time.Sleep(jitter)
+
+	// Re-read cache after jitter — another pod may have authenticated in the meantime
+	if cached, err := c.tokenCache.ReadToken(); err == nil && cached != "" && cached != c.authToken {
+		c.log.Info("using refreshed token from secret after jitter")
+		c.authToken = cached
+		return nil
+	}
+
+	return c.authenticateAndCache()
 }
 
 // makeRequest is a helper to make authenticated HTTP requests with automatic token refresh.
 func (c *FlashSystemAPIClient) makeRequest(method, path string, payload interface{}) ([]byte, int, error) {
-	// Try the request first, and handle 403 (token expiry) by re-authenticating
 	respBodyBytes, statusCode, err := c.doRequest(method, path, payload)
 
-	// Handle 403 Forbidden - token expired, re-authenticate and retry once
+	// Handle 403 Forbidden - token expired or invalidated by another pod
 	if statusCode == http.StatusForbidden {
-		c.log.Info("received 403 forbidden, token likely expired, re-authenticating")
-		if authErr := c.authenticate(); authErr != nil {
-			return nil, statusCode, fmt.Errorf("re-authentication failed: %w", authErr)
+		c.log.Info("received 403 forbidden, refreshing token")
+		if refreshErr := c.refreshToken(); refreshErr != nil {
+			return nil, statusCode, fmt.Errorf("token refresh failed: %w", refreshErr)
 		}
-		// Retry the request with new token
 		return c.doRequest(method, path, payload)
 	}
 
@@ -405,9 +485,9 @@ func (c *FlashSystemClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
 // NewFlashSystemClonner creates a new FlashSystemClonner.
 // It checks that vdisk protection is disabled on the FlashSystem; if protection is enabled,
 // it returns an error because it must be off for Virtual Machines (see README, section IBM FlashSystem).
-func NewFlashSystemClonner(managementIP, username, password string, sslSkipVerify bool) (FlashSystemClonner, error) {
+func NewFlashSystemClonner(managementIP, username, password string, sslSkipVerify bool, tokenCache TokenCache) (FlashSystemClonner, error) {
 	log := logger.New("flashsystem")
-	client, err := NewFlashSystemAPIClient(managementIP, username, password, sslSkipVerify)
+	client, err := NewFlashSystemAPIClient(managementIP, username, password, sslSkipVerify, tokenCache)
 	if err != nil {
 		return FlashSystemClonner{}, fmt.Errorf("failed to create FlashSystem API client: %w", err)
 	}

--- a/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
+++ b/cmd/vsphere-copy-offload-populator/internal/flashsystem/flashsystem.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	crand "crypto/rand"
+	"math/big"
 	"net/http"
 	"strings"
 	"time"
@@ -102,11 +104,14 @@ type FlashSystemAPIClient struct {
 	authToken    string // Session token from /auth
 	username     string // Store for re-authentication
 	password     string // Store for re-authentication
+	tokenCache   TokenCache
 	log          klog.Logger
 }
 
 // NewFlashSystemAPIClient creates and authenticates a new API client.
-func NewFlashSystemAPIClient(managementIP, username, password string, sslSkipVerify bool) (*FlashSystemAPIClient, error) {
+// If tokenCache is provided, the client will try to use a cached token before authenticating,
+// and will save new tokens to the cache after authentication.
+func NewFlashSystemAPIClient(managementIP, username, password string, sslSkipVerify bool, tokenCache TokenCache) (*FlashSystemAPIClient, error) {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: sslSkipVerify},
 	}
@@ -117,25 +122,56 @@ func NewFlashSystemAPIClient(managementIP, username, password string, sslSkipVer
 		httpClient:   httpClient,
 		username:     username,
 		password:     password,
+		tokenCache:   tokenCache,
 		log:          logger.New("flashsystem"),
 	}
 
-	// Initial authentication
-	if err := client.authenticate(); err != nil {
+	if tokenCache != nil {
+		if cached, err := tokenCache.ReadToken(); err == nil && cached != "" {
+			client.log.Info("using cached FlashSystem auth token from shared secret")
+			client.authToken = cached
+			return client, nil
+		}
+	}
+
+	if err := client.authenticateAndCache(); err != nil {
 		return nil, fmt.Errorf("initial authentication failed: %w", err)
 	}
 
 	return client, nil
 }
 
-// authenticate handles the authentication process using v1 API best practices
+// authenticate handles authentication with retry on 429 (Too Many Requests).
+// Uses exponential backoff + jitter to spread concurrent re-auth attempts.
 func (c *FlashSystemAPIClient) authenticate() error {
+	var lastStatus int
+	var lastErr error
+	for attempt := 0; attempt <= 3; attempt++ {
+		if attempt > 0 {
+			jitterMs, _ := crand.Int(crand.Reader, big.NewInt(500))
+			backoff := time.Duration(1<<uint(attempt-1))*time.Second +
+				time.Duration(jitterMs.Int64())*time.Millisecond
+			c.log.Info("auth rate limited (429), retrying", "attempt", attempt, "backoff", backoff)
+			time.Sleep(backoff)
+		}
+
+		lastStatus, lastErr = c.doAuthenticate()
+		if lastErr == nil {
+			return nil
+		}
+		if lastStatus != http.StatusTooManyRequests {
+			return lastErr
+		}
+	}
+	return lastErr
+}
+
+func (c *FlashSystemAPIClient) doAuthenticate() (int, error) {
 	authURL := fmt.Sprintf("https://%s:7443/rest/v1/auth", c.ManagementIP)
 
-	// FlashSystem expects username and password via HTTP headers, not JSON body
 	req, err := http.NewRequest("POST", authURL, bytes.NewBuffer([]byte{}))
 	if err != nil {
-		return fmt.Errorf("failed to create auth request: %w", err)
+		return 0, fmt.Errorf("failed to create auth request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -146,32 +182,72 @@ func (c *FlashSystemAPIClient) authenticate() error {
 	c.log.V(2).Info("authenticating with FlashSystem", "host", c.ManagementIP)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to send auth request to FlashSystem: %w", err)
+		return 0, fmt.Errorf("failed to send auth request to FlashSystem: %w", err)
 	}
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read auth response body: %w", err)
+		return resp.StatusCode, fmt.Errorf("failed to read auth response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("FlashSystem authentication failed. Status: %s, Body: %s", resp.Status, string(bodyBytes))
+		return resp.StatusCode, fmt.Errorf("FlashSystem authentication failed. Status: %s, Body: %s", resp.Status, string(bodyBytes))
 	}
 
 	var authResp AuthResponse
 	if err := json.Unmarshal(bodyBytes, &authResp); err != nil {
-		return fmt.Errorf("failed to unmarshal auth token response: %w. Body: %s", err, string(bodyBytes))
+		return resp.StatusCode, fmt.Errorf("failed to unmarshal auth token response: %w. Body: %s", err, string(bodyBytes))
 	}
 
 	if authResp.Token == "" {
-		return fmt.Errorf("FlashSystem authentication successful but no token found in response")
+		return resp.StatusCode, fmt.Errorf("FlashSystem authentication successful but no token found in response")
 	}
 
 	c.authToken = authResp.Token
 
 	c.log.V(2).Info("Successfully authenticated with FlashSystem and obtained session token.")
+	return resp.StatusCode, nil
+}
+
+func (c *FlashSystemAPIClient) authenticateAndCache() error {
+	if err := c.authenticate(); err != nil {
+		return err
+	}
+	if c.tokenCache != nil {
+		if err := c.tokenCache.WriteToken(c.authToken); err != nil {
+			c.log.Info("failed to cache auth token in shared secret (non-fatal)", "error", err)
+		}
+	}
 	return nil
+}
+
+// refreshToken tries to get a fresh token without hitting the auth endpoint.
+// Checks the cache first (another pod may have already refreshed), then
+// uses jitter before re-authenticating to avoid simultaneous auth storms.
+func (c *FlashSystemAPIClient) refreshToken() error {
+	if c.tokenCache == nil {
+		return c.authenticateAndCache()
+	}
+
+	if cached, err := c.tokenCache.ReadToken(); err == nil && cached != "" && cached != c.authToken {
+		c.log.Info("using refreshed token from shared secret (another pod already re-authenticated)")
+		c.authToken = cached
+		return nil
+	}
+
+	jitterMs, _ := crand.Int(crand.Reader, big.NewInt(900))
+	jitter := time.Duration(100+jitterMs.Int64()) * time.Millisecond
+	c.log.Info("waiting before re-authentication", "jitter", jitter)
+	time.Sleep(jitter)
+
+	if cached, err := c.tokenCache.ReadToken(); err == nil && cached != "" && cached != c.authToken {
+		c.log.Info("using refreshed token from shared secret after jitter")
+		c.authToken = cached
+		return nil
+	}
+
+	return c.authenticateAndCache()
 }
 
 // makeRequest is a helper to make authenticated HTTP requests with automatic token refresh.
@@ -179,13 +255,11 @@ func (c *FlashSystemAPIClient) makeRequest(method, path string, payload interfac
 	// Try the request first, and handle 403 (token expiry) by re-authenticating
 	respBodyBytes, statusCode, err := c.doRequest(method, path, payload)
 
-	// Handle 403 Forbidden - token expired, re-authenticate and retry once
-	if statusCode == http.StatusForbidden {
-		c.log.Info("received 403 forbidden, token likely expired, re-authenticating")
-		if authErr := c.authenticate(); authErr != nil {
-			return nil, statusCode, fmt.Errorf("re-authentication failed: %w", authErr)
+	if statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized {
+		c.log.Info("received auth error, refreshing token", "status", statusCode)
+		if refreshErr := c.refreshToken(); refreshErr != nil {
+			return nil, statusCode, fmt.Errorf("token refresh failed: %w", refreshErr)
 		}
-		// Retry the request with new token
 		return c.doRequest(method, path, payload)
 	}
 
@@ -405,9 +479,9 @@ func (c *FlashSystemClonner) GetStorageArrayInfo() populator.StorageArrayInfo {
 // NewFlashSystemClonner creates a new FlashSystemClonner.
 // It checks that vdisk protection is disabled on the FlashSystem; if protection is enabled,
 // it returns an error because it must be off for Virtual Machines (see README, section IBM FlashSystem).
-func NewFlashSystemClonner(managementIP, username, password string, sslSkipVerify bool) (FlashSystemClonner, error) {
+func NewFlashSystemClonner(managementIP, username, password string, sslSkipVerify bool, tokenCache TokenCache) (FlashSystemClonner, error) {
 	log := logger.New("flashsystem")
-	client, err := NewFlashSystemAPIClient(managementIP, username, password, sslSkipVerify)
+	client, err := NewFlashSystemAPIClient(managementIP, username, password, sslSkipVerify, tokenCache)
 	if err != nil {
 		return FlashSystemClonner{}, fmt.Errorf("failed to create FlashSystem API client: %w", err)
 	}

--- a/cmd/vsphere-copy-offload-populator/internal/flashsystem/token_cache.go
+++ b/cmd/vsphere-copy-offload-populator/internal/flashsystem/token_cache.go
@@ -1,0 +1,63 @@
+package flashsystem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+const tokenKey = "FLASHSYSTEM_AUTH_TOKEN"
+
+// TokenCache allows sharing FlashSystem auth tokens across populator pod instances
+// to avoid token invalidation storms (each user can only have one valid token).
+type TokenCache interface {
+	ReadToken() (string, error)
+	WriteToken(token string) error
+}
+
+// SecretTokenCache stores the FlashSystem auth token in the existing populator-secret
+// using a strategic merge patch to avoid overwriting other keys.
+type SecretTokenCache struct {
+	client     kubernetes.Interface
+	namespace  string
+	secretName string
+}
+
+func NewSecretTokenCache(client kubernetes.Interface, namespace, secretName string) *SecretTokenCache {
+	return &SecretTokenCache{
+		client:     client,
+		namespace:  namespace,
+		secretName: secretName,
+	}
+}
+
+func (c *SecretTokenCache) ReadToken() (string, error) {
+	secret, err := c.client.CoreV1().Secrets(c.namespace).Get(context.Background(), c.secretName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to read token from secret %s/%s: %w", c.namespace, c.secretName, err)
+	}
+	return string(secret.Data[tokenKey]), nil
+}
+
+func (c *SecretTokenCache) WriteToken(token string) error {
+	patch := map[string]interface{}{
+		"stringData": map[string]string{
+			tokenKey: token,
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal token patch: %w", err)
+	}
+	_, err = c.client.CoreV1().Secrets(c.namespace).Patch(
+		context.Background(), c.secretName, types.MergePatchType, patchBytes, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to patch secret %s/%s with token: %w", c.namespace, c.secretName, err)
+	}
+	return nil
+}

--- a/cmd/vsphere-copy-offload-populator/internal/flashsystem/token_cache.go
+++ b/cmd/vsphere-copy-offload-populator/internal/flashsystem/token_cache.go
@@ -1,0 +1,134 @@
+package flashsystem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	StorageArraySecretName             = "storage-array-secret"
+	StorageArraySecretDefaultNamespace = "openshift-mtv"
+)
+
+type CachedToken struct {
+	Token     string    `json:"token"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type TokenCache interface {
+	ReadToken() (string, error)
+	WriteToken(token string) error
+}
+
+type SecretTokenCache struct {
+	client     kubernetes.Interface
+	namespace  string
+	secretName string
+	dataKey    string
+	log        klog.Logger
+}
+
+func NewSecretTokenCache(client kubernetes.Interface, managementIP string) *SecretTokenCache {
+	namespace := StorageArraySecretDefaultNamespace
+	if ns := os.Getenv("HOST_LEASE_NAMESPACE"); ns != "" {
+		namespace = ns
+	}
+
+	sanitized := strings.NewReplacer(".", "-", ":", "-").Replace(managementIP)
+	dataKey := "flashsystem-token-" + sanitized
+
+	return &SecretTokenCache{
+		client:     client,
+		namespace:  namespace,
+		secretName: StorageArraySecretName,
+		dataKey:    dataKey,
+		log:        klog.Background().WithName("flashsystem").WithName("token-cache"),
+	}
+}
+
+func (c *SecretTokenCache) ReadToken() (string, error) {
+	secret, err := c.client.CoreV1().Secrets(c.namespace).Get(
+		context.Background(), c.secretName, metav1.GetOptions{},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to read token from secret %s/%s: %w",
+			c.namespace, c.secretName, err)
+	}
+
+	raw, ok := secret.Data[c.dataKey]
+	if !ok || len(raw) == 0 {
+		return "", nil
+	}
+
+	var cached CachedToken
+	if err := json.Unmarshal(raw, &cached); err != nil {
+		c.log.Info("malformed cached token entry, treating as empty", "key", c.dataKey, "err", err)
+		return "", nil
+	}
+
+	return cached.Token, nil
+}
+
+func (c *SecretTokenCache) WriteToken(token string) error {
+	entry := CachedToken{
+		Token:     token,
+		UpdatedAt: time.Now().UTC(),
+	}
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal token entry: %w", err)
+	}
+
+	patch := map[string]interface{}{
+		"data": map[string]interface{}{
+			c.dataKey: entryJSON,
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal token patch: %w", err)
+	}
+
+	_, err = c.client.CoreV1().Secrets(c.namespace).Patch(
+		context.Background(),
+		c.secretName,
+		types.MergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			return fmt.Errorf("failed to patch secret %s/%s with token: %w",
+				c.namespace, c.secretName, err)
+		}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      c.secretName,
+				Namespace: c.namespace,
+			},
+			Data: map[string][]byte{
+				c.dataKey: entryJSON,
+			},
+		}
+		if _, err := c.client.CoreV1().Secrets(c.namespace).Create(
+			context.Background(), secret, metav1.CreateOptions{},
+		); err != nil {
+			return fmt.Errorf("failed to create secret %s/%s: %w",
+				c.namespace, c.secretName, err)
+		}
+	}
+
+	c.log.V(2).Info("token cached in shared secret", "key", c.dataKey)
+	return nil
+}

--- a/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator.go
+++ b/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator.go
@@ -95,7 +95,8 @@ func main() {
 		}
 		storageApi = &sm
 	case forklift.StorageVendorProductFlashSystem:
-		sm, err := flashsystem.NewFlashSystemClonner(storageHostname, storageUsername, storagePassword, storageSkipSSLVerification == "true")
+		tokenCache := flashsystem.NewSecretTokenCache(clientSet, targetNamespace, secretName)
+		sm, err := flashsystem.NewFlashSystemClonner(storageHostname, storageUsername, storagePassword, storageSkipSSLVerification == "true", tokenCache)
 		if err != nil {
 			klog.Fatalf("failed to initialize flashsystem storage mapper with %s", err)
 		}

--- a/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator.go
+++ b/cmd/vsphere-copy-offload-populator/vsphere-copy-offload-populator.go
@@ -97,7 +97,8 @@ func main() {
 		}
 		storageApi = &sm
 	case forklift.StorageVendorProductFlashSystem:
-		sm, err := flashsystem.NewFlashSystemClonner(storageHostname, storageUsername, storagePassword, storageSkipSSLVerification == "true")
+		tokenCache := flashsystem.NewSecretTokenCache(clientSet, storageHostname)
+		sm, err := flashsystem.NewFlashSystemClonner(storageHostname, storageUsername, storagePassword, storageSkipSSLVerification == "true", tokenCache)
 		if err != nil {
 			klog.Fatalf("failed to initialize flashsystem storage mapper with %s", err)
 		}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -2192,7 +2192,7 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 		dst.Data[key] = value
 	}
 
-	for key, value := range dst.Data {
+	for key, value := range baseMigrationSecret.Data {
 		switch key {
 		case "user":
 			dst.Data["GOVMOMI_USERNAME"] = value
@@ -2202,6 +2202,20 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 			dst.Data["secretKey"] = value
 		case "insecureSkipVerify":
 			dst.Data["GOVMOMI_INSECURE"] = value
+		}
+	}
+
+	// Map storage vendor keys to the env var names the populator expects.
+	// Uses src.Data (the vendor secret) to avoid picking up overwritten
+	// keys from dst.Data.
+	for key, value := range src.Data {
+		switch key {
+		case "management_address":
+			dst.Data["STORAGE_HOSTNAME"] = value
+		case "username":
+			dst.Data["STORAGE_USERNAME"] = value
+		case "password":
+			dst.Data["STORAGE_PASSWORD"] = value
 		}
 	}
 
@@ -2337,22 +2351,29 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 		return err
 	}
 
-	// Create Role in openshift-mtv namespace for cross-namespace lease access
-	mtvRole := rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "populator-lease-reader",
-			Namespace: "openshift-mtv",
+	// Create or update Role in openshift-mtv namespace for cross-namespace lease + secret access
+	desiredRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"get", "list", "watch", "create", "update"},
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"coordination.k8s.io"},
-				Resources: []string{"leases"},
-				Verbs:     []string{"get", "list", "watch", "create", "update"},
-			},
+		{
+			APIGroups:     []string{""},
+			Resources:     []string{"secrets"},
+			Verbs:         []string{"get", "update", "patch"},
+			ResourceNames: []string{storageArraySecretName},
 		},
 	}
-	err = r.Destination.Client.Create(context.TODO(), &mtvRole, &client.CreateOptions{})
-	if err != nil && !k8serr.IsAlreadyExists(err) {
+	updatedMtvRole := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "populator-lease-reader", Namespace: storageArraySecretNSName}}
+	_, err = controllerutil.CreateOrPatch(
+		context.TODO(),
+		r.Destination.Client,
+		updatedMtvRole, func() error {
+			updatedMtvRole.Rules = desiredRules
+			return nil
+		})
+	if err != nil {
 		return err
 	}
 
@@ -2360,7 +2381,7 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 	mtvBinding := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "populator-lease-reader-binding",
-			Namespace: "openshift-mtv",
+			Namespace: storageArraySecretNSName,
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -2392,6 +2413,19 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 			return nil
 		})
 	if err != nil {
+		return err
+	}
+
+	// Pre-create the shared storage-array-secret so populator pods can
+	// cache FlashSystem auth tokens in it via Patch.
+	storageSecret := &core.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      storageArraySecretName,
+			Namespace: storageArraySecretNSName,
+		},
+		Data: map[string][]byte{},
+	}
+	if err := r.Destination.Create(context.TODO(), storageSecret, &client.CreateOptions{}); err != nil && !k8serr.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -2451,6 +2485,11 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 
 	return nil
 }
+
+const (
+	storageArraySecretName   = "storage-array-secret"
+	storageArraySecretNSName = "openshift-mtv"
+)
 
 // addSSHKeysToSecret adds SSH keys from provider controller to the migration secret
 func (r *Builder) addSSHKeysToSecret(secret *core.Secret) error {


### PR DESCRIPTION
## Summary
- Cache the FlashSystem REST API auth token in the existing `populator-secret` K8s Secret to prevent **429 Too Many Requests** errors when multiple populator pods authenticate concurrently
- IBM FlashSystem allows only **one valid token per user** — each auth call invalidates the previous token, creating a cascading re-auth storm that triggers 429
- Pods now read the cached token on startup (skipping auth), and on 403 (token expired) re-read the Secret with jitter before re-authenticating to avoid storms
- Auth endpoint retries on 429 with exponential backoff + jitter

## How it works
1. **Startup**: Read cached token from `populator-secret` → skip auth if found
2. **403 (token expired)**: Re-read Secret (another pod may have refreshed) → jitter → re-read again → auth only if still stale → cache new token
3. **429 on auth**: Retry up to 3x with exponential backoff (1s/2s/4s) + random jitter

Resolves: MTV-5631

## Test plan
- [ ] Deploy two+ FlashSystem populator pods simultaneously, verify only one auth call in logs
- [ ] Verify cached token is picked up by subsequent pods (check logs for "using cached FlashSystem auth token")
- [ ] Verify 403 recovery: wait for token expiry (~1h), confirm pods recover via cache re-read
- [ ] Verify 429 retry: artificially rate-limit auth endpoint, confirm retries with backoff in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)