### PR TITLE
MTV-5940 | fix OpenStack populator SIGSEGV when c.Log is nil

### DIFF
--- a/pkg/lib/client/openstack/client.go
+++ b/pkg/lib/client/openstack/client.go
@@ -175,7 +175,9 @@ func (c *Client) Authenticate() (err error) {
 func (c *Client) getTLSConfig() (tlsConfig *tls.Config, err error) {
 	identityUrl, err := url.Parse(c.URL)
 	if err != nil {
-		c.Log.Error(err, "error parsing the URL", "url", c.URL)
+		if c.Log != nil {
+			c.Log.Error(err, "error parsing the URL", "url", c.URL)
+		}
 		return
 	}
 	if identityUrl.Scheme == "https" {
@@ -188,7 +190,9 @@ func (c *Client) getTLSConfig() (tlsConfig *tls.Config, err error) {
 				cacert, hasCACert = util.GetCACert(c.secret)
 			}
 			if !hasCACert {
-				c.Log.Info("CA certificate was not provided,system CA cert pool is used")
+				if c.Log != nil {
+					c.Log.Info("CA certificate was not provided,system CA cert pool is used")
+				}
 			} else {
 				roots := x509.NewCertPool()
 				ok := roots.AppendCertsFromPEM(cacert)
@@ -205,6 +209,9 @@ func (c *Client) getTLSConfig() (tlsConfig *tls.Config, err error) {
 
 // Connect
 func (c *Client) Connect() (err error) {
+	if c.Log == nil {
+		c.Log = logging.WithName("openstack")
+	}
 	err = c.Authenticate()
 	if err != nil {
 		return


### PR DESCRIPTION
The OpenStack populator creates a bare `Client{}` without setting `c.Log`.
When `getTLSConfig()` tries to log "CA certificate was not provided" with
`insecureSkipVerify=false` and no CA cert, it dereferences nil and panics
with SIGSEGV.

Initialize a default logger in `Connect()` when `c.Log` is nil, and add
nil guards in `getTLSConfig()` as belt-and-suspenders protection.

Ref: https://redhat.atlassian.net/browse/MTV-5940
Resolves: MTV-5940