### PR TITLE
MTV-5750 | Fix seccomp profile for DI pod

### DIFF
--- a/pkg/controller/conversion/builder.go
+++ b/pkg/controller/conversion/builder.go
@@ -320,6 +320,13 @@ func (b *Builder) GetDeepInspectionPodSpec(volumes []core.Volume, volumeMounts [
 	}
 
 	seccompProfile := core.SeccompProfile{Type: core.SeccompProfileTypeRuntimeDefault}
+	if settings.Settings.OpenShift {
+		unshare := "profiles/unshare.json"
+		seccompProfile = core.SeccompProfile{
+			Type:             core.SeccompProfileTypeLocalhost,
+			LocalhostProfile: &unshare,
+		}
+	}
 
 	podLabels := make(map[string]string)
 	if cfg.PodLabels != nil {


### PR DESCRIPTION
Issue: DI pod was using onl the runtime default seccomp profile which blocked network request to the Tang server (network namespace isolation).

Fix: use localhost profile

Resolves: MTV-5750

Ref: https://redhat.atlassian.net/browse/MTV-5750