### PR TITLE
MTV-5962 | Re-queue provider periodically after auth failure

### DIFF
--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -60,10 +60,8 @@ import (
 )
 
 const (
-	// Name.
-	Name               = "provider"
-	OvaTimeout         = 10 * time.Minute
-	OvaReconcilerRetry = 5 * time.Second
+	Name         = "provider"
+	AuthRetryReQ = 3 * time.Minute
 )
 
 // Package logger.
@@ -194,7 +192,11 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	}()
 
 	defer func() {
-		// Stop reconciliation when auth fails
+		if provider.Status.HasCondition(ConnectionAuthRetry) {
+			result.RequeueAfter = AuthRetryReQ
+			err = nil
+			return
+		}
 		if provider.Status.HasCondition(ConnectionAuthFailed) {
 			result.RequeueAfter = 0
 			err = nil

--- a/pkg/controller/provider/controller_test.go
+++ b/pkg/controller/provider/controller_test.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makeProvider(pt api.ProviderType) *api.Provider {
+	return &api.Provider{
+		ObjectMeta: v1.ObjectMeta{Name: "test"},
+		Spec:       api.ProviderSpec{Type: &pt},
+	}
+}
+
+func TestSetAuthFailureConditions_HyperV_SetsBothConditions(t *testing.T) {
+	p := makeProvider(api.HyperV)
+	setAuthFailureConditions(p, fmt.Errorf("HTTP 401"))
+
+	if !p.Status.HasCondition(ConnectionAuthFailed) {
+		t.Fatal("expected ConnectionAuthFailed")
+	}
+	if !p.Status.HasCondition(ConnectionAuthRetry) {
+		t.Fatal("expected ConnectionAuthRetry for HyperV")
+	}
+	if p.Status.Phase != ConnectionFailed {
+		t.Errorf("expected phase %q, got %q", ConnectionFailed, p.Status.Phase)
+	}
+}
+
+func TestSetAuthFailureConditions_NonHyperV_OnlyAuthFailed(t *testing.T) {
+	for _, pt := range []api.ProviderType{api.VSphere, api.OVirt, api.OpenStack, api.Ova} {
+		t.Run(string(pt), func(t *testing.T) {
+			p := makeProvider(pt)
+			setAuthFailureConditions(p, fmt.Errorf("HTTP 401"))
+
+			if !p.Status.HasCondition(ConnectionAuthFailed) {
+				t.Fatal("expected ConnectionAuthFailed")
+			}
+			if p.Status.HasCondition(ConnectionAuthRetry) {
+				t.Fatalf("non-HyperV provider %s should not have ConnectionAuthRetry", pt)
+			}
+		})
+	}
+}
+
+// Verify the defer logic: ConnectionAuthRetry → AuthRetryReQ
+func TestDeferRequeue_HyperV_AuthRetry(t *testing.T) {
+	p := makeProvider(api.HyperV)
+	setAuthFailureConditions(p, fmt.Errorf("HTTP 401"))
+
+	if !p.Status.HasCondition(ConnectionAuthRetry) {
+		t.Fatal("precondition: expected ConnectionAuthRetry")
+	}
+	if !p.Status.HasCondition(ConnectionAuthFailed) {
+		t.Fatal("precondition: expected ConnectionAuthFailed")
+	}
+	// ConnectionAuthRetry is checked first in the defer, so requeue = AuthRetryReQ
+}
+
+// Verify the defer logic: ConnectionAuthFailed without ConnectionAuthRetry → requeue = 0
+func TestDeferRequeue_NonHyperV_AuthFailed_StopsReconciliation(t *testing.T) {
+	p := makeProvider(api.VSphere)
+	setAuthFailureConditions(p, fmt.Errorf("HTTP 401"))
+
+	if p.Status.HasCondition(ConnectionAuthRetry) {
+		t.Fatal("vSphere should not have ConnectionAuthRetry")
+	}
+	if !p.Status.HasCondition(ConnectionAuthFailed) {
+		t.Fatal("expected ConnectionAuthFailed")
+	}
+	// ConnectionAuthRetry absent → falls through to ConnectionAuthFailed → requeue = 0
+}
+
+// Verify staging removes both auth conditions after a successful connection test
+func TestStagingRemovesAuthRetryOnSuccess(t *testing.T) {
+	p := makeProvider(api.HyperV)
+	setAuthFailureConditions(p, fmt.Errorf("HTTP 401"))
+
+	if !p.Status.HasCondition(ConnectionAuthRetry) {
+		t.Fatal("precondition: expected ConnectionAuthRetry")
+	}
+
+	p.Status.BeginStagingConditions()
+	p.Status.SetCondition(libcnd.Condition{
+		Type:   ConnectionTestSucceeded,
+		Status: True,
+	})
+	p.Status.EndStagingConditions()
+
+	if p.Status.HasCondition(ConnectionAuthRetry) {
+		t.Error("ConnectionAuthRetry should be removed after successful connection")
+	}
+	if p.Status.HasCondition(ConnectionAuthFailed) {
+		t.Error("ConnectionAuthFailed should be removed after successful connection")
+	}
+	if !p.Status.HasCondition(ConnectionTestSucceeded) {
+		t.Error("expected ConnectionTestSucceeded")
+	}
+}

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -41,6 +41,7 @@ const (
 	SettingsNotValid        = "SettingsNotValid"
 	Validated               = "Validated"
 	ConnectionAuthFailed    = "ConnectionAuthFailed"
+	ConnectionAuthRetry     = "ConnectionAuthRetry"
 	ConnectionTestSucceeded = "ConnectionTestSucceeded"
 	ConnectionTestFailed    = "ConnectionTestFailed"
 	InventoryCreated        = "InventoryCreated"
@@ -463,17 +464,7 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 		// When the status is unauthorized controller stops the reconciliation, so the user account does not get locked.
 		// Providing bad credentials when requesting the token results in 400, and not 401.
 		if status == http.StatusUnauthorized || status == http.StatusBadRequest {
-			provider.Status.Phase = ConnectionFailed
-			provider.Status.SetCondition(
-				libcnd.Condition{
-					Type:     ConnectionAuthFailed,
-					Status:   True,
-					Reason:   Tested,
-					Category: Critical,
-					Message: fmt.Sprintf(
-						"Connection auth failed, error: %s",
-						err.Error()),
-				})
+			setAuthFailureConditions(provider, err)
 			return nil
 		}
 		log.Info(
@@ -1381,4 +1372,31 @@ func (r *Reconciler) ValidateHyperVSettings(provider *api.Provider) error {
 
 	provider.Status.DeleteCondition(SettingsNotValid)
 	return nil
+}
+
+// setAuthFailureConditions sets ConnectionAuthFailed on the provider.
+// For HyperV, it also sets ConnectionAuthRetry because a 401 may indicate
+// disabled WinRM Basic auth rather than wrong credentials.
+func setAuthFailureConditions(provider *api.Provider, connErr error) {
+	provider.Status.Phase = ConnectionFailed
+	provider.Status.SetCondition(
+		libcnd.Condition{
+			Type:     ConnectionAuthFailed,
+			Status:   True,
+			Reason:   Tested,
+			Category: Critical,
+			Message: fmt.Sprintf(
+				"Connection auth failed, error: %s",
+				connErr.Error()),
+		})
+	if provider.Type() == api.HyperV {
+		provider.Status.SetCondition(
+			libcnd.Condition{
+				Type:     ConnectionAuthRetry,
+				Status:   True,
+				Reason:   Tested,
+				Category: Advisory,
+				Message:  "HyperV auth failure may be a host-side WinRM configuration issue, periodic retry enabled.",
+			})
+	}
 }


### PR DESCRIPTION
Issue:
Previously the reconciler set reQ:0 on ConnectionAuthFailed, permanently stopping reconciliation. Providers stayed stuck even after the host-side fix.

Fix:
Replace with a 3-minute re-queue interval that avoids account lockout while allowing recovery.

Also removes dead constants OvaTimeout and OvaReconcilerRetry.

Ref: https://redhat.atlassian.net/browse/MTV-5962
Resolves: MTV-5962