### PR TITLE
MTV-5980 | Add Failover Cluster inventory support for Hyper-V provider

### DIFF
--- a/pkg/apis/forklift/v1beta1/provider.go
+++ b/pkg/apis/forklift/v1beta1/provider.go
@@ -86,6 +86,13 @@ const (
 	ESXiCloneMethodSSH = "ssh"
 )
 
+// Hyper-V management type setting key and values.
+const (
+	ManagementType   = "managementType"
+	HyperVStandalone = "standalone"
+	HyperVCluster    = "cluster"
+)
+
 const OvaProviderFinalizer = "forklift/ova-provider"
 const HyperVProviderFinalizer = "forklift/hyperv-provider"
 
@@ -199,4 +206,9 @@ func (p *Provider) UseVddkAioOptimization() bool {
 		return false
 	}
 	return parseBool
+}
+
+// Whether this Hyper-V provider is configured for Failover Cluster mode.
+func (p *Provider) IsHyperVCluster() bool {
+	return p.Type() == HyperV && p.Spec.Settings[ManagementType] == HyperVCluster
 }

--- a/pkg/controller/provider/container/hyperv/client.go
+++ b/pkg/controller/provider/container/hyperv/client.go
@@ -45,6 +45,42 @@ type securityInfo struct {
 	SecureBoot bool `json:"SecureBoot"`
 }
 
+// batchVMDetail holds the merged result of BatchGetVMHardware and BatchGetVMGuest for one VM.
+// JSON tags match PowerShell output format (PascalCase), not the model types.
+type batchVMDetail struct {
+	Security      securityInfo `json:"Security"`
+	HasCheckpoint bool         `json:"HasCheckpoint"`
+	Disks         []struct {
+		Path           string `json:"Path"`
+		Capacity       int64  `json:"Capacity"`
+		RCTEnabled     bool   `json:"RCTEnabled"`
+		ControllerType int    `json:"CT"`
+		ControllerNum  int    `json:"CN"`
+		ControllerLoc  int    `json:"CL"`
+	} `json:"Disks"`
+	NICs []struct {
+		Name       string `json:"Name"`
+		MACAddress string `json:"MAC"`
+		SwitchName string `json:"Switch"`
+		VlanId     int    `json:"Vlan"`
+	} `json:"NICs"`
+	GuestOS       string `json:"GuestOS"`
+	GuestNetworks []struct {
+		MAC     string   `json:"MAC"`
+		IPs     []string `json:"IPs"`
+		Subnets []string `json:"Subnets"`
+		DHCP    bool     `json:"DHCP"`
+		GW      []string `json:"GW"`
+		DNS     []string `json:"DNS"`
+	} `json:"GuestNetworks"`
+}
+
+// Cached cluster metadata, fetched once per collection cycle.
+type clusterCache struct {
+	cluster *driver.ClusterData
+	nodes   []driver.ClusterNodeData
+}
+
 // Client talks directly to HyperV host via WinRM.
 type Client struct {
 	driver           driver.HyperVDriver
@@ -54,6 +90,7 @@ type Client struct {
 	smbUrl           string
 	smbMountPath     string
 	smbWindowsPrefix string
+	cache            *clusterCache
 }
 
 // Connect establishes a WinRM connection to the HyperV host using Secret credentials.
@@ -91,21 +128,123 @@ func (r *Client) Connect(provider *api.Provider) (err error) {
 	return nil
 }
 
+// getClusterCache returns cached cluster+node data, fetching on first call per cycle.
+func (r *Client) getClusterCache() (*clusterCache, error) {
+	if r.cache != nil {
+		return r.cache, nil
+	}
+	clusterData, err := r.driver.GetCluster()
+	if err != nil {
+		return nil, fmt.Errorf("GetCluster failed: %w", err)
+	}
+	nodesData, err := r.driver.GetClusterNodes()
+	if err != nil {
+		return nil, fmt.Errorf("GetClusterNodes failed: %w", err)
+	}
+	r.cache = &clusterCache{cluster: clusterData, nodes: nodesData}
+	return r.cache, nil
+}
+
+// InvalidateClusterCache clears cached cluster data so the next call re-fetches.
+func (r *Client) InvalidateClusterCache() {
+	r.cache = nil
+}
+
+// ListCluster returns the cluster info when in cluster mode, nil for standalone.
+func (r *Client) ListCluster() (*types.Cluster, error) {
+	if r.provider == nil || !r.provider.IsHyperVCluster() {
+		return nil, nil //nolint:nilnil
+	}
+	cc, err := r.getClusterCache()
+	if err != nil {
+		return nil, err
+	}
+	var nodeNames []string
+	for _, n := range cc.nodes {
+		nodeNames = append(nodeNames, n.Name)
+	}
+	return &types.Cluster{
+		Name:   cc.cluster.Name,
+		Domain: cc.cluster.Domain,
+		Nodes:  nodeNames,
+	}, nil
+}
+
+// ListHosts returns the cluster hosts when in cluster mode.
+func (r *Client) ListHosts() ([]types.Host, error) {
+	if r.provider == nil || !r.provider.IsHyperVCluster() {
+		return nil, nil
+	}
+	cc, err := r.getClusterCache()
+	if err != nil {
+		return nil, err
+	}
+	var hosts []types.Host
+	for _, n := range cc.nodes {
+		host := types.Host{
+			ID:          n.Id,
+			Name:        n.Name,
+			State:       driver.ClusterNodeStateName(n.State),
+			ClusterName: cc.cluster.Name,
+		}
+		info, err := r.getNodeComputerInfo(n.Name)
+		if err != nil {
+			r.Log.V(1).Info("Failed to get hardware info for node", "node", n.Name, "error", err)
+		} else if info != nil {
+			host.CpuCount = info.NumberOfProcessors
+			host.CpuCores = info.NumberOfLogicalProcessors
+			host.MemoryMB = info.TotalVisibleMemoryKB / 1024
+		}
+		hosts = append(hosts, host)
+	}
+	return hosts, nil
+}
+
+// getNodeComputerInfo fetches hardware info from a specific cluster node.
+func (r *Client) getNodeComputerInfo(nodeName string) (*driver.ComputerInfoData, error) {
+	stdout, err := r.driver.RunOnNode(ps.GetComputerInfo, nodeName)
+	if err != nil {
+		return nil, err
+	}
+	if stdout == "" {
+		return nil, nil //nolint:nilnil
+	}
+	var info driver.ComputerInfoData
+	if err := json.Unmarshal([]byte(stdout), &info); err != nil {
+		return nil, fmt.Errorf("parse ComputerInfo: %w", err)
+	}
+	return &info, nil
+}
+
 // ListVMs collects all VMs from the HyperV host via WinRM.
+// In cluster mode, VMs are enriched with OwnerNode from cluster group data.
+// Uses batch PowerShell to minimize WinRM round trips.
 func (r *Client) ListVMs() ([]types.VM, error) {
 	networks, err := r.ListNetworks()
 	if err != nil {
 		return nil, err
 	}
 
-	domains, err := r.driver.ListAllDomains()
+	isCluster := r.provider != nil && r.provider.IsHyperVCluster()
+
+	var domains []driver.Domain
+	if isCluster {
+		domains, err = r.driver.ListAllClusterDomains()
+	} else {
+		domains, err = r.driver.ListAllDomains()
+	}
 	if err != nil {
 		return nil, err
 	}
 
 	var vms []types.VM
 	for _, domain := range domains {
-		vm, err := r.getVMFromDomain(domain, networks, r.smbWindowsPrefix)
+		var vm *types.VM
+		if isCluster {
+			vm, err = r.getVMBaseFromDomain(domain)
+		} else {
+			vm, err = r.getVMFromDomain(domain, networks, r.smbWindowsPrefix)
+		}
 		if err != nil {
 			r.Log.Error(err, "Failed to process domain")
 			_ = domain.Free()
@@ -115,9 +254,311 @@ func (r *Client) ListVMs() ([]types.VM, error) {
 		_ = domain.Free()
 	}
 
+	if isCluster {
+		r.enrichVMsWithOwnerNode(vms)
+	}
+
+	r.enrichVMDetails(vms, networks)
+
 	r.validateDisksOnSMB(vms)
 
 	return vms, nil
+}
+
+// enrichVMDetails populates VM security, checkpoints, disk capacity/RCT, guest OS,
+// and guest networks using batch PowerShell (per-node in cluster mode, local otherwise).
+func (r *Client) enrichVMDetails(vms []types.VM, networks []types.Network) {
+	if r.provider != nil && r.provider.IsHyperVCluster() {
+		// Group VMs by OwnerNode for per-node batch calls.
+		nodeVMs := make(map[string][]int)
+		for i := range vms {
+			node := vms[i].OwnerNode
+			nodeVMs[node] = append(nodeVMs[node], i)
+		}
+		for node, indices := range nodeVMs {
+			batchMap, err := r.collectBatchVMDetails(node)
+			if err != nil {
+				r.Log.Error(err, "Batch detail collection failed for node, falling back to per-VM", "node", node)
+				r.fallbackPerVMDetails(vms, indices, networks)
+				continue
+			}
+			r.applyBatchDetails(vms, indices, batchMap, networks)
+		}
+	} else {
+		// Standalone: single batch call for all VMs on this host.
+		allIndices := make([]int, len(vms))
+		for i := range vms {
+			allIndices[i] = i
+		}
+		batchMap, err := r.collectBatchVMDetails("")
+		if err != nil {
+			r.Log.Error(err, "Batch detail collection failed, falling back to per-VM")
+			r.fallbackPerVMDetails(vms, allIndices, networks)
+			return
+		}
+		r.applyBatchDetails(vms, allIndices, batchMap, networks)
+	}
+}
+
+// fallbackPerVMDetails collects details individually for the given VM indices.
+// Used when the batch script fails (e.g., older Windows versions).
+func (r *Client) fallbackPerVMDetails(vms []types.VM, indices []int, networks []types.Network) {
+	for _, idx := range indices {
+		vm := &vms[idx]
+		computerName := vm.OwnerNode
+
+		// If disks/NICs weren't populated (cluster mode with getVMBaseFromDomain),
+		// collect them per-VM as fallback.
+		if len(vm.Disks) == 0 {
+			vm.Disks = r.collectPerVMDisks(vm.Name, vm.UUID, computerName)
+		}
+		if len(vm.NICs) == 0 {
+			vm.NICs = r.collectPerVMNICs(vm.Name, computerName, networks)
+		}
+
+		if vm.Firmware == "uefi" {
+			si, err := r.collectSecurityInfo(vm.Name, computerName)
+			if err != nil {
+				r.Log.V(1).Info("Failed to collect security info", "vm", vm.Name, "error", err)
+			} else {
+				vm.TpmEnabled = si.TpmEnabled
+				vm.SecureBoot = si.SecureBoot
+			}
+		}
+
+		hasCheckpoint, err := r.collectHasCheckpoint(vm.Name, computerName)
+		if err != nil {
+			r.Log.V(1).Info("Failed to check for checkpoints", "vm", vm.Name, "error", err)
+		} else {
+			vm.HasCheckpoint = hasCheckpoint
+		}
+
+		for j := range vm.Disks {
+			vm.Disks[j].Capacity = r.getDiskCapacity(vm.Disks[j].WindowsPath, computerName)
+			vm.Disks[j].RCTEnabled = r.getDiskRCTEnabled(vm.Disks[j].WindowsPath, computerName)
+		}
+
+		if vm.PowerState == "On" {
+			guestOS, err := r.collectGuestOS(vm.Name, computerName)
+			if err != nil {
+				r.Log.V(1).Info("Guest OS detection failed", "vm", vm.Name, "error", err)
+			} else if guestOS != "" {
+				vm.GuestOS = guestOS
+			}
+
+			guestNetworks, err := r.collectGuestNetworkConfig(vm.Name, vm.NICs, computerName)
+			if err != nil {
+				r.Log.Info("KVP data collection failed", "vm", vm.Name, "error", err)
+			} else if len(guestNetworks) > 0 {
+				vm.GuestNetworks = guestNetworks
+			}
+		}
+	}
+}
+
+// enrichVMsWithOwnerNode maps cluster VM groups to VMs by name and sets OwnerNode.
+func (r *Client) enrichVMsWithOwnerNode(vms []types.VM) {
+	groups, err := r.driver.GetClusterVMGroups()
+	if err != nil {
+		r.Log.Error(err, "Failed to get cluster VM groups for OwnerNode enrichment")
+		return
+	}
+	ownerMap := make(map[string]string, len(groups))
+	for _, g := range groups {
+		ownerMap[g.Name] = g.OwnerNode
+	}
+	for i := range vms {
+		if owner, found := ownerMap[vms[i].Name]; found {
+			vms[i].OwnerNode = owner
+			vms[i].IsClusterRole = true
+		}
+	}
+}
+
+// collectBatchVMDetails runs the two batch PowerShell scripts (hardware + guest)
+// on the given node and returns a merged map of VM name -> details.
+func (r *Client) collectBatchVMDetails(computerName string) (map[string]*batchVMDetail, error) {
+	// Part 1: Security, checkpoints, disk capacity/RCT
+	hwOut, err := r.driver.RunOnNode(ps.BatchGetVMHardware, computerName)
+	if err != nil {
+		return nil, fmt.Errorf("batch hardware details failed: %w", err)
+	}
+	hwOut = strings.TrimSpace(hwOut)
+	result := make(map[string]*batchVMDetail)
+	if hwOut != "" && hwOut != "{}" && hwOut != "null" {
+		if err := json.Unmarshal([]byte(hwOut), &result); err != nil {
+			return nil, fmt.Errorf("parse batch hardware details: %w", err)
+		}
+	}
+
+	// Part 2: Guest OS and guest networks (only running VMs)
+	guestOut, err := r.driver.RunOnNode(ps.BatchGetVMGuest, computerName)
+	if err != nil {
+		r.Log.V(1).Info("Batch guest details failed, hardware details still usable", "node", computerName, "error", err)
+		return result, nil
+	}
+	guestOut = strings.TrimSpace(guestOut)
+	if guestOut == "" || guestOut == "{}" || guestOut == "null" {
+		return result, nil
+	}
+	var guestMap map[string]*batchVMDetail
+	if err := json.Unmarshal([]byte(guestOut), &guestMap); err != nil {
+		r.Log.V(1).Info("Parse batch guest details failed", "node", computerName, "error", err)
+		return result, nil
+	}
+
+	// Merge guest info into hardware results
+	for vmName, guest := range guestMap {
+		if hw, exists := result[vmName]; exists {
+			hw.GuestOS = guest.GuestOS
+			hw.GuestNetworks = guest.GuestNetworks
+		} else {
+			result[vmName] = guest
+		}
+	}
+	return result, nil
+}
+
+// applyBatchDetails enriches the VMs at the given indices with details from the batch script result.
+// In cluster mode (disks/NICs empty), it builds full Disk and NIC arrays from batch data.
+// In standalone mode (disks/NICs pre-populated), it only enriches capacity/RCT on existing disks.
+func (r *Client) applyBatchDetails(vms []types.VM, indices []int, batchMap map[string]*batchVMDetail, networks []types.Network) {
+	for _, i := range indices {
+		detail, found := batchMap[vms[i].Name]
+		if !found {
+			continue
+		}
+
+		vms[i].TpmEnabled = detail.Security.TpmEnabled
+		vms[i].SecureBoot = detail.Security.SecureBoot
+		vms[i].HasCheckpoint = detail.HasCheckpoint
+
+		if detail.GuestOS != "" {
+			vms[i].GuestOS = detail.GuestOS
+		}
+
+		if len(vms[i].Disks) == 0 && len(detail.Disks) > 0 {
+			// Cluster mode: build full disk array from batch data.
+			for j, bd := range detail.Disks {
+				if bd.Path == "" {
+					continue
+				}
+				smbPath := r.mapWindowsPathToSMB(bd.Path, r.smbWindowsPrefix)
+				format := "vhdx"
+				if strings.HasSuffix(strings.ToLower(bd.Path), ".vhd") {
+					format = "vhd"
+				}
+				vms[i].Disks = append(vms[i].Disks, types.Disk{
+					ID:          fmt.Sprintf("%s-disk-%d", vms[i].UUID, j),
+					WindowsPath: bd.Path,
+					SMBPath:     smbPath,
+					Capacity:    bd.Capacity,
+					RCTEnabled:  bd.RCTEnabled,
+					Format:      format,
+				})
+			}
+		} else {
+			// Standalone mode: enrich existing disks with capacity/RCT.
+			for j := range vms[i].Disks {
+				for _, bd := range detail.Disks {
+					if strings.EqualFold(
+						strings.ReplaceAll(vms[i].Disks[j].WindowsPath, "\\", "/"),
+						strings.ReplaceAll(bd.Path, "\\", "/")) {
+						vms[i].Disks[j].Capacity = bd.Capacity
+						vms[i].Disks[j].RCTEnabled = bd.RCTEnabled
+						break
+					}
+				}
+			}
+		}
+
+		if len(vms[i].NICs) == 0 && len(detail.NICs) > 0 {
+			// Cluster mode: build full NIC array from batch data.
+			for j, nd := range detail.NICs {
+				mac := formatMAC(nd.MACAddress)
+				vms[i].NICs = append(vms[i].NICs, types.NIC{
+					Name:        fmt.Sprintf("nic-%d", j),
+					MAC:         mac,
+					DeviceIndex: j,
+					NetworkUUID: resolveNetworkUUID(nd.SwitchName, networks),
+					NetworkName: nd.SwitchName,
+					VlanId:      nd.VlanId,
+				})
+			}
+		}
+
+		if len(detail.GuestNetworks) > 0 {
+			var cfgs []guestNetCfg
+			for _, g := range detail.GuestNetworks {
+				cfgs = append(cfgs, guestNetCfg(g))
+			}
+			vms[i].GuestNetworks = buildGuestNetworks(cfgs, vms[i].NICs)
+		}
+	}
+}
+
+type guestNetCfg struct {
+	MAC     string   `json:"MAC"`
+	IPs     []string `json:"IPs"`
+	Subnets []string `json:"Subnets"`
+	DHCP    bool     `json:"DHCP"`
+	GW      []string `json:"GW"`
+	DNS     []string `json:"DNS"`
+}
+
+// buildGuestNetworks converts raw PowerShell guest-network configs into typed GuestNetwork entries.
+// Shared by both the batch-enrichment and per-VM fallback paths.
+func buildGuestNetworks(cfgs []guestNetCfg, nics []types.NIC) []types.GuestNetwork {
+	var guestNetworks []types.GuestNetwork
+	for _, cfg := range cfgs {
+		mac := formatMAC(cfg.MAC)
+		deviceIndex := findNICDeviceIndex(mac, nics)
+		origin := "Manual"
+		if cfg.DHCP {
+			origin = "Dhcp"
+		}
+		for k, ip := range cfg.IPs {
+			parsedIP := net.ParseIP(ip)
+			if parsedIP == nil {
+				continue
+			}
+			isIPv4 := parsedIP.To4() != nil
+			gateway := ""
+			for _, gw := range cfg.GW {
+				gwIP := net.ParseIP(gw)
+				if gwIP == nil {
+					continue
+				}
+				if (gwIP.To4() != nil) == isIPv4 {
+					gateway = gw
+					break
+				}
+			}
+			var prefixLen int32
+			if k < len(cfg.Subnets) {
+				if isIPv4 {
+					prefixLen = subnetToPrefixLength(cfg.Subnets[k])
+				} else {
+					prefixLen = parseIPv6PrefixLength(cfg.Subnets[k])
+				}
+			} else if isIPv4 {
+				prefixLen = 24
+			} else {
+				prefixLen = 64
+			}
+			dns := filterDNSByFamily(cfg.DNS, isIPv4)
+			guestNetworks = append(guestNetworks, types.GuestNetwork{
+				MAC:          mac,
+				IP:           ip,
+				DeviceIndex:  deviceIndex,
+				Origin:       origin,
+				PrefixLength: prefixLen,
+				DNS:          dns,
+				Gateway:      gateway,
+			})
+		}
+	}
+	return guestNetworks
 }
 
 // validateDisksOnSMB calls the provider-server validation endpoint to verify
@@ -286,6 +727,49 @@ func (r *Client) ListDisks() ([]types.Disk, error) {
 	return disks, nil
 }
 
+// getVMBaseFromDomain extracts base VM metadata without disk/NIC WinRM calls.
+// Used in cluster mode where disks and NICs are collected in batch per node.
+func (r *Client) getVMBaseFromDomain(domain driver.Domain) (*types.VM, error) {
+	uuid, err := domain.GetUUIDString()
+	if err != nil {
+		return nil, err
+	}
+
+	name, err := domain.GetName()
+	if err != nil {
+		return nil, err
+	}
+
+	state, _, err := domain.GetState()
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := domain.GetInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	generation, err := domain.GetGeneration()
+	if err != nil {
+		r.Log.V(1).Info("Failed to get VM generation, defaulting to BIOS", "vm", name, "error", err)
+	}
+	firmware := "bios"
+	if generation == VMGenerationGen2 {
+		firmware = "uefi"
+	}
+
+	return &types.VM{
+		UUID:       uuid,
+		Name:       name,
+		PowerState: mapPowerState(state),
+		CpuCount:   int(info.NrVirtCpu),
+		MemoryMB:   int64(info.Memory / 1024),
+		Firmware:   firmware,
+		OwnerNode:  domain.GetComputerName(),
+	}, nil
+}
+
 func (r *Client) getVMFromDomain(domain driver.Domain, networks []types.Network, smbWindowsPrefix string) (*types.VM, error) {
 	uuid, err := domain.GetUUIDString()
 	if err != nil {
@@ -316,6 +800,8 @@ func (r *Client) getVMFromDomain(domain driver.Domain, networks []types.Network,
 		firmware = "uefi"
 	}
 
+	computerName := domain.GetComputerName()
+
 	vm := &types.VM{
 		UUID:       uuid,
 		Name:       name,
@@ -323,43 +809,11 @@ func (r *Client) getVMFromDomain(domain driver.Domain, networks []types.Network,
 		CpuCount:   int(info.NrVirtCpu),
 		MemoryMB:   int64(info.Memory / 1024), // KB to MB
 		Firmware:   firmware,
-	}
-
-	if generation == VMGenerationGen2 {
-		si, err := r.collectSecurityInfo(name)
-		if err != nil {
-			r.Log.V(1).Info("Failed to collect security info", "vm", name, "error", err)
-		} else {
-			vm.TpmEnabled = si.TpmEnabled
-			vm.SecureBoot = si.SecureBoot
-		}
-	}
-
-	hasCheckpoint, err := r.collectHasCheckpoint(name)
-	if err != nil {
-		r.Log.V(1).Info("Failed to check for checkpoints", "vm", name, "error", err)
-	} else {
-		vm.HasCheckpoint = hasCheckpoint
+		OwnerNode:  computerName,
 	}
 
 	vm.Disks = r.extractDisks(domain, smbWindowsPrefix, uuid)
 	vm.NICs = r.extractNICs(domain, networks)
-
-	if vm.PowerState == "On" {
-		guestOS, err := r.collectGuestOS(name)
-		if err != nil {
-			r.Log.V(1).Info("Guest OS detection failed", "vm", name, "error", err)
-		} else if guestOS != "" {
-			vm.GuestOS = guestOS
-		}
-
-		guestNetworks, err := r.collectGuestNetworkConfig(name, vm.NICs)
-		if err != nil {
-			r.Log.Info("KVP data collection failed", "vm", name, "error", err)
-		} else if len(guestNetworks) > 0 {
-			vm.GuestNetworks = guestNetworks
-		}
-	}
 
 	return vm, nil
 }
@@ -378,8 +832,6 @@ func (r *Client) extractDisks(domain driver.Domain, smbWindowsPrefix string, vmU
 		}
 
 		smbPath := r.mapWindowsPathToSMB(di.Path, smbWindowsPrefix)
-		capacity := r.getDiskCapacity(di.Path)
-		rctEnabled := r.getDiskRCTEnabled(di.Path)
 
 		format := "vhdx"
 		if strings.HasSuffix(strings.ToLower(di.Path), ".vhd") {
@@ -390,9 +842,7 @@ func (r *Client) extractDisks(domain driver.Domain, smbWindowsPrefix string, vmU
 			ID:          fmt.Sprintf("%s-disk-%d", vmUUID, i),
 			WindowsPath: di.Path,
 			SMBPath:     smbPath,
-			Capacity:    capacity,
 			Format:      format,
-			RCTEnabled:  rctEnabled,
 		})
 	}
 	return disks
@@ -422,6 +872,93 @@ func (r *Client) extractNICs(domain driver.Domain, networks []types.Network) []t
 	return nics
 }
 
+// collectPerVMDisks fetches disk info for a single VM on a specific node.
+// Used as fallback in cluster mode when the batch script fails.
+func (r *Client) collectPerVMDisks(vmName, vmUUID, computerName string) []types.Disk {
+	stdout, err := r.driver.RunOnNode(ps.BuildCommand(ps.GetVMDisks, vmName), computerName)
+	if err != nil {
+		r.Log.Error(err, "Failed to get disks per-VM", "vm", vmName)
+		return []types.Disk{}
+	}
+	if stdout == "" {
+		return []types.Disk{}
+	}
+	type diskData struct {
+		Path               string `json:"Path"`
+		ControllerType     int    `json:"ControllerType"`
+		ControllerNumber   int    `json:"ControllerNumber"`
+		ControllerLocation int    `json:"ControllerLocation"`
+	}
+	var disksData []diskData
+	if err := json.Unmarshal([]byte(stdout), &disksData); err != nil {
+		var single diskData
+		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
+			r.Log.Error(err, "Failed to parse disks JSON", "vm", vmName)
+			return []types.Disk{}
+		}
+		disksData = append(disksData, single)
+	}
+	var disks []types.Disk
+	for i, dd := range disksData {
+		if dd.Path == "" {
+			continue
+		}
+		smbPath := r.mapWindowsPathToSMB(dd.Path, r.smbWindowsPrefix)
+		format := "vhdx"
+		if strings.HasSuffix(strings.ToLower(dd.Path), ".vhd") {
+			format = "vhd"
+		}
+		disks = append(disks, types.Disk{
+			ID:          fmt.Sprintf("%s-disk-%d", vmUUID, i),
+			WindowsPath: dd.Path,
+			SMBPath:     smbPath,
+			Format:      format,
+		})
+	}
+	return disks
+}
+
+// collectPerVMNICs fetches NIC info for a single VM on a specific node.
+// Used as fallback in cluster mode when the batch script fails.
+func (r *Client) collectPerVMNICs(vmName, computerName string, networks []types.Network) []types.NIC {
+	stdout, err := r.driver.RunOnNode(ps.BuildCommand(ps.GetVMNICs, vmName), computerName)
+	if err != nil {
+		r.Log.Error(err, "Failed to get NICs per-VM", "vm", vmName)
+		return []types.NIC{}
+	}
+	if stdout == "" {
+		return []types.NIC{}
+	}
+	type nicData struct {
+		Name       string `json:"Name"`
+		MacAddress string `json:"MacAddress"`
+		SwitchName string `json:"SwitchName"`
+		VlanId     int    `json:"VlanId"`
+	}
+	var nicsData []nicData
+	if err := json.Unmarshal([]byte(stdout), &nicsData); err != nil {
+		var single nicData
+		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
+			r.Log.Error(err, "Failed to parse NICs JSON", "vm", vmName)
+			return []types.NIC{}
+		}
+		nicsData = append(nicsData, single)
+	}
+	var nics []types.NIC
+	for i, nd := range nicsData {
+		mac := formatMAC(nd.MacAddress)
+		nics = append(nics, types.NIC{
+			Name:        fmt.Sprintf("nic-%d", i),
+			MAC:         mac,
+			DeviceIndex: i,
+			NetworkUUID: resolveNetworkUUID(nd.SwitchName, networks),
+			NetworkName: nd.SwitchName,
+			VlanId:      nd.VlanId,
+		})
+	}
+	return nics
+}
+
 func formatMAC(mac string) string {
 	mac = strings.ReplaceAll(mac, "-", "")
 	mac = strings.ReplaceAll(mac, ":", "")
@@ -433,18 +970,18 @@ func formatMAC(mac string) string {
 	return mac
 }
 
-func (r *Client) collectGuestOS(vmName string) (string, error) {
+func (r *Client) collectGuestOS(vmName, computerName string) (string, error) {
 	script := ps.BuildCommand(ps.GetGuestOS, vmName)
-	stdout, err := r.driver.ExecuteCommand(script)
+	stdout, err := r.driver.RunOnNode(script, computerName)
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(stdout), nil
 }
 
-func (r *Client) collectSecurityInfo(vmName string) (*securityInfo, error) {
+func (r *Client) collectSecurityInfo(vmName, computerName string) (*securityInfo, error) {
 	script := ps.BuildCommand(ps.GetVMSecurityInfo, vmName, vmName, vmName)
-	stdout, err := r.driver.ExecuteCommand(script)
+	stdout, err := r.driver.RunOnNode(script, computerName)
 	if err != nil {
 		return nil, err
 	}
@@ -461,19 +998,22 @@ func (r *Client) collectSecurityInfo(vmName string) (*securityInfo, error) {
 	return &info, nil
 }
 
-func (r *Client) collectHasCheckpoint(vmName string) (bool, error) {
+func (r *Client) collectHasCheckpoint(vmName, computerName string) (bool, error) {
 	script := ps.BuildCommand(ps.GetVMHasCheckpoint, vmName)
-	stdout, err := r.driver.ExecuteCommand(script)
+	stdout, err := r.driver.RunOnNode(script, computerName)
 	if err != nil {
 		return false, err
 	}
-	result, _ := strconv.ParseBool(strings.TrimSpace(stdout))
+	result, err := strconv.ParseBool(strings.TrimSpace(stdout))
+	if err != nil {
+		return false, fmt.Errorf("parse checkpoint state for VM %q: %w", vmName, err)
+	}
 	return result, nil
 }
 
-func (r *Client) collectGuestNetworkConfig(vmName string, nics []types.NIC) ([]types.GuestNetwork, error) {
+func (r *Client) collectGuestNetworkConfig(vmName string, nics []types.NIC, computerName string) ([]types.GuestNetwork, error) {
 	script := ps.BuildCommand(ps.GetGuestNetworkConfig, vmName)
-	stdout, err := r.driver.ExecuteCommand(script)
+	stdout, err := r.driver.RunOnNode(script, computerName)
 	if err != nil {
 		return nil, err
 	}
@@ -482,86 +1022,16 @@ func (r *Client) collectGuestNetworkConfig(vmName string, nics []types.NIC) ([]t
 		return []types.GuestNetwork{}, nil
 	}
 
-	type guestNetConfig struct {
-		MAC     string   `json:"MAC"`
-		IPs     []string `json:"IPs"`
-		Subnets []string `json:"Subnets"`
-		DHCP    bool     `json:"DHCP"`
-		GW      []string `json:"GW"`
-		DNS     []string `json:"DNS"`
-	}
-
-	var configs []guestNetConfig
+	var configs []guestNetCfg
 	if err := json.Unmarshal([]byte(stdout), &configs); err != nil {
-		var single guestNetConfig
+		var single guestNetCfg
 		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
 			return nil, fmt.Errorf("failed to parse KVP JSON: %w", err)
 		}
 		configs = append(configs, single)
 	}
 
-	var guestNetworks []types.GuestNetwork
-	for _, cfg := range configs {
-		mac := cfg.MAC
-		if len(mac) == 12 && !strings.Contains(mac, ":") {
-			mac = fmt.Sprintf("%s:%s:%s:%s:%s:%s", mac[0:2], mac[2:4], mac[4:6], mac[6:8], mac[8:10], mac[10:12])
-		}
-
-		deviceIndex := findNICDeviceIndex(mac, nics)
-		origin := "Manual"
-		if cfg.DHCP {
-			origin = "Dhcp"
-		}
-
-		for i, ip := range cfg.IPs {
-			parsedIP := net.ParseIP(ip)
-			if parsedIP == nil {
-				continue
-			}
-
-			isIPv4 := parsedIP.To4() != nil
-
-			gateway := ""
-			for _, gw := range cfg.GW {
-				gwIP := net.ParseIP(gw)
-				if gwIP == nil {
-					continue
-				}
-				if (gwIP.To4() != nil) == isIPv4 {
-					gateway = gw
-					break
-				}
-			}
-
-			var prefixLen int32
-			if i < len(cfg.Subnets) {
-				if isIPv4 {
-					prefixLen = subnetToPrefixLength(cfg.Subnets[i])
-				} else {
-					prefixLen = parseIPv6PrefixLength(cfg.Subnets[i])
-				}
-			} else {
-				if isIPv4 {
-					prefixLen = 24
-				} else {
-					prefixLen = 64
-				}
-			}
-
-			dns := filterDNSByFamily(cfg.DNS, isIPv4)
-
-			guestNetworks = append(guestNetworks, types.GuestNetwork{
-				MAC:          mac,
-				IP:           ip,
-				DeviceIndex:  deviceIndex,
-				Origin:       origin,
-				PrefixLength: prefixLen,
-				DNS:          dns,
-				Gateway:      gateway,
-			})
-		}
-	}
-	return guestNetworks, nil
+	return buildGuestNetworks(configs, nics), nil
 }
 
 func filterDNSByFamily(dns []string, ipv4 bool) []string {
@@ -656,9 +1126,9 @@ func (r *Client) mapWindowsPathToSMB(windowsPath, smbWindowsPrefix string) strin
 	return ""
 }
 
-func (r *Client) getDiskCapacity(windowsPath string) int64 {
+func (r *Client) getDiskCapacity(windowsPath, computerName string) int64 {
 	command := ps.BuildCommand(ps.GetDiskCapacity, windowsPath)
-	stdout, err := r.driver.ExecuteCommand(command)
+	stdout, err := r.driver.RunOnNode(command, computerName)
 	if err != nil {
 		r.Log.Error(err, "Failed to get disk capacity", "path", windowsPath)
 		return 0
@@ -670,9 +1140,9 @@ func (r *Client) getDiskCapacity(windowsPath string) int64 {
 	return capacity
 }
 
-func (r *Client) getDiskRCTEnabled(windowsPath string) bool {
+func (r *Client) getDiskRCTEnabled(windowsPath, computerName string) bool {
 	command := ps.BuildCommand(ps.GetDiskRCTEnabled, windowsPath)
-	stdout, err := r.driver.ExecuteCommand(command)
+	stdout, err := r.driver.RunOnNode(command, computerName)
 	if err != nil {
 		r.Log.Error(err, "Failed to get disk RCT status", "path", windowsPath)
 		return false

--- a/pkg/controller/provider/container/hyperv/client_test.go
+++ b/pkg/controller/provider/container/hyperv/client_test.go
@@ -1,0 +1,852 @@
+package hyperv
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	"github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv/types"
+	"github.com/kubev2v/forklift/pkg/lib/hyperv/driver"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// mockDriver implements driver.HyperVDriver for unit tests.
+type mockDriver struct {
+	clusterData  *driver.ClusterData
+	clusterNodes []driver.ClusterNodeData
+	clusterVMs   []driver.ClusterGroupData
+	runOnNodeFn  func(command, computerName string) (string, error)
+}
+
+func (m *mockDriver) Connect() error                                           { return nil }
+func (m *mockDriver) Close() error                                             { return nil }
+func (m *mockDriver) IsAlive() (bool, error)                                   { return true, nil }
+func (m *mockDriver) ListAllDomains() ([]driver.Domain, error)                 { return nil, nil }
+func (m *mockDriver) ListAllClusterDomains() ([]driver.Domain, error)          { return nil, nil }
+func (m *mockDriver) LookupDomainByName(string) (driver.Domain, error)         { return nil, nil } //nolint:nilnil
+func (m *mockDriver) LookupDomainByUUIDString(string) (driver.Domain, error)   { return nil, nil } //nolint:nilnil
+func (m *mockDriver) ListAllNetworks() ([]driver.Network, error)               { return nil, nil }
+func (m *mockDriver) LookupNetworkByUUIDString(string) (driver.Network, error) { return nil, nil } //nolint:nilnil
+func (m *mockDriver) ExecuteCommand(string) (string, error)                    { return "", nil }
+func (m *mockDriver) GetComputerInfo() (*driver.ComputerInfoData, error)       { return nil, nil } //nolint:nilnil
+func (m *mockDriver) GetCluster() (*driver.ClusterData, error)                 { return m.clusterData, nil }
+func (m *mockDriver) GetClusterNodes() ([]driver.ClusterNodeData, error)       { return m.clusterNodes, nil }
+func (m *mockDriver) GetClusterVMGroups() ([]driver.ClusterGroupData, error) {
+	return m.clusterVMs, nil
+}
+func (m *mockDriver) RunOnNode(command, computerName string) (string, error) {
+	if m.runOnNodeFn != nil {
+		return m.runOnNodeFn(command, computerName)
+	}
+	return "", nil
+}
+
+func newClusterProvider() *api.Provider {
+	pt := api.HyperV
+	return &api.Provider{
+		ObjectMeta: v1.ObjectMeta{Name: "test-provider"},
+		Spec: api.ProviderSpec{
+			Type:     &pt,
+			Settings: map[string]string{api.ManagementType: api.HyperVCluster},
+		},
+	}
+}
+
+func newStandaloneProvider() *api.Provider {
+	pt := api.HyperV
+	return &api.Provider{
+		ObjectMeta: v1.ObjectMeta{Name: "test-provider"},
+		Spec: api.ProviderSpec{
+			Type:     &pt,
+			Settings: map[string]string{api.ManagementType: api.HyperVStandalone},
+		},
+	}
+}
+
+// testLogger returns a LevelLogger suitable for unit tests.
+func testLogger() logging.LevelLogger {
+	return logging.WithName("test")
+}
+
+func TestParseBatchVMDetails(t *testing.T) {
+	payload := `{
+		"vm-linux-01": {
+			"Security": {"TpmEnabled": false, "SecureBoot": false},
+			"HasCheckpoint": true,
+			"Disks": [
+				{"Path": "C:\\VMs\\vm-linux-01\\disk0.vhdx", "Capacity": 42949672960, "RCTEnabled": true},
+				{"Path": "C:\\VMs\\vm-linux-01\\disk1.vhdx", "Capacity": 10737418240, "RCTEnabled": false}
+			],
+			"GuestOS": "Red Hat Enterprise Linux 9",
+			"GuestNetworks": [
+				{"MAC": "00155D010101", "IPs": ["192.168.1.10"], "Subnets": ["255.255.255.0"], "DHCP": false, "GW": ["192.168.1.1"], "DNS": ["8.8.8.8"]}
+			]
+		},
+		"vm-win-02": {
+			"Security": {"TpmEnabled": true, "SecureBoot": true},
+			"HasCheckpoint": false,
+			"Disks": [
+				{"Path": "C:\\VMs\\vm-win-02\\os.vhdx", "Capacity": 107374182400, "RCTEnabled": true}
+			],
+			"GuestOS": "Microsoft Windows Server 2022 Standard"
+		}
+	}`
+
+	var result map[string]*batchVMDetail
+	if err := json.Unmarshal([]byte(payload), &result); err != nil {
+		t.Fatalf("Failed to parse batch payload: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 VMs, got %d", len(result))
+	}
+
+	linux := result["vm-linux-01"]
+	if linux == nil {
+		t.Fatal("vm-linux-01 not found in results")
+	}
+	if linux.Security.TpmEnabled {
+		t.Error("Expected TpmEnabled=false for vm-linux-01")
+	}
+	if !linux.HasCheckpoint {
+		t.Error("Expected HasCheckpoint=true for vm-linux-01")
+	}
+	if len(linux.Disks) != 2 {
+		t.Fatalf("Expected 2 disks for vm-linux-01, got %d", len(linux.Disks))
+	}
+	if linux.Disks[0].Capacity != 42949672960 {
+		t.Errorf("Expected disk0 capacity 42949672960, got %d", linux.Disks[0].Capacity)
+	}
+	if !linux.Disks[0].RCTEnabled {
+		t.Error("Expected disk0 RCTEnabled=true")
+	}
+	if linux.GuestOS != "Red Hat Enterprise Linux 9" {
+		t.Errorf("Expected GuestOS 'Red Hat Enterprise Linux 9', got '%s'", linux.GuestOS)
+	}
+	if len(linux.GuestNetworks) != 1 {
+		t.Fatalf("Expected 1 guest network, got %d", len(linux.GuestNetworks))
+	}
+	if linux.GuestNetworks[0].MAC != "00155D010101" {
+		t.Errorf("Expected MAC '00155D010101', got '%s'", linux.GuestNetworks[0].MAC)
+	}
+
+	win := result["vm-win-02"]
+	if win == nil {
+		t.Fatal("vm-win-02 not found in results")
+	}
+	if !win.Security.TpmEnabled || !win.Security.SecureBoot {
+		t.Error("Expected TPM and SecureBoot enabled for vm-win-02")
+	}
+	if win.HasCheckpoint {
+		t.Error("Expected HasCheckpoint=false for vm-win-02")
+	}
+	if len(win.Disks) != 1 {
+		t.Errorf("Expected 1 disk for vm-win-02, got %d", len(win.Disks))
+	}
+}
+
+func TestApplyBatchDetails(t *testing.T) {
+	vms := []types.VM{
+		{
+			Name:      "vm-linux-01",
+			Firmware:  "bios",
+			OwnerNode: "node1",
+			Disks: []types.Disk{
+				{WindowsPath: `C:\VMs\vm-linux-01\disk0.vhdx`},
+				{WindowsPath: `C:\VMs\vm-linux-01\disk1.vhdx`},
+			},
+			NICs: []types.NIC{
+				{Name: "nic-0", MAC: "00:15:5D:01:01:01", DeviceIndex: 0},
+			},
+		},
+		{
+			Name:      "vm-win-02",
+			Firmware:  "uefi",
+			OwnerNode: "node1",
+			Disks: []types.Disk{
+				{WindowsPath: `C:\VMs\vm-win-02\os.vhdx`},
+			},
+		},
+	}
+
+	batchMap := map[string]*batchVMDetail{
+		"vm-linux-01": {
+			HasCheckpoint: true,
+			Disks: []struct {
+				Path           string `json:"Path"`
+				Capacity       int64  `json:"Capacity"`
+				RCTEnabled     bool   `json:"RCTEnabled"`
+				ControllerType int    `json:"CT"`
+				ControllerNum  int    `json:"CN"`
+				ControllerLoc  int    `json:"CL"`
+			}{
+				{Path: `C:\VMs\vm-linux-01\disk0.vhdx`, Capacity: 42949672960, RCTEnabled: true, ControllerType: 1},
+				{Path: `C:\VMs\vm-linux-01\disk1.vhdx`, Capacity: 10737418240, RCTEnabled: false, ControllerType: 1},
+			},
+			GuestOS: "Red Hat Enterprise Linux 9",
+			GuestNetworks: []struct {
+				MAC     string   `json:"MAC"`
+				IPs     []string `json:"IPs"`
+				Subnets []string `json:"Subnets"`
+				DHCP    bool     `json:"DHCP"`
+				GW      []string `json:"GW"`
+				DNS     []string `json:"DNS"`
+			}{
+				{
+					MAC:     "00155D010101",
+					IPs:     []string{"192.168.1.10"},
+					Subnets: []string{"255.255.255.0"},
+					DHCP:    false,
+					GW:      []string{"192.168.1.1"},
+					DNS:     []string{"8.8.8.8"},
+				},
+			},
+		},
+		"vm-win-02": {
+			Disks: []struct {
+				Path           string `json:"Path"`
+				Capacity       int64  `json:"Capacity"`
+				RCTEnabled     bool   `json:"RCTEnabled"`
+				ControllerType int    `json:"CT"`
+				ControllerNum  int    `json:"CN"`
+				ControllerLoc  int    `json:"CL"`
+			}{
+				{Path: `C:\VMs\vm-win-02\os.vhdx`, Capacity: 107374182400, RCTEnabled: true, ControllerType: 1},
+			},
+		},
+	}
+	batchMap["vm-win-02"].Security.TpmEnabled = true
+	batchMap["vm-win-02"].Security.SecureBoot = true
+
+	client := &Client{}
+	allIndices := []int{0, 1}
+	client.applyBatchDetails(vms, allIndices, batchMap, nil)
+
+	// Verify vm-linux-01
+	if !vms[0].HasCheckpoint {
+		t.Error("vm-linux-01: expected HasCheckpoint=true")
+	}
+	if vms[0].GuestOS != "Red Hat Enterprise Linux 9" {
+		t.Errorf("vm-linux-01: expected GuestOS 'Red Hat Enterprise Linux 9', got '%s'", vms[0].GuestOS)
+	}
+	if vms[0].Disks[0].Capacity != 42949672960 {
+		t.Errorf("vm-linux-01 disk0: expected capacity 42949672960, got %d", vms[0].Disks[0].Capacity)
+	}
+	if !vms[0].Disks[0].RCTEnabled {
+		t.Error("vm-linux-01 disk0: expected RCTEnabled=true")
+	}
+	if vms[0].Disks[1].Capacity != 10737418240 {
+		t.Errorf("vm-linux-01 disk1: expected capacity 10737418240, got %d", vms[0].Disks[1].Capacity)
+	}
+	if vms[0].Disks[1].RCTEnabled {
+		t.Error("vm-linux-01 disk1: expected RCTEnabled=false")
+	}
+	if len(vms[0].GuestNetworks) != 1 {
+		t.Fatalf("vm-linux-01: expected 1 guest network, got %d", len(vms[0].GuestNetworks))
+	}
+	if vms[0].GuestNetworks[0].IP != "192.168.1.10" {
+		t.Errorf("vm-linux-01: expected guest IP '192.168.1.10', got '%s'", vms[0].GuestNetworks[0].IP)
+	}
+	if vms[0].GuestNetworks[0].PrefixLength != 24 {
+		t.Errorf("vm-linux-01: expected prefix length 24, got %d", vms[0].GuestNetworks[0].PrefixLength)
+	}
+	// MAC should be normalized to colon-separated format
+	expectedMAC := "00:15:5D:01:01:01"
+	if vms[0].GuestNetworks[0].MAC != expectedMAC {
+		t.Errorf("vm-linux-01: expected MAC '%s', got '%s'", expectedMAC, vms[0].GuestNetworks[0].MAC)
+	}
+
+	// Verify vm-win-02
+	if !vms[1].TpmEnabled {
+		t.Error("vm-win-02: expected TpmEnabled=true")
+	}
+	if !vms[1].SecureBoot {
+		t.Error("vm-win-02: expected SecureBoot=true")
+	}
+	if vms[1].Disks[0].Capacity != 107374182400 {
+		t.Errorf("vm-win-02 disk0: expected capacity 107374182400, got %d", vms[1].Disks[0].Capacity)
+	}
+	if !vms[1].Disks[0].RCTEnabled {
+		t.Error("vm-win-02 disk0: expected RCTEnabled=true")
+	}
+}
+
+func TestApplyBatchDetails_DiskPathNormalization(t *testing.T) {
+	vms := []types.VM{
+		{
+			Name: "test-vm",
+			Disks: []types.Disk{
+				{WindowsPath: `C:\VMs\test\disk.vhdx`},
+			},
+		},
+	}
+
+	batchMap := map[string]*batchVMDetail{
+		"test-vm": {
+			Disks: []struct {
+				Path           string `json:"Path"`
+				Capacity       int64  `json:"Capacity"`
+				RCTEnabled     bool   `json:"RCTEnabled"`
+				ControllerType int    `json:"CT"`
+				ControllerNum  int    `json:"CN"`
+				ControllerLoc  int    `json:"CL"`
+			}{
+				// Path uses forward slashes — should still match
+				{Path: "C:/VMs/test/disk.vhdx", Capacity: 5368709120, RCTEnabled: true},
+			},
+		},
+	}
+
+	client := &Client{}
+	client.applyBatchDetails(vms, []int{0}, batchMap, nil)
+
+	if vms[0].Disks[0].Capacity != 5368709120 {
+		t.Errorf("Expected capacity 5368709120, got %d (path normalization failed)", vms[0].Disks[0].Capacity)
+	}
+}
+
+func TestApplyBatchDetails_ClusterModeBuildDisksAndNICs(t *testing.T) {
+	networks := []types.Network{
+		{UUID: "switch-uuid-1", Name: "External Switch"},
+	}
+	// Cluster mode: VMs have no disks/NICs pre-populated
+	vms := []types.VM{
+		{Name: "vm-cluster-01", UUID: "uuid-01"},
+	}
+
+	batchMap := map[string]*batchVMDetail{
+		"vm-cluster-01": {
+			Disks: []struct {
+				Path           string `json:"Path"`
+				Capacity       int64  `json:"Capacity"`
+				RCTEnabled     bool   `json:"RCTEnabled"`
+				ControllerType int    `json:"CT"`
+				ControllerNum  int    `json:"CN"`
+				ControllerLoc  int    `json:"CL"`
+			}{
+				{Path: `C:\VMs\vm-cluster-01\os.vhdx`, Capacity: 42949672960, RCTEnabled: true, ControllerType: 1, ControllerNum: 0, ControllerLoc: 0},
+				{Path: `C:\VMs\vm-cluster-01\data.vhd`, Capacity: 10737418240, RCTEnabled: false, ControllerType: 1, ControllerNum: 0, ControllerLoc: 1},
+			},
+			NICs: []struct {
+				Name       string `json:"Name"`
+				MACAddress string `json:"MAC"`
+				SwitchName string `json:"Switch"`
+				VlanId     int    `json:"Vlan"`
+			}{
+				{Name: "Network Adapter", MACAddress: "00155D010101", SwitchName: "External Switch", VlanId: 100},
+			},
+		},
+	}
+
+	client := &Client{Log: testLogger()}
+	client.applyBatchDetails(vms, []int{0}, batchMap, networks)
+
+	if len(vms[0].Disks) != 2 {
+		t.Fatalf("Expected 2 disks, got %d", len(vms[0].Disks))
+	}
+	if vms[0].Disks[0].ID != "uuid-01-disk-0" {
+		t.Errorf("Expected disk ID 'uuid-01-disk-0', got '%s'", vms[0].Disks[0].ID)
+	}
+	if vms[0].Disks[0].Capacity != 42949672960 {
+		t.Errorf("Expected capacity 42949672960, got %d", vms[0].Disks[0].Capacity)
+	}
+	if !vms[0].Disks[0].RCTEnabled {
+		t.Error("Expected RCTEnabled=true for disk 0")
+	}
+	if vms[0].Disks[0].Format != "vhdx" {
+		t.Errorf("Expected format 'vhdx', got '%s'", vms[0].Disks[0].Format)
+	}
+	if vms[0].Disks[1].Format != "vhd" {
+		t.Errorf("Expected format 'vhd' for .vhd file, got '%s'", vms[0].Disks[1].Format)
+	}
+
+	if len(vms[0].NICs) != 1 {
+		t.Fatalf("Expected 1 NIC, got %d", len(vms[0].NICs))
+	}
+	if vms[0].NICs[0].MAC != "00:15:5D:01:01:01" {
+		t.Errorf("Expected normalized MAC '00:15:5D:01:01:01', got '%s'", vms[0].NICs[0].MAC)
+	}
+	if vms[0].NICs[0].NetworkUUID != "switch-uuid-1" {
+		t.Errorf("Expected NetworkUUID 'switch-uuid-1', got '%s'", vms[0].NICs[0].NetworkUUID)
+	}
+	if vms[0].NICs[0].VlanId != 100 {
+		t.Errorf("Expected VlanId 100, got %d", vms[0].NICs[0].VlanId)
+	}
+}
+
+func TestApplyBatchDetails_EmptyBatch(t *testing.T) {
+	vms := []types.VM{
+		{Name: "orphan-vm", Disks: []types.Disk{{WindowsPath: `D:\vhd\x.vhdx`}}},
+	}
+
+	batchMap := map[string]*batchVMDetail{}
+
+	client := &Client{}
+	client.applyBatchDetails(vms, []int{0}, batchMap, nil)
+
+	if vms[0].Disks[0].Capacity != 0 {
+		t.Error("Expected no change for VM not in batch")
+	}
+}
+
+func TestBatchVMDetailsJSON_RealFormat(t *testing.T) {
+	// Simulates the actual PowerShell ConvertTo-Json output format
+	payload := `{"vm-01":{"Security":{"TpmEnabled":false,"SecureBoot":false},"HasCheckpoint":false,"Disks":[],"GuestOS":"","GuestNetworks":null}}`
+
+	var result map[string]*batchVMDetail
+	if err := json.Unmarshal([]byte(payload), &result); err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+	if result["vm-01"] == nil {
+		t.Fatal("vm-01 not found")
+	}
+	if result["vm-01"].HasCheckpoint {
+		t.Error("Expected HasCheckpoint=false")
+	}
+	if len(result["vm-01"].Disks) != 0 {
+		t.Error("Expected empty disk array")
+	}
+}
+
+func TestMapWindowsPathToSMB(t *testing.T) {
+	client := &Client{
+		smbMountPath: "/mnt/smb/hyperv-share",
+		Log:          testLogger(),
+	}
+
+	tests := []struct {
+		name             string
+		windowsPath      string
+		smbWindowsPrefix string
+		expected         string
+	}{
+		{
+			name:             "standard path mapping",
+			windowsPath:      `C:\ClusterStorage\VMs\test\disk.vhdx`,
+			smbWindowsPrefix: `C:\ClusterStorage\VMs`,
+			expected:         "/mnt/smb/hyperv-share/test/disk.vhdx",
+		},
+		{
+			name:             "case insensitive prefix matching",
+			windowsPath:      `c:\clusterstorage\vms\test\disk.vhdx`,
+			smbWindowsPrefix: `C:\ClusterStorage\VMs`,
+			expected:         "/mnt/smb/hyperv-share/test/disk.vhdx",
+		},
+		{
+			name:             "no match returns empty",
+			windowsPath:      `D:\Other\disk.vhdx`,
+			smbWindowsPrefix: `C:\ClusterStorage\VMs`,
+			expected:         "",
+		},
+		{
+			name:             "empty prefix returns empty",
+			windowsPath:      `C:\VMs\disk.vhdx`,
+			smbWindowsPrefix: "",
+			expected:         "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := client.mapWindowsPathToSMB(tc.windowsPath, tc.smbWindowsPrefix)
+			if result != tc.expected {
+				t.Errorf("Expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestFormatMAC(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"00155D010101", "00:15:5D:01:01:01"},
+		{"00-15-5D-01-01-01", "00:15:5D:01:01:01"},
+		{"00:15:5D:01:01:01", "00:15:5D:01:01:01"},
+		{"short", "SHORT"},
+	}
+
+	for _, tc := range tests {
+		result := formatMAC(tc.input)
+		if result != tc.expected {
+			t.Errorf("formatMAC(%q) = %q, want %q", tc.input, result, tc.expected)
+		}
+	}
+}
+
+func TestListCluster_ClusterMode(t *testing.T) {
+	md := &mockDriver{
+		clusterData: &driver.ClusterData{Name: "cluster01", Domain: "lab.local"},
+		clusterNodes: []driver.ClusterNodeData{
+			{Name: "node-a", State: 0, Id: "id-a"},
+			{Name: "node-b", State: 0, Id: "id-b"},
+		},
+	}
+	client := &Client{driver: md, provider: newClusterProvider(), Log: testLogger()}
+
+	cluster, err := client.ListCluster()
+	if err != nil {
+		t.Fatalf("ListCluster error: %v", err)
+	}
+	if cluster == nil {
+		t.Fatal("Expected non-nil cluster")
+	}
+	if cluster.Name != "cluster01" {
+		t.Errorf("Expected cluster name 'cluster01', got '%s'", cluster.Name)
+	}
+	if cluster.Domain != "lab.local" {
+		t.Errorf("Expected domain 'lab.local', got '%s'", cluster.Domain)
+	}
+	if len(cluster.Nodes) != 2 {
+		t.Fatalf("Expected 2 nodes, got %d", len(cluster.Nodes))
+	}
+	if cluster.Nodes[0] != "node-a" || cluster.Nodes[1] != "node-b" {
+		t.Errorf("Unexpected node names: %v", cluster.Nodes)
+	}
+}
+
+func TestListCluster_StandaloneReturnsNil(t *testing.T) {
+	client := &Client{provider: newStandaloneProvider(), Log: testLogger()}
+
+	cluster, err := client.ListCluster()
+	if err != nil {
+		t.Fatalf("ListCluster error: %v", err)
+	}
+	if cluster != nil {
+		t.Error("Expected nil cluster for standalone provider")
+	}
+}
+
+func TestListHosts_ClusterMode(t *testing.T) {
+	computerInfoJSON := `{"CsDNSHostName":"node-a","CsDomain":"lab.local","CsNumberOfProcessors":2,"CsNumberOfLogicalProcessors":8,"OsTotalVisibleMemorySize":16777216}`
+	md := &mockDriver{
+		clusterData: &driver.ClusterData{Name: "cluster01", Domain: "lab.local"},
+		clusterNodes: []driver.ClusterNodeData{
+			{Name: "node-a", State: 0, Id: "id-a"},
+		},
+		runOnNodeFn: func(command, computerName string) (string, error) {
+			return computerInfoJSON, nil
+		},
+	}
+	client := &Client{driver: md, provider: newClusterProvider(), Log: testLogger()}
+
+	hosts, err := client.ListHosts()
+	if err != nil {
+		t.Fatalf("ListHosts error: %v", err)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("Expected 1 host, got %d", len(hosts))
+	}
+	if hosts[0].Name != "node-a" {
+		t.Errorf("Expected host name 'node-a', got '%s'", hosts[0].Name)
+	}
+	if hosts[0].State != "Up" {
+		t.Errorf("Expected state 'Up', got '%s'", hosts[0].State)
+	}
+	if hosts[0].CpuCount != 2 {
+		t.Errorf("Expected 2 CPU sockets, got %d", hosts[0].CpuCount)
+	}
+	if hosts[0].CpuCores != 8 {
+		t.Errorf("Expected 8 logical processors, got %d", hosts[0].CpuCores)
+	}
+	if hosts[0].MemoryMB != 16384 {
+		t.Errorf("Expected 16384 MB memory, got %d", hosts[0].MemoryMB)
+	}
+	if hosts[0].ClusterName != "cluster01" {
+		t.Errorf("Expected cluster 'cluster01', got '%s'", hosts[0].ClusterName)
+	}
+}
+
+func TestListHosts_StandaloneReturnsNil(t *testing.T) {
+	client := &Client{provider: newStandaloneProvider(), Log: testLogger()}
+
+	hosts, err := client.ListHosts()
+	if err != nil {
+		t.Fatalf("ListHosts error: %v", err)
+	}
+	if hosts != nil {
+		t.Error("Expected nil hosts for standalone provider")
+	}
+}
+
+func TestGetClusterCache_Caching(t *testing.T) {
+	callCount := 0
+	md := &mockDriver{
+		clusterData:  &driver.ClusterData{Name: "c1"},
+		clusterNodes: []driver.ClusterNodeData{{Name: "n1", State: 0, Id: "1"}},
+	}
+	origGetCluster := md.GetCluster
+	_ = origGetCluster
+	client := &Client{driver: md, provider: newClusterProvider(), Log: testLogger()}
+
+	// Wrap to count calls
+	md2 := &countingMockDriver{mockDriver: md, getClusterCalls: &callCount}
+	client.driver = md2
+
+	cc1, err := client.getClusterCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cc2, err := client.getClusterCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cc1 != cc2 {
+		t.Error("Expected same cache object on second call")
+	}
+	if callCount != 1 {
+		t.Errorf("Expected 1 GetCluster call (cached), got %d", callCount)
+	}
+
+	client.InvalidateClusterCache()
+	_, err = client.getClusterCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callCount != 2 {
+		t.Errorf("Expected 2 GetCluster calls after invalidation, got %d", callCount)
+	}
+}
+
+type countingMockDriver struct {
+	*mockDriver
+	getClusterCalls *int
+}
+
+func (c *countingMockDriver) GetCluster() (*driver.ClusterData, error) {
+	*c.getClusterCalls++
+	return c.mockDriver.GetCluster()
+}
+
+func TestEnrichVMsWithOwnerNode(t *testing.T) {
+	md := &mockDriver{
+		clusterVMs: []driver.ClusterGroupData{
+			{Name: "vm-web", OwnerNode: "node-a", State: 0, Id: "g1"},
+			{Name: "vm-db", OwnerNode: "node-b", State: 0, Id: "g2"},
+		},
+	}
+	client := &Client{driver: md, Log: testLogger()}
+
+	vms := []types.VM{
+		{Name: "vm-web"},
+		{Name: "vm-db"},
+		{Name: "vm-orphan"},
+	}
+	client.enrichVMsWithOwnerNode(vms)
+
+	if vms[0].OwnerNode != "node-a" {
+		t.Errorf("vm-web: expected OwnerNode 'node-a', got '%s'", vms[0].OwnerNode)
+	}
+	if !vms[0].IsClusterRole {
+		t.Error("vm-web: expected IsClusterRole=true")
+	}
+	if vms[1].OwnerNode != "node-b" {
+		t.Errorf("vm-db: expected OwnerNode 'node-b', got '%s'", vms[1].OwnerNode)
+	}
+	if !vms[1].IsClusterRole {
+		t.Error("vm-db: expected IsClusterRole=true")
+	}
+	if vms[2].OwnerNode != "" {
+		t.Errorf("vm-orphan: expected empty OwnerNode, got '%s'", vms[2].OwnerNode)
+	}
+	if vms[2].IsClusterRole {
+		t.Error("vm-orphan: expected IsClusterRole=false")
+	}
+}
+
+func TestCollectBatchVMDetails_MergesHardwareAndGuest(t *testing.T) {
+	hwJSON := `{"vm-01":{"Security":{"TpmEnabled":true,"SecureBoot":true},"HasCheckpoint":false,"Disks":[{"Path":"C:\\disk.vhdx","Capacity":1000,"RCTEnabled":true}]}}`
+	guestJSON := `{"vm-01":{"GuestOS":"RHEL 9","GuestNetworks":[{"MAC":"00155D010101","IPs":["10.0.0.1"],"Subnets":["255.255.255.0"],"DHCP":false,"GW":["10.0.0.1"],"DNS":["8.8.8.8"]}]}}`
+	callNum := 0
+	md := &mockDriver{
+		runOnNodeFn: func(command, computerName string) (string, error) {
+			callNum++
+			if callNum == 1 {
+				return hwJSON, nil
+			}
+			return guestJSON, nil
+		},
+	}
+	client := &Client{driver: md, Log: testLogger()}
+
+	result, err := client.collectBatchVMDetails("node-a")
+	if err != nil {
+		t.Fatalf("collectBatchVMDetails error: %v", err)
+	}
+	vm, found := result["vm-01"]
+	if !found {
+		t.Fatal("vm-01 not found")
+	}
+	if !vm.Security.TpmEnabled {
+		t.Error("Expected TpmEnabled=true")
+	}
+	if vm.GuestOS != "RHEL 9" {
+		t.Errorf("Expected GuestOS 'RHEL 9', got '%s'", vm.GuestOS)
+	}
+	if len(vm.Disks) != 1 || vm.Disks[0].Capacity != 1000 {
+		t.Error("Disk data not preserved after merge")
+	}
+	if len(vm.GuestNetworks) != 1 || vm.GuestNetworks[0].MAC != "00155D010101" {
+		t.Error("Guest network data not merged")
+	}
+}
+
+func TestCollectBatchVMDetails_GuestFailureStillReturnsHardware(t *testing.T) {
+	hwJSON := `{"vm-01":{"Security":{"TpmEnabled":false,"SecureBoot":false},"HasCheckpoint":true,"Disks":[]}}`
+	callNum := 0
+	md := &mockDriver{
+		runOnNodeFn: func(command, computerName string) (string, error) {
+			callNum++
+			if callNum == 1 {
+				return hwJSON, nil
+			}
+			return "", fmt.Errorf("WinRM timeout")
+		},
+	}
+	client := &Client{driver: md, Log: testLogger()}
+
+	result, err := client.collectBatchVMDetails("")
+	if err != nil {
+		t.Fatalf("Expected no error when guest fails: %v", err)
+	}
+	if result["vm-01"] == nil {
+		t.Fatal("Expected hardware data even though guest failed")
+	}
+	if !result["vm-01"].HasCheckpoint {
+		t.Error("Expected HasCheckpoint=true from hardware data")
+	}
+}
+
+func TestBuildGuestNetworks(t *testing.T) {
+	cfgs := []guestNetCfg{
+		{
+			MAC:     "00155D010101",
+			IPs:     []string{"192.168.1.10", "fe80::1"},
+			Subnets: []string{"255.255.255.0", "64"},
+			DHCP:    true,
+			GW:      []string{"192.168.1.1", "fe80::gw"},
+			DNS:     []string{"8.8.8.8", "2001:4860:4860::8888"},
+		},
+	}
+	nics := []types.NIC{
+		{Name: "nic-0", MAC: "00:15:5D:01:01:01", DeviceIndex: 0},
+	}
+
+	result := buildGuestNetworks(cfgs, nics)
+
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 guest networks (one per IP), got %d", len(result))
+	}
+
+	ipv4 := result[0]
+	if ipv4.IP != "192.168.1.10" {
+		t.Errorf("Expected IPv4 '192.168.1.10', got '%s'", ipv4.IP)
+	}
+	if ipv4.MAC != "00:15:5D:01:01:01" {
+		t.Errorf("Expected normalized MAC, got '%s'", ipv4.MAC)
+	}
+	if ipv4.Origin != "Dhcp" {
+		t.Errorf("Expected origin 'Dhcp', got '%s'", ipv4.Origin)
+	}
+	if ipv4.PrefixLength != 24 {
+		t.Errorf("Expected prefix 24, got %d", ipv4.PrefixLength)
+	}
+	if ipv4.Gateway != "192.168.1.1" {
+		t.Errorf("Expected gateway '192.168.1.1', got '%s'", ipv4.Gateway)
+	}
+	if len(ipv4.DNS) != 1 || ipv4.DNS[0] != "8.8.8.8" {
+		t.Errorf("Expected IPv4 DNS [8.8.8.8], got %v", ipv4.DNS)
+	}
+
+	ipv6 := result[1]
+	if ipv6.IP != "fe80::1" {
+		t.Errorf("Expected IPv6 'fe80::1', got '%s'", ipv6.IP)
+	}
+	if ipv6.PrefixLength != 64 {
+		t.Errorf("Expected prefix 64, got %d", ipv6.PrefixLength)
+	}
+}
+
+func TestBuildGuestNetworks_DashedMAC(t *testing.T) {
+	cfgs := []guestNetCfg{
+		{MAC: "00-15-5D-01-01-01", IPs: []string{"10.0.0.1"}, Subnets: []string{"255.255.255.0"}},
+	}
+	result := buildGuestNetworks(cfgs, nil)
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(result))
+	}
+	if result[0].MAC != "00:15:5D:01:01:01" {
+		t.Errorf("Expected colon-separated MAC from dashed input, got '%s'", result[0].MAC)
+	}
+}
+
+func TestBuildGuestNetworks_Empty(t *testing.T) {
+	result := buildGuestNetworks(nil, nil)
+	if len(result) != 0 {
+		t.Errorf("Expected empty result, got %d entries", len(result))
+	}
+}
+
+func TestApplyClusterTo(t *testing.T) {
+	cluster := &types.Cluster{
+		Name:   "cluster01",
+		Domain: "lab.local",
+		Nodes:  []string{"node-a", "node-b"},
+	}
+	m := &model.Cluster{}
+	applyClusterTo(cluster, m)
+
+	if m.ID != "cluster01" || m.Name != "cluster01" {
+		t.Errorf("Expected ID/Name 'cluster01', got '%s'/'%s'", m.ID, m.Name)
+	}
+	if m.Domain != "lab.local" {
+		t.Errorf("Expected Domain 'lab.local', got '%s'", m.Domain)
+	}
+	if len(m.Nodes) != 2 {
+		t.Fatalf("Expected 2 node refs, got %d", len(m.Nodes))
+	}
+	if m.Nodes[0].Kind != model.HostKind || m.Nodes[0].ID != "node-a" {
+		t.Errorf("Node[0] = %+v, want Kind=%s ID=node-a", m.Nodes[0], model.HostKind)
+	}
+	if m.Nodes[1].ID != "node-b" {
+		t.Errorf("Node[1].ID = '%s', want 'node-b'", m.Nodes[1].ID)
+	}
+}
+
+func TestApplyHostTo(t *testing.T) {
+	host := &types.Host{
+		ID:          "id-a",
+		Name:        "node-a",
+		State:       "Up",
+		ClusterName: "cluster01",
+		CpuCount:    2,
+		CpuCores:    16,
+		MemoryMB:    32768,
+	}
+	m := &model.Host{}
+	applyHostTo(host, m)
+
+	if m.ID != "node-a" || m.Name != "node-a" {
+		t.Errorf("Expected ID/Name 'node-a', got '%s'/'%s'", m.ID, m.Name)
+	}
+	if m.State != "Up" {
+		t.Errorf("Expected State 'Up', got '%s'", m.State)
+	}
+	if m.Cluster != "cluster01" {
+		t.Errorf("Expected Cluster 'cluster01', got '%s'", m.Cluster)
+	}
+	if m.CpuSockets != 2 {
+		t.Errorf("Expected CpuSockets 2, got %d", m.CpuSockets)
+	}
+	if m.CpuCores != 16 {
+		t.Errorf("Expected CpuCores 16, got %d", m.CpuCores)
+	}
+	expectedMemBytes := int64(32768) * 1024 * 1024
+	if m.MemoryBytes != expectedMemBytes {
+		t.Errorf("Expected MemoryBytes %d, got %d", expectedMemBytes, m.MemoryBytes)
+	}
+}

--- a/pkg/controller/provider/container/hyperv/collector.go
+++ b/pkg/controller/provider/container/hyperv/collector.go
@@ -178,8 +178,26 @@ func (r *Collector) Test() (status int, err error) {
 		}
 		return
 	}
-	r.log.Info("Connected to Hyper-V host via WinRM/HTTPS.")
+	if r.provider.IsHyperVCluster() {
+		if err = r.validateClusterMembership(); err != nil {
+			return
+		}
+		r.log.Info("Connected to Hyper-V Failover Cluster via WinRM/HTTPS.")
+	} else {
+		r.log.Info("Connected to Hyper-V host via WinRM/HTTPS.")
+	}
 	return
+}
+
+// validateClusterMembership verifies the connected host is a Failover Cluster member.
+func (r *Collector) validateClusterMembership() error {
+	_, err := r.client.driver.GetCluster()
+	if err != nil {
+		return fmt.Errorf(
+			"managementType is 'cluster' but Get-Cluster failed on this host — "+
+				"verify the host is a Failover Cluster member: %w", err)
+	}
+	return nil
 }
 
 // NO-OP
@@ -253,11 +271,21 @@ func (r *Collector) run(ctx *Context) (err error) {
 
 	r.parity = true
 	r.phase = Parity
-	r.log.Info("Initial inventory loaded.",
-		"vms", r.vmCount(),
-		"networks", r.networkCount(),
-		"storages", r.storageCount(),
-		"disks", r.diskCount())
+	if r.provider.IsHyperVCluster() {
+		r.log.Info("Initial inventory loaded (cluster mode).",
+			"clusters", r.clusterCount(),
+			"hosts", r.hostCount(),
+			"vms", r.vmCount(),
+			"networks", r.networkCount(),
+			"storages", r.storageCount(),
+			"disks", r.diskCount())
+	} else {
+		r.log.Info("Initial inventory loaded.",
+			"vms", r.vmCount(),
+			"networks", r.networkCount(),
+			"storages", r.storageCount(),
+			"disks", r.diskCount())
+	}
 
 	// Start periodic refresh
 	r.beginWatch()
@@ -274,11 +302,20 @@ func (r *Collector) run(ctx *Context) (err error) {
 	}
 }
 
+// adapters returns the full adapter list, prepending cluster adapters if in cluster mode.
+func (r *Collector) adapters() []Adapter {
+	if r.provider.IsHyperVCluster() {
+		return append(clusterAdapterList, adapterList...)
+	}
+	return adapterList
+}
+
 // Load the inventory.
 func (r *Collector) load(ctx *Context) (err error) {
 	r.phase = Load
+	r.client.InvalidateClusterCache()
 	mark := time.Now()
-	for _, adapter := range adapterList {
+	for _, adapter := range r.adapters() {
 		if ctx.canceled() {
 			return
 		}
@@ -337,9 +374,10 @@ func (r *Collector) create(ctx *Context, adapter Adapter) (err error) {
 // can block or be slow.
 func (r *Collector) refresh(ctx *Context) (err error) {
 	r.phase = Refresh
+	r.client.InvalidateClusterCache()
 	var deletions, updates []Updater
 	mark := time.Now()
-	for _, adapter := range adapterList {
+	for _, adapter := range r.adapters() {
 		if ctx.canceled() {
 			return
 		}
@@ -386,6 +424,24 @@ func (r *Collector) apply(changeSet []Updater) (err error) {
 	return
 }
 
+// clusterCount returns the number of clusters in the database.
+func (r *Collector) clusterCount() int {
+	count, err := r.db.Count(&model.Cluster{}, nil)
+	if err != nil {
+		r.log.Error(err, "Cluster count failed.")
+	}
+	return int(count)
+}
+
+// hostCount returns the number of hosts in the database.
+func (r *Collector) hostCount() int {
+	count, err := r.db.Count(&model.Host{}, nil)
+	if err != nil {
+		r.log.Error(err, "Host count failed.")
+	}
+	return int(count)
+}
+
 // vmCount returns the number of VMs in the database.
 func (r *Collector) vmCount() int {
 	count, _ := r.db.Count(&model.VM{}, nil)
@@ -412,6 +468,33 @@ func (r *Collector) diskCount() int {
 
 // Add model watches.
 func (r *Collector) beginWatch() {
+	// Cluster watch — triggers VM revalidation when cluster state changes.
+	if r.provider.IsHyperVCluster() {
+		w, err := r.db.Watch(
+			&model.Cluster{},
+			&ClusterEventHandler{
+				DB:  r.db,
+				log: r.log,
+			})
+		if err != nil {
+			r.log.Error(err, "Cluster watch failed.")
+		} else {
+			r.watches = append(r.watches, w)
+		}
+
+		w, err = r.db.Watch(
+			&model.Host{},
+			&HostEventHandler{
+				DB:  r.db,
+				log: r.log,
+			})
+		if err != nil {
+			r.log.Error(err, "Host watch failed.")
+		} else {
+			r.watches = append(r.watches, w)
+		}
+	}
+
 	w, err := r.db.Watch(
 		&model.VM{},
 		&VMEventHandler{

--- a/pkg/controller/provider/container/hyperv/model.go
+++ b/pkg/controller/provider/container/hyperv/model.go
@@ -15,12 +15,19 @@ import (
 // All adapters.
 var adapterList []Adapter
 
+// Cluster-mode adapters prepended when provider is a Failover Cluster.
+var clusterAdapterList []Adapter
+
 func init() {
 	adapterList = []Adapter{
 		&NetworkAdapter{},
 		&StorageAdapter{},
 		&DiskAdapter{},
 		&VMAdapter{},
+	}
+	clusterAdapterList = []Adapter{
+		&ClusterAdapter{},
+		&HostAdapter{},
 	}
 }
 
@@ -385,6 +392,162 @@ func (r *VMAdapter) DeleteUnexisting(ctx *Context) (deletions []Updater, err err
 	return
 }
 
+// Cluster adapter.
+type ClusterAdapter struct {
+	BaseAdapter
+}
+
+func (r *ClusterAdapter) List(ctx *Context, provider *api.Provider) (itr fb.Iterator, err error) {
+	cluster, err := ctx.client.ListCluster()
+	if err != nil {
+		return
+	}
+	list := fb.NewList()
+	if cluster != nil {
+		m := &model.Cluster{}
+		applyClusterTo(cluster, m)
+		list.Append(m)
+	}
+	itr = list.Iter()
+	return
+}
+
+func (r *ClusterAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
+	cluster, err := ctx.client.ListCluster()
+	if err != nil || cluster == nil {
+		return
+	}
+	updater := func(tx *libmodel.Tx) (err error) {
+		m := &model.Cluster{
+			Base: model.Base{ID: cluster.Name},
+		}
+		err = tx.Get(m)
+		if err != nil {
+			if errors.Is(err, libmodel.NotFound) {
+				applyClusterTo(cluster, m)
+				err = tx.Insert(m)
+			}
+			return
+		}
+		applyClusterTo(cluster, m)
+		err = tx.Update(m)
+		return
+	}
+	updates = append(updates, updater)
+	return
+}
+
+func (r *ClusterAdapter) DeleteUnexisting(ctx *Context) (deletions []Updater, err error) {
+	return
+}
+
+// Host adapter.
+type HostAdapter struct {
+	BaseAdapter
+}
+
+func (r *HostAdapter) List(ctx *Context, provider *api.Provider) (itr fb.Iterator, err error) {
+	hosts, err := ctx.client.ListHosts()
+	if err != nil {
+		return
+	}
+	list := fb.NewList()
+	for i := range hosts {
+		m := &model.Host{}
+		applyHostTo(&hosts[i], m)
+		list.Append(m)
+	}
+	itr = list.Iter()
+	return
+}
+
+func (r *HostAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
+	hosts, err := ctx.client.ListHosts()
+	if err != nil {
+		return
+	}
+	for i := range hosts {
+		host := &hosts[i]
+		updater := func(tx *libmodel.Tx) (err error) {
+			m := &model.Host{
+				Base: model.Base{ID: host.Name},
+			}
+			err = tx.Get(m)
+			if err != nil {
+				if errors.Is(err, libmodel.NotFound) {
+					applyHostTo(host, m)
+					err = tx.Insert(m)
+				}
+				return
+			}
+			applyHostTo(host, m)
+			err = tx.Update(m)
+			return
+		}
+		updates = append(updates, updater)
+	}
+	return
+}
+
+func (r *HostAdapter) DeleteUnexisting(ctx *Context) (deletions []Updater, err error) {
+	existing := []model.Host{}
+	err = ctx.db.List(&existing, libmodel.ListOptions{})
+	if err != nil {
+		if errors.Is(err, libmodel.NotFound) {
+			err = nil
+		}
+		return
+	}
+	serverList, err := ctx.client.ListHosts()
+	if err != nil {
+		return
+	}
+	serverMap := make(map[string]bool)
+	for _, h := range serverList {
+		serverMap[h.Name] = true
+	}
+	for _, h := range existing {
+		if _, found := serverMap[h.ID]; !found {
+			currentID := h.ID
+			updater := func(tx *libmodel.Tx) (err error) {
+				m := &model.Host{Base: model.Base{ID: currentID}}
+				err = tx.Delete(m)
+				if err != nil && errors.Is(err, libmodel.NotFound) {
+					err = nil
+				}
+				return
+			}
+			deletions = append(deletions, updater)
+		}
+	}
+	return
+}
+
+// Apply Cluster to (update) the model.
+func applyClusterTo(r *types.Cluster, m *model.Cluster) {
+	m.ID = r.Name
+	m.Name = r.Name
+	m.Domain = r.Domain
+	m.Nodes = nil
+	for _, nodeName := range r.Nodes {
+		m.Nodes = append(m.Nodes, model.Ref{
+			Kind: model.HostKind,
+			ID:   nodeName,
+		})
+	}
+}
+
+// Apply Host to (update) the model.
+func applyHostTo(r *types.Host, m *model.Host) {
+	m.ID = r.Name
+	m.Name = r.Name
+	m.State = r.State
+	m.Cluster = r.ClusterName
+	m.CpuSockets = int16(r.CpuCount)
+	m.CpuCores = int16(r.CpuCores)
+	m.MemoryBytes = r.MemoryMB * 1024 * 1024
+}
+
 // Apply VM to (update) the model.
 func applyVMTo(r *types.VM, m *model.VM) {
 	m.ID = r.UUID
@@ -398,6 +561,8 @@ func applyVMTo(r *types.VM, m *model.VM) {
 	m.TpmEnabled = r.TpmEnabled
 	m.SecureBoot = r.SecureBoot
 	m.HasCheckpoint = r.HasCheckpoint
+	m.Host = r.OwnerNode
+	m.IsClusterRole = r.IsClusterRole
 	addVMDisks(r, m)
 	addVMNICs(r, m)
 	addVMGuestNetworks(r, m)

--- a/pkg/controller/provider/container/hyperv/watch.go
+++ b/pkg/controller/provider/container/hyperv/watch.go
@@ -363,3 +363,90 @@ func (r *VMEventHandler) workload(vmID string) (object interface{}, err error) {
 
 	return
 }
+
+// Watch for cluster changes and trigger VM revalidation.
+type ClusterEventHandler struct {
+	libmodel.StockEventHandler
+	DB  libmodel.DB
+	log logging.LevelLogger
+}
+
+// Cluster updated — revalidate all VMs on cluster member hosts.
+func (r *ClusterEventHandler) Updated(event libmodel.Event) {
+	cluster, cast := event.Model.(*model.Cluster)
+	if cast {
+		r.validate(cluster)
+	}
+}
+
+func (r *ClusterEventHandler) Error(err error) {
+	r.log.Error(liberr.Wrap(err), err.Error())
+}
+
+func (r *ClusterEventHandler) validate(cluster *model.Cluster) {
+	for _, ref := range cluster.Nodes {
+		host := &model.Host{Base: model.Base{ID: ref.ID}}
+		err := r.DB.Get(host)
+		if err != nil {
+			r.log.Error(err, "Host (get) failed.", "hostID", ref.ID)
+			continue
+		}
+		hostHandler := HostEventHandler{DB: r.DB, log: r.log}
+		hostHandler.validate(host)
+	}
+}
+
+// Watch for host changes and trigger VM revalidation.
+type HostEventHandler struct {
+	libmodel.StockEventHandler
+	DB  libmodel.DB
+	log logging.LevelLogger
+}
+
+// Host updated — revalidate all VMs running on this host.
+func (r *HostEventHandler) Updated(event libmodel.Event) {
+	host, cast := event.Model.(*model.Host)
+	if cast {
+		r.validate(host)
+	}
+}
+
+func (r *HostEventHandler) Error(err error) {
+	r.log.Error(liberr.Wrap(err), err.Error())
+}
+
+func (r *HostEventHandler) validate(host *model.Host) {
+	tx, err := r.DB.Begin()
+	if err != nil {
+		r.log.Error(err, "begin tx failed.")
+		return
+	}
+	defer func() {
+		_ = tx.End()
+	}()
+	list := []model.VM{}
+	err = tx.List(
+		&list,
+		model.ListOptions{
+			Detail: model.MaxDetail,
+			Predicate: libmodel.Eq(
+				"Host",
+				host.Name),
+		})
+	if err != nil {
+		r.log.Error(err, "VM (list) failed.")
+		return
+	}
+	for i := range list {
+		list[i].RevisionValidated = 0
+		err = tx.Update(&list[i])
+		if err != nil {
+			r.log.Error(err, "VM (update) failed.")
+			return
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		r.log.Error(err, "Tx commit failed.")
+	}
+}

--- a/pkg/controller/provider/model/hyperv/doc.go
+++ b/pkg/controller/provider/model/hyperv/doc.go
@@ -8,9 +8,11 @@ import (
 func All() []interface{} {
 	return []interface{}{
 		&ocp.Provider{},
-		&VM{},
+		&Cluster{},
+		&Host{},
 		&Network{},
-		&Disk{},
 		&Storage{},
+		&VM{},
+		&Disk{},
 	}
 }

--- a/pkg/controller/provider/model/hyperv/model.go
+++ b/pkg/controller/provider/model/hyperv/model.go
@@ -70,6 +70,32 @@ func (m *Base) GetName() string {
 	return m.Name
 }
 
+// Cluster node state constants.
+const (
+	NodeStateUp      = "Up"
+	NodeStateDown    = "Down"
+	NodeStatePaused  = "Paused"
+	NodeStateJoining = "Joining"
+)
+
+// Cluster represents a Windows Failover Cluster.
+type Cluster struct {
+	Base
+	Domain string `sql:""`
+	Nodes  []Ref  `sql:""`
+}
+
+// Host represents a Hyper-V cluster node.
+type Host struct {
+	Base
+	Cluster     string `sql:"d0,index(cluster)"`
+	State       string `sql:""`
+	CpuSockets  int16  `sql:""`
+	CpuCores    int16  `sql:""`
+	MemoryBytes int64  `sql:""`
+	Networks    []Ref  `sql:""`
+}
+
 type Network struct {
 	Base
 	UUID string `sql:"d0,index(uuid)"`
@@ -78,6 +104,8 @@ type Network struct {
 	// Switch type: External, Internal, Private
 	SwitchType  string `sql:""`
 	Description string `sql:""`
+	// Hosts tracks which cluster nodes have this virtual switch (empty in standalone mode).
+	Hosts []Ref `sql:""`
 }
 
 type Storage struct {
@@ -103,6 +131,8 @@ type VM struct {
 	TpmEnabled        bool           `sql:""`
 	SecureBoot        bool           `sql:""`
 	HasCheckpoint     bool           `sql:""`
+	IsClusterRole     bool           `sql:""`
+	Host              string         `sql:"d0,index(host)"`
 	RevisionValidated int64          `sql:"d0,index(revisionValidated)"`
 	PolicyVersion     int            `sql:"d0,index(policyVersion)"`
 	Disks             []Disk         `sql:""`

--- a/pkg/controller/provider/model/hyperv/tree.go
+++ b/pkg/controller/provider/model/hyperv/tree.go
@@ -7,6 +7,8 @@ import (
 
 // Kinds
 var (
+	ClusterKind = libref.ToKind(Cluster{})
+	HostKind    = libref.ToKind(Host{})
 	VmKind      = libref.ToKind(VM{})
 	NetKind     = libref.ToKind(Network{})
 	DiskKind    = libref.ToKind(Disk{})

--- a/pkg/controller/provider/model/hyperv/types/types.go
+++ b/pkg/controller/provider/model/hyperv/types/types.go
@@ -1,5 +1,23 @@
 package types
 
+// Cluster represents a Windows Failover Cluster.
+type Cluster struct {
+	Name   string   `json:"name"`
+	Domain string   `json:"domain"`
+	Nodes  []string `json:"nodes"`
+}
+
+// Host represents a Hyper-V cluster node.
+type Host struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	State       string `json:"state"`
+	ClusterName string `json:"clusterName"`
+	CpuCount    int    `json:"cpuCount"`
+	CpuCores    int    `json:"cpuCores"`
+	MemoryMB    int64  `json:"memoryMB"`
+}
+
 // VM represents a Hyper-V virtual machine.
 type VM struct {
 	UUID          string         `json:"uuid"`
@@ -12,6 +30,8 @@ type VM struct {
 	TpmEnabled    bool           `json:"tpmEnabled"`
 	SecureBoot    bool           `json:"secureBoot"`
 	HasCheckpoint bool           `json:"hasCheckpoint"`
+	OwnerNode     string         `json:"ownerNode,omitempty"`
+	IsClusterRole bool           `json:"isClusterRole,omitempty"`
 	Disks         []Disk         `json:"disks"`
 	NICs          []NIC          `json:"nics"`
 	GuestNetworks []GuestNetwork `json:"guestNetworks,omitempty"`

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -144,6 +144,12 @@ func (r *Reconciler) validate(provider *api.Provider) error {
 		return liberr.Wrap(err)
 	}
 
+	// Validate Hyper-V settings (managementType)
+	err = r.validateHyperVSettings(provider)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+
 	if !provider.Status.HasBlockerCondition() {
 		provider.Status.SetCondition(
 			libcnd.Condition{
@@ -1364,5 +1370,32 @@ func (r *Reconciler) validateSMBCSI(provider *api.Provider) error {
 
 	// SMB CSI driver is installed - remove any previous condition
 	provider.Status.DeleteCondition(SMBCSIDriverNotReady)
+	return nil
+}
+
+func (r *Reconciler) validateHyperVSettings(provider *api.Provider) error {
+	if provider.Type() != api.HyperV {
+		return nil
+	}
+	if provider.Status.HasBlockerCondition() {
+		return nil
+	}
+
+	mt := provider.Spec.Settings[api.ManagementType]
+	if mt != "" && mt != api.HyperVStandalone && mt != api.HyperVCluster {
+		provider.Status.Phase = ValidationFailed
+		provider.Status.SetCondition(libcnd.Condition{
+			Type:     SettingsNotValid,
+			Status:   True,
+			Category: Critical,
+			Reason:   "InvalidManagementType",
+			Message: fmt.Sprintf(
+				"Invalid managementType '%s'. Allowed values: '%s', '%s', or empty (defaults to standalone).",
+				mt, api.HyperVStandalone, api.HyperVCluster),
+		})
+		return nil
+	}
+
+	provider.Status.DeleteCondition(SettingsNotValid)
 	return nil
 }

--- a/pkg/controller/provider/validation_hyperv_test.go
+++ b/pkg/controller/provider/validation_hyperv_test.go
@@ -1,0 +1,78 @@
+package provider
+
+import (
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func hypervProvider(settings map[string]string) *api.Provider {
+	pt := api.HyperV
+	return &api.Provider{
+		ObjectMeta: v1.ObjectMeta{Name: "test"},
+		Spec:       api.ProviderSpec{Type: &pt, Settings: settings},
+	}
+}
+
+func TestValidateHyperVSettings_ValidCluster(t *testing.T) {
+	p := hypervProvider(map[string]string{api.ManagementType: api.HyperVCluster})
+	r := Reconciler{}
+	if err := r.validateHyperVSettings(p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Status.HasCondition(SettingsNotValid) {
+		t.Error("Expected no SettingsNotValid condition for cluster mode")
+	}
+}
+
+func TestValidateHyperVSettings_ValidStandalone(t *testing.T) {
+	p := hypervProvider(map[string]string{api.ManagementType: api.HyperVStandalone})
+	r := Reconciler{}
+	if err := r.validateHyperVSettings(p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Status.HasCondition(SettingsNotValid) {
+		t.Error("Expected no SettingsNotValid condition for standalone mode")
+	}
+}
+
+func TestValidateHyperVSettings_EmptyDefaultsToValid(t *testing.T) {
+	p := hypervProvider(map[string]string{})
+	r := Reconciler{}
+	if err := r.validateHyperVSettings(p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Status.HasCondition(SettingsNotValid) {
+		t.Error("Expected no SettingsNotValid condition when managementType is empty")
+	}
+}
+
+func TestValidateHyperVSettings_InvalidType(t *testing.T) {
+	p := hypervProvider(map[string]string{api.ManagementType: "bogus"})
+	r := Reconciler{}
+	if err := r.validateHyperVSettings(p); err != nil {
+		t.Fatal(err)
+	}
+	if !p.Status.HasCondition(SettingsNotValid) {
+		t.Error("Expected SettingsNotValid condition for invalid managementType")
+	}
+	if p.Status.Phase != ValidationFailed {
+		t.Errorf("Expected phase '%s', got '%s'", ValidationFailed, p.Status.Phase)
+	}
+}
+
+func TestValidateHyperVSettings_NonHyperVSkipped(t *testing.T) {
+	pt := api.VSphere
+	p := &api.Provider{
+		ObjectMeta: v1.ObjectMeta{Name: "test"},
+		Spec:       api.ProviderSpec{Type: &pt, Settings: map[string]string{api.ManagementType: "bogus"}},
+	}
+	r := Reconciler{}
+	if err := r.validateHyperVSettings(p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Status.HasCondition(SettingsNotValid) {
+		t.Error("Expected validation to be skipped for non-HyperV provider")
+	}
+}

--- a/pkg/controller/provider/web/hyperv/cluster.go
+++ b/pkg/controller/provider/web/hyperv/cluster.go
@@ -1,0 +1,136 @@
+package hyperv
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+)
+
+// Routes.
+const (
+	ClusterParam      = "cluster"
+	ClusterCollection = "clusters"
+	ClustersRoot      = ProviderRoot + "/" + ClusterCollection
+	ClusterRoot       = ClustersRoot + "/:" + ClusterParam
+)
+
+// Cluster handler.
+type ClusterHandler struct {
+	Handler
+}
+
+func (h *ClusterHandler) AddRoutes(e *gin.Engine) {
+	e.GET(ClustersRoot, h.List)
+	e.GET(ClustersRoot+"/", h.List)
+	e.GET(ClusterRoot, h.Get)
+}
+
+func (h ClusterHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+	db := h.Collector.DB()
+	list := []model.Cluster{}
+	err := db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		log.Trace(err, "url", ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := []interface{}{}
+	for _, m := range list {
+		r := &Cluster{}
+		r.With(&m)
+		r.Link(h.Provider)
+		content = append(content, r.Content(h.Detail))
+	}
+	ctx.JSON(http.StatusOK, content)
+}
+
+func (h ClusterHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	m := &model.Cluster{
+		Base: model.Base{
+			ID: ctx.Param(ClusterParam),
+		},
+	}
+	db := h.Collector.DB()
+	err := db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		log.Trace(err, "url", ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r := &Cluster{}
+	r.With(m)
+	r.Link(h.Provider)
+	ctx.JSON(http.StatusOK, r.Content(model.MaxDetail))
+}
+
+func (h *ClusterHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.Cluster{},
+		func(in libmodel.Model) (r interface{}) {
+			m := in.(*model.Cluster)
+			cluster := &Cluster{}
+			cluster.With(m)
+			cluster.Link(h.Provider)
+			r = cluster
+			return
+		})
+	if err != nil {
+		log.Trace(err, "url", ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+	}
+}
+
+// REST Resource.
+type Cluster struct {
+	Resource
+	Domain string      `json:"domain"`
+	Nodes  []model.Ref `json:"nodes"`
+}
+
+func (r *Cluster) With(m *model.Cluster) {
+	r.Resource.With(&m.Base)
+	r.Domain = m.Domain
+	r.Nodes = m.Nodes
+}
+
+func (r *Cluster) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		ClusterRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			ClusterParam:       r.ID,
+		})
+}
+
+func (r *Cluster) Content(detail int) interface{} {
+	if detail == 0 {
+		return r.Resource
+	}
+	return r
+}

--- a/pkg/controller/provider/web/hyperv/doc.go
+++ b/pkg/controller/provider/web/hyperv/doc.go
@@ -29,6 +29,20 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 			},
 			Config: DefaultConfig,
 		},
+		&ClusterHandler{
+			Handler: Handler{
+				Handler: base.Handler{
+					Container: container,
+				},
+			},
+		},
+		&HostHandler{
+			Handler: Handler{
+				Handler: base.Handler{
+					Container: container,
+				},
+			},
+		},
 		&VMHandler{
 			Handler: Handler{
 				Handler: base.Handler{

--- a/pkg/controller/provider/web/hyperv/host.go
+++ b/pkg/controller/provider/web/hyperv/host.go
@@ -1,0 +1,145 @@
+package hyperv
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+)
+
+// Routes.
+const (
+	HostParam      = "host"
+	HostCollection = "hosts"
+	HostsRoot      = ProviderRoot + "/" + HostCollection
+	HostRoot       = HostsRoot + "/:" + HostParam
+)
+
+// Host handler.
+type HostHandler struct {
+	Handler
+}
+
+func (h *HostHandler) AddRoutes(e *gin.Engine) {
+	e.GET(HostsRoot, h.List)
+	e.GET(HostsRoot+"/", h.List)
+	e.GET(HostRoot, h.Get)
+}
+
+func (h HostHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+	db := h.Collector.DB()
+	list := []model.Host{}
+	err := db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		log.Trace(err, "url", ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := []interface{}{}
+	for _, m := range list {
+		r := &Host{}
+		r.With(&m)
+		r.Link(h.Provider)
+		content = append(content, r.Content(h.Detail))
+	}
+	ctx.JSON(http.StatusOK, content)
+}
+
+func (h HostHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	m := &model.Host{
+		Base: model.Base{
+			ID: ctx.Param(HostParam),
+		},
+	}
+	db := h.Collector.DB()
+	err := db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		log.Trace(err, "url", ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r := &Host{}
+	r.With(m)
+	r.Link(h.Provider)
+	ctx.JSON(http.StatusOK, r.Content(model.MaxDetail))
+}
+
+func (h *HostHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.Host{},
+		func(in libmodel.Model) (r interface{}) {
+			m := in.(*model.Host)
+			host := &Host{}
+			host.With(m)
+			host.Link(h.Provider)
+			r = host
+			return
+		})
+	if err != nil {
+		log.Trace(err, "url", ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+	}
+}
+
+// REST Resource.
+type Host struct {
+	Resource
+	Cluster     string      `json:"cluster"`
+	State       string      `json:"state"`
+	CpuSockets  int16       `json:"cpuSockets"`
+	CpuCores    int16       `json:"cpuCores"`
+	MemoryBytes int64       `json:"memoryBytes"`
+	Networks    []model.Ref `json:"networks"`
+	VMs         []model.Ref `json:"vms,omitempty"`
+}
+
+func (r *Host) With(m *model.Host) {
+	r.Resource.With(&m.Base)
+	r.Cluster = m.Cluster
+	r.State = m.State
+	r.CpuSockets = m.CpuSockets
+	r.CpuCores = m.CpuCores
+	r.MemoryBytes = m.MemoryBytes
+	r.Networks = m.Networks
+}
+
+func (r *Host) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		HostRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			HostParam:          r.ID,
+		})
+}
+
+func (r *Host) Content(detail int) interface{} {
+	if detail == 0 {
+		return r.Resource
+	}
+	return r
+}

--- a/pkg/controller/provider/web/hyperv/tree.go
+++ b/pkg/controller/provider/web/hyperv/tree.go
@@ -11,6 +11,12 @@ import (
 	libref "github.com/kubev2v/forklift/pkg/lib/ref"
 )
 
+// Routes.
+const (
+	TreeRoot     = ProviderRoot + "/tree"
+	TreeHostRoot = TreeRoot + "/host"
+)
+
 // Types.
 type TreeNode = base.TreeNode
 
@@ -20,30 +26,72 @@ type TreeHandler struct {
 }
 
 func (h *TreeHandler) AddRoutes(e *gin.Engine) {
-	// HyperV has a flat topology — no tree endpoints.
+	e.GET(TreeHostRoot, h.HostTree)
 }
 
-// List not supported.
-func (h TreeHandler) List(ctx *gin.Context) {
-	ctx.Status(http.StatusMethodNotAllowed)
-}
-
-// Get not supported.
-func (h TreeHandler) Get(ctx *gin.Context) {
-	ctx.Status(http.StatusMethodNotAllowed)
-}
-
-// Tree.
-func (h TreeHandler) Tree(ctx *gin.Context) {
-	// Not implemented — HyperV has a flat topology.
+// HostTree builds a Cluster → Host → VM tree for clustered providers,
+// or an empty response for standalone providers.
+func (h TreeHandler) HostTree(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	db := h.Collector.DB()
+	clusters := []model.Cluster{}
+	if err := db.List(&clusters, libmodel.ListOptions{}); err != nil {
+		log.Trace(err, "url", ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	if len(clusters) == 0 {
+		ctx.JSON(http.StatusOK, []interface{}{})
+		return
+	}
+	nb := &NodeBuilder{
+		provider: h.Provider,
+		detail:   map[string]int{},
+		db:       db,
+	}
+	var roots []*TreeNode
+	for i := range clusters {
+		clusterNode := nb.Node(nil, &clusters[i])
+		hosts := []model.Host{}
+		err := db.List(&hosts, libmodel.ListOptions{
+			Predicate: libmodel.Eq("cluster", clusters[i].Pk()),
+		})
+		if err != nil {
+			log.Trace(err, "url", ctx.Request.URL)
+			ctx.Status(http.StatusInternalServerError)
+			return
+		}
+		for j := range hosts {
+			hostNode := nb.Node(clusterNode, &hosts[j])
+			clusterNode.Children = append(clusterNode.Children, hostNode)
+			vms := []model.VM{}
+			err := db.List(&vms, libmodel.ListOptions{
+				Predicate: libmodel.Eq("host", hosts[j].Name),
+			})
+			if err != nil {
+				log.Trace(err, "url", ctx.Request.URL)
+				ctx.Status(http.StatusInternalServerError)
+				return
+			}
+			for k := range vms {
+				vmNode := nb.Node(hostNode, &vms[k])
+				hostNode.Children = append(hostNode.Children, vmNode)
+			}
+		}
+		roots = append(roots, clusterNode)
+	}
+	ctx.JSON(http.StatusOK, roots)
 }
 
 // Tree node builder.
 type NodeBuilder struct {
-	// Provider.
 	provider *api.Provider
-	// Resource details by kind.
-	detail map[string]int
+	detail   map[string]int
+	db       libmodel.DB
 }
 
 // Node builds a tree node for the model.
@@ -51,6 +99,26 @@ func (r *NodeBuilder) Node(parent *TreeNode, m libmodel.Model) *TreeNode {
 	kind := libref.ToKind(m)
 	node := &TreeNode{}
 	switch kind {
+	case model.ClusterKind:
+		resource := &Cluster{}
+		resource.With(m.(*model.Cluster))
+		resource.Link(r.provider)
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
+	case model.HostKind:
+		resource := &Host{}
+		resource.With(m.(*model.Host))
+		resource.Link(r.provider)
+		object := resource.Content(r.withDetail(kind))
+		node = &TreeNode{
+			Parent: parent,
+			Kind:   kind,
+			Object: object,
+		}
 	case model.VmKind:
 		resource := &VM{}
 		resource.With(m.(*model.VM))
@@ -95,7 +163,6 @@ func (r *NodeBuilder) Node(parent *TreeNode, m libmodel.Model) *TreeNode {
 	return node
 }
 
-// withDetail returns the detail level for a kind.
 func (r *NodeBuilder) withDetail(kind string) int {
 	if b, found := r.detail[kind]; found {
 		return b

--- a/pkg/controller/provider/web/hyperv/types.go
+++ b/pkg/controller/provider/web/hyperv/types.go
@@ -22,6 +22,16 @@ type Resolver struct {
 // Path builds the URL path for a resource.
 func (r *Resolver) Path(resource interface{}, id string) (path string, err error) {
 	switch resource.(type) {
+	case *Cluster:
+		path = base.Link(ClusterRoot, base.Params{
+			base.ProviderParam: string(r.UID),
+			ClusterParam:       id,
+		})
+	case *Host:
+		path = base.Link(HostRoot, base.Params{
+			base.ProviderParam: string(r.UID),
+			HostParam:          id,
+		})
 	case *VM:
 		path = base.Link(VMRoot, base.Params{
 			base.ProviderParam: string(r.Provider.UID),
@@ -219,6 +229,40 @@ func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
 		} else {
 			err = base.NotFoundError{Ref: ref}
 		}
+	case *Host:
+		id := ref.ID
+		if id != "" {
+			err = r.Get(resource, id)
+			return
+		}
+		name := ref.Name
+		if name != "" {
+			list := []Host{}
+			err = r.List(
+				&list,
+				base.Param{
+					Key:   DetailParam,
+					Value: "all",
+				},
+				base.Param{
+					Key:   NameParam,
+					Value: name,
+				})
+			if err != nil {
+				return
+			}
+			if len(list) == 0 {
+				err = base.NotFoundError{Ref: ref}
+				return
+			}
+			if len(list) > 1 {
+				err = base.RefNotUniqueError{Ref: ref}
+				return
+			}
+			*res = list[0]
+		} else {
+			err = base.NotFoundError{Ref: ref}
+		}
 	default:
 		err = base.ResourceNotResolvedError{Object: resource}
 	}
@@ -309,6 +353,12 @@ func (r *Finder) Storage(ref *base.Ref) (object interface{}, err error) {
 //	NotFoundErr
 //	RefNotUniqueErr
 func (r *Finder) Host(ref *base.Ref) (object interface{}, err error) {
-	err = base.ResourceNotResolvedError{Object: ref}
+	host := &Host{}
+	err = r.ByRef(host, *ref)
+	if err == nil {
+		ref.ID = host.ID
+		ref.Name = host.Name
+		object = host
+	}
 	return
 }

--- a/pkg/controller/provider/web/hyperv/types_test.go
+++ b/pkg/controller/provider/web/hyperv/types_test.go
@@ -1,0 +1,168 @@
+package hyperv
+
+import (
+	"strings"
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+func testProvider() *api.Provider {
+	pt := api.HyperV
+	return &api.Provider{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-provider",
+			UID:  k8stypes.UID("provider-uid-123"),
+		},
+		Spec: api.ProviderSpec{Type: &pt},
+	}
+}
+
+func TestCluster_With(t *testing.T) {
+	m := &model.Cluster{
+		Base:   model.Base{ID: "c1", Name: "cluster01", Revision: 5},
+		Domain: "lab.local",
+		Nodes: []model.Ref{
+			{Kind: model.HostKind, ID: "node-a"},
+			{Kind: model.HostKind, ID: "node-b"},
+		},
+	}
+	r := &Cluster{}
+	r.With(m)
+
+	if r.ID != "c1" {
+		t.Errorf("ID = %q, want 'c1'", r.ID)
+	}
+	if r.Name != "cluster01" {
+		t.Errorf("Name = %q, want 'cluster01'", r.Name)
+	}
+	if r.Domain != "lab.local" {
+		t.Errorf("Domain = %q, want 'lab.local'", r.Domain)
+	}
+	if len(r.Nodes) != 2 {
+		t.Fatalf("Nodes count = %d, want 2", len(r.Nodes))
+	}
+}
+
+func TestCluster_Link(t *testing.T) {
+	r := &Cluster{}
+	r.ID = "c1"
+	r.Link(testProvider())
+
+	if !strings.Contains(r.SelfLink, "provider-uid-123") {
+		t.Errorf("SelfLink missing provider UID: %s", r.SelfLink)
+	}
+	if !strings.Contains(r.SelfLink, "c1") {
+		t.Errorf("SelfLink missing cluster ID: %s", r.SelfLink)
+	}
+}
+
+func TestCluster_Content(t *testing.T) {
+	r := &Cluster{Domain: "lab.local"}
+	r.ID = "c1"
+
+	summary := r.Content(0)
+	if _, ok := summary.(Resource); !ok {
+		t.Error("Content(0) should return Resource (summary)")
+	}
+	full := r.Content(1)
+	if _, ok := full.(*Cluster); !ok {
+		t.Error("Content(1) should return *Cluster (full)")
+	}
+}
+
+func TestHost_With(t *testing.T) {
+	m := &model.Host{
+		Base:        model.Base{ID: "h1", Name: "node-a", Revision: 3},
+		Cluster:     "cluster01",
+		State:       "Up",
+		CpuSockets:  2,
+		CpuCores:    16,
+		MemoryBytes: 34359738368,
+		Networks:    []model.Ref{{Kind: model.NetKind, ID: "net-1"}},
+	}
+	r := &Host{}
+	r.With(m)
+
+	if r.ID != "h1" {
+		t.Errorf("ID = %q, want 'h1'", r.ID)
+	}
+	if r.Cluster != "cluster01" {
+		t.Errorf("Cluster = %q, want 'cluster01'", r.Cluster)
+	}
+	if r.State != "Up" {
+		t.Errorf("State = %q, want 'Up'", r.State)
+	}
+	if r.CpuSockets != 2 {
+		t.Errorf("CpuSockets = %d, want 2", r.CpuSockets)
+	}
+	if r.CpuCores != 16 {
+		t.Errorf("CpuCores = %d, want 16", r.CpuCores)
+	}
+	if r.MemoryBytes != 34359738368 {
+		t.Errorf("MemoryBytes = %d, want 34359738368", r.MemoryBytes)
+	}
+	if len(r.Networks) != 1 {
+		t.Fatalf("Networks count = %d, want 1", len(r.Networks))
+	}
+}
+
+func TestHost_Link(t *testing.T) {
+	r := &Host{}
+	r.ID = "h1"
+	r.Link(testProvider())
+
+	if !strings.Contains(r.SelfLink, "provider-uid-123") {
+		t.Errorf("SelfLink missing provider UID: %s", r.SelfLink)
+	}
+	if !strings.Contains(r.SelfLink, "h1") {
+		t.Errorf("SelfLink missing host ID: %s", r.SelfLink)
+	}
+}
+
+func TestResolver_Path_Cluster(t *testing.T) {
+	r := &Resolver{Provider: testProvider()}
+	path, err := r.Path(&Cluster{}, "c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "clusters/c1") {
+		t.Errorf("Path = %q, expected to contain 'clusters/c1'", path)
+	}
+	if !strings.Contains(path, "provider-uid-123") {
+		t.Errorf("Path = %q, expected to contain provider UID", path)
+	}
+}
+
+func TestResolver_Path_Host(t *testing.T) {
+	r := &Resolver{Provider: testProvider()}
+	path, err := r.Path(&Host{}, "h1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "hosts/h1") {
+		t.Errorf("Path = %q, expected to contain 'hosts/h1'", path)
+	}
+}
+
+func TestResolver_Path_VM(t *testing.T) {
+	r := &Resolver{Provider: testProvider()}
+	path, err := r.Path(&VM{}, "vm1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "vms/vm1") {
+		t.Errorf("Path = %q, expected to contain 'vms/vm1'", path)
+	}
+}
+
+func TestResolver_Path_Unknown(t *testing.T) {
+	r := &Resolver{Provider: testProvider()}
+	_, err := r.Path("unsupported", "id")
+	if err == nil {
+		t.Error("Expected error for unsupported resource type")
+	}
+}

--- a/pkg/controller/provider/web/hyperv/vm.go
+++ b/pkg/controller/provider/web/hyperv/vm.go
@@ -192,6 +192,7 @@ type VM struct {
 	TpmEnabled    bool                 `json:"tpmEnabled"`
 	SecureBoot    bool                 `json:"secureBoot"`
 	HasCheckpoint bool                 `json:"hasCheckpoint"`
+	Host          string               `json:"host,omitempty"`
 	GuestNetworks []model.GuestNetwork `json:"guestNetworks"`
 }
 
@@ -215,6 +216,7 @@ func (r *VM) With(m *model.VM) {
 	r.TpmEnabled = m.TpmEnabled
 	r.SecureBoot = m.SecureBoot
 	r.HasCheckpoint = m.HasCheckpoint
+	r.Host = m.Host
 	if m.GuestNetworks != nil {
 		r.GuestNetworks = m.GuestNetworks
 	} else {

--- a/pkg/controller/provider/web/hyperv/workload.go
+++ b/pkg/controller/provider/web/hyperv/workload.go
@@ -80,22 +80,24 @@ func (h WorkloadHandler) Get(ctx *gin.Context) {
 type Workload struct {
 	SelfLink string `json:"selfLink"`
 	// Embed VM fields for validation
-	ID            string               `json:"id"`
-	Name          string               `json:"name"`
-	UUID          string               `json:"uuid"`
-	Firmware      string               `json:"firmware"`
-	CpuCount      int32                `json:"cpuCount"`
-	MemoryMB      int32                `json:"memoryMB"`
-	PowerState    string               `json:"powerState"`
-	GuestOS       string               `json:"guestOS,omitempty"`
-	TpmEnabled    bool                 `json:"tpmEnabled"`
-	SecureBoot    bool                 `json:"secureBoot"`
-	HasCheckpoint bool                 `json:"hasCheckpoint"`
-	Disks         []model.Disk         `json:"disks"`
-	NICs          []model.NIC          `json:"nics"`
-	GuestNetworks []model.GuestNetwork `json:"guestNetworks"`
-	Concerns      []model.Concern      `json:"concerns"`
-	config        Config               // unexported, not serialized
+	ID             string               `json:"id"`
+	Name           string               `json:"name"`
+	UUID           string               `json:"uuid"`
+	Firmware       string               `json:"firmware"`
+	CpuCount       int32                `json:"cpuCount"`
+	MemoryMB       int32                `json:"memoryMB"`
+	PowerState     string               `json:"powerState"`
+	GuestOS        string               `json:"guestOS,omitempty"`
+	TpmEnabled     bool                 `json:"tpmEnabled"`
+	SecureBoot     bool                 `json:"secureBoot"`
+	HasCheckpoint  bool                 `json:"hasCheckpoint"`
+	IsClusterRole  bool                 `json:"isClusterRole"`
+	ManagementType string               `json:"managementType,omitempty"`
+	Disks          []model.Disk         `json:"disks"`
+	NICs           []model.NIC          `json:"nics"`
+	GuestNetworks  []model.GuestNetwork `json:"guestNetworks"`
+	Concerns       []model.Concern      `json:"concerns"`
+	config         Config               // unexported, not serialized
 }
 
 func (r *Workload) IsWindows() bool {
@@ -115,6 +117,7 @@ func (r *Workload) With(m *model.VM) {
 	r.TpmEnabled = m.TpmEnabled
 	r.SecureBoot = m.SecureBoot
 	r.HasCheckpoint = m.HasCheckpoint
+	r.IsClusterRole = m.IsClusterRole
 	r.Disks = m.Disks
 	r.NICs = m.NICs
 	r.GuestNetworks = m.GuestNetworks
@@ -142,6 +145,7 @@ func (r *Workload) Link(p *api.Provider) {
 			base.ProviderParam: string(p.UID),
 			VMParam:            r.ID,
 		})
+	r.ManagementType = p.Spec.Settings[api.ManagementType]
 }
 
 // Expand the resource.

--- a/pkg/lib/hyperv/driver/driver.go
+++ b/pkg/lib/hyperv/driver/driver.go
@@ -32,14 +32,25 @@ type HyperVDriver interface {
 	IsAlive() (bool, error)
 
 	ListAllDomains() ([]Domain, error)
+	ListAllClusterDomains() ([]Domain, error)
 	LookupDomainByName(name string) (Domain, error)
 	LookupDomainByUUIDString(uuid string) (Domain, error)
 
 	ListAllNetworks() ([]Network, error)
 	LookupNetworkByUUIDString(uuid string) (Network, error)
 
+	// Failover Cluster queries
+	GetCluster() (*ClusterData, error)
+	GetClusterNodes() ([]ClusterNodeData, error)
+	GetClusterVMGroups() ([]ClusterGroupData, error)
+	GetComputerInfo() (*ComputerInfoData, error)
+
 	// Raw command execution
 	ExecuteCommand(command string) (string, error)
+	// RunOnNode wraps a command to execute on a specific cluster node via
+	// Invoke-Command with explicit credentials. Returns the command output.
+	// If computerName is empty, executes locally.
+	RunOnNode(command, computerName string) (string, error)
 }
 
 // Domain represents a virtual machine
@@ -51,6 +62,8 @@ type Domain interface {
 	GetGeneration() (int, error)
 	GetDisks() ([]DiskInfo, error)
 	GetNICs() ([]NICInfo, error)
+	// GetComputerName returns the cluster node hosting this VM, or "" for local VMs.
+	GetComputerName() string
 	Shutdown(ctx context.Context) error
 	Free() error
 }

--- a/pkg/lib/hyperv/driver/winrm.go
+++ b/pkg/lib/hyperv/driver/winrm.go
@@ -35,12 +35,62 @@ type VMData struct {
 	ProcessorCount int    `json:"ProcessorCount"`
 	MemoryStartup  int64  `json:"MemoryStartup"`
 	Generation     int    `json:"Generation"`
+	ComputerName   string `json:"ComputerName,omitempty"`
 }
 
 type SwitchData struct {
 	Id         string `json:"Id"`
 	Name       string `json:"Name"`
 	SwitchType int    `json:"SwitchType"`
+}
+
+type ClusterData struct {
+	Name   string `json:"Name"`
+	Domain string `json:"Domain"`
+}
+
+type ClusterNodeData struct {
+	Name  string `json:"Name"`
+	State int    `json:"State"`
+	Id    string `json:"Id"`
+}
+
+// ClusterNode State values from the FailoverClusters module.
+const (
+	ClusterNodeStateUp      = 0
+	ClusterNodeStateDown    = 1
+	ClusterNodeStatePaused  = 2
+	ClusterNodeStateJoining = 3
+)
+
+func ClusterNodeStateName(state int) string {
+	switch state {
+	case ClusterNodeStateUp:
+		return "Up"
+	case ClusterNodeStateDown:
+		return "Down"
+	case ClusterNodeStatePaused:
+		return "Paused"
+	case ClusterNodeStateJoining:
+		return "Joining"
+	default:
+		return "Unknown"
+	}
+}
+
+type ClusterGroupData struct {
+	Name      string `json:"Name"`
+	OwnerNode string `json:"OwnerNode"`
+	State     int    `json:"State"`
+	Id        string `json:"Id"`
+}
+
+type ComputerInfoData struct {
+	DNSHostName               string `json:"CsDNSHostName"`
+	Domain                    string `json:"CsDomain"`
+	NumberOfProcessors        int    `json:"CsNumberOfProcessors"`
+	NumberOfLogicalProcessors int    `json:"CsNumberOfLogicalProcessors"`
+	TotalVisibleMemoryKB      int64  `json:"OsTotalVisibleMemorySize"`
 }
 
 type WinRMDriver struct {
@@ -72,7 +122,8 @@ func (d *WinRMDriver) Connect() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	endpoint := winrm.NewEndpoint(d.host, d.port, true, d.insecureSkipVerify, d.caCert, nil, nil, 0)
+	useHTTPS := true
+	endpoint := winrm.NewEndpoint(d.host, d.port, useHTTPS, d.insecureSkipVerify, d.caCert, nil, nil, 0)
 	client, err := winrm.NewClient(endpoint, d.username, d.password)
 	if err != nil {
 		return fmt.Errorf("failed to create WinRM client: %w", err)
@@ -133,6 +184,11 @@ func (d *WinRMDriver) ExecuteCommandWithTimeout(command string, timeout time.Dur
 	return strings.TrimSpace(stdout), nil
 }
 
+func (d *WinRMDriver) RunOnNode(command, computerName string) (string, error) {
+	cmd := ps.RunOnNode(command, computerName, d.password, d.username)
+	return d.ExecuteCommand(cmd)
+}
+
 func utf16LEEncode(s string) []byte {
 	u16 := utf16.Encode([]rune(s))
 	encoded := make([]byte, len(u16)*2)
@@ -160,6 +216,36 @@ func (d *WinRMDriver) ListAllDomains() ([]Domain, error) {
 		var single VMData
 		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
 			return nil, fmt.Errorf("failed to parse VMs JSON: %w", err)
+		}
+		vmsData = append(vmsData, single)
+	}
+
+	var domains []Domain
+	for i := range vmsData {
+		domains = append(domains, &WinRMDomain{
+			driver: d,
+			vmData: &vmsData[i],
+		})
+	}
+	return domains, nil
+}
+
+func (d *WinRMDriver) ListAllClusterDomains() ([]Domain, error) {
+	cmd := ps.BuildCommand(ps.ListClusterVMs, d.password, d.username)
+	stdout, err := d.ExecuteCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	if stdout == "" {
+		return []Domain{}, nil
+	}
+
+	var vmsData []VMData
+	if err := json.Unmarshal([]byte(stdout), &vmsData); err != nil {
+		var single VMData
+		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
+			return nil, fmt.Errorf("failed to parse cluster VMs JSON: %w", err)
 		}
 		vmsData = append(vmsData, single)
 	}
@@ -257,6 +343,61 @@ func (d *WinRMDriver) LookupNetworkByUUIDString(uuid string) (Network, error) {
 	return nil, fmt.Errorf("network not found: %s", uuid)
 }
 
+// runSingle executes a PowerShell script and unmarshals the JSON output into a
+// single object of type T. Returns an error when stdout is empty.
+func runSingle[T any](d *WinRMDriver, script, label string) (*T, error) {
+	stdout, err := d.ExecuteCommand(script)
+	if err != nil {
+		return nil, err
+	}
+	if stdout == "" {
+		return nil, fmt.Errorf("no %s returned", label)
+	}
+	var result T
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse %s JSON: %w", label, err)
+	}
+	return &result, nil
+}
+
+// runList executes a PowerShell script and unmarshals the JSON output into a
+// slice of T. Handles PowerShell's behavior of returning a bare object instead
+// of a one-element array.
+func runList[T any](d *WinRMDriver, script, label string) ([]T, error) {
+	stdout, err := d.ExecuteCommand(script)
+	if err != nil {
+		return nil, err
+	}
+	if stdout == "" {
+		return []T{}, nil
+	}
+	var results []T
+	if err := json.Unmarshal([]byte(stdout), &results); err != nil {
+		var single T
+		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
+			return nil, fmt.Errorf("failed to parse %s JSON: %w", label, err)
+		}
+		results = append(results, single)
+	}
+	return results, nil
+}
+
+func (d *WinRMDriver) GetCluster() (*ClusterData, error) {
+	return runSingle[ClusterData](d, ps.GetCluster, "cluster")
+}
+
+func (d *WinRMDriver) GetClusterNodes() ([]ClusterNodeData, error) {
+	return runList[ClusterNodeData](d, ps.GetClusterNodes, "cluster nodes")
+}
+
+func (d *WinRMDriver) GetClusterVMGroups() ([]ClusterGroupData, error) {
+	return runList[ClusterGroupData](d, ps.GetClusterVMGroups, "cluster VM groups")
+}
+
+func (d *WinRMDriver) GetComputerInfo() (*ComputerInfoData, error) {
+	return runSingle[ComputerInfoData](d, ps.GetComputerInfo, "computer info")
+}
+
 // WinRMDomain implements Domain interface
 type WinRMDomain struct {
 	driver *WinRMDriver
@@ -303,8 +444,18 @@ func (d *WinRMDomain) GetGeneration() (int, error) {
 	return d.vmData.Generation, nil
 }
 
+func (d *WinRMDomain) GetComputerName() string {
+	return d.vmData.ComputerName
+}
+
+// nodeCommand wraps cmd to run on the VM's owner node via Invoke-Command
+// when ComputerName is set (cluster mode). In standalone mode it returns cmd unchanged.
+func (d *WinRMDomain) nodeCommand(cmd string) string {
+	return ps.RunOnNode(cmd, d.vmData.ComputerName, d.driver.password, d.driver.username)
+}
+
 func (d *WinRMDomain) GetDisks() ([]DiskInfo, error) {
-	cmd := ps.BuildCommand(ps.GetVMDisks, d.vmData.Name)
+	cmd := d.nodeCommand(ps.BuildCommand(ps.GetVMDisks, d.vmData.Name))
 	stdout, err := d.driver.ExecuteCommand(cmd)
 	if err != nil {
 		return nil, err
@@ -347,7 +498,7 @@ func (d *WinRMDomain) GetDisks() ([]DiskInfo, error) {
 }
 
 func (d *WinRMDomain) GetNICs() ([]NICInfo, error) {
-	cmd := ps.BuildCommand(ps.GetVMNICs, d.vmData.Name)
+	cmd := d.nodeCommand(ps.BuildCommand(ps.GetVMNICs, d.vmData.Name))
 	stdout, err := d.driver.ExecuteCommand(cmd)
 	if err != nil {
 		return nil, err

--- a/pkg/lib/hyperv/powershell/scripts.go
+++ b/pkg/lib/hyperv/powershell/scripts.go
@@ -16,6 +16,23 @@ func BuildCommand(template string, args ...string) string {
 	return fmt.Sprintf(template, sanitized...)
 }
 
+// RunOnNode wraps cmd to run on a remote node via Invoke-Command -Credential.
+// If computerName is empty, returns cmd unchanged (runs on the connected host).
+func RunOnNode(cmd, computerName, password, username string) string {
+	if computerName == "" {
+		return cmd
+	}
+	escPass := strings.ReplaceAll(password, "'", "''")
+	escUser := strings.ReplaceAll(username, "'", "''")
+	escNode := strings.ReplaceAll(computerName, "'", "''")
+	return fmt.Sprintf(
+		"$pw = ConvertTo-SecureString '%s' -AsPlainText -Force; "+
+			"$cred = New-Object System.Management.Automation.PSCredential('%s', $pw); "+
+			"Invoke-Command -ComputerName '%s' -Credential $cred -ScriptBlock { %s }",
+		escPass, escUser, escNode, cmd,
+	)
+}
+
 const (
 	// TestConnection verifies WinRM connectivity
 	TestConnection = `echo ok`
@@ -24,6 +41,12 @@ const (
 const (
 	// ListAllVMs returns all VMs with basic properties
 	ListAllVMs = `Get-VM | Select-Object Id, Name, State, ProcessorCount, MemoryStartup, Generation | ConvertTo-Json`
+
+	// ListClusterVMs collects VMs from all cluster nodes using Invoke-Command
+	// with explicit credentials to avoid WinRM double-hop issues.
+	// Remote State enums must be cast to [int] to avoid complex JSON objects.
+	// Parameters: password, username
+	ListClusterVMs = `$pw = ConvertTo-SecureString '%s' -AsPlainText -Force; $cred = New-Object System.Management.Automation.PSCredential('%s', $pw); $localName = $env:COMPUTERNAME; $allVMs = @(); $allVMs += Get-VM | Select-Object Id, Name, @{N='State';E={[int]$_.State}}, ProcessorCount, MemoryStartup, Generation, @{N='ComputerName';E={$localName}}; Get-ClusterNode | Where-Object { $_.Name -ne $localName -and $_.State -eq 0 } | ForEach-Object { $node = $_.Name; try { $remote = Invoke-Command -ComputerName $node -Credential $cred -ScriptBlock { Get-VM | Select-Object Id, Name, @{N='State';E={[int]$_.State}}, ProcessorCount, MemoryStartup, Generation } -ErrorAction Stop; $remote | ForEach-Object { $_ | Add-Member -NotePropertyName ComputerName -NotePropertyValue $node -Force; $allVMs += $_ } } catch { Write-Warning "Node ${node}: $($_.Exception.Message)" } }; $allVMs | ConvertTo-Json`
 
 	// GetVMByName returns a single VM by name
 	// Parameters: vmName
@@ -133,4 +156,47 @@ const (
 	// Parameters: windowsPath
 	GetDiskRCTEnabled = `$vhd=Get-VHD -Path '%s' -ErrorAction SilentlyContinue
 if($vhd -and $vhd.RctId){'true'}else{'false'}`
+)
+
+// Failover Clustering scripts.
+// Cluster-level scripts run on the CNO (Cluster Name Object) entry node.
+// Per-node scripts run on direct WinRM connections to individual cluster nodes.
+const (
+	// GetCluster returns the Failover Cluster identity (name and domain).
+	// Run on the CNO / entry node connection.
+	GetCluster = `Get-Cluster | Select-Object Name, Domain | ConvertTo-Json`
+
+	// GetClusterNodes returns all nodes in the Failover Cluster with their state.
+	// Node State values: Up, Down, Paused, Joining.
+	// Run on the CNO / entry node connection.
+	GetClusterNodes = `Get-ClusterNode | Select-Object Name, @{N='State';E={[int]$_.State}}, Id | ConvertTo-Json`
+
+	// GetClusterVMGroups returns all VM roles in the cluster with their owner node.
+	// GroupType 'VirtualMachine' filters to only Hyper-V VM cluster roles.
+	// OwnerNode indicates which node currently runs the VM (real-time).
+	// Run on the CNO / entry node connection.
+	GetClusterVMGroups = `Get-ClusterGroup | Where-Object {$_.GroupType -eq 'VirtualMachine'} | Select-Object Name, @{N='OwnerNode';E={$_.OwnerNode.Name}}, @{N='State';E={[int]$_.State}}, Id | ConvertTo-Json`
+)
+
+const (
+	// GetComputerInfo returns hardware information for a cluster node.
+	// CsNumberOfProcessors = physical CPU sockets,
+	// CsNumberOfLogicalProcessors = total logical CPUs (cores x threads),
+	// OsTotalVisibleMemorySize = total RAM in KB,
+	// CsDNSHostName = node hostname, CsDomain = AD domain.
+	// Run on a direct per-node WinRM connection.
+	GetComputerInfo = `Get-ComputerInfo | Select-Object CsDNSHostName, CsDomain, CsNumberOfProcessors, CsNumberOfLogicalProcessors, OsTotalVisibleMemorySize | ConvertTo-Json`
+)
+
+// Batch VM detail scripts — split into two to fit WinRM's command-line limit.
+// Each returns JSON keyed by VM name.
+const (
+	// BatchGetVMHardware collects security info, checkpoint status, disk
+	// topology+capacity+RCT, and NIC info for all VMs on the host.
+	// Disk entries include controller type/number/location so the caller
+	// can build full Disk objects without per-VM WinRM round-trips.
+	BatchGetVMHardware = `$r=@{};foreach($vm in(Get-VM)){$n=$vm.Name;$e=@{};if($vm.Generation-eq 2){$s=Get-VMSecurity -VMName $n -EA 0;$f=Get-VMFirmware -VMName $n -EA 0;$t=$false;$b=$false;if($s){$t=$s.TpmEnabled};if($f-and$f.SecureBoot-eq'On'){$b=$true};$e['Security']=@{TpmEnabled=$t;SecureBoot=$b}}else{$e['Security']=@{TpmEnabled=$false;SecureBoot=$false}};$e['HasCheckpoint']=[bool](Get-VMSnapshot -VMName $n -EA 0);$dd=@();foreach($d in(Get-VMHardDiskDrive -VMName $n -EA 0)){if(-not$d.Path){continue};$v=Get-VHD -Path $d.Path -EA 0;$c=0;$rc=$false;if($v){$c=$v.Size;if($v.RctId){$rc=$true}};$dd+=@{Path=$d.Path;Capacity=$c;RCTEnabled=$rc;CT=[int]$d.ControllerType;CN=$d.ControllerNumber;CL=$d.ControllerLocation}};$e['Disks']=$dd;$nn=@();foreach($a in(Get-VMNetworkAdapter -VMName $n -EA 0)){$vl=0;$vi=$a|Get-VMNetworkAdapterVlan -EA 0;if($vi-and$vi.AccessVlanId){$vl=$vi.AccessVlanId};$nn+=@{Name=$a.Name;MAC=$a.MacAddress;Switch=$a.SwitchName;Vlan=$vl}};$e['NICs']=$nn;$r[$n]=$e};$r|ConvertTo-Json -Depth 4 -Compress`
+
+	// BatchGetVMGuest collects guest OS and guest network config for running VMs.
+	BatchGetVMGuest = `$r=@{};foreach($vm in(Get-VM|?{$_.State-eq'Running'})){$n=$vm.Name;$e=@{};$ci=Get-CimInstance -Namespace root\virtualization\v2 -ClassName Msvm_ComputerSystem -Filter "ElementName='$n'" -EA 0;if($ci){$kv=Get-CimAssociatedInstance -InputObject $ci -ResultClassName Msvm_KvpExchangeComponent -EA 0;if($kv-and$kv.GuestIntrinsicExchangeItems){$os='';$om='';foreach($i in $kv.GuestIntrinsicExchangeItems){$x=[xml]$i;$pn=$x.INSTANCE.PROPERTY|?{$_.NAME-eq'Name'}|Select -Exp VALUE;$pv=$x.INSTANCE.PROPERTY|?{$_.NAME-eq'Data'}|Select -Exp VALUE;if($pn-eq'OSName'){$os=$pv}elseif($pn-eq'OSMajorVersion'){$om=$pv}};if($os-and$om-and$os-notmatch'\d'){$os="$os $om"};$e['GuestOS']=$os};$vs=Get-CimAssociatedInstance -InputObject $ci -ResultClassName Msvm_VirtualSystemSettingData|?{$_.VirtualSystemType-eq'Microsoft:Hyper-V:System:Realized'};if($vs){$ps=Get-CimAssociatedInstance -InputObject $vs -ResultClassName Msvm_SyntheticEthernetPortSettingData;$nc=@();foreach($p in $ps){$gc=Get-CimAssociatedInstance -InputObject $p -ResultClassName Msvm_GuestNetworkAdapterConfiguration;if($gc){$nc+=[PSCustomObject]@{MAC=$p.Address;IPs=$gc.IPAddresses;Subnets=$gc.Subnets;DHCP=$gc.DHCPEnabled;GW=$gc.DefaultGateways;DNS=$gc.DNSServers}}};if($nc.Count-gt 0){$e['GuestNetworks']=$nc}}};if($e.Count-gt 0){$r[$n]=$e}};$r|ConvertTo-Json -Depth 4 -Compress`
 )

--- a/validation/policies/io/konveyor/forklift/hyperv/cluster_role.rego
+++ b/validation/policies/io/konveyor/forklift/hyperv/cluster_role.rego
@@ -1,0 +1,26 @@
+package io.konveyor.forklift.hyperv
+
+import rego.v1
+
+default is_cluster_mode := false
+default is_cluster_role := false
+
+is_cluster_mode if {
+	input.managementType == "cluster"
+}
+
+
+is_cluster_role if {
+	input.isClusterRole
+}
+
+concerns contains flag if {
+	is_cluster_mode
+	not is_cluster_role
+	flag := {
+		"id": "hyperv.cluster_role.not_registered",
+		"category": "Warning",
+		"label": "VM is not a Failover Cluster role",
+		"assessment": "This VM exists on a cluster node but is not registered as a Failover Cluster role. It will not fail over automatically if its host goes down. The VM can still be migrated.",
+	}
+}

--- a/validation/policies/io/konveyor/forklift/hyperv/cluster_role_test.rego
+++ b/validation/policies/io/konveyor/forklift/hyperv/cluster_role_test.rego
@@ -1,0 +1,56 @@
+package io.konveyor.forklift.hyperv
+
+import rego.v1
+
+test_cluster_mode_not_registered if {
+	mock_vm := {
+		"name": "test-vm",
+		"powerState": "On",
+		"managementType": "cluster",
+		"isClusterRole": false,
+		"disks": [{"name": "disk-0", "capacity": 1000}],
+	}
+	results := concerns with input as mock_vm
+	some result in results
+	result.id == "hyperv.cluster_role.not_registered"
+}
+
+test_cluster_mode_registered if {
+	mock_vm := {
+		"name": "test-vm",
+		"powerState": "On",
+		"managementType": "cluster",
+		"isClusterRole": true,
+		"disks": [{"name": "disk-0", "capacity": 1000}],
+	}
+	results := concerns with input as mock_vm
+	not any_cluster_role_concern(results)
+}
+
+test_standalone_mode_not_registered if {
+	mock_vm := {
+		"name": "test-vm",
+		"powerState": "On",
+		"managementType": "standalone",
+		"isClusterRole": false,
+		"disks": [{"name": "disk-0", "capacity": 1000}],
+	}
+	results := concerns with input as mock_vm
+	not any_cluster_role_concern(results)
+}
+
+test_no_management_type_not_registered if {
+	mock_vm := {
+		"name": "test-vm",
+		"powerState": "On",
+		"isClusterRole": false,
+		"disks": [{"name": "disk-0", "capacity": 1000}],
+	}
+	results := concerns with input as mock_vm
+	not any_cluster_role_concern(results)
+}
+
+any_cluster_role_concern(results) if {
+	some result in results
+	result.id == "hyperv.cluster_role.not_registered"
+}


### PR DESCRIPTION
Introduce cluster management mode for Hyper-V providers, allowing a single provider to inventory an entire Windows Failover Cluster instead of requiring one provider per host.

Provider settings:
- New managementType setting (cluster/standalone) controls behavior
- Standalone mode (default) is fully unchanged

Inventory collection (cluster mode):
- Single WinRM entry point using Invoke-Command -Credential to query remote cluster nodes, bypassing the double-hop limitation
- Get-Cluster / Get-ClusterNode / Get-ClusterGroup cmdlets discover cluster topology and VM-to-node ownership
- Per-node Get-VM via Invoke-Command collects all VMs across nodes
- Per-VM detail collection (disks, NICs, guest OS, security) routed to the correct owner node via RunOnNode helper

New models and web API:
- Cluster and Host models with types, adapters, and DB persistence
- REST handlers for /clusters and /hosts endpoints
- Cluster -> Host -> VM tree hierarchy
- Finder and Resolver support for Host and Cluster resources
- VM.Host field exposes OwnerNode in API responses

Validation:
- Rego concern for VMs not registered as Failover Cluster roles
- IsClusterRole and managementType added to Workload (rego input)

Ref: https://redhat.atlassian.net/browse/MTV-5980
Resolves: MTV-5980


<img width="1061" height="620" alt="image" src="https://github.com/user-attachments/assets/e02ee678-3db5-4d6e-b40b-52ae411ede00" />


<img width="1826" height="210" alt="image" src="https://github.com/user-attachments/assets/996b0794-3927-4174-852d-02937a36f61a" />


<img width="1509" height="669" alt="image" src="https://github.com/user-attachments/assets/069c2f63-9059-44fc-a969-ef9b4054dd18" />

