### PR TITLE
MTV-6042 | Fix kubectl-mtv binary shows "version: unknown"

### DIFF
--- a/build/forklift-cli-download/Containerfile
+++ b/build/forklift-cli-download/Containerfile
@@ -12,7 +12,7 @@ WORKDIR /app/cmd/kubectl-mtv
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 make build-all
 
 # Build a native binary for the MCP server running inside the container
-RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o mcp-bin/kubectl-mtv
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 make build-mcp
 
 # Nginx + MCP server stage
 FROM registry.access.redhat.com/ubi9/nginx-126:1-1772411898

--- a/build/forklift-cli-download/Containerfile-downstream
+++ b/build/forklift-cli-download/Containerfile-downstream
@@ -13,7 +13,7 @@ WORKDIR /app/cmd/kubectl-mtv
 RUN --mount=type=cache,target=${GOCACHE},uid=1001 make build-all
 
 # Build a native binary for the MCP server running inside the container
-RUN --mount=type=cache,target=${GOCACHE},uid=1001 go build -buildvcs=false -ldflags="-w -s" -o mcp-bin/kubectl-mtv
+RUN --mount=type=cache,target=${GOCACHE},uid=1001 make build-mcp
 
 # Nginx + MCP server stage
 FROM registry.redhat.io/ubi9/nginx-126:1-1756959223

--- a/cmd/kubectl-mtv/Makefile
+++ b/cmd/kubectl-mtv/Makefile
@@ -13,8 +13,9 @@ vet:
 	go vet ./...
 
 # Build flags
-PROD_LDFLAGS := -buildvcs=false -ldflags="-w -s"
-DEV_LDFLAGS := 
+VERSION_PKG := github.com/yaacov/kubectl-mtv/cmd
+PROD_LDFLAGS := -buildvcs=false -ldflags="-w -s -X '$(VERSION_PKG).clientVersion=$(MTV_VERSION)'"
+DEV_LDFLAGS := -ldflags="-X '$(VERSION_PKG).clientVersion=$(MTV_VERSION)'"
 
 .PHONY: build
 build: fmt vet
@@ -33,6 +34,10 @@ build-windows: fmt vet
 build-darwin: fmt vet
 	GOOS=darwin GOARCH=amd64 go build $(PROD_LDFLAGS) -o bin/kubectl-mtv-darwin-amd64
 	GOOS=darwin GOARCH=arm64 go build $(PROD_LDFLAGS) -o bin/kubectl-mtv-darwin-arm64
+
+.PHONY: build-mcp
+build-mcp:
+	go build $(PROD_LDFLAGS) -o mcp-bin/kubectl-mtv
 
 .PHONY: build-all
 build-all: build-linux build-windows build-darwin


### PR DESCRIPTION
Inject MTV_VERSION into the kubectl-mtv binary at build time via
`-ldflags -X` so that `kubectl-mtv version` reports the actual forklift
operator version instead of "unknown".

- Add `-X` linker flag to `PROD_LDFLAGS` and `DEV_LDFLAGS` in the
  kubectl-mtv Makefile, reading the version from `build/release.conf`
- Add a `build-mcp` Makefile target for the MCP server binary
- Update both Containerfiles to use `make build-mcp` instead of a raw
  `go build` that bypassed the version injection

Ref: https://redhat.atlassian.net/browse/MTV-6042
Resolves: MTV-6042