### PR TITLE
MTV-4416 | Skip map-back when LUN is already mapped to original groups

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
@@ -265,13 +265,7 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, migrationHostId, sourceVMD
 			cleanupLog.Info("failed to unmap during cleanup", "lun", lun.Name, "err", errUnmap)
 		}
 
-		cleanupLog.V(2).Info("mapping volume back to original initiator groups", "groups", originalInitiatorGroups)
-		for _, group := range originalInitiatorGroups {
-			_, errMap := p.StorageApi.Map(group, lun, mappingContext)
-			if errMap != nil {
-				cleanupLog.Info("failed to map volume back to original holder", "group", group, "err", errMap)
-			}
-		}
+		remapOriginalGroups(p.StorageApi, lun, mappingContext, originalInitiatorGroups, cleanupLog)
 		cleanupLog.V(2).Info("deleting dead devices after short delay")
 		time.Sleep(5 * time.Second)
 		deleteDeadDevices(cleanupCtx, p.VSphereClient, host, dsActiveAdapters)
@@ -328,6 +322,31 @@ func (p *RemoteEsxcliPopulator) Populate(vmId string, migrationHostId, sourceVMD
 }
 
 // waitForDeviceStateOff waits for the device state to become "off" using exponential backoff
+func remapOriginalGroups(storageApi VMDKCapable, lun LUN, mappingContext MappingContext, originalGroups []string, log klog.Logger) {
+	if len(originalGroups) == 0 {
+		return
+	}
+	currentGroups, errCurrent := storageApi.CurrentMappedGroups(lun, mappingContext)
+	if errCurrent != nil {
+		// unknown current state → safer to attempt all remaps than silently skip them;
+		// nil makes slices.Contains return false for every group
+		log.Info("failed to fetch current mapped groups, attempting remap for all original groups", "err", errCurrent)
+		currentGroups = nil
+	}
+	for _, group := range originalGroups {
+		if slices.Contains(currentGroups, group) {
+			log.V(2).Info("volume already mapped to original group, skipping", "group", group)
+			continue
+		}
+		_, errMap := storageApi.Map(group, lun, mappingContext)
+		if errMap != nil {
+			log.Info("failed to map volume back to original holder", "group", group, "err", errMap)
+		} else {
+			log.V(2).Info("volume remapped to original group", "group", group)
+		}
+	}
+}
+
 func waitForDeviceStateOff(ctx context.Context, client vmware.Client, host *object.HostSystem, deviceNAA string) error {
 	backoff := wait.Backoff{
 		Duration: 1 * time.Second,

--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli_test.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/object"
 	"go.uber.org/mock/gomock"
+	"k8s.io/klog/v2"
 
 	vmware_mocks "github.com/kubev2v/forklift/cmd/vsphere-copy-offload-populator/internal/vmware/mocks"
 )
@@ -304,6 +305,95 @@ var _ = Describe("checkScriptVersion", func() {
 			err := checkScriptVersion(context.Background(), client, datastore, "invalid-version", publicKey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid embedded version format"))
+		})
+	})
+})
+
+// stubRemapApi is a test double for VMDKCapable covering only the methods used by remapOriginalGroups.
+type stubRemapApi struct {
+	currentGroupsResult []string
+	currentGroupsErr    error
+	currentGroupsCalled bool
+	mapCalls            []string
+	mapFn               func(group string) (LUN, error)
+}
+
+func (s *stubRemapApi) CurrentMappedGroups(_ LUN, _ MappingContext) ([]string, error) {
+	s.currentGroupsCalled = true
+	return s.currentGroupsResult, s.currentGroupsErr
+}
+
+func (s *stubRemapApi) Map(group string, lun LUN, _ MappingContext) (LUN, error) {
+	s.mapCalls = append(s.mapCalls, group)
+	if s.mapFn != nil {
+		return s.mapFn(group)
+	}
+	return lun, nil
+}
+
+func (s *stubRemapApi) EnsureClonnerIgroup(string, []string) (MappingContext, error) { return nil, nil }
+func (s *stubRemapApi) MapTarget(lun LUN, _ MappingContext) (LUN, error)             { return lun, nil }
+func (s *stubRemapApi) UnmapTarget(LUN, MappingContext) error                        { return nil }
+func (s *stubRemapApi) UnMap(string, LUN, MappingContext) error                      { return nil }
+func (s *stubRemapApi) ResolvePVToLUN(PersistentVolume) (LUN, error)                 { return LUN{}, nil }
+
+var _ = Describe("remapOriginalGroups", func() {
+	var (
+		api *stubRemapApi
+		lun LUN
+		ctx MappingContext
+		log klog.Logger
+	)
+
+	BeforeEach(func() {
+		api = &stubRemapApi{}
+		lun = LUN{Name: "test-lun"}
+		ctx = MappingContext{}
+		log = klog.Background()
+	})
+
+	Context("when originalGroups is empty", func() {
+		It("makes no storage calls", func() {
+			remapOriginalGroups(api, lun, ctx, nil, log)
+			Expect(api.currentGroupsCalled).To(BeFalse())
+			Expect(api.mapCalls).To(BeEmpty())
+		})
+	})
+
+	Context("when all groups are already mapped", func() {
+		It("skips all Map calls", func() {
+			api.currentGroupsResult = []string{"group-a", "group-b"}
+			remapOriginalGroups(api, lun, ctx, []string{"group-a", "group-b"}, log)
+			Expect(api.mapCalls).To(BeEmpty())
+		})
+	})
+
+	Context("when only some groups are already mapped", func() {
+		It("calls Map only for the missing group", func() {
+			api.currentGroupsResult = []string{"group-a"}
+			remapOriginalGroups(api, lun, ctx, []string{"group-a", "group-b"}, log)
+			Expect(api.mapCalls).To(ConsistOf("group-b"))
+		})
+	})
+
+	Context("when CurrentMappedGroups fails", func() {
+		It("attempts remap for all original groups", func() {
+			api.currentGroupsErr = errors.New("storage unreachable")
+			remapOriginalGroups(api, lun, ctx, []string{"group-a", "group-b"}, log)
+			Expect(api.mapCalls).To(ConsistOf("group-a", "group-b"))
+		})
+	})
+
+	Context("when Map fails for one group", func() {
+		It("continues and attempts remaining groups", func() {
+			api.mapFn = func(group string) (LUN, error) {
+				if group == "group-a" {
+					return LUN{}, errors.New("404 not found")
+				}
+				return lun, nil
+			}
+			remapOriginalGroups(api, lun, ctx, []string{"group-a", "group-b"}, log)
+			Expect(api.mapCalls).To(ConsistOf("group-a", "group-b"))
 		})
 	})
 })


### PR DESCRIPTION
## Problem

On HPE Primera/3PAR, xcopy cleanup logged a spurious 404 error when
attempting to remap the source LUN back to its original initiator groups.
The error appeared despite the migration completing successfully.

## What it achieves

The cleanup now checks the live mapped groups on the array before
attempting to remap. Any group the LUN is still mapped to (which in
practice is all of them, since only the temporary xcopy group is ever
unmapped) is skipped silently. Groups that were genuinely lost are
still remapped.

## Why this approach

The original map-back assumed the LUN's existing mappings were removed
during xcopy, but they weren't — only the xcopy initiator group is
unmapped. The 404 was the array rejecting a duplicate mapping creation.
A live check at cleanup time eliminates the error without weakening the
safety net.

Verified by running a full migration of `tshefismall` on HPE Primera/3PAR:
xcopy completes successfully, no 404 in cleanup, VM boots on OCP.

## How to test

Migrate any VM from an HPE Primera/3PAR iSCSI datastore via xcopy.
Confirm no `failed to map volume back to original holder` warning in
the populator logs and that the migration succeeds.