### PR TITLE
MTV-6050 | Set SCSI reservation and errorPolicy on shared RDM LUN disks

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1035,7 +1035,10 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 		}
 		if disk.RDM && r.shouldRDMAsLun(vm) {
 			diskDevice = cnv.DiskDevice{
-				LUN: &cnv.LunTarget{Bus: cnv.DiskBusSCSI},
+				LUN: &cnv.LunTarget{
+					Bus:         cnv.DiskBusSCSI,
+					Reservation: disk.Shared,
+				},
 			}
 		}
 		kubevirtDisk := cnv.Disk{
@@ -1045,6 +1048,9 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 		if disk.Shared {
 			kubevirtDisk.Shareable = ptr.To(true)
 			kubevirtDisk.Cache = cnv.CacheNone
+			if disk.RDM && r.shouldRDMAsLun(vm) {
+				kubevirtDisk.ErrorPolicy = ptr.To(cnv.DiskErrorPolicyReport)
+			}
 		}
 		// Disk serial numbers are only presented to the source guest if
 		// the disk is connected with SCSI and disk.EnableUUID is set to

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	cnv "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -1145,6 +1146,148 @@ var _ = Describe("PopulatorXcopyUsed", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
 		Expect(xcopyUsed).To(Equal("0"))
+	})
+})
+
+var _ = Describe("mapDisks SCSI reservation", func() {
+	var builder *Builder
+
+	BeforeEach(func() {
+		builder = createBuilder()
+	})
+
+	buildPVC := func(diskFile string) *core.PersistentVolumeClaim {
+		return &core.PersistentVolumeClaim{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "test-pvc",
+				Namespace: "test",
+				Annotations: map[string]string{
+					"forklift.konveyor.io/disk-source": diskFile,
+				},
+			},
+		}
+	}
+
+	It("should set Reservation and ErrorPolicy on shared RDM LUN disk", func() {
+		builder.Plan.Spec.RDMAsLun = true
+		vm := &model.VM{
+			VM1: model.VM1{
+				VM0: model.VM0{ID: "vm-1", Name: "test-vm"},
+				Disks: []vsphere.Disk{
+					{
+						Key:      2000,
+						File:     "[ds1] vm/disk.vmdk",
+						Capacity: 1 << 30,
+						RDM:      true,
+						Shared:   true,
+						Bus:      vsphere.SCSI,
+					},
+				},
+			},
+		}
+		pvcs := []*core.PersistentVolumeClaim{buildPVC("[ds1] vm/disk.vmdk")}
+		spec := &cnv.VirtualMachineSpec{Template: &cnv.VirtualMachineInstanceTemplateSpec{}}
+
+		err := builder.mapDisks(vm, ref.Ref{ID: "vm-1"}, pvcs, spec, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(spec.Template.Spec.Domain.Devices.Disks).To(HaveLen(1))
+		disk := spec.Template.Spec.Domain.Devices.Disks[0]
+		Expect(disk.LUN).NotTo(BeNil())
+		Expect(disk.LUN.Bus).To(Equal(cnv.DiskBusSCSI))
+		Expect(disk.LUN.Reservation).To(BeTrue())
+		Expect(disk.Shareable).To(Equal(ptr.To(true)))
+		Expect(disk.ErrorPolicy).To(Equal(ptr.To(cnv.DiskErrorPolicyReport)))
+	})
+
+	It("should NOT set Reservation when disk is RDM+LUN but not shared", func() {
+		builder.Plan.Spec.RDMAsLun = true
+		vm := &model.VM{
+			VM1: model.VM1{
+				VM0: model.VM0{ID: "vm-1", Name: "test-vm"},
+				Disks: []vsphere.Disk{
+					{
+						Key:      2000,
+						File:     "[ds1] vm/disk.vmdk",
+						Capacity: 1 << 30,
+						RDM:      true,
+						Shared:   false,
+						Bus:      vsphere.SCSI,
+					},
+				},
+			},
+		}
+		pvcs := []*core.PersistentVolumeClaim{buildPVC("[ds1] vm/disk.vmdk")}
+		spec := &cnv.VirtualMachineSpec{Template: &cnv.VirtualMachineInstanceTemplateSpec{}}
+
+		err := builder.mapDisks(vm, ref.Ref{ID: "vm-1"}, pvcs, spec, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		disk := spec.Template.Spec.Domain.Devices.Disks[0]
+		Expect(disk.LUN).NotTo(BeNil())
+		Expect(disk.LUN.Reservation).To(BeFalse())
+		Expect(disk.Shareable).To(BeNil())
+		Expect(disk.ErrorPolicy).To(BeNil())
+	})
+
+	It("should NOT set LUN or Reservation when disk is shared but not RDM", func() {
+		builder.Plan.Spec.RDMAsLun = true
+		vm := &model.VM{
+			VM1: model.VM1{
+				VM0: model.VM0{ID: "vm-1", Name: "test-vm"},
+				Disks: []vsphere.Disk{
+					{
+						Key:      2000,
+						File:     "[ds1] vm/disk.vmdk",
+						Capacity: 1 << 30,
+						RDM:      false,
+						Shared:   true,
+						Bus:      vsphere.SCSI,
+					},
+				},
+			},
+		}
+		pvcs := []*core.PersistentVolumeClaim{buildPVC("[ds1] vm/disk.vmdk")}
+		spec := &cnv.VirtualMachineSpec{Template: &cnv.VirtualMachineInstanceTemplateSpec{}}
+
+		err := builder.mapDisks(vm, ref.Ref{ID: "vm-1"}, pvcs, spec, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		disk := spec.Template.Spec.Domain.Devices.Disks[0]
+		Expect(disk.LUN).To(BeNil())
+		Expect(disk.Disk).NotTo(BeNil())
+		Expect(disk.Shareable).To(Equal(ptr.To(true)))
+		Expect(disk.ErrorPolicy).To(BeNil())
+	})
+
+	It("should NOT set Reservation when rdmAsLun is false", func() {
+		builder.Plan.Spec.RDMAsLun = false
+		vm := &model.VM{
+			VM1: model.VM1{
+				VM0: model.VM0{ID: "vm-1", Name: "test-vm"},
+				Disks: []vsphere.Disk{
+					{
+						Key:      2000,
+						File:     "[ds1] vm/disk.vmdk",
+						Capacity: 1 << 30,
+						RDM:      true,
+						Shared:   true,
+						Bus:      vsphere.SCSI,
+					},
+				},
+			},
+		}
+		pvcs := []*core.PersistentVolumeClaim{buildPVC("[ds1] vm/disk.vmdk")}
+		spec := &cnv.VirtualMachineSpec{Template: &cnv.VirtualMachineInstanceTemplateSpec{}}
+
+		err := builder.mapDisks(vm, ref.Ref{ID: "vm-1"}, pvcs, spec, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		disk := spec.Template.Spec.Domain.Devices.Disks[0]
+		Expect(disk.LUN).To(BeNil())
+		Expect(disk.Disk).NotTo(BeNil())
+		Expect(disk.Shareable).To(Equal(ptr.To(true)))
+		Expect(disk.ErrorPolicy).To(BeNil())
 	})
 })
 


### PR DESCRIPTION
When rdmAsLun=true and a disk is shared, set LunTarget.Reservation=true and Disk.ErrorPolicy="report" on the target KubeVirt VM spec. This enables SCSI-3 Persistent Reservations (pr-helper) so clustered workloads (WSFC, Oracle RAC, Veritas) can coordinate disk ownership, and reports I/O errors to the guest instead of pausing the VM, allowing proper failover.

Ref: https://redhat.atlassian.net/browse/MTV-6050
Resolves: MTV-6050