### PR TITLE
MTV-5880 | Skip re-adding persistent route when DefaultGateway already provides it

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
@@ -84,10 +84,10 @@ if (-not $groupedRoutes) {
     
     # First, handle duplicate default gateways
     foreach ($group in $gatewayDuplicates) {
-        $routes = $group.Group
+        $dupRoutes = $group.Group
 
         # Choose the route on a live interface with the lowest metric
-        $sortedRoutes = $routes | Sort-Object RouteMetric
+        $sortedRoutes = $dupRoutes | Sort-Object RouteMetric
         $toKeep = $null
         foreach ($route in $sortedRoutes) {
             $interface = $liveAdapters | Where-Object { $_.InterfaceIndex -eq $route.InterfaceIndex }
@@ -109,39 +109,53 @@ if (-not $groupedRoutes) {
         Write-Host "  Cleaning duplicate default gateway: $gateway (metric $metric) - keeping IF $($toKeep.InterfaceIndex)" -ForegroundColor Yellow
         
         # Remove ALL instances
-        foreach ($route in $routes) {
+        foreach ($route in $dupRoutes) {
             Remove-PersistentRoute $route
             Write-Host "    Deleted: $($route.DestinationPrefix) via $($route.NextHop) on IF $($route.InterfaceIndex)" -ForegroundColor Red
         }
         
-        # Re-add only ONE instance (preserve the first interface)
-        $reAddSucceeded = $false
-        try {
-            New-NetRoute -DestinationPrefix $dest -InterfaceIndex $toKeep.InterfaceIndex -NextHop $gateway -RouteMetric $metric -PolicyStore PersistentStore -ErrorAction Stop
-            Write-Host "    Re-added: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
-            $reAddSucceeded = $true
-        } catch {
-            Write-Host "      PolicyStore method failed: $($_.Exception.Message)" -ForegroundColor Yellow
+        # Check if the chosen interface already has this gateway via its IP
+        # configuration (DefaultGateway registry, set by the network-configure
+        # script). If so, skip the PersistentStore re-add to avoid creating a
+        # duplicate persistent entry from a different source.
+        $ipCfg = Get-NetIPConfiguration -InterfaceIndex $toKeep.InterfaceIndex -ErrorAction SilentlyContinue
+        $alreadyHasGateway = $false
+        if ($ipCfg -and $ipCfg.IPv4DefaultGateway) {
+            $alreadyHasGateway = $ipCfg.IPv4DefaultGateway.NextHop -contains $gateway
         }
-        
-        # Fallback to route.exe if PolicyStore failed
-        if (-not $reAddSucceeded) {
+
+        if ($alreadyHasGateway) {
+            Write-Host "    Skipping re-add: IF $($toKeep.InterfaceIndex) already has gateway $gateway via DefaultGateway" -ForegroundColor Green
+        } else {
+            # Re-add only ONE instance (preserve the first interface)
+            $reAddSucceeded = $false
             try {
-                $parts = $dest.Split("/")
-                $network = $parts[0]
-                $prefix = [int]$parts[1]
-                $netmask = Convert-PrefixToMask $prefix
-                $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
-                $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
-                Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
-                cmd /c $command
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Error "route.exe failed with exit code $LASTEXITCODE, command: $command"
-                } else {
-                    Write-Host "    Re-added with route.exe: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
-                }
+                New-NetRoute -DestinationPrefix $dest -InterfaceIndex $toKeep.InterfaceIndex -NextHop $gateway -RouteMetric $metric -PolicyStore PersistentStore -ErrorAction Stop
+                Write-Host "    Re-added: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                $reAddSucceeded = $true
             } catch {
-                Write-Host "      route.exe also failed: $($_.Exception.Message)" -ForegroundColor Red
+                Write-Host "      PolicyStore method failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            }
+            
+            # Fallback to route.exe if PolicyStore failed
+            if (-not $reAddSucceeded) {
+                try {
+                    $parts = $dest.Split("/")
+                    $network = $parts[0]
+                    $prefix = [int]$parts[1]
+                    $netmask = Convert-PrefixToMask $prefix
+                    $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
+                    $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
+                    Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
+                    cmd /c $command
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Error "route.exe failed with exit code $LASTEXITCODE, command: $command"
+                    } else {
+                        Write-Host "    Re-added with route.exe: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                    }
+                } catch {
+                    Write-Host "      route.exe also failed: $($_.Exception.Message)" -ForegroundColor Red
+                }
             }
         }
     }

--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
@@ -81,10 +81,10 @@ if (-not $groupedRoutes) {
     
     # First, handle duplicate default gateways
     foreach ($group in $gatewayDuplicates) {
-        $routes = $group.Group
+        $dupRoutes = $group.Group
         
         # Choose the route on a live interface with the lowest metric
-        $sortedRoutes = $routes | Sort-Object RouteMetric
+        $sortedRoutes = $dupRoutes | Sort-Object RouteMetric
         $toKeep = $null
         foreach ($route in $sortedRoutes) {
             $interface = $liveAdapters | Where-Object { $_.InterfaceIndex -eq $route.InterfaceIndex }
@@ -106,36 +106,53 @@ if (-not $groupedRoutes) {
         Write-Host "  Cleaning duplicate default gateway: $gateway (metric $metric) - keeping IF $($toKeep.InterfaceIndex)" -ForegroundColor Yellow
         
         # Remove ALL instances
-        foreach ($route in $routes) {
+        foreach ($route in $dupRoutes) {
             Remove-PersistentRoute $route
             Write-Host "    Deleted: $($route.DestinationPrefix) via $($route.NextHop) on IF $($route.InterfaceIndex)" -ForegroundColor Red
         }
         
-        # Re-add only ONE instance (preserve the first interface)
-        $reAddSucceeded = $false
-        try {
-            New-NetRoute -DestinationPrefix $dest -InterfaceIndex $toKeep.InterfaceIndex -NextHop $gateway -RouteMetric $metric -PolicyStore PersistentStore -ErrorAction Stop
-            Write-Host "    Re-added: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
-            $reAddSucceeded = $true
-        } catch {
-            Write-Host "      PolicyStore method failed: $($_.Exception.Message)" -ForegroundColor Yellow
+        # Check if the chosen interface already has this gateway via its IP
+        # configuration (DefaultGateway registry, set by the network-configure
+        # script). If so, skip the PersistentStore re-add to avoid creating a
+        # duplicate persistent entry from a different source.
+        $ipCfg = Get-NetIPConfiguration -InterfaceIndex $toKeep.InterfaceIndex -ErrorAction SilentlyContinue
+        $alreadyHasGateway = $false
+        if ($ipCfg -and $ipCfg.IPv4DefaultGateway) {
+            $alreadyHasGateway = $ipCfg.IPv4DefaultGateway.NextHop -contains $gateway
         }
-        
-        # Fallback to route.exe if PolicyStore failed
-        if (-not $reAddSucceeded) {
+
+        if ($alreadyHasGateway) {
+            Write-Host "    Skipping re-add: IF $($toKeep.InterfaceIndex) already has gateway $gateway via DefaultGateway" -ForegroundColor Green
+        } else {
+            # Re-add only ONE instance (preserve the first interface)
+            $reAddSucceeded = $false
             try {
-                $parts = $dest.Split("/")
-                $network = $parts[0]
-                $prefix = [int]$parts[1]
-                $netmask = Convert-PrefixToMask $prefix
-                $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
-                $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
-                Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
-                cmd /c $command
-                
-                Write-Host "    Re-added with route.exe: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                New-NetRoute -DestinationPrefix $dest -InterfaceIndex $toKeep.InterfaceIndex -NextHop $gateway -RouteMetric $metric -PolicyStore PersistentStore -ErrorAction Stop
+                Write-Host "    Re-added: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                $reAddSucceeded = $true
             } catch {
-                Write-Host "      route.exe also failed: $($_.Exception.Message)" -ForegroundColor Red
+                Write-Host "      PolicyStore method failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            }
+            
+            # Fallback to route.exe if PolicyStore failed
+            if (-not $reAddSucceeded) {
+                try {
+                    $parts = $dest.Split("/")
+                    $network = $parts[0]
+                    $prefix = [int]$parts[1]
+                    $netmask = Convert-PrefixToMask $prefix
+                    $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
+                    $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
+                    Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
+                    cmd /c $command
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Error "route.exe failed with exit code $LASTEXITCODE, command: $command"
+                    } else {
+                        Write-Host "    Re-added with route.exe: $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                    }
+                } catch {
+                    Write-Host "      route.exe also failed: $($_.Exception.Message)" -ForegroundColor Red
+                }
             }
         }
     }
@@ -197,7 +214,11 @@ if (-not $groupedRoutes) {
 
             try {
                 cmd /c $command
-                Write-Host "  Re-added with route.exe: $dest via $gateway metric $metric on IF $interfaceIndex" -ForegroundColor Green
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error "route.exe failed with exit code $LASTEXITCODE, command: $command"
+                } else {
+                    Write-Host "  Re-added with route.exe: $dest via $gateway metric $metric on IF $interfaceIndex" -ForegroundColor Green
+                }
             } catch {
                 Write-Host "    Failed to re-add route: $($_.Exception.Message)" -ForegroundColor Red
             }


### PR DESCRIPTION
## Summary

After Hyper-V to KubeVirt migration, the duplicate persistent route cleanup
script removes all duplicate default gateways and then re-adds one instance
via `PersistentStore` or `route.exe -p`. However, when the target interface
already has the same gateway configured through the `DefaultGateway` registry
key (set by the network-configure firstboot script), this re-add creates a
new duplicate from a different source.

### Changes

- Check `Get-NetIPConfiguration` before re-adding a cleaned default gateway,
  skip the `PersistentStore` write when the interface already has that gateway
  via its IP configuration
- Rename loop variable `$routes` → `$dupRoutes` to avoid shadowing the outer
  `$routes` collection
- Apply the fix to both the standard and registry script variants

Ref: https://redhat.atlassian.net/browse/MTV-5880
Resolves: MTV-5880