### PR TITLE
MTV-6060 | Fix static UDN IP preservation for OpenStack migrations

### DIFF
--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -546,6 +547,7 @@ func (r *Builder) mapDisks(vm *model.Workload, persistentVolumeClaims []*core.Pe
 func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec) (err error) {
 	var kNetworks []cnv.Network
 	var kInterfaces []cnv.Interface
+	staticIpInterfaces := make(map[string][]string)
 
 	hasUDN := r.Plan.DestinationHasUdnNetwork(r.Destination)
 	numNetworks := 0
@@ -627,6 +629,11 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 						kInterface.Binding = &cnv.PluginBinding{
 							Name: planbase.UdnL2bridge,
 						}
+						if r.Plan.Spec.PreserveStaticIPs {
+							if ip := getFixedIPv4ForNetwork(vm, vmNetworkName); ip != "" {
+								staticIpInterfaces[networkName] = append(staticIpInterfaces[networkName], ip)
+							}
+						}
 					} else {
 						kInterface.Masquerade = &cnv.InterfaceMasquerade{}
 					}
@@ -647,6 +654,18 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 
 	object.Template.Spec.Networks = kNetworks
 	object.Template.Spec.Domain.Devices.Interfaces = kInterfaces
+
+	if settings.Settings.StaticUdnIpAddresses && hasUDN && r.Plan.Spec.PreserveStaticIPs && len(staticIpInterfaces) > 0 {
+		var staticIpInterfacesAnnotation []byte
+		staticIpInterfacesAnnotation, err = json.Marshal(staticIpInterfaces)
+		if err != nil {
+			return err
+		}
+		if object.Template.ObjectMeta.Annotations == nil {
+			object.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		object.Template.ObjectMeta.Annotations[planbase.AnnStaticUdnIp] = string(staticIpInterfacesAnnotation)
+	}
 
 	var vifMultiQueueEnabled *bool
 	if imageVifMultiQueueEnabled, ok := vm.Image.Properties[VifMultiQueueEnabled]; ok {

--- a/pkg/controller/plan/adapter/openstack/builder_test.go
+++ b/pkg/controller/plan/adapter/openstack/builder_test.go
@@ -1,9 +1,23 @@
 package openstack
 
 import (
+	"encoding/json"
+
+	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/openstack"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/settings"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	cnv "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("OpenStack builder", func() {
@@ -21,5 +35,316 @@ var _ = Describe("OpenStack builder", func() {
 var _ = Describe("OpenStack Glance const test", func() {
 	It("GlanceSource should be glance, changing it may break the UI", func() {
 		Expect(v1beta1.GlanceSource).Should(Equal("glance"))
+	})
+})
+
+var builderLog = logging.WithName("openstack-builder-test")
+
+var _ = Describe("OpenStack builder mapNetworks", func() {
+	var (
+		origStaticUdnIpAddresses bool
+		origUdnSupportsMac       bool
+	)
+
+	BeforeEach(func() {
+		origStaticUdnIpAddresses = settings.Settings.StaticUdnIpAddresses
+		origUdnSupportsMac = settings.Settings.UdnSupportsMac
+	})
+
+	AfterEach(func() {
+		settings.Settings.StaticUdnIpAddresses = origStaticUdnIpAddresses
+		settings.Settings.UdnSupportsMac = origUdnSupportsMac
+	})
+
+	newBuilder := func(hasUDN bool, preserveStaticIPs bool) *Builder {
+		scheme := runtime.NewScheme()
+		_ = core.AddToScheme(scheme)
+		_ = k8snet.AddToScheme(scheme)
+
+		objs := []runtime.Object{}
+		ns := &core.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ns",
+			},
+		}
+		if hasUDN {
+			ns.Labels = map[string]string{
+				"k8s.ovn.org/primary-user-defined-network": "",
+			}
+			objs = append(objs, ns, &k8snet.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "udn-nad",
+					Namespace: "test-ns",
+					Labels:    map[string]string{"k8s.ovn.org/user-defined-network": ""},
+				},
+			})
+		} else {
+			objs = append(objs, ns)
+		}
+
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(objs...).
+			Build()
+
+		plan := &v1beta1.Plan{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-plan", Namespace: "test-ns"},
+			Spec: v1beta1.PlanSpec{
+				TargetNamespace:   "test-ns",
+				PreserveStaticIPs: preserveStaticIPs,
+			},
+		}
+
+		networkMap := &v1beta1.NetworkMap{
+			Spec: v1beta1.NetworkMapSpec{
+				Map: []v1beta1.NetworkPair{
+					{
+						Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{ID: "net-001"}},
+						Destination: v1beta1.DestinationNetwork{
+							Type: Pod,
+						},
+					},
+				},
+			},
+		}
+		plan.Map.Network = networkMap
+
+		ctx := &plancontext.Context{
+			Plan: plan,
+			Destination: plancontext.Destination{
+				Client: cl,
+			},
+			Log: builderLog,
+		}
+		ctx.Map.Network = networkMap
+
+		return &Builder{
+			Context: ctx,
+		}
+	}
+
+	vmWithFixedIP := func(networkName, networkID, ip, mac string) *model.Workload {
+		return &model.Workload{
+			XVM: model.XVM{
+				VM: model.VM{
+					VM1: model.VM1{
+						Addresses: map[string]interface{}{
+							networkName: []interface{}{
+								map[string]interface{}{
+									"addr":                    ip,
+									"version":                 float64(4),
+									"OS-EXT-IPS:type":         "fixed",
+									"OS-EXT-IPS-MAC:mac_addr": mac,
+								},
+							},
+						},
+					},
+				},
+				Networks: []model.Network{
+					{Resource: model.Resource{ID: networkID, Name: networkName}},
+				},
+			},
+		}
+	}
+
+	It("should set static IP annotation when UDN + PreserveStaticIPs + feature flag enabled", func() {
+		settings.Settings.StaticUdnIpAddresses = true
+		settings.Settings.UdnSupportsMac = false
+		builder := newBuilder(true, true)
+
+		vm := vmWithFixedIP("my-network", "net-001", "10.220.0.5", "fa:16:3e:aa:bb:cc")
+		spec := &cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		}
+
+		err := builder.mapNetworks(vm, spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(spec.Template.ObjectMeta.Annotations).To(HaveKey(planbase.AnnStaticUdnIp))
+		var parsed map[string][]string
+		Expect(json.Unmarshal([]byte(spec.Template.ObjectMeta.Annotations[planbase.AnnStaticUdnIp]), &parsed)).To(Succeed())
+		Expect(parsed).To(HaveLen(1))
+		Expect(parsed).To(HaveKeyWithValue("net-0", []string{"10.220.0.5"}))
+	})
+
+	It("should NOT set annotation when feature flag is off", func() {
+		settings.Settings.StaticUdnIpAddresses = false
+		builder := newBuilder(true, true)
+
+		vm := vmWithFixedIP("my-network", "net-001", "10.220.0.5", "fa:16:3e:aa:bb:cc")
+		spec := &cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		}
+
+		err := builder.mapNetworks(vm, spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		if spec.Template.ObjectMeta.Annotations != nil {
+			Expect(spec.Template.ObjectMeta.Annotations).NotTo(HaveKey(planbase.AnnStaticUdnIp))
+		}
+	})
+
+	It("should NOT set annotation when PreserveStaticIPs is false", func() {
+		settings.Settings.StaticUdnIpAddresses = true
+		builder := newBuilder(true, false)
+
+		vm := vmWithFixedIP("my-network", "net-001", "10.220.0.5", "fa:16:3e:aa:bb:cc")
+		spec := &cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		}
+
+		err := builder.mapNetworks(vm, spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		if spec.Template.ObjectMeta.Annotations != nil {
+			Expect(spec.Template.ObjectMeta.Annotations).NotTo(HaveKey(planbase.AnnStaticUdnIp))
+		}
+	})
+
+	It("should NOT set annotation when namespace has no UDN", func() {
+		settings.Settings.StaticUdnIpAddresses = true
+		builder := newBuilder(false, true)
+
+		vm := vmWithFixedIP("my-network", "net-001", "10.220.0.5", "fa:16:3e:aa:bb:cc")
+		spec := &cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		}
+
+		err := builder.mapNetworks(vm, spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		if spec.Template.ObjectMeta.Annotations != nil {
+			Expect(spec.Template.ObjectMeta.Annotations).NotTo(HaveKey(planbase.AnnStaticUdnIp))
+		}
+	})
+
+	It("should skip floating IPs", func() {
+		settings.Settings.StaticUdnIpAddresses = true
+		settings.Settings.UdnSupportsMac = false
+		builder := newBuilder(true, true)
+
+		vm := &model.Workload{
+			XVM: model.XVM{
+				VM: model.VM{
+					VM1: model.VM1{
+						Addresses: map[string]interface{}{
+							"my-network": []interface{}{
+								map[string]interface{}{
+									"addr":                    "192.168.1.100",
+									"version":                 float64(4),
+									"OS-EXT-IPS:type":         "floating",
+									"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+								},
+							},
+						},
+					},
+				},
+				Networks: []model.Network{
+					{Resource: model.Resource{ID: "net-001", Name: "my-network"}},
+				},
+			},
+		}
+		spec := &cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		}
+
+		err := builder.mapNetworks(vm, spec)
+		Expect(err).NotTo(HaveOccurred())
+		// floating IPs cause a `continue`, so no networks/interfaces are created
+		Expect(spec.Template.Spec.Networks).To(BeEmpty())
+	})
+
+	It("should exclude IPv6 addresses from static IP annotation", func() {
+		settings.Settings.StaticUdnIpAddresses = true
+		settings.Settings.UdnSupportsMac = false
+		builder := newBuilder(true, true)
+
+		vm := &model.Workload{
+			XVM: model.XVM{
+				VM: model.VM{
+					VM1: model.VM1{
+						Addresses: map[string]interface{}{
+							"my-network": []interface{}{
+								map[string]interface{}{
+									"addr":                    "fe80::1",
+									"version":                 float64(6),
+									"OS-EXT-IPS:type":         "fixed",
+									"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+								},
+							},
+						},
+					},
+				},
+				Networks: []model.Network{
+					{Resource: model.Resource{ID: "net-001", Name: "my-network"}},
+				},
+			},
+		}
+		spec := &cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		}
+
+		err := builder.mapNetworks(vm, spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		// UDN interface should be created but no static IP annotation since IPv6
+		Expect(spec.Template.Spec.Networks).To(HaveLen(1))
+		if spec.Template.ObjectMeta.Annotations != nil {
+			Expect(spec.Template.ObjectMeta.Annotations).NotTo(HaveKey(planbase.AnnStaticUdnIp))
+		}
+	})
+
+	It("should use l2bridge binding when UDN is present", func() {
+		settings.Settings.StaticUdnIpAddresses = false
+		settings.Settings.UdnSupportsMac = false
+		builder := newBuilder(true, false)
+
+		vm := vmWithFixedIP("my-network", "net-001", "10.220.0.5", "fa:16:3e:aa:bb:cc")
+		spec := &cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		}
+
+		err := builder.mapNetworks(vm, spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(spec.Template.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
+		iface := spec.Template.Spec.Domain.Devices.Interfaces[0]
+		Expect(iface.Binding).NotTo(BeNil())
+		Expect(iface.Binding.Name).To(Equal(planbase.UdnL2bridge))
+		Expect(iface.Masquerade).To(BeNil())
+	})
+
+	It("should use masquerade when no UDN", func() {
+		settings.Settings.StaticUdnIpAddresses = false
+		builder := newBuilder(false, false)
+
+		vm := vmWithFixedIP("my-network", "net-001", "10.220.0.5", "fa:16:3e:aa:bb:cc")
+		spec := &cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		}
+
+		err := builder.mapNetworks(vm, spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(spec.Template.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
+		iface := spec.Template.Spec.Domain.Devices.Interfaces[0]
+		Expect(iface.Masquerade).NotTo(BeNil())
+		Expect(iface.Binding).To(BeNil())
 	})
 })

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -1,14 +1,26 @@
 package openstack
 
 import (
+	"context"
+	"encoding/json"
+	"net"
+
+	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	ocpmodel "github.com/kubev2v/forklift/pkg/controller/provider/model/ocp"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/openstack"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	core "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	namespaceLabelPrimaryUDN = "k8s.ovn.org/primary-user-defined-network"
+	nadLabelUDN              = "k8s.ovn.org/user-defined-network"
 )
 
 // Validator
@@ -67,9 +79,142 @@ func (r *Validator) MaintenanceMode(vmRef ref.Ref) (ok bool, err error) {
 	return
 }
 
-// NO-OP
-func (r *Validator) UdnStaticIPs(vmRef ref.Ref, client client.Client) (ok bool, err error) {
-	return true, nil
+func (r *Validator) UdnStaticIPs(vmRef ref.Ref, cl client.Client) (ok bool, err error) {
+	if !r.Plan.DestinationHasUdnNetwork(cl) {
+		return true, nil
+	}
+	if !r.Plan.Spec.PreserveStaticIPs {
+		return true, nil
+	}
+
+	sourceNetwork, err := r.getSourceNetworkForPodNetworkTarget(vmRef)
+	if err != nil {
+		err = liberr.Wrap(err, "vm", vmRef)
+		return
+	}
+	if sourceNetwork == nil {
+		return true, nil
+	}
+
+	vm := &model.Workload{}
+	err = r.Source.Inventory.Find(vm, vmRef)
+	if err != nil {
+		err = liberr.Wrap(err, "vm", vmRef)
+		return
+	}
+
+	udnSubnet, err := r.getUdnSubnet(cl)
+	if err != nil {
+		return false, liberr.Wrap(err, "vm", vmRef)
+	}
+	if udnSubnet == "" {
+		return true, nil
+	}
+
+	_, ipNet, err := net.ParseCIDR(udnSubnet)
+	if err != nil {
+		return false, liberr.Wrap(err, "udnSubnet", udnSubnet)
+	}
+
+	sourceIP := getFixedIPv4ForNetwork(vm, sourceNetwork.Name)
+	if sourceIP == "" {
+		r.Log.V(4).Info("No fixed IPv4 found for VM on source network, nothing to preserve", "vm", vmRef.String(), "network", sourceNetwork.Name)
+		return true, nil
+	}
+
+	ip := net.ParseIP(sourceIP)
+	if ip == nil {
+		r.Log.V(4).Info("Invalid IP in VM addresses", "vm", vmRef.String(), "ip", sourceIP)
+		return false, nil
+	}
+
+	return ipNet.Contains(ip), nil
+}
+
+func (r *Validator) getSourceNetworkForPodNetworkTarget(vmRef ref.Ref) (network *model.Network, err error) {
+	mapping := r.Plan.Map.Network.Spec.Map
+	for i := range mapping {
+		mapped := &mapping[i]
+		if mapped.Destination.Type == Pod {
+			network = &model.Network{}
+			err = r.Source.Inventory.Find(network, mapped.Source.Ref)
+			if err != nil {
+				err = liberr.Wrap(err, "network", mapped.Source.Ref)
+			}
+			return
+		}
+	}
+	return
+}
+
+func (r *Validator) getUdnSubnet(cl client.Client) (string, error) {
+	key := client.ObjectKey{
+		Name: r.Plan.Spec.TargetNamespace,
+	}
+	namespace := &core.Namespace{}
+	err := cl.Get(context.TODO(), key, namespace)
+	if err != nil {
+		return "", err
+	}
+	_, hasUdnLabel := namespace.Labels[namespaceLabelPrimaryUDN]
+	if !hasUdnLabel {
+		return "", nil
+	}
+
+	nadList := &k8snet.NetworkAttachmentDefinitionList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(r.Plan.Spec.TargetNamespace),
+		client.MatchingLabels{nadLabelUDN: ""},
+	}
+
+	err = cl.List(context.TODO(), nadList, listOpts...)
+	if err != nil {
+		return "", err
+	}
+	for _, nad := range nadList.Items {
+		var networkConfig ocpmodel.NetworkConfig
+		err = json.Unmarshal([]byte(nad.Spec.Config), &networkConfig)
+		if err != nil {
+			r.Log.Info("Skipping NAD: failed to parse network config", "namespace", nad.Namespace, "name", nad.Name, "error", err.Error())
+			continue
+		}
+		if networkConfig.IsUnsupportedUdn() && networkConfig.AllowPersistentIPs {
+			return networkConfig.Subnets, nil
+		}
+	}
+	return "", nil
+}
+
+// getFixedIPv4ForNetwork extracts the first fixed IPv4 address for the given
+// network name from the VM's Addresses map.
+func getFixedIPv4ForNetwork(vm *model.Workload, networkName string) string {
+	addrs, exists := vm.Addresses[networkName]
+	if !exists {
+		return ""
+	}
+	nics, ok := addrs.([]interface{})
+	if !ok {
+		return ""
+	}
+	for _, nic := range nics {
+		m, ok := nic.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		ipType, _ := m["OS-EXT-IPS:type"].(string)
+		if ipType != "fixed" {
+			continue
+		}
+		version, _ := m["version"].(float64)
+		if version != 4 {
+			continue
+		}
+		addr, _ := m["addr"].(string)
+		if addr != "" {
+			return addr
+		}
+	}
+	return ""
 }
 
 func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {

--- a/pkg/controller/plan/adapter/openstack/validator_test.go
+++ b/pkg/controller/plan/adapter/openstack/validator_test.go
@@ -1,0 +1,460 @@
+package openstack
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	ocpmodel "github.com/kubev2v/forklift/pkg/controller/provider/model/ocp"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/openstack"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var validatorLog = logging.WithName("openstack-validator-test")
+
+var ErrNotImplemented = errors.New("not implemented")
+
+type mockOpenstackInventory struct {
+	workloads map[string]*model.Workload
+	networks  map[string]*model.Network
+}
+
+func (m *mockOpenstackInventory) Find(resource interface{}, ref ref.Ref) error {
+	switch res := resource.(type) {
+	case *model.Workload:
+		if wl, ok := m.workloads[ref.ID]; ok {
+			*res = *wl
+			return nil
+		}
+		if wl, ok := m.workloads[ref.Name]; ok {
+			*res = *wl
+			return nil
+		}
+		return base.NotFoundError{}
+	case *model.Network:
+		if net, ok := m.networks[ref.ID]; ok {
+			*res = *net
+			return nil
+		}
+		return base.NotFoundError{}
+	}
+	return fmt.Errorf("unsupported resource type")
+}
+
+func (m *mockOpenstackInventory) Finder() web.Finder            { return nil }
+func (m *mockOpenstackInventory) Get(interface{}, string) error { return ErrNotImplemented }
+func (m *mockOpenstackInventory) Host(*ref.Ref) (interface{}, error) {
+	return nil, ErrNotImplemented
+}
+func (m *mockOpenstackInventory) List(interface{}, ...web.Param) error { return ErrNotImplemented }
+func (m *mockOpenstackInventory) Network(*ref.Ref) (interface{}, error) {
+	return nil, ErrNotImplemented
+}
+func (m *mockOpenstackInventory) Storage(*ref.Ref) (interface{}, error) {
+	return nil, ErrNotImplemented
+}
+func (m *mockOpenstackInventory) VM(*ref.Ref) (interface{}, error) { return nil, ErrNotImplemented }
+func (m *mockOpenstackInventory) Watch(interface{}, web.EventHandler) (*web.Watch, error) {
+	return nil, ErrNotImplemented
+}
+func (m *mockOpenstackInventory) Workload(*ref.Ref) (interface{}, error) {
+	return nil, ErrNotImplemented
+}
+
+var _ = Describe("OpenStack validator", func() {
+	Describe("getFixedIPv4ForNetwork", func() {
+		DescribeTable("should extract fixed IPv4 correctly",
+			func(addresses map[string]interface{}, networkName string, expectedIP string) {
+				vm := &model.Workload{
+					XVM: model.XVM{
+						VM: model.VM{
+							VM1: model.VM1{
+								Addresses: addresses,
+							},
+						},
+					},
+				}
+				result := getFixedIPv4ForNetwork(vm, networkName)
+				Expect(result).To(Equal(expectedIP))
+			},
+			Entry("fixed IPv4 found",
+				map[string]interface{}{
+					"production": []interface{}{
+						map[string]interface{}{
+							"addr":                    "10.220.0.5",
+							"version":                 float64(4),
+							"OS-EXT-IPS:type":         "fixed",
+							"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+						},
+					},
+				},
+				"production",
+				"10.220.0.5",
+			),
+			Entry("floating IP excluded",
+				map[string]interface{}{
+					"production": []interface{}{
+						map[string]interface{}{
+							"addr":                    "203.0.113.5",
+							"version":                 float64(4),
+							"OS-EXT-IPS:type":         "floating",
+							"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+						},
+					},
+				},
+				"production",
+				"",
+			),
+			Entry("IPv6 excluded",
+				map[string]interface{}{
+					"production": []interface{}{
+						map[string]interface{}{
+							"addr":                    "fe80::1",
+							"version":                 float64(6),
+							"OS-EXT-IPS:type":         "fixed",
+							"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+						},
+					},
+				},
+				"production",
+				"",
+			),
+			Entry("network not present",
+				map[string]interface{}{
+					"other-net": []interface{}{
+						map[string]interface{}{
+							"addr":                    "10.0.0.1",
+							"version":                 float64(4),
+							"OS-EXT-IPS:type":         "fixed",
+							"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+						},
+					},
+				},
+				"production",
+				"",
+			),
+			Entry("multiple NICs returns first fixed IPv4",
+				map[string]interface{}{
+					"production": []interface{}{
+						map[string]interface{}{
+							"addr":                    "fe80::1",
+							"version":                 float64(6),
+							"OS-EXT-IPS:type":         "fixed",
+							"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:11:22:33",
+						},
+						map[string]interface{}{
+							"addr":                    "10.220.0.99",
+							"version":                 float64(4),
+							"OS-EXT-IPS:type":         "fixed",
+							"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:44:55:66",
+						},
+					},
+				},
+				"production",
+				"10.220.0.99",
+			),
+			Entry("empty addresses map",
+				map[string]interface{}{},
+				"production",
+				"",
+			),
+		)
+	})
+
+	Describe("UdnStaticIPs", func() {
+		udnNADConfig := func(subnet string) string {
+			cfg := ocpmodel.NetworkConfig{
+				AllowPersistentIPs: true,
+				Type:               ocpmodel.OvnOverlayType,
+				Role:               ocpmodel.RolePrimary,
+				Subnets:            subnet,
+			}
+			b, _ := json.Marshal(cfg)
+			return string(b)
+		}
+
+		newValidatorWithClient := func(hasUDN bool, subnet string, vm *model.Workload, sourceNetworkID string) (*Validator, error) {
+			scheme := runtime.NewScheme()
+			if err := core.AddToScheme(scheme); err != nil {
+				return nil, err
+			}
+			if err := k8snet.AddToScheme(scheme); err != nil {
+				return nil, err
+			}
+
+			objs := []runtime.Object{}
+			ns := &core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "target-ns",
+				},
+			}
+			if hasUDN {
+				ns.Labels = map[string]string{
+					"k8s.ovn.org/primary-user-defined-network": "",
+				}
+				objs = append(objs, ns)
+				objs = append(objs, &k8snet.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "udn-nad",
+						Namespace: "target-ns",
+						Labels:    map[string]string{"k8s.ovn.org/user-defined-network": ""},
+					},
+					Spec: k8snet.NetworkAttachmentDefinitionSpec{
+						Config: udnNADConfig(subnet),
+					},
+				})
+			} else {
+				objs = append(objs, ns)
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(objs...).
+				Build()
+
+			inventory := &mockOpenstackInventory{
+				workloads: map[string]*model.Workload{},
+				networks:  map[string]*model.Network{},
+			}
+			if vm != nil {
+				inventory.workloads[vm.ID] = vm
+			}
+			if sourceNetworkID != "" {
+				inventory.networks[sourceNetworkID] = &model.Network{
+					Resource: model.Resource{ID: sourceNetworkID, Name: "source-net"},
+				}
+			}
+
+			plan := &v1beta1.Plan{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-plan", Namespace: "target-ns"},
+				Spec: v1beta1.PlanSpec{
+					TargetNamespace:   "target-ns",
+					PreserveStaticIPs: true,
+				},
+			}
+			plan.Map.Network = &v1beta1.NetworkMap{
+				Spec: v1beta1.NetworkMapSpec{
+					Map: []v1beta1.NetworkPair{
+						{
+							Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{ID: sourceNetworkID}},
+							Destination: v1beta1.DestinationNetwork{
+								Type: Pod,
+							},
+						},
+					},
+				},
+			}
+
+			return &Validator{
+				Context: &plancontext.Context{
+					Plan: plan,
+					Destination: plancontext.Destination{
+						Client: cl,
+					},
+					Source: plancontext.Source{
+						Inventory: inventory,
+					},
+					Log: validatorLog,
+				},
+			}, nil
+		}
+
+		It("should return true when no UDN in destination", func() {
+			vm := &model.Workload{
+				XVM: model.XVM{
+					VM: model.VM{
+						VM1: model.VM1{
+							VM0: model.VM0{ID: "vm-1"},
+							Addresses: map[string]interface{}{
+								"source-net": []interface{}{
+									map[string]interface{}{
+										"addr": "10.220.0.5", "version": float64(4),
+										"OS-EXT-IPS:type": "fixed", "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			v, err := newValidatorWithClient(false, "", vm, "net-001")
+			Expect(err).NotTo(HaveOccurred())
+
+			ok, err := v.UdnStaticIPs(ref.Ref{ID: "vm-1"}, v.Destination.Client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return true when PreserveStaticIPs is false", func() {
+			vm := &model.Workload{
+				XVM: model.XVM{
+					VM: model.VM{
+						VM1: model.VM1{
+							VM0: model.VM0{ID: "vm-1"},
+							Addresses: map[string]interface{}{
+								"source-net": []interface{}{
+									map[string]interface{}{
+										"addr": "10.220.0.5", "version": float64(4),
+										"OS-EXT-IPS:type": "fixed", "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			v, err := newValidatorWithClient(true, "10.220.0.0/24", vm, "net-001")
+			Expect(err).NotTo(HaveOccurred())
+			v.Plan.Spec.PreserveStaticIPs = false
+
+			ok, err := v.UdnStaticIPs(ref.Ref{ID: "vm-1"}, v.Destination.Client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return true when IP is within UDN subnet", func() {
+			vm := &model.Workload{
+				XVM: model.XVM{
+					VM: model.VM{
+						VM1: model.VM1{
+							VM0: model.VM0{ID: "vm-1"},
+							Addresses: map[string]interface{}{
+								"source-net": []interface{}{
+									map[string]interface{}{
+										"addr": "10.220.0.5", "version": float64(4),
+										"OS-EXT-IPS:type": "fixed", "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			v, err := newValidatorWithClient(true, "10.220.0.0/24", vm, "net-001")
+			Expect(err).NotTo(HaveOccurred())
+
+			ok, err := v.UdnStaticIPs(ref.Ref{ID: "vm-1"}, v.Destination.Client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return false when IP is outside UDN subnet", func() {
+			vm := &model.Workload{
+				XVM: model.XVM{
+					VM: model.VM{
+						VM1: model.VM1{
+							VM0: model.VM0{ID: "vm-1"},
+							Addresses: map[string]interface{}{
+								"source-net": []interface{}{
+									map[string]interface{}{
+										"addr": "192.168.1.100", "version": float64(4),
+										"OS-EXT-IPS:type": "fixed", "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			v, err := newValidatorWithClient(true, "10.220.0.0/24", vm, "net-001")
+			Expect(err).NotTo(HaveOccurred())
+
+			ok, err := v.UdnStaticIPs(ref.Ref{ID: "vm-1"}, v.Destination.Client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should return true when VM has no fixed IPv4 on source network (nothing to preserve)", func() {
+			vm := &model.Workload{
+				XVM: model.XVM{
+					VM: model.VM{
+						VM1: model.VM1{
+							VM0: model.VM0{ID: "vm-1"},
+							Addresses: map[string]interface{}{
+								"source-net": []interface{}{
+									map[string]interface{}{
+										"addr": "fe80::1", "version": float64(6),
+										"OS-EXT-IPS:type": "fixed", "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			v, err := newValidatorWithClient(true, "10.220.0.0/24", vm, "net-001")
+			Expect(err).NotTo(HaveOccurred())
+
+			ok, err := v.UdnStaticIPs(ref.Ref{ID: "vm-1"}, v.Destination.Client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return true when no network is mapped to Pod type", func() {
+			vm := &model.Workload{
+				XVM: model.XVM{
+					VM: model.VM{
+						VM1: model.VM1{
+							VM0: model.VM0{ID: "vm-1"},
+							Addresses: map[string]interface{}{
+								"source-net": []interface{}{
+									map[string]interface{}{
+										"addr": "10.220.0.5", "version": float64(4),
+										"OS-EXT-IPS:type": "fixed", "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			v, err := newValidatorWithClient(true, "10.220.0.0/24", vm, "net-001")
+			Expect(err).NotTo(HaveOccurred())
+			// Change mapping to Multus (not Pod) so no pod-target source network exists
+			v.Plan.Map.Network.Spec.Map[0].Destination.Type = Multus
+
+			ok, err := v.UdnStaticIPs(ref.Ref{ID: "vm-1"}, v.Destination.Client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return true when UDN NAD has no subnet configured", func() {
+			vm := &model.Workload{
+				XVM: model.XVM{
+					VM: model.VM{
+						VM1: model.VM1{
+							VM0: model.VM0{ID: "vm-1"},
+							Addresses: map[string]interface{}{
+								"source-net": []interface{}{
+									map[string]interface{}{
+										"addr": "10.220.0.5", "version": float64(4),
+										"OS-EXT-IPS:type": "fixed", "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:aa:bb:cc",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			// Pass empty subnet - NAD exists but no matching UDN config
+			v, err := newValidatorWithClient(true, "", vm, "net-001")
+			Expect(err).NotTo(HaveOccurred())
+
+			ok, err := v.UdnStaticIPs(ref.Ref{ID: "vm-1"}, v.Destination.Client)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
Issue:
When migrating VMs from RHOSP to OpenShift Virtualization, static IP preservation did not work when the destination network is a primary UserDefinedNetwork (UDN). The OpenStack adapter's UdnStaticIPs validator was a no-op stub, and the builder did not extract or annotate fixed IPs.

Fix:
Add isIPv4 helper and extend mapNetworks to extract fixed IPv4 addresses from source VMs, setting the network.kubevirt.io/addresses annotation on the target VM when migrating to a primary UDN namespace with preserveStaticIPs enabled.

Implement UdnStaticIPs validator for OpenStack to verify the source VM's static IP falls within the destination UDN subnet.

Add unit tests for builder and validator UDN static IP logic.

Ref: https://redhat.atlassian.net/browse/MTV-6060
Resolves: MTV-6060