### PR TITLE
MTV-6074 | Fix OpenStack populator CA certificate regression

### DIFF
--- a/pkg/lib/client/openstack/client.go
+++ b/pkg/lib/client/openstack/client.go
@@ -175,9 +175,7 @@ func (c *Client) Authenticate() (err error) {
 func (c *Client) getTLSConfig() (tlsConfig *tls.Config, err error) {
 	identityUrl, err := url.Parse(c.URL)
 	if err != nil {
-		if c.Log != nil {
-			c.Log.Error(err, "error parsing the URL", "url", c.URL)
-		}
+		c.Log.Error(err, "error parsing the URL", "url", c.URL)
 		return
 	}
 	if identityUrl.Scheme == "https" {
@@ -185,14 +183,13 @@ func (c *Client) getTLSConfig() (tlsConfig *tls.Config, err error) {
 			tlsConfig = &tls.Config{InsecureSkipVerify: true}
 		} else {
 			var cacert []byte
-			var hasCACert bool
 			if c.secret != nil {
-				cacert, hasCACert = util.GetCACert(c.secret)
+				cacert, _ = util.GetCACert(c.secret)
+			} else {
+				cacert = []byte(c.getStringFromOptions(CACert))
 			}
-			if !hasCACert {
-				if c.Log != nil {
-					c.Log.Info("CA certificate was not provided,system CA cert pool is used")
-				}
+			if len(cacert) == 0 {
+				c.Log.Info("CA certificate was not provided, system CA cert pool is used")
 			} else {
 				roots := x509.NewCertPool()
 				ok := roots.AppendCertsFromPEM(cacert)


### PR DESCRIPTION
Commit f24a1192f (MTV-5867) changed getTLSConfig() to read the CA certificate exclusively from c.secret via util.GetCACert(), bypassing c.Options. The OpenStack populator binary creates a bare Client without c.secret (it receives secret data as environment variables into c.Options), so the CA certificate was silently ignored and the populator always fell back to the system CA pool. This caused TLS failures for OpenStack endpoints using custom/self-signed certificates.

The nil pointer dereference on c.Log (fixed by 42e7aba7e / MTV-5940 with c.Log != nil guards) was a secondary symptom: the regression forced the populator into a code path it never reached before (the "no CA cert" branch), where c.Log was uninitialized.

Fix: use util.GetCACert(c.secret) when c.secret is available (controller path), fall back to c.Options["cacert"] when c.secret is nil (populator path). Remove the c.Log != nil guards added by 42e7aba7e — they are artifacts of the regression; Connect() initializes c.Log before Authenticate() is called, and Authenticate() itself already has unguarded c.Log calls.

Resolves: MTV-6074