### PR TITLE
MTV-5805 | Surface wait status when warm migration is scheduler-queued

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -139,7 +139,7 @@ func (r *Migration) Run() (reQ time.Duration, err error) {
 				return
 			}
 		} else {
-			r.Log.Info("The scheduler does not have any additional VMs.")
+			r.markSchedulerQueuedVMs()
 			break
 		}
 	}
@@ -1666,6 +1666,51 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 	}
 
 	return
+}
+
+const schedulerQueuedStepReasonFmt = "Waiting to start migration: in-flight limit reached (max %d)."
+
+func (r *Migration) markSchedulerQueuedVMs() {
+	snapshot := r.Plan.Status.Migration.ActiveSnapshot()
+	limit := settings.Settings.MaxInFlight
+	queued := 0
+
+	for i := range r.Plan.Status.Migration.VMs {
+		vm := r.Plan.Status.Migration.VMs[i]
+		if vm.MarkedStarted() || vm.MarkedCompleted() || vm.HasCondition(api.ConditionCanceled) {
+			continue
+		}
+		queued++
+		if step, found := vm.FindStep(planmigrbase.Initialize); found {
+			step.Phase = api.StepPending
+			step.Reason = fmt.Sprintf(schedulerQueuedStepReasonFmt, limit)
+		}
+	}
+
+	if queued == 0 {
+		return
+	}
+
+	r.Plan.Status.SetCondition(libcnd.Condition{
+		Type:     libcnd.Ready,
+		Status:   True,
+		Category: api.CategoryRequired,
+		Message: fmt.Sprintf(
+			"%d VM(s) waiting to start migration (in-flight limit: %d).",
+			queued,
+			limit),
+	})
+	r.Log.Info("VMs waiting for scheduler capacity.", "count", queued, "limit", limit)
+	snapshot.SetCondition(libcnd.Condition{
+		Type:     api.ConditionExecuting,
+		Status:   True,
+		Category: api.CategoryAdvisory,
+		Message: fmt.Sprintf(
+			"The plan is EXECUTING. %d VM(s) waiting to start (in-flight limit: %d).",
+			queued,
+			limit),
+		Durable: true,
+	})
 }
 
 func (r *Migration) resetPrecopyTasks(vm *plan.VMStatus, step *plan.Step) {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -704,6 +704,7 @@ func (r *Migration) runningVMs() (vms []*plan.VMStatus) {
 // Steps a VM through the migration itinerary
 // and updates its status.
 func (r *Migration) execute(vm *plan.VMStatus) (err error) {
+	vm.DeleteCondition(api.ConditionPending)
 	// check whether the VM has been canceled by the user
 	if r.Context.Migration.Spec.Canceled(vm.Ref) {
 		vm.SetCondition(
@@ -1668,10 +1669,9 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 	return
 }
 
-const schedulerQueuedStepReasonFmt = "Waiting to start migration: in-flight limit reached (max %d)."
+const schedulerQueuedReasonFmt = "Waiting to start migration: in-flight limit reached (max %d)."
 
 func (r *Migration) markSchedulerQueuedVMs() {
-	snapshot := r.Plan.Status.Migration.ActiveSnapshot()
 	limit := settings.Settings.MaxInFlight
 	queued := 0
 
@@ -1681,10 +1681,13 @@ func (r *Migration) markSchedulerQueuedVMs() {
 			continue
 		}
 		queued++
-		if step, found := vm.FindStep(planmigrbase.Initialize); found {
-			step.Phase = api.StepPending
-			step.Reason = fmt.Sprintf(schedulerQueuedStepReasonFmt, limit)
-		}
+		vm.SetCondition(libcnd.Condition{
+			Type:     api.ConditionPending,
+			Status:   True,
+			Category: api.CategoryAdvisory,
+			Message:  fmt.Sprintf(schedulerQueuedReasonFmt, limit),
+			Durable:  true,
+		})
 	}
 
 	if queued == 0 {
@@ -1701,16 +1704,6 @@ func (r *Migration) markSchedulerQueuedVMs() {
 			limit),
 	})
 	r.Log.Info("VMs waiting for scheduler capacity.", "count", queued, "limit", limit)
-	snapshot.SetCondition(libcnd.Condition{
-		Type:     api.ConditionExecuting,
-		Status:   True,
-		Category: api.CategoryAdvisory,
-		Message: fmt.Sprintf(
-			"The plan is EXECUTING. %d VM(s) waiting to start (in-flight limit: %d).",
-			queued,
-			limit),
-		Durable: true,
-	})
 }
 
 func (r *Migration) resetPrecopyTasks(vm *plan.VMStatus, step *plan.Step) {

--- a/pkg/controller/plan/migration_test.go
+++ b/pkg/controller/plan/migration_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
-	planmigrbase "github.com/kubev2v/forklift/pkg/controller/plan/migrator/base"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	"github.com/kubev2v/forklift/pkg/settings"
@@ -286,33 +285,18 @@ var _ = ginkgo.Describe("Cancellation", func() {
 func TestMarkSchedulerQueuedVMs(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	initStep := &plan.Step{
-		Task: plan.Task{
-			Name:  planmigrbase.Initialize,
-			Phase: api.StepPending,
-		},
-	}
-	vm := &plan.VMStatus{
-		Phase:    api.PhaseStarted,
-		Pipeline: []*plan.Step{initStep},
-	}
-	snapshot := plan.Snapshot{}
-	snapshot.SetCondition(libcnd.Condition{
-		Type:     api.ConditionExecuting,
-		Status:   libcnd.True,
-		Category: api.CategoryAdvisory,
-		Message:  "The plan is EXECUTING.",
-		Durable:  true,
-	})
-
+	originalLimit := settings.Settings.MaxInFlight
 	settings.Settings.MaxInFlight = 20
+	t.Cleanup(func() { settings.Settings.MaxInFlight = originalLimit })
+
+	queuedVM := &plan.VMStatus{Phase: api.PhaseStarted}
+
 	m := &Migration{
 		Context: &plancontext.Context{
 			Plan: &api.Plan{
 				Status: api.PlanStatus{
 					Migration: plan.MigrationStatus{
-						VMs:     []*plan.VMStatus{vm},
-						History: []plan.Snapshot{snapshot},
+						VMs: []*plan.VMStatus{queuedVM},
 					},
 				},
 			},
@@ -322,9 +306,44 @@ func TestMarkSchedulerQueuedVMs(t *testing.T) {
 
 	m.markSchedulerQueuedVMs()
 
-	g.Expect(initStep.Phase).To(gomega.Equal(api.StepPending))
-	g.Expect(initStep.Reason).To(gomega.Equal("Waiting to start migration: in-flight limit reached (max 20)."))
+	g.Expect(queuedVM.HasCondition(api.ConditionPending)).To(gomega.BeTrue())
+	pending := queuedVM.FindCondition(api.ConditionPending)
+	g.Expect(pending.Message).To(gomega.Equal("Waiting to start migration: in-flight limit reached (max 20)."))
+
 	ready := m.Plan.Status.FindCondition(libcnd.Ready)
 	g.Expect(ready).NotTo(gomega.BeNil())
 	g.Expect(ready.Message).To(gomega.Equal("1 VM(s) waiting to start migration (in-flight limit: 20)."))
+}
+
+func TestExecuteClearsSchedulerPendingCondition(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	vm := &plan.VMStatus{
+		VM: plan.VM{
+			Ref: ref.Ref{ID: "vm-1", Name: "test-vm"},
+		},
+		Phase: api.PhaseStarted,
+	}
+	vm.SetCondition(libcnd.Condition{
+		Type:     api.ConditionPending,
+		Status:   libcnd.True,
+		Category: api.CategoryAdvisory,
+		Message:  "Waiting to start migration: in-flight limit reached (max 20).",
+		Durable:  true,
+	})
+
+	m := &Migration{
+		Context: &plancontext.Context{
+			Migration: &api.Migration{
+				Spec: api.MigrationSpec{
+					Cancel: []ref.Ref{{ID: "vm-1", Name: "test-vm"}},
+				},
+			},
+			Log: logging.WithName("test"),
+		},
+	}
+
+	err := m.execute(vm)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(vm.HasCondition(api.ConditionPending)).To(gomega.BeFalse())
 }

--- a/pkg/controller/plan/migration_test.go
+++ b/pkg/controller/plan/migration_test.go
@@ -2,10 +2,16 @@
 package plan
 
 import (
+	"testing"
+
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	planmigrbase "github.com/kubev2v/forklift/pkg/controller/plan/migrator/base"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/settings"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -276,3 +282,49 @@ var _ = ginkgo.Describe("Cancellation", func() {
 		})
 	})
 })
+
+func TestMarkSchedulerQueuedVMs(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	initStep := &plan.Step{
+		Task: plan.Task{
+			Name:  planmigrbase.Initialize,
+			Phase: api.StepPending,
+		},
+	}
+	vm := &plan.VMStatus{
+		Phase:    api.PhaseStarted,
+		Pipeline: []*plan.Step{initStep},
+	}
+	snapshot := plan.Snapshot{}
+	snapshot.SetCondition(libcnd.Condition{
+		Type:     api.ConditionExecuting,
+		Status:   libcnd.True,
+		Category: api.CategoryAdvisory,
+		Message:  "The plan is EXECUTING.",
+		Durable:  true,
+	})
+
+	settings.Settings.MaxInFlight = 20
+	m := &Migration{
+		Context: &plancontext.Context{
+			Plan: &api.Plan{
+				Status: api.PlanStatus{
+					Migration: plan.MigrationStatus{
+						VMs:     []*plan.VMStatus{vm},
+						History: []plan.Snapshot{snapshot},
+					},
+				},
+			},
+			Log: logging.WithName("test"),
+		},
+	}
+
+	m.markSchedulerQueuedVMs()
+
+	g.Expect(initStep.Phase).To(gomega.Equal(api.StepPending))
+	g.Expect(initStep.Reason).To(gomega.Equal("Waiting to start migration: in-flight limit reached (max 20)."))
+	ready := m.Plan.Status.FindCondition(libcnd.Ready)
+	g.Expect(ready).NotTo(gomega.BeNil())
+	g.Expect(ready.Message).To(gomega.Equal("1 VM(s) waiting to start migration (in-flight limit: 20)."))
+}


### PR DESCRIPTION
Set plan Ready/Executing messages and Initialize step reasons when VMs are waiting on controller_max_vm_inflight instead of leaving the plan showing only "ready" and "EXECUTING".

Ref: https://redhat.atlassian.net/browse/MTV-5805
Resolves: MTV-5805