### PR TITLE
MTV-5980 | Add cluster-aware migration support

### DIFF
--- a/pkg/controller/plan/adapter/hyperv/client.go
+++ b/pkg/controller/plan/adapter/hyperv/client.go
@@ -12,6 +12,7 @@ import (
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
 	"github.com/kubev2v/forklift/pkg/lib/hyperv/driver"
+	ps "github.com/kubev2v/forklift/pkg/lib/hyperv/powershell"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
@@ -96,6 +97,17 @@ func (r *Client) PowerOff(vmRef ref.Ref) error {
 	drv, err := r.connect()
 	if err != nil {
 		return err
+	}
+
+	// In cluster mode, the VM may be on a different node than the entry
+	// point. Route the Stop-VM command to the correct node via RunOnNode.
+	if r.Source.Provider.IsHyperVCluster() && vm.Host != "" {
+		cmd := ps.BuildCommand(ps.StopVM, vm.Name)
+		if _, err = drv.RunOnNode(cmd, vm.Host); err != nil {
+			return fmt.Errorf("failed to power off VM %s on node %s: %w", vm.Name, vm.Host, err)
+		}
+		log.Info("Powered off VM via RunOnNode", "vm", vm.Name, "node", vm.Host)
+		return nil
 	}
 
 	domain, err := drv.LookupDomainByName(vm.Name)

--- a/pkg/controller/plan/adapter/hyperv/validator.go
+++ b/pkg/controller/plan/adapter/hyperv/validator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
 	webbase "github.com/kubev2v/forklift/pkg/controller/provider/web/base"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
@@ -81,9 +82,36 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (bool, error) {
 	return true, nil
 }
 
-// NO-OP
-func (r *Validator) MaintenanceMode(_ ref.Ref) (bool, error) {
-	return true, nil
+// MaintenanceMode checks whether the VM's owner node is in a Paused or Down
+// state. In standalone mode there are no Host records, so it always returns ok.
+func (r *Validator) MaintenanceMode(vmRef ref.Ref) (bool, error) {
+	if !r.Source.Provider.IsHyperVCluster() {
+		return true, nil
+	}
+
+	vm := &hyperv.VM{}
+	err := r.Source.Inventory.Find(vm, vmRef)
+	if err != nil {
+		return false, liberr.Wrap(err, "vm", vmRef.String())
+	}
+
+	if vm.Host == "" {
+		return true, nil
+	}
+
+	host := &hyperv.Host{}
+	hostRef := ref.Ref{ID: vm.Host}
+	err = r.Source.Inventory.Find(host, hostRef)
+	if err != nil {
+		return false, liberr.Wrap(err, "vm", vmRef.String(), "host", hostRef.String())
+	}
+
+	switch host.State {
+	case model.NodeStatePaused, model.NodeStateDown:
+		return false, nil
+	default:
+		return true, nil
+	}
 }
 
 // NICNetworkRefs returns one source-network ref per VM NIC.

--- a/pkg/controller/plan/adapter/hyperv/validator_test.go
+++ b/pkg/controller/plan/adapter/hyperv/validator_test.go
@@ -1,0 +1,215 @@
+package hyperv
+
+import (
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
+)
+
+// stubInventory returns pre-configured VMs and Hosts for testing.
+type stubInventory struct {
+	base.Client
+	vms   map[string]*hyperv.VM
+	hosts map[string]*hyperv.Host
+}
+
+func (s *stubInventory) Find(resource interface{}, r base.Ref) error {
+	switch res := resource.(type) {
+	case *hyperv.VM:
+		vm, ok := s.vms[r.ID]
+		if !ok {
+			return base.NotFoundError{Ref: r}
+		}
+		*res = *vm
+	case *hyperv.Host:
+		host, ok := s.hosts[r.ID]
+		if !ok {
+			return base.NotFoundError{Ref: r}
+		}
+		*res = *host
+	}
+	return nil
+}
+
+func newClusterProvider() *api.Provider {
+	pt := api.HyperV
+	return &api.Provider{
+		Spec: api.ProviderSpec{
+			Type: &pt,
+			Settings: map[string]string{
+				api.ManagementType: api.HyperVCluster,
+			},
+		},
+	}
+}
+
+func newStandaloneProvider() *api.Provider {
+	pt := api.HyperV
+	return &api.Provider{
+		Spec: api.ProviderSpec{
+			Type: &pt,
+		},
+	}
+}
+
+func TestMaintenanceMode_StandaloneAlwaysOK(t *testing.T) {
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{
+				Provider: newStandaloneProvider(),
+			},
+		},
+	}
+
+	ok, err := v.MaintenanceMode(ref.Ref{ID: "any-vm"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("standalone mode should always return ok=true")
+	}
+}
+
+func makeVM(id, host string) *hyperv.VM {
+	vm := &hyperv.VM{Host: host}
+	vm.ID = id
+	return vm
+}
+
+func makeHost(id, state string) *hyperv.Host {
+	h := &hyperv.Host{State: state}
+	h.ID = id
+	return h
+}
+
+func TestMaintenanceMode_ClusterHostUp(t *testing.T) {
+	inv := &stubInventory{
+		vms:   map[string]*hyperv.VM{"vm-1": makeVM("vm-1", "node-1")},
+		hosts: map[string]*hyperv.Host{"node-1": makeHost("node-1", model.NodeStateUp)},
+	}
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{
+				Provider:  newClusterProvider(),
+				Inventory: inv,
+			},
+		},
+	}
+
+	ok, err := v.MaintenanceMode(ref.Ref{ID: "vm-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("expected ok=true when host state is Up")
+	}
+}
+
+func TestMaintenanceMode_ClusterHostPaused(t *testing.T) {
+	inv := &stubInventory{
+		vms:   map[string]*hyperv.VM{"vm-1": makeVM("vm-1", "node-1")},
+		hosts: map[string]*hyperv.Host{"node-1": makeHost("node-1", model.NodeStatePaused)},
+	}
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{
+				Provider:  newClusterProvider(),
+				Inventory: inv,
+			},
+		},
+	}
+
+	ok, err := v.MaintenanceMode(ref.Ref{ID: "vm-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false when host state is Paused")
+	}
+}
+
+func TestMaintenanceMode_ClusterHostDown(t *testing.T) {
+	inv := &stubInventory{
+		vms:   map[string]*hyperv.VM{"vm-1": makeVM("vm-1", "node-1")},
+		hosts: map[string]*hyperv.Host{"node-1": makeHost("node-1", model.NodeStateDown)},
+	}
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{
+				Provider:  newClusterProvider(),
+				Inventory: inv,
+			},
+		},
+	}
+
+	ok, err := v.MaintenanceMode(ref.Ref{ID: "vm-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false when host state is Down")
+	}
+}
+
+func TestMaintenanceMode_ClusterVMNoHost(t *testing.T) {
+	inv := &stubInventory{
+		vms: map[string]*hyperv.VM{"vm-1": makeVM("vm-1", "")},
+	}
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{
+				Provider:  newClusterProvider(),
+				Inventory: inv,
+			},
+		},
+	}
+
+	ok, err := v.MaintenanceMode(ref.Ref{ID: "vm-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("expected ok=true when VM has no host (unregistered cluster VM)")
+	}
+}
+
+func TestMaintenanceMode_ClusterHostNotFound(t *testing.T) {
+	inv := &stubInventory{
+		vms: map[string]*hyperv.VM{"vm-1": makeVM("vm-1", "missing-node")},
+	}
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{
+				Provider:  newClusterProvider(),
+				Inventory: inv,
+			},
+		},
+	}
+
+	_, err := v.MaintenanceMode(ref.Ref{ID: "vm-1"})
+	if err == nil {
+		t.Error("expected error when host lookup fails")
+	}
+}
+
+func TestMaintenanceMode_VMNotFound(t *testing.T) {
+	inv := &stubInventory{}
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{
+				Provider:  newClusterProvider(),
+				Inventory: inv,
+			},
+		},
+	}
+
+	_, err := v.MaintenanceMode(ref.Ref{ID: "nonexistent"})
+	if err == nil {
+		t.Error("expected error when VM lookup fails")
+	}
+}

--- a/pkg/controller/plan/scheduler/hyperv/scheduler.go
+++ b/pkg/controller/plan/scheduler/hyperv/scheduler.go
@@ -2,11 +2,14 @@ package hyperv
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 )
 
@@ -14,54 +17,101 @@ var mutex sync.Mutex
 
 const Canceled = "Canceled"
 
+// Scheduler for Hyper-V migrations.
+// In cluster mode, tracks in-flight migrations per host (OwnerNode) so that
+// no single node is overloaded. In standalone mode, all VMs share a single
+// empty-string host key, preserving the original global-counter behavior.
 type Scheduler struct {
 	*plancontext.Context
 	MaxInFlight int
+	inFlight    map[string]int
 }
 
+// Next returns the next VM to migrate, iterating in plan order to
+// preserve deterministic FIFO selection across hosts.
 func (r *Scheduler) Next() (vm *plan.VMStatus, hasNext bool, err error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	planList := &api.PlanList{}
-	err = r.List(context.TODO(), planList)
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-
-	inFlight := 0
-	for _, p := range planList.Items {
-		if p.Spec.Provider.Source != r.Plan.Spec.Provider.Source {
-			continue
-		}
-
-		snapshot := p.Status.Migration.ActiveSnapshot()
-		if !snapshot.HasCondition("Executing") {
-			continue
-		}
-
-		for _, vmStatus := range p.Status.Migration.VMs {
-			if vmStatus.Running() {
-				inFlight++
-			}
-		}
-	}
-
-	if inFlight >= r.MaxInFlight {
+	if err = r.buildInFlight(); err != nil {
 		return
 	}
 
 	for _, vmStatus := range r.Plan.Status.Migration.VMs {
-		if vmStatus.HasCondition(Canceled) {
+		if vmStatus.HasCondition(Canceled) || vmStatus.MarkedStarted() || vmStatus.MarkedCompleted() {
 			continue
 		}
-		if !vmStatus.MarkedStarted() && !vmStatus.MarkedCompleted() {
-			vm = vmStatus
-			hasNext = true
-			return
+		host := r.hostForVM(vmStatus)
+		if r.inFlight[host] >= r.MaxInFlight {
+			continue
 		}
+		vm = vmStatus
+		hasNext = true
+		return
+	}
+	return
+}
+
+// buildInFlight counts running migrations grouped by host across all
+// executing plans that share the same source provider.
+func (r *Scheduler) buildInFlight() error {
+	r.inFlight = make(map[string]int)
+
+	r.countRunning(r.Plan.Status.Migration.VMs)
+
+	planList := &api.PlanList{}
+	if err := r.List(context.TODO(), planList); err != nil {
+		return liberr.Wrap(err)
 	}
 
-	return
+	for i := range planList.Items {
+		p := &planList.Items[i]
+		if r.sharesSourceProvider(p) {
+			r.countRunning(p.Status.Migration.VMs)
+		}
+	}
+	return nil
+}
+
+// sharesSourceProvider returns true if p is another active plan migrating
+// from the same Hyper-V provider. Its running VMs must be counted to avoid
+// exceeding per-host concurrency limits across plans.
+func (r *Scheduler) sharesSourceProvider(p *api.Plan) bool {
+	if p.Name == r.Plan.Name && p.Namespace == r.Plan.Namespace {
+		return false
+	}
+	if p.Spec.Provider.Source != r.Plan.Spec.Provider.Source {
+		return false
+	}
+	if p.Spec.Archived {
+		return false
+	}
+	return p.Status.Migration.ActiveSnapshot().HasCondition("Executing")
+}
+
+// countRunning increments per-host in-flight counters for running VMs.
+func (r *Scheduler) countRunning(vms []*plan.VMStatus) {
+	for _, vmStatus := range vms {
+		if vmStatus.HasCondition(Canceled) || !vmStatus.Running() {
+			continue
+		}
+		r.inFlight[r.hostForVM(vmStatus)]++
+	}
+}
+
+// hostForVM resolves the host (OwnerNode) for a VM from inventory.
+// In standalone mode or on lookup failure, returns "" which groups
+// all VMs under a single key (global counter behavior).
+func (r *Scheduler) hostForVM(vmStatus *plan.VMStatus) string {
+	vm := &model.VM{}
+	if err := r.Source.Inventory.Find(vm, vmStatus.Ref); err != nil {
+		if !errors.As(err, &web.NotFoundError{}) {
+			r.Log.V(1).Info(
+				"Could not resolve host for VM, using global slot",
+				"vm", vmStatus.String(),
+				"error", err)
+		}
+		return ""
+	}
+	return vm.Host
 }

--- a/pkg/controller/provider/container/hyperv/client.go
+++ b/pkg/controller/provider/container/hyperv/client.go
@@ -1105,15 +1105,35 @@ func parseIPv6PrefixLength(subnet string) int32 {
 }
 
 func (r *Client) mapWindowsPathToSMB(windowsPath, smbWindowsPrefix string) string {
-	if smbWindowsPrefix == "" || r.smbMountPath == "" {
-		r.Log.V(1).Info("Cannot map disk path: SMB Windows prefix not discovered",
+	if r.smbMountPath == "" {
+		r.Log.V(1).Info("Cannot map disk path: SMB mount path not configured",
 			"windowsPath", windowsPath)
 		return ""
 	}
 
 	normalizedWindowsPath := strings.ReplaceAll(windowsPath, "\\", "/")
-	normalizedPrefix := strings.ReplaceAll(smbWindowsPrefix, "\\", "/")
 
+	// Handle UNC paths (e.g. //SERVER/ShareName/file.vhdx) from cluster
+	// nodes that reference the SMB share by network path.
+	shareName := extractShareName(r.smbUrl)
+	if shareName != "" && strings.HasPrefix(normalizedWindowsPath, "//") {
+		parts := strings.SplitN(strings.TrimPrefix(normalizedWindowsPath, "//"), "/", 3)
+		if len(parts) >= 2 && strings.EqualFold(parts[1], shareName) {
+			relativePath := ""
+			if len(parts) == 3 {
+				relativePath = parts[2]
+			}
+			return r.smbMountPath + "/" + relativePath
+		}
+	}
+
+	// Handle local paths that start with the share's Windows directory.
+	if smbWindowsPrefix == "" {
+		r.Log.V(1).Info("Cannot map disk path: SMB Windows prefix not discovered",
+			"windowsPath", windowsPath)
+		return ""
+	}
+	normalizedPrefix := strings.ReplaceAll(smbWindowsPrefix, "\\", "/")
 	if strings.HasPrefix(strings.ToLower(normalizedWindowsPath), strings.ToLower(normalizedPrefix)) {
 		relativePath := normalizedWindowsPath[len(normalizedPrefix):]
 		relativePath = strings.TrimPrefix(relativePath, "/")

--- a/pkg/controller/provider/container/hyperv/client_test.go
+++ b/pkg/controller/provider/container/hyperv/client_test.go
@@ -459,6 +459,67 @@ func TestMapWindowsPathToSMB(t *testing.T) {
 	}
 }
 
+func TestMapWindowsPathToSMB_UNC(t *testing.T) {
+	client := &Client{
+		smbMountPath: "/hyperv",
+		smbUrl:       "//10.0.0.1/VMShare",
+		Log:          testLogger(),
+	}
+
+	tests := []struct {
+		name             string
+		windowsPath      string
+		smbWindowsPrefix string
+		expected         string
+	}{
+		{
+			name:             "UNC backslash path matching share name",
+			windowsPath:      `\\WIN-SERVER\VMShare\vm1.vhdx`,
+			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
+			expected:         "/hyperv/vm1.vhdx",
+		},
+		{
+			name:             "UNC forward slash path matching share name",
+			windowsPath:      "//WIN-SERVER/VMShare/subdir/disk.vhdx",
+			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
+			expected:         "/hyperv/subdir/disk.vhdx",
+		},
+		{
+			name:             "UNC case insensitive share name match",
+			windowsPath:      `\\SERVER\vmshare\disk.vhdx`,
+			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
+			expected:         "/hyperv/disk.vhdx",
+		},
+		{
+			name:             "UNC different share name falls through to local",
+			windowsPath:      `\\SERVER\OtherShare\disk.vhdx`,
+			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
+			expected:         "",
+		},
+		{
+			name:             "UNC share root without trailing file",
+			windowsPath:      `\\SERVER\VMShare`,
+			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
+			expected:         "/hyperv/",
+		},
+		{
+			name:             "local path still works when smbUrl is set",
+			windowsPath:      `C:\Hyper-V\Virtual_Hard_Disks\vm2.vhdx`,
+			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
+			expected:         "/hyperv/vm2.vhdx",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := client.mapWindowsPathToSMB(tc.windowsPath, tc.smbWindowsPrefix)
+			if result != tc.expected {
+				t.Errorf("Expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestFormatMAC(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
- Refactor Hyper-V scheduler to track in-flight migrations **per host** (OwnerNode), preventing single-node overload while preserving global-counter behavior in standalone mode
- Route `Stop-VM` to the correct cluster node via `RunOnNode` during PowerOffSource phase
- Implement `MaintenanceMode` validation to block migration from nodes in Paused or Down state
- Extend `mapWindowsPathToSMB` to handle UNC disk paths (`\\server\share\file.vhdx`) for cluster nodes referencing disks on a remote SMB share


Depends on: #7342

Ref: https://redhat.atlassian.net/browse/MTV-5980