### PR TITLE
MTV-6073 | Fix vSphere inventory data loss on VM Leave events

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -553,7 +553,7 @@ func (r *Collector) getUpdates(ctx context.Context) error {
 				err,
 				"tx commit failed.")
 		}
-		if updateSet.Truncated == nil || !*updateSet.Truncated {
+		if err == nil && (updateSet.Truncated == nil || !*updateSet.Truncated) {
 			if !r.parity {
 				r.parity = true
 				r.log.Info(
@@ -1127,7 +1127,7 @@ func (r *Collector) apply(ctx context.Context, tx *libmodel.Tx, updates []types.
 			break
 		}
 
-		if u.Obj.Type == VirtualMachine {
+		if u.Obj.Type == VirtualMachine && string(u.Kind) != Leave {
 			if !vmTagsFetched {
 				vmTagsMap, vmTagsErr = r.getVMsWithTags(ctx)
 				if vmTagsErr != nil {

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -549,7 +549,9 @@ func (r *Collector) getUpdates(ctx context.Context) error {
 				r.log.Error(err, "tx commit failed.")
 			}
 		} else {
-			_ = tx.End()
+			if endErr := tx.End(); endErr != nil {
+				r.log.Error(endErr, "tx rollback failed.")
+			}
 		}
 		if err == nil && (updateSet.Truncated == nil || !*updateSet.Truncated) {
 			if !r.parity {

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -545,13 +545,11 @@ func (r *Collector) getUpdates(ctx context.Context) error {
 		}
 		if err == nil {
 			err = tx.Commit()
+			if err != nil {
+				r.log.Error(err, "tx commit failed.")
+			}
 		} else {
-			err = tx.End()
-		}
-		if err != nil {
-			r.log.Error(
-				err,
-				"tx commit failed.")
+			_ = tx.End()
 		}
 		if err == nil && (updateSet.Truncated == nil || !*updateSet.Truncated) {
 			if !r.parity {


### PR DESCRIPTION
Fix 1 — Skip tag update for Leave events:
In apply(), updateVMWithTags() was called for all VM events including Leave (delete) events. After applyLeave() deletes the VM record from SQLite within the transaction, updateVMWithTags() calls tx.Get(vm) on the deleted row, which fails. This error causes the entire batch to be rolled back. Since req.Version was already advanced before tx.Commit(), vCenter never re-sends these events — all other VMs in the rolled-back batch are permanently lost from inventory.

The fix adds a string(u.Kind) != Leave guard to the condition, skipping the tag update for VMs being removed.

This bug was introduced in commit 2a7c27a38 (MTV-4904, 2026-04-30) which added the updateVMWithTags call.

Fix 2 — Gate parity on successful commit:
The parity flag (r.parity = true) was set without checking if the apply/commit succeeded. This meant the provider could be marked Ready even after a failed batch. The oVirt and OpenStack collectors both gate parity on err == nil — the vSphere collector was missing this guard since the original implementation.
Changed `err = tx.End()` to `_ = tx.End()` so the original apply error is preserved on the rollback path. Previously, tx.End() returning nil would mask the apply failure and allow the parity guard (`if err == nil && ...`) to set parity incorrectly, causing inventory data loss. Also moved the "tx commit failed" log inside the commit branch so it only fires for actual commit failures, not rollback results. This aligns with the pattern used in the oVirt and OpenStack
collectors

The fix adds err == nil to the parity condition, aligning vSphere with the other collectors.

Resolves: MTV-6073