### PR TITLE
MTV-5871 | Fix xcopyUsed metric scraping regex

### DIFF
--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -980,7 +980,7 @@ func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolum
 	}
 
 	if populatorKind == api.VSphereXcopyVolumePopulatorKind {
-		xcopyRegExp := regexp.MustCompile(`xcopy_used\{ownerUID="` + string(pvc.UID) + `"\} (\d+)`)
+		xcopyRegExp := regexp.MustCompile(`vsphere_xcopy_volume_populator_xcopy_used\{[^}]*owner_uid="` + string(pvc.UID) + `"[^}]*\} (\d+)`)
 		xcopyMatch := xcopyRegExp.FindStringSubmatch(string(body))
 		if xcopyMatch != nil {
 			if err := unstructured.SetNestedField(latestPopulator.Object, xcopyMatch[1], "status", "xcopyUsed"); err != nil {


### PR DESCRIPTION
## Summary
- Fix the `xcopyUsed` metric scraping regex in the populator-machinery controller to use the correct full metric name (`vsphere_xcopy_volume_populator_xcopy_used`) and snake_case label (`owner_uid`) with wildcard matching for multi-label support
- Without this fix, the `xcopyUsed` field is never written to the populator CR status, so the plan task annotations never get the `xcopyUsed` annotation

## Root Cause
The original regex `xcopy_used{ownerUID="..."}` didn't match the actual Prometheus metric line because:
1. The metric name is `vsphere_xcopy_volume_populator_xcopy_used` (full name, not substring)
2. The label is `owner_uid` (snake_case), not `ownerUID` (camelCase)
3. The gauge has multiple labels (`owner_uid`, `storage_vendor`, `clone_method`), requiring `[^}]*` wildcard matching

## Test plan
- [x] E2E verified on ocp-edge114: 2 VMs in same plan, one on shared storage (xcopyUsed="1") and one on local disk (xcopyUsed="0")
- [x] Populator CR status correctly shows `xcopyUsed` field
- [x] Plan task annotations correctly show `xcopyUsed` per-disk

Resolves: MTV-5871

🤖 Generated with [Claude Code](https://claude.com/claude-code)