### PR TITLE
MTV-6103 | Preserve VMware NIC "Connect at power on" as link state in OCPV

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -810,6 +810,10 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 			kInterface.PciAddress = nic.PciAddress
 		}
 
+		if !nic.StartConnected {
+			kInterface.State = cnv.InterfaceStateLinkDown
+		}
+
 		switch mapped.Destination.Type {
 		case Pod:
 			kNetwork.Pod = &cnv.PodNetwork{}

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -1306,11 +1306,17 @@ func (v *VmAdapter) collectNICs(devArray types.ArrayOfVirtualDevice) []model.NIC
 			network = backing.OpaqueNetworkId
 		}
 
+		startConnected := true
+		if vd.Connectable != nil {
+			startConnected = vd.Connectable.StartConnected
+		}
+
 		nicList = append(nicList, model.NIC{
-			MAC:        strings.ToLower(nic.MacAddress),
-			Index:      len(nicList),
-			DeviceKey:  nic.Key,
-			PciAddress: computePciAddress(pciSlotNumber(vd), v.model.PciBridges),
+			MAC:            strings.ToLower(nic.MacAddress),
+			Index:          len(nicList),
+			DeviceKey:      nic.Key,
+			PciAddress:     computePciAddress(pciSlotNumber(vd), v.model.PciBridges),
+			StartConnected: startConnected,
 			Network: model.Ref{
 				Kind: model.NetKind,
 				ID:   network,

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -412,11 +412,12 @@ type PciBridge struct {
 
 // Virtual ethernet card.
 type NIC struct {
-	Network    Ref    `json:"network"`
-	MAC        string `json:"mac"`
-	Index      int    `json:"order"`
-	DeviceKey  int32  `json:"deviceKey"`
-	PciAddress string `json:"pciAddress"`
+	Network        Ref    `json:"network"`
+	MAC            string `json:"mac"`
+	Index          int    `json:"order"`
+	DeviceKey      int32  `json:"deviceKey"`
+	PciAddress     string `json:"pciAddress"`
+	StartConnected bool   `json:"startConnected"`
 }
 
 // Guest network.


### PR DESCRIPTION
When a VMware VM has a NIC with "Connect at power on" unchecked,
the migrated KubeVirt VM should have the interface state set to "down".
Previously this setting was not captured during inventory collection
and was lost during migration.

Add `StartConnected` field to the vSphere NIC model, extract it from
`VirtualDevice.Connectable.StartConnected` during inventory collection
(defaulting to `true` when `Connectable` is nil), and set the KubeVirt
interface state to `"down"` when `StartConnected` is `false`.

Ref: https://redhat.atlassian.net/browse/MTV-6103
Resolves: MTV-6103