### PR TITLE
MTV-6063 | Fail migration on AAP hook launch errors

### DIFF
--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -450,6 +450,7 @@ func (r *HookRunner) runAAPJob(step *planapi.Step) (err error) {
 	if err != nil {
 		step.AddError(err.Error())
 		step.MarkCompleted()
+		err = nil
 		return
 	}
 
@@ -482,6 +483,7 @@ func (r *HookRunner) runAAPJob(step *planapi.Step) (err error) {
 	if err != nil {
 		step.AddError(err.Error())
 		step.MarkCompleted()
+		err = nil
 		return
 	}
 
@@ -525,6 +527,7 @@ func (r *HookRunner) runAAPJob(step *planapi.Step) (err error) {
 		r.Log.Error(err, "AAP job failed", "jobId", jobID)
 		step.AddError(err.Error())
 		step.MarkCompleted()
+		err = nil
 		return
 	}
 

--- a/pkg/controller/plan/hook_test.go
+++ b/pkg/controller/plan/hook_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/lib/aap"
+	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -289,5 +291,45 @@ func TestGetAAPTokenFromSecretName(t *testing.T) {
 				t.Fatalf("token = %q, want %q", tok, tt.want)
 			}
 		})
+	}
+}
+
+func TestAAPLaunchFailureIsTerminalViaReflectPipeline(t *testing.T) {
+	t.Parallel()
+
+	vm := &planapi.VMStatus{
+		Phase: api.PhasePreHook,
+		Pipeline: []*planapi.Step{
+			{Task: planapi.Task{Name: api.PhasePreHook}},
+		},
+	}
+	step, found := vm.FindStep(api.PhasePreHook)
+	if !found {
+		t.Fatal("PreHook step missing")
+	}
+
+	// Mimic runAAPJob after LaunchJob failure: record on step, clear err, return.
+	step.AddError("failed to launch AAP job: tls: failed to verify certificate: x509: certificate signed by unknown authority")
+	step.MarkCompleted()
+
+	if step.MarkedCompleted() && step.Error == nil {
+		t.Fatal("must not advance phase on hook failure")
+	}
+
+	vm.ReflectPipeline()
+	if vm.Error == nil {
+		t.Fatal("expected ReflectPipeline to copy step error onto VM")
+	}
+
+	vm.Phase = api.PhaseCompleted
+	vm.SetCondition(libcnd.Condition{
+		Type:     api.ConditionFailed,
+		Status:   libcnd.True,
+		Category: api.CategoryAdvisory,
+		Message:  "The VM migration has FAILED.",
+		Durable:  true,
+	})
+	if !vm.HasCondition(api.ConditionFailed) {
+		t.Fatal("expected Failed condition")
 	}
 }


### PR DESCRIPTION
Clear returned error after recording AAP step failures so execute() reaches ReflectPipeline and marks the VM Failed instead of requeueing forever on TLS or other launch/poll errors.

Ref: https://redhat.atlassian.net/browse/MTV-6063
Resolves: MTV-6063