### PR TITLE
MTV-6080 | Fix CSI import reading skipSSL from wrong secret

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1725,7 +1725,11 @@ func (r *Builder) buildCsiImportPVC(
 	host := string(storageSecret.Data["STORAGE_HOSTNAME"])
 	user := string(storageSecret.Data["STORAGE_USERNAME"])
 	pass := string(storageSecret.Data["STORAGE_PASSWORD"])
-	skipSSL := basecontroller.GetInsecureSkipVerifyFlag(r.Source.Secret)
+	skipSSL, err := strconv.ParseBool(string(storageSecret.Data["STORAGE_SKIP_SSL_VERIFICATION"]))
+	if err != nil {
+		r.Log.Error(err, "CSI import: invalid STORAGE_SKIP_SSL_VERIFICATION value, defaulting to false", "secretRef", csiCfg.SecretRef)
+		skipSSL = false
+	}
 
 	var missing []string
 	if host == "" {


### PR DESCRIPTION
## Problem

CSI Volume Import fails with TLS errors connecting to the storage array API even when `STORAGE_SKIP_SSL_VERIFICATION=true` is set in the storage secret. The workaround was to patch the vSphere provider secret (`insecureSkipVerify=true`), which is the wrong secret and triggers a re-inventory.

## What it achieves

CSI import now correctly reads the TLS skip flag from the storage vendor secret, consistent with how xcopy reads it. Users with self-signed certs on their storage array no longer need to touch the vSphere provider secret.

## Non-obvious decisions

`GetInsecureSkipVerifyFlag` reads the `insecureSkipVerify` key — a vSphere provider secret convention. The storage secret uses a different key schema (`STORAGE_*` env var names). The fix reads `STORAGE_SKIP_SSL_VERIFICATION` directly via `strconv.ParseBool`, matching the exact key the xcopy populator's certificate-tool writes into the secret.