### PR TITLE
MTV-5926 | Register Azure as a new provider type with noop stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.dylib
 bin
+forklift-controller
 
 # Test binary, build with `go test -c`
 *.test

--- a/pkg/apis/forklift/v1beta1/provider.go
+++ b/pkg/apis/forklift/v1beta1/provider.go
@@ -45,6 +45,9 @@ const (
 
 	// HyperV
 	HyperV ProviderType = "hyperv"
+
+	// Azure
+	Azure ProviderType = "azure"
 )
 
 var ProviderTypes = []ProviderType{
@@ -55,6 +58,7 @@ var ProviderTypes = []ProviderType{
 	Ova,
 	EC2,
 	HyperV,
+	Azure,
 }
 
 func (t ProviderType) String() string {
@@ -192,7 +196,7 @@ func (p *Provider) HasReconciled() bool {
 
 // This provider requires VM guest conversion.
 func (p *Provider) RequiresConversion() bool {
-	return p.Type() == VSphere || p.Type() == Ova || p.Type() == HyperV || p.Type() == EC2
+	return p.Type() == VSphere || p.Type() == Ova || p.Type() == HyperV || p.Type() == EC2 || p.Type() == Azure
 }
 
 // This provider support the vddk aio parameters.

--- a/pkg/controller/host/handler/doc.go
+++ b/pkg/controller/host/handler/doc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/host/handler/vsphere"
 	"github.com/kubev2v/forklift/pkg/controller/watch/handler"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	azurehandler "github.com/kubev2v/forklift/pkg/provider/azure/controller/handler"
 	ec2handler "github.com/kubev2v/forklift/pkg/provider/ec2/controller/handler"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -64,6 +65,8 @@ func New(
 		// EC2 provider does not support host-level operations
 		// Return a no-op handler that satisfies the interface
 		h = &ec2handler.NoOpHostHandler{}
+	case api.Azure:
+		h = &azurehandler.NoOpHostHandler{}
 	default:
 		err = liberr.New("provider not supported.")
 	}

--- a/pkg/controller/map/network/handler/doc.go
+++ b/pkg/controller/map/network/handler/doc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/map/network/handler/vsphere"
 	"github.com/kubev2v/forklift/pkg/controller/watch/handler"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	azurehandler "github.com/kubev2v/forklift/pkg/provider/azure/controller/handler"
 	ec2handler "github.com/kubev2v/forklift/pkg/provider/ec2/controller/handler"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -62,6 +63,11 @@ func New(
 			provider)
 	case api.EC2:
 		h, err = ec2handler.NewNetworkHandler(
+			client,
+			channel,
+			provider)
+	case api.Azure:
+		h, err = azurehandler.NewNetworkHandler(
 			client,
 			channel,
 			provider)

--- a/pkg/controller/map/storage/handler/doc.go
+++ b/pkg/controller/map/storage/handler/doc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/map/storage/handler/vsphere"
 	"github.com/kubev2v/forklift/pkg/controller/watch/handler"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	azurehandler "github.com/kubev2v/forklift/pkg/provider/azure/controller/handler"
 	ec2handler "github.com/kubev2v/forklift/pkg/provider/ec2/controller/handler"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -62,6 +63,11 @@ func New(
 			provider)
 	case api.EC2:
 		h, err = ec2handler.NewStorageHandler(
+			client,
+			channel,
+			provider)
+	case api.Azure:
+		h, err = azurehandler.NewStorageHandler(
 			client,
 			channel,
 			provider)

--- a/pkg/controller/plan/adapter/doc.go
+++ b/pkg/controller/plan/adapter/doc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/ovirt"
 	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/vsphere"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	azureadapter "github.com/kubev2v/forklift/pkg/provider/azure/controller/adapter"
 	ec2adapter "github.com/kubev2v/forklift/pkg/provider/ec2/controller/adapter"
 )
 
@@ -38,6 +39,8 @@ func New(provider *api.Provider) (adapter Adapter, err error) {
 		adapter = ec2adapter.New()
 	case api.HyperV:
 		adapter = &hyperv.Adapter{}
+	case api.Azure:
+		adapter = azureadapter.New()
 	default:
 		err = liberr.New("provider not supported.")
 	}

--- a/pkg/controller/plan/handler/doc.go
+++ b/pkg/controller/plan/handler/doc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/plan/handler/vsphere"
 	"github.com/kubev2v/forklift/pkg/controller/watch/handler"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	azurehandler "github.com/kubev2v/forklift/pkg/provider/azure/controller/handler"
 	ec2handler "github.com/kubev2v/forklift/pkg/provider/ec2/controller/handler"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -62,6 +63,11 @@ func New(
 			provider)
 	case api.EC2:
 		h, err = ec2handler.New(
+			client,
+			channel,
+			provider)
+	case api.Azure:
+		h, err = azurehandler.New(
 			client,
 			channel,
 			provider)

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -1645,7 +1645,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			}
 
 			switch r.Source.Provider.Type() {
-			case api.Ova, api.VSphere, api.HyperV, api.EC2:
+			case api.Ova, api.VSphere, api.HyperV, api.EC2, api.Azure:
 				// fetch config from the conversion pod
 				pod, err := r.kubevirt.GetGuestConversionPod(vm)
 				if err != nil {

--- a/pkg/controller/plan/migrator/doc.go
+++ b/pkg/controller/plan/migrator/doc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/plan/migrator/base"
 	"github.com/kubev2v/forklift/pkg/controller/plan/migrator/ocp"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
+	azuremigrator "github.com/kubev2v/forklift/pkg/provider/azure/controller/migrator"
 	ec2migrator "github.com/kubev2v/forklift/pkg/provider/ec2/controller/migrator"
 )
 
@@ -26,6 +27,11 @@ func New(context *plancontext.Context) (migrator Migrator, err error) {
 		}
 	case api.EC2:
 		migrator, err = ec2migrator.New(context)
+		if err != nil {
+			return
+		}
+	case api.Azure:
+		migrator, err = azuremigrator.New(context)
 		if err != nil {
 			return
 		}

--- a/pkg/controller/plan/scheduler/doc.go
+++ b/pkg/controller/plan/scheduler/doc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/plan/scheduler/ovirt"
 	"github.com/kubev2v/forklift/pkg/controller/plan/scheduler/vsphere"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	azurescheduler "github.com/kubev2v/forklift/pkg/provider/azure/controller/scheduler"
 	ec2scheduler "github.com/kubev2v/forklift/pkg/provider/ec2/controller/scheduler"
 	"github.com/kubev2v/forklift/pkg/settings"
 )
@@ -57,6 +58,11 @@ func New(ctx *plancontext.Context) (scheduler Scheduler, err error) {
 		}
 	case api.EC2:
 		scheduler = &ec2scheduler.Scheduler{
+			Context:     ctx,
+			MaxInFlight: settings.Settings.MaxInFlight,
+		}
+	case api.Azure:
+		scheduler = &azurescheduler.Scheduler{
 			Context:     ctx,
 			MaxInFlight: settings.Settings.MaxInFlight,
 		}

--- a/pkg/controller/provider/container/doc.go
+++ b/pkg/controller/provider/container/doc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/provider/container/vsphere"
 	libcontainer "github.com/kubev2v/forklift/pkg/lib/inventory/container"
 	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+	azurecollector "github.com/kubev2v/forklift/pkg/provider/azure/inventory/collector"
 	ec2collector "github.com/kubev2v/forklift/pkg/provider/ec2/inventory/collector"
 	core "k8s.io/api/core/v1"
 )
@@ -35,6 +36,8 @@ func Build(
 		return ec2collector.New(db, provider, secret)
 	case api.HyperV:
 		return hyperv.New(db, provider, secret)
+	case api.Azure:
+		return azurecollector.New(db, provider, secret)
 	}
 
 	return nil

--- a/pkg/controller/provider/model/doc.go
+++ b/pkg/controller/provider/model/doc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/provider/model/ovf"
 	"github.com/kubev2v/forklift/pkg/controller/provider/model/ovirt"
 	"github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	azuremodel "github.com/kubev2v/forklift/pkg/provider/azure/inventory/model"
 	ec2model "github.com/kubev2v/forklift/pkg/provider/ec2/inventory/model"
 )
 
@@ -42,6 +43,10 @@ func Models(provider *api.Provider) (all []interface{}) {
 		all = append(
 			all,
 			ec2model.All()...)
+	case api.Azure:
+		all = append(
+			all,
+			azuremodel.All()...)
 	}
 
 	return

--- a/pkg/controller/provider/web/client.go
+++ b/pkg/controller/provider/web/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/ovirt"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	azureweb "github.com/kubev2v/forklift/pkg/provider/azure/inventory/web"
 	ec2web "github.com/kubev2v/forklift/pkg/provider/ec2/inventory/web"
 )
 
@@ -114,6 +115,14 @@ func NewClient(provider *api.Provider) (client Client, err error) {
 			finder:   hyperv.NewFinder(),
 			restClient: base.RestClient{
 				Resolver: &hyperv.Resolver{Provider: provider},
+			},
+		}
+	case api.Azure:
+		client = &ProviderClient{
+			provider: provider,
+			finder:   &azureweb.Finder{},
+			restClient: base.RestClient{
+				Resolver: &azureweb.Resolver{Provider: provider},
 			},
 		}
 	default:

--- a/pkg/controller/provider/web/doc.go
+++ b/pkg/controller/provider/web/doc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
 	"github.com/kubev2v/forklift/pkg/lib/inventory/container"
 	libweb "github.com/kubev2v/forklift/pkg/lib/inventory/web"
+	azureweb "github.com/kubev2v/forklift/pkg/provider/azure/inventory/web"
 	ec2web "github.com/kubev2v/forklift/pkg/provider/ec2/inventory/web"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,5 +48,8 @@ func All(container *container.Container, k8s client.Client) (all []libweb.Reques
 	all = append(
 		all,
 		hyperv.Handlers(container)...)
+	all = append(
+		all,
+		azureweb.Handlers(container)...)
 	return
 }

--- a/pkg/provider/azure/constants.go
+++ b/pkg/provider/azure/constants.go
@@ -1,0 +1,1 @@
+package azure

--- a/pkg/provider/azure/controller/adapter/adapter.go
+++ b/pkg/provider/azure/controller/adapter/adapter.go
@@ -1,0 +1,40 @@
+package adapter
+
+import (
+	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/provider/azure/controller/builder"
+	"github.com/kubev2v/forklift/pkg/provider/azure/controller/client"
+	azureensurer "github.com/kubev2v/forklift/pkg/provider/azure/controller/ensurer"
+	"github.com/kubev2v/forklift/pkg/provider/azure/controller/validator"
+)
+
+type Adapter struct{}
+
+func New() *Adapter {
+	return &Adapter{}
+}
+
+func (r *Adapter) Ensurer(ctx *plancontext.Context) (base.Ensurer, error) {
+	return azureensurer.New(ctx), nil
+}
+
+func (r *Adapter) Builder(ctx *plancontext.Context) (base.Builder, error) {
+	return builder.New(ctx), nil
+}
+
+func (r *Adapter) Validator(ctx *plancontext.Context) (base.Validator, error) {
+	return validator.New(ctx), nil
+}
+
+func (r *Adapter) Client(ctx *plancontext.Context) (base.Client, error) {
+	c := &client.Client{Context: ctx}
+	if err := c.Connect(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (r *Adapter) DestinationClient(ctx *plancontext.Context) (base.DestinationClient, error) {
+	return &DestinationClient{Context: ctx}, nil
+}

--- a/pkg/provider/azure/controller/adapter/destinationclient.go
+++ b/pkg/provider/azure/controller/adapter/destinationclient.go
@@ -1,0 +1,21 @@
+package adapter
+
+import (
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+)
+
+var _ base.DestinationClient = &DestinationClient{}
+
+type DestinationClient struct {
+	*plancontext.Context
+}
+
+func (r *DestinationClient) DeletePopulatorDataSource(vm *planapi.VMStatus) error {
+	return nil
+}
+
+func (r *DestinationClient) SetPopulatorCrOwnership() error {
+	return nil
+}

--- a/pkg/provider/azure/controller/builder/core.go
+++ b/pkg/provider/azure/controller/builder/core.go
@@ -1,0 +1,22 @@
+package builder
+
+import (
+	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+)
+
+var _ base.Builder = &Builder{}
+
+type Builder struct {
+	*plancontext.Context
+	log logging.LevelLogger
+}
+
+func New(ctx *plancontext.Context) *Builder {
+	log := logging.WithName("builder|azure")
+	return &Builder{
+		Context: ctx,
+		log:     log,
+	}
+}

--- a/pkg/provider/azure/controller/builder/noop.go
+++ b/pkg/provider/azure/controller/builder/noop.go
@@ -1,0 +1,107 @@
+package builder
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	core "k8s.io/api/core/v1"
+	cnv "kubevirt.io/api/core/v1"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) error {
+	return nil
+}
+
+func (r *Builder) ConfigMap(vmRef ref.Ref, secret *core.Secret, object *core.ConfigMap) error {
+	return nil
+}
+
+func (r *Builder) ConfigMaps(vmRef ref.Ref) ([]core.ConfigMap, error) {
+	return nil, nil
+}
+
+func (r *Builder) Secrets(vmRef ref.Ref) ([]core.Secret, error) {
+	return nil, nil
+}
+
+func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) ([]cdi.DataVolume, error) {
+	return nil, nil
+}
+
+func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
+	return ""
+}
+
+func (r *Builder) LunPersistentVolumes(vmRef ref.Ref) ([]core.PersistentVolume, error) {
+	return nil, nil
+}
+
+func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) ([]core.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+
+func (r *Builder) PreferenceName(vmRef ref.Ref, configMap *core.ConfigMap) (string, error) {
+	return "", nil
+}
+
+func (r *Builder) CsiImportPVCs(_ ref.Ref, _ map[string]string) ([]core.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+
+func (r *Builder) PopulatorXcopyUsed(_ *core.PersistentVolumeClaim) (string, bool, error) {
+	return "", false, nil
+}
+
+func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim, usesInstanceType bool, sortVolumesByLibvirt bool) error {
+	return nil
+}
+
+func (r *Builder) Tasks(vmRef ref.Ref) ([]*plan.Task, error) {
+	return nil, nil
+}
+
+func (r *Builder) TemplateLabels(vmRef ref.Ref) (map[string]string, error) {
+	return nil, nil
+}
+
+func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) ([]core.EnvVar, error) {
+	return nil, nil
+}
+
+func (r *Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVolumeClaim) string {
+	return ""
+}
+
+func (r *Builder) SupportsVolumePopulators() bool {
+	return false
+}
+
+func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string, secretName string) ([]*core.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+
+func (r *Builder) PopulatorTransferredBytes(pvc *core.PersistentVolumeClaim) (int64, error) {
+	return 0, nil
+}
+
+func (r *Builder) SetPopulatorDataSourceLabels(vmRef ref.Ref, pvcs []*core.PersistentVolumeClaim) error {
+	return nil
+}
+
+func (r *Builder) GetPopulatorTaskName(pvc *core.PersistentVolumeClaim) (string, error) {
+	return "", nil
+}
+
+func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigResult, error) {
+	return &planbase.ConversionPodConfigResult{}, nil
+}
+
+func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]core.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+
+func (r *Builder) SourceVMLabelsAndAnnotations(vmRef ref.Ref, tagMapping *api.TagMapping) (map[string]string, map[string]string, map[string]string, error) {
+	return nil, nil, nil, nil
+}

--- a/pkg/provider/azure/controller/client/client.go
+++ b/pkg/provider/azure/controller/client/client.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+)
+
+type Client struct {
+	*plancontext.Context
+}
+
+func (r *Client) Connect() error {
+	return nil
+}
+
+func (r *Client) Close() {}

--- a/pkg/provider/azure/controller/client/noop.go
+++ b/pkg/provider/azure/controller/client/noop.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	"github.com/kubev2v/forklift/pkg/controller/plan/util"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+func (r *Client) PowerOn(vmRef ref.Ref) error  { return nil }
+func (r *Client) PowerOff(vmRef ref.Ref) error { return nil }
+func (r *Client) PowerState(vmRef ref.Ref) (planapi.VMPowerState, error) {
+	return planapi.VMPowerStateUnknown, nil
+}
+func (r *Client) PoweredOff(vmRef ref.Ref) (bool, error)            { return true, nil }
+func (r *Client) PreTransferActions(vmRef ref.Ref) (bool, error)    { return true, nil }
+func (r *Client) DetachDisks(vmRef ref.Ref) error                   { return nil }
+func (r *Client) Finalize(vms []*planapi.VMStatus, planName string) {}
+func (r *Client) CreateSnapshot(vmRef ref.Ref, hostsFunc util.HostsFunc) (string, string, error) {
+	return "", "", nil
+}
+func (r *Client) RemoveSnapshot(vmRef ref.Ref, snapshot string, hostsFunc util.HostsFunc) (string, error) {
+	return "", nil
+}
+func (r *Client) CheckSnapshotReady(vmRef ref.Ref, precopy planapi.Precopy, hosts util.HostsFunc) (bool, string, error) {
+	return true, "", nil
+}
+func (r *Client) CheckSnapshotRemove(vmRef ref.Ref, precopy planapi.Precopy, hosts util.HostsFunc) (bool, error) {
+	return true, nil
+}
+func (r *Client) SetCheckpoints(vmRef ref.Ref, precopies []planapi.Precopy, datavolumes []cdi.DataVolume, final bool, hostsFunc util.HostsFunc) error {
+	return nil
+}
+func (r *Client) GetSnapshotDeltas(vmRef ref.Ref, snapshot string, hostsFunc util.HostsFunc) (map[string]string, error) {
+	return nil, nil
+}
+
+var _ base.Client = &Client{}

--- a/pkg/provider/azure/controller/ensurer/ensurer.go
+++ b/pkg/provider/azure/controller/ensurer/ensurer.go
@@ -1,0 +1,30 @@
+package ensurer
+
+import (
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	core "k8s.io/api/core/v1"
+)
+
+var _ base.Ensurer = &Ensurer{}
+
+type Ensurer struct {
+	*plancontext.Context
+}
+
+func New(ctx *plancontext.Context) *Ensurer {
+	return &Ensurer{Context: ctx}
+}
+
+func (r *Ensurer) SharedConfigMaps(vm *planapi.VMStatus, configMaps []core.ConfigMap) error {
+	return nil
+}
+
+func (r *Ensurer) SharedSecrets(vm *planapi.VMStatus, secrets []core.Secret) error {
+	return nil
+}
+
+func (r *Ensurer) PersistentVolumeClaims(vm *planapi.VMStatus, pvcs []core.PersistentVolumeClaim) error {
+	return nil
+}

--- a/pkg/provider/azure/controller/handler/config.go
+++ b/pkg/provider/azure/controller/handler/config.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	AzureControllerIntervalEnv = "AZURE_CONTROLLER_INTERVAL_SECONDS"
+)
+
+const (
+	DefaultInventoryPollingInterval = 15 * time.Second
+)
+
+var InventoryPollingInterval = loadInventoryPollingInterval()
+
+func loadInventoryPollingInterval() time.Duration {
+	if s, found := os.LookupEnv(AzureControllerIntervalEnv); found {
+		if seconds, err := strconv.Atoi(s); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return DefaultInventoryPollingInterval
+}

--- a/pkg/provider/azure/controller/handler/doc.go
+++ b/pkg/provider/azure/controller/handler/doc.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/controller/watch/handler"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func New(
+	client client.Client,
+	channel chan event.GenericEvent,
+	provider *api.Provider) (h *PlanHandler, err error) {
+	b, err := handler.New(client, channel, provider)
+	if err != nil {
+		return
+	}
+	h = &PlanHandler{Handler: b}
+	return
+}
+
+func NewNetworkHandler(
+	client client.Client,
+	channel chan event.GenericEvent,
+	provider *api.Provider) (h *NetworkHandler, err error) {
+	b, err := handler.New(client, channel, provider)
+	if err != nil {
+		return
+	}
+	h = &NetworkHandler{Handler: b}
+	return
+}
+
+func NewStorageHandler(
+	client client.Client,
+	channel chan event.GenericEvent,
+	provider *api.Provider) (h *StorageHandler, err error) {
+	b, err := handler.New(client, channel, provider)
+	if err != nil {
+		return
+	}
+	h = &StorageHandler{Handler: b}
+	return
+}

--- a/pkg/provider/azure/controller/handler/host.go
+++ b/pkg/provider/azure/controller/handler/host.go
@@ -1,0 +1,11 @@
+package handler
+
+import (
+	"github.com/kubev2v/forklift/pkg/controller/watch/handler"
+)
+
+type NoOpHostHandler struct{}
+
+func (r *NoOpHostHandler) Watch(watch *handler.WatchManager) (err error) {
+	return
+}

--- a/pkg/provider/azure/controller/handler/network.go
+++ b/pkg/provider/azure/controller/handler/network.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"context"
+	"path"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/controller/watch/handler"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	libweb "github.com/kubev2v/forklift/pkg/lib/inventory/web"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var logNetwork = logging.WithName("network|azure")
+
+type NetworkHandler struct {
+	*handler.Handler
+}
+
+func (r *NetworkHandler) Watch(watch *handler.WatchManager) (err error) {
+	watch.EnsurePeriodicEvents(
+		r.Provider(),
+		&struct{}{},
+		InventoryPollingInterval,
+		r.generateEvents,
+	)
+
+	logNetwork.Info(
+		"Periodic network mapping events ensured.",
+		"provider",
+		path.Join(
+			r.Provider().Namespace,
+			r.Provider().Name),
+		"interval",
+		InventoryPollingInterval,
+	)
+
+	return
+}
+
+func (r *NetworkHandler) Created(e libweb.Event) {
+}
+
+func (r *NetworkHandler) Deleted(e libweb.Event) {
+}
+
+func (r *NetworkHandler) generateEvents() {
+	list := api.NetworkMapList{}
+	err := r.List(context.TODO(), &list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		logNetwork.Error(err, "Failed to list NetworkMap CRs")
+		return
+	}
+
+	for i := range list.Items {
+		mapping := &list.Items[i]
+		if r.MatchProvider(mapping.Spec.Provider.Source) || r.MatchProvider(mapping.Spec.Provider.Destination) {
+			r.Enqueue(event.GenericEvent{
+				Object: mapping,
+			})
+		}
+	}
+}

--- a/pkg/provider/azure/controller/handler/plan.go
+++ b/pkg/provider/azure/controller/handler/plan.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"context"
+	"path"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/controller/watch/handler"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	libweb "github.com/kubev2v/forklift/pkg/lib/inventory/web"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var log = logging.WithName("plan|azure")
+
+type PlanHandler struct {
+	*handler.Handler
+}
+
+func (r *PlanHandler) Watch(watch *handler.WatchManager) (err error) {
+	watch.EnsurePeriodicEvents(
+		r.Provider(),
+		&struct{}{},
+		InventoryPollingInterval,
+		r.generateEvents,
+	)
+
+	log.Info(
+		"Periodic inventory events ensured.",
+		"provider",
+		path.Join(
+			r.Provider().Namespace,
+			r.Provider().Name),
+		"interval",
+		InventoryPollingInterval,
+	)
+
+	return
+}
+
+func (r *PlanHandler) Created(e libweb.Event) {
+}
+
+func (r *PlanHandler) Deleted(e libweb.Event) {
+}
+
+func (r *PlanHandler) generateEvents() {
+	list := api.PlanList{}
+	err := r.List(context.TODO(), &list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		log.Error(err, "Failed to list Plan CRs")
+		return
+	}
+
+	for i := range list.Items {
+		plan := &list.Items[i]
+		if r.MatchProvider(plan.Spec.Provider.Source) || r.MatchProvider(plan.Spec.Provider.Destination) {
+			r.Enqueue(event.GenericEvent{
+				Object: plan,
+			})
+		}
+	}
+}

--- a/pkg/provider/azure/controller/handler/storage.go
+++ b/pkg/provider/azure/controller/handler/storage.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"context"
+	"path"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/controller/watch/handler"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	libweb "github.com/kubev2v/forklift/pkg/lib/inventory/web"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var logStorage = logging.WithName("storage|azure")
+
+type StorageHandler struct {
+	*handler.Handler
+}
+
+func (r *StorageHandler) Watch(watch *handler.WatchManager) (err error) {
+	watch.EnsurePeriodicEvents(
+		r.Provider(),
+		&struct{}{},
+		InventoryPollingInterval,
+		r.generateEvents,
+	)
+
+	logStorage.Info(
+		"Periodic storage mapping events ensured.",
+		"provider",
+		path.Join(
+			r.Provider().Namespace,
+			r.Provider().Name),
+		"interval",
+		InventoryPollingInterval,
+	)
+
+	return
+}
+
+func (r *StorageHandler) Created(e libweb.Event) {
+}
+
+func (r *StorageHandler) Deleted(e libweb.Event) {
+}
+
+func (r *StorageHandler) generateEvents() {
+	list := api.StorageMapList{}
+	err := r.List(context.TODO(), &list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		logStorage.Error(err, "Failed to list StorageMap CRs")
+		return
+	}
+
+	for i := range list.Items {
+		mapping := &list.Items[i]
+		if r.MatchProvider(mapping.Spec.Provider.Source) || r.MatchProvider(mapping.Spec.Provider.Destination) {
+			r.Enqueue(event.GenericEvent{
+				Object: mapping,
+			})
+		}
+	}
+}

--- a/pkg/provider/azure/controller/migrator/core.go
+++ b/pkg/provider/azure/controller/migrator/core.go
@@ -1,0 +1,62 @@
+package migrator
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	migbase "github.com/kubev2v/forklift/pkg/controller/plan/migrator/base"
+	libitr "github.com/kubev2v/forklift/pkg/lib/itinerary"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+)
+
+var _ migbase.Migrator = &Migrator{}
+
+type Migrator struct {
+	*plancontext.Context
+	log logging.LevelLogger
+}
+
+func New(ctx *plancontext.Context) (migbase.Migrator, error) {
+	return &Migrator{
+		Context: ctx,
+		log:     logging.WithName("migrator|azure"),
+	}, nil
+}
+
+func (r *Migrator) Type() api.MigrationType       { return api.MigrationCold }
+func (r *Migrator) Logger() logging.LevelLogger   { return r.log }
+func (r *Migrator) Init() error                   { return nil }
+func (r *Migrator) Begin() error                  { return nil }
+func (r *Migrator) Complete(vm *planapi.VMStatus) {}
+func (r *Migrator) Status(vm planapi.VM) *planapi.VMStatus {
+	return &planapi.VMStatus{VM: vm}
+}
+func (r *Migrator) Reset(vm *planapi.VMStatus, pipeline []*planapi.Step) {
+	vm.Pipeline = pipeline
+	vm.Phase = api.PhaseStarted
+	vm.Error = nil
+	vm.Started = nil
+	vm.Completed = nil
+}
+
+func (r *Migrator) Itinerary(vm planapi.VM) *libitr.Itinerary {
+	return &libitr.Itinerary{
+		Name: "Azure Cold Migration",
+		Pipeline: libitr.Pipeline{
+			{Name: api.PhaseStarted},
+			{Name: api.PhaseCompleted},
+		},
+	}
+}
+
+func (r *Migrator) Pipeline(vm planapi.VM) ([]*planapi.Step, error) {
+	return nil, nil
+}
+
+func (r *Migrator) Step(status *planapi.VMStatus) string {
+	return ""
+}
+
+func (r *Migrator) ExecutePhase(vm *planapi.VMStatus) (bool, error) {
+	return false, nil
+}

--- a/pkg/provider/azure/controller/scheduler/scheduler.go
+++ b/pkg/provider/azure/controller/scheduler/scheduler.go
@@ -1,0 +1,70 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+)
+
+var mutex sync.Mutex
+
+const Canceled = "Canceled"
+
+type Scheduler struct {
+	*plancontext.Context
+	MaxInFlight int
+}
+
+func (r *Scheduler) Next() (vm *plan.VMStatus, hasNext bool, err error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	planList := &api.PlanList{}
+	err = r.List(context.TODO(), planList)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+
+	if r.calcInFlight(planList) >= r.MaxInFlight {
+		return
+	}
+
+	for _, vmStatus := range r.Plan.Status.Migration.VMs {
+		if vmStatus.HasCondition(Canceled) {
+			continue
+		}
+		if !vmStatus.MarkedStarted() && !vmStatus.MarkedCompleted() {
+			vm = vmStatus
+			hasNext = true
+			return
+		}
+	}
+
+	return
+}
+
+func (r *Scheduler) calcInFlight(planList *api.PlanList) int {
+	inFlight := 0
+	for _, p := range planList.Items {
+		if p.Spec.Provider.Source != r.Plan.Spec.Provider.Source {
+			continue
+		}
+
+		snapshot := p.Status.Migration.ActiveSnapshot()
+		if !snapshot.HasCondition("Executing") {
+			continue
+		}
+
+		for _, vmStatus := range p.Status.Migration.VMs {
+			if vmStatus.Running() {
+				inFlight++
+			}
+		}
+	}
+	return inFlight
+}

--- a/pkg/provider/azure/controller/validator/noop.go
+++ b/pkg/provider/azure/controller/validator/noop.go
@@ -1,0 +1,46 @@
+package validator
+
+import (
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ base.Validator = &Validator{}
+
+type Validator struct {
+	*plancontext.Context
+}
+
+func New(ctx *plancontext.Context) *Validator {
+	return &Validator{Context: ctx}
+}
+
+func (r *Validator) StorageMapped(vmRef ref.Ref) (bool, error)       { return true, nil }
+func (r *Validator) DirectStorage(vmRef ref.Ref) (bool, error)       { return true, nil }
+func (r *Validator) NetworksMapped(vmRef ref.Ref) (bool, error)      { return true, nil }
+func (r *Validator) MaintenanceMode(vmRef ref.Ref) (bool, error)     { return true, nil }
+func (r *Validator) WarmMigration() bool                             { return false }
+func (r *Validator) MigrationType() bool                             { return true }
+func (r *Validator) NICNetworkRefs(vmRef ref.Ref) ([]ref.Ref, error) { return nil, nil }
+func (r *Validator) StaticIPs(vmRef ref.Ref) (bool, error)           { return true, nil }
+func (r *Validator) UdnStaticIPs(vmRef ref.Ref, c client.Client) (bool, error) {
+	return true, nil
+}
+func (r *Validator) SharedDisks(vmRef ref.Ref, c client.Client) (bool, string, string, error) {
+	return true, "", "", nil
+}
+func (r *Validator) ChangeTrackingEnabled(vmRef ref.Ref) (bool, error) { return true, nil }
+func (r *Validator) HasSnapshot(vmRef ref.Ref) (bool, string, string, error) {
+	return true, "", "", nil
+}
+func (r *Validator) PowerState(vmRef ref.Ref) (bool, error)                 { return true, nil }
+func (r *Validator) VMMigrationType(vmRef ref.Ref) (bool, error)            { return true, nil }
+func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error)       { return nil, nil }
+func (r *Validator) MacConflicts(vmRef ref.Ref) ([]base.MacConflict, error) { return nil, nil }
+func (r *Validator) PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (bool, error) {
+	return true, nil
+}
+func (r *Validator) GuestToolsInstalled(vmRef ref.Ref) (bool, error) { return true, nil }
+func (r *Validator) ConsolidationNeeded(vmRef ref.Ref) (bool, error) { return false, nil }

--- a/pkg/provider/azure/inventory/collector/collector.go
+++ b/pkg/provider/azure/inventory/collector/collector.go
@@ -1,0 +1,115 @@
+package collector
+
+import (
+	"context"
+	"path"
+	"sync"
+	"time"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	libcontainer "github.com/kubev2v/forklift/pkg/lib/inventory/container"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ libcontainer.Collector = &Collector{}
+
+type Collector struct {
+	libcontainer.Collector
+	db         libmodel.DB
+	provider   *api.Provider
+	secret     *core.Secret
+	log        logging.LevelLogger
+	cancel     context.CancelFunc
+	parity     bool
+	collecting bool
+	mutex      sync.Mutex
+}
+
+func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) libcontainer.Collector {
+	log := logging.WithName("collector|azure").WithValues(
+		"provider",
+		path.Join(
+			provider.GetNamespace(),
+			provider.GetName()))
+
+	return &Collector{
+		db:       db,
+		provider: provider,
+		secret:   secret,
+		log:      log,
+	}
+}
+
+func (r *Collector) Name() string {
+	return "Azure"
+}
+
+func (r *Collector) HasParity() bool {
+	return r.parity
+}
+
+func (r *Collector) Start() error {
+	ctx := context.Background()
+	ctx, r.cancel = context.WithCancel(ctx)
+
+	start := func() {
+		defer func() {
+			r.log.Info("Collection loop stopped.")
+		}()
+
+		r.parity = true
+		r.log.Info("Initial collection completed (noop), parity achieved.")
+
+		ticker := time.NewTicker(RefreshInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				r.log.V(1).Info("Periodic collection (noop)")
+				r.parity = true
+			}
+		}
+	}
+
+	go start()
+
+	r.log.Info("Collector started.")
+	return nil
+}
+
+func (r *Collector) Shutdown() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.log.Info("Collector shut down.")
+}
+
+func (r *Collector) Reset() {
+	r.parity = false
+	r.log.Info("Collector reset.")
+}
+
+func (r *Collector) DB() libmodel.DB {
+	return r.db
+}
+
+func (r *Collector) Version() (version, product, apiVersion, instanceUuid string, err error) {
+	version = "azure"
+	product = "Microsoft Azure"
+	return
+}
+
+func (r *Collector) Owner() meta.Object {
+	return r.provider
+}
+
+func (r *Collector) Test() (status int, err error) {
+	status = 200
+	return
+}

--- a/pkg/provider/azure/inventory/collector/config.go
+++ b/pkg/provider/azure/inventory/collector/config.go
@@ -1,0 +1,26 @@
+package collector
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	AzureInventoryIntervalEnv = "AZURE_INVENTORY_INTERVAL_SECONDS"
+)
+
+const (
+	DefaultRefreshInterval = 10 * time.Second
+)
+
+var RefreshInterval = loadRefreshInterval()
+
+func loadRefreshInterval() time.Duration {
+	if s, found := os.LookupEnv(AzureInventoryIntervalEnv); found {
+		if seconds, err := strconv.Atoi(s); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return DefaultRefreshInterval
+}

--- a/pkg/provider/azure/inventory/model/model.go
+++ b/pkg/provider/azure/inventory/model/model.go
@@ -1,0 +1,238 @@
+package model
+
+import (
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+)
+
+var NotFound = libmodel.NotFound
+
+// d0..d3 = detail levels for inventory queries (d0 = lightest list, d3 = full).
+const (
+	MaxDetail = 3
+)
+
+// Base is embedded by every inventory model (VM, Disk, Network, Storage).
+// pk = primary key. UID holds the qualified ID ({resourceGroup}--{name}).
+// Revision auto-increments on every DB update (optimistic concurrency).
+type Base struct {
+	UID           string `sql:"pk"`
+	Name          string `sql:"d0,index(name)"`
+	ResourceGroup string `sql:"d0,index(resourceGroup)"`
+	Kind          string `sql:"d0,index(kind)"`
+	Provider      string `sql:"d0,index(provider)"`
+	Revision      int64  `sql:"incremented,d0,index(revision)"`
+}
+
+func (m *Base) Pk() string {
+	return m.UID
+}
+
+func (m *Base) String() string {
+	return m.UID
+}
+
+type VM struct {
+	Base
+	VMSize     string   `sql:"d0,index(vmSize)"`     // Azure SKU size, e.g. "Standard_D2s_v3"
+	PowerState string   `sql:"d0,index(powerState)"` // e.g. "PowerState/running", "PowerState/deallocated"
+	OSType     string   `sql:"d0,index(osType)"`
+	CpuCount   int32    `sql:"d0"`
+	MemoryMB   int32    `sql:"d0"`
+	GuestId    string   `sql:"d0"` // guest OS identifier
+	Disks      []VMDisk `sql:"d0"`
+}
+
+func (m *VM) Labels() libmodel.Labels {
+	return nil
+}
+
+func (m *VM) GetDetails() (*VMDetails, error) {
+	return &VMDetails{
+		ID:            m.UID,
+		Name:          m.Name,
+		ResourceGroup: m.ResourceGroup,
+		Kind:          m.Kind,
+		Provider:      m.Provider,
+		Revision:      m.Revision,
+	}, nil
+}
+
+// HasChanged is a cheap diff for inventory reconciliation — only update the DB row if needed.
+func (m *VM) HasChanged(new *VM) bool {
+	return m.Name != new.Name || m.Kind != new.Kind ||
+		m.VMSize != new.VMSize || m.PowerState != new.PowerState
+}
+
+type VMDisk struct {
+	Name   string `json:"name"`
+	ID     string `json:"id"`
+	SizeGB int32  `json:"sizeGB"`
+	SKU    string `json:"sku"`  // disk performance tier, e.g. "Premium_LRS", "Standard_SSD_LRS"
+	IsOS   bool   `json:"isOS"` // true = boot/OS disk, false = data disk
+	OSType string `json:"osType,omitempty"`
+}
+
+type VMNetworkInterface struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	SubnetID string `json:"subnetId,omitempty"` // Azure resource ID of the subnet this NIC is in
+	Primary  bool   `json:"primary"`
+}
+
+// VMDetails is the JSON-friendly view returned by the REST API.
+type VMDetails struct {
+	ID                string               `json:"id"`
+	Name              string               `json:"name"`
+	ResourceGroup     string               `json:"resourceGroup"`
+	Kind              string               `json:"kind"`
+	Provider          string               `json:"provider"`
+	Revision          int64                `json:"revision"`
+	PowerState        string               `json:"powerState"`
+	CpuCount          int32                `json:"cpuCount"`
+	MemoryMB          int32                `json:"memoryMB"`
+	GuestId           string               `json:"guestId"`
+	Disks             []VMDisk             `json:"disks,omitempty"`
+	ManagedDisks      []VMDisk             `json:"managedDisks,omitempty"` // Azure-managed disks (vs. unmanaged/blob)
+	NetworkInterfaces []VMNetworkInterface `json:"networkInterfaces,omitempty"`
+	Location          *string              `json:"location,omitempty"` // Azure region, e.g. "eastus"
+}
+
+// Disk represents an Azure managed disk.
+type Disk struct {
+	Base
+	DiskType string `sql:"d0,index(diskType)"` // performance tier, e.g. "Premium_LRS"
+	State    string `sql:"d0,index(state)"`    // lifecycle state: "Attached", "Unattached", etc.
+	SizeGB   int64  `sql:"d0,index(sizeGB)"`
+}
+
+func (m *Disk) Labels() libmodel.Labels {
+	return nil
+}
+
+func (m *Disk) GetDetails() (*DiskDetails, error) {
+	return &DiskDetails{
+		ID:            m.UID,
+		Name:          m.Name,
+		ResourceGroup: m.ResourceGroup,
+		Kind:          m.Kind,
+		Provider:      m.Provider,
+		Revision:      m.Revision,
+	}, nil
+}
+
+func (m *Disk) HasChanged(new *Disk) bool {
+	return m.Name != new.Name || m.DiskType != new.DiskType ||
+		m.State != new.State || m.SizeGB != new.SizeGB
+}
+
+type DiskDetails struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	ResourceGroup string `json:"resourceGroup"`
+	Kind          string `json:"kind"`
+	Provider      string `json:"provider"`
+	Revision      int64  `json:"revision"`
+	SizeGB        int32  `json:"sizeGB"`
+	SKU           string `json:"sku"` // disk performance tier
+}
+
+// Network represents either a VNet or a Subnet (both stored as Network rows).
+type Network struct {
+	Base
+	NetworkType string `sql:"d0,index(networkType)"` // "VNet" or "Subnet"
+	CIDR        string `sql:"d0,index(cidr)"`        // CIDR block, e.g. "10.0.0.0/16"
+}
+
+func (m *Network) Labels() libmodel.Labels {
+	return nil
+}
+
+func (m *Network) GetDetails() (*NetworkDetails, error) {
+	return &NetworkDetails{
+		ID:            m.UID,
+		Name:          m.Name,
+		ResourceGroup: m.ResourceGroup,
+		Kind:          m.Kind,
+		Provider:      m.Provider,
+		Revision:      m.Revision,
+		Variant:       m.NetworkType,
+		CIDR:          m.CIDR,
+	}, nil
+}
+
+func (m *Network) HasChanged(new *Network) bool {
+	return m.Name != new.Name || m.NetworkType != new.NetworkType ||
+		m.CIDR != new.CIDR
+}
+
+type NetworkDetails struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	ResourceGroup string `json:"resourceGroup"`
+	Kind          string `json:"kind"`
+	Provider      string `json:"provider"`
+	Revision      int64  `json:"revision"`
+	Variant       string `json:"variant"`
+	CIDR          string `json:"cidr,omitempty"`
+}
+
+// Storage represents an Azure disk SKU (performance tier definition, not a specific disk).
+type Storage struct {
+	Base
+	SKU    string      `sql:"d0,index(sku)"` // e.g. "Premium_LRS", "StandardSSD_LRS"
+	Object StorageData `sql:"d0"`
+}
+
+// StorageData holds the performance characteristics of a disk SKU.
+type StorageData struct {
+	SKU         string `json:"sku"`
+	Description string `json:"description"`
+	MaxIOPS     int32  `json:"maxIOPS"` // max I/O operations per second
+	MaxMBps     int32  `json:"maxMBps"` // max throughput in MB/s
+}
+
+func (m *Storage) Labels() libmodel.Labels {
+	return nil
+}
+
+func (m *Storage) GetDetails() (*StorageDetails, error) {
+	return &StorageDetails{
+		ID:            m.UID,
+		Name:          m.Name,
+		ResourceGroup: m.ResourceGroup,
+		Kind:          m.Kind,
+		Provider:      m.Provider,
+		Revision:      m.Revision,
+		SKU:           m.Object.SKU,
+		Description:   m.Object.Description,
+		MaxIOPS:       m.Object.MaxIOPS,
+		MaxMBps:       m.Object.MaxMBps,
+	}, nil
+}
+
+func (m *Storage) HasChanged(new *Storage) bool {
+	return m.Name != new.Name || m.SKU != new.SKU
+}
+
+type StorageDetails struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	ResourceGroup string `json:"resourceGroup"`
+	Kind          string `json:"kind"`
+	Provider      string `json:"provider"`
+	Revision      int64  `json:"revision"`
+	SKU           string `json:"sku"`
+	Description   string `json:"description"`
+	MaxIOPS       int32  `json:"maxIOPS"`
+	MaxMBps       int32  `json:"maxMBps"`
+}
+
+// All returns every model type so the DB can auto-create all tables.
+func All() []interface{} {
+	return []interface{}{
+		&VM{},
+		&Disk{},
+		&Network{},
+		&Storage{},
+	}
+}

--- a/pkg/provider/azure/inventory/web/base.go
+++ b/pkg/provider/azure/inventory/web/base.go
@@ -1,0 +1,40 @@
+package web
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/provider/azure/inventory/model"
+)
+
+var log = logging.WithName("azure|web")
+
+const (
+	NameParam = base.NameParam
+)
+
+type Handler struct {
+	base.Handler
+}
+
+func (h Handler) Predicate(ctx *gin.Context) (p libmodel.Predicate) {
+	q := ctx.Request.URL.Query()
+	name := q.Get(NameParam)
+	if len(name) > 0 {
+		p = libmodel.Eq(NameParam, name)
+	}
+	return
+}
+
+func (h Handler) ListOptions(ctx *gin.Context) libmodel.ListOptions {
+	detail := h.Detail
+	if detail > 0 {
+		detail = model.MaxDetail
+	}
+	return libmodel.ListOptions{
+		Predicate: h.Predicate(ctx),
+		Detail:    detail,
+		Page:      &h.Page,
+	}
+}

--- a/pkg/provider/azure/inventory/web/client.go
+++ b/pkg/provider/azure/inventory/web/client.go
@@ -1,0 +1,266 @@
+package web
+
+import (
+	"strings"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+)
+
+type ResourceNotResolvedError = base.ResourceNotResolvedError
+type RefNotUniqueError = base.RefNotUniqueError
+type NotFoundError = base.NotFoundError
+
+// Resolver builds URL paths for Azure resources.
+// Uses the short resource name (extracted from the full Azure resource ID) as
+// the path parameter, since full IDs contain slashes that break URL routing.
+type Resolver struct {
+	*api.Provider
+}
+
+func (r *Resolver) Path(resource interface{}, id string) (path string, err error) {
+	var kind string
+
+	switch resource.(type) {
+	case *VM, *[]VM:
+		kind = "VM"
+	case *Disk, *[]Disk:
+		kind = "Disk"
+	case *Network, *[]Network:
+		kind = "Network"
+	case *Storage, *[]Storage:
+		kind = "Storage"
+	case *Provider, *[]Provider:
+		kind = "Provider"
+	case *Workload, *[]Workload:
+		kind = "VM"
+	default:
+		err = liberr.Wrap(
+			base.ResourceNotResolvedError{
+				Object: resource,
+			})
+		return
+	}
+
+	return r.PathForKind(kind, id)
+}
+
+func (r *Resolver) PathForKind(kind string, id string) (path string, err error) {
+	provider := r.Provider
+	providerUID := string(provider.UID)
+
+	switch kind {
+	case "VM":
+		path = base.Link(VMRoot, base.Params{
+			base.ProviderParam: providerUID,
+			VMParam:            id,
+		})
+	case "Disk":
+		path = base.Link(ProviderRoot+"/disks/:id", base.Params{
+			base.ProviderParam: providerUID,
+			"id":               id,
+		})
+	case "Network":
+		path = base.Link(ProviderRoot+"/networks/:id", base.Params{
+			base.ProviderParam: providerUID,
+			"id":               id,
+		})
+	case "Storage":
+		path = base.Link(ProviderRoot+"/storages/:id", base.Params{
+			base.ProviderParam: providerUID,
+			"id":               id,
+		})
+	case "Provider":
+		path = base.Link(ProviderRoot, base.Params{
+			base.ProviderParam: id,
+		})
+	default:
+		err = liberr.Wrap(
+			base.ResourceNotResolvedError{
+				Object: kind,
+			})
+		return
+	}
+
+	path = strings.TrimRight(path, "/")
+	return
+}
+
+var _ base.Resolver = &Resolver{}
+
+type Finder struct {
+	base.Client
+}
+
+func (r *Finder) With(client base.Client) base.Finder {
+	r.Client = client
+	return r
+}
+
+func (r *Finder) ByRef(resource interface{}, ref base.Ref) (err error) {
+	switch res := resource.(type) {
+	case *VM:
+		err = r.findByRef(res, ref)
+	case *Disk:
+		err = r.findByRef(res, ref)
+	case *Network:
+		err = r.findByRef(res, ref)
+	case *Storage:
+		err = r.findByRef(res, ref)
+	case *Workload:
+		err = r.findByRef(res, ref)
+	default:
+		err = liberr.Wrap(
+			ResourceNotResolvedError{
+				Object: resource,
+			})
+	}
+	return
+}
+
+func (r *Finder) findByRef(resource interface{}, ref base.Ref) (err error) {
+	if ref.ID != "" {
+		err = r.Get(resource, ref.ID)
+		return
+	}
+	if ref.Name == "" {
+		err = liberr.Wrap(NotFoundError{Ref: ref})
+		return
+	}
+
+	switch resource.(type) {
+	case *VM, *Workload:
+		vmList := []VM{}
+		err = r.List(
+			&vmList,
+			base.Param{Key: base.DetailParam, Value: "all"},
+			base.Param{Key: base.NameParam, Value: ref.Name},
+		)
+		if err != nil {
+			return
+		}
+		if len(vmList) == 0 {
+			err = liberr.Wrap(NotFoundError{Ref: ref})
+			return
+		}
+		if len(vmList) > 1 {
+			err = liberr.Wrap(RefNotUniqueError{Ref: ref})
+			return
+		}
+		if vm, ok := resource.(*VM); ok {
+			*vm = vmList[0]
+		} else if wl, ok := resource.(*Workload); ok {
+			*wl = Workload{Resource: vmList[0].Resource}
+		}
+	case *Disk:
+		diskList := []Disk{}
+		err = r.List(
+			&diskList,
+			base.Param{Key: base.DetailParam, Value: "all"},
+			base.Param{Key: base.NameParam, Value: ref.Name},
+		)
+		if err != nil {
+			return
+		}
+		if len(diskList) == 0 {
+			err = liberr.Wrap(NotFoundError{Ref: ref})
+			return
+		}
+		if len(diskList) > 1 {
+			err = liberr.Wrap(RefNotUniqueError{Ref: ref})
+			return
+		}
+		*resource.(*Disk) = diskList[0]
+	case *Network:
+		networkList := []Network{}
+		err = r.List(
+			&networkList,
+			base.Param{Key: base.DetailParam, Value: "all"},
+			base.Param{Key: base.NameParam, Value: ref.Name},
+		)
+		if err != nil {
+			return
+		}
+		if len(networkList) == 0 {
+			err = liberr.Wrap(NotFoundError{Ref: ref})
+			return
+		}
+		if len(networkList) > 1 {
+			err = liberr.Wrap(RefNotUniqueError{Ref: ref})
+			return
+		}
+		*resource.(*Network) = networkList[0]
+	case *Storage:
+		storageList := []Storage{}
+		err = r.List(
+			&storageList,
+			base.Param{Key: base.DetailParam, Value: "all"},
+			base.Param{Key: base.NameParam, Value: ref.Name},
+		)
+		if err != nil {
+			return
+		}
+		if len(storageList) == 0 {
+			err = liberr.Wrap(NotFoundError{Ref: ref})
+			return
+		}
+		if len(storageList) > 1 {
+			err = liberr.Wrap(RefNotUniqueError{Ref: ref})
+			return
+		}
+		*resource.(*Storage) = storageList[0]
+	}
+	return
+}
+
+func (r *Finder) VM(ref *base.Ref) (object interface{}, err error) {
+	vm := &VM{}
+	err = r.findByRef(vm, *ref)
+	if err == nil {
+		ref.ID = vm.ID
+		ref.Name = vm.Name
+		object = vm
+	}
+	return
+}
+
+func (r *Finder) Workload(ref *base.Ref) (object interface{}, err error) {
+	workload := &Workload{}
+	err = r.findByRef(workload, *ref)
+	if err == nil {
+		ref.ID = workload.ID
+		ref.Name = workload.Name
+		object = workload
+	}
+	return
+}
+
+func (r *Finder) Network(ref *base.Ref) (object interface{}, err error) {
+	network := &Network{}
+	err = r.findByRef(network, *ref)
+	if err == nil {
+		ref.ID = network.ID
+		ref.Name = network.Name
+		object = network
+	}
+	return
+}
+
+func (r *Finder) Storage(ref *base.Ref) (object interface{}, err error) {
+	storage := &Storage{}
+	err = r.findByRef(storage, *ref)
+	if err == nil {
+		ref.ID = storage.ID
+		ref.Name = storage.Name
+		object = storage
+	}
+	return
+}
+
+func (r *Finder) Host(ref *base.Ref) (object interface{}, err error) {
+	err = liberr.New("Host resources are not supported for Azure provider")
+	return
+}
+
+var _ base.Finder = &Finder{}

--- a/pkg/provider/azure/inventory/web/disk.go
+++ b/pkg/provider/azure/inventory/web/disk.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+	"github.com/kubev2v/forklift/pkg/provider/azure/inventory/model"
+)
+
+type DiskHandler struct {
+	Handler
+}
+
+func (h *DiskHandler) AddRoutes(e *gin.Engine) {
+	e.GET(ProviderRoot+"/disks", h.List)
+	e.GET(ProviderRoot+"/disks/:id", h.Get)
+}
+
+func (h *DiskHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+
+	db := h.Collector.DB()
+	var list []model.Disk
+	err = db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		log.Error(err, "Failed to list disks")
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+
+	var result []interface{}
+	for _, m := range list {
+		r := &Disk{}
+		r.ID = m.UID
+		r.Name = m.Name
+		r.ResourceGroup = m.ResourceGroup
+		r.Revision = m.Revision
+		r.Link(h.Provider)
+		if details, err := m.GetDetails(); err == nil {
+			r.Object = details
+		}
+		result = append(result, r)
+	}
+
+	ctx.JSON(http.StatusOK, result)
+}
+
+func (h *DiskHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+
+	uid := ctx.Param("id")
+	db := h.Collector.DB()
+
+	m := &model.Disk{Base: model.Base{UID: uid}}
+	err = db.Get(m)
+	if err != nil {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+
+	r := &Disk{}
+	r.ID = m.UID
+	r.Name = m.Name
+	r.ResourceGroup = m.ResourceGroup
+	r.Revision = m.Revision
+	r.Link(h.Provider)
+	details, err := m.GetDetails()
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r.Object = details
+
+	ctx.JSON(http.StatusOK, r)
+}
+
+func (h *DiskHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.Disk{},
+		func(in libmodel.Model) (r interface{}) {
+			m := in.(*model.Disk)
+			disk := &Disk{}
+			disk.ID = m.UID
+			disk.Name = m.Name
+			disk.ResourceGroup = m.ResourceGroup
+			disk.Revision = m.Revision
+			disk.Link(h.Provider)
+			if details, err := m.GetDetails(); err == nil {
+				disk.Object = details
+			}
+			r = disk
+			return
+		})
+	if err != nil {
+		log.Error(err, "watch failed")
+		ctx.Status(http.StatusInternalServerError)
+	}
+}

--- a/pkg/provider/azure/inventory/web/doc.go
+++ b/pkg/provider/azure/inventory/web/doc.go
@@ -1,0 +1,42 @@
+package web
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	"github.com/kubev2v/forklift/pkg/lib/inventory/container"
+	libweb "github.com/kubev2v/forklift/pkg/lib/inventory/web"
+)
+
+const (
+	ProviderParam = base.ProviderParam
+	Root          = base.ProvidersRoot + "/" + string(api.Azure)
+	ProviderRoot  = Root + "/:" + ProviderParam
+)
+
+func Handlers(container *container.Container) []libweb.RequestHandler {
+	return []libweb.RequestHandler{
+		&ProviderHandler{
+			Handler: base.Handler{Container: container},
+		},
+		&VMHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
+		&DiskHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
+		&NetworkHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
+		&StorageHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
+	}
+}

--- a/pkg/provider/azure/inventory/web/network.go
+++ b/pkg/provider/azure/inventory/web/network.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+	"github.com/kubev2v/forklift/pkg/provider/azure/inventory/model"
+)
+
+type NetworkHandler struct {
+	Handler
+}
+
+func (h *NetworkHandler) AddRoutes(e *gin.Engine) {
+	e.GET(ProviderRoot+"/networks", h.List)
+	e.GET(ProviderRoot+"/networks/:id", h.Get)
+}
+
+func (h *NetworkHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+
+	db := h.Collector.DB()
+	var list []model.Network
+	err = db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		log.Error(err, "Failed to list networks")
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+
+	var result []interface{}
+	for _, m := range list {
+		r := &Network{}
+		r.ID = m.UID
+		r.Name = m.Name
+		r.ResourceGroup = m.ResourceGroup
+		r.Revision = m.Revision
+		r.Link(h.Provider)
+		if details, err := m.GetDetails(); err == nil {
+			r.Object = details
+		}
+		result = append(result, r)
+	}
+
+	ctx.JSON(http.StatusOK, result)
+}
+
+func (h *NetworkHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+
+	uid := ctx.Param("id")
+	db := h.Collector.DB()
+
+	m := &model.Network{Base: model.Base{UID: uid}}
+	err = db.Get(m)
+	if err != nil {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+
+	r := &Network{}
+	r.ID = m.UID
+	r.Name = m.Name
+	r.ResourceGroup = m.ResourceGroup
+	r.Revision = m.Revision
+	r.Link(h.Provider)
+	details, err := m.GetDetails()
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r.Object = details
+
+	ctx.JSON(http.StatusOK, r)
+}
+
+func (h *NetworkHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.Network{},
+		func(in libmodel.Model) (r interface{}) {
+			m := in.(*model.Network)
+			network := &Network{}
+			network.ID = m.UID
+			network.Name = m.Name
+			network.ResourceGroup = m.ResourceGroup
+			network.Revision = m.Revision
+			network.Link(h.Provider)
+			if details, err := m.GetDetails(); err == nil {
+				network.Object = details
+			}
+			r = network
+			return
+		})
+	if err != nil {
+		log.Error(err, "watch failed")
+		ctx.Status(http.StatusInternalServerError)
+	}
+}

--- a/pkg/provider/azure/inventory/web/provider.go
+++ b/pkg/provider/azure/inventory/web/provider.go
@@ -1,0 +1,180 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	ocpmodel "github.com/kubev2v/forklift/pkg/controller/provider/model/ocp"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/ocp"
+	"github.com/kubev2v/forklift/pkg/provider/azure/inventory/model"
+)
+
+type ProviderHandler struct {
+	base.Handler
+}
+
+func (h *ProviderHandler) Prepare(ctx *gin.Context) (int, error) {
+	return h.Handler.Prepare(ctx)
+}
+
+func (h *ProviderHandler) AddRoutes(e *gin.Engine) {
+	e.GET(Root, h.List)
+	e.GET(Root+"/", h.List)
+	e.GET(ProviderRoot, h.Get)
+}
+
+func (h ProviderHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		ctx.Status(http.StatusBadRequest)
+		return
+	}
+	content, err := h.ListContent(ctx)
+	if err != nil {
+		log.Trace(err, "url", ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	ctx.JSON(http.StatusOK, content)
+}
+
+func (h *ProviderHandler) ListContent(ctx *gin.Context) (content []interface{}, err error) {
+	content = []interface{}{}
+	q := ctx.Request.URL.Query()
+	ns := q.Get(base.NsParam)
+	for _, collector := range h.Container.List() {
+		p, cast := collector.Owner().(*api.Provider)
+		if !cast {
+			continue
+		}
+		if p.Type() != api.Azure || (ns != "" && ns != p.Namespace) {
+			continue
+		}
+		var found bool
+		h.Collector, found = h.Container.Get(p)
+		if !found {
+			continue
+		}
+		m := &ocpmodel.Provider{}
+		m.With(p)
+		r := &ProviderResource{}
+		r.With(m)
+		r.Link()
+		aErr := h.AddDerived(r)
+		if aErr != nil {
+			err = aErr
+			return
+		}
+		content = append(content, r.Content(model.MaxDetail))
+	}
+	return
+}
+
+func (h ProviderHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.Provider.Type() != api.Azure {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	var found bool
+	h.Collector, found = h.Container.Get(h.Provider)
+	if !found {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	m := &ocpmodel.Provider{}
+	m.With(h.Provider)
+	r := &ProviderResource{}
+	r.With(m)
+	r.Link()
+	err = h.AddDerived(r)
+	if err != nil {
+		log.Trace(err, "url", ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := r.Content(model.MaxDetail)
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+type ProviderResource struct {
+	ocp.Resource
+	Type         string       `json:"type"`
+	Object       api.Provider `json:"object"`
+	APIVersion   string       `json:"apiVersion"`
+	Product      string       `json:"product"`
+	VMCount      int64        `json:"vmCount"`
+	NetworkCount int64        `json:"networkCount"`
+	DiskCount    int64        `json:"diskCount"`
+	StorageCount int64        `json:"storageCount"`
+}
+
+func (r *ProviderResource) With(m *ocpmodel.Provider) {
+	r.Resource.With(&m.Base)
+	r.Type = m.Type
+	r.Object = m.Object
+	r.APIVersion = "v1beta1"
+	r.Product = "Azure"
+}
+
+func (r *ProviderResource) Link() {
+	r.SelfLink = base.Link(
+		ProviderRoot,
+		base.Params{
+			base.ProviderParam: r.UID,
+		})
+}
+
+func (r *ProviderResource) Content(detail int) interface{} {
+	if detail == 0 {
+		return r.Resource
+	}
+	return r
+}
+
+func (h ProviderHandler) AddDerived(r *ProviderResource) (err error) {
+	var n int64
+	if h.Detail == 0 {
+		return
+	}
+	db := h.Collector.DB()
+
+	n, err = db.Count(&model.VM{}, nil)
+	if err != nil {
+		return
+	}
+	r.VMCount = n
+
+	n, err = db.Count(&model.Network{}, nil)
+	if err != nil {
+		return
+	}
+	r.NetworkCount = n
+
+	n, err = db.Count(&model.Disk{}, nil)
+	if err != nil {
+		return
+	}
+	r.DiskCount = n
+
+	n, err = db.Count(&model.Storage{}, nil)
+	if err != nil {
+		return
+	}
+	r.StorageCount = n
+
+	return
+}

--- a/pkg/provider/azure/inventory/web/resource.go
+++ b/pkg/provider/azure/inventory/web/resource.go
@@ -1,0 +1,105 @@
+package web
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	"github.com/kubev2v/forklift/pkg/provider/azure/inventory/model"
+)
+
+type Resource struct {
+	ID            string `json:"id"`
+	Revision      int64  `json:"revision"`
+	Path          string `json:"path,omitempty"`
+	Name          string `json:"name"`
+	ResourceGroup string `json:"resourceGroup"`
+	SelfLink      string `json:"selfLink"`
+}
+
+type Provider struct {
+	Resource
+	UID    string                 `json:"uid"`
+	Object map[string]interface{} `json:"object,omitempty"`
+}
+
+func (r *Provider) With(p *api.Provider) {
+	r.UID = string(p.UID)
+	r.Name = p.Name
+}
+
+func (r *Provider) Link() {
+	r.SelfLink = base.Link(
+		ProviderRoot,
+		base.Params{
+			base.ProviderParam: r.UID,
+		})
+}
+
+type VM struct {
+	Resource
+	Object *model.VMDetails `json:"object,omitempty"`
+}
+
+func (r *VM) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		VMRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			VMParam:            r.ID,
+		})
+}
+
+type Disk struct {
+	Resource
+	Object *model.DiskDetails `json:"object,omitempty"`
+}
+
+func (r *Disk) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		ProviderRoot+"/disks/:id",
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			"id":               r.ID,
+		})
+}
+
+type Network struct {
+	Resource
+	Object *model.NetworkDetails `json:"object,omitempty"`
+}
+
+func (r *Network) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		ProviderRoot+"/networks/:id",
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			"id":               r.ID,
+		})
+}
+
+type Storage struct {
+	Resource
+	Object *model.StorageDetails `json:"object,omitempty"`
+}
+
+func (r *Storage) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		ProviderRoot+"/storages/:id",
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			"id":               r.ID,
+		})
+}
+
+type Workload struct {
+	Resource
+	Object *model.VMDetails `json:"object,omitempty"`
+}
+
+func (r *Workload) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		VMRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			VMParam:            r.ID,
+		})
+}

--- a/pkg/provider/azure/inventory/web/storage.go
+++ b/pkg/provider/azure/inventory/web/storage.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+	"github.com/kubev2v/forklift/pkg/provider/azure/inventory/model"
+)
+
+type StorageHandler struct {
+	Handler
+}
+
+func (h *StorageHandler) AddRoutes(e *gin.Engine) {
+	e.GET(ProviderRoot+"/storages", h.List)
+	e.GET(ProviderRoot+"/storages/:id", h.Get)
+}
+
+func (h *StorageHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+
+	db := h.Collector.DB()
+	var list []model.Storage
+	err = db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		log.Error(err, "Failed to list storage types")
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+
+	var result []interface{}
+	for _, m := range list {
+		r := &Storage{}
+		r.ID = m.UID
+		r.Name = m.Name
+		r.ResourceGroup = m.ResourceGroup
+		r.Revision = m.Revision
+		r.Link(h.Provider)
+		if details, err := m.GetDetails(); err == nil {
+			r.Object = details
+		}
+		result = append(result, r)
+	}
+
+	ctx.JSON(http.StatusOK, result)
+}
+
+func (h *StorageHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+
+	uid := ctx.Param("id")
+	db := h.Collector.DB()
+
+	m := &model.Storage{Base: model.Base{UID: uid}}
+	err = db.Get(m)
+	if err != nil {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+
+	r := &Storage{}
+	r.ID = m.UID
+	r.Name = m.Name
+	r.ResourceGroup = m.ResourceGroup
+	r.Revision = m.Revision
+	r.Link(h.Provider)
+	details, err := m.GetDetails()
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r.Object = details
+
+	ctx.JSON(http.StatusOK, r)
+}
+
+func (h *StorageHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.Storage{},
+		func(in libmodel.Model) (r interface{}) {
+			m := in.(*model.Storage)
+			storage := &Storage{}
+			storage.ID = m.UID
+			storage.Name = m.Name
+			storage.ResourceGroup = m.ResourceGroup
+			storage.Revision = m.Revision
+			storage.Link(h.Provider)
+			if details, err := m.GetDetails(); err == nil {
+				storage.Object = details
+			}
+			r = storage
+			return
+		})
+	if err != nil {
+		log.Error(err, "watch failed")
+		ctx.Status(http.StatusInternalServerError)
+	}
+}

--- a/pkg/provider/azure/inventory/web/vm.go
+++ b/pkg/provider/azure/inventory/web/vm.go
@@ -1,0 +1,125 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+	"github.com/kubev2v/forklift/pkg/provider/azure/inventory/model"
+)
+
+const (
+	VMParam = "vm"
+	VMsRoot = ProviderRoot + "/vms"
+	VMRoot  = VMsRoot + "/:" + VMParam
+)
+
+type VMHandler struct {
+	Handler
+}
+
+func (h *VMHandler) AddRoutes(e *gin.Engine) {
+	e.GET(VMsRoot, h.List)
+	e.GET(VMsRoot+"/", h.List)
+	e.GET(VMRoot, h.Get)
+}
+
+func (h *VMHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+
+	db := h.Collector.DB()
+	var list []model.VM
+	err = db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		log.Error(err, "Failed to list VMs")
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+
+	var result []interface{}
+	for _, m := range list {
+		r := &VM{}
+		r.ID = m.UID
+		r.Name = m.Name
+		r.ResourceGroup = m.ResourceGroup
+		r.Revision = m.Revision
+		r.Link(h.Provider)
+		if details, err := m.GetDetails(); err == nil {
+			r.Object = details
+		}
+		result = append(result, r)
+	}
+
+	ctx.JSON(http.StatusOK, result)
+}
+
+// Get VM by qualified ID ({resourceGroup}--{name}).
+func (h *VMHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+
+	uid := ctx.Param(VMParam)
+	db := h.Collector.DB()
+
+	m := &model.VM{Base: model.Base{UID: uid}}
+	err = db.Get(m)
+	if err != nil {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+
+	r := &VM{}
+	r.ID = m.UID
+	r.Name = m.Name
+	r.ResourceGroup = m.ResourceGroup
+	r.Revision = m.Revision
+	r.Link(h.Provider)
+	details, err := m.GetDetails()
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r.Object = details
+
+	ctx.JSON(http.StatusOK, r)
+}
+
+func (h *VMHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.VM{},
+		func(in libmodel.Model) (r interface{}) {
+			m := in.(*model.VM)
+			vm := &VM{}
+			vm.ID = m.UID
+			vm.Name = m.Name
+			vm.ResourceGroup = m.ResourceGroup
+			vm.Revision = m.Revision
+			vm.Link(h.Provider)
+			if details, err := m.GetDetails(); err == nil {
+				vm.Object = details
+			}
+			r = vm
+			return
+		})
+	if err != nil {
+		log.Error(err, "watch failed")
+		ctx.Status(http.StatusInternalServerError)
+	}
+}

--- a/pkg/provider/azure/resourceid/resourceid.go
+++ b/pkg/provider/azure/resourceid/resourceid.go
@@ -1,0 +1,168 @@
+package resourceid
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Separator is the delimiter used in qualified IDs: {resourceGroup}--{name}.
+const Separator = "--"
+
+// Azure resource ID path segments.
+const (
+	subscriptionsKey  = "subscriptions"
+	resourceGroupsKey = "resourceGroups"
+	providersKey      = "providers"
+)
+
+// Well-known Azure resource providers and types.
+const (
+	ComputeProvider = "Microsoft.Compute"
+	NetworkProvider = "Microsoft.Network"
+
+	VMType           = "virtualMachines"
+	DiskType         = "disks"
+	NICType          = "networkInterfaces"
+	VNetType         = "virtualNetworks"
+	SubnetType       = "subnets"
+	SnapshotType     = "snapshots"
+	DiskAccessType   = "diskAccesses"
+	ResourceGroupAll = ""
+)
+
+// Parsed holds the components of a parsed Azure resource ID.
+type Parsed struct {
+	Subscription  string
+	ResourceGroup string
+	Provider      string // e.g. "Microsoft.Compute"
+	ResourceType  string // e.g. "virtualMachines"
+	Name          string
+	SubType       string // nested type, e.g. "subnets" in .../virtualNetworks/vnet1/subnets/sub1
+	SubName       string // nested name
+}
+
+// Parse breaks a full Azure resource ID into its components.
+//
+//	/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{type}/{name}
+//	/subscriptions/{sub}/resourceGroups/{rg}/providers/{provider}/{type}/{name}/{subType}/{subName}
+func Parse(id string) (Parsed, error) {
+	segments := splitAndClean(id)
+
+	subIdx := indexOf(segments, subscriptionsKey)
+	rgIdx := indexOf(segments, resourceGroupsKey)
+	provIdx := indexOf(segments, providersKey)
+
+	if subIdx < 0 || subIdx+1 >= len(segments) {
+		return Parsed{}, fmt.Errorf("missing subscriptions segment in %q", id)
+	}
+	if rgIdx < 0 || rgIdx+1 >= len(segments) {
+		return Parsed{}, fmt.Errorf("missing resourceGroups segment in %q", id)
+	}
+	if provIdx < 0 || provIdx+2 >= len(segments) {
+		return Parsed{}, fmt.Errorf("missing providers segment in %q", id)
+	}
+
+	p := Parsed{
+		Subscription:  segments[subIdx+1],
+		ResourceGroup: segments[rgIdx+1],
+		Provider:      segments[provIdx+1],
+		ResourceType:  segments[provIdx+2],
+	}
+
+	if provIdx+3 < len(segments) {
+		p.Name = segments[provIdx+3]
+	}
+	// Nested resource: .../virtualNetworks/vnet1/subnets/sub1
+	if provIdx+5 < len(segments) {
+		p.SubType = segments[provIdx+4]
+		p.SubName = segments[provIdx+5]
+	}
+
+	return p, nil
+}
+
+// Build constructs a full Azure resource ID from components.
+func Build(subscription, resourceGroup, provider, resourceType, name string) string {
+	return fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/%s/%s/%s",
+		subscription, resourceGroup, provider, resourceType, name,
+	)
+}
+
+// BuildNested constructs a nested Azure resource ID (e.g. a subnet within a VNet).
+func BuildNested(subscription, resourceGroup, provider, parentType, parentName, childType, childName string) string {
+	return fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/%s/%s/%s/%s/%s",
+		subscription, resourceGroup, provider, parentType, parentName, childType, childName,
+	)
+}
+
+// MaxQualifiedIDLen is the Kubernetes resource-name length limit (DNS-1123).
+const MaxQualifiedIDLen = 253
+
+// QualifiedID converts a full Azure ARM resource ID into a Kubernetes-friendly
+// short identifier in the format {resourceGroup}--{name}.
+// Returns an error if the resource group contains the separator (making the
+// result ambiguous) or if the result exceeds the Kubernetes name length limit.
+func QualifiedID(armID string) (string, error) {
+	p, err := Parse(armID)
+	if err != nil {
+		return "", fmt.Errorf("cannot build qualified ID: %w", err)
+	}
+	name := p.Name
+	if p.SubName != "" {
+		name = p.SubName
+	}
+	if strings.Contains(p.ResourceGroup, Separator) {
+		return "", fmt.Errorf(
+			"resource group %q contains separator %q, qualified ID would be ambiguous",
+			p.ResourceGroup, Separator)
+	}
+	qid := p.ResourceGroup + Separator + name
+	if len(qid) > MaxQualifiedIDLen {
+		return "", fmt.Errorf(
+			"qualified ID %q is %d characters, exceeds Kubernetes limit of %d",
+			qid, len(qid), MaxQualifiedIDLen)
+	}
+	return qid, nil
+}
+
+// SplitQualifiedID breaks a qualified ID ({resourceGroup}--{name}) into its
+// resource-group and name components. Splits on the first occurrence of "--"
+// so resource names containing "--" are handled correctly.
+func SplitQualifiedID(qualifiedID string) (resourceGroup, name string) {
+	idx := strings.Index(qualifiedID, Separator)
+	if idx < 0 {
+		return "", qualifiedID
+	}
+	return qualifiedID[:idx], qualifiedID[idx+len(Separator):]
+}
+
+// Name extracts the resource name (last meaningful path segment) from a full ID.
+func Name(id string) string {
+	segments := splitAndClean(id)
+	if len(segments) == 0 {
+		return ""
+	}
+	return segments[len(segments)-1]
+}
+
+func splitAndClean(id string) []string {
+	parts := strings.Split(id, "/")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func indexOf(segments []string, key string) int {
+	for i, s := range segments {
+		if strings.EqualFold(s, key) {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/provider/azure/resourceid/resourceid_test.go
+++ b/pkg/provider/azure/resourceid/resourceid_test.go
@@ -1,0 +1,208 @@
+package resourceid
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		want    Parsed
+		wantErr bool
+	}{
+		{
+			name: "VM",
+			id:   "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/my-vm",
+			want: Parsed{
+				Subscription:  "sub1",
+				ResourceGroup: "rg1",
+				Provider:      "Microsoft.Compute",
+				ResourceType:  "virtualMachines",
+				Name:          "my-vm",
+			},
+		},
+		{
+			name: "managed disk",
+			id:   "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/disks/os-disk-0",
+			want: Parsed{
+				Subscription:  "sub1",
+				ResourceGroup: "rg1",
+				Provider:      "Microsoft.Compute",
+				ResourceType:  "disks",
+				Name:          "os-disk-0",
+			},
+		},
+		{
+			name: "subnet (nested resource)",
+			id:   "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default",
+			want: Parsed{
+				Subscription:  "sub1",
+				ResourceGroup: "rg1",
+				Provider:      "Microsoft.Network",
+				ResourceType:  "virtualNetworks",
+				Name:          "vnet1",
+				SubType:       "subnets",
+				SubName:       "default",
+			},
+		},
+		{
+			name:    "empty string",
+			id:      "",
+			wantErr: true,
+		},
+		{
+			name:    "missing providers segment",
+			id:      "/subscriptions/sub1/resourceGroups/rg1",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Parse() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuild(t *testing.T) {
+	got := Build("sub1", "rg1", ComputeProvider, VMType, "my-vm")
+	want := "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/my-vm"
+	if got != want {
+		t.Errorf("Build() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildNested(t *testing.T) {
+	got := BuildNested("sub1", "rg1", NetworkProvider, VNetType, "vnet1", SubnetType, "default")
+	want := "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default"
+	if got != want {
+		t.Errorf("BuildNested() = %q, want %q", got, want)
+	}
+}
+
+func TestName(t *testing.T) {
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{
+			id:   "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/my-vm",
+			want: "my-vm",
+		},
+		{
+			id:   "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default",
+			want: "default",
+		},
+		{id: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			if got := Name(tt.id); got != tt.want {
+				t.Errorf("Name(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQualifiedID(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "VM",
+			id:   "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/my-vm",
+			want: "rg1--my-vm",
+		},
+		{
+			name: "nested subnet",
+			id:   "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default",
+			want: "rg1--default",
+		},
+		{
+			name:    "invalid ARM ID",
+			id:      "not-an-arm-id",
+			wantErr: true,
+		},
+		{
+			name:    "separator in resource group",
+			id:      "/subscriptions/sub1/resourceGroups/my--rg/providers/Microsoft.Compute/virtualMachines/vm1",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := QualifiedID(tt.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("QualifiedID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("QualifiedID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQualifiedIDLengthLimit(t *testing.T) {
+	longRG := strings.Repeat("a", 90)
+	longName := strings.Repeat("b", 200)
+	armID := "/subscriptions/sub1/resourceGroups/" + longRG +
+		"/providers/Microsoft.Compute/virtualMachines/" + longName
+	_, err := QualifiedID(armID)
+	if err == nil {
+		t.Error("expected error for qualified ID exceeding length limit")
+	}
+}
+
+func TestSplitQualifiedID(t *testing.T) {
+	tests := []struct {
+		input  string
+		wantRG string
+		wantN  string
+	}{
+		{"rg1--my-vm", "rg1", "my-vm"},
+		{"rg1--name--with--dashes", "rg1", "name--with--dashes"},
+		{"no-separator", "", "no-separator"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			rg, name := SplitQualifiedID(tt.input)
+			if rg != tt.wantRG || name != tt.wantN {
+				t.Errorf("SplitQualifiedID(%q) = (%q, %q), want (%q, %q)", tt.input, rg, name, tt.wantRG, tt.wantN)
+			}
+		})
+	}
+}
+
+func TestParseRoundTrip(t *testing.T) {
+	original := "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/my-vm"
+	p, err := Parse(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rebuilt := Build(p.Subscription, p.ResourceGroup, p.Provider, p.ResourceType, p.Name)
+	if rebuilt != original {
+		t.Errorf("round-trip failed: got %q, want %q", rebuilt, original)
+	}
+}


### PR DESCRIPTION
Add the infrastructure scaffolding to recognise Azure as a first-class Forklift provider without any real Azure SDK implementation. This is the first incremental slice of the full Azure provider (MTV-5926).

What is included:
- Azure ProviderType constant and RequiresConversion() entry
- Controller routing (case api.Azure) in all handler, adapter, migrator, scheduler, model, web, and container doc.go files
- Noop provider packages under pkg/provider/azure/ that satisfy every interface (Builder, Client, Validator, Ensurer, Migrator, Collector, Finder, Resolver) with empty return values
- Inventory model with plain structs (no Azure SDK types)
- RBAC manifests for volumesnapshots (CSI snapshot permissions)
- Operator task definitions for the Azure provider

No Azure SDK, CSI snapshotter, or external cloud dependencies are added; go.mod is unchanged from main apart from the new provider registration.

Ref: https://redhat.atlassian.net/browse/MTV-5926
Resolves: MTV-5926

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure as a supported provider.
  * Added Azure inventory for virtual machines, disks, networks, and storage through API endpoints.
  * Added Azure migration planning, scheduling, networking, storage, and mapping support.
  * Added configurable inventory and controller polling intervals.
  * Added utilities for parsing, building, and validating Azure resource IDs.
* **Tests**
  * Added coverage for Azure resource ID parsing, construction, validation, and round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->