### PR TITLE
MTV-5493 | Add AnnDiskSource annotation to EC2 PVCs

### DIFF
--- a/pkg/provider/ec2/controller/builder/volumes.go
+++ b/pkg/provider/ec2/controller/builder/volumes.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	utils "github.com/kubev2v/forklift/pkg/controller/plan/util"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libitr "github.com/kubev2v/forklift/pkg/lib/itinerary"
@@ -284,6 +285,7 @@ func (r *Builder) BuildDirectPVC(vmRef ref.Ref, volumeInfo *VolumeInfo, index in
 	pvcLabels["forklift.konveyor.io/volume-id"] = volumeInfo.OriginalVolumeID
 
 	pvcAnnotations := map[string]string{
+		planbase.AnnDiskSource:                     volumeInfo.OriginalVolumeID,
 		"forklift.konveyor.io/original-volume-id": volumeInfo.OriginalVolumeID,
 		"forklift.konveyor.io/ebs-volume-id":      volumeInfo.EBSVolumeID,
 		"forklift.konveyor.io/snapshot-id":        volumeInfo.SnapshotID,

--- a/pkg/provider/ec2/controller/builder/volumes.go
+++ b/pkg/provider/ec2/controller/builder/volumes.go
@@ -285,7 +285,7 @@ func (r *Builder) BuildDirectPVC(vmRef ref.Ref, volumeInfo *VolumeInfo, index in
 	pvcLabels["forklift.konveyor.io/volume-id"] = volumeInfo.OriginalVolumeID
 
 	pvcAnnotations := map[string]string{
-		planbase.AnnDiskSource:                     volumeInfo.OriginalVolumeID,
+		planbase.AnnDiskSource:                    volumeInfo.OriginalVolumeID,
 		"forklift.konveyor.io/original-volume-id": volumeInfo.OriginalVolumeID,
 		"forklift.konveyor.io/ebs-volume-id":      volumeInfo.EBSVolumeID,
 		"forklift.konveyor.io/snapshot-id":        volumeInfo.SnapshotID,

--- a/pkg/provider/ec2/controller/builder/volumes_test.go
+++ b/pkg/provider/ec2/controller/builder/volumes_test.go
@@ -1,0 +1,64 @@
+package builder
+
+import (
+	"fmt"
+
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/provider/testutil"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+)
+
+var _ = Describe("BuildDirectPVC", func() {
+	var (
+		builder    *Builder
+		vmRef      ref.Ref
+		volumeInfo *VolumeInfo
+	)
+
+	BeforeEach(func() {
+		ctx := testutil.NewContextBuilder().Build()
+		ctx.Labeler = plancontext.Labeler{Context: ctx}
+		builder = New(ctx)
+		vmRef = ref.Ref{ID: "i-123", Name: "test-vm"}
+		volumeInfo = &VolumeInfo{
+			EBSVolumeID:      "vol-0abc123",
+			OriginalVolumeID: "vol-0original",
+			SnapshotID:       "snap-0abc123",
+			SizeGiB:          10,
+			VolumeType:       "gp3",
+			AvailabilityZone: "us-east-1a",
+		}
+	})
+
+	It("should set AnnDiskSource annotation to the original volume ID", func() {
+		pvc, err := builder.BuildDirectPVC(vmRef, volumeInfo, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvc.Annotations).To(HaveKeyWithValue(planbase.AnnDiskSource, volumeInfo.OriginalVolumeID))
+	})
+
+	It("should set all expected annotations", func() {
+		pvc, err := builder.BuildDirectPVC(vmRef, volumeInfo, 2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvc.Annotations).To(HaveKeyWithValue("forklift.konveyor.io/original-volume-id", "vol-0original"))
+		Expect(pvc.Annotations).To(HaveKeyWithValue("forklift.konveyor.io/ebs-volume-id", "vol-0abc123"))
+		Expect(pvc.Annotations).To(HaveKeyWithValue("forklift.konveyor.io/snapshot-id", "snap-0abc123"))
+		Expect(pvc.Annotations).To(HaveKeyWithValue("forklift.konveyor.io/disk-index", fmt.Sprintf("%d", 2)))
+	})
+
+	It("should set volume-id label", func() {
+		pvc, err := builder.BuildDirectPVC(vmRef, volumeInfo, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvc.Labels).To(HaveKeyWithValue("forklift.konveyor.io/volume-id", "vol-0original"))
+	})
+
+	It("should use block volume mode", func() {
+		pvc, err := builder.BuildDirectPVC(vmRef, volumeInfo, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvc.Spec.VolumeMode).NotTo(BeNil())
+		Expect(*pvc.Spec.VolumeMode).To(Equal(core.PersistentVolumeBlock))
+	})
+})


### PR DESCRIPTION
## Summary
- The EC2 provider's `BuildDirectPVC()` was not setting the `forklift.konveyor.io/disk-source` (`AnnDiskSource`) annotation on PVCs. Every other provider (vSphere, oVirt, OpenStack, HyperV, OCP) sets this annotation.
- Without it, `hasDiskIdentity()` returns `false` and `getPVCs()` skips all EC2 PVCs, causing the conversion pod to get no disk mounts.
- Fix: set `AnnDiskSource` to the original EC2 volume ID (`volumeInfo.OriginalVolumeID`) in the PVC annotations map.

## Verification
- Built and deployed the controller with this fix
- Migrated EC2 VMs (RHEL8, Windows 2019) successfully — conversion pods received their disk mounts
- Confirmed the conversion pod `nodeSelector` correctly targets the EBS volume's availability zone:
  ```
  $ aws ec2 describe-volumes --volume-ids vol-0211b71ea454391a2 --query 'Volumes[*].AvailabilityZone' --output text
  us-east-1a

  $ oc get pod plan-rhel8-... -o jsonpath='{.spec.nodeSelector}'
  {"kubevirt.io/schedulable":"true","topology.kubernetes.io/zone":"us-east-1a"}
  ```

## Test plan
- [ ] Deploy controller with this change
- [ ] Create an EC2 provider and migrate a VM with a supported OS (RHEL, CentOS, etc.)
- [ ] Verify the conversion pod has disk mounts (`/var/tmp/v2v/` paths)
- [ ] Verify PVC annotations include `forklift.konveyor.io/disk-source`

🤖 Generated with [Claude Code](https://claude.com/claude-code)