### PR TITLE
MTV-5917 | Add critical concern when VM disk count exceeds 165

### DIFF
--- a/validation/policies/io/konveyor/forklift/hyperv/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/hyperv/disk_count.rego
@@ -1,0 +1,20 @@
+package io.konveyor.forklift.hyperv
+
+import rego.v1
+
+# CNV limits the number of disks per VM to 165.
+max_disk_count := 165
+
+has_too_many_disks if {
+	count(input.disks) > max_disk_count
+}
+
+concerns contains flag if {
+	has_too_many_disks
+	flag := {
+		"id": "hyperv.disk.count.exceeds.limit",
+		"category": "Critical",
+		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.disks), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.disks), max_disk_count]),
+	}
+}

--- a/validation/policies/io/konveyor/forklift/hyperv/disk_count_test.rego
+++ b/validation/policies/io/konveyor/forklift/hyperv/disk_count_test.rego
@@ -1,0 +1,29 @@
+package io.konveyor.forklift.hyperv
+
+import rego.v1
+
+test_disk_count_at_limit if {
+	disks := [{"name": sprintf("disk%d", [i]), "capacity": 17179869184} | some i in numbers.range(1, 165)]
+	test_input := {"disks": disks}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}
+
+test_disk_count_exceeds_limit if {
+	disks := [{"name": sprintf("disk%d", [i]), "capacity": 17179869184} | some i in numbers.range(1, 166)]
+	test_input := {"disks": disks}
+
+	results := concerns with input as test_input
+	has_too_many_disks with input as test_input
+}
+
+test_disk_count_well_under_limit if {
+	test_input := {"disks": [
+		{"name": "disk1", "capacity": 17179869184},
+		{"name": "disk2", "capacity": 17179869184},
+	]}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}

--- a/validation/policies/io/konveyor/forklift/openstack/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_count.rego
@@ -1,0 +1,20 @@
+package io.konveyor.forklift.openstack
+
+import rego.v1
+
+# CNV limits the number of disks per VM to 165.
+max_disk_count := 165
+
+has_too_many_disks if {
+	count(input.volumes) > max_disk_count
+}
+
+concerns contains flag if {
+	has_too_many_disks
+	flag := {
+		"id": "openstack.disk.count.exceeds.limit",
+		"category": "Critical",
+		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.volumes), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.volumes), max_disk_count]),
+	}
+}

--- a/validation/policies/io/konveyor/forklift/openstack/disk_count_test.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_count_test.rego
@@ -1,0 +1,29 @@
+package io.konveyor.forklift.openstack
+
+import rego.v1
+
+test_disk_count_at_limit if {
+	volumes := [{"name": sprintf("vol%d", [i]), "size": 16} | some i in numbers.range(1, 165)]
+	test_input := {"volumes": volumes}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}
+
+test_disk_count_exceeds_limit if {
+	volumes := [{"name": sprintf("vol%d", [i]), "size": 16} | some i in numbers.range(1, 166)]
+	test_input := {"volumes": volumes}
+
+	results := concerns with input as test_input
+	has_too_many_disks with input as test_input
+}
+
+test_disk_count_well_under_limit if {
+	test_input := {"volumes": [
+		{"name": "vol1", "size": 16},
+		{"name": "vol2", "size": 16},
+	]}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}

--- a/validation/policies/io/konveyor/forklift/ova/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/ova/disk_count.rego
@@ -1,0 +1,20 @@
+package io.konveyor.forklift.ova
+
+import rego.v1
+
+# CNV limits the number of disks per VM to 165.
+max_disk_count := 165
+
+has_too_many_disks if {
+	count(input.disks) > max_disk_count
+}
+
+concerns contains flag if {
+	has_too_many_disks
+	flag := {
+		"id": "ova.disk.count.exceeds.limit",
+		"category": "Critical",
+		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.disks), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.disks), max_disk_count]),
+	}
+}

--- a/validation/policies/io/konveyor/forklift/ova/disk_count_test.rego
+++ b/validation/policies/io/konveyor/forklift/ova/disk_count_test.rego
@@ -1,0 +1,29 @@
+package io.konveyor.forklift.ova
+
+import rego.v1
+
+test_disk_count_at_limit if {
+	disks := [{"filePath": sprintf("disk%d.vmdk", [i]), "capacity": 17179869184} | some i in numbers.range(1, 165)]
+	test_input := {"disks": disks}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}
+
+test_disk_count_exceeds_limit if {
+	disks := [{"filePath": sprintf("disk%d.vmdk", [i]), "capacity": 17179869184} | some i in numbers.range(1, 166)]
+	test_input := {"disks": disks}
+
+	results := concerns with input as test_input
+	has_too_many_disks with input as test_input
+}
+
+test_disk_count_well_under_limit if {
+	test_input := {"disks": [
+		{"filePath": "disk1.vmdk", "capacity": 17179869184},
+		{"filePath": "disk2.vmdk", "capacity": 17179869184},
+	]}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_count.rego
@@ -1,0 +1,20 @@
+package io.konveyor.forklift.ovirt
+
+import rego.v1
+
+# CNV limits the number of disks per VM to 165.
+max_disk_count := 165
+
+has_too_many_disks if {
+	count(input.diskAttachments) > max_disk_count
+}
+
+concerns contains flag if {
+	has_too_many_disks
+	flag := {
+		"id": "ovirt.disk.count.exceeds.limit",
+		"category": "Critical",
+		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.diskAttachments), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.diskAttachments), max_disk_count]),
+	}
+}

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_count_test.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_count_test.rego
@@ -1,0 +1,29 @@
+package io.konveyor.forklift.ovirt
+
+import rego.v1
+
+test_disk_count_at_limit if {
+	attachments := [{"disk": {"provisionedSize": 17179869184}} | some i in numbers.range(1, 165)]
+	test_input := {"diskAttachments": attachments}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}
+
+test_disk_count_exceeds_limit if {
+	attachments := [{"disk": {"provisionedSize": 17179869184}} | some i in numbers.range(1, 166)]
+	test_input := {"diskAttachments": attachments}
+
+	results := concerns with input as test_input
+	has_too_many_disks with input as test_input
+}
+
+test_disk_count_well_under_limit if {
+	test_input := {"diskAttachments": [
+		{"disk": {"provisionedSize": 17179869184}},
+		{"disk": {"provisionedSize": 17179869184}},
+	]}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}

--- a/validation/policies/io/konveyor/forklift/vmware/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_count.rego
@@ -1,0 +1,20 @@
+package io.konveyor.forklift.vmware
+
+import rego.v1
+
+# CNV limits the number of disks per VM to 165.
+max_disk_count := 165
+
+has_too_many_disks if {
+	count(input.disks) > max_disk_count
+}
+
+concerns contains flag if {
+	has_too_many_disks
+	flag := {
+		"id": "vmware.disk.count.exceeds.limit",
+		"category": "Critical",
+		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.disks), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.disks), max_disk_count]),
+	}
+}

--- a/validation/policies/io/konveyor/forklift/vmware/disk_count_test.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_count_test.rego
@@ -1,0 +1,29 @@
+package io.konveyor.forklift.vmware
+
+import rego.v1
+
+test_disk_count_at_limit if {
+	disks := [{"file": sprintf("disk%d.vmdk", [i]), "capacity": 17179869184} | some i in numbers.range(1, 165)]
+	test_input := {"disks": disks}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}
+
+test_disk_count_exceeds_limit if {
+	disks := [{"file": sprintf("disk%d.vmdk", [i]), "capacity": 17179869184} | some i in numbers.range(1, 166)]
+	test_input := {"disks": disks}
+
+	results := concerns with input as test_input
+	has_too_many_disks with input as test_input
+}
+
+test_disk_count_well_under_limit if {
+	test_input := {"disks": [
+		{"file": "disk1.vmdk", "capacity": 17179869184},
+		{"file": "disk2.vmdk", "capacity": 17179869184},
+	]}
+
+	results := concerns with input as test_input
+	not has_too_many_disks with input as test_input
+}


### PR DESCRIPTION
CNV limits the number of disks per VM to 165. VMs with more disks lose network connectivity on boot after migration. Add a Critical OPA validation concern for all providers (VMware, oVirt, Hyper-V, OpenStack, OVA) that blocks migration when the disk count exceeds the limit.

Ref: https://redhat.atlassian.net/browse/MTV-5917
Resolves: MTV-5917