### PR TITLE
MTV-5917 | Change disk count concern from Critical to Warning

### DIFF
--- a/validation/policies/io/konveyor/forklift/hyperv/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/hyperv/disk_count.rego
@@ -2,7 +2,7 @@ package io.konveyor.forklift.hyperv
 
 import rego.v1
 
-# CNV limits the number of disks per VM to 165.
+# CNV limits the number of disks per VM to 165 (CNV-91554).
 max_disk_count := 165
 
 has_too_many_disks if {
@@ -13,8 +13,8 @@ concerns contains flag if {
 	has_too_many_disks
 	flag := {
 		"id": "hyperv.disk.count.exceeds.limit",
-		"category": "Critical",
+		"category": "Warning",
 		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.disks), max_disk_count]),
-		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.disks), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. Migration may result in network connectivity issues.", [count(input.disks), max_disk_count]),
 	}
 }

--- a/validation/policies/io/konveyor/forklift/openstack/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/openstack/disk_count.rego
@@ -2,7 +2,7 @@ package io.konveyor.forklift.openstack
 
 import rego.v1
 
-# CNV limits the number of disks per VM to 165.
+# CNV limits the number of disks per VM to 165 (CNV-91554).
 max_disk_count := 165
 
 has_too_many_disks if {
@@ -13,8 +13,8 @@ concerns contains flag if {
 	has_too_many_disks
 	flag := {
 		"id": "openstack.disk.count.exceeds.limit",
-		"category": "Critical",
+		"category": "Warning",
 		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.volumes), max_disk_count]),
-		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.volumes), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. Migration may result in network connectivity issues.", [count(input.volumes), max_disk_count]),
 	}
 }

--- a/validation/policies/io/konveyor/forklift/ova/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/ova/disk_count.rego
@@ -2,7 +2,7 @@ package io.konveyor.forklift.ova
 
 import rego.v1
 
-# CNV limits the number of disks per VM to 165.
+# CNV limits the number of disks per VM to 165 (CNV-91554).
 max_disk_count := 165
 
 has_too_many_disks if {
@@ -13,8 +13,8 @@ concerns contains flag if {
 	has_too_many_disks
 	flag := {
 		"id": "ova.disk.count.exceeds.limit",
-		"category": "Critical",
+		"category": "Warning",
 		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.disks), max_disk_count]),
-		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.disks), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. Migration may result in network connectivity issues.", [count(input.disks), max_disk_count]),
 	}
 }

--- a/validation/policies/io/konveyor/forklift/ovirt/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/ovirt/disk_count.rego
@@ -2,7 +2,7 @@ package io.konveyor.forklift.ovirt
 
 import rego.v1
 
-# CNV limits the number of disks per VM to 165.
+# CNV limits the number of disks per VM to 165 (CNV-91554).
 max_disk_count := 165
 
 has_too_many_disks if {
@@ -13,8 +13,8 @@ concerns contains flag if {
 	has_too_many_disks
 	flag := {
 		"id": "ovirt.disk.count.exceeds.limit",
-		"category": "Critical",
+		"category": "Warning",
 		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.diskAttachments), max_disk_count]),
-		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.diskAttachments), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. Migration may result in network connectivity issues.", [count(input.diskAttachments), max_disk_count]),
 	}
 }

--- a/validation/policies/io/konveyor/forklift/vmware/disk_count.rego
+++ b/validation/policies/io/konveyor/forklift/vmware/disk_count.rego
@@ -2,7 +2,7 @@ package io.konveyor.forklift.vmware
 
 import rego.v1
 
-# CNV limits the number of disks per VM to 165.
+# CNV limits the number of disks per VM to 165 (CNV-91554).
 max_disk_count := 165
 
 has_too_many_disks if {
@@ -13,8 +13,8 @@ concerns contains flag if {
 	has_too_many_disks
 	flag := {
 		"id": "vmware.disk.count.exceeds.limit",
-		"category": "Critical",
+		"category": "Warning",
 		"label": sprintf("VM has %d disks, which exceeds the limit of %d", [count(input.disks), max_disk_count]),
-		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. The VM cannot be migrated.", [count(input.disks), max_disk_count]),
+		"assessment": sprintf("The VM has %d disks but the target platform supports a maximum of %d disks per VM. Migration may result in network connectivity issues.", [count(input.disks), max_disk_count]),
 	}
 }


### PR DESCRIPTION
Downgrade the disk count validation concern from Critical to Warning . The CNV
disk limit of 165 may cause network connectivity issues but should not block migration entirely.

See: https://redhat.atlassian.net/browse/CNV-91554
Ref: https://redhat.atlassian.net/browse/MTV-5917
Resolves: MTV-5917