### PR TITLE
MTV-6137 | Fall back to datastore matching when RDM NAA vendor resolution fails

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1366,6 +1366,46 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 	dsMapIn := r.Context.Map.Storage.Spec.Map
 	naaPrefixes := loadNAAPrefixes(r.Client)
 	dsNaaMap := make(map[string]string)
+
+	// Pre-pass: resolve RDM disks by NAA vendor prefix.
+	// Builds a map from disk index to the storage map entry whose offload
+	// plugin matches the RDM's vendor. Disks that fail NAA resolution are
+	// left out and will fall back to datastore-based matching in the main loop.
+	rdmMapped := make(map[int]*api.StoragePair)
+	for diskIndex, disk := range sortedDisks {
+		if !disk.RDM || disk.DeviceName == "" {
+			continue
+		}
+		rdmVendor, matched := vendorFromNAA(disk.DeviceName, naaPrefixes)
+		if !matched {
+			r.Log.Info("RDM disk NAA prefix not recognized, falling back to datastore matching",
+				"diskKey", disk.Key, "deviceName", disk.DeviceName)
+			continue
+		}
+		candidates := findStorageMapEntriesForVendor(dsMapIn, rdmVendor)
+		switch len(candidates) {
+		case 0:
+			r.Log.Info("No storage map entry found for RDM vendor, falling back to datastore matching",
+				"diskKey", disk.Key, "vendor", rdmVendor)
+		case 1:
+			rdmMapped[diskIndex] = candidates[0]
+			r.Log.Info("RDM disk resolved to storage vendor by NAA",
+				"diskKey", disk.Key, "deviceName", disk.DeviceName,
+				"vendor", rdmVendor, "storageClass", candidates[0].Destination.StorageClass)
+		default:
+			entry, disambigErr := disambiguateRDMByNAA(r.Source.Inventory, candidates, disk.DeviceName, naaPrefixes)
+			if disambigErr != nil {
+				r.Log.Info("RDM NAA disambiguation failed, falling back to datastore matching",
+					"diskKey", disk.Key, "vendor", rdmVendor, "error", disambigErr)
+			} else {
+				rdmMapped[diskIndex] = entry
+				r.Log.Info("RDM disk resolved to storage vendor by NAA",
+					"diskKey", disk.Key, "deviceName", disk.DeviceName,
+					"vendor", rdmVendor, "storageClass", entry.Destination.StorageClass)
+			}
+		}
+	}
+
 	for i := range dsMapIn {
 		mapped := &dsMapIn[i]
 		sourceRef := mapped.Source
@@ -1378,38 +1418,21 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 
 		pvblock := core.PersistentVolumeBlock
 		for diskIndex, disk := range sortedDisks {
-			// Resolve the effective storage map entry for this disk.
-			// RDM disks are matched by NAA vendor prefix (not datastore)
-			// because the RDM's backing LUN may reside on a different
-			// storage array than the VM's datastore.
 			var effectiveMapped *api.StoragePair
 			if disk.RDM && disk.DeviceName != "" {
-				if i > 0 {
-					continue // RDM disks are processed once, in the first outer iteration
-				}
-				rdmVendor, matched := vendorFromNAA(disk.DeviceName, naaPrefixes)
-				if !matched {
-					return nil, fmt.Errorf(
-						"RDM disk (key=%d) has device name %q that does not match any known storage vendor NAA prefix",
-						disk.Key, disk.DeviceName)
-				}
-				candidates := findStorageMapEntriesForVendor(dsMapIn, rdmVendor)
-				switch len(candidates) {
-				case 0:
-					return nil, fmt.Errorf(
-						"no storage map entry with offload plugin found for vendor %q; "+
-							"add a storage map entry with an offload plugin for this vendor", rdmVendor)
-				case 1:
-					effectiveMapped = candidates[0]
-				default:
-					effectiveMapped, err = disambiguateRDMByNAA(r.Source.Inventory, candidates, disk.DeviceName, naaPrefixes)
-					if err != nil {
-						return nil, err
+				if entry, ok := rdmMapped[diskIndex]; ok {
+					if mapped != entry {
+						continue
 					}
+					effectiveMapped = entry
+				} else if disk.Datastore.ID == ds.ID {
+					effectiveMapped = mapped
+					r.Log.Info("RDM disk matched by datastore fallback",
+						"diskKey", disk.Key, "deviceName", disk.DeviceName,
+						"datastoreID", ds.ID)
+				} else {
+					continue
 				}
-				r.Log.Info("RDM disk resolved to storage vendor by NAA",
-					"diskKey", disk.Key, "deviceName", disk.DeviceName,
-					"vendor", rdmVendor, "storageClass", effectiveMapped.Destination.StorageClass)
 			} else if disk.Datastore.ID == ds.ID {
 				effectiveMapped = mapped
 			} else {


### PR DESCRIPTION
## Summary
- RDM disks whose NAA prefix resolves to a vendor with no matching storage map entry (e.g. 3PAR RDMs on a cluster with only PowerFlex configured) caused a hard failure at `CreateDataVolumes`: `"no storage map entry with offload plugin found for vendor primera3par"`
- Convert the three `return nil, fmt.Errorf(...)` paths in `PopulatorVolumes()` into log warnings that fall through to regular datastore-based matching, so the xcopy populator can still handle the disk (e.g. via `DISABLE_RDM_METHOD`)
- No changes to `rdm_storage.go` — the NAA resolution functions are unchanged; only the error handling in `builder.go` is softened

## Test plan
- [x] All 173 existing unit tests pass
- [x] Reproduced the bug on SNO cluster (tshefisno4) with VM `amit-3par-csi-test` (vm-170953, has a 3PAR RDM disk)
- [x] Old migration `rdm-3par-test` fails at `CreateDataVolumes` with `"no storage map entry with offload plugin found for vendor primera3par"`
- [x] New migration `rdm-3par-fix-test` with the fix passes `CreateDataVolumes`, creates PVCs, and reaches `CopyDisks`
- [x] Controller logs confirm the fallback: `"No storage map entry found for RDM vendor, falling back to datastore matching"` → `"RDM disk matched by datastore fallback"`

Resolves: MTV-6137

🤖 Generated with [Claude Code](https://claude.com/claude-code)