### PR TITLE
MTV-5756 | Fix signal-conversion-done.ps1 for PowerShell Constrained Language Mode

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/99999-signal-conversion-done.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/99999-signal-conversion-done.ps1
@@ -1,10 +1,3 @@
-$port = New-Object System.IO.Ports.SerialPort "COM1", 9600, "None", 8, "One"
-try {
-    $port.Open()
-    $port.WriteLine("CONVERSION_DONE")
-} catch {
-    if ($port.IsOpen) { try { $port.Close() } catch {} }
-    [System.IO.File]::WriteAllText("\\.\COM1", "CONVERSION_DONE`r`n")
-} finally {
-    if ($port.IsOpen) { try { $port.Close() } catch {} }
-}
+# Use cmd /c to avoid PowerShell Constrained Language Mode restrictions
+# that block New-Object for non-core types and static method invocation.
+cmd /c "echo CONVERSION_DONE>\\.\COM1" 2>&1 | Out-Null


### PR DESCRIPTION
Replace .NET-based serial port communication (New-Object System.IO.Ports.SerialPort and [System.IO.File]::WriteAllText) with cmd /c echo, which is not subject to CLM restrictions. Windows VMs with Constrained Language Mode enabled blocked the original approach because CLM prevents instantiation of non-core .NET types and static method invocation.

Ref: https://redhat.atlassian.net/browse/MTV-5756
Resolves: MTV-5756