### PR TITLE
MTV-2419 | Preserve DataVolumeTemplates for OCP→OCP cold migration

### DIFF
--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -300,10 +300,137 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	// Preserve DataVolumeTemplates from source VM to maintain user workflows
 	// that may expect the VM's DataVolume to be present
 	object.DataVolumeTemplates = targetVmSpec.DataVolumeTemplates
+
+	// Sanitize DataVolumeTemplates to prevent conflicts with Forklift-created DataVolumes:
+	// 1. Match template names to the PVC names (Forklift creates DataVolumes with Name = pvc.Name)
+	// 2. Clear spec.source to prevent KubeVirt from trying to create new DataVolumes with invalid sources
+	// 3. Ensure namespace is set correctly (will be set by KubeVirt to match VM namespace)
+	// 4. Update volume references to match renamed DataVolumeTemplates
+	r.sanitizeDataVolumeTemplates(vmRef, object.DataVolumeTemplates, object)
+
 	r.mapNetworks(sourceVm, targetVmSpec)
 	r.mapVolumes(sourceVm, targetVmSpec, persistentVolumeClaims)
 
 	return nil
+}
+
+// sanitizeDataVolumeTemplates ensures DataVolumeTemplates are compatible with Forklift-created DataVolumes.
+// Forklift creates DataVolumes with Name = pvc.Name, so templates must match these names.
+// We also clear spec.source to prevent KubeVirt from trying to create new DataVolumes with invalid source URLs.
+// Additionally, we update volume references to match any renamed DataVolumeTemplates.
+func (r *Builder) sanitizeDataVolumeTemplates(vmRef ref.Ref, templates []cnv.DataVolumeTemplateSpec, object *cnv.VirtualMachineSpec) {
+	// Build a map of volume name -> PVC name from VM volumes
+	// This allows us to match DataVolumeTemplates to the PVCs that Forklift will create DataVolumes for
+	volumeToPVCName := make(map[string]string)
+	sourceVm, err := r.getSourceVmFromDefinition(vmRef)
+	if err != nil {
+		r.Log.Error(err, "Failed to get source VM for DataVolumeTemplate sanitization")
+		return
+	}
+
+	for _, vol := range sourceVm.Spec.Template.Spec.Volumes {
+		var pvcName string
+		switch {
+		case vol.PersistentVolumeClaim != nil:
+			// Volume references PVC directly
+			pvcName = vol.PersistentVolumeClaim.ClaimName
+		case vol.DataVolume != nil:
+			// Volume references DataVolume - need to find the PVC it creates
+			// In OCP, DataVolumes typically create PVCs with the same name as the DataVolume
+			// But we need to check the actual PVC name from the source
+			dv := &cdi.DataVolume{}
+			err := r.sourceClient.Get(context.TODO(), client.ObjectKey{
+				Namespace: vmRef.Namespace,
+				Name:      vol.DataVolume.Name,
+			}, dv)
+			if err != nil {
+				r.Log.V(1).Info("Could not find source DataVolume, using DataVolume name as PVC name",
+					"dataVolume", vol.DataVolume.Name, "error", err)
+				pvcName = vol.DataVolume.Name
+			} else {
+				// Use the actual PVC name that the DataVolume created
+				if dv.Status.ClaimName != "" {
+					pvcName = dv.Status.ClaimName
+				} else {
+					// Fallback: DataVolume name typically matches PVC name
+					pvcName = vol.DataVolume.Name
+				}
+			}
+		default:
+			continue
+		}
+		if pvcName != "" {
+			volumeToPVCName[vol.Name] = pvcName
+		}
+	}
+
+	// Track template name changes so we can update volume references
+	templateNameMap := make(map[string]string) // old name -> new name
+
+	// Sanitize each template
+	for i := range templates {
+		template := &templates[i]
+		oldName := template.Name
+
+		// Find the corresponding PVC name by matching template to VM volumes
+		// DataVolumeTemplates are referenced by volumes via vol.DataVolume.Name matching template name
+		var targetPVCName string
+		for volName, pvcName := range volumeToPVCName {
+			// Check if any volume references this template by name
+			for _, vol := range sourceVm.Spec.Template.Spec.Volumes {
+				if vol.Name == volName && vol.DataVolume != nil && vol.DataVolume.Name == template.Name {
+					targetPVCName = pvcName
+					break
+				}
+			}
+			if targetPVCName != "" {
+				break
+			}
+		}
+
+		// If we found a matching PVC name, update the template name to match
+		// Forklift creates DataVolumes with Name = pvc.Name, so template must match
+		if targetPVCName != "" && template.Name != targetPVCName {
+			template.Name = targetPVCName
+			template.GenerateName = ""
+			templateNameMap[oldName] = targetPVCName
+			r.Log.V(1).Info("Updated DataVolumeTemplate name to match Forklift-created DataVolume",
+				"oldName", oldName, "newName", template.Name, "pvcName", targetPVCName)
+		} else {
+			// If we can't find a match, clear GenerateName to use explicit Name
+			// and log a warning
+			if template.GenerateName != "" {
+				r.Log.Info("DataVolumeTemplate has GenerateName but no matching volume found, "+
+					"template may not match Forklift-created DataVolume",
+					"generateName", template.GenerateName, "templateName", template.Name)
+				template.GenerateName = ""
+			}
+		}
+
+		// Clear spec.source to prevent KubeVirt from trying to create new DataVolumes
+		// with source URLs/namespaces that don't exist on the destination cluster.
+		// Forklift has already created the DataVolumes, so templates should not have source specs.
+		template.Spec.Source = nil
+
+		// Ensure namespace is empty - KubeVirt will set it to match the VM namespace
+		template.Namespace = ""
+	}
+
+	// Update volume references to match renamed DataVolumeTemplates
+	// Volumes that reference DataVolumes by name need to be updated if the template name changed
+	if len(templateNameMap) > 0 && object.Template != nil {
+		for i := range object.Template.Spec.Volumes {
+			vol := &object.Template.Spec.Volumes[i]
+			if vol.DataVolume != nil {
+				if newName, renamed := templateNameMap[vol.DataVolume.Name]; renamed {
+					oldDVName := vol.DataVolume.Name
+					vol.DataVolume.Name = newName
+					r.Log.V(1).Info("Updated volume DataVolume reference to match renamed template",
+						"volumeName", vol.Name, "oldDVName", oldDVName, "newDVName", newName)
+				}
+			}
+		}
+	}
 }
 
 // ConfigMaps builds CRs for each of the ConfigMaps that the source VM depends upon.

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -297,6 +297,9 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 
 	targetVmSpec := sourceVm.Spec.DeepCopy()
 	object.Template = targetVmSpec.Template
+	// Preserve DataVolumeTemplates from source VM to maintain user workflows
+	// that may expect the VM's DataVolume to be present
+	object.DataVolumeTemplates = targetVmSpec.DataVolumeTemplates
 	r.mapNetworks(sourceVm, targetVmSpec)
 	r.mapVolumes(sourceVm, targetVmSpec, persistentVolumeClaims)
 

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -303,10 +303,11 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 
 	// Sanitize DataVolumeTemplates to prevent conflicts with Forklift-created DataVolumes:
 	// 1. Match template names to the PVC names (Forklift creates DataVolumes with Name = pvc.Name)
-	// 2. Clear spec.source to prevent KubeVirt from trying to create new DataVolumes with invalid sources
+	// 2. Clear spec.source so CDI does not re-import from source-cluster references
+	//    (HTTP/registry/PVC sources); Forklift already created the destination DataVolumes
 	// 3. Ensure namespace is set correctly (will be set by KubeVirt to match VM namespace)
 	// 4. Update volume references to match renamed DataVolumeTemplates
-	r.sanitizeDataVolumeTemplates(vmRef, object.DataVolumeTemplates, object)
+	r.sanitizeDataVolumeTemplates(sourceVm, object.DataVolumeTemplates, object)
 
 	r.mapNetworks(sourceVm, targetVmSpec)
 	r.mapVolumes(sourceVm, targetVmSpec, persistentVolumeClaims)
@@ -316,18 +317,13 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 
 // sanitizeDataVolumeTemplates ensures DataVolumeTemplates are compatible with Forklift-created DataVolumes.
 // Forklift creates DataVolumes with Name = pvc.Name, so templates must match these names.
-// We also clear spec.source to prevent KubeVirt from trying to create new DataVolumes with invalid source URLs.
+// spec.source is cleared because templates copied from the source VM still point at
+// source-cluster import specs; Forklift has already created the destination DataVolumes.
 // Additionally, we update volume references to match any renamed DataVolumeTemplates.
-func (r *Builder) sanitizeDataVolumeTemplates(vmRef ref.Ref, templates []cnv.DataVolumeTemplateSpec, object *cnv.VirtualMachineSpec) {
+func (r *Builder) sanitizeDataVolumeTemplates(sourceVm *cnv.VirtualMachine, templates []cnv.DataVolumeTemplateSpec, object *cnv.VirtualMachineSpec) {
 	// Build a map of volume name -> PVC name from VM volumes
 	// This allows us to match DataVolumeTemplates to the PVCs that Forklift will create DataVolumes for
 	volumeToPVCName := make(map[string]string)
-	sourceVm, err := r.getSourceVmFromDefinition(vmRef)
-	if err != nil {
-		r.Log.Error(err, "Failed to get source VM for DataVolumeTemplate sanitization")
-		return
-	}
-
 	for _, vol := range sourceVm.Spec.Template.Spec.Volumes {
 		var pvcName string
 		switch {
@@ -340,7 +336,7 @@ func (r *Builder) sanitizeDataVolumeTemplates(vmRef ref.Ref, templates []cnv.Dat
 			// But we need to check the actual PVC name from the source
 			dv := &cdi.DataVolume{}
 			err := r.sourceClient.Get(context.TODO(), client.ObjectKey{
-				Namespace: vmRef.Namespace,
+				Namespace: sourceVm.Namespace,
 				Name:      vol.DataVolume.Name,
 			}, dv)
 			if err != nil {
@@ -407,9 +403,9 @@ func (r *Builder) sanitizeDataVolumeTemplates(vmRef ref.Ref, templates []cnv.Dat
 			}
 		}
 
-		// Clear spec.source to prevent KubeVirt from trying to create new DataVolumes
-		// with source URLs/namespaces that don't exist on the destination cluster.
-		// Forklift has already created the DataVolumes, so templates should not have source specs.
+		// Clear spec.source: templates still carry source-cluster import specs, but Forklift
+		// already created the destination DataVolumes. Leaving source set would make CDI try
+		// to import again from URLs/registry/PVC refs that do not exist on the destination.
 		template.Spec.Source = nil
 
 		// Ensure namespace is empty - KubeVirt will set it to match the VM namespace

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -3137,7 +3137,12 @@ func (r *KubeVirt) vmTemplate(vm *plan.VMStatus) (virtualMachine *cnv.VirtualMac
 	virtualMachine.Namespace = r.Plan.Spec.TargetNamespace
 	virtualMachine.Spec.Template.Spec.Volumes = []cnv.Volume{}
 	virtualMachine.Spec.Template.Spec.Networks = []cnv.Network{}
-	virtualMachine.Spec.DataVolumeTemplates = []cnv.DataVolumeTemplateSpec{}
+	// Preserve DataVolumeTemplates for OCP source VMs to maintain user workflows
+	// that may expect the VM's DataVolume to be present. The OCP builder will
+	// set them from the source VM spec if they exist.
+	if !r.Plan.IsSourceProviderOCP() {
+		virtualMachine.Spec.DataVolumeTemplates = []cnv.DataVolumeTemplateSpec{}
+	}
 	delete(virtualMachine.Annotations, AnnKubevirtValidations)
 
 	ok = true


### PR DESCRIPTION
## Summary
- Preserve `dataVolumeTemplates` on the target VM for OCP→OCP cold migration (previously cleared, so the VM only referenced the PVC).
- Sanitize copied templates: align names with Forklift-created DataVolumes/PVCs, clear `spec.source` (invalid on destination), clear namespace, and keep volume DataVolume refs in sync.
- Skip clearing `DataVolumeTemplates` in `vmTemplate` when the source provider is OCP so the OCP builder can keep them.

Resolves: MTV-2419

## Notes
Rebased successor to closed PR #4290 (stale). Same approach with sanitization from review feedback.

## Test plan
- [ ] Cold-migrate an OCP→OCP VM that has `dataVolumeTemplates`
- [ ] Confirm target VM retains sanitized `dataVolumeTemplates` (not only PVC volume refs)
- [ ] Confirm no KubeVirt/CDI attempt to re-import from the source URL/namespace
- [ ] Confirm volume DataVolume names match template names and destination PVCs
- [ ] Cold-migrate a VM without DVTs (no regression)
- [ ] Non-OCP source plan still clears DVTs as before


Made with [Cursor](https://cursor.com)