### PR TITLE
MTV-4974 | Short Multus networkName when NAD is in target namespace (…

### DIFF
--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -128,6 +128,10 @@ spec:
         - name: MAX_PARENT_BACKING_RETRIES
           value: "{{ controller_max_parent_backing_retries }}"
 {% endif %}
+{% if controller_multus_network_name_always_qualified is defined and controller_multus_network_name_always_qualified|length > 0 %}
+        - name: MULTUS_NETWORK_NAME_ALWAYS_QUALIFIED
+          value: "{{ controller_multus_network_name_always_qualified }}"
+{% endif %}
 {% if controller_migration_service_account is defined and controller_migration_service_account|length > 0 %}
         - name: MIGRATION_SERVICE_ACCOUNT
           value: "{{ controller_migration_service_account }}"

--- a/pkg/apis/forklift/v1beta1/forkliftcontroller.go
+++ b/pkg/apis/forklift/v1beta1/forkliftcontroller.go
@@ -567,6 +567,13 @@ type ForkliftControllerSpec struct {
 	// +kubebuilder:validation:Minimum=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	ControllerMaxParentBackingRetries *int32 `json:"controller_max_parent_backing_retries,omitempty"`
+	// Always use qualified namespace/nad-name format for Multus networks.
+	// When false, uses unqualified nad-name when NAD is in same namespace as target VM.
+	// +optional
+	// +kubebuilder:default="false"
+	// +kubebuilder:validation:Enum="true";"false"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:radio:true","urn:alm:descriptor:com.tectonic.ui:radio:false"}
+	ControllerMultusNetworkNameAlwaysQualified string `json:"controller_multus_network_name_always_qualified,omitempty"`
 
 	// Ansible Automation Platform (AAP) Settings
 

--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -16,6 +16,7 @@ import (
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libitr "github.com/kubev2v/forklift/pkg/lib/itinerary"
+	"github.com/kubev2v/forklift/pkg/settings"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
@@ -159,6 +160,23 @@ func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {
 	}
 }
 
+// shouldUseQualifiedNetworkName determines whether to use namespace/nad-name format
+// for Multus networks based on ForkliftController settings and namespace comparison.
+func (r *Builder) shouldUseQualifiedNetworkName(nadNamespace, targetVMNamespace string) bool {
+	// If global setting forces qualified names, always use qualified format
+	if settings.Settings.Migration.MultusNetworkNameAlwaysQualified {
+		return true
+	}
+
+	// If NAD and target VM are in different namespaces, use qualified format for safety
+	if nadNamespace != targetVMNamespace {
+		return true
+	}
+
+	// NAD and VM are in same namespace, use unqualified format
+	return false
+}
+
 func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	var kNetworks []cnv.Network
 	var kInterfaces []cnv.Interface
@@ -190,8 +208,14 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) {
 
 		switch mapped.Destination.Type {
 		case Multus:
+			var networkName string
+			if r.shouldUseQualifiedNetworkName(mapped.Destination.Namespace, r.Plan.Spec.TargetNamespace) {
+				networkName = path.Join(mapped.Destination.Namespace, mapped.Destination.Name)
+			} else {
+				networkName = mapped.Destination.Name
+			}
 			kNetwork.Multus = &cnv.MultusNetwork{
-				NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
+				NetworkName: networkName,
 			}
 			kInterface.Bridge = &cnv.InterfaceBridge{}
 		case Pod:

--- a/pkg/controller/plan/adapter/ovfbase/builder.go
+++ b/pkg/controller/plan/adapter/ovfbase/builder.go
@@ -214,6 +214,23 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	return
 }
 
+// shouldUseQualifiedNetworkName determines whether to use namespace/nad-name format
+// for Multus networks based on ForkliftController settings and namespace comparison.
+func (r *Builder) shouldUseQualifiedNetworkName(nadNamespace, targetVMNamespace string) bool {
+	// If global setting forces qualified names, always use qualified format
+	if settings.Settings.Migration.MultusNetworkNameAlwaysQualified {
+		return true
+	}
+
+	// If NAD and target VM are in different namespaces, use qualified format for safety
+	if nadNamespace != targetVMNamespace {
+		return true
+	}
+
+	// NAD and VM are in same namespace, use unqualified format
+	return false
+}
+
 func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err error) {
 	var kNetworks []cnv.Network
 	var kInterfaces []cnv.Interface
@@ -254,8 +271,14 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 				kInterface.Masquerade = &cnv.InterfaceMasquerade{}
 			}
 		case Multus:
+			var networkName string
+			if r.shouldUseQualifiedNetworkName(mapped.Destination.Namespace, r.Plan.Spec.TargetNamespace) {
+				networkName = path.Join(mapped.Destination.Namespace, mapped.Destination.Name)
+			} else {
+				networkName = mapped.Destination.Name
+			}
 			kNetwork.Multus = &cnv.MultusNetwork{
-				NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
+				NetworkName: networkName,
 			}
 			kInterface.Bridge = &cnv.InterfaceBridge{}
 		}

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -296,6 +296,23 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	return
 }
 
+// shouldUseQualifiedNetworkName determines whether to use namespace/nad-name format
+// for Multus networks based on ForkliftController settings and namespace comparison.
+func (r *Builder) shouldUseQualifiedNetworkName(nadNamespace, targetVMNamespace string) bool {
+	// If global setting forces qualified names, always use qualified format
+	if settings.Settings.Migration.MultusNetworkNameAlwaysQualified {
+		return true
+	}
+
+	// If NAD and target VM are in different namespaces, use qualified format for safety
+	if nadNamespace != targetVMNamespace {
+		return true
+	}
+
+	// NAD and VM are in same namespace, use unqualified format
+	return false
+}
+
 func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec) (err error) {
 	var kNetworks []cnv.Network
 	var kInterfaces []cnv.Interface
@@ -338,8 +355,14 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 				kInterface.Masquerade = &cnv.InterfaceMasquerade{}
 			}
 		case Multus:
+			var networkName string
+			if r.shouldUseQualifiedNetworkName(mapped.Destination.Namespace, r.Plan.Spec.TargetNamespace) {
+				networkName = path.Join(mapped.Destination.Namespace, mapped.Destination.Name)
+			} else {
+				networkName = mapped.Destination.Name
+			}
 			kNetwork.Multus = &cnv.MultusNetwork{
-				NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
+				NetworkName: networkName,
 			}
 			if nic.Profile.PassThrough {
 				kInterface.SRIOV = &cnv.InterfaceSRIOV{}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -758,6 +758,23 @@ func (r *Builder) findInterfaceIps(vm *model.VM, nic vsphere.NIC) []string {
 	return interfaceIps
 }
 
+// shouldUseQualifiedNetworkName determines whether to use namespace/nad-name format
+// for Multus networks based on ForkliftController settings and namespace comparison.
+func (r *Builder) shouldUseQualifiedNetworkName(nadNamespace, targetVMNamespace string) bool {
+	// If global setting forces qualified names, always use qualified format
+	if settings.Settings.Migration.MultusNetworkNameAlwaysQualified {
+		return true
+	}
+
+	// If NAD and target VM are in different namespaces, use qualified format for safety
+	if nadNamespace != targetVMNamespace {
+		return true
+	}
+
+	// NAD and VM are in same namespace, use unqualified format
+	return false
+}
+
 func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err error) {
 	var kNetworks []cnv.Network
 	var kInterfaces []cnv.Interface
@@ -831,8 +848,14 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 				kInterface.Masquerade = &cnv.InterfaceMasquerade{}
 			}
 		case Multus:
+			var networkName string
+			if r.shouldUseQualifiedNetworkName(mapped.Destination.Namespace, r.Plan.Spec.TargetNamespace) {
+				networkName = path.Join(mapped.Destination.Namespace, mapped.Destination.Name)
+			} else {
+				networkName = mapped.Destination.Name
+			}
 			kNetwork.Multus = &cnv.MultusNetwork{
-				NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
+				NetworkName: networkName,
 			}
 			kInterface.Bridge = &cnv.InterfaceBridge{}
 		}

--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -19,6 +19,7 @@ import (
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libitr "github.com/kubev2v/forklift/pkg/lib/itinerary"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/settings"
 	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -1337,6 +1338,23 @@ func (r *Builder) VirtualMachine(vm *planapi.VMStatus) (object *cnv.VirtualMachi
 	return
 }
 
+// shouldUseQualifiedNetworkName determines whether to use namespace/nad-name format
+// for Multus networks based on ForkliftController settings and namespace comparison.
+func (r *Builder) shouldUseQualifiedNetworkName(nadNamespace, targetVMNamespace string) bool {
+	// If global setting forces qualified names, always use qualified format
+	if settings.Settings.Migration.MultusNetworkNameAlwaysQualified {
+		return true
+	}
+
+	// If NAD and target VM are in different namespaces, use qualified format for safety
+	if nadNamespace != targetVMNamespace {
+		return true
+	}
+
+	// NAD and VM are in same namespace, use unqualified format
+	return false
+}
+
 func (r *Builder) mapNetworks(srcNS string, target *cnv.VirtualMachine) {
 	networkMap := make(map[string]api.DestinationNetwork)
 	for _, network := range r.Map.Network.Spec.Map {
@@ -1351,7 +1369,11 @@ func (r *Builder) mapNetworks(srcNS string, target *cnv.VirtualMachine) {
 				sourceNetwork = path.Join(srcNS, sourceNetwork)
 			}
 			destination := networkMap[sourceNetwork]
-			network.Multus.NetworkName = path.Join(destination.Namespace, destination.Name)
+			if r.shouldUseQualifiedNetworkName(destination.Namespace, r.Plan.Spec.TargetNamespace) {
+				network.Multus.NetworkName = path.Join(destination.Namespace, destination.Name)
+			} else {
+				network.Multus.NetworkName = destination.Name
+			}
 		case network.Pod != nil:
 		}
 	}

--- a/pkg/controller/plan/migrator/ocp/live_test.go
+++ b/pkg/controller/plan/migrator/ocp/live_test.go
@@ -56,13 +56,15 @@ var _ = Describe("Builder", func() {
 		It("Remaps an unqualified network", func() {
 			target = makeVM("net-attach-def")
 			builder.mapNetworks("source", target)
-			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("target/net-attach-target"))
+			// NAD and VM are in same namespace "target", so use unqualified name
+			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("net-attach-target"))
 		})
 
 		It("Remaps a namespace-qualified network", func() {
 			target = makeVM("source/net-attach-def")
 			builder.mapNetworks("source", target)
-			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("target/net-attach-target"))
+			// NAD and VM are in same namespace "target", so use unqualified name
+			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("net-attach-target"))
 		})
 	})
 
@@ -97,13 +99,38 @@ var _ = Describe("Builder", func() {
 		It("Remaps an unqualified network", func() {
 			target = makeVM("net-attach-def")
 			builder.mapNetworks("source", target)
-			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("target/net-attach-target"))
+			// NAD and VM are in same namespace "target", so use unqualified name
+			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("net-attach-target"))
 		})
 
 		It("Remaps a namespace-qualified network", func() {
 			target = makeVM("source/net-attach-def")
 			builder.mapNetworks("source", target)
-			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("target/net-attach-target"))
+			// NAD and VM are in same namespace "target", so use unqualified name
+			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("net-attach-target"))
+		})
+	})
+
+	Context("mapNetworks with different namespaces", func() {
+		BeforeEach(func() {
+			source := api.NetworkPair{
+				Source: api.NetworkSourceRef{Ref: ref.Ref{
+					Namespace: "source",
+					Name:      "net-attach-def",
+				}},
+				Destination: api.DestinationNetwork{
+					Namespace: "different", // NAD in different namespace than target VM
+					Name:      "net-attach-target",
+				},
+			}
+			builder = makeBuilder(source)
+		})
+
+		It("Uses qualified name when NAD and VM are in different namespaces", func() {
+			target = makeVM("net-attach-def")
+			builder.mapNetworks("source", target)
+			// NAD is in "different" namespace, VM is in "target" - use qualified name
+			Expect(target.Spec.Template.Spec.Networks[0].Multus.NetworkName).To(Equal("different/net-attach-target"))
 		})
 	})
 })
@@ -208,6 +235,12 @@ func makeBuilder(networkPairs ...api.NetworkPair) *Builder {
 	b.Context.Map.Network = &api.NetworkMap{
 		Spec: api.NetworkMapSpec{
 			Map: networkPairs,
+		},
+	}
+	// Set up a Plan with target namespace for testing
+	b.Plan = &api.Plan{
+		Spec: api.PlanSpec{
+			TargetNamespace: "target",
 		},
 	}
 	return b

--- a/pkg/provider/ec2/controller/builder/vm.go
+++ b/pkg/provider/ec2/controller/builder/vm.go
@@ -267,6 +267,23 @@ func (r *Builder) mapDisks(awsInstance *model.InstanceDetails, persistentVolumeC
 }
 
 // mapNetworks configures VM networks based on EC2 network interfaces and network mappings.
+// shouldUseQualifiedNetworkName determines whether to use namespace/nad-name format
+// for Multus networks based on ForkliftController settings and namespace comparison.
+func (r *Builder) shouldUseQualifiedNetworkName(nadNamespace, targetVMNamespace string) bool {
+	// If global setting forces qualified names, always use qualified format
+	if settings.Settings.Migration.MultusNetworkNameAlwaysQualified {
+		return true
+	}
+
+	// If NAD and target VM are in different namespaces, use qualified format for safety
+	if nadNamespace != targetVMNamespace {
+		return true
+	}
+
+	// NAD and VM are in same namespace, use unqualified format
+	return false
+}
+
 // Supports pod networking, Multus, and UDN (User Defined Networks).
 // Preserves MAC addresses from source (when UDN supports it or when not using UDN).
 // In compatibility mode, uses E1000e NIC model instead of VirtIO.
@@ -356,8 +373,14 @@ func (r *Builder) mapNetworks(awsInstance *model.InstanceDetails, object *cnv.Vi
 				}
 			} else if mapped.Destination.Type == Multus {
 				// Multus network
+				var networkName string
+				if r.shouldUseQualifiedNetworkName(mapped.Destination.Namespace, r.Plan.Spec.TargetNamespace) {
+					networkName = path.Join(mapped.Destination.Namespace, mapped.Destination.Name)
+				} else {
+					networkName = mapped.Destination.Name
+				}
 				kNetwork.Multus = &cnv.MultusNetwork{
-					NetworkName: path.Join(mapped.Destination.Namespace, mapped.Destination.Name),
+					NetworkName: networkName,
 				}
 				kInterface.InterfaceBindingMethod = cnv.InterfaceBindingMethod{
 					Bridge: &cnv.InterfaceBridge{},

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -48,6 +48,7 @@ const (
 	VirtV2vContainerRequestsMemory         = "VIRT_V2V_CONTAINER_REQUESTS_MEMORY"
 	HooksContainerLimitsCpu                = "HOOKS_CONTAINER_LIMITS_CPU"
 	HooksContainerLimitsMemory             = "HOOKS_CONTAINER_LIMITS_MEMORY"
+	MultusNetworkNameAlwaysQualified       = "MULTUS_NETWORK_NAME_ALWAYS_QUALIFIED"
 	HooksContainerRequestsCpu              = "HOOKS_CONTAINER_REQUESTS_CPU"
 	HooksContainerRequestsMemory           = "HOOKS_CONTAINER_REQUESTS_MEMORY"
 	OvaContainerLimitsCpu                  = "OVA_CONTAINER_LIMITS_CPU"
@@ -202,6 +203,9 @@ type Migration struct {
 	// ConversionPodPendingTimeout is how long (in minutes) a conversion pod may stay
 	// in Pending phase before the controller fails it. 0 means no timeout.
 	ConversionPodPendingTimeout int
+	// MultusNetworkNameAlwaysQualified controls whether Multus network names are always
+	// qualified with namespace (true) or use unqualified names when NAD is in same namespace (false).
+	MultusNetworkNameAlwaysQualified bool
 }
 
 // Load settings.
@@ -460,6 +464,7 @@ func (r *Migration) Load() (err error) {
 		r.DeepInspectionImageXFS = strings.TrimSpace(val)
 	}
 	r.WaitForFinalSnapshotConsolidation = getEnvBool(WaitForFinalSnapshotConsolidation, true)
+	r.MultusNetworkNameAlwaysQualified = getEnvBool(MultusNetworkNameAlwaysQualified, false)
 	if r.ConversionPodPendingTimeout, err = getEnvLimit(ConversionPodPendingTimeout, DefaultPendingPodTimeoutMinutes, 0); err != nil {
 		return liberr.Wrap(err)
 	}


### PR DESCRIPTION
…with revert flag)

A new global setting (MULTUS_NETWORK_NAME_ALWAYS_QUALIFIED) that forces qualified network names 
Namespace comparison logic - when NAD and VM are in different namespaces, qualified names are used for safety