### PR TITLE
MTV-2838 | Preserve source PVC access/volume mode on cold OCP DVs

### DIFF
--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -140,8 +140,9 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *v1.Secret, configMap *v1.Co
 		if url == "" {
 			return nil, liberr.Wrap(fmt.Errorf("failed to get export URL, available formats: %v", volume.Formats))
 		}
-		storageClassName := storageMap[*pvc.Spec.StorageClassName].StorageClass
-		dataVolume.Spec = *createDataVolumeSpec(size, storageClassName, url, configMap.Name, secret.Name)
+		destination := storageMap[*pvc.Spec.StorageClassName]
+		dataVolume.Spec = *createDataVolumeSpec(size, destination.StorageClass, url, configMap.Name, secret.Name)
+		applyDestinationStorageModes(&dataVolume.Spec, destination, pvc)
 
 		err = r.Destination.Client.Create(context.TODO(), dataVolume, &client.CreateOptions{})
 		if err != nil {
@@ -669,6 +670,28 @@ func createDataVolumeSpec(size resource.Quantity, storageClassName, url, configM
 			},
 			StorageClassName: &storageClassName,
 		},
+	}
+}
+
+// applyDestinationStorageModes sets AccessModes and VolumeMode on the DataVolume.
+// When the plan storage mapping specifies a mode, that value wins. Otherwise the
+// source PVC values are preserved so CDI does not fall back to StorageProfile
+// defaults (e.g. RWO→RWX on ocs-storagecluster-ceph-rbd-virtualization).
+func applyDestinationStorageModes(spec *cdi.DataVolumeSpec, destination v1beta1.DestinationStorage, sourcePVC *core.PersistentVolumeClaim) {
+	if spec == nil || spec.Storage == nil || sourcePVC == nil {
+		return
+	}
+	if destination.AccessMode != "" {
+		spec.Storage.AccessModes = []core.PersistentVolumeAccessMode{destination.AccessMode}
+	} else if len(sourcePVC.Spec.AccessModes) > 0 {
+		spec.Storage.AccessModes = append([]core.PersistentVolumeAccessMode(nil), sourcePVC.Spec.AccessModes...)
+	}
+	if destination.VolumeMode != "" {
+		volumeMode := destination.VolumeMode
+		spec.Storage.VolumeMode = &volumeMode
+	} else if sourcePVC.Spec.VolumeMode != nil {
+		volumeMode := *sourcePVC.Spec.VolumeMode
+		spec.Storage.VolumeMode = &volumeMode
 	}
 }
 

--- a/pkg/controller/plan/adapter/ocp/builder_test.go
+++ b/pkg/controller/plan/adapter/ocp/builder_test.go
@@ -7,6 +7,9 @@ import (
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
 func newBuilder(plan *api.Plan) *Builder {
@@ -176,4 +179,84 @@ func TestExecuteTemplate_OCPTemplateData(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyDestinationStorageModes_UsesMappingAccessModeWhenSet(t *testing.T) {
+	spec := createDataVolumeSpec(resource.MustParse("10Gi"), "target-sc", "https://example", "cm", "secret")
+	sourcePVC := &core.PersistentVolumeClaim{
+		Spec: core.PersistentVolumeClaimSpec{
+			AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+		},
+	}
+	destination := api.DestinationStorage{
+		StorageClass: "target-sc",
+		AccessMode:   core.ReadWriteMany,
+	}
+
+	applyDestinationStorageModes(spec, destination, sourcePVC)
+
+	if len(spec.Storage.AccessModes) != 1 || spec.Storage.AccessModes[0] != core.ReadWriteMany {
+		t.Fatalf("expected mapping AccessMode RWX, got %v", spec.Storage.AccessModes)
+	}
+}
+
+func TestApplyDestinationStorageModes_PreservesSourceAccessModeWhenMappingOmits(t *testing.T) {
+	spec := createDataVolumeSpec(resource.MustParse("11Mi"), "ocs-storagecluster-ceph-rbd-virtualization", "https://example", "cm", "secret")
+	sourcePVC := &core.PersistentVolumeClaim{
+		Spec: core.PersistentVolumeClaimSpec{
+			AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+		},
+	}
+	destination := api.DestinationStorage{
+		StorageClass: "ocs-storagecluster-ceph-rbd-virtualization",
+	}
+
+	applyDestinationStorageModes(spec, destination, sourcePVC)
+
+	if len(spec.Storage.AccessModes) != 1 || spec.Storage.AccessModes[0] != core.ReadWriteOnce {
+		t.Fatalf("expected source AccessMode RWO, got %v", spec.Storage.AccessModes)
+	}
+}
+
+func TestApplyDestinationStorageModes_PreservesSourceVolumeModeWhenMappingOmits(t *testing.T) {
+	blockMode := core.PersistentVolumeBlock
+	spec := createDataVolumeSpec(resource.MustParse("10Gi"), "target-sc", "https://example", "cm", "secret")
+	sourcePVC := &core.PersistentVolumeClaim{
+		Spec: core.PersistentVolumeClaimSpec{
+			VolumeMode: &blockMode,
+		},
+	}
+	destination := api.DestinationStorage{StorageClass: "target-sc"}
+
+	applyDestinationStorageModes(spec, destination, sourcePVC)
+
+	if spec.Storage.VolumeMode == nil || *spec.Storage.VolumeMode != core.PersistentVolumeBlock {
+		t.Fatalf("expected source VolumeMode Block, got %v", spec.Storage.VolumeMode)
+	}
+}
+
+func TestApplyDestinationStorageModes_UsesMappingVolumeModeWhenSet(t *testing.T) {
+	filesystemMode := core.PersistentVolumeFilesystem
+	spec := createDataVolumeSpec(resource.MustParse("10Gi"), "target-sc", "https://example", "cm", "secret")
+	sourcePVC := &core.PersistentVolumeClaim{
+		Spec: core.PersistentVolumeClaimSpec{
+			VolumeMode: &filesystemMode,
+		},
+	}
+	destination := api.DestinationStorage{
+		StorageClass: "target-sc",
+		VolumeMode:   core.PersistentVolumeBlock,
+	}
+
+	applyDestinationStorageModes(spec, destination, sourcePVC)
+
+	if spec.Storage.VolumeMode == nil || *spec.Storage.VolumeMode != core.PersistentVolumeBlock {
+		t.Fatalf("expected mapping VolumeMode Block, got %v", spec.Storage.VolumeMode)
+	}
+}
+
+func TestApplyDestinationStorageModes_NilSafe(t *testing.T) {
+	applyDestinationStorageModes(nil, api.DestinationStorage{}, &core.PersistentVolumeClaim{})
+	applyDestinationStorageModes(&cdi.DataVolumeSpec{}, api.DestinationStorage{}, &core.PersistentVolumeClaim{})
+	applyDestinationStorageModes(createDataVolumeSpec(resource.MustParse("1Gi"), "sc", "https://example", "cm", "secret"), api.DestinationStorage{}, nil)
 }


### PR DESCRIPTION
## Summary
- Cold OCP→OCP DataVolumes previously set only storage class and size, so CDI fell back to StorageProfile defaults and could flip RWO→RWX (seen on TPM persistent-state PVCs).
- When the plan storage mapping omits AccessMode/VolumeMode, preserve the source PVC values; mapping values still win when set.
- Adds unit tests for `applyDestinationStorageModes`.

Supersedes #4517 (that PR targeted live migration; this bug is cold OCP→OCP).

Resolves: MTV-2838

## Test plan
- [ ] Cold OCP→OCP migrate a VM whose source PVC is RWO on a storage class whose StorageProfile defaults to RWX; confirm destination DV/PVC stays RWO when the storage map omits AccessMode
- [ ] Confirm an explicit AccessMode/VolumeMode on the storage map is still honored
- [ ] Optional: TPM VM — confirm migrated `persistent-state-for-*` stays RWO; note if CNV still creates a second state PVC (expected leftover for CNV)


Made with [Cursor](https://cursor.com)