### PR TITLE
MTV-6183 | Prevent Plan deletion from destroying in-use PVCs

### DIFF
--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -41,6 +41,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage/names"
+	cnv "kubevirt.io/api/core/v1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -922,36 +923,88 @@ func (r *Reconciler) deleteOrphanedResources(list client.ObjectList, labels clie
 		r.Log.Error(err, "Failed to list resources for cleanup.", "kind", kind)
 		return
 	}
+
+	checkVolRefs := preserveVMOwned && (kind == "PVC" || kind == "DataVolume")
+	// Per-namespace cache of volume names referenced by VMs/VMIs (avoids N+1 API calls).
+	refCache := &volumeRefCache{
+		names: map[string]map[string]bool{},
+		errs:  map[string]bool{},
+	}
+
 	_ = apimeta.EachListItem(list, func(obj runtime.Object) error {
 		resource, ok := obj.(client.Object)
 		if !ok {
 			r.Log.Error(nil, "Unexpected object type during cleanup.", "kind", kind)
 			return nil
 		}
-		// Preserve resources already owned by a migrated VirtualMachine.
-		if preserveVMOwned && hasVMOwner(resource.GetOwnerReferences()) {
-			r.Log.V(1).Info(
-				"Skipping resource owned by VirtualMachine.",
-				"kind", kind,
-				"name", resource.GetName(),
-				"namespace", resource.GetNamespace())
+		if r.shouldPreserveResource(resource, kind, preserveVMOwned, checkVolRefs, refCache) {
 			return nil
 		}
-		if err := r.Delete(context.TODO(), resource); err != nil {
-			if !k8serr.IsNotFound(err) {
-				r.Log.Error(err, "Failed to delete resource.",
-					"kind", kind,
-					"name", resource.GetName(),
-					"namespace", resource.GetNamespace())
-			}
+		r.deleteResource(resource, kind)
+		return nil
+	})
+}
+
+// volumeRefCache caches per-namespace volume names referenced by VMs/VMIs.
+type volumeRefCache struct {
+	names map[string]map[string]bool
+	errs  map[string]bool
+}
+
+// shouldPreserveResource returns true if the resource should be kept rather than deleted.
+func (r *Reconciler) shouldPreserveResource(resource client.Object, kind string, preserveVMOwned, checkVolRefs bool, refCache *volumeRefCache) bool {
+	if preserveVMOwned && hasVMOwner(resource.GetOwnerReferences()) {
+		r.Log.V(1).Info(
+			"Skipping resource owned by VirtualMachine.",
+			"kind", kind,
+			"name", resource.GetName(),
+			"namespace", resource.GetNamespace())
+		return true
+	}
+	if checkVolRefs && r.isReferencedVolume(resource, kind, refCache) {
+		return true
+	}
+	return false
+}
+
+// isReferencedVolume checks whether a PVC/DataVolume is actively referenced in
+// a VM/VMI spec.volumes, even if ownership hasn't been transferred yet (MTV-6183).
+func (r *Reconciler) isReferencedVolume(resource client.Object, kind string, cache *volumeRefCache) bool {
+	ns := resource.GetNamespace()
+	if _, seen := cache.names[ns]; !seen && !cache.errs[ns] {
+		refs, err := r.referencedVolumeNames(ns)
+		if err != nil {
+			cache.errs[ns] = true
 		} else {
-			r.Log.Info("Deleted orphaned resource.",
+			cache.names[ns] = refs
+		}
+	}
+	if cache.errs[ns] || cache.names[ns][resource.GetName()] {
+		r.Log.Info(
+			"Skipping resource referenced by a VirtualMachine spec.",
+			"kind", kind,
+			"name", resource.GetName(),
+			"namespace", resource.GetNamespace())
+		return true
+	}
+	return false
+}
+
+// deleteResource attempts to delete a resource and logs the outcome.
+func (r *Reconciler) deleteResource(resource client.Object, kind string) {
+	if err := r.Delete(context.TODO(), resource); err != nil {
+		if !k8serr.IsNotFound(err) {
+			r.Log.Error(err, "Failed to delete resource.",
 				"kind", kind,
 				"name", resource.GetName(),
 				"namespace", resource.GetNamespace())
 		}
-		return nil
-	})
+	} else {
+		r.Log.Info("Deleted orphaned resource.",
+			"kind", kind,
+			"name", resource.GetName(),
+			"namespace", resource.GetNamespace())
+	}
 }
 
 func hasVMOwner(owners []meta.OwnerReference) bool {
@@ -961,4 +1014,49 @@ func hasVMOwner(owners []meta.OwnerReference) bool {
 		}
 	}
 	return false
+}
+
+// referencedVolumeNames returns the set of PVC/DataVolume names referenced by
+// any VM or VMI in the given namespace.
+func (r *Reconciler) referencedVolumeNames(ns string) (map[string]bool, error) {
+	refs := map[string]bool{}
+
+	vms := &cnv.VirtualMachineList{}
+	if err := r.APIReader.List(context.TODO(), vms, &client.ListOptions{Namespace: ns}); err != nil {
+		r.Log.Error(err, "Failed to list VMs for in-use check, preserving resources as precaution.", "namespace", ns)
+		return nil, err
+	}
+	for _, vm := range vms.Items {
+		if vm.Spec.Template == nil {
+			continue
+		}
+		for _, vol := range vm.Spec.Template.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil {
+				refs[vol.PersistentVolumeClaim.ClaimName] = true
+			}
+			if vol.DataVolume != nil {
+				refs[vol.DataVolume.Name] = true
+			}
+		}
+	}
+
+	// Also check running VMIs — during live volume migration the VMI may reference
+	// the new PVC before the VM spec is updated.
+	vmis := &cnv.VirtualMachineInstanceList{}
+	if err := r.APIReader.List(context.TODO(), vmis, &client.ListOptions{Namespace: ns}); err != nil {
+		r.Log.Error(err, "Failed to list VMIs for in-use check, preserving resources as precaution.", "namespace", ns)
+		return nil, err
+	}
+	for _, vmi := range vmis.Items {
+		for _, vol := range vmi.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil {
+				refs[vol.PersistentVolumeClaim.ClaimName] = true
+			}
+			if vol.DataVolume != nil {
+				refs[vol.DataVolume.Name] = true
+			}
+		}
+	}
+
+	return refs, nil
 }

--- a/pkg/controller/plan/controller_test.go
+++ b/pkg/controller/plan/controller_test.go
@@ -17,6 +17,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	cnv "kubevirt.io/api/core/v1"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -28,6 +29,7 @@ func newTestScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = core.AddToScheme(scheme)
 	_ = cdi.AddToScheme(scheme)
+	_ = cnv.AddToScheme(scheme)
 	return scheme
 }
 
@@ -419,6 +421,307 @@ var _ = ginkgo.Describe("hasVMOwner", func() {
 	)
 })
 
+var _ = ginkgo.Describe("referencedVolumeNames / in-use PVC protection (MTV-6183)", func() {
+	const (
+		planName      = "test-plan"
+		planNamespace = "test-ns"
+		targetNS      = "target-ns"
+	)
+
+	labels := func() map[string]string {
+		return map[string]string{
+			kPlanName:      planName,
+			kPlanNamespace: planNamespace,
+		}
+	}
+
+	ginkgo.Context("PVC referenced in VM spec.volumes via persistentVolumeClaim", func() {
+		ginkgo.It("should NOT delete a PVC referenced by a VM's persistentVolumeClaim volume", func() {
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "target-pvc",
+					Namespace: targetNS,
+					Labels:    labels(),
+				},
+			}
+			vm := &cnv.VirtualMachine{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "my-vm",
+					Namespace: targetNS,
+				},
+				Spec: cnv.VirtualMachineSpec{
+					Template: &cnv.VirtualMachineInstanceTemplateSpec{
+						Spec: cnv.VirtualMachineInstanceSpec{
+							Volumes: []cnv.Volume{
+								{
+									Name: "disk-0",
+									VolumeSource: cnv.VolumeSource{
+										PersistentVolumeClaim: &cnv.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: core.PersistentVolumeClaimVolumeSource{
+												ClaimName: "target-pvc",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			r := newTestReconciler(pvc, vm)
+
+			r.cleanupOrphanedResources(planName, planNamespace)
+
+			gomega.Expect(objectExists(r.Client, types.NamespacedName{
+				Name: "target-pvc", Namespace: targetNS,
+			}, &core.PersistentVolumeClaim{})).To(gomega.BeTrue(),
+				"PVC referenced in VM spec.volumes should be preserved")
+		})
+	})
+
+	ginkgo.Context("PVC referenced in VM spec.volumes via dataVolume", func() {
+		ginkgo.It("should NOT delete a PVC whose name matches a VM's dataVolume volume", func() {
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "dv-backed-pvc",
+					Namespace: targetNS,
+					Labels:    labels(),
+				},
+			}
+			vm := &cnv.VirtualMachine{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "my-vm",
+					Namespace: targetNS,
+				},
+				Spec: cnv.VirtualMachineSpec{
+					Template: &cnv.VirtualMachineInstanceTemplateSpec{
+						Spec: cnv.VirtualMachineInstanceSpec{
+							Volumes: []cnv.Volume{
+								{
+									Name: "disk-0",
+									VolumeSource: cnv.VolumeSource{
+										DataVolume: &cnv.DataVolumeSource{
+											Name: "dv-backed-pvc",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			r := newTestReconciler(pvc, vm)
+
+			r.cleanupOrphanedResources(planName, planNamespace)
+
+			gomega.Expect(objectExists(r.Client, types.NamespacedName{
+				Name: "dv-backed-pvc", Namespace: targetNS,
+			}, &core.PersistentVolumeClaim{})).To(gomega.BeTrue(),
+				"PVC matching a dataVolume name in VM spec should be preserved")
+		})
+	})
+
+	ginkgo.Context("DataVolume referenced in VM spec.volumes", func() {
+		ginkgo.It("should NOT delete a DataVolume referenced in VM's dataVolume volume", func() {
+			dv := &cdi.DataVolume{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "target-dv",
+					Namespace: targetNS,
+					Labels:    labels(),
+				},
+			}
+			vm := &cnv.VirtualMachine{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "my-vm",
+					Namespace: targetNS,
+				},
+				Spec: cnv.VirtualMachineSpec{
+					Template: &cnv.VirtualMachineInstanceTemplateSpec{
+						Spec: cnv.VirtualMachineInstanceSpec{
+							Volumes: []cnv.Volume{
+								{
+									Name: "disk-0",
+									VolumeSource: cnv.VolumeSource{
+										DataVolume: &cnv.DataVolumeSource{
+											Name: "target-dv",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			r := newTestReconciler(dv, vm)
+
+			r.cleanupOrphanedResources(planName, planNamespace)
+
+			gomega.Expect(objectExists(r.Client, types.NamespacedName{
+				Name: "target-dv", Namespace: targetNS,
+			}, &cdi.DataVolume{})).To(gomega.BeTrue(),
+				"DataVolume referenced in VM spec.volumes should be preserved")
+		})
+	})
+
+	ginkgo.Context("PVC referenced in VMI spec.volumes (live volume migration)", func() {
+		ginkgo.It("should NOT delete a PVC referenced by a running VMI", func() {
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "vmi-ref-pvc",
+					Namespace: targetNS,
+					Labels:    labels(),
+				},
+			}
+			vmi := &cnv.VirtualMachineInstance{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "my-vmi",
+					Namespace: targetNS,
+				},
+				Spec: cnv.VirtualMachineInstanceSpec{
+					Volumes: []cnv.Volume{
+						{
+							Name: "disk-0",
+							VolumeSource: cnv.VolumeSource{
+								PersistentVolumeClaim: &cnv.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: core.PersistentVolumeClaimVolumeSource{
+										ClaimName: "vmi-ref-pvc",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			r := newTestReconciler(pvc, vmi)
+
+			r.cleanupOrphanedResources(planName, planNamespace)
+
+			gomega.Expect(objectExists(r.Client, types.NamespacedName{
+				Name: "vmi-ref-pvc", Namespace: targetNS,
+			}, &core.PersistentVolumeClaim{})).To(gomega.BeTrue(),
+				"PVC referenced in VMI spec.volumes should be preserved")
+		})
+
+		ginkgo.It("should NOT delete a DataVolume referenced by a running VMI", func() {
+			dv := &cdi.DataVolume{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "vmi-ref-dv",
+					Namespace: targetNS,
+					Labels:    labels(),
+				},
+			}
+			vmi := &cnv.VirtualMachineInstance{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "my-vmi",
+					Namespace: targetNS,
+				},
+				Spec: cnv.VirtualMachineInstanceSpec{
+					Volumes: []cnv.Volume{
+						{
+							Name: "disk-0",
+							VolumeSource: cnv.VolumeSource{
+								DataVolume: &cnv.DataVolumeSource{
+									Name: "vmi-ref-dv",
+								},
+							},
+						},
+					},
+				},
+			}
+			r := newTestReconciler(dv, vmi)
+
+			r.cleanupOrphanedResources(planName, planNamespace)
+
+			gomega.Expect(objectExists(r.Client, types.NamespacedName{
+				Name: "vmi-ref-dv", Namespace: targetNS,
+			}, &cdi.DataVolume{})).To(gomega.BeTrue(),
+				"DataVolume referenced in VMI spec.volumes should be preserved")
+		})
+
+		ginkgo.It("should delete PVC not referenced by VM or VMI", func() {
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "no-vmi-ref-pvc",
+					Namespace: targetNS,
+					Labels:    labels(),
+				},
+			}
+			vmi := &cnv.VirtualMachineInstance{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "my-vmi",
+					Namespace: targetNS,
+				},
+				Spec: cnv.VirtualMachineInstanceSpec{
+					Volumes: []cnv.Volume{
+						{
+							Name: "disk-0",
+							VolumeSource: cnv.VolumeSource{
+								PersistentVolumeClaim: &cnv.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: core.PersistentVolumeClaimVolumeSource{
+										ClaimName: "different-pvc",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			r := newTestReconciler(pvc, vmi)
+
+			r.cleanupOrphanedResources(planName, planNamespace)
+
+			gomega.Expect(objectExists(r.Client, types.NamespacedName{
+				Name: "no-vmi-ref-pvc", Namespace: targetNS,
+			}, &core.PersistentVolumeClaim{})).To(gomega.BeFalse(),
+				"PVC not referenced by any VM or VMI should be deleted")
+		})
+	})
+
+	ginkgo.Context("unreferenced resources are still deleted", func() {
+		ginkgo.It("should delete PVC not referenced by any VM", func() {
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "unreferenced-pvc",
+					Namespace: targetNS,
+					Labels:    labels(),
+				},
+			}
+			vm := &cnv.VirtualMachine{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "unrelated-vm",
+					Namespace: targetNS,
+				},
+				Spec: cnv.VirtualMachineSpec{
+					Template: &cnv.VirtualMachineInstanceTemplateSpec{
+						Spec: cnv.VirtualMachineInstanceSpec{
+							Volumes: []cnv.Volume{
+								{
+									Name: "disk-0",
+									VolumeSource: cnv.VolumeSource{
+										PersistentVolumeClaim: &cnv.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: core.PersistentVolumeClaimVolumeSource{
+												ClaimName: "some-other-pvc",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			r := newTestReconciler(pvc, vm)
+
+			r.cleanupOrphanedResources(planName, planNamespace)
+
+			gomega.Expect(objectExists(r.Client, types.NamespacedName{
+				Name: "unreferenced-pvc", Namespace: targetNS,
+			}, &core.PersistentVolumeClaim{})).To(gomega.BeFalse(),
+				"PVC not referenced by any VM should be deleted")
+		})
+	})
+})
+
 var _ = ginkgo.Describe("failExecutingMigrationOnBlocker", func() {
 	newPlanWithSnapshot := func(snapshotConditions ...libcnd.Condition) *api.Plan {
 		plan := &api.Plan{
@@ -779,5 +1082,132 @@ var _ = ginkgo.Describe("criticalOrErrorCondition", func() {
 			"old condition should be included")
 		gomega.Expect(result).NotTo(gomega.ContainSubstring("Map.Storage"),
 			"recent condition should be excluded")
+	})
+})
+
+// countingReader wraps a client.Reader and counts List calls by GVK.
+type countingReader struct {
+	client.Reader
+	vmListCount  int
+	vmiListCount int
+}
+
+func (c *countingReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	switch list.(type) {
+	case *cnv.VirtualMachineList:
+		c.vmListCount++
+	case *cnv.VirtualMachineInstanceList:
+		c.vmiListCount++
+	}
+	return c.Reader.List(ctx, list, opts...)
+}
+
+var _ = ginkgo.Describe("referencedVolumeNames caching (N+1 regression)", func() {
+	const (
+		planName      = "test-plan"
+		planNamespace = "test-ns"
+		targetNS      = "target-ns"
+	)
+
+	labels := func() map[string]string {
+		return map[string]string{
+			kPlanName:      planName,
+			kPlanNamespace: planNamespace,
+		}
+	}
+
+	ginkgo.It("should issue exactly one VM and one VMI List call for multiple PVCs in the same namespace", func() {
+		pvc1 := &core.PersistentVolumeClaim{
+			ObjectMeta: meta.ObjectMeta{Name: "pvc-1", Namespace: targetNS, Labels: labels()},
+		}
+		pvc2 := &core.PersistentVolumeClaim{
+			ObjectMeta: meta.ObjectMeta{Name: "pvc-2", Namespace: targetNS, Labels: labels()},
+		}
+		pvc3 := &core.PersistentVolumeClaim{
+			ObjectMeta: meta.ObjectMeta{Name: "pvc-3", Namespace: targetNS, Labels: labels()},
+		}
+		vm := &cnv.VirtualMachine{
+			ObjectMeta: meta.ObjectMeta{Name: "my-vm", Namespace: targetNS},
+			Spec: cnv.VirtualMachineSpec{
+				Template: &cnv.VirtualMachineInstanceTemplateSpec{
+					Spec: cnv.VirtualMachineInstanceSpec{
+						Volumes: []cnv.Volume{
+							{
+								Name: "disk-0",
+								VolumeSource: cnv.VolumeSource{
+									PersistentVolumeClaim: &cnv.PersistentVolumeClaimVolumeSource{
+										PersistentVolumeClaimVolumeSource: core.PersistentVolumeClaimVolumeSource{
+											ClaimName: "pvc-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		scheme := newTestScheme()
+		c := fakeClient.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(pvc1, pvc2, pvc3, vm).
+			Build()
+		counter := &countingReader{Reader: c}
+		r := &Reconciler{
+			Reconciler: base.Reconciler{
+				Client: c,
+				Log:    controllerLog,
+			},
+			APIReader: counter,
+		}
+
+		r.cleanupOrphanedResources(planName, planNamespace)
+
+		gomega.Expect(counter.vmListCount).To(gomega.Equal(1),
+			"VMs should be listed exactly once for the namespace, not per-PVC")
+		gomega.Expect(counter.vmiListCount).To(gomega.Equal(1),
+			"VMIs should be listed exactly once for the namespace, not per-PVC")
+
+		// pvc-1 is referenced by the VM — preserved.
+		gomega.Expect(objectExists(c, types.NamespacedName{
+			Name: "pvc-1", Namespace: targetNS,
+		}, &core.PersistentVolumeClaim{})).To(gomega.BeTrue())
+		// pvc-2 and pvc-3 are not referenced — deleted.
+		gomega.Expect(objectExists(c, types.NamespacedName{
+			Name: "pvc-2", Namespace: targetNS,
+		}, &core.PersistentVolumeClaim{})).To(gomega.BeFalse())
+		gomega.Expect(objectExists(c, types.NamespacedName{
+			Name: "pvc-3", Namespace: targetNS,
+		}, &core.PersistentVolumeClaim{})).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should issue separate List calls for PVCs in different namespaces", func() {
+		pvcA := &core.PersistentVolumeClaim{
+			ObjectMeta: meta.ObjectMeta{Name: "pvc-a", Namespace: "ns-a", Labels: labels()},
+		}
+		pvcB := &core.PersistentVolumeClaim{
+			ObjectMeta: meta.ObjectMeta{Name: "pvc-b", Namespace: "ns-b", Labels: labels()},
+		}
+
+		scheme := newTestScheme()
+		c := fakeClient.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(pvcA, pvcB).
+			Build()
+		counter := &countingReader{Reader: c}
+		r := &Reconciler{
+			Reconciler: base.Reconciler{
+				Client: c,
+				Log:    controllerLog,
+			},
+			APIReader: counter,
+		}
+
+		r.cleanupOrphanedResources(planName, planNamespace)
+
+		// Two different namespaces = two VM lists + two VMI lists.
+		gomega.Expect(counter.vmListCount).To(gomega.Equal(2))
+		gomega.Expect(counter.vmiListCount).To(gomega.Equal(2))
 	})
 })


### PR DESCRIPTION
### Problem

Deleting a storage-migration Plan triggers `cleanupOrphanedResources` which finds PVCs/DVs by plan labels and deletes them. The only protection was checking `ownerReferences` — but there's a race window between mounting a PVC into a VM/VMI and the `SetOwnerReferences` phase stamping the VM as owner. If the Plan is deleted in that window, the target PVC is destroyed.

### Solution

Before deleting any PVC or DataVolume, query the API server for all VMs and VMIs in the same namespace and build a set of referenced volume names. Skip deletion of any resource whose name appears in that set.

Ref: https://redhat.atlassian.net/browse/MTV-6183
Resolves: MTV-6183

```mermaid
flowchart TD
    A[Plan deleted] --> B[Cleanup orphaned resources]
    B --> C[For each labeled PVC/DataVolume]
    C --> D{Owned by a VM?}
    D -->|yes| E[PRESERVE - already transferred]
    D -->|no| F{Referenced in any VM or VMI spec.volumes?}
    F -->|yes| G[PRESERVE - in-use, ownership pending]
    F -->|no| H[DELETE - orphaned]
    F --> I[referencedVolumeNames]
    I --> J[APIReader.List VMs in namespace]
    I --> K[APIReader.List VMIs in namespace]
    J --> L[Collect PVC/DV names from spec.template.spec.volumes]
    K --> M[Collect PVC/DV names from spec.volumes]
    L --> N[Combined reference set per namespace]
    M --> N
    I -->|error| O[PRESERVE ALL - fail-safe]
```
