### PR TITLE
MTV-6176 | Require target credentials for EC2 providers

### DIFF
--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/provider/container"
 	vsphereCollector "github.com/kubev2v/forklift/pkg/controller/provider/container/vsphere"
 	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	providervalidation "github.com/kubev2v/forklift/pkg/controller/provider/validation"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/kubev2v/forklift/pkg/lib/inventory/model"
@@ -123,6 +124,7 @@ func (r *Reconciler) validate(provider *api.Provider) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	providervalidation.Build(provider).Validate(provider, secret, r.Client)
 	err = r.validateVSpherePrivileges(provider)
 	if err != nil {
 		return liberr.Wrap(err)

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -124,30 +124,11 @@ func (r *Reconciler) validate(provider *api.Provider) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	providervalidation.Build(provider).Validate(provider, secret, r.Client)
-	err = r.validateVSpherePrivileges(provider)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
 	err = r.inventoryCreated(provider)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-
-	// Validate SSH readiness for vSphere providers when SSH method is enabled
-	err = r.validateSSHReadiness(provider, secret)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
-
-	// Validate SMB CSI driver for HyperV providers
-	err = r.validateSMBCSI(provider)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
-
-	// Validate Hyper-V settings (managementType)
-	err = r.validateHyperVSettings(provider)
+	err = providervalidation.Build(r, r.Client).Validate(provider, secret)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -516,7 +497,7 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 }
 
 // Validate vSphere service account privileges.
-func (r *Reconciler) validateVSpherePrivileges(provider *api.Provider) error {
+func (r *Reconciler) ValidateVSpherePrivileges(provider *api.Provider) error {
 	if provider.Type() != api.VSphere {
 		return nil
 	}
@@ -1060,7 +1041,7 @@ func (r *Reconciler) loadHostIPs(provider *api.Provider) map[string]string {
 }
 
 // validateSSHReadiness validates SSH readiness for vSphere providers when SSH method is enabled
-func (r *Reconciler) validateSSHReadiness(provider *api.Provider, secret *core.Secret) error {
+func (r *Reconciler) ValidateSSHReadiness(provider *api.Provider, secret *core.Secret) error {
 	// Only validate SSH for vSphere providers
 	if provider.Type() != api.VSphere {
 		r.Log.V(3).Info("SSH validation: skipping non-vSphere provider",
@@ -1346,7 +1327,7 @@ func isValidSMBPath(smbPath string) bool {
 
 // validateSMBCSI validates that the SMB CSI driver is installed for HyperV providers.
 // HyperV migrations require the SMB CSI driver (smb.csi.k8s.io) to mount SMB shares.
-func (r *Reconciler) validateSMBCSI(provider *api.Provider) error {
+func (r *Reconciler) ValidateSMBCSI(provider *api.Provider) error {
 	if provider.Type() != api.HyperV {
 		return nil
 	}
@@ -1375,7 +1356,7 @@ func (r *Reconciler) validateSMBCSI(provider *api.Provider) error {
 	return nil
 }
 
-func (r *Reconciler) validateHyperVSettings(provider *api.Provider) error {
+func (r *Reconciler) ValidateHyperVSettings(provider *api.Provider) error {
 	if provider.Type() != api.HyperV {
 		return nil
 	}

--- a/pkg/controller/provider/validation/doc.go
+++ b/pkg/controller/provider/validation/doc.go
@@ -2,24 +2,57 @@ package validation
 
 import (
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	ec2validation "github.com/kubev2v/forklift/pkg/provider/ec2/controller/validation"
 	core "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ProviderValidator interface {
-	Validate(provider *api.Provider, secret *core.Secret, client client.Client)
+// Runner is implemented by the provider reconciler so provider-specific
+// validation methods can be invoked from this package without an import cycle.
+type Runner interface {
+	ValidateVSpherePrivileges(provider *api.Provider) error
+	ValidateSSHReadiness(provider *api.Provider, secret *core.Secret) error
+	ValidateSMBCSI(provider *api.Provider) error
+	ValidateHyperVSettings(provider *api.Provider) error
 }
 
-type NoopValidator struct{}
+// ProviderValidator runs provider-type-specific validation.
+type ProviderValidator struct {
+	runner Runner
+	client client.Client
+}
 
-func (v *NoopValidator) Validate(_ *api.Provider, _ *core.Secret, _ client.Client) {}
+func Build(runner Runner, cl client.Client) *ProviderValidator {
+	return &ProviderValidator{runner: runner, client: cl}
+}
 
-func Build(provider *api.Provider) ProviderValidator {
+func (v *ProviderValidator) Validate(provider *api.Provider, secret *core.Secret) error {
 	switch provider.Type() {
 	case api.EC2:
-		return &ec2validation.Validator{}
+		(&ec2validation.Validator{}).Validate(provider, secret, v.client)
+		return nil
+	case api.VSphere:
+		err := v.runner.ValidateVSpherePrivileges(provider)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+		err = v.runner.ValidateSSHReadiness(provider, secret)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+		return nil
+	case api.HyperV:
+		err := v.runner.ValidateSMBCSI(provider)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+		err = v.runner.ValidateHyperVSettings(provider)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+		return nil
 	default:
-		return &NoopValidator{}
+		return nil
 	}
 }

--- a/pkg/controller/provider/validation/doc.go
+++ b/pkg/controller/provider/validation/doc.go
@@ -1,0 +1,25 @@
+package validation
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	ec2validation "github.com/kubev2v/forklift/pkg/provider/ec2/controller/validation"
+	core "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ProviderValidator interface {
+	Validate(provider *api.Provider, secret *core.Secret, client client.Client)
+}
+
+type NoopValidator struct{}
+
+func (v *NoopValidator) Validate(_ *api.Provider, _ *core.Secret, _ client.Client) {}
+
+func Build(provider *api.Provider) ProviderValidator {
+	switch provider.Type() {
+	case api.EC2:
+		return &ec2validation.Validator{}
+	default:
+		return &NoopValidator{}
+	}
+}

--- a/pkg/controller/provider/validation_hyperv_test.go
+++ b/pkg/controller/provider/validation_hyperv_test.go
@@ -18,7 +18,7 @@ func hypervProvider(settings map[string]string) *api.Provider {
 func TestValidateHyperVSettings_ValidCluster(t *testing.T) {
 	p := hypervProvider(map[string]string{api.ManagementType: api.HyperVCluster})
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if p.Status.HasCondition(SettingsNotValid) {
@@ -29,7 +29,7 @@ func TestValidateHyperVSettings_ValidCluster(t *testing.T) {
 func TestValidateHyperVSettings_ValidStandalone(t *testing.T) {
 	p := hypervProvider(map[string]string{api.ManagementType: api.HyperVStandalone})
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if p.Status.HasCondition(SettingsNotValid) {
@@ -40,7 +40,7 @@ func TestValidateHyperVSettings_ValidStandalone(t *testing.T) {
 func TestValidateHyperVSettings_EmptyDefaultsToValid(t *testing.T) {
 	p := hypervProvider(map[string]string{})
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if p.Status.HasCondition(SettingsNotValid) {
@@ -51,7 +51,7 @@ func TestValidateHyperVSettings_EmptyDefaultsToValid(t *testing.T) {
 func TestValidateHyperVSettings_InvalidType(t *testing.T) {
 	p := hypervProvider(map[string]string{api.ManagementType: "bogus"})
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if !p.Status.HasCondition(SettingsNotValid) {
@@ -69,7 +69,7 @@ func TestValidateHyperVSettings_NonHyperVSkipped(t *testing.T) {
 		Spec:       api.ProviderSpec{Type: &pt, Settings: map[string]string{api.ManagementType: "bogus"}},
 	}
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if p.Status.HasCondition(SettingsNotValid) {

--- a/pkg/provider/ec2/controller/validation/crossaccount.go
+++ b/pkg/provider/ec2/controller/validation/crossaccount.go
@@ -1,0 +1,40 @@
+package validation
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
+	core "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	TargetCredentialsMissing = "TargetCredentialsMissing"
+	ValidationFailed         = "ValidationFailed"
+)
+
+type Validator struct{}
+
+func (v *Validator) Validate(provider *api.Provider, secret *core.Secret, _ client.Client) {
+	if provider.Status.HasBlockerCondition() {
+		return
+	}
+	if secret == nil {
+		return
+	}
+
+	_, hasKeyID := secret.Data["targetAccessKeyId"]
+	_, hasSecret := secret.Data["targetSecretAccessKey"]
+
+	if !hasKeyID || !hasSecret {
+		provider.Status.Phase = ValidationFailed
+		provider.Status.SetCondition(libcnd.Condition{
+			Type:     TargetCredentialsMissing,
+			Status:   libcnd.True,
+			Category: libcnd.Critical,
+			Reason:   "TargetCredentialsRequired",
+			Message:  "The provider secret must include 'targetAccessKeyId' and 'targetSecretAccessKey'. Recreate the provider with --auto-target-credentials or provide them manually.",
+		})
+	} else {
+		provider.Status.DeleteCondition(TargetCredentialsMissing)
+	}
+}


### PR DESCRIPTION
## Summary
- Make `targetAccessKeyId` and `targetSecretAccessKey` required fields in the EC2 provider secret. Without them, the provider fails validation with a Critical condition.
- This prevents cross-account migrations from silently creating EBS volumes in the wrong AWS account, which causes `InvalidVolume.NotFound` and migrations hanging forever.
- Introduces a `ProviderValidator` that delegates provider-specific validations to provider packages. Moves existing vSphere, HyperV, and EC2 validations into the dispatch.

## Design
- **General code** (`pkg/controller/provider/validation.go`): one line — `providervalidation.Build(r, r.Client).Validate(provider, secret)`
- **Dispatch** (`pkg/controller/provider/validation/doc.go`): `ProviderValidator` struct with a `Runner` interface. `Build()` takes the reconciler and k8s client. `Validate()` switches on provider type and calls the appropriate validations.
- **Runner interface**: exposes `ValidateVSpherePrivileges`, `ValidateSSHReadiness`, `ValidateSMBCSI`, `ValidateHyperVSettings` — implemented by the existing `Reconciler`, avoiding import cycles.
- **EC2 validator** (`pkg/provider/ec2/controller/validation/crossaccount.go`): checks two secret fields exist, sets Critical condition if missing.

## What moved into the dispatch
| Provider | Validations |
|----------|------------|
| EC2 | Target credentials check (new) |
| vSphere | `ValidateVSpherePrivileges`, `ValidateSSHReadiness` |
| HyperV | `ValidateSMBCSI`, `ValidateHyperVSettings` |

## Provider secret
Without target credentials (provider fails validation):
```yaml
data:
  accessKeyId: <source-account-key>
  secretAccessKey: <source-account-secret>
  region: us-east-2
```

With target credentials (provider passes validation):
```yaml
data:
  accessKeyId: <source-account-key>
  secretAccessKey: <source-account-secret>
  targetAccessKeyId: <cluster-account-key>
  targetSecretAccessKey: <cluster-account-secret>
  region: us-east-2
```

## Test plan
- [ ] Create EC2 provider without `--auto-target-credentials` → provider NOT Ready with `TargetCredentialsMissing` condition
- [ ] Create EC2 provider with `--auto-target-credentials` → provider Ready
- [ ] Verify vSphere provider validations still work (privileges, SSH readiness)
- [ ] Verify HyperV provider validations still work (SMB CSI, settings)
- [ ] Run unit tests: `go test ./pkg/controller/provider/...`

Resolves: MTV-6176

🤖 Generated with [Claude Code](https://claude.com/claude-code)