### PR TITLE
MTV-6212 | Scope populator CR cleanup to completing VM in oVirt and OpenStack

### DIFF
--- a/pkg/controller/plan/adapter/openstack/destinationclient.go
+++ b/pkg/controller/plan/adapter/openstack/destinationclient.go
@@ -19,9 +19,9 @@ type DestinationClient struct {
 	*plancontext.Context
 }
 
-// Delete OpenstackVolumePopulator CustomResource list.
+// Delete OpenstackVolumePopulator CustomResource list for a specific VM.
 func (r *DestinationClient) DeletePopulatorDataSource(vm *plan.VMStatus) error {
-	populatorCrList, err := r.getPopulatorCrList()
+	populatorCrList, err := r.getPopulatorCrList(vm.ID)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (r *DestinationClient) DeletePopulatorDataSource(vm *plan.VMStatus) error {
 
 // Set the OpenstackVolumePopulator CustomResource Ownership.
 func (r *DestinationClient) SetPopulatorCrOwnership() (err error) {
-	populatorCrList, err := r.getPopulatorCrList()
+	populatorCrList, err := r.getPopulatorCrList("")
 	if err != nil {
 		return
 	}
@@ -60,14 +60,19 @@ func (r *DestinationClient) SetPopulatorCrOwnership() (err error) {
 }
 
 // Get the OpenstackVolumePopulator CustomResource List.
-func (r *DestinationClient) getPopulatorCrList() (populatorCrList v1beta1.OpenstackVolumePopulatorList, err error) {
+// When vmID is non-empty, results are filtered to that VM only.
+func (r *DestinationClient) getPopulatorCrList(vmID string) (populatorCrList v1beta1.OpenstackVolumePopulatorList, err error) {
 	populatorCrList = v1beta1.OpenstackVolumePopulatorList{}
+	labelSet := map[string]string{"migration": string(r.Plan.Status.Migration.ActiveSnapshot().Migration.UID)}
+	if vmID != "" {
+		labelSet["vmID"] = vmID
+	}
 	err = r.Destination.Client.List(
 		context.TODO(),
 		&populatorCrList,
 		&client.ListOptions{
 			Namespace:     r.Plan.Spec.TargetNamespace,
-			LabelSelector: labels.SelectorFromSet(map[string]string{"migration": string(r.Plan.Status.Migration.ActiveSnapshot().Migration.UID)}),
+			LabelSelector: labels.SelectorFromSet(labelSet),
 		})
 	return
 }

--- a/pkg/controller/plan/adapter/openstack/destionationclient_test.go
+++ b/pkg/controller/plan/adapter/openstack/destionationclient_test.go
@@ -95,6 +95,48 @@ var _ = Describe("openstack destinationclient tests", func() {
 			Expect(patchedOpenstackVolPopCr.GetOwnerReferences()[0].Name).To(Equal("testPVC"))
 		})
 	})
+
+	Describe("DeletePopulatorDataSource (MTV-6212)", func() {
+		It("should only delete populator CRs belonging to the completing VM", func() {
+			vm1PopCr := &v1beta1.OpenstackVolumePopulator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1-image",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "migration1",
+						"vmID":      "vm-1111",
+						"imageID":   "img-aaa",
+					},
+				},
+				Spec: v1beta1.OpenstackVolumePopulatorSpec{ImageID: "img-aaa"},
+			}
+			vm2PopCr := &v1beta1.OpenstackVolumePopulator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm2-image",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "migration1",
+						"vmID":      "vm-2222",
+						"imageID":   "img-bbb",
+					},
+				},
+				Spec: v1beta1.OpenstackVolumePopulatorSpec{ImageID: "img-bbb"},
+			}
+
+			destinationClient = createDestinationClient(vm1PopCr, vm2PopCr)
+
+			vm1Status := &plan.VMStatus{}
+			vm1Status.ID = "vm-1111"
+			err := destinationClient.DeletePopulatorDataSource(vm1Status)
+			Expect(err).ToNot(HaveOccurred())
+
+			list := &v1beta1.OpenstackVolumePopulatorList{}
+			err = destinationClient.Destination.List(context.TODO(), list, &client.ListOptions{Namespace: "test"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(list.Items).To(HaveLen(1))
+			Expect(list.Items[0].Name).To(Equal("vm2-image"))
+		})
+	})
 })
 
 func createDestinationClient(objs ...runtime.Object) *DestinationClient {

--- a/pkg/controller/plan/adapter/ovirt/destinationclient.go
+++ b/pkg/controller/plan/adapter/ovirt/destinationclient.go
@@ -19,9 +19,9 @@ type DestinationClient struct {
 	*plancontext.Context
 }
 
-// Delete OvirtVolumePopulator CustomResource list.
+// Delete OvirtVolumePopulator CustomResource list for a specific VM.
 func (r *DestinationClient) DeletePopulatorDataSource(vm *plan.VMStatus) error {
-	populatorCrList, err := r.getPopulatorCrList()
+	populatorCrList, err := r.getPopulatorCrList(vm.ID)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -36,7 +36,7 @@ func (r *DestinationClient) DeletePopulatorDataSource(vm *plan.VMStatus) error {
 
 // Set the OvirtVolumePopulator CustomResource Ownership.
 func (r *DestinationClient) SetPopulatorCrOwnership() (err error) {
-	populatorCrList, err := r.getPopulatorCrList()
+	populatorCrList, err := r.getPopulatorCrList("")
 	if err != nil {
 		return
 	}
@@ -62,14 +62,19 @@ func (r *DestinationClient) SetPopulatorCrOwnership() (err error) {
 }
 
 // Get the OvirtVolumePopulator CustomResource List.
-func (r *DestinationClient) getPopulatorCrList() (populatorCrList v1beta1.OvirtVolumePopulatorList, err error) {
+// When vmID is non-empty, results are filtered to that VM only.
+func (r *DestinationClient) getPopulatorCrList(vmID string) (populatorCrList v1beta1.OvirtVolumePopulatorList, err error) {
 	populatorCrList = v1beta1.OvirtVolumePopulatorList{}
+	labelSet := map[string]string{"migration": string(r.Plan.Status.Migration.ActiveSnapshot().Migration.UID)}
+	if vmID != "" {
+		labelSet["vmID"] = vmID
+	}
 	err = r.Destination.Client.List(
 		context.TODO(),
 		&populatorCrList,
 		&client.ListOptions{
 			Namespace:     r.Plan.Spec.TargetNamespace,
-			LabelSelector: labels.SelectorFromSet(map[string]string{"migration": string(r.Plan.Status.Migration.ActiveSnapshot().Migration.UID)}),
+			LabelSelector: labels.SelectorFromSet(labelSet),
 		})
 	return
 }

--- a/pkg/controller/plan/adapter/ovirt/destinationclient_test.go
+++ b/pkg/controller/plan/adapter/ovirt/destinationclient_test.go
@@ -94,6 +94,50 @@ var _ = Describe("ovirt destinationclient tests", func() {
 			Expect(patchedOvirtVolPopCr.GetOwnerReferences()[0].Name).To(Equal("testPVC"))
 		})
 	})
+
+	Describe("DeletePopulatorDataSource (MTV-6212)", func() {
+		It("should only delete populator CRs belonging to the completing VM", func() {
+			vm1PopCr := &v1beta1.OvirtVolumePopulator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1-disk",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "migration1",
+						"vmID":      "vm-1111",
+						"diskID":    "disk-aaa",
+					},
+				},
+				Spec: v1beta1.OvirtVolumePopulatorSpec{DiskID: "disk-aaa"},
+			}
+			vm2PopCr := &v1beta1.OvirtVolumePopulator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm2-disk",
+					Namespace: "test",
+					Labels: map[string]string{
+						"migration": "migration1",
+						"vmID":      "vm-2222",
+						"diskID":    "disk-bbb",
+					},
+				},
+				Spec: v1beta1.OvirtVolumePopulatorSpec{DiskID: "disk-bbb"},
+			}
+
+			destinationClient = createDestinationClient(vm1PopCr, vm2PopCr)
+
+			// Delete populator CRs for vm-1111 only.
+			vm1Status := &plan.VMStatus{}
+			vm1Status.ID = "vm-1111"
+			err := destinationClient.DeletePopulatorDataSource(vm1Status)
+			Expect(err).ToNot(HaveOccurred())
+
+			// vm1's CR should be gone.
+			list := &v1beta1.OvirtVolumePopulatorList{}
+			err = destinationClient.Destination.List(context.TODO(), list, &client.ListOptions{Namespace: "test"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(list.Items).To(HaveLen(1))
+			Expect(list.Items[0].Name).To(Equal("vm2-disk"))
+		})
+	})
 })
 
 func createDestinationClient(objs ...runtime.Object) *DestinationClient {


### PR DESCRIPTION
getPopulatorCrList() filtered only by migration UID, so when one VM completed its cleanup deleted populator CRs for ALL VMs in the plan. Remaining VMs failed with "OvirtVolumePopulator not found".

Add vmID to the label selector when called from DeletePopulatorDataSource(), matching the approach already used by the vSphere adapter. SetPopulatorCrOwnership() still lists all CRs (empty vmID) as intended.

Resolves: MTV-6212