### PR TITLE
MTV-6221 | EC2: add powerState, workload/snapshot endpoints, rename UID

### DIFF
--- a/pkg/provider/README.md
+++ b/pkg/provider/README.md
@@ -18,3 +18,22 @@ To add a provider, use an existing one (for example, `ec2`) as a reference and c
 6. **Register the host handler** in `pkg/controller/host/handler/doc.go` (or a no-op handler if the provider has no host concept).
 
 After wiring these points, implement the new provider under `pkg/provider/<name>` following the common layout.
+
+## Field Naming Convention
+
+Inventory API responses contain two categories of fields:
+
+**Provider-native fields** -- Embed or expose the source platform's data
+structures using the provider's original field names. This preserves maximum
+information and lets users familiar with the source platform find fields by the
+names they know. When it makes sense, embed the full provider struct (e.g. EC2
+embeds `ec2types.Instance`).
+
+**MTV metadata fields** -- Fields added by Forklift that do not exist in the
+provider API. These always use camelCase:
+- Common base: `id`, `name`, `revision`, `selfLink`, `path`
+- VM-specific: `powerState` (normalized On/Off/Unknown), `concerns`
+- Resource discrimination: `provider`, `kind`, `networkType`
+
+Do not rename provider-native fields to MTV conventions. Instead, add
+MTV-specific fields alongside the provider data.

--- a/pkg/provider/ec2/inventory/client/client.go
+++ b/pkg/provider/ec2/inventory/client/client.go
@@ -165,6 +165,28 @@ func (c *Client) DescribeVolumes(ctx context.Context) ([]ec2types.Volume, error)
 	return volumes, nil
 }
 
+// DescribeSnapshots fetches all owned EBS snapshots in the configured region.
+// Filters to only return snapshots owned by the caller (not public/shared).
+// Used by inventory collector to discover available snapshots.
+func (c *Client) DescribeSnapshots(ctx context.Context) ([]ec2types.Snapshot, error) {
+	var snapshots []ec2types.Snapshot
+
+	paginator := ec2.NewDescribeSnapshotsPaginator(c.ec2Client, &ec2.DescribeSnapshotsInput{
+		OwnerIds: []string{"self"},
+	})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, liberr.Wrap(err, "failed to describe snapshots")
+		}
+
+		snapshots = append(snapshots, output.Snapshots...)
+	}
+
+	return snapshots, nil
+}
+
 // DescribeVpcs fetches all VPCs
 // A VPC is a logically isolated virtual network within AWS
 func (c *Client) DescribeVpcs(ctx context.Context) ([]ec2types.Vpc, error) {

--- a/pkg/provider/ec2/inventory/client/ec2api.go
+++ b/pkg/provider/ec2/inventory/client/ec2api.go
@@ -23,6 +23,9 @@ type EC2API interface {
 	// Volume operations
 	DescribeVolumes(ctx context.Context, params *ec2.DescribeVolumesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVolumesOutput, error)
 
+	// Snapshot operations
+	DescribeSnapshots(ctx context.Context, params *ec2.DescribeSnapshotsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error)
+
 	// Network operations
 	DescribeVpcs(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
 	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)

--- a/pkg/provider/ec2/inventory/collector/collector.go
+++ b/pkg/provider/ec2/inventory/collector/collector.go
@@ -166,6 +166,7 @@ func (r *Collector) Collect() error {
 		{"volumes", r.collectVolumes},
 		{"networks", r.collectNetworks},
 		{"storageTypes", r.collectStorageTypes},
+		{"snapshots", r.collectSnapshots},
 	}
 
 	// Execute all collection tasks

--- a/pkg/provider/ec2/inventory/collector/collector_test.go
+++ b/pkg/provider/ec2/inventory/collector/collector_test.go
@@ -97,7 +97,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify: Check DB has the instance
-			m := &model.Instance{Base: model.Base{UID: "i-1234567890abcdef0"}}
+			m := &model.Instance{Base: model.Base{ID: "i-1234567890abcdef0"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.Name).To(Equal("test-vm"))
@@ -139,7 +139,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify initial state
-			m := &model.Instance{Base: model.Base{UID: "i-123"}}
+			m := &model.Instance{Base: model.Base{ID: "i-123"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.State).To(Equal("running"))
@@ -154,7 +154,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify: State should be updated, revision incremented
-			m = &model.Instance{Base: model.Base{UID: "i-123"}}
+			m = &model.Instance{Base: model.Base{ID: "i-123"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.State).To(Equal("stopped"))
@@ -205,7 +205,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify: Name should fallback to instance ID
-			m := &model.Instance{Base: model.Base{UID: "i-noname"}}
+			m := &model.Instance{Base: model.Base{ID: "i-noname"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.Name).To(Equal("i-noname"))
@@ -230,7 +230,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify: Check DB has the volume
-			m := &model.Volume{Base: model.Base{UID: "vol-1234567890abcdef0"}}
+			m := &model.Volume{Base: model.Base{ID: "vol-1234567890abcdef0"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.Name).To(Equal("test-volume"))
@@ -274,7 +274,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get initial revision
-			m := &model.Volume{Base: model.Base{UID: "vol-123"}}
+			m := &model.Volume{Base: model.Base{ID: "vol-123"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.State).To(Equal("available"))
@@ -288,7 +288,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify: State should be updated
-			m = &model.Volume{Base: model.Base{UID: "vol-123"}}
+			m = &model.Volume{Base: model.Base{ID: "vol-123"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.State).To(Equal("in-use"))
@@ -319,7 +319,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify: Check DB has the VPC
-			m := &model.Network{Base: model.Base{UID: "vpc-123"}}
+			m := &model.Network{Base: model.Base{ID: "vpc-123"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.Name).To(Equal("test-vpc"))
@@ -342,7 +342,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify: Check DB has the subnet
-			m := &model.Network{Base: model.Base{UID: "subnet-123"}}
+			m := &model.Network{Base: model.Base{ID: "subnet-123"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.Name).To(Equal("test-subnet"))
@@ -389,6 +389,57 @@ var _ = Describe("EC2 Collector", func() {
 		})
 	})
 
+	Describe("collectSnapshots", func() {
+		It("should collect snapshots and store in DB", func() {
+			// Setup: Add snapshot to fake API
+			snapshot := testutil.NewSnapshotBuilder("snap-123").
+				WithVolumeID("vol-123").
+				WithState(ec2types.SnapshotStateCompleted).
+				WithTag("Name", "test-snapshot").
+				Build()
+			fakeEC2.AddSnapshot(snapshot)
+
+			// Execute
+			err := collector.collectSnapshots(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify: Check DB has the snapshot
+			m := &model.Snapshot{Base: model.Base{ID: "snap-123"}}
+			err = db.Get(m)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(m.Name).To(Equal("test-snapshot"))
+			Expect(m.State).To(Equal("completed"))
+			Expect(m.VolumeID).To(Equal("vol-123"))
+			Expect(m.Kind).To(Equal("Snapshot"))
+		})
+
+		It("should handle multiple snapshots", func() {
+			snap1 := testutil.NewSnapshotBuilder("snap-111").
+				WithState(ec2types.SnapshotStateCompleted).
+				Build()
+			snap2 := testutil.NewSnapshotBuilder("snap-222").
+				WithState(ec2types.SnapshotStatePending).
+				Build()
+			fakeEC2.AddSnapshot(snap1)
+			fakeEC2.AddSnapshot(snap2)
+
+			err := collector.collectSnapshots(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			var snapshots []model.Snapshot
+			err = db.List(&snapshots, libmodel.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(snapshots).To(HaveLen(2))
+		})
+
+		It("should handle API errors", func() {
+			fakeEC2.Errors[testutil.MethodDescribeSnapshots] = errAPIFailed
+
+			err := collector.collectSnapshots(ctx)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Describe("collectStorageTypes", func() {
 		It("should collect all EBS volume types", func() {
 			// Execute
@@ -421,7 +472,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get revision of gp3 after first collection
-			m := &model.Storage{Base: model.Base{UID: "gp3"}}
+			m := &model.Storage{Base: model.Base{ID: "gp3"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			initialRevision := m.Revision
@@ -432,7 +483,7 @@ var _ = Describe("EC2 Collector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify storage type still exists with valid data
-			m = &model.Storage{Base: model.Base{UID: "gp3"}}
+			m = &model.Storage{Base: model.Base{ID: "gp3"}}
 			err = db.Get(m)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m.VolumeType).To(Equal("gp3"))
@@ -441,16 +492,22 @@ var _ = Describe("EC2 Collector", func() {
 	})
 
 	Describe("Collect", func() {
-		It("should collect all resource types", func() {
+		It("should collect all resource types including snapshots", func() {
 			// Setup: Add resources
 			instance := testutil.NewInstanceBuilder("i-123", "test-vm").Build()
 			volume := testutil.NewVolumeBuilder("vol-123").Build()
 			vpc := testutil.NewVpcBuilder("vpc-123").Build()
 			subnet := testutil.NewSubnetBuilder("subnet-123", "vpc-123").Build()
+			snap := testutil.NewSnapshotBuilder("snap-123").
+				WithVolumeID("vol-123").
+				WithState(ec2types.SnapshotStateCompleted).
+				WithTag("Name", "test-snap").
+				Build()
 			fakeEC2.AddInstance(instance)
 			fakeEC2.AddVolume(volume)
 			fakeEC2.AddVpc(vpc)
 			fakeEC2.AddSubnet(subnet)
+			fakeEC2.AddSnapshot(snap)
 
 			// Execute
 			err := collector.Collect()
@@ -476,6 +533,16 @@ var _ = Describe("EC2 Collector", func() {
 			err = db.List(&storages, libmodel.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(storages).To(HaveLen(len(ebsVolumeTypes)))
+
+			// Verify: Snapshot collected via "snapshots" task
+			var snapshots []model.Snapshot
+			err = db.List(&snapshots, libmodel.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(snapshots).To(HaveLen(1))
+			Expect(snapshots[0].ID).To(Equal("snap-123"))
+			Expect(snapshots[0].Name).To(Equal("test-snap"))
+			Expect(snapshots[0].VolumeID).To(Equal("vol-123"))
+			Expect(snapshots[0].State).To(Equal("completed"))
 		})
 
 		It("should succeed with partial failures", func() {
@@ -501,8 +568,9 @@ var _ = Describe("EC2 Collector", func() {
 			fakeEC2.Errors[testutil.MethodDescribeInstances] = errAPIFailed
 			fakeEC2.Errors[testutil.MethodDescribeVolumes] = errAPIFailed
 			fakeEC2.Errors[testutil.MethodDescribeVpcs] = errAPIFailed
+			fakeEC2.Errors[testutil.MethodDescribeSnapshots] = errAPIFailed
 
-			// Execute - should succeed because storageTypes (1/4) succeeds
+			// Execute - should succeed because storageTypes (1/5) succeeds
 			err := collector.Collect()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -560,6 +628,28 @@ var _ = Describe("EC2 Collector", func() {
 			table.Entry("handles nil value",
 				[]ec2types.Tag{{Key: aws.String("Name"), Value: nil}},
 				""),
+		)
+
+		table.DescribeTable("mapPowerState",
+			func(state *ec2types.InstanceState, expected string) {
+				Expect(mapPowerState(state)).To(Equal(expected))
+			},
+			table.Entry("running maps to On",
+				&ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning}, "On"),
+			table.Entry("pending maps to On",
+				&ec2types.InstanceState{Name: ec2types.InstanceStateNamePending}, "On"),
+			table.Entry("stopped maps to Off",
+				&ec2types.InstanceState{Name: ec2types.InstanceStateNameStopped}, "Off"),
+			table.Entry("stopping maps to Off",
+				&ec2types.InstanceState{Name: ec2types.InstanceStateNameStopping}, "Off"),
+			table.Entry("terminated maps to Off",
+				&ec2types.InstanceState{Name: ec2types.InstanceStateNameTerminated}, "Off"),
+			table.Entry("shutting-down maps to Off",
+				&ec2types.InstanceState{Name: ec2types.InstanceStateNameShuttingDown}, "Off"),
+			table.Entry("nil state maps to Unknown",
+				nil, "Unknown"),
+			table.Entry("unknown state maps to Unknown",
+				&ec2types.InstanceState{Name: "some-other-state"}, "Unknown"),
 		)
 
 		table.DescribeTable("getPlatform",

--- a/pkg/provider/ec2/inventory/collector/instance.go
+++ b/pkg/provider/ec2/inventory/collector/instance.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/provider/ec2/inventory/model"
 )
 
@@ -23,14 +24,14 @@ func (r *Collector) collectInstances(ctx context.Context) error {
 
 		// Set minimal indexed fields
 		if awsInstance.InstanceId != nil {
-			m.UID = *awsInstance.InstanceId
+			m.ID = *awsInstance.InstanceId
 		} else {
 			continue // Skip instances without ID
 		}
 
 		m.Name = getNameFromTags(awsInstance.Tags)
 		if m.Name == "" {
-			m.Name = m.UID // Use instance ID as name if no Name tag
+			m.Name = m.ID // Use instance ID as name if no Name tag
 		}
 
 		m.Kind = "Instance"
@@ -41,6 +42,7 @@ func (r *Collector) collectInstances(ctx context.Context) error {
 		if awsInstance.State != nil {
 			m.State = string(awsInstance.State.Name)
 		}
+		m.PowerState = mapPowerState(awsInstance.State)
 		m.Platform = getPlatform(awsInstance.Platform, awsInstance.PlatformDetails)
 
 		// Store complete AWS instance object
@@ -48,7 +50,7 @@ func (r *Collector) collectInstances(ctx context.Context) error {
 
 		// Check if record exists and has changed
 		existing := &model.Instance{}
-		existing.UID = m.UID
+		existing.ID = m.ID
 		if err := r.db.Get(existing); err == nil {
 			// Record exists - check if it changed
 			if !existing.HasChanged(m) {
@@ -58,7 +60,7 @@ func (r *Collector) collectInstances(ctx context.Context) error {
 			// Changed - update with incremented revision
 			m.Revision = existing.Revision + 1
 			if err := r.db.Update(m); err != nil {
-				r.log.Error(err, "Failed to update instance", "instanceId", m.UID)
+				r.log.Error(err, "Failed to update instance", "instanceId", m.ID)
 				continue
 			}
 			updated++
@@ -66,7 +68,7 @@ func (r *Collector) collectInstances(ctx context.Context) error {
 			// New record - insert
 			m.Revision = 1
 			if err := r.db.Insert(m); err != nil {
-				r.log.Error(err, "Failed to insert instance", "instanceId", m.UID)
+				r.log.Error(err, "Failed to insert instance", "instanceId", m.ID)
 				continue
 			}
 			created++
@@ -85,6 +87,22 @@ func getNameFromTags(tags []ec2types.Tag) string {
 		}
 	}
 	return ""
+}
+
+// mapPowerState maps AWS instance state to normalized MTV power state.
+func mapPowerState(state *ec2types.InstanceState) string {
+	if state == nil {
+		return string(planapi.VMPowerStateUnknown)
+	}
+	switch state.Name {
+	case ec2types.InstanceStateNameRunning, ec2types.InstanceStateNamePending:
+		return string(planapi.VMPowerStateOn)
+	case ec2types.InstanceStateNameStopped, ec2types.InstanceStateNameStopping,
+		ec2types.InstanceStateNameShuttingDown, ec2types.InstanceStateNameTerminated:
+		return string(planapi.VMPowerStateOff)
+	default:
+		return string(planapi.VMPowerStateUnknown)
+	}
 }
 
 // getPlatform determines platform (linux or windows)

--- a/pkg/provider/ec2/inventory/collector/network.go
+++ b/pkg/provider/ec2/inventory/collector/network.go
@@ -22,14 +22,14 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 		m := &model.Network{}
 
 		if awsVpc.VpcId != nil {
-			m.UID = *awsVpc.VpcId
+			m.ID = *awsVpc.VpcId
 		} else {
 			continue
 		}
 
 		m.Name = getNameFromTags(awsVpc.Tags)
 		if m.Name == "" {
-			m.Name = m.UID
+			m.Name = m.ID
 		}
 
 		m.Kind = "Network"
@@ -44,7 +44,7 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 
 		// Check if record exists and has changed
 		existing := &model.Network{}
-		existing.UID = m.UID
+		existing.ID = m.ID
 		if err := r.db.Get(existing); err == nil {
 			// Record exists - check if it changed
 			if !existing.HasChanged(m) {
@@ -54,7 +54,7 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 			// Changed - update with incremented revision
 			m.Revision = existing.Revision + 1
 			if err := r.db.Update(m); err != nil {
-				r.log.Error(err, "Failed to update VPC", "vpcId", m.UID)
+				r.log.Error(err, "Failed to update VPC", "vpcId", m.ID)
 				continue
 			}
 			totalUpdated++
@@ -62,7 +62,7 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 			// New record - insert
 			m.Revision = 1
 			if err := r.db.Insert(m); err != nil {
-				r.log.Error(err, "Failed to insert VPC", "vpcId", m.UID)
+				r.log.Error(err, "Failed to insert VPC", "vpcId", m.ID)
 				continue
 			}
 			totalCreated++
@@ -81,14 +81,14 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 		m := &model.Network{}
 
 		if awsSubnet.SubnetId != nil {
-			m.UID = *awsSubnet.SubnetId
+			m.ID = *awsSubnet.SubnetId
 		} else {
 			continue
 		}
 
 		m.Name = getNameFromTags(awsSubnet.Tags)
 		if m.Name == "" {
-			m.Name = m.UID
+			m.Name = m.ID
 		}
 
 		m.Kind = "Network"
@@ -103,7 +103,7 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 
 		// Check if record exists and has changed
 		existing := &model.Network{}
-		existing.UID = m.UID
+		existing.ID = m.ID
 		if err := r.db.Get(existing); err == nil {
 			// Record exists - check if it changed
 			if !existing.HasChanged(m) {
@@ -113,7 +113,7 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 			// Changed - update with incremented revision
 			m.Revision = existing.Revision + 1
 			if err := r.db.Update(m); err != nil {
-				r.log.Error(err, "Failed to update Subnet", "subnetId", m.UID)
+				r.log.Error(err, "Failed to update Subnet", "subnetId", m.ID)
 				continue
 			}
 			totalUpdated++
@@ -121,7 +121,7 @@ func (r *Collector) collectNetworks(ctx context.Context) error {
 			// New record - insert
 			m.Revision = 1
 			if err := r.db.Insert(m); err != nil {
-				r.log.Error(err, "Failed to insert Subnet", "subnetId", m.UID)
+				r.log.Error(err, "Failed to insert Subnet", "subnetId", m.ID)
 				continue
 			}
 			totalCreated++

--- a/pkg/provider/ec2/inventory/collector/snapshot.go
+++ b/pkg/provider/ec2/inventory/collector/snapshot.go
@@ -1,0 +1,110 @@
+package collector
+
+import (
+	"context"
+	"errors"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+	"github.com/kubev2v/forklift/pkg/provider/ec2/inventory/model"
+)
+
+// collectSnapshots collects EBS snapshots
+func (r *Collector) collectSnapshots(ctx context.Context) error {
+	snapshots, err := r.client.DescribeSnapshots(ctx)
+	if err != nil {
+		return err
+	}
+
+	r.log.V(1).Info("Collected snapshots", "count", len(snapshots))
+
+	providerUID := string(r.provider.UID)
+	var created, updated, unchanged int
+	for _, awsSnapshot := range snapshots {
+		m := snapshotFromAWS(awsSnapshot, providerUID)
+		if m == nil {
+			continue
+		}
+
+		action, err := r.upsertSnapshot(m)
+		if err != nil {
+			r.log.Error(err, "Failed to persist snapshot", "snapshotId", m.ID)
+			continue
+		}
+		switch action {
+		case actionCreated:
+			created++
+		case actionUpdated:
+			updated++
+		case actionUnchanged:
+			unchanged++
+		}
+	}
+
+	r.log.V(1).Info("Snapshots processed", "created", created, "updated", updated, "unchanged", unchanged)
+	return nil
+}
+
+// snapshotFromAWS maps an AWS Snapshot to the inventory model.
+// Returns nil when the snapshot has no ID and should be skipped.
+func snapshotFromAWS(s ec2types.Snapshot, providerUID string) *model.Snapshot {
+	if s.SnapshotId == nil {
+		return nil
+	}
+
+	m := &model.Snapshot{}
+	m.ID = *s.SnapshotId
+
+	m.Name = getNameFromTags(s.Tags)
+	if m.Name == "" {
+		m.Name = m.ID
+	}
+
+	m.Kind = "Snapshot"
+	m.Provider = providerUID
+
+	m.State = string(s.State)
+	if s.VolumeId != nil {
+		m.VolumeID = *s.VolumeId
+	}
+
+	m.Object = s
+	return m
+}
+
+// upsertAction describes what upsertSnapshot did.
+type upsertAction int
+
+const (
+	actionCreated upsertAction = iota
+	actionUpdated
+	actionUnchanged
+)
+
+// upsertSnapshot inserts or updates a snapshot in the database.
+// It distinguishes not-found (new record) from other DB errors.
+func (r *Collector) upsertSnapshot(m *model.Snapshot) (upsertAction, error) {
+	existing := &model.Snapshot{}
+	existing.ID = m.ID
+
+	err := r.db.Get(existing)
+	switch {
+	case err == nil:
+		if !existing.HasChanged(m) {
+			return actionUnchanged, nil
+		}
+		m.Revision = existing.Revision + 1
+		if err := r.db.Update(m); err != nil {
+			return 0, err
+		}
+		return actionUpdated, nil
+	case errors.Is(err, libmodel.NotFound):
+		m.Revision = 1
+		if err := r.db.Insert(m); err != nil {
+			return 0, err
+		}
+		return actionCreated, nil
+	default:
+		return 0, err
+	}
+}

--- a/pkg/provider/ec2/inventory/collector/storage.go
+++ b/pkg/provider/ec2/inventory/collector/storage.go
@@ -32,8 +32,8 @@ func (r *Collector) collectStorageTypes(ctx context.Context) error {
 	for _, volType := range ebsVolumeTypes {
 		m := &model.Storage{}
 
-		// UID is just the volume type since each provider has its own database
-		m.UID = volType.Type
+		// ID is just the volume type since each provider has its own database
+		m.ID = volType.Type
 		m.Name = volType.Type // Use type code as name for storage map lookups
 		m.Kind = "Storage"
 		m.Provider = string(r.provider.UID)
@@ -49,7 +49,7 @@ func (r *Collector) collectStorageTypes(ctx context.Context) error {
 
 		// Check if record exists and has changed
 		existing := &model.Storage{}
-		existing.UID = m.UID
+		existing.ID = m.ID
 		if err := r.db.Get(existing); err == nil {
 			// Record exists - check if it changed
 			if !existing.HasChanged(m) {

--- a/pkg/provider/ec2/inventory/collector/volume.go
+++ b/pkg/provider/ec2/inventory/collector/volume.go
@@ -21,14 +21,14 @@ func (r *Collector) collectVolumes(ctx context.Context) error {
 
 		// Set minimal indexed fields
 		if awsVolume.VolumeId != nil {
-			m.UID = *awsVolume.VolumeId
+			m.ID = *awsVolume.VolumeId
 		} else {
 			continue // Skip volumes without ID
 		}
 
 		m.Name = getNameFromTags(awsVolume.Tags)
 		if m.Name == "" {
-			m.Name = m.UID // Use volume ID as name if no Name tag
+			m.Name = m.ID // Use volume ID as name if no Name tag
 		}
 
 		m.Kind = "Volume"
@@ -46,7 +46,7 @@ func (r *Collector) collectVolumes(ctx context.Context) error {
 
 		// Check if record exists and has changed
 		existing := &model.Volume{}
-		existing.UID = m.UID
+		existing.ID = m.ID
 		if err := r.db.Get(existing); err == nil {
 			// Record exists - check if it changed
 			if !existing.HasChanged(m) {
@@ -56,7 +56,7 @@ func (r *Collector) collectVolumes(ctx context.Context) error {
 			// Changed - update with incremented revision
 			m.Revision = existing.Revision + 1
 			if err := r.db.Update(m); err != nil {
-				r.log.Error(err, "Failed to update volume", "volumeId", m.UID)
+				r.log.Error(err, "Failed to update volume", "volumeId", m.ID)
 				continue
 			}
 			updated++
@@ -64,7 +64,7 @@ func (r *Collector) collectVolumes(ctx context.Context) error {
 			// New record - insert
 			m.Revision = 1
 			if err := r.db.Insert(m); err != nil {
-				r.log.Error(err, "Failed to insert volume", "volumeId", m.UID)
+				r.log.Error(err, "Failed to insert volume", "volumeId", m.ID)
 				continue
 			}
 			created++

--- a/pkg/provider/ec2/inventory/model/model.go
+++ b/pkg/provider/ec2/inventory/model/model.go
@@ -21,7 +21,7 @@ const (
 // Base model with indexed fields for efficient queries.
 // Each resource type adds its own typed Object field.
 type Base struct {
-	UID      string `sql:"pk"`                             // Primary key - AWS resource ID
+	ID       string `sql:"pk"`                             // Primary key - AWS resource ID
 	Name     string `sql:"d0,index(name)"`                 // Resource name
 	Kind     string `sql:"d0,index(kind)"`                 // Resource type (Instance, Volume, Network, Storage)
 	Provider string `sql:"d0,index(provider)"`             // Provider UID
@@ -34,12 +34,12 @@ type Base struct {
 
 // Pk returns the primary key.
 func (m *Base) Pk() string {
-	return m.UID
+	return m.ID
 }
 
 // String representation.
 func (m *Base) String() string {
-	return m.UID
+	return m.ID
 }
 
 //
@@ -52,6 +52,7 @@ type Instance struct {
 	Base
 	InstanceType string            `sql:"d0,index(instanceType)"` // t2.micro, m5.large, etc.
 	State        string            `sql:"d0,index(state)"`        // running, stopped, terminated, etc.
+	PowerState   string            `sql:"d0,index(powerState)"`   // Normalized: On, Off, Unknown
 	Platform     string            `sql:"d0,index(platform)"`     // Linux, Windows, etc.
 	Object       ec2types.Instance `sql:"d0"`                     // Complete AWS Instance object
 }
@@ -73,12 +74,13 @@ func (m *Instance) Labels() libmodel.Labels {
 // GetDetails returns the instance details for API responses.
 func (m *Instance) GetDetails() (*InstanceDetails, error) {
 	details := &InstanceDetails{
-		Instance: m.Object,
-		ID:       m.UID,
-		Name:     m.Name,
-		Kind:     m.Kind,
-		Provider: m.Provider,
-		Revision: m.Revision,
+		Instance:   m.Object,
+		ID:         m.ID,
+		Name:       m.Name,
+		Kind:       m.Kind,
+		Provider:   m.Provider,
+		Revision:   m.Revision,
+		PowerState: m.PowerState,
 	}
 
 	// Convert AWS BlockDeviceMappings to our simplified type
@@ -111,7 +113,7 @@ func (m *Instance) HasChanged(new *Instance) bool {
 	if m.Name != new.Name || m.Kind != new.Kind {
 		return true
 	}
-	if m.InstanceType != new.InstanceType || m.State != new.State || m.Platform != new.Platform {
+	if m.InstanceType != new.InstanceType || m.State != new.State || m.PowerState != new.PowerState || m.Platform != new.Platform {
 		return true
 	}
 	return !reflect.DeepEqual(m.Object, new.Object)
@@ -126,6 +128,7 @@ type InstanceDetails struct {
 	Kind                string                       `json:"kind"`
 	Provider            string                       `json:"provider"`
 	Revision            int64                        `json:"revision"`
+	PowerState          string                       `json:"powerState"`
 }
 
 // InstanceBlockDeviceMapping represents a simplified block device mapping.
@@ -174,7 +177,7 @@ func (m *Volume) Labels() libmodel.Labels {
 func (m *Volume) GetDetails() (*VolumeDetails, error) {
 	return &VolumeDetails{
 		Volume:   m.Object,
-		ID:       m.UID,
+		ID:       m.ID,
 		Name:     m.Name,
 		Kind:     m.Kind,
 		Provider: m.Provider,
@@ -232,12 +235,13 @@ func (m *Network) Labels() libmodel.Labels {
 // GetDetails returns the network details for API responses.
 func (m *Network) GetDetails() (*NetworkDetails, error) {
 	return &NetworkDetails{
-		Subnet:   m.Object,
-		ID:       m.UID,
-		Name:     m.Name,
-		Kind:     m.Kind,
-		Provider: m.Provider,
-		Revision: m.Revision,
+		Subnet:      m.Object,
+		ID:          m.ID,
+		Name:        m.Name,
+		Kind:        m.Kind,
+		Provider:    m.Provider,
+		Revision:    m.Revision,
+		NetworkType: m.NetworkType,
 	}, nil
 }
 
@@ -254,11 +258,12 @@ func (m *Network) HasChanged(new *Network) bool {
 
 type NetworkDetails struct {
 	ec2types.Subnet
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Kind     string `json:"kind"`
-	Provider string `json:"provider"`
-	Revision int64  `json:"revision"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Kind        string `json:"kind"`
+	Provider    string `json:"provider"`
+	Revision    int64  `json:"revision"`
+	NetworkType string `json:"networkType"`
 }
 
 // Storage represents EBS volume types (analogous to storage classes).
@@ -286,7 +291,7 @@ func (m *Storage) Labels() libmodel.Labels {
 // GetDetails returns the storage details for API responses.
 func (m *Storage) GetDetails() (*StorageDetails, error) {
 	return &StorageDetails{
-		ID:            m.UID,
+		ID:            m.ID,
 		Name:          m.Name,
 		Kind:          m.Kind,
 		Provider:      m.Provider,
@@ -321,6 +326,52 @@ type StorageDetails struct {
 	MaxThroughput int32  `json:"maxThroughput"`
 }
 
+// Snapshot represents an EBS snapshot.
+// Extends Base with snapshot-specific indexed fields and typed AWS object.
+type Snapshot struct {
+	Base
+	VolumeID string            `sql:"d0,index(volumeID)"` // Source volume ID
+	State    string            `sql:"d0,index(state)"`    // pending, completed, error
+	Object   ec2types.Snapshot `sql:"d0"`                 // Complete AWS Snapshot object
+}
+
+// Labels returns AWS tags as labels for label-based filtering.
+func (m *Snapshot) Labels() libmodel.Labels {
+	if len(m.Object.Tags) == 0 {
+		return nil
+	}
+	labels := make(libmodel.Labels, len(m.Object.Tags))
+	for _, tag := range m.Object.Tags {
+		if tag.Key != nil && tag.Value != nil {
+			labels[*tag.Key] = *tag.Value
+		}
+	}
+	return labels
+}
+
+// GetDetails returns the snapshot details for API responses.
+func (m *Snapshot) GetDetails() (*SnapshotDetails, error) {
+	return &SnapshotDetails{
+		Snapshot: m.Object,
+		ID:       m.ID,
+		Name:     m.Name,
+		Kind:     m.Kind,
+		Provider: m.Provider,
+		Revision: m.Revision,
+	}, nil
+}
+
+// HasChanged checks if the snapshot has changed.
+func (m *Snapshot) HasChanged(new *Snapshot) bool {
+	if m.Name != new.Name || m.Kind != new.Kind {
+		return true
+	}
+	if m.VolumeID != new.VolumeID || m.State != new.State {
+		return true
+	}
+	return !reflect.DeepEqual(m.Object, new.Object)
+}
+
 type SnapshotDetails struct {
 	ec2types.Snapshot
 	ID       string `json:"id"`
@@ -342,5 +393,6 @@ func All() []interface{} {
 		&Volume{},
 		&Network{},
 		&Storage{},
+		&Snapshot{},
 	}
 }

--- a/pkg/provider/ec2/inventory/web/doc.go
+++ b/pkg/provider/ec2/inventory/web/doc.go
@@ -40,5 +40,15 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 				base.Handler{Container: container},
 			},
 		},
+		&WorkloadHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
+		&SnapshotHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
 	}
 }

--- a/pkg/provider/ec2/inventory/web/network.go
+++ b/pkg/provider/ec2/inventory/web/network.go
@@ -53,7 +53,7 @@ func (h *NetworkHandler) List(ctx *gin.Context) {
 	var result []interface{}
 	for _, network := range list {
 		r := &Network{}
-		r.ID = network.UID
+		r.ID = network.ID
 		r.Name = network.Name
 		r.Revision = network.Revision
 		r.Link(h.Provider)
@@ -77,7 +77,7 @@ func (h *NetworkHandler) Get(ctx *gin.Context) {
 	}
 
 	network := &model.Network{}
-	network.UID = ctx.Param("id")
+	network.ID = ctx.Param("id")
 
 	db := h.Collector.DB()
 	err = db.Get(network)
@@ -87,7 +87,7 @@ func (h *NetworkHandler) Get(ctx *gin.Context) {
 	}
 
 	r := &Network{}
-	r.ID = network.UID
+	r.ID = network.ID
 	r.Name = network.Name
 	r.Revision = network.Revision
 	r.Link(h.Provider)
@@ -114,7 +114,7 @@ func (h *NetworkHandler) watch(ctx *gin.Context) {
 		func(in libmodel.Model) (r interface{}) {
 			m := in.(*model.Network)
 			network := &Network{}
-			network.ID = m.UID
+			network.ID = m.ID
 			network.Name = m.Name
 			network.Revision = m.Revision
 			network.Link(h.Provider)

--- a/pkg/provider/ec2/inventory/web/resource.go
+++ b/pkg/provider/ec2/inventory/web/resource.go
@@ -45,7 +45,8 @@ func (r *Provider) Link() {
 // VM Resource.
 type VM struct {
 	Resource
-	Object *model.InstanceDetails `json:"object,omitempty"`
+	PowerState string                 `json:"powerState"`
+	Object     *model.InstanceDetails `json:"object,omitempty"`
 }
 
 // Build self link (URI).
@@ -90,6 +91,22 @@ func (r *Storage) Link(p *api.Provider) {
 		})
 }
 
+// Snapshot Resource.
+type Snapshot struct {
+	Resource
+	Object *model.SnapshotDetails `json:"object,omitempty"`
+}
+
+// Build self link (URI).
+func (r *Snapshot) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		SnapshotRoot,
+		base.Params{
+			base.ProviderParam: string(p.UID),
+			"id":               r.ID,
+		})
+}
+
 // Volume Resource.
 type Volume struct {
 	Resource
@@ -109,13 +126,14 @@ func (r *Volume) Link(p *api.Provider) {
 // Workload Resource (same as VM for EC2).
 type Workload struct {
 	Resource
-	Object *model.InstanceDetails `json:"object,omitempty"`
+	PowerState string                 `json:"powerState"`
+	Object     *model.InstanceDetails `json:"object,omitempty"`
 }
 
 // Build self link (URI).
 func (r *Workload) Link(p *api.Provider) {
 	r.SelfLink = base.Link(
-		VMRoot,
+		WorkloadRoot,
 		base.Params{
 			base.ProviderParam: string(p.UID),
 			VMParam:            r.ID,

--- a/pkg/provider/ec2/inventory/web/snapshot.go
+++ b/pkg/provider/ec2/inventory/web/snapshot.go
@@ -1,0 +1,127 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
+	"github.com/kubev2v/forklift/pkg/provider/ec2/inventory/model"
+)
+
+// Routes
+const (
+	SnapshotsRoot = ProviderRoot + "/snapshots"
+	SnapshotRoot  = SnapshotsRoot + "/:id"
+)
+
+// Snapshot handler
+type SnapshotHandler struct {
+	Handler
+}
+
+// Add routes
+func (h *SnapshotHandler) AddRoutes(e *gin.Engine) {
+	e.GET(SnapshotsRoot, h.List)
+	e.GET(SnapshotRoot, h.Get)
+}
+
+// List snapshots
+func (h *SnapshotHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	if h.WatchRequest {
+		h.watch(ctx)
+		return
+	}
+
+	listOptions := h.ListOptionsWithLabels(ctx)
+
+	db := h.Collector.DB()
+	var list []model.Snapshot
+	err = db.List(&list, listOptions)
+	if err != nil {
+		log.Error(err, "Failed to list snapshots")
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+
+	var result []interface{}
+	for _, snapshot := range list {
+		r := &Snapshot{}
+		r.ID = snapshot.ID
+		r.Name = snapshot.Name
+		r.Revision = snapshot.Revision
+		r.Link(h.Provider)
+		if details, err := snapshot.GetDetails(); err == nil {
+			r.Object = details
+		}
+		result = append(result, r)
+	}
+
+	ctx.JSON(http.StatusOK, result)
+}
+
+// Get snapshot
+func (h *SnapshotHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+
+	snapshot := &model.Snapshot{}
+	snapshot.ID = ctx.Param("id")
+
+	db := h.Collector.DB()
+	err = db.Get(snapshot)
+	if err != nil {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+
+	r := &Snapshot{}
+	r.ID = snapshot.ID
+	r.Name = snapshot.Name
+	r.Revision = snapshot.Revision
+	r.Link(h.Provider)
+	details, err := snapshot.GetDetails()
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r.Object = details
+
+	ctx.JSON(http.StatusOK, r)
+}
+
+// Watch snapshots via WebSocket.
+func (h *SnapshotHandler) watch(ctx *gin.Context) {
+	db := h.Collector.DB()
+	err := h.Watch(
+		ctx,
+		db,
+		&model.Snapshot{},
+		func(in libmodel.Model) (r interface{}) {
+			m := in.(*model.Snapshot)
+			snapshot := &Snapshot{}
+			snapshot.ID = m.ID
+			snapshot.Name = m.Name
+			snapshot.Revision = m.Revision
+			snapshot.Link(h.Provider)
+			if details, err := m.GetDetails(); err == nil {
+				snapshot.Object = details
+			}
+			r = snapshot
+			return
+		})
+	if err != nil {
+		log.Error(err, "watch failed")
+		ctx.Status(http.StatusInternalServerError)
+	}
+}

--- a/pkg/provider/ec2/inventory/web/storage.go
+++ b/pkg/provider/ec2/inventory/web/storage.go
@@ -52,7 +52,7 @@ func (h *StorageHandler) List(ctx *gin.Context) {
 	var result []interface{}
 	for _, storage := range list {
 		r := &Storage{}
-		r.ID = storage.UID
+		r.ID = storage.ID
 		r.Name = storage.Name
 		r.Revision = storage.Revision
 		r.Link(h.Provider)
@@ -76,7 +76,7 @@ func (h *StorageHandler) Get(ctx *gin.Context) {
 	}
 
 	storage := &model.Storage{}
-	storage.UID = ctx.Param("id")
+	storage.ID = ctx.Param("id")
 
 	db := h.Collector.DB()
 	err = db.Get(storage)
@@ -86,7 +86,7 @@ func (h *StorageHandler) Get(ctx *gin.Context) {
 	}
 
 	r := &Storage{}
-	r.ID = storage.UID
+	r.ID = storage.ID
 	r.Name = storage.Name
 	r.Revision = storage.Revision
 	r.Link(h.Provider)
@@ -113,7 +113,7 @@ func (h *StorageHandler) watch(ctx *gin.Context) {
 		func(in libmodel.Model) (r interface{}) {
 			m := in.(*model.Storage)
 			storage := &Storage{}
-			storage.ID = m.UID
+			storage.ID = m.ID
 			storage.Name = m.Name
 			storage.Revision = m.Revision
 			storage.Link(h.Provider)

--- a/pkg/provider/ec2/inventory/web/vm.go
+++ b/pkg/provider/ec2/inventory/web/vm.go
@@ -62,9 +62,10 @@ func (h *VMHandler) List(ctx *gin.Context) {
 	var result []interface{}
 	for _, instance := range list {
 		r := &VM{}
-		r.ID = instance.UID
+		r.ID = instance.ID
 		r.Name = instance.Name
 		r.Revision = instance.Revision
+		r.PowerState = instance.PowerState
 		r.Link(h.Provider)
 		// Include full object data
 		if details, err := instance.GetDetails(); err == nil {
@@ -86,7 +87,7 @@ func (h *VMHandler) Get(ctx *gin.Context) {
 	}
 
 	instance := &model.Instance{}
-	instance.UID = ctx.Param(VMParam)
+	instance.ID = ctx.Param(VMParam)
 
 	db := h.Collector.DB()
 	err = db.Get(instance)
@@ -96,9 +97,10 @@ func (h *VMHandler) Get(ctx *gin.Context) {
 	}
 
 	r := &VM{}
-	r.ID = instance.UID
+	r.ID = instance.ID
 	r.Name = instance.Name
 	r.Revision = instance.Revision
+	r.PowerState = instance.PowerState
 	r.Link(h.Provider)
 	// Include full object data
 	details, err := instance.GetDetails()
@@ -123,9 +125,10 @@ func (h *VMHandler) watch(ctx *gin.Context) {
 		func(in libmodel.Model) (r interface{}) {
 			m := in.(*model.Instance)
 			vm := &VM{}
-			vm.ID = m.UID
+			vm.ID = m.ID
 			vm.Name = m.Name
 			vm.Revision = m.Revision
+			vm.PowerState = m.PowerState
 			vm.Link(h.Provider)
 			if details, err := m.GetDetails(); err == nil {
 				vm.Object = details

--- a/pkg/provider/ec2/inventory/web/volume.go
+++ b/pkg/provider/ec2/inventory/web/volume.go
@@ -53,7 +53,7 @@ func (h *VolumeHandler) List(ctx *gin.Context) {
 	var result []interface{}
 	for _, volume := range list {
 		r := &Volume{}
-		r.ID = volume.UID
+		r.ID = volume.ID
 		r.Name = volume.Name
 		r.Revision = volume.Revision
 		r.Link(h.Provider)
@@ -77,7 +77,7 @@ func (h *VolumeHandler) Get(ctx *gin.Context) {
 	}
 
 	volume := &model.Volume{}
-	volume.UID = ctx.Param("id")
+	volume.ID = ctx.Param("id")
 
 	db := h.Collector.DB()
 	err = db.Get(volume)
@@ -87,7 +87,7 @@ func (h *VolumeHandler) Get(ctx *gin.Context) {
 	}
 
 	r := &Volume{}
-	r.ID = volume.UID
+	r.ID = volume.ID
 	r.Name = volume.Name
 	r.Revision = volume.Revision
 	r.Link(h.Provider)
@@ -114,7 +114,7 @@ func (h *VolumeHandler) watch(ctx *gin.Context) {
 		func(in libmodel.Model) (r interface{}) {
 			m := in.(*model.Volume)
 			volume := &Volume{}
-			volume.ID = m.UID
+			volume.ID = m.ID
 			volume.Name = m.Name
 			volume.Revision = m.Revision
 			volume.Link(h.Provider)

--- a/pkg/provider/ec2/inventory/web/workload.go
+++ b/pkg/provider/ec2/inventory/web/workload.go
@@ -1,0 +1,61 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	"github.com/kubev2v/forklift/pkg/provider/ec2/inventory/model"
+)
+
+// Routes
+const (
+	WorkloadsRoot = ProviderRoot + "/workloads"
+	WorkloadRoot  = WorkloadsRoot + "/:" + VMParam
+)
+
+// Workload handler.
+// EC2 workloads are instances with expanded context for migration planning.
+type WorkloadHandler struct {
+	Handler
+}
+
+// Add routes
+func (h *WorkloadHandler) AddRoutes(e *gin.Engine) {
+	e.GET(WorkloadRoot, h.Get)
+}
+
+// Get workload
+func (h *WorkloadHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+
+	instance := &model.Instance{}
+	instance.ID = ctx.Param(VMParam)
+
+	db := h.Collector.DB()
+	err = db.Get(instance)
+	if err != nil {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+
+	r := &Workload{}
+	r.ID = instance.ID
+	r.Name = instance.Name
+	r.Revision = instance.Revision
+	r.PowerState = instance.PowerState
+	r.Link(h.Provider)
+	details, err := instance.GetDetails()
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r.Object = details
+
+	ctx.JSON(http.StatusOK, r)
+}


### PR DESCRIPTION
Add missing powerState field to the EC2 VM inventory resource, mapped from AWS instance state (running/pending → On, stopped/stopping/terminated → Off, other → Unknown). The field is indexed for query support, fixing the documented query filter "where powerState = 'Off'" which did not work.

Rename Base.UID to Base.ID in the EC2 inventory model to align with all other providers (vSphere, oVirt, OpenStack, OVA, Hyper-V).

Add WorkloadHandler with GET /workloads/:vm endpoint, matching the pattern used by vSphere for migration planning lookups.

Add full EBS Snapshot inventory support: Snapshot model, collector (DescribeSnapshots with owner-self filter), and web handler with GET /snapshots and GET /snapshots/:id endpoints.

Expose networkType in NetworkDetails and add a field naming convention section to pkg/provider/README.md.

Test runs of before and after added to the Jira ticket.

Ref: https://redhat.atlassian.net/browse/MTV-6221
Resolves: MTV-6221