### PR TITLE
chore(migration): Metadata update for OpenShift 5 changes

### DIFF
--- a/build/release.conf
+++ b/build/release.conf
@@ -17,4 +17,4 @@ DEFAULT_CHANNEL=release-v2.12
 REGISTRY=mtv-candidate
 
 # Which OCP versions are supported by this release
-OCP_VERSIONS=v4.21-v4.23
+OCP_VERSIONS=v4.21-v5.0

--- a/build/release.conf
+++ b/build/release.conf
@@ -17,4 +17,4 @@ DEFAULT_CHANNEL=release-v2.12
 REGISTRY=mtv-candidate
 
 # Which OCP versions are supported by this release
-OCP_VERSIONS=v4.21-v5.0
+OCP_VERSIONS=v4.22-v5.0

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -12617,7 +12617,7 @@ spec:
   - email: openshift-operators@redhat.com
     name: Red Hat
   maturity: stable
-  minKubeVersion: 1.27.0
+  minKubeVersion: 1.35.0
   provider:
     name: Red Hat
   version: ${MTV_VERSION}

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -109,7 +109,7 @@ spec:
     - name: Forklift Operator
       url: https://github.com/kubev2v/forklift
   version: ${MTV_VERSION}
-  minKubeVersion: 1.27.0
+  minKubeVersion: 1.36.0
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -109,7 +109,7 @@ spec:
     - name: Forklift Operator
       url: https://github.com/kubev2v/forklift
   version: ${MTV_VERSION}
-  minKubeVersion: 1.36.0
+  minKubeVersion: 1.35.0
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:


### PR DESCRIPTION
- Bumps to cutover to account for major version change since OLM _should_ allow for the range to be across major versions
- Sets the minimum kubeversion to the OCP5 minimum

**_DOES NOT_** make any API changes that will need to be validated by those more knowledgeable about MTVs dependencies per https://docs.google.com/document/d/1humaZXIe2yvRA0zjObyMBrIHWDmQXqO_p0SAGD9uX3k/edit?usp=sharing

Currently sets the range to `v4.21-v5.0` so we don't skip v4.21 support but @mnecas if the decision is confirmed to have the support range be `v4.22-v5.0` let me know and I can update accordingly.