### PR TITLE
MTV-3013 | Propagate ConvertorNodeSelector to CDI VDDK importer pods

### DIFF
--- a/cmd/kubectl-mtv/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan.go
+++ b/cmd/kubectl-mtv/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan.go
@@ -92,6 +92,10 @@ type PlanSpec struct {
 	// ConvertorNodeSelector constrains the scheduler to only schedule virt-v2v convertor pods on nodes
 	// which contain the specified labels. This is useful for dedicating specific nodes for disk conversion
 	// workloads that require high I/O performance or network access to source VMware infrastructure.
+	// For vSphere warm migrations that use CDI VDDK DataVolumes for disk transfer,
+	// this selector is also propagated to the CDI importer pods via the VDDK extra-args
+	// ConfigMap (requires CDI with CNV-84595 support). The ConfigMap is automatically
+	// cleaned up when the migration completes.
 	// See Pod NodeSelector documentation for more details,
 	// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 	ConvertorNodeSelector map[string]string `json:"convertorNodeSelector,omitempty"`

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan.go
@@ -92,6 +92,10 @@ type PlanSpec struct {
 	// ConvertorNodeSelector constrains the scheduler to only schedule virt-v2v convertor pods on nodes
 	// which contain the specified labels. This is useful for dedicating specific nodes for disk conversion
 	// workloads that require high I/O performance or network access to source VMware infrastructure.
+	// For vSphere warm migrations that use CDI VDDK DataVolumes for disk transfer,
+	// this selector is also propagated to the CDI importer pods via the VDDK extra-args
+	// ConfigMap (requires CDI with CNV-84595 support). The ConfigMap is automatically
+	// cleaned up when the migration completes.
 	// See Pod NodeSelector documentation for more details,
 	// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 	ConvertorNodeSelector map[string]string `json:"convertorNodeSelector,omitempty"`

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -7288,6 +7288,10 @@ spec:
                   ConvertorNodeSelector constrains the scheduler to only schedule virt-v2v convertor pods on nodes
                   which contain the specified labels. This is useful for dedicating specific nodes for disk conversion
                   workloads that require high I/O performance or network access to source VMware infrastructure.
+                  For vSphere warm migrations that use CDI VDDK DataVolumes for disk transfer,
+                  this selector is also propagated to the CDI importer pods via the VDDK extra-args
+                  ConfigMap (requires CDI with CNV-84595 support). The ConfigMap is automatically
+                  cleaned up when the migration completes.
                   See Pod NodeSelector documentation for more details,
                   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
                 type: object

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -7288,6 +7288,10 @@ spec:
                   ConvertorNodeSelector constrains the scheduler to only schedule virt-v2v convertor pods on nodes
                   which contain the specified labels. This is useful for dedicating specific nodes for disk conversion
                   workloads that require high I/O performance or network access to source VMware infrastructure.
+                  For vSphere warm migrations that use CDI VDDK DataVolumes for disk transfer,
+                  this selector is also propagated to the CDI importer pods via the VDDK extra-args
+                  ConfigMap (requires CDI with CNV-84595 support). The ConfigMap is automatically
+                  cleaned up when the migration completes.
                   See Pod NodeSelector documentation for more details,
                   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
                 type: object

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1024,6 +1024,10 @@ spec:
                   ConvertorNodeSelector constrains the scheduler to only schedule virt-v2v convertor pods on nodes
                   which contain the specified labels. This is useful for dedicating specific nodes for disk conversion
                   workloads that require high I/O performance or network access to source VMware infrastructure.
+                  For vSphere warm migrations that use CDI VDDK DataVolumes for disk transfer,
+                  this selector is also propagated to the CDI importer pods via the VDDK extra-args
+                  ConfigMap (requires CDI with CNV-84595 support). The ConfigMap is automatically
+                  cleaned up when the migration completes.
                   See Pod NodeSelector documentation for more details,
                   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
                 type: object

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -92,6 +92,10 @@ type PlanSpec struct {
 	// ConvertorNodeSelector constrains the scheduler to only schedule virt-v2v convertor pods on nodes
 	// which contain the specified labels. This is useful for dedicating specific nodes for disk conversion
 	// workloads that require high I/O performance or network access to source VMware infrastructure.
+	// For vSphere warm migrations that use CDI VDDK DataVolumes for disk transfer,
+	// this selector is also propagated to the CDI importer pods via the VDDK extra-args
+	// ConfigMap (requires CDI with CNV-84595 support). The ConfigMap is automatically
+	// cleaned up when the migration completes.
 	// See Pod NodeSelector documentation for more details,
 	// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 	ConvertorNodeSelector map[string]string `json:"convertorNodeSelector,omitempty"`

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -245,7 +245,7 @@ func (r *KubeVirt) resolveConversionResources(vm *plan.VMStatus, podType convctx
 	}
 
 	var vddkConfigMap *core.ConfigMap
-	if r.Source.Provider.UseVddkAioOptimization() {
+	if r.needsVddkConfigMap() {
 		vddkConfigMap, err = r.ensureVddkConfigMap()
 		if err != nil {
 			return
@@ -1842,7 +1842,7 @@ func (r *KubeVirt) DataVolumes(vm *plan.VMStatus) (dataVolumes []cdi.DataVolume,
 		return
 	}
 	var vddkConfigMap *core.ConfigMap
-	if r.Source.Provider.UseVddkAioOptimization() {
+	if r.needsVddkConfigMap() {
 		vddkConfigMap, err = r.ensureVddkConfigMap()
 		if err != nil {
 			return nil, err
@@ -1922,6 +1922,11 @@ func (r *KubeVirt) CsiImportPVCs(vm *plan.VMStatus) ([]core.PersistentVolumeClai
 	return r.Builder.CsiImportPVCs(vm.Ref, labels)
 }
 
+// Whether a VDDK extra-args ConfigMap is needed for AIO tuning or node selector propagation.
+func (r *KubeVirt) needsVddkConfigMap() bool {
+	return r.Source.Provider.UseVddkAioOptimization() || len(r.Plan.Spec.ConvertorNodeSelector) > 0
+}
+
 func (r *KubeVirt) vddkConfigMap(labels map[string]string) (*core.ConfigMap, error) {
 	data := make(map[string]string)
 	if r.Source.Provider.UseVddkAioOptimization() {
@@ -1932,6 +1937,13 @@ func (r *KubeVirt) vddkConfigMap(labels map[string]string) (*core.ConfigMap, err
 			data["vddk-config-file"] = "VixDiskLib.nfcAio.Session.BufSizeIn64KB=16\n" +
 				"VixDiskLib.nfcAio.Session.BufCount=4"
 		}
+	}
+	if len(r.Plan.Spec.ConvertorNodeSelector) > 0 {
+		nsJSON, err := json.Marshal(r.Plan.Spec.ConvertorNodeSelector)
+		if err != nil {
+			return nil, liberr.Wrap(err)
+		}
+		data["vddk-node-selector"] = string(nsJSON)
 	}
 	configMap := core.ConfigMap{
 		Data: data,

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -702,6 +702,45 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 		})
 	})
 
+	ginkgo.Describe("vddkConfigMap", func() {
+		ginkgo.It("should include vddk-node-selector when ConvertorNodeSelector is set", func() {
+			kubevirt := createKubeVirtWithProvider(v1beta1.VSphere)
+			kubevirt.Plan.Spec.ConvertorNodeSelector = map[string]string{
+				"dedicated-nic": "vmware",
+				"zone":          "east",
+			}
+			cm, err := kubevirt.vddkConfigMap(map[string]string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cm.Data).To(HaveKey("vddk-node-selector"))
+			Expect(cm.Data["vddk-node-selector"]).To(SatisfyAll(
+				ContainSubstring(`"dedicated-nic":"vmware"`),
+				ContainSubstring(`"zone":"east"`),
+			))
+		})
+
+		ginkgo.It("should not include vddk-node-selector when ConvertorNodeSelector is empty", func() {
+			kubevirt := createKubeVirtWithProvider(v1beta1.VSphere)
+			cm, err := kubevirt.vddkConfigMap(map[string]string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cm.Data).ToNot(HaveKey("vddk-node-selector"))
+		})
+
+		ginkgo.It("should include both AIO config and node selector when both are set", func() {
+			kubevirt := createKubeVirtWithProvider(v1beta1.VSphere)
+			kubevirt.Source.Provider.Spec.Settings = map[string]string{
+				v1beta1.UseVddkAioOptimization: "true",
+			}
+			kubevirt.Plan.Spec.ConvertorNodeSelector = map[string]string{
+				"node-role": "migration",
+			}
+			cm, err := kubevirt.vddkConfigMap(map[string]string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cm.Data).To(HaveKey("vddk-config-file"))
+			Expect(cm.Data).To(HaveKey("vddk-node-selector"))
+			Expect(cm.Data["vddk-node-selector"]).To(ContainSubstring(`"node-role":"migration"`))
+		})
+	})
+
 	ginkgo.Describe("podVolumeMounts", func() {
 		var kubevirt *KubeVirt
 


### PR DESCRIPTION
For vSphere warm migrations that use CDI DataVolumes with VDDK source, the CDI importer pods now respect Plan.Spec.ConvertorNodeSelector.

The selector is JSON-encoded into the vddk-node-selector key of the VDDK extra-args ConfigMap, which CDI reads and merges into the importer pod's NodeSelector (requires CDI with CNV-84595 support). The ConfigMap is automatically cleaned up when the migration completes.

Test and run logs added to Jira ticket.

Refs:
https://redhat.atlassian.net/browse/MTV-3013
https://github.com/kubevirt/containerized-data-importer/pull/4096

Resolves: MTV-3207