### PR TITLE
fix(upstream): protect system namespaces from deletion in remove-deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -713,12 +713,15 @@ deploy-ocp-controller: kubectl ## Deploy ForkliftController CR on OpenShift. Usa
 	fi; \
 	KUBECTL=$(KUBECTL) ./hack/deploy-ocp-controller.sh $$NAMESPACE
 
+.PHONY: deploy-all
+deploy-all: deploy-operator-index deploy-ocp deploy-ocp-controller ## Deploy operator index, OLM subscription, and ForkliftController CR in sequence
+
 .PHONY: remove-deployment
 remove-deployment: ## Remove all Forklift resources from the cluster. Usage: make remove-deployment [NAMESPACE=konveyor-forklift] [DRY_RUN=true]
 	@ARGS=""; \
 	if [ "$(DRY_RUN)" = "true" ]; then ARGS="$$ARGS --dry-run"; fi; \
 	if [ -n "$(NAMESPACE)" ]; then ARGS="$$ARGS --namespace $(NAMESPACE)"; fi; \
-	KUBECTL=$(KUBECTL) ./hack/remove-deployment.sh $$ARGS
+	KUBECTL=$(KUBECTL) bash ./hack/remove-deployment.sh $$ARGS
 
 ##@ Tool Installation
 

--- a/hack/remove-deployment.sh
+++ b/hack/remove-deployment.sh
@@ -240,8 +240,21 @@ done < <(
 # --- Delete namespaces ---
 header "Deleting namespaces"
 
+is_protected_ns() {
+    local ns="$1"
+    case "$ns" in
+        openshift-mtv) return 1 ;;
+        openshift-*|kube-*|default|openshift) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 for ns in "${ALL_NS[@]+"${ALL_NS[@]}"}"; do
     [[ -z "$ns" ]] && continue
+    if is_protected_ns "$ns"; then
+        echo "  Namespace $ns: SKIPPED (protected system namespace)"
+        continue
+    fi
     status=$($KUBECTL get ns "$ns" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
     if [[ "$status" == "NotFound" ]]; then
         echo "  Namespace $ns: already gone"
@@ -303,6 +316,7 @@ if ! $DRY_RUN && [[ ${#ALL_NS[@]} -gt 0 ]]; then
     header "Waiting for namespace deletion"
     for ns in "${ALL_NS[@]+"${ALL_NS[@]}"}"; do
         [[ -z "$ns" ]] && continue
+        is_protected_ns "$ns" && continue
         ELAPSED=0
         TIMEOUT=120
         while [[ $ELAPSED -lt $TIMEOUT ]]; do


### PR DESCRIPTION
Guard openshift-*, kube-*, default, and openshift namespaces so remove-deployment.sh never accidentally deletes them. Also invoke the script with explicit `bash` and add a deploy-all convenience target.

Resolves: none