### PR TITLE
MTV-6213 | Cache the NetApp Shift SC resolution

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -10013,6 +10013,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              netAppShiftDestination:
+                description: |-
+                  NetAppShiftDestination indicates whether the plan's storage map resolves to a NetApp
+                  Shift/Trident destination StorageClass.
+                type: boolean
               observedGeneration:
                 description: The most recent generation observed by the controller.
                 format: int64

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -10013,6 +10013,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              netAppShiftDestination:
+                description: |-
+                  NetAppShiftDestination indicates whether the plan's storage map resolves to a NetApp
+                  Shift/Trident destination StorageClass.
+                type: boolean
               observedGeneration:
                 description: The most recent generation observed by the controller.
                 format: int64

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -3692,6 +3692,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              netAppShiftDestination:
+                description: |-
+                  NetAppShiftDestination indicates whether the plan's storage map resolves to a NetApp
+                  Shift/Trident destination StorageClass.
+                type: boolean
               observedGeneration:
                 description: The most recent generation observed by the controller.
                 format: int64

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -429,6 +429,10 @@ type PlanStatus struct {
 	// The most recent generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// NetAppShiftDestination indicates whether the plan's storage map resolves to a NetApp
+	// Shift/Trident destination StorageClass.
+	// +optional
+	NetAppShiftDestination bool `json:"netAppShiftDestination,omitempty"`
 	// Migration
 	Migration plan.MigrationStatus `json:"migration,omitempty"`
 }
@@ -463,12 +467,15 @@ func (p *Plan) IsWarm() bool {
 // just use virt-v2v directly to convert the vm while copying data over. In other
 // cases, we use CDI to transfer disks to the destination cluster and then use
 // virt-v2v-in-place to convert these disks after cutover.
-func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref, destinationClient k8sclient.Client) (bool, error) {
-	source := p.Referenced.Provider.Source
+//
+// Note: this is called once per VM from several places (adapters, scheduler, migrator,
+// kubevirt.go, migration.go) on every reconcile, so it must not perform any API/client calls itself.
+func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref) (bool, error) {
+	source := p.Provider.Source
 	if source == nil {
 		return false, liberr.New("Cannot analyze plan, source provider is missing.")
 	}
-	destination := p.Referenced.Provider.Destination
+	destination := p.Provider.Destination
 	if destination == nil {
 		return false, liberr.New("Cannot analyze plan, destination provider is missing.")
 	}
@@ -485,14 +492,8 @@ func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref, destinationClient k8sclien
 			p.Spec.SkipGuestConversion || p.Spec.Type == MigrationOnlyConversion {
 			return false, nil
 		}
-		if p.Map.Storage != nil {
-			hasNetAppShift, err := p.Map.Storage.HasNetAppShiftDestination(destinationClient)
-			if err != nil {
-				return false, err
-			}
-			if hasNetAppShift {
-				return false, nil
-			}
+		if p.HasNetAppShiftDestination() {
+			return false, nil
 		}
 		if p.IsUsingOffloadPlugin() {
 			return false, nil
@@ -503,6 +504,10 @@ func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref, destinationClient k8sclien
 	default:
 		return false, nil
 	}
+}
+
+func (p *Plan) HasNetAppShiftDestination() bool {
+	return p.Status.NetAppShiftDestination
 }
 
 func (r *Plan) DestinationHasUdnNetwork(client k8sclient.Client) bool {

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -563,7 +563,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 
 		storageClass := mapped.Destination.StorageClass
 		var dvSource cdi.DataVolumeSource
-		useV2vForTransfer, vErr := r.Context.Plan.ShouldUseV2vForTransfer(vmRef, r.Context.Destination.Client)
+		useV2vForTransfer, vErr := r.Plan.ShouldUseV2vForTransfer(vmRef)
 		if vErr != nil {
 			err = vErr
 			return

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -432,7 +432,7 @@ func (r *Client) getTaskById(vmRef ref.Ref, taskId string, hosts util.HostsFunc)
 }
 
 func (r *Client) getClient(vm *model.VM, hosts util.HostsFunc) (client *vim25.Client, err error) {
-	if useV2vForTransfer, vErr := r.Plan.ShouldUseV2vForTransfer(ref.Ref{ID: vm.ID}, r.Destination.Client); vErr == nil && useV2vForTransfer {
+	if useV2vForTransfer, vErr := r.Plan.ShouldUseV2vForTransfer(ref.Ref{ID: vm.ID}); vErr == nil && useV2vForTransfer {
 		// when virt-v2v runs the migration, forklift-controller should interact only
 		// with the component that serves the SDK endpoint of the provider
 		client = r.client.Client

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -236,7 +236,7 @@ func (r *KubeVirt) resolveConversionResources(vm *plan.VMStatus, podType convctx
 			return
 		}
 
-		useV2v, v2vErr := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref, r.Destination.Client)
+		useV2v, v2vErr := r.Plan.ShouldUseV2vForTransfer(vm.Ref)
 		if v2vErr != nil {
 			err = v2vErr
 			return
@@ -355,7 +355,7 @@ func (r *KubeVirt) checkProviderReady(vmID string) (ready bool, err error) {
 // should use InPlace or Remote conversion based on the plan transfer mode
 // and PVC copy-offload annotations.
 func (r *KubeVirt) ResolveConversionType(vm *plan.VMStatus) (api.ConversionType, error) {
-	useV2v, err := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref, r.Destination.Client)
+	useV2v, err := r.Plan.ShouldUseV2vForTransfer(vm.Ref)
 	if err != nil {
 		return "", err
 	}
@@ -2838,7 +2838,7 @@ func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap
 
 	// Add vmUUID for any migration where copy and conversion are separate,
 	// so PVCs can be discovered by a resume-conversion migration.
-	if util.HasSeparateCopyAndConversion(r.Plan, vm.Ref, r.Destination.Client) {
+	if util.HasSeparateCopyAndConversion(r.Plan, vm.Ref) {
 		if uuid, uuidErr := vmUUIDFromInventory(srcVM, vm.Ref); uuidErr != nil {
 			r.Log.Error(uuidErr, "Failed to resolve vmUUID label for DV; resume-conversion discovery may fail.", "vm", vm.String())
 		} else {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -215,7 +215,7 @@ func (r *Migration) begin() (err error) {
 	if r.Migration.Spec.ResumeConversion {
 		hasResumable := false
 		for _, specVM := range r.Plan.Spec.VMs {
-			if !util.HasSeparateCopyAndConversion(r.Plan, specVM.Ref, r.Destination.Client) {
+			if !util.HasSeparateCopyAndConversion(r.Plan, specVM.Ref) {
 				snapshot.SetCondition(libcnd.Condition{
 					Type:     api.ConditionFailed,
 					Status:   True,
@@ -1604,7 +1604,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		case api.PhaseCreateGuestConversionPod:
 
 			if !vm.DisksCopied && !r.IsResumeConversion() &&
-				util.HasSeparateCopyAndConversion(r.Plan, vm.Ref, r.Destination.Client) {
+				util.HasSeparateCopyAndConversion(r.Plan, vm.Ref) {
 				vm.DisksCopied = true
 				r.Log.Info("All disks copied, marking VM as resumable on conversion failure.",
 					"vm", vm.String())
@@ -2248,7 +2248,7 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 			break
 		}
 
-		useV2vForTransfer, err := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref, r.Destination.Client)
+		useV2vForTransfer, err := r.Plan.ShouldUseV2vForTransfer(vm.Ref)
 		switch {
 		case err != nil:
 			return liberr.Wrap(err)

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -445,7 +445,7 @@ func (r *BasePredicate) ensureUseV2vForTransfer() (bool, error) {
 		}
 		return *r.useV2vForTransfer, nil
 	}
-	result, vErr := r.context.Plan.ShouldUseV2vForTransfer(r.vm.Ref, r.context.Destination.Client)
+	result, vErr := r.context.Plan.ShouldUseV2vForTransfer(r.vm.Ref)
 	r.useV2vResolved = true
 	if vErr != nil {
 		r.useV2vErr = vErr

--- a/pkg/controller/plan/migrator/base/migrator_test.go
+++ b/pkg/controller/plan/migrator/base/migrator_test.go
@@ -26,7 +26,7 @@ func (c *getCountingClient) Get(ctx context.Context, key client.ObjectKey, obj c
 	return c.Client.Get(ctx, key, obj, opts...)
 }
 
-func newVsphereColdPredicate(t *testing.T, c client.Client, storageClass string) *BasePredicate {
+func newVsphereColdPredicate(t *testing.T, c client.Client, storageClass string, netAppShift bool) *BasePredicate {
 	t.Helper()
 	vsphere, openshift := api.VSphere, api.OpenShift
 	return &BasePredicate{
@@ -34,6 +34,9 @@ func newVsphereColdPredicate(t *testing.T, c client.Client, storageClass string)
 		context: &plancontext.Context{
 			Plan: &api.Plan{
 				Spec: api.PlanSpec{MigrateSharedDisks: true},
+				// Simulates the result validateNetAppShift persists once per reconcile,
+				// during plan validation, before ShouldUseV2vForTransfer is ever called.
+				Status: api.PlanStatus{NetAppShiftDestination: netAppShift},
 				Referenced: api.Referenced{
 					Provider: struct {
 						Source, Destination *api.Provider
@@ -58,7 +61,10 @@ func newVsphereColdPredicate(t *testing.T, c client.Client, storageClass string)
 	}
 }
 
-// ShouldUseV2vForTransfer hits the API once per predicate; second Evaluate must reuse the cache.
+// ShouldUseV2vForTransfer must never query the API itself: the NetApp Shift destination
+// check is resolved once per reconcile by plan validation and persisted on
+// Plan.Status.NetAppShiftDestination, so BasePredicate's own cache (and repeat Evaluate
+// calls) should never trigger a destination Get.
 func TestBasePredicate_useV2vForTransferCached(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = storagev1.AddToScheme(scheme)
@@ -67,16 +73,50 @@ func TestBasePredicate_useV2vForTransferCached(t *testing.T) {
 		WithObjects(&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "sc1"}}).
 		Build()}
 
-	pred := newVsphereColdPredicate(t, cl, "sc1")
+	pred := newVsphereColdPredicate(t, cl, "sc1", false)
 
-	if _, err := pred.Evaluate(CDIDiskCopy); err != nil {
+	cdiAllowed, err := pred.Evaluate(CDIDiskCopy)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := pred.Evaluate(VirtV2vDiskCopy); err != nil {
+	v2vAllowed, err := pred.Evaluate(VirtV2vDiskCopy)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if cl.n.Load() != 1 {
-		t.Fatalf("destination Get calls = %d, want 1 (cached)", cl.n.Load())
+	if cdiAllowed || !v2vAllowed {
+		t.Fatalf("netAppShift=false: CDIDiskCopy allowed = %v (want false), VirtV2vDiskCopy allowed = %v (want true)", cdiAllowed, v2vAllowed)
+	}
+	if cl.n.Load() != 0 {
+		t.Fatalf("destination Get calls = %d, want 0 (never queried; must use cached Status.NetAppShiftDestination)", cl.n.Load())
+	}
+}
+
+// When the destination is a NetApp Shift StorageClass, ShouldUseV2vForTransfer must reject
+// virt-v2v transfer (CDI handles the copy instead), and this must still be decided purely
+// from the cached Status.NetAppShiftDestination without ever querying the destination.
+func TestBasePredicate_useV2vForTransferNetAppShift(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = storagev1.AddToScheme(scheme)
+	cl := &getCountingClient{Client: fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "sc1"}}).
+		Build()}
+
+	pred := newVsphereColdPredicate(t, cl, "sc1", true)
+
+	cdiAllowed, err := pred.Evaluate(CDIDiskCopy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2vAllowed, err := pred.Evaluate(VirtV2vDiskCopy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cdiAllowed || v2vAllowed {
+		t.Fatalf("netAppShift=true: CDIDiskCopy allowed = %v (want true), VirtV2vDiskCopy allowed = %v (want false)", cdiAllowed, v2vAllowed)
+	}
+	if cl.n.Load() != 0 {
+		t.Fatalf("destination Get calls = %d, want 0 (never queried; must use cached Status.NetAppShiftDestination)", cl.n.Load())
 	}
 }
 

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -248,7 +248,7 @@ func (r *Scheduler) migratesSharedDisks(vmStatus *plan.VMStatus) bool {
 }
 
 func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {
-	useV2vForTransfer, _ := r.Plan.ShouldUseV2vForTransfer(vmStatus.Ref, r.Destination.Client)
+	useV2vForTransfer, _ := r.Plan.ShouldUseV2vForTransfer(vmStatus.Ref)
 	if useV2vForTransfer || r.Plan.IsUsingOffloadPlugin() {
 		switch vmStatus.Phase {
 		case CreateVM, PostHook, Completed:

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -232,14 +232,14 @@ func AnyNetAppShiftPersistentVolumeClaim(pvcs []*core.PersistentVolumeClaim) boo
 // virt-v2v-for-transfer (single-step copy+convert), providers that don't
 // require guest conversion (oVirt, OpenStack, OCP), EC2 (whose "copy" is
 // a near-instant EBS snapshot-to-volume operation), or on error.
-func HasSeparateCopyAndConversion(plan *api.Plan, vmRef ref.Ref, client k8sclient.Client) bool {
+func HasSeparateCopyAndConversion(plan *api.Plan, vmRef ref.Ref) bool {
 	if plan.Provider.Source == nil || !plan.Provider.Source.RequiresConversion() {
 		return false
 	}
 	if plan.Provider.Source.Type() == api.EC2 {
 		return false
 	}
-	useV2v, err := plan.ShouldUseV2vForTransfer(vmRef, client)
+	useV2v, err := plan.ShouldUseV2vForTransfer(vmRef)
 	if err != nil {
 		return false
 	}

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -377,7 +377,7 @@ func (r *Reconciler) ensureSecretForProvider(plan *api.Plan) error {
 // and returns whether the plan uses Shift storage so callers can pass the flag forward.
 func (r *Reconciler) validateNetAppShift(ctx *plancontext.Context) (err error) {
 	plan := ctx.Plan
-	src := plan.Referenced.Provider.Source
+	src := plan.Provider.Source
 	if src == nil || src.Type() != api.VSphere || plan.Map.Storage == nil {
 		return nil
 	}
@@ -385,6 +385,7 @@ func (r *Reconciler) validateNetAppShift(ctx *plancontext.Context) (err error) {
 	if err != nil {
 		return liberr.Wrap(err, "check NetApp Shift storage")
 	}
+	plan.Status.NetAppShiftDestination = shift
 	if !shift {
 		return nil
 	}
@@ -1004,17 +1005,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 	source := plan.Referenced.Provider.Source
 	checkMixedUsage := source != nil && source.Type() == api.VSphere && settings.Settings.Features.CopyOffload
 	planUsesOffload := checkMixedUsage && plan.IsUsingOffloadPlugin()
-	netAppShift := false
-	var err error
-	if source != nil && source.Type() == api.VSphere && plan.Map.Storage != nil {
-		netAppShift, err = plan.Map.Storage.HasNetAppShiftDestination(ctx.Destination.Client)
-		if err != nil {
-			return liberr.Wrap(err, "check NetApp Shift storage")
-		}
-	}
-	if err != nil {
-		return liberr.Wrap(err, "check NetApp Shift storage")
-	}
+	netAppShift := plan.HasNetAppShiftDestination()
 
 	// Referenced VMs.
 	for i := range plan.Spec.VMs {


### PR DESCRIPTION
Issue: the netapp shift resolution was called multiple times per VM and per plan reconcile which was very wasteful. Cache the result and only call the resolution once per plan reconcile.

Resolves: MTV-6213