### PR TITLE
MTV-6176 | [release-2.12] Require target credentials for EC2 providers

### DIFF
--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/ova"
 	"github.com/kubev2v/forklift/pkg/controller/provider/container"
 	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	providervalidation "github.com/kubev2v/forklift/pkg/controller/provider/validation"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/kubev2v/forklift/pkg/lib/inventory/model"
@@ -125,21 +126,7 @@ func (r *Reconciler) validate(provider *api.Provider) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-
-	// Validate SSH readiness for vSphere providers when SSH method is enabled
-	err = r.validateSSHReadiness(provider, secret)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
-
-	// Validate SMB CSI driver for HyperV providers
-	err = r.validateSMBCSI(provider)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
-
-	// Validate Hyper-V settings (managementType)
-	err = r.validateHyperVSettings(provider)
+	err = providervalidation.Build(r, r.Client).Validate(provider, secret)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -994,7 +981,7 @@ func (r *Reconciler) loadHostIPs(provider *api.Provider) map[string]string {
 }
 
 // validateSSHReadiness validates SSH readiness for vSphere providers when SSH method is enabled
-func (r *Reconciler) validateSSHReadiness(provider *api.Provider, secret *core.Secret) error {
+func (r *Reconciler) ValidateSSHReadiness(provider *api.Provider, secret *core.Secret) error {
 	// Only validate SSH for vSphere providers
 	if provider.Type() != api.VSphere {
 		r.Log.V(3).Info("SSH validation: skipping non-vSphere provider",
@@ -1280,7 +1267,7 @@ func isValidSMBPath(smbPath string) bool {
 
 // validateSMBCSI validates that the SMB CSI driver is installed for HyperV providers.
 // HyperV migrations require the SMB CSI driver (smb.csi.k8s.io) to mount SMB shares.
-func (r *Reconciler) validateSMBCSI(provider *api.Provider) error {
+func (r *Reconciler) ValidateSMBCSI(provider *api.Provider) error {
 	if provider.Type() != api.HyperV {
 		return nil
 	}
@@ -1309,7 +1296,7 @@ func (r *Reconciler) validateSMBCSI(provider *api.Provider) error {
 	return nil
 }
 
-func (r *Reconciler) validateHyperVSettings(provider *api.Provider) error {
+func (r *Reconciler) ValidateHyperVSettings(provider *api.Provider) error {
 	if provider.Type() != api.HyperV {
 		return nil
 	}

--- a/pkg/controller/provider/validation/doc.go
+++ b/pkg/controller/provider/validation/doc.go
@@ -1,0 +1,53 @@
+package validation
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	ec2validation "github.com/kubev2v/forklift/pkg/provider/ec2/controller/validation"
+	core "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Runner is implemented by the provider reconciler so provider-specific
+// validation methods can be invoked from this package without an import cycle.
+type Runner interface {
+	ValidateSSHReadiness(provider *api.Provider, secret *core.Secret) error
+	ValidateSMBCSI(provider *api.Provider) error
+	ValidateHyperVSettings(provider *api.Provider) error
+}
+
+// ProviderValidator runs provider-type-specific validation.
+type ProviderValidator struct {
+	runner Runner
+	client client.Client
+}
+
+func Build(runner Runner, cl client.Client) *ProviderValidator {
+	return &ProviderValidator{runner: runner, client: cl}
+}
+
+func (v *ProviderValidator) Validate(provider *api.Provider, secret *core.Secret) error {
+	switch provider.Type() {
+	case api.EC2:
+		(&ec2validation.Validator{}).Validate(provider, secret, v.client)
+		return nil
+	case api.VSphere:
+		err := v.runner.ValidateSSHReadiness(provider, secret)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+		return nil
+	case api.HyperV:
+		err := v.runner.ValidateSMBCSI(provider)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+		err = v.runner.ValidateHyperVSettings(provider)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+		return nil
+	default:
+		return nil
+	}
+}

--- a/pkg/controller/provider/validation_hyperv_test.go
+++ b/pkg/controller/provider/validation_hyperv_test.go
@@ -18,7 +18,7 @@ func hypervProvider(settings map[string]string) *api.Provider {
 func TestValidateHyperVSettings_ValidCluster(t *testing.T) {
 	p := hypervProvider(map[string]string{api.ManagementType: api.HyperVCluster})
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if p.Status.HasCondition(SettingsNotValid) {
@@ -29,7 +29,7 @@ func TestValidateHyperVSettings_ValidCluster(t *testing.T) {
 func TestValidateHyperVSettings_ValidStandalone(t *testing.T) {
 	p := hypervProvider(map[string]string{api.ManagementType: api.HyperVStandalone})
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if p.Status.HasCondition(SettingsNotValid) {
@@ -40,7 +40,7 @@ func TestValidateHyperVSettings_ValidStandalone(t *testing.T) {
 func TestValidateHyperVSettings_EmptyDefaultsToValid(t *testing.T) {
 	p := hypervProvider(map[string]string{})
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if p.Status.HasCondition(SettingsNotValid) {
@@ -51,7 +51,7 @@ func TestValidateHyperVSettings_EmptyDefaultsToValid(t *testing.T) {
 func TestValidateHyperVSettings_InvalidType(t *testing.T) {
 	p := hypervProvider(map[string]string{api.ManagementType: "bogus"})
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if !p.Status.HasCondition(SettingsNotValid) {
@@ -69,7 +69,7 @@ func TestValidateHyperVSettings_NonHyperVSkipped(t *testing.T) {
 		Spec:       api.ProviderSpec{Type: &pt, Settings: map[string]string{api.ManagementType: "bogus"}},
 	}
 	r := Reconciler{}
-	if err := r.validateHyperVSettings(p); err != nil {
+	if err := r.ValidateHyperVSettings(p); err != nil {
 		t.Fatal(err)
 	}
 	if p.Status.HasCondition(SettingsNotValid) {

--- a/pkg/provider/ec2/controller/validation/crossaccount.go
+++ b/pkg/provider/ec2/controller/validation/crossaccount.go
@@ -1,0 +1,40 @@
+package validation
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
+	core "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	TargetCredentialsMissing = "TargetCredentialsMissing"
+	ValidationFailed         = "ValidationFailed"
+)
+
+type Validator struct{}
+
+func (v *Validator) Validate(provider *api.Provider, secret *core.Secret, _ client.Client) {
+	if provider.Status.HasBlockerCondition() {
+		return
+	}
+	if secret == nil {
+		return
+	}
+
+	_, hasKeyID := secret.Data["targetAccessKeyId"]
+	_, hasSecret := secret.Data["targetSecretAccessKey"]
+
+	if !hasKeyID || !hasSecret {
+		provider.Status.Phase = ValidationFailed
+		provider.Status.SetCondition(libcnd.Condition{
+			Type:     TargetCredentialsMissing,
+			Status:   libcnd.True,
+			Category: libcnd.Critical,
+			Reason:   "TargetCredentialsRequired",
+			Message:  "The provider secret must include 'targetAccessKeyId' and 'targetSecretAccessKey'. Recreate the provider with --auto-target-credentials or provide them manually.",
+		})
+	} else {
+		provider.Status.DeleteCondition(TargetCredentialsMissing)
+	}
+}


### PR DESCRIPTION
Backport: [#7576](https://github.com/kubev2v/forklift/pull/7576)

Make targetAccessKeyId and targetSecretAccessKey required fields in the EC2 provider secret. Without them, the provider fails validation with a Critical condition. This prevents cross-account migrations from silently creating volumes in the wrong AWS account.

Introduces a ProviderValidator interface that delegates provider- specific validations to provider packages. The shared validate() calls Build().Validate() which routes to the correct provider.

Moves vSphere (SSH readiness), HyperV (SMB CSI, settings), and EC2 (target credentials) validations into the dispatch.

This is manual backport, the automated backport failed:
https://github.com/kubev2v/forklift/pull/7633

Ref: https://redhat.atlassian.net/browse/MTV-6176
Resolves: MTV-6176