### PR TITLE
MTV-6279 | Validate Hyper-V disk existence on SMB mount

### DIFF
--- a/pkg/controller/provider/container/hyperv/client.go
+++ b/pkg/controller/provider/container/hyperv/client.go
@@ -562,8 +562,9 @@ func buildGuestNetworks(cfgs []guestNetCfg, nics []types.NIC) []types.GuestNetwo
 }
 
 // validateDisksOnSMB calls the provider-server validation endpoint to verify
-// that disk files mapped to SMB paths actually exist on the mount. Disks that
-// are missing get a DiskNotFoundOnSMB concern attached to their parent VM.
+// that disk files mapped to SMB paths actually exist on the mount. Disks whose
+// files are missing have their SMBPath cleared so the OPA validation policy
+// (hyperv.disk.smb_path.missing) can flag them.
 func (r *Client) validateDisksOnSMB(vms []types.VM) {
 	if r.provider == nil || r.provider.Status.Service == nil {
 		r.Log.V(1).Info("Skipping SMB disk validation: no provider service available")
@@ -573,22 +574,22 @@ func (r *Client) validateDisksOnSMB(vms []types.VM) {
 	svc := r.provider.Status.Service
 	baseURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", svc.Name, svc.Namespace)
 
-	// Collect all SMB paths, tracking which VM(s) own each path.
-	type pathOwner struct {
-		vmIndex  int
-		diskPath string
+	type diskRef struct {
+		vmIdx   int
+		diskIdx int
 	}
 	var allPaths []string
-	pathOwners := make(map[string][]pathOwner)
-	for i, vm := range vms {
-		for _, disk := range vm.Disks {
-			if disk.SMBPath == "" {
+	pathToDiskRefs := make(map[string][]diskRef)
+	for i := range vms {
+		for j := range vms[i].Disks {
+			p := vms[i].Disks[j].SMBPath
+			if p == "" {
 				continue
 			}
-			if _, seen := pathOwners[disk.SMBPath]; !seen {
-				allPaths = append(allPaths, disk.SMBPath)
+			if _, seen := pathToDiskRefs[p]; !seen {
+				allPaths = append(allPaths, p)
 			}
-			pathOwners[disk.SMBPath] = append(pathOwners[disk.SMBPath], pathOwner{vmIndex: i, diskPath: disk.SMBPath})
+			pathToDiskRefs[p] = append(pathToDiskRefs[p], diskRef{vmIdx: i, diskIdx: j})
 		}
 	}
 
@@ -629,16 +630,16 @@ func (r *Client) validateDisksOnSMB(vms []types.VM) {
 		missingSet[p] = true
 	}
 
-	for path, owners := range pathOwners {
+	for path, refs := range pathToDiskRefs {
 		if !missingSet[path] {
 			continue
 		}
-		for _, o := range owners {
-			vms[o.vmIndex].Concerns = append(vms[o.vmIndex].Concerns, types.Concern{
-				Category: "Warning",
-				Label:    "DiskNotFoundOnSMB",
-				Message:  fmt.Sprintf("Disk file not found on SMB mount: %s", o.diskPath),
-			})
+		for _, ref := range refs {
+			r.Log.Info("Disk file not found on SMB mount, clearing SMBPath",
+				"vm", vms[ref.vmIdx].Name,
+				"windowsPath", vms[ref.vmIdx].Disks[ref.diskIdx].WindowsPath,
+				"smbPath", path)
+			vms[ref.vmIdx].Disks[ref.diskIdx].SMBPath = ""
 		}
 	}
 

--- a/pkg/controller/provider/container/hyperv/client_test.go
+++ b/pkg/controller/provider/container/hyperv/client_test.go
@@ -461,10 +461,12 @@ func TestMapWindowsPathToSMB(t *testing.T) {
 
 func TestMapWindowsPathToSMB_UNC(t *testing.T) {
 	client := &Client{
-		smbMountPath: "/hyperv",
+		smbMountPath: "/mnt/smb/hyperv-share",
 		smbUrl:       "//10.0.0.1/VMShare",
 		Log:          testLogger(),
 	}
+
+	localPrefix := `C:\Hyper-V\Virtual_Hard_Disks`
 
 	tests := []struct {
 		name             string
@@ -475,38 +477,38 @@ func TestMapWindowsPathToSMB_UNC(t *testing.T) {
 		{
 			name:             "UNC backslash path matching share name",
 			windowsPath:      `\\WIN-SERVER\VMShare\vm1.vhdx`,
-			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
-			expected:         "/hyperv/vm1.vhdx",
+			smbWindowsPrefix: localPrefix,
+			expected:         "/mnt/smb/hyperv-share/vm1.vhdx",
 		},
 		{
 			name:             "UNC forward slash path matching share name",
 			windowsPath:      "//WIN-SERVER/VMShare/subdir/disk.vhdx",
-			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
-			expected:         "/hyperv/subdir/disk.vhdx",
+			smbWindowsPrefix: localPrefix,
+			expected:         "/mnt/smb/hyperv-share/subdir/disk.vhdx",
 		},
 		{
 			name:             "UNC case insensitive share name match",
 			windowsPath:      `\\SERVER\vmshare\disk.vhdx`,
-			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
-			expected:         "/hyperv/disk.vhdx",
+			smbWindowsPrefix: localPrefix,
+			expected:         "/mnt/smb/hyperv-share/disk.vhdx",
 		},
 		{
 			name:             "UNC different share name falls through to local",
 			windowsPath:      `\\SERVER\OtherShare\disk.vhdx`,
-			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
+			smbWindowsPrefix: localPrefix,
 			expected:         "",
 		},
 		{
 			name:             "UNC share root without trailing file",
 			windowsPath:      `\\SERVER\VMShare`,
-			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
-			expected:         "/hyperv/",
+			smbWindowsPrefix: localPrefix,
+			expected:         "/mnt/smb/hyperv-share/",
 		},
 		{
 			name:             "local path still works when smbUrl is set",
 			windowsPath:      `C:\Hyper-V\Virtual_Hard_Disks\vm2.vhdx`,
-			smbWindowsPrefix: `C:\Hyper-V\Virtual_Hard_Disks`,
-			expected:         "/hyperv/vm2.vhdx",
+			smbWindowsPrefix: localPrefix,
+			expected:         "/mnt/smb/hyperv-share/vm2.vhdx",
 		},
 	}
 

--- a/validation/policies/io/konveyor/forklift/hyperv/disk_smb_path.rego
+++ b/validation/policies/io/konveyor/forklift/hyperv/disk_smb_path.rego
@@ -24,6 +24,6 @@ concerns contains flag if {
 		"id": "hyperv.disk.smb_path.missing",
 		"category": "Warning",
 		"label": sprintf("Disk '%v' cannot be mapped to SMB share", [disk.name]),
-		"assessment": sprintf("Cannot map Windows path '%v' to SMB share. Ensure the disk is located on a configured SMB share.", [disk.windowsPath]),
+		"assessment": sprintf("Cannot map Windows path '%v' to SMB share. Ensure the disk is located on a configured SMB share. In multi-node clusters, disks local to a node that does not host the SMB share are not accessible — move the disk to shared storage or to the SMB-shared directory.", [disk.windowsPath]),
 	}
 }


### PR DESCRIPTION
Previously, mapWindowsPathToSMB only performed string-based path mapping. In multi-node Hyper-V clusters a disk path can map syntactically but the file may not exist on the mounted SMB share (e.g. when the disk is local to a different cluster node).

validateDisksOnSMB now calls the hyperv-provider-server's /validate-disks endpoint to verify each mapped path with os.Stat. Disks that are missing have their SMBPath cleared, which triggers the existing OPA policy (hyperv.disk.smb_path.missing) to surface a warning in the UI.

The Rego assessment message is updated to mention multi-node clusters and recommend moving disks to shared storage.

Ref: https://redhat.atlassian.net/browse/MTV-6279
Resolves: MTV-6279