### PR TITLE
MTV-6203 | Implement conversion resume for migrations with completed disk copy

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -4979,6 +4979,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              resumeConversion:
+                description: |-
+                  ResumeConversion skips disk copy and runs only the virt-v2v
+                  conversion step, reusing PVCs from a previous failed migration.
+                  Valid for any plan whose disk copy and conversion are separate
+                  phases and whose disk copy completed before conversion failed.
+                type: boolean
             required:
             - plan
             type: object
@@ -5105,6 +5112,12 @@ spec:
                       description: Boot disk index (0-based) detected by virt-v2v.
                         nil means undetected.
                       type: integer
+                    disksCopied:
+                      description: |-
+                        DisksCopied is set to true when all disk transfer tasks complete
+                        successfully. Used to determine if conversion can be resumed
+                        without re-copying disks.
+                      type: boolean
                     enableNestedVirtualization:
                       description: |-
                         EnableNestedVirtualization controls whether nested virtualization CPU features (vmx/svm)
@@ -9482,6 +9495,12 @@ spec:
                           description: Boot disk index (0-based) detected by virt-v2v.
                             nil means undetected.
                           type: integer
+                        disksCopied:
+                          description: |-
+                            DisksCopied is set to true when all disk transfer tasks complete
+                            successfully. Used to determine if conversion can be resumed
+                            without re-copying disks.
+                          type: boolean
                         enableNestedVirtualization:
                           description: |-
                             EnableNestedVirtualization controls whether nested virtualization CPU features (vmx/svm)

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -4979,6 +4979,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              resumeConversion:
+                description: |-
+                  ResumeConversion skips disk copy and runs only the virt-v2v
+                  conversion step, reusing PVCs from a previous failed migration.
+                  Valid for any plan whose disk copy and conversion are separate
+                  phases and whose disk copy completed before conversion failed.
+                type: boolean
             required:
             - plan
             type: object
@@ -5105,6 +5112,12 @@ spec:
                       description: Boot disk index (0-based) detected by virt-v2v.
                         nil means undetected.
                       type: integer
+                    disksCopied:
+                      description: |-
+                        DisksCopied is set to true when all disk transfer tasks complete
+                        successfully. Used to determine if conversion can be resumed
+                        without re-copying disks.
+                      type: boolean
                     enableNestedVirtualization:
                       description: |-
                         EnableNestedVirtualization controls whether nested virtualization CPU features (vmx/svm)
@@ -9482,6 +9495,12 @@ spec:
                           description: Boot disk index (0-based) detected by virt-v2v.
                             nil means undetected.
                           type: integer
+                        disksCopied:
+                          description: |-
+                            DisksCopied is set to true when all disk transfer tasks complete
+                            successfully. Used to determine if conversion can be resumed
+                            without re-copying disks.
+                          type: boolean
                         enableNestedVirtualization:
                           description: |-
                             EnableNestedVirtualization controls whether nested virtualization CPU features (vmx/svm)

--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -132,6 +132,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              resumeConversion:
+                description: |-
+                  ResumeConversion skips disk copy and runs only the virt-v2v
+                  conversion step, reusing PVCs from a previous failed migration.
+                  Valid for any plan whose disk copy and conversion are separate
+                  phases and whose disk copy completed before conversion failed.
+                type: boolean
             required:
             - plan
             type: object
@@ -258,6 +265,12 @@ spec:
                       description: Boot disk index (0-based) detected by virt-v2v.
                         nil means undetected.
                       type: integer
+                    disksCopied:
+                      description: |-
+                        DisksCopied is set to true when all disk transfer tasks complete
+                        successfully. Used to determine if conversion can be resumed
+                        without re-copying disks.
+                      type: boolean
                     enableNestedVirtualization:
                       description: |-
                         EnableNestedVirtualization controls whether nested virtualization CPU features (vmx/svm)

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -3174,6 +3174,12 @@ spec:
                           description: Boot disk index (0-based) detected by virt-v2v.
                             nil means undetected.
                           type: integer
+                        disksCopied:
+                          description: |-
+                            DisksCopied is set to true when all disk transfer tasks complete
+                            successfully. Used to determine if conversion can be resumed
+                            without re-copying disks.
+                          type: boolean
                         enableNestedVirtualization:
                           description: |-
                             EnableNestedVirtualization controls whether nested virtualization CPU features (vmx/svm)

--- a/pkg/apis/forklift/v1beta1/migration.go
+++ b/pkg/apis/forklift/v1beta1/migration.go
@@ -33,6 +33,12 @@ type MigrationSpec struct {
 	// Date and time to finalize a warm migration.
 	// If present, this will override the value set on the Plan.
 	Cutover *meta.Time `json:"cutover,omitempty"`
+	// ResumeConversion skips disk copy and runs only the virt-v2v
+	// conversion step, reusing PVCs from a previous failed migration.
+	// Valid for any plan whose disk copy and conversion are separate
+	// phases and whose disk copy completed before conversion failed.
+	// +optional
+	ResumeConversion bool `json:"resumeConversion,omitempty"`
 }
 
 // Canceled indicates whether a VM ref is present
@@ -102,4 +108,8 @@ type MigrationList struct {
 
 func init() {
 	SchemeBuilder.Register(&Migration{}, &MigrationList{})
+}
+
+func (r *Migration) IsResumeConversion() bool {
+	return r.Spec.ResumeConversion
 }

--- a/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -240,6 +240,11 @@ type VMStatus struct {
 	DetectedBootDisk *int `json:"detectedBootDisk,omitempty"`
 	// The new name of the VM after matching DNS1123 requirements.
 	NewName string `json:"newName,omitempty"`
+	// DisksCopied is set to true when all disk transfer tasks complete
+	// successfully. Used to determine if conversion can be resumed
+	// without re-copying disks.
+	// +optional
+	DisksCopied bool `json:"disksCopied,omitempty"`
 
 	// Conditions.
 	libcnd.Conditions `json:",inline"`

--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -13,6 +13,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// Labels
+const (
+	// LabelVMUUID is the PVC/DV label that carries the source VM UUID,
+	// used by resume-conversion and conversion-only flows to discover
+	// PVCs across migration boundaries.
+	LabelVMUUID = "vmUUID"
+)
+
 // Annotations
 const (
 	// JSON map of original → sanitized label/annotation keys on the destination VM.

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1783,6 +1783,9 @@ func (r *Builder) buildCsiImportPVC(
 		"vmdkKey":   fmt.Sprint(disk.Key),
 		"vmID":      vmRef.ID,
 	}
+	if vm.UUID != "" {
+		pvcLabels[planbase.LabelVMUUID] = vm.UUID
+	}
 
 	pvc := &core.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/plan/context/migration.go
+++ b/pkg/controller/plan/context/migration.go
@@ -67,6 +67,12 @@ type Context struct {
 	Labeler Labeler
 }
 
+// IsResumeConversion returns true when the active migration is a
+// resume-conversion run (disk copy skipped, only virt-v2v conversion).
+func (r *Context) IsResumeConversion() bool {
+	return r.Migration != nil && r.Migration.IsResumeConversion()
+}
+
 // Build.
 func (r *Context) build() (err error) {
 	r.Map.Network = r.Plan.Referenced.Map.Network

--- a/pkg/controller/plan/context/migration_test.go
+++ b/pkg/controller/plan/context/migration_test.go
@@ -1,0 +1,55 @@
+package context
+
+import (
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+)
+
+func TestIsResumeConversion(t *testing.T) {
+	tests := []struct {
+		name      string
+		migration *api.Migration
+		expected  bool
+	}{
+		{
+			name:      "nil migration returns false",
+			migration: nil,
+			expected:  false,
+		},
+		{
+			name:      "migration without resumeConversion returns false",
+			migration: &api.Migration{},
+			expected:  false,
+		},
+		{
+			name: "migration with resumeConversion=true returns true",
+			migration: &api.Migration{
+				Spec: api.MigrationSpec{
+					ResumeConversion: true,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "migration with resumeConversion=false returns false",
+			migration: &api.Migration{
+				Spec: api.MigrationSpec{
+					ResumeConversion: false,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &Context{
+				Migration: tt.migration,
+			}
+			if got := ctx.IsResumeConversion(); got != tt.expected {
+				t.Errorf("IsResumeConversion() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -488,6 +488,7 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	if migration == nil {
 		r.Log.Info("No pending migrations found.")
 		plan.Status.DeleteCondition(Executing)
+		r.checkConversionResumable(plan)
 		return
 	}
 
@@ -517,6 +518,10 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 				t)
 		}
 	}
+
+	// Check if the failed plan is resumable
+	r.checkConversionResumable(plan)
+
 	if len(pending) > 1 && reQ == 0 {
 		r.Log.V(1).Info(
 			"Found pending migrations.",

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -121,8 +121,8 @@ const (
 	kPlanNamespace = "plan-namespace"
 	// VM label (value=vmID)
 	kVM = "vmID"
-	// VM UUID label
-	kVmUuid = "vmUUID"
+	// VM UUID label — alias for planbase.LabelVMUUID
+	kVmUuid = planbase.LabelVMUUID
 	// App label
 	kApp = "forklift.app"
 	// LUKS
@@ -2075,17 +2075,12 @@ func (r *KubeVirt) getPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, e
 		kVM: vmRef.ID,
 	}
 	// We need to have this in getPVCs so we create VM with corect disks, this will also help us with the guest generation
-	if r.Plan.Spec.Type == api.MigrationOnlyConversion {
-		v, err := r.Source.Inventory.VM(&vmRef)
-		if err != nil {
-			err = liberr.Wrap(err)
-			return nil, err
+	if r.Plan.Spec.Type == api.MigrationOnlyConversion || r.IsResumeConversion() {
+		uuid, uuidErr := r.resolveVMUUID(vmRef)
+		if uuidErr != nil {
+			return nil, uuidErr
 		}
-		if vm, ok := v.(*model.VM); ok {
-			labelSelector[kVmUuid] = vm.UUID
-		} else {
-			return nil, fmt.Errorf("failed to parse the VM for only conversion mode, we need to UUID to prevent accidental overwrites, stopping migration")
-		}
+		labelSelector[kVmUuid] = uuid
 	} else {
 		labelSelector[kMigration] = string(r.Migration.UID)
 	}
@@ -2118,6 +2113,98 @@ func (r *KubeVirt) getPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, e
 	})
 
 	return
+}
+
+// resolveVMUUID fetches the source VM from inventory and extracts the UUID
+// used as the vmUUID label value for PVC/DV discovery.
+func (r *KubeVirt) resolveVMUUID(vmRef ref.Ref) (string, error) {
+	v, err := r.Source.Inventory.VM(&vmRef)
+	if err != nil {
+		return "", liberr.Wrap(err)
+	}
+	return vmUUIDFromInventory(v, vmRef)
+}
+
+// vmUUIDFromInventory extracts the UUID from an already-fetched inventory VM.
+func vmUUIDFromInventory(v interface{}, vmRef ref.Ref) (string, error) {
+	if vsVM, ok := v.(*model.VM); ok {
+		if vsVM.UUID != "" {
+			return vsVM.UUID, nil
+		}
+		return "", fmt.Errorf("vSphere VM %q has an empty UUID", vmRef.ID)
+	}
+	// Non-vSphere providers use vmRef.ID as the vmUUID label.
+	if vmRef.ID == "" {
+		return "", fmt.Errorf("VM ref has an empty ID for non-vSphere provider")
+	}
+	return vmRef.ID, nil
+}
+
+// ValidateResumePVCs checks that reusable PVCs exist for the VM, are Bound,
+// and have no duplicate disk source or index.
+func (r *KubeVirt) ValidateResumePVCs(vmRef ref.Ref) error {
+	uuid, err := r.resolveVMUUID(vmRef)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	return r.validateResumePVCsByUUID(vmRef, uuid)
+}
+
+// validateResumePVCsByUUID performs the actual PVC validation given a
+// pre-resolved VM UUID. Separated for testability without inventory.
+func (r *KubeVirt) validateResumePVCsByUUID(vmRef ref.Ref, vmUUID string) error {
+	pvcsList := &core.PersistentVolumeClaimList{}
+	err := r.Destination.List(
+		context.TODO(),
+		pvcsList,
+		&client.ListOptions{
+			LabelSelector: k8slabels.SelectorFromSet(map[string]string{
+				kVM:     vmRef.ID,
+				kVmUuid: vmUUID,
+			}),
+			Namespace: r.Plan.Spec.TargetNamespace,
+		},
+	)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+
+	var pvcs []*core.PersistentVolumeClaim
+	for i := range pvcsList.Items {
+		pvc := &pvcsList.Items[i]
+		if strings.HasPrefix(pvc.Name, "prime-") || !hasDiskIdentity(pvc) {
+			continue
+		}
+		pvcs = append(pvcs, pvc)
+	}
+
+	if len(pvcs) == 0 {
+		return fmt.Errorf("no reusable PVCs found for VM %q in namespace %q", vmRef.ID, r.Plan.Spec.TargetNamespace)
+	}
+
+	seenSources := map[string]string{}
+	seenIndexes := map[int]string{}
+	for _, pvc := range pvcs {
+		if pvc.Status.Phase != core.ClaimBound {
+			return fmt.Errorf("PVC %q is not Bound (phase=%s); cannot resume conversion", pvc.Name, pvc.Status.Phase)
+		}
+
+		source := pvc.Annotations[planbase.AnnDiskSource]
+		if prev, dup := seenSources[source]; dup {
+			return fmt.Errorf("duplicate disk source %q on PVCs %q and %q; ambiguous disk set", source, prev, pvc.Name)
+		}
+		seenSources[source] = pvc.Name
+
+		idx := getDiskIndex(pvc)
+		if idx >= 0 {
+			if prev, dup := seenIndexes[idx]; dup {
+				return fmt.Errorf("duplicate disk index %d on PVCs %q and %q; ambiguous disk set", idx, prev, pvc.Name)
+			}
+			seenIndexes[idx] = pvc.Name
+		}
+	}
+
+	return nil
 }
 
 // hasDiskIdentity reports whether the PVC carries the AnnDiskSource annotation
@@ -2698,7 +2785,7 @@ func (r *KubeVirt) getPopulatorPods(vmID string) (pods []core.Pod, err error) {
 
 // Build the DataVolume CRs.
 func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap *core.ConfigMap, vddkConfigMap *core.ConfigMap) (dataVolumes []cdi.DataVolume, err error) {
-	_, err = r.Source.Inventory.VM(&vm.Ref)
+	srcVM, err := r.Source.Inventory.VM(&vm.Ref)
 	if err != nil {
 		return
 	}
@@ -2748,6 +2835,15 @@ func (r *KubeVirt) dataVolumes(vm *plan.VMStatus, secret *core.Secret, configMap
 	}
 	dvTemplate.Labels = r.vmLabels(vm.Ref)
 
+	// Add vmUUID for any migration where copy and conversion are separate,
+	// so PVCs can be discovered by a resume-conversion migration.
+	if util.HasSeparateCopyAndConversion(r.Plan, vm.Ref, r.Destination.Client) {
+		if uuid, uuidErr := vmUUIDFromInventory(srcVM, vm.Ref); uuidErr != nil {
+			r.Log.Error(uuidErr, "Failed to resolve vmUUID label for DV; resume-conversion discovery may fail.", "vm", vm.String())
+		} else {
+			dvTemplate.Labels[kVmUuid] = uuid
+		}
+	}
 	dataVolumes, err = r.Builder.DataVolumes(vm.Ref, secret, configMap, &dvTemplate, vddkConfigMap)
 	if err != nil {
 		return

--- a/pkg/controller/plan/kubevirt_resume_test.go
+++ b/pkg/controller/plan/kubevirt_resume_test.go
@@ -1,0 +1,354 @@
+package plan
+
+import (
+	"time"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/settings"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var resumeLog = logging.WithName("resumeTest")
+
+const (
+	resumePlanName      = "plan-resume"
+	resumePlanNamespace = "plan-ns"
+	resumeTargetNS      = "target-ns"
+	resumeVMID          = "vm-1234"
+	resumePlanUID       = types.UID("plan-uid-1")
+)
+
+// resumeConvPodLabels returns the labels a guest-conversion pod carries.
+func resumeConvPodLabels(migrationUID types.UID) map[string]string {
+	return map[string]string{
+		kMigration:     string(migrationUID),
+		kPlan:          string(resumePlanUID),
+		kPlanName:      resumePlanName,
+		kPlanNamespace: resumePlanNamespace,
+		kVM:            resumeVMID,
+		kResource:      ResourceVMConfig,
+		kApp:           "virt-v2v",
+	}
+}
+
+func newResumeKubeVirt(migrationUID types.UID, objects ...client.Object) (KubeVirt, *Migration) {
+	scheme := runtime.NewScheme()
+	_ = core.AddToScheme(scheme)
+
+	c := fakeClient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+
+	ctx := &plancontext.Context{
+		Plan: &api.Plan{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      resumePlanName,
+				Namespace: resumePlanNamespace,
+				UID:       resumePlanUID,
+			},
+			Spec: api.PlanSpec{TargetNamespace: resumeTargetNS},
+		},
+		Migration: &api.Migration{
+			ObjectMeta: meta.ObjectMeta{UID: migrationUID},
+		},
+		Destination: plancontext.Destination{Client: c},
+		Log:         resumeLog,
+	}
+
+	kv := KubeVirt{Context: ctx}
+	m := &Migration{Context: ctx, kubevirt: kv}
+	return kv, m
+}
+
+func newResumeVMStatus() *planapi.VMStatus {
+	return &planapi.VMStatus{
+		VM: planapi.VM{
+			Ref: ref.Ref{ID: resumeVMID},
+		},
+	}
+}
+
+var _ = ginkgo.Describe("Resume-conversion stale workload cleanup", func() {
+	var (
+		oldMigrationUID types.UID
+		newMigrationUID types.UID
+	)
+
+	ginkgo.BeforeEach(func() {
+		oldMigrationUID = types.UID("old-migration-" + rand.String(6))
+		newMigrationUID = types.UID("new-migration-" + rand.String(6))
+		settings.Settings.UseConversionCR = false
+	})
+
+	ginkgo.Context("deleteStaleConversionWorkloads", func() {
+		ginkgo.It("should request deletion of stale pod and return done=false", func() {
+			stalePod := &core.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "stale-conv-pod",
+					Namespace: resumeTargetNS,
+					Labels:    resumeConvPodLabels(oldMigrationUID),
+				},
+			}
+			_, m := newResumeKubeVirt(newMigrationUID, stalePod)
+			vm := newResumeVMStatus()
+
+			done, err := m.deleteStaleConversionWorkloads(vm)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(done).To(gomega.BeFalse(), "should requeue after requesting deletion")
+		})
+
+		ginkgo.It("should return done=true when no stale pods exist", func() {
+			_, m := newResumeKubeVirt(newMigrationUID)
+			vm := newResumeVMStatus()
+
+			done, err := m.deleteStaleConversionWorkloads(vm)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(done).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should return done=false when a pod is still terminating", func() {
+			now := meta.NewTime(time.Now())
+			terminatingPod := &core.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Name:              "terminating-conv-pod",
+					Namespace:         resumeTargetNS,
+					Labels:            resumeConvPodLabels(oldMigrationUID),
+					DeletionTimestamp: &now,
+					Finalizers:        []string{"test-finalizer"},
+				},
+			}
+			_, m := newResumeKubeVirt(newMigrationUID, terminatingPod)
+			vm := newResumeVMStatus()
+
+			done, err := m.deleteStaleConversionWorkloads(vm)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(done).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should preserve copied PVCs while deleting stale conversion pods", func() {
+			stalePod := &core.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "stale-conv-pod",
+					Namespace: resumeTargetNS,
+					Labels:    resumeConvPodLabels(oldMigrationUID),
+				},
+			}
+			copiedPVC := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "copied-disk-pvc",
+					Namespace: resumeTargetNS,
+					Labels: map[string]string{
+						kPlan:          string(resumePlanUID),
+						kPlanName:      resumePlanName,
+						kPlanNamespace: resumePlanNamespace,
+						kVM:            resumeVMID,
+					},
+				},
+			}
+
+			_, m := newResumeKubeVirt(newMigrationUID, stalePod, copiedPVC)
+			vm := newResumeVMStatus()
+
+			done, err := m.deleteStaleConversionWorkloads(vm)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(done).To(gomega.BeFalse(), "should requeue after requesting pod deletion")
+
+			gomega.Expect(objectExists(m.Destination.Client, types.NamespacedName{
+				Name: "copied-disk-pvc", Namespace: resumeTargetNS,
+			}, &core.PersistentVolumeClaim{})).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should return done=false on first call, done=true once pod is gone", func() {
+			stalePod := &core.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "stale-conv-pod",
+					Namespace: resumeTargetNS,
+					Labels:    resumeConvPodLabels(oldMigrationUID),
+				},
+			}
+			_, m := newResumeKubeVirt(newMigrationUID, stalePod)
+			vm := newResumeVMStatus()
+
+			done, err := m.deleteStaleConversionWorkloads(vm)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(done).To(gomega.BeFalse(), "first call requests deletion and requeues")
+
+			// Fake-client removes the object synchronously, so the next
+			// reconciliation finds no stale resources.
+			done, err = m.deleteStaleConversionWorkloads(vm)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(done).To(gomega.BeTrue(), "no stale objects remain")
+		})
+	})
+})
+
+var _ = ginkgo.Describe("Resume-conversion PVC validation", func() {
+	const testUUID = "test-uuid"
+
+	ginkgo.Context("validateResumePVCsByUUID", func() {
+		ginkgo.It("should reject when no PVCs exist", func() {
+			migUID := types.UID("mig-" + rand.String(6))
+			kv, _ := newResumeKubeVirt(migUID)
+
+			err := kv.validateResumePVCsByUUID(ref.Ref{ID: resumeVMID}, testUUID)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("no reusable PVCs"))
+		})
+
+		ginkgo.It("should reject unbound PVCs", func() {
+			migUID := types.UID("mig-" + rand.String(6))
+			pvc := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "pending-pvc",
+					Namespace: resumeTargetNS,
+					Labels: map[string]string{
+						kVM:     resumeVMID,
+						kVmUuid: testUUID,
+					},
+					Annotations: map[string]string{
+						planbase.AnnDiskSource: "[disk-1]",
+						planbase.AnnDiskIndex:  "0",
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{
+					Phase: core.ClaimPending,
+				},
+			}
+			kv, _ := newResumeKubeVirt(migUID, pvc)
+
+			err := kv.validateResumePVCsByUUID(ref.Ref{ID: resumeVMID}, testUUID)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("not Bound"))
+		})
+
+		ginkgo.It("should reject duplicate disk sources", func() {
+			migUID := types.UID("mig-" + rand.String(6))
+			pvc1 := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "pvc-1",
+					Namespace: resumeTargetNS,
+					Labels: map[string]string{
+						kVM:     resumeVMID,
+						kVmUuid: testUUID,
+					},
+					Annotations: map[string]string{
+						planbase.AnnDiskSource: "[disk-1]",
+						planbase.AnnDiskIndex:  "0",
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+			}
+			pvc2 := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "pvc-2",
+					Namespace: resumeTargetNS,
+					Labels: map[string]string{
+						kVM:     resumeVMID,
+						kVmUuid: testUUID,
+					},
+					Annotations: map[string]string{
+						planbase.AnnDiskSource: "[disk-1]",
+						planbase.AnnDiskIndex:  "1",
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+			}
+			kv, _ := newResumeKubeVirt(migUID, pvc1, pvc2)
+
+			err := kv.validateResumePVCsByUUID(ref.Ref{ID: resumeVMID}, testUUID)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("duplicate disk source"))
+		})
+
+		ginkgo.It("should reject duplicate disk indexes", func() {
+			migUID := types.UID("mig-" + rand.String(6))
+			pvc1 := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "pvc-1",
+					Namespace: resumeTargetNS,
+					Labels: map[string]string{
+						kVM:     resumeVMID,
+						kVmUuid: testUUID,
+					},
+					Annotations: map[string]string{
+						planbase.AnnDiskSource: "[disk-1]",
+						planbase.AnnDiskIndex:  "0",
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+			}
+			pvc2 := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "pvc-2",
+					Namespace: resumeTargetNS,
+					Labels: map[string]string{
+						kVM:     resumeVMID,
+						kVmUuid: testUUID,
+					},
+					Annotations: map[string]string{
+						planbase.AnnDiskSource: "[disk-2]",
+						planbase.AnnDiskIndex:  "0",
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+			}
+			kv, _ := newResumeKubeVirt(migUID, pvc1, pvc2)
+
+			err := kv.validateResumePVCsByUUID(ref.Ref{ID: resumeVMID}, testUUID)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("duplicate disk index"))
+		})
+
+		ginkgo.It("should accept a valid set of Bound PVCs with unique identities", func() {
+			migUID := types.UID("mig-" + rand.String(6))
+			pvc1 := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "pvc-1",
+					Namespace: resumeTargetNS,
+					Labels: map[string]string{
+						kVM:     resumeVMID,
+						kVmUuid: testUUID,
+					},
+					Annotations: map[string]string{
+						planbase.AnnDiskSource: "[disk-1]",
+						planbase.AnnDiskIndex:  "0",
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+			}
+			pvc2 := &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "pvc-2",
+					Namespace: resumeTargetNS,
+					Labels: map[string]string{
+						kVM:     resumeVMID,
+						kVmUuid: testUUID,
+					},
+					Annotations: map[string]string{
+						planbase.AnnDiskSource: "[disk-2]",
+						planbase.AnnDiskIndex:  "1",
+					},
+				},
+				Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+			}
+			kv, _ := newResumeKubeVirt(migUID, pvc1, pvc2)
+
+			err := kv.validateResumePVCsByUUID(ref.Ref{ID: resumeVMID}, testUUID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+})

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubev2v/forklift/pkg/controller/plan/migrator"
 	planmigrbase "github.com/kubev2v/forklift/pkg/controller/plan/migrator/base"
 	"github.com/kubev2v/forklift/pkg/controller/plan/scheduler"
+	util "github.com/kubev2v/forklift/pkg/controller/plan/util"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web"
 
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
@@ -97,6 +98,17 @@ func (r *Migration) Run() (reQ time.Duration, err error) {
 	err = r.begin()
 	if err != nil {
 		err = liberr.Wrap(err)
+		return
+	}
+
+	// begin() may reject the migration early (setting Failed/Canceled
+	// without Executing). Return now to prevent end() from overwriting
+	// the specific error with a generic status.
+	snapshot := r.Plan.Status.Migration.ActiveSnapshot()
+	if !snapshot.HasCondition(api.ConditionExecuting) {
+		if snapshot.HasAnyCondition(api.ConditionFailed, api.ConditionCanceled) {
+			reQ = NoReQ
+		}
 		return
 	}
 
@@ -198,6 +210,41 @@ func (r *Migration) begin() (err error) {
 	if snapshot.HasAnyCondition(api.ConditionExecuting, api.ConditionSucceeded, api.ConditionFailed, api.ConditionCanceled) {
 		return
 	}
+
+	// Validate resume-conversion prerequisites
+	if r.Migration.Spec.ResumeConversion {
+		hasResumable := false
+		for _, specVM := range r.Plan.Spec.VMs {
+			if !util.HasSeparateCopyAndConversion(r.Plan, specVM.Ref, r.Destination.Client) {
+				snapshot.SetCondition(libcnd.Condition{
+					Type:     api.ConditionFailed,
+					Status:   True,
+					Category: api.CategoryCritical,
+					Message: fmt.Sprintf(
+						"Resume conversion is not supported for VM %q: disk copy and conversion are not separate phases.",
+						specVM.ID),
+					Durable: true,
+				})
+				return
+			}
+			if status, found := r.Plan.Status.Migration.FindVM(specVM.Ref); found &&
+				status.DisksCopied && status.HasCondition(api.ConditionFailed) {
+				hasResumable = true
+			}
+		}
+		if !hasResumable {
+			snapshot.SetCondition(libcnd.Condition{
+				Type:     api.ConditionFailed,
+				Status:   True,
+				Category: api.CategoryCritical,
+				Message:  "Resume conversion requires VMs with completed disk copy (DisksCopied=true).",
+				Durable:  true,
+			})
+			return
+		}
+		r.Log.Info("Resume-conversion mode: skipping disk copy, running conversion only.")
+	}
+
 	r.Plan.Status.Migration.MarkReset()
 	r.Plan.Status.Migration.MarkStarted()
 	snapshot.SetCondition(
@@ -246,6 +293,17 @@ func (r *Migration) begin() (err error) {
 	for _, vm := range r.Plan.Spec.VMs {
 		status := r.migrator.Status(vm)
 		if status.Phase != api.PhaseCompleted || status.HasAnyCondition(api.ConditionCanceled, api.ConditionFailed) {
+			// For resume-conversion, only reset VMs that actually have their disks copied.
+			// VMs that failed before disk copy completed cannot be resumed — exclude them
+			// from this migration's VM list so stale failures don't cause end() to
+			// mark the overall migration as failed.
+			if r.IsResumeConversion() && !status.DisksCopied {
+				log.Info(
+					"Skipping VM without completed disk copy in resume-conversion.",
+					"vm",
+					vm.String())
+				continue
+			}
 			pipeline, pErr := r.migrator.Pipeline(vm)
 			if pErr != nil {
 				err = liberr.Wrap(pErr)
@@ -415,9 +473,12 @@ func markStartedStepsCompleted(vm *plan.VMStatus) {
 func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, forceDeleteGuestConversionPod bool) error {
 	r.Log.Info("Starting cleanup of migration resources.", "vm", vm.String())
 
-	// If the migration fails and the DeleteVmOnFailMigration is enabled, clean up the VM.
+	// If the migration fails, DeleteVmOnFailMigration is enabled and the disks were NOT fully copied, clean up the VM.
 	// When DeleteVmOnFailMigration is disabled, VM resources are preserved on failure.
-	if !vm.HasCondition(api.ConditionSucceeded) && (r.Plan.Spec.DeleteVmOnFailMigration || vm.DeleteVmOnFailMigration) && r.Plan.Spec.Type != api.MigrationOnlyConversion {
+	// During archive/cancel (forceDeleteGuestConversionPod=true), allow deletion even when
+	// DisksCopied is set — there's no opportunity to resume from those contexts.
+	if !vm.HasCondition(api.ConditionSucceeded) && (r.Plan.Spec.DeleteVmOnFailMigration || vm.DeleteVmOnFailMigration) &&
+		r.Plan.Spec.Type != api.MigrationOnlyConversion && (!vm.DisksCopied || forceDeleteGuestConversionPod) {
 		r.Log.Info("Deleting VM (failed migration with deleteVmOnFailMigration enabled).", "vm", vm.String())
 		if err := r.kubevirt.DeleteVM(vm); failOnErr(err) {
 			return err
@@ -508,10 +569,75 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, force
 		return err
 	}
 
-	r.removeLastWarmSnapshot(vm)
+	if !r.IsResumeConversion() {
+		r.removeLastWarmSnapshot(vm)
+	}
 
 	r.Log.Info("Cleanup of migration resources completed.", "vm", vm.String())
 	return nil
+}
+
+// deleteStaleConversionWorkloads requests deletion of guest-conversion pods
+// and CRs left over from a prior failed migration. Returns done=true when
+// no stale objects remain (safe to proceed), or done=false when objects are
+// still terminating (caller should requeue and retry). If an object has been
+// terminating longer than staleTerminationTimeout, it is force-deleted.
+func (r *Migration) deleteStaleConversionWorkloads(vm *plan.VMStatus) (done bool, err error) {
+	r.Log.Info("Checking for stale conversion workloads.", "vm", vm.String())
+
+	stalePods, err := r.kubevirt.GetPodsWithLabels(r.kubevirt.conversionLabels(vm.Ref, true))
+	if err != nil {
+		return false, err
+	}
+	if len(stalePods.Items) > 0 {
+		pod := &stalePods.Items[0]
+		if pod.DeletionTimestamp != nil {
+			timeout := time.Duration(settings.Settings.StaleConversionTimeout) * time.Second
+			if time.Since(pod.DeletionTimestamp.Time) < timeout {
+				r.Log.Info("Stale conversion pod still terminating, will requeue.",
+					"pod", pod.Name, "vm", vm.String())
+				return false, nil
+			}
+			r.Log.Info("Stale conversion pod stuck terminating, force-deleting.",
+				"pod", pod.Name, "vm", vm.String(),
+				"terminatingSince", pod.DeletionTimestamp.Time)
+			grace := int64(0)
+			if delErr := r.Destination.Delete(context.TODO(), pod, &client.DeleteOptions{GracePeriodSeconds: &grace}); delErr != nil {
+				return false, delErr
+			}
+			return false, nil
+		}
+		if delErr := r.kubevirt.DeleteObject(pod, vm, "Deleted stale conversion pod.", "pod"); delErr != nil {
+			return false, delErr
+		}
+		return false, nil
+	}
+
+	if settings.Settings.UseConversionCR {
+		gConv, gErr := r.kubevirt.GetGuestConversion(vm)
+		if gErr != nil {
+			return false, gErr
+		}
+		if gConv != nil {
+			if gConv.DeletionTimestamp != nil {
+				timeout := time.Duration(settings.Settings.StaleConversionTimeout) * time.Second
+				if time.Since(gConv.DeletionTimestamp.Time) < timeout {
+					r.Log.Info("Stale Conversion CR still terminating, will requeue.",
+						"conversion", gConv.Name, "vm", vm.String())
+					return false, nil
+				}
+				r.Log.Info("Stale Conversion CR stuck terminating, force-deleting.",
+					"conversion", gConv.Name, "vm", vm.String(),
+					"terminatingSince", gConv.DeletionTimestamp.Time)
+			}
+			if delErr := r.kubevirt.DeleteConversion(gConv); delErr != nil {
+				return false, delErr
+			}
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func (r *Migration) removeLastWarmSnapshot(vm *plan.VMStatus) {
@@ -755,11 +881,34 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			vm.MarkStarted()
 			step.MarkStarted()
 			step.Phase = api.StepRunning
-			err = r.cleanup(vm, func(err error) bool { return err != nil }, true)
+			// Resume-conversion passes forceCleanup=false to preserve copied PVCs/DVs,
+			// but we must still remove stale conversion pods/CRs from the prior
+			// failed migration so the new workload can mount the reused disks.
+			forceCleanup := !r.IsResumeConversion()
+			err = r.cleanup(vm, func(err error) bool { return err != nil }, forceCleanup)
 			if err != nil {
 				step.AddError(err.Error())
 				err = nil
 				break
+			}
+			if r.IsResumeConversion() {
+				var staleGone bool
+				staleGone, err = r.deleteStaleConversionWorkloads(vm)
+				if err != nil {
+					step.AddError(err.Error())
+					err = nil
+					break
+				}
+				if !staleGone {
+					r.Log.Info("Stale conversion workloads still terminating, requeuing.",
+						"vm", vm.String())
+					return
+				}
+				if err = r.kubevirt.ValidateResumePVCs(vm.Ref); err != nil {
+					step.AddError(fmt.Sprintf("Resume-conversion PVC validation failed: %v", err))
+					err = nil
+					break
+				}
 			}
 
 			// Check if user provided explicit a target virtual machine name
@@ -1443,6 +1592,13 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				}
 			}
 		case api.PhaseCreateGuestConversionPod:
+
+			if !vm.DisksCopied && !r.IsResumeConversion() &&
+				util.HasSeparateCopyAndConversion(r.Plan, vm.Ref, r.Destination.Client) {
+				vm.DisksCopied = true
+				r.Log.Info("All disks copied, marking VM as resumable on conversion failure.",
+					"vm", vm.String())
+			}
 			step, found := vm.FindStep(r.migrator.Step(vm))
 			if !found {
 				vm.AddError(fmt.Sprintf("Step '%s' not found", r.migrator.Step(vm)))
@@ -1669,7 +1825,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 
 		// Failed warm migration can't follow its planned itinerary to snapshot removal phase
 		// so we remove the snapshot here to prevent an orphaned snapshot.
-		if r.Plan.IsWarm() && !vm.HasCondition(api.ConditionFailed) {
+		if r.Plan.IsWarm() && !vm.HasCondition(api.ConditionFailed) && !r.IsResumeConversion() {
 			r.removeLastWarmSnapshot(vm)
 		}
 

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -61,6 +61,10 @@ func (r *BaseMigrator) Reset(vm *plan.VMStatus, pipeline []*plan.Step) {
 	vm.Phase = step.Name
 	vm.Pipeline = pipeline
 	vm.Error = nil
+	if r.IsResumeConversion() {
+		return
+	}
+	vm.DisksCopied = false
 	if r.Context.Plan.IsWarm() {
 		vm.Warm = &plan.Warm{}
 	}
@@ -250,12 +254,14 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 }
 
 func (r *BaseMigrator) Itinerary(vm plan.VM) (itinerary *libitr.Itinerary) {
-	// Plan.Spec.Type supersedes the deprecated Warm boolean.
-	if r.Context.Plan.Spec.Type == api.MigrationOnlyConversion {
+	switch {
+	case r.IsResumeConversion():
+		itinerary = r.resumeConversionItinerary()
+	case r.Plan.Spec.Type == api.MigrationOnlyConversion:
 		itinerary = r.onlyConversionItinerary()
-	} else if r.Context.Plan.IsWarm() {
+	case r.Plan.IsWarm():
 		itinerary = r.warmItinerary()
-	} else {
+	default:
 		itinerary = r.coldItinerary()
 	}
 	itinerary.Predicate = &BasePredicate{vm: &vm, context: r.Context}
@@ -391,6 +397,24 @@ func (r *BaseMigrator) onlyConversionItinerary() *libitr.Itinerary {
 			{Name: api.PhaseStorePowerState},
 			{Name: api.PhasePowerOffSource},
 			{Name: api.PhaseWaitForPowerOff},
+			{Name: api.PhaseCreateGuestConversionPod, All: RequiresConversion},
+			{Name: api.PhaseConvertGuest, All: RequiresConversion},
+			{Name: api.PhaseCreateVM},
+			{Name: api.PhaseWaitForGuestReboots, All: WindowsWaitForGuestReboot},
+			{Name: api.PhasePostHook, All: HasPostHook},
+			{Name: api.PhaseCompleted},
+		},
+	}
+}
+
+// resumeConversionItinerary skips disk copy AND power-off (source was already
+// powered off during the original migration's cutover).
+func (r *BaseMigrator) resumeConversionItinerary() *libitr.Itinerary {
+	return &libitr.Itinerary{
+		Name: "ResumeConversion",
+		Pipeline: libitr.Pipeline{
+			{Name: api.PhaseStarted},
+			{Name: api.PhasePreHook, All: HasPreHook},
 			{Name: api.PhaseCreateGuestConversionPod, All: RequiresConversion},
 			{Name: api.PhaseConvertGuest, All: RequiresConversion},
 			{Name: api.PhaseCreateVM},

--- a/pkg/controller/plan/migrator/base/migrator_test.go
+++ b/pkg/controller/plan/migrator/base/migrator_test.go
@@ -79,3 +79,154 @@ func TestBasePredicate_useV2vForTransferCached(t *testing.T) {
 		t.Fatalf("destination Get calls = %d, want 1 (cached)", cl.n.Load())
 	}
 }
+
+func newBaseMigratorWithProvider(t *testing.T, p *api.Plan, migration *api.Migration) *BaseMigrator {
+	t.Helper()
+	vsphere, openshift := api.VSphere, api.OpenShift
+
+	scheme := runtime.NewScheme()
+	if err := storagev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register storage types: %v", err)
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	ctx := &plancontext.Context{
+		Plan:      p,
+		Migration: migration,
+		Source: plancontext.Source{
+			Provider: &api.Provider{Spec: api.ProviderSpec{Type: &vsphere, URL: "https://vc"}},
+		},
+		Destination: plancontext.Destination{
+			Client: cl,
+		},
+	}
+
+	if p.Provider.Source == nil {
+		p.Provider.Source = &api.Provider{Spec: api.ProviderSpec{Type: &vsphere, URL: "https://vc"}}
+	}
+	if p.Provider.Destination == nil {
+		p.Provider.Destination = &api.Provider{Spec: api.ProviderSpec{Type: &openshift, URL: ""}}
+	}
+
+	return &BaseMigrator{Context: ctx}
+}
+
+func TestItinerary_ResumeConversion_SelectsResumeConversion(t *testing.T) {
+	p := &api.Plan{Spec: api.PlanSpec{Warm: true}}
+	m := &api.Migration{}
+	m.Spec.ResumeConversion = true
+	migrator := newBaseMigratorWithProvider(t, p, m)
+
+	vm := plan.VM{Ref: ref.Ref{ID: "vm-1"}}
+	itr := migrator.Itinerary(vm)
+
+	if itr.Name != "ResumeConversion" {
+		t.Fatalf("expected ResumeConversion itinerary, got %q", itr.Name)
+	}
+
+	phases := map[string]bool{}
+	for _, step := range itr.Pipeline {
+		phases[step.Name] = true
+	}
+
+	excluded := []string{
+		api.PhaseCopyDisks,
+		api.PhaseCopyDisksVirtV2V,
+		api.PhaseStorePowerState,
+		api.PhasePowerOffSource,
+	}
+	for _, p := range excluded {
+		if phases[p] {
+			t.Errorf("resume-conversion itinerary should not contain %q", p)
+		}
+	}
+
+	required := []string{
+		api.PhaseCreateGuestConversionPod,
+		api.PhaseConvertGuest,
+		api.PhaseCreateVM,
+		api.PhaseCompleted,
+	}
+	for _, p := range required {
+		if !phases[p] {
+			t.Errorf("resume-conversion itinerary missing required phase %q", p)
+		}
+	}
+}
+
+func TestItinerary_ConversionOnlyPlanType(t *testing.T) {
+	p := &api.Plan{Spec: api.PlanSpec{Type: api.MigrationOnlyConversion}}
+	migrator := newBaseMigratorWithProvider(t, p, nil)
+
+	vm := plan.VM{Ref: ref.Ref{ID: "vm-1"}}
+	itr := migrator.Itinerary(vm)
+
+	if itr.Name != "OnlyConversion" {
+		t.Fatalf("expected OnlyConversion itinerary for conversion-only plan type, got %q", itr.Name)
+	}
+}
+
+func TestItinerary_NormalWarm_SelectsWarm(t *testing.T) {
+	p := &api.Plan{Spec: api.PlanSpec{Warm: true}}
+	migrator := newBaseMigratorWithProvider(t, p, nil)
+
+	vm := plan.VM{Ref: ref.Ref{ID: "vm-1"}}
+	itr := migrator.Itinerary(vm)
+
+	if itr.Name != "Warm" {
+		t.Fatalf("expected Warm itinerary, got %q", itr.Name)
+	}
+}
+
+func TestItinerary_NilMigration_DoesNotSelectConversion(t *testing.T) {
+	p := &api.Plan{}
+	migrator := newBaseMigratorWithProvider(t, p, nil)
+
+	vm := plan.VM{Ref: ref.Ref{ID: "vm-1"}}
+	itr := migrator.Itinerary(vm)
+
+	if itr.Name == "OnlyConversion" || itr.Name == "Warm" {
+		t.Fatalf("expected default (cold) itinerary with nil migration, got %q", itr.Name)
+	}
+}
+
+func TestReset_ResumeConversion_PreservesState(t *testing.T) {
+	p := &api.Plan{Spec: api.PlanSpec{Warm: true}}
+	m := &api.Migration{}
+	m.Spec.ResumeConversion = true
+	migrator := newBaseMigratorWithProvider(t, p, m)
+
+	vmStatus := &plan.VMStatus{
+		VM:          plan.VM{Ref: ref.Ref{ID: "vm-1"}},
+		DisksCopied: true,
+	}
+	pipeline := []*plan.Step{}
+
+	migrator.Reset(vmStatus, pipeline)
+
+	if vmStatus.Warm != nil {
+		t.Fatal("expected Warm to remain nil during resume-conversion reset")
+	}
+	if !vmStatus.DisksCopied {
+		t.Fatal("expected DisksCopied to be preserved during reset")
+	}
+	if vmStatus.Phase != api.PhaseStarted {
+		t.Fatalf("expected phase Started, got %q", vmStatus.Phase)
+	}
+}
+
+func TestReset_NormalWarm_SetsWarm(t *testing.T) {
+	p := &api.Plan{Spec: api.PlanSpec{Warm: true}}
+	migrator := newBaseMigratorWithProvider(t, p, nil)
+
+	vmStatus := &plan.VMStatus{
+		VM: plan.VM{Ref: ref.Ref{ID: "vm-1"}},
+	}
+	pipeline := []*plan.Step{}
+
+	migrator.Reset(vmStatus, pipeline)
+
+	if vmStatus.Warm == nil {
+		t.Fatal("expected Warm to be set during normal warm reset")
+	}
+}

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	"github.com/kubev2v/forklift/pkg/settings"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -224,4 +225,23 @@ func AnyNetAppShiftPersistentVolumeClaim(pvcs []*core.PersistentVolumeClaim) boo
 		}
 	}
 	return false
+}
+
+// HasSeparateCopyAndConversion reports whether copy (CDI/populators) and
+// conversion (virt-v2v-in-place) are distinct phases. False for
+// virt-v2v-for-transfer (single-step copy+convert), providers that don't
+// require guest conversion (oVirt, OpenStack, OCP), EC2 (whose "copy" is
+// a near-instant EBS snapshot-to-volume operation), or on error.
+func HasSeparateCopyAndConversion(plan *api.Plan, vmRef ref.Ref, client k8sclient.Client) bool {
+	if plan.Provider.Source == nil || !plan.Provider.Source.RequiresConversion() {
+		return false
+	}
+	if plan.Provider.Source.Type() == api.EC2 {
+		return false
+	}
+	useV2v, err := plan.ShouldUseV2vForTransfer(vmRef, client)
+	if err != nil {
+		return false
+	}
+	return !useV2v
 }

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -117,6 +117,7 @@ const (
 	// NetAppShiftDatastoreNASMissing (Critical) blocks when a disk maps to NetApp Shift but the source
 	// datastore lacks NAS export details in inventory (required for MTV annotations).
 	NetAppShiftDatastoreNASMissing = "NetAppShiftDatastoreNASMissing"
+	ConversionResumable            = "ConversionResumable"
 )
 
 // Categories
@@ -2544,4 +2545,41 @@ func (r *Reconciler) vmUsesVddk(storageMap *api.StorageMap, vsphereVM *vsphere.V
 	}
 
 	return false, nil
+}
+
+// checkConversionResumable sets the ConversionResumable condition on plans
+// whose migration failed after disk copy completed (DisksCopied=true).
+// Works for any provider where copy and conversion are separate phases.
+func (r *Reconciler) checkConversionResumable(plan *api.Plan) {
+	plan.Status.DeleteCondition(ConversionResumable)
+
+	if !plan.Status.HasCondition(Failed) {
+		return
+	}
+
+	resumableVMs := []string{}
+	for _, vm := range plan.Status.Migration.VMs {
+		if !vm.DisksCopied {
+			continue
+		}
+		if !vm.HasCondition(api.ConditionFailed) {
+			continue
+		}
+		resumableVMs = append(resumableVMs, vm.Name)
+	}
+
+	if len(resumableVMs) == 0 {
+		return
+	}
+
+	plan.Status.SetCondition(libcnd.Condition{
+		Type:     ConversionResumable,
+		Status:   True,
+		Durable:  true,
+		Category: api.CategoryAdvisory,
+		Message: fmt.Sprintf(
+			"%d VM(s) have migrated disks available for conversion resume: %s",
+			len(resumableVMs),
+			strings.Join(resumableVMs, ", ")),
+	})
 }

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -1521,3 +1521,119 @@ var _ = ginkgo.Describe("validateVirtV2vImage", func() {
 		gomega.Expect(plan.Status.HasCondition(VirtV2vImageNotValid)).To(gomega.BeFalse())
 	})
 })
+
+var _ = ginkgo.Describe("checkConversionResumable", func() {
+	var reconciler *Reconciler
+
+	ginkgo.BeforeEach(func() {
+		reconciler = &Reconciler{
+			base.Reconciler{},
+			nil,
+		}
+	})
+
+	ginkgo.It("should set ConversionResumable when plan is failed and VM has DisksCopied", func() {
+		p := &api.Plan{}
+		p.Status.SetCondition(libcnd.Condition{
+			Type:   Failed,
+			Status: True,
+		})
+		p.Status.Migration.VMs = []*apisplan.VMStatus{
+			{
+				VM:          apisplan.VM{Ref: ref.Ref{Name: "test-vm"}},
+				DisksCopied: true,
+			},
+		}
+		p.Status.Migration.VMs[0].SetCondition(libcnd.Condition{
+			Type:   api.ConditionFailed,
+			Status: True,
+		})
+
+		reconciler.checkConversionResumable(p)
+		gomega.Expect(p.Status.HasCondition(ConversionResumable)).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("should not set ConversionResumable when plan is not failed", func() {
+		p := &api.Plan{}
+		p.Status.SetCondition(libcnd.Condition{
+			Type:   Succeeded,
+			Status: True,
+		})
+		p.Status.Migration.VMs = []*apisplan.VMStatus{
+			{
+				VM:          apisplan.VM{Ref: ref.Ref{Name: "test-vm"}},
+				DisksCopied: true,
+			},
+		}
+
+		reconciler.checkConversionResumable(p)
+		gomega.Expect(p.Status.HasCondition(ConversionResumable)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should not set ConversionResumable when no VMs have DisksCopied", func() {
+		p := &api.Plan{}
+		p.Status.SetCondition(libcnd.Condition{
+			Type:   Failed,
+			Status: True,
+		})
+		p.Status.Migration.VMs = []*apisplan.VMStatus{
+			{
+				VM:          apisplan.VM{Ref: ref.Ref{Name: "test-vm"}},
+				DisksCopied: false,
+			},
+		}
+		p.Status.Migration.VMs[0].SetCondition(libcnd.Condition{
+			Type:   api.ConditionFailed,
+			Status: True,
+		})
+
+		reconciler.checkConversionResumable(p)
+		gomega.Expect(p.Status.HasCondition(ConversionResumable)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should clear ConversionResumable on successful resume", func() {
+		p := &api.Plan{}
+		p.Status.SetCondition(libcnd.Condition{
+			Type:   ConversionResumable,
+			Status: True,
+		})
+		p.Status.SetCondition(libcnd.Condition{
+			Type:   Succeeded,
+			Status: True,
+		})
+
+		reconciler.checkConversionResumable(p)
+		gomega.Expect(p.Status.HasCondition(ConversionResumable)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should only count VMs that are both DisksCopied and Failed", func() {
+		p := &api.Plan{}
+		p.Status.SetCondition(libcnd.Condition{
+			Type:   Failed,
+			Status: True,
+		})
+		succeededVM := &apisplan.VMStatus{
+			VM:          apisplan.VM{Ref: ref.Ref{Name: "succeeded-vm"}},
+			DisksCopied: true,
+		}
+		succeededVM.SetCondition(libcnd.Condition{
+			Type:   api.ConditionSucceeded,
+			Status: True,
+		})
+		failedVM := &apisplan.VMStatus{
+			VM:          apisplan.VM{Ref: ref.Ref{Name: "failed-vm"}},
+			DisksCopied: true,
+		}
+		failedVM.SetCondition(libcnd.Condition{
+			Type:   api.ConditionFailed,
+			Status: True,
+		})
+		p.Status.Migration.VMs = []*apisplan.VMStatus{succeededVM, failedVM}
+
+		reconciler.checkConversionResumable(p)
+		gomega.Expect(p.Status.HasCondition(ConversionResumable)).To(gomega.BeTrue())
+		cnd := p.Status.FindCondition(ConversionResumable)
+		gomega.Expect(cnd.Message).To(gomega.ContainSubstring("failed-vm"))
+		gomega.Expect(cnd.Message).NotTo(gomega.ContainSubstring("succeeded-vm"))
+	})
+})

--- a/pkg/provider/ec2/controller/migrator/executor.go
+++ b/pkg/provider/ec2/controller/migrator/executor.go
@@ -118,7 +118,9 @@ func (r *Migrator) ExecutePhase(vm *planapi.VMStatus) (ok bool, err error) {
 		}
 	case api.PhaseStorePowerState:
 		ok = false
-	case api.PhaseCreateGuestConversionPod, api.PhaseConvertGuest:
+	case api.PhaseCreateGuestConversionPod:
+		ok = false
+	case api.PhaseConvertGuest:
 		ok = false
 	case api.PhaseFinalize:
 		ok = false

--- a/pkg/provider/ec2/controller/migrator/itinerary.go
+++ b/pkg/provider/ec2/controller/migrator/itinerary.go
@@ -15,14 +15,16 @@ const (
 	CrossAccountFlag = 1 << 3 // Include cross-account snapshot sharing phase
 )
 
-// Itinerary builds the EC2 cold migration workflow sequence defining phase order.
-// Includes: Initialize→PreHook→PowerOff→CreateSnapshots→WaitSnapshots→[ShareSnapshots]→CreateVolumes→WaitForVolumes→CreatePVsAndPVCs→CreateGuestConversionPod→ConvertGuest→Finalize→CreateVM→RemoveSnapshots→PostHook→Completed.
-// Pre/post hooks are conditionally included based on VM hook configuration.
-// ShareSnapshots phase is conditionally included for cross-account migrations.
+// Itinerary builds the EC2 migration workflow sequence defining phase order.
 func (r *Migrator) Itinerary(vm planapi.VM) *libitr.Itinerary {
 	r.vm = &vm
+	return r.coldItinerary(vm)
+}
 
-	itinerary := &libitr.Itinerary{
+// coldItinerary is the full EC2 cold migration workflow.
+// Includes: Initialize→PreHook→PowerOff→CreateSnapshots→WaitSnapshots→[ShareSnapshots]→CreateVolumes→WaitForVolumes→CreatePVsAndPVCs→CreateGuestConversionPod→ConvertGuest→Finalize→CreateVM→RemoveSnapshots→PostHook→Completed.
+func (r *Migrator) coldItinerary(vm planapi.VM) *libitr.Itinerary {
+	return &libitr.Itinerary{
 		Name: "EC2 Cold Migration",
 		Pipeline: libitr.Pipeline{
 			{Name: api.PhaseStarted},
@@ -50,8 +52,6 @@ func (r *Migrator) Itinerary(vm planapi.VM) *libitr.Itinerary {
 			migrator: r,
 		},
 	}
-
-	return itinerary
 }
 
 // EC2Predicate implements conditional phase evaluation for the EC2 migration itinerary.

--- a/pkg/provider/ec2/controller/migrator/itinerary_test.go
+++ b/pkg/provider/ec2/controller/migrator/itinerary_test.go
@@ -1,0 +1,56 @@
+package migrator
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EC2 Itinerary", func() {
+	newMigrator := func() *Migrator {
+		ec2Type := api.EC2
+		return &Migrator{
+			Context: &plancontext.Context{
+				Plan: &api.Plan{},
+				Source: plancontext.Source{
+					Provider: &api.Provider{Spec: api.ProviderSpec{Type: &ec2Type}},
+				},
+			},
+			log: logging.WithName("test"),
+		}
+	}
+
+	Describe("Itinerary selection", func() {
+		It("should return cold itinerary", func() {
+			m := newMigrator()
+			vm := planapi.VM{Ref: ref.Ref{ID: "i-123"}}
+			itr := m.Itinerary(vm)
+			Expect(itr.Name).To(Equal("EC2 Cold Migration"))
+		})
+
+		It("cold itinerary should include all phases", func() {
+			m := newMigrator()
+			vm := planapi.VM{Ref: ref.Ref{ID: "i-123"}}
+			itr := m.Itinerary(vm)
+
+			phaseNames := make(map[string]bool)
+			for _, step := range itr.Pipeline {
+				phaseNames[step.Name] = true
+			}
+			Expect(phaseNames).To(HaveKey(PhaseCreateSnapshots))
+			Expect(phaseNames).To(HaveKey(PhaseWaitForSnapshots))
+			Expect(phaseNames).To(HaveKey(PhaseCreateVolumes))
+			Expect(phaseNames).To(HaveKey(PhaseWaitForVolumes))
+			Expect(phaseNames).To(HaveKey(PhaseCreatePVsAndPVCs))
+			Expect(phaseNames).To(HaveKey(PhaseRemoveSnapshots))
+			Expect(phaseNames).To(HaveKey(api.PhaseCreateGuestConversionPod))
+			Expect(phaseNames).To(HaveKey(api.PhaseConvertGuest))
+			Expect(phaseNames).To(HaveKey(api.PhaseCreateVM))
+			Expect(phaseNames).To(HaveKey(api.PhaseCompleted))
+		})
+	})
+})

--- a/pkg/provider/ec2/controller/migrator/lifecycle.go
+++ b/pkg/provider/ec2/controller/migrator/lifecycle.go
@@ -34,13 +34,15 @@ func (r *Migrator) Status(vm planapi.VM) *planapi.VMStatus {
 }
 
 // Reset re-initializes a VM's migration status for retry after failure or cancellation.
-// Replaces pipeline, resets phase to Started, clears errors and timestamps. Preserves VM reference.
+// Replaces pipeline, resets phase to first in itinerary, clears errors and timestamps.
 func (r *Migrator) Reset(vm *planapi.VMStatus, pipeline []*planapi.Step) {
+	vm.DeleteCondition(api.ConditionCanceled, api.ConditionFailed)
+	vm.MarkReset()
 	vm.Pipeline = pipeline
-	vm.Phase = api.PhaseStarted
+	itr := r.Itinerary(vm.VM)
+	step, _ := itr.First()
+	vm.Phase = step.Name
 	vm.Error = nil
-	vm.Started = nil
-	vm.Completed = nil
 
 	r.log.V(1).Info("VM status reset", "vm", vm.Name)
 }

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -82,6 +82,7 @@ const (
 	AAPCASecretName                        = "AAP_CA_SECRET_NAME"
 	WaitForFinalSnapshotConsolidation      = "WAIT_FOR_FINAL_SNAPSHOT_CONSOLIDATION"
 	ConversionPodPendingTimeout            = "CONVERSION_POD_PENDING_TIMEOUT"
+	StaleConversionTimeout                 = "STALE_CONVERSION_TIMEOUT"
 )
 
 // Default values for populator container resources
@@ -95,6 +96,10 @@ var (
 // DefaultPendingPodTimeoutMinutes is the default number of minutes a
 // conversion pod may stay in Pending before the controller fails it.
 const DefaultPendingPodTimeoutMinutes = 5
+
+// DefaultStaleConversionTimeoutSeconds is the default number of seconds to
+// wait for a stale conversion pod/CR to finish terminating before force-deleting it.
+const DefaultStaleConversionTimeoutSeconds = 180
 
 // Migration settings
 type Migration struct {
@@ -210,6 +215,10 @@ type Migration struct {
 	// ConversionPodPendingTimeout is how long (in minutes) a conversion pod may stay
 	// in Pending phase before the controller fails it. 0 means no timeout.
 	ConversionPodPendingTimeout int
+	// StaleConversionTimeout is how long (in seconds) to wait for a stale
+	// conversion pod/CR to finish terminating before force-deleting it
+	// during resume-conversion. Default 180s (3 minutes).
+	StaleConversionTimeout int
 }
 
 // Load settings.
@@ -475,6 +484,9 @@ func (r *Migration) Load() (err error) {
 	}
 	r.WaitForFinalSnapshotConsolidation = getEnvBool(WaitForFinalSnapshotConsolidation, true)
 	if r.ConversionPodPendingTimeout, err = getEnvLimit(ConversionPodPendingTimeout, DefaultPendingPodTimeoutMinutes, 0); err != nil {
+		return liberr.Wrap(err)
+	}
+	if r.StaleConversionTimeout, err = getPositiveEnvLimit(StaleConversionTimeout, DefaultStaleConversionTimeoutSeconds); err != nil {
 		return liberr.Wrap(err)
 	}
 	return


### PR DESCRIPTION
When a migration fails during guest conversion (virt-v2v) after disks have been fully copied, users can now resume from the conversion phase without re-copying all disks. Applies to any plan where disk copy and conversion are separate phases (warm, cold with populators/CDI).

Changes:
- Add DisksCopied flag to VMStatus, set when entering conversion phase
- Add ResumeConversion field to Migration spec
- Add ConversionResumable condition on plans with resumable VMs
- Introduce ResumeConversion itinerary that skips disk copy and power-off phases (source already off, disks already on PVCs)
- Skip warm snapshot removal during resume (already cleaned at cutover)
- Guard checkConversionResumable to run on terminal plans and mark condition as durable
- Add unit tests for context, controller, validation, and migrator
- Update EC2 migrator to support resume-conversion itinerary

Ref: https://redhat.atlassian.net/browse/MTV-6203
Resolves: MTV-6203

***Blocked-By**:* https://github.com/kubev2v/forklift/pull/6838

