### PR TITLE
chore(refactor): consolidate resume-conversion helpers

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -1222,11 +1222,16 @@ func (r *KubeVirt) EnsureGuestInspectionPod(vm *plan.VMStatus, step *plan.Step) 
 }
 
 // GetConversionPod returns the managed pod for the given VM ref and pod type.
-func (r *KubeVirt) GetConversionPod(vmRef ref.Ref, podType convctx.V2vPodType) (*core.Pod, error) {
+// When filterOutMigrationLabel is true the search spans all migrations for the
+// VM (used for stale-workload discovery). when false it is scoped to the
+// current migration only. Note: filterOutMigrationLabel only applies to
+// VirtV2vConversionPod. inspection pods use plan-scoped labels that already
+// span migrations.
+func (r *KubeVirt) GetConversionPod(vmRef ref.Ref, podType convctx.V2vPodType, filterOutMigrationLabel bool) (*core.Pod, error) {
 	var labels map[string]string
 	switch podType {
 	case convctx.VirtV2vConversionPod:
-		labels = r.conversionLabels(vmRef, true)
+		labels = r.conversionLabels(vmRef, filterOutMigrationLabel)
 	case convctx.VirtV2vInspectionPod:
 		labels = r.inspectionLabels(vmRef)
 	}
@@ -2069,21 +2074,18 @@ func getDiskIndex(pvc *core.PersistentVolumeClaim) int {
 
 // Return PersistentVolumeClaims associated with a VM.
 func (r *KubeVirt) getPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, err error) {
-	pvcsList := &core.PersistentVolumeClaimList{}
-	// Add VM uuid
-	labelSelector := map[string]string{
-		kVM: vmRef.ID,
-	}
-	// We need to have this in getPVCs so we create VM with corect disks, this will also help us with the guest generation
 	if r.Plan.Spec.Type == api.MigrationOnlyConversion || r.IsResumeConversion() {
 		uuid, uuidErr := r.resolveVMUUID(vmRef)
 		if uuidErr != nil {
 			return nil, uuidErr
 		}
-		labelSelector[kVmUuid] = uuid
-	} else {
-		labelSelector[kMigration] = string(r.Migration.UID)
+		return r.listDiskPVCsByUUID(vmRef.ID, uuid)
 	}
+	labelSelector := map[string]string{
+		kVM:        vmRef.ID,
+		kMigration: string(r.Migration.UID),
+	}
+	pvcsList := &core.PersistentVolumeClaimList{}
 	err = r.Destination.Client.List(
 		context.TODO(),
 		pvcsList,
@@ -2105,14 +2107,47 @@ func (r *KubeVirt) getPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, e
 		pvcs = append(pvcs, pvc)
 	}
 
-	// Sort the pvcs slice by disk index
 	sort.Slice(pvcs, func(i, j int) bool {
-		iIdx := getDiskIndex(pvcs[i])
-		jIdx := getDiskIndex(pvcs[j])
-		return iIdx < jIdx
+		return getDiskIndex(pvcs[i]) < getDiskIndex(pvcs[j])
 	})
 
 	return
+}
+
+// listDiskPVCsByUUID returns the disk PVCs for a VM identified by vmID and
+// vmUUID labels, filtered (excluding prime- and non-disk PVCs) and sorted by
+// disk index. Used by getPVCs, validateResumePVCsByUUID, and validation code.
+func (r *KubeVirt) listDiskPVCsByUUID(vmID, vmUUID string) ([]*core.PersistentVolumeClaim, error) {
+	pvcsList := &core.PersistentVolumeClaimList{}
+	err := r.Destination.List(
+		context.TODO(),
+		pvcsList,
+		&client.ListOptions{
+			LabelSelector: k8slabels.SelectorFromSet(map[string]string{
+				kVM:     vmID,
+				kVmUuid: vmUUID,
+			}),
+			Namespace: r.Plan.Spec.TargetNamespace,
+		},
+	)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+
+	var pvcs []*core.PersistentVolumeClaim
+	for i := range pvcsList.Items {
+		pvc := &pvcsList.Items[i]
+		if strings.HasPrefix(pvc.Name, "prime-") || !hasDiskIdentity(pvc) {
+			continue
+		}
+		pvcs = append(pvcs, pvc)
+	}
+
+	sort.Slice(pvcs, func(i, j int) bool {
+		return getDiskIndex(pvcs[i]) < getDiskIndex(pvcs[j])
+	})
+
+	return pvcs, nil
 }
 
 // resolveVMUUID fetches the source VM from inventory and extracts the UUID
@@ -2153,29 +2188,9 @@ func (r *KubeVirt) ValidateResumePVCs(vmRef ref.Ref) error {
 // validateResumePVCsByUUID performs the actual PVC validation given a
 // pre-resolved VM UUID. Separated for testability without inventory.
 func (r *KubeVirt) validateResumePVCsByUUID(vmRef ref.Ref, vmUUID string) error {
-	pvcsList := &core.PersistentVolumeClaimList{}
-	err := r.Destination.List(
-		context.TODO(),
-		pvcsList,
-		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(map[string]string{
-				kVM:     vmRef.ID,
-				kVmUuid: vmUUID,
-			}),
-			Namespace: r.Plan.Spec.TargetNamespace,
-		},
-	)
+	pvcs, err := r.listDiskPVCsByUUID(vmRef.ID, vmUUID)
 	if err != nil {
-		return liberr.Wrap(err)
-	}
-
-	var pvcs []*core.PersistentVolumeClaim
-	for i := range pvcsList.Items {
-		pvc := &pvcsList.Items[i]
-		if strings.HasPrefix(pvc.Name, "prime-") || !hasDiskIdentity(pvc) {
-			continue
-		}
-		pvcs = append(pvcs, pvc)
+		return err
 	}
 
 	if len(pvcs) == 0 {
@@ -2401,24 +2416,10 @@ func (r *KubeVirt) EnsureProviderVirtV2VPVCStatus(vmID string) (ready bool, err 
 	return
 }
 
-// Get the guest conversion pod for the VM.
-func (r *KubeVirt) GetGuestConversionPod(vm *plan.VMStatus) (pod *core.Pod, err error) {
-	list := &core.PodList{}
-	err = r.Destination.Client.List(
-		context.TODO(),
-		list,
-		&client.ListOptions{
-			LabelSelector: k8slabels.SelectorFromSet(r.conversionLabels(vm.Ref, false)),
-			Namespace:     r.Plan.Spec.TargetNamespace,
-		})
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-	if len(list.Items) > 0 {
-		pod = &list.Items[0]
-	}
-	return
+// GetGuestConversionPod returns the guest-conversion pod scoped to the
+// current migration for the given VM.
+func (r *KubeVirt) GetGuestConversionPod(vm *plan.VMStatus) (*core.Pod, error) {
+	return r.GetConversionPod(vm.Ref, convctx.VirtV2vConversionPod, false)
 }
 
 func (r *KubeVirt) getInspectionXml(pod *core.Pod) (string, error) {

--- a/pkg/controller/plan/kubevirt_resume_test.go
+++ b/pkg/controller/plan/kubevirt_resume_test.go
@@ -1,11 +1,14 @@
 package plan
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	convctx "github.com/kubev2v/forklift/pkg/controller/conversion/context"
 	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
@@ -13,12 +16,14 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	core "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var resumeLog = logging.WithName("resumeTest")
@@ -45,8 +50,15 @@ func resumeConvPodLabels(migrationUID types.UID) map[string]string {
 }
 
 func newResumeKubeVirt(migrationUID types.UID, objects ...client.Object) (KubeVirt, *Migration) {
+	return newResumeKubeVirtWithScheme(migrationUID, false, objects...)
+}
+
+func newResumeKubeVirtWithScheme(migrationUID types.UID, withAPI bool, objects ...client.Object) (KubeVirt, *Migration) {
 	scheme := runtime.NewScheme()
 	_ = core.AddToScheme(scheme)
+	if withAPI {
+		_ = api.SchemeBuilder.AddToScheme(scheme)
+	}
 
 	c := fakeClient.NewClientBuilder().
 		WithScheme(scheme).
@@ -65,6 +77,7 @@ func newResumeKubeVirt(migrationUID types.UID, objects ...client.Object) (KubeVi
 		Migration: &api.Migration{
 			ObjectMeta: meta.ObjectMeta{UID: migrationUID},
 		},
+		Client:      c,
 		Destination: plancontext.Destination{Client: c},
 		Log:         resumeLog,
 	}
@@ -74,6 +87,24 @@ func newResumeKubeVirt(migrationUID types.UID, objects ...client.Object) (KubeVi
 	return kv, m
 }
 
+func resumeDiskPVC(name, vmUUID, diskSource, diskIndex string) *core.PersistentVolumeClaim {
+	return &core.PersistentVolumeClaim{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: resumeTargetNS,
+			Labels: map[string]string{
+				kVM:     resumeVMID,
+				kVmUuid: vmUUID,
+			},
+			Annotations: map[string]string{
+				planbase.AnnDiskSource: diskSource,
+				planbase.AnnDiskIndex:  diskIndex,
+			},
+		},
+		Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+	}
+}
+
 func newResumeVMStatus() *planapi.VMStatus {
 	return &planapi.VMStatus{
 		VM: planapi.VM{
@@ -81,6 +112,82 @@ func newResumeVMStatus() *planapi.VMStatus {
 		},
 	}
 }
+
+var _ = ginkgo.Describe("GetConversionPod", func() {
+	var (
+		oldMigrationUID types.UID
+		newMigrationUID types.UID
+		vmRef           ref.Ref
+	)
+
+	ginkgo.BeforeEach(func() {
+		oldMigrationUID = types.UID("old-migration-" + rand.String(6))
+		newMigrationUID = types.UID("new-migration-" + rand.String(6))
+		vmRef = ref.Ref{ID: resumeVMID}
+	})
+
+	ginkgo.It("should find the current migration pod when filterOutMigrationLabel is false", func() {
+		currentPod := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "current-conv-pod",
+				Namespace: resumeTargetNS,
+				Labels:    resumeConvPodLabels(newMigrationUID),
+			},
+		}
+		stalePod := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "stale-conv-pod",
+				Namespace: resumeTargetNS,
+				Labels:    resumeConvPodLabels(oldMigrationUID),
+			},
+		}
+		kv, _ := newResumeKubeVirt(newMigrationUID, currentPod, stalePod)
+
+		pod, err := kv.GetConversionPod(vmRef, VirtV2vConversionPod, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pod).NotTo(gomega.BeNil())
+		gomega.Expect(pod.Name).To(gomega.Equal("current-conv-pod"))
+	})
+
+	ginkgo.It("should find a prior migration pod when filterOutMigrationLabel is true", func() {
+		stalePod := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "stale-conv-pod",
+				Namespace: resumeTargetNS,
+				Labels:    resumeConvPodLabels(oldMigrationUID),
+			},
+		}
+		kv, _ := newResumeKubeVirt(newMigrationUID, stalePod)
+
+		pod, err := kv.GetConversionPod(vmRef, VirtV2vConversionPod, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pod).NotTo(gomega.BeNil())
+		gomega.Expect(pod.Name).To(gomega.Equal("stale-conv-pod"))
+	})
+
+	ginkgo.It("should not find a prior migration pod when filterOutMigrationLabel is false", func() {
+		stalePod := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "stale-conv-pod",
+				Namespace: resumeTargetNS,
+				Labels:    resumeConvPodLabels(oldMigrationUID),
+			},
+		}
+		kv, _ := newResumeKubeVirt(newMigrationUID, stalePod)
+
+		pod, err := kv.GetConversionPod(vmRef, VirtV2vConversionPod, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pod).To(gomega.BeNil())
+	})
+
+	ginkgo.It("should return nil when no matching pod exists", func() {
+		kv, _ := newResumeKubeVirt(newMigrationUID)
+
+		pod, err := kv.GetConversionPod(vmRef, VirtV2vConversionPod, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pod).To(gomega.BeNil())
+	})
+})
 
 var _ = ginkgo.Describe("Resume-conversion stale workload cleanup", func() {
 	var (
@@ -193,6 +300,268 @@ var _ = ginkgo.Describe("Resume-conversion stale workload cleanup", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(done).To(gomega.BeTrue(), "no stale objects remain")
 		})
+
+		ginkgo.It("should request DeleteConversion for a stale Conversion CR", func() {
+			settings.Settings.UseConversionCR = true
+			staleCR := &api.Conversion{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "stale-conversion",
+					Namespace: resumePlanNamespace,
+					Labels: map[string]string{
+						convctx.LabelPlan:           string(resumePlanUID),
+						convctx.LabelVM:             resumeVMID,
+						convctx.LabelConversionType: string(api.Remote),
+					},
+				},
+				Spec: api.ConversionSpec{
+					Type: api.Remote,
+				},
+			}
+			_, m := newResumeKubeVirtWithScheme(newMigrationUID, true, staleCR)
+			vm := newResumeVMStatus()
+
+			done, err := m.deleteStaleConversionWorkloads(vm)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(done).To(gomega.BeFalse(), "should requeue after requesting CR deletion")
+			gomega.Expect(objectExists(m.Client, types.NamespacedName{
+				Name: "stale-conversion", Namespace: resumePlanNamespace,
+			}, &api.Conversion{})).To(gomega.BeFalse(), "Conversion CR should be deleted")
+		})
+	})
+})
+
+var _ = ginkgo.Describe("ensureStaleObjectDeleted", func() {
+	var (
+		newMigrationUID types.UID
+	)
+
+	ginkgo.BeforeEach(func() {
+		newMigrationUID = types.UID("new-migration-" + rand.String(6))
+		settings.Settings.StaleConversionTimeout = 60
+	})
+
+	ginkgo.It("should requeue without deleting when object is terminating within timeout", func() {
+		recent := meta.NewTime(time.Now().Add(-10 * time.Second))
+		pod := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:              "terminating-pod",
+				Namespace:         resumeTargetNS,
+				Labels:            resumeConvPodLabels(newMigrationUID),
+				DeletionTimestamp: &recent,
+				Finalizers:        []string{"block-deletion"},
+			},
+		}
+		_, m := newResumeKubeVirt(newMigrationUID, pod)
+		vm := newResumeVMStatus()
+
+		done, err := m.ensureStaleObjectDeleted(pod, vm, "pod", func() error {
+			return fmt.Errorf("should not be called")
+		}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(done).To(gomega.BeFalse())
+		gomega.Expect(objectExists(m.Destination.Client, types.NamespacedName{
+			Name: "terminating-pod", Namespace: resumeTargetNS,
+		}, &core.Pod{})).To(gomega.BeTrue(), "pod should not have been deleted")
+	})
+
+	ginkgo.It("should force-delete when object exceeds stale timeout", func() {
+		expired := meta.NewTime(time.Now().Add(-120 * time.Second))
+		pod := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:              "stuck-pod",
+				Namespace:         resumeTargetNS,
+				Labels:            resumeConvPodLabels(newMigrationUID),
+				DeletionTimestamp: &expired,
+				Finalizers:        []string{"block-deletion"},
+			},
+		}
+		_, m := newResumeKubeVirt(newMigrationUID, pod)
+		vm := newResumeVMStatus()
+
+		done, err := m.ensureStaleObjectDeleted(pod, vm, "pod", func() error {
+			return fmt.Errorf("should not be called")
+		}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(done).To(gomega.BeFalse(), "always returns false after delete")
+	})
+
+	ginkgo.It("should treat force-delete NotFound as successful cleanup", func() {
+		expired := meta.NewTime(time.Now().Add(-120 * time.Second))
+		pod := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:              "gone-pod",
+				Namespace:         resumeTargetNS,
+				Labels:            resumeConvPodLabels(newMigrationUID),
+				DeletionTimestamp: &expired,
+				Finalizers:        []string{"block-deletion"},
+			},
+		}
+		scheme := runtime.NewScheme()
+		_ = core.AddToScheme(scheme)
+		c := fakeClient.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(pod).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					return k8serr.NewNotFound(core.Resource("pods"), obj.GetName())
+				},
+			}).
+			Build()
+		ctx := &plancontext.Context{
+			Plan: &api.Plan{
+				ObjectMeta: meta.ObjectMeta{
+					Name: resumePlanName, Namespace: resumePlanNamespace, UID: resumePlanUID,
+				},
+				Spec: api.PlanSpec{TargetNamespace: resumeTargetNS},
+			},
+			Migration:   &api.Migration{ObjectMeta: meta.ObjectMeta{UID: newMigrationUID}},
+			Destination: plancontext.Destination{Client: c},
+			Log:         resumeLog,
+		}
+		m := &Migration{Context: ctx}
+		vm := newResumeVMStatus()
+
+		done, err := m.ensureStaleObjectDeleted(pod, vm, "pod", func() error {
+			return fmt.Errorf("should not be called")
+		}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(done).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should call deleteFn when conversion CR exceeds stale timeout", func() {
+		expired := meta.NewTime(time.Now().Add(-120 * time.Second))
+		cr := &api.Conversion{
+			ObjectMeta: meta.ObjectMeta{
+				Name:              "stuck-conversion",
+				Namespace:         resumePlanNamespace,
+				DeletionTimestamp: &expired,
+				Finalizers:        []string{"block-deletion"},
+			},
+		}
+		_, m := newResumeKubeVirt(newMigrationUID)
+		vm := newResumeVMStatus()
+
+		called := false
+		done, err := m.ensureStaleObjectDeleted(cr, vm, "conversion", func() error {
+			called = true
+			return nil
+		}, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(done).To(gomega.BeFalse())
+		gomega.Expect(called).To(gomega.BeTrue(), "timeout path should use deleteFn for Conversion CRs")
+	})
+
+	ginkgo.It("should call deleteFn for objects without DeletionTimestamp", func() {
+		pod := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "active-pod",
+				Namespace: resumeTargetNS,
+				Labels:    resumeConvPodLabels(newMigrationUID),
+			},
+		}
+		_, m := newResumeKubeVirt(newMigrationUID, pod)
+		vm := newResumeVMStatus()
+
+		called := false
+		done, err := m.ensureStaleObjectDeleted(pod, vm, "pod", func() error {
+			called = true
+			return nil
+		}, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(done).To(gomega.BeFalse())
+		gomega.Expect(called).To(gomega.BeTrue(), "deleteFn should have been invoked")
+	})
+
+	ginkgo.It("should propagate deleteFn errors", func() {
+		pod := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "active-pod",
+				Namespace: resumeTargetNS,
+				Labels:    resumeConvPodLabels(newMigrationUID),
+			},
+		}
+		_, m := newResumeKubeVirt(newMigrationUID, pod)
+		vm := newResumeVMStatus()
+
+		done, err := m.ensureStaleObjectDeleted(pod, vm, "pod", func() error {
+			return fmt.Errorf("delete failed")
+		}, true)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("delete failed"))
+		gomega.Expect(done).To(gomega.BeFalse())
+	})
+})
+
+var _ = ginkgo.Describe("listDiskPVCsByUUID", func() {
+	const testUUID = "test-uuid"
+
+	ginkgo.It("should filter prime and non-disk PVCs and sort by disk index", func() {
+		migUID := types.UID("mig-" + rand.String(6))
+		pvc0 := resumeDiskPVC("pvc-0", testUUID, "[disk-1]", "1")
+		pvc1 := resumeDiskPVC("pvc-1", testUUID, "[disk-2]", "0")
+		primePVC := &core.PersistentVolumeClaim{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "prime-populator",
+				Namespace: resumeTargetNS,
+				Labels: map[string]string{
+					kVM:     resumeVMID,
+					kVmUuid: testUUID,
+				},
+				Annotations: map[string]string{
+					planbase.AnnDiskSource: "[disk-3]",
+					planbase.AnnDiskIndex:  "2",
+				},
+			},
+			Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+		}
+		noisePVC := &core.PersistentVolumeClaim{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "noise-pvc",
+				Namespace: resumeTargetNS,
+				Labels: map[string]string{
+					kVM:     resumeVMID,
+					kVmUuid: testUUID,
+				},
+			},
+			Status: core.PersistentVolumeClaimStatus{Phase: core.ClaimBound},
+		}
+		kv, _ := newResumeKubeVirt(migUID, pvc0, pvc1, primePVC, noisePVC)
+
+		pvcs, err := kv.listDiskPVCsByUUID(resumeVMID, testUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvcs).To(gomega.HaveLen(2))
+		gomega.Expect(pvcs[0].Name).To(gomega.Equal("pvc-1"))
+		gomega.Expect(pvcs[1].Name).To(gomega.Equal("pvc-0"))
+	})
+
+	ginkgo.It("should reject duplicate disk sources found via listDiskPVCsByUUID", func() {
+		migUID := types.UID("mig-" + rand.String(6))
+		pvc1 := resumeDiskPVC("pvc-1", testUUID, "[disk-1]", "0")
+		pvc2 := resumeDiskPVC("pvc-2", testUUID, "[disk-1]", "1")
+		kv, _ := newResumeKubeVirt(migUID, pvc1, pvc2)
+
+		pvcs, err := kv.listDiskPVCsByUUID(resumeVMID, testUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvcs).To(gomega.HaveLen(2))
+
+		err = kv.validateResumePVCsByUUID(ref.Ref{ID: resumeVMID}, testUUID)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("duplicate disk source"))
+	})
+
+	ginkgo.It("should reject duplicate disk indexes found via listDiskPVCsByUUID", func() {
+		migUID := types.UID("mig-" + rand.String(6))
+		pvc1 := resumeDiskPVC("pvc-1", testUUID, "[disk-1]", "0")
+		pvc2 := resumeDiskPVC("pvc-2", testUUID, "[disk-2]", "0")
+		kv, _ := newResumeKubeVirt(migUID, pvc1, pvc2)
+
+		pvcs, err := kv.listDiskPVCsByUUID(resumeVMID, testUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvcs).To(gomega.HaveLen(2))
+
+		err = kv.validateResumePVCsByUUID(ref.Ref{ID: resumeVMID}, testUUID)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("duplicate disk index"))
 	})
 })
 

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -577,6 +577,46 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, force
 	return nil
 }
 
+// ensureStaleObjectDeleted checks whether a stale object is terminating and
+// either waits (returns done=false) or force-deletes it after the timeout.
+// If the object has no DeletionTimestamp, it issues a normal delete via deleteFn.
+// When forceDeleteDirect is true and the timeout has elapsed, a zero-grace-period
+// client delete is issued (used for pods). Otherwise deleteFn is called on timeout
+// as well (used for Conversion CRs where DeleteConversion performs full teardown).
+// Always returns done=false after issuing a delete — the caller should requeue
+// and will observe done=true on the next reconciliation when no objects remain.
+func (r *Migration) ensureStaleObjectDeleted(obj client.Object, vm *plan.VMStatus, kind string, deleteFn func() error, forceDeleteDirect bool) (done bool, err error) {
+	if obj.GetDeletionTimestamp() != nil {
+		timeout := time.Duration(settings.Settings.StaleConversionTimeout) * time.Second
+		if time.Since(obj.GetDeletionTimestamp().Time) < timeout {
+			r.Log.Info("Stale object still terminating, will requeue.",
+				"kind", kind, "name", obj.GetName(), "namespace", obj.GetNamespace(), "vm", vm.String())
+			return false, nil
+		}
+		r.Log.Info("Stale object stuck terminating, force-deleting.",
+			"kind", kind, "name", obj.GetName(), "namespace", obj.GetNamespace(), "vm", vm.String(),
+			"terminatingSince", obj.GetDeletionTimestamp().Time)
+		var delErr error
+		if forceDeleteDirect {
+			grace := int64(0)
+			delErr = r.Destination.Delete(context.TODO(), obj, &client.DeleteOptions{GracePeriodSeconds: &grace})
+		} else {
+			delErr = deleteFn()
+		}
+		if delErr != nil {
+			if k8serr.IsNotFound(delErr) {
+				return false, nil
+			}
+			return false, delErr
+		}
+		return false, nil
+	}
+	if delErr := deleteFn(); delErr != nil {
+		return false, delErr
+	}
+	return false, nil
+}
+
 // deleteStaleConversionWorkloads requests deletion of guest-conversion pods
 // and CRs left over from a prior failed migration. Returns done=true when
 // no stale objects remain (safe to proceed), or done=false when objects are
@@ -585,32 +625,14 @@ func (r *Migration) cleanup(vm *plan.VMStatus, failOnErr func(error) bool, force
 func (r *Migration) deleteStaleConversionWorkloads(vm *plan.VMStatus) (done bool, err error) {
 	r.Log.Info("Checking for stale conversion workloads.", "vm", vm.String())
 
-	stalePods, err := r.kubevirt.GetPodsWithLabels(r.kubevirt.conversionLabels(vm.Ref, true))
+	stalePod, err := r.kubevirt.GetConversionPod(vm.Ref, VirtV2vConversionPod, true)
 	if err != nil {
 		return false, err
 	}
-	if len(stalePods.Items) > 0 {
-		pod := &stalePods.Items[0]
-		if pod.DeletionTimestamp != nil {
-			timeout := time.Duration(settings.Settings.StaleConversionTimeout) * time.Second
-			if time.Since(pod.DeletionTimestamp.Time) < timeout {
-				r.Log.Info("Stale conversion pod still terminating, will requeue.",
-					"pod", pod.Name, "vm", vm.String())
-				return false, nil
-			}
-			r.Log.Info("Stale conversion pod stuck terminating, force-deleting.",
-				"pod", pod.Name, "vm", vm.String(),
-				"terminatingSince", pod.DeletionTimestamp.Time)
-			grace := int64(0)
-			if delErr := r.Destination.Delete(context.TODO(), pod, &client.DeleteOptions{GracePeriodSeconds: &grace}); delErr != nil {
-				return false, delErr
-			}
-			return false, nil
-		}
-		if delErr := r.kubevirt.DeleteObject(pod, vm, "Deleted stale conversion pod.", "pod"); delErr != nil {
-			return false, delErr
-		}
-		return false, nil
+	if stalePod != nil {
+		return r.ensureStaleObjectDeleted(stalePod, vm, "pod", func() error {
+			return r.kubevirt.DeleteObject(stalePod, vm, "Deleted stale conversion pod.", "pod")
+		}, true)
 	}
 
 	if settings.Settings.UseConversionCR {
@@ -619,21 +641,9 @@ func (r *Migration) deleteStaleConversionWorkloads(vm *plan.VMStatus) (done bool
 			return false, gErr
 		}
 		if gConv != nil {
-			if gConv.DeletionTimestamp != nil {
-				timeout := time.Duration(settings.Settings.StaleConversionTimeout) * time.Second
-				if time.Since(gConv.DeletionTimestamp.Time) < timeout {
-					r.Log.Info("Stale Conversion CR still terminating, will requeue.",
-						"conversion", gConv.Name, "vm", vm.String())
-					return false, nil
-				}
-				r.Log.Info("Stale Conversion CR stuck terminating, force-deleting.",
-					"conversion", gConv.Name, "vm", vm.String(),
-					"terminatingSince", gConv.DeletionTimestamp.Time)
-			}
-			if delErr := r.kubevirt.DeleteConversion(gConv); delErr != nil {
-				return false, delErr
-			}
-			return false, nil
+			return r.ensureStaleObjectDeleted(gConv, vm, "conversion", func() error {
+				return r.kubevirt.DeleteConversion(gConv)
+			}, false)
 		}
 	}
 
@@ -1746,7 +1756,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			}
 
 			var pod *core.Pod
-			pod, err = r.kubevirt.GetConversionPod(vm.Ref, VirtV2vInspectionPod)
+			pod, err = r.kubevirt.GetConversionPod(vm.Ref, VirtV2vInspectionPod, true)
 			if err != nil {
 				step.AddError(err.Error())
 				err = nil

--- a/pkg/provider/ec2/controller/migrator/itinerary_test.go
+++ b/pkg/provider/ec2/controller/migrator/itinerary_test.go
@@ -5,10 +5,66 @@ import (
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("EC2 Migrator Reset", func() {
+	newMigrator := func() *Migrator {
+		ec2Type := api.EC2
+		return &Migrator{
+			Context: &plancontext.Context{
+				Plan: &api.Plan{},
+				Source: plancontext.Source{
+					Provider: &api.Provider{Spec: api.ProviderSpec{Type: &ec2Type}},
+				},
+			},
+			log: logging.WithName("test"),
+		}
+	}
+
+	It("should reset VM to PhaseStarted, clear error, and remove conditions", func() {
+		m := newMigrator()
+		vm := &planapi.VMStatus{
+			VM: planapi.VM{Ref: ref.Ref{ID: "i-456"}},
+		}
+		vm.Phase = PhaseCreateVolumes
+		vm.Error = &planapi.Error{Reasons: []string{"snapshot timeout"}}
+		vm.SetCondition(libcnd.Condition{Type: api.ConditionCanceled, Status: "True"})
+		vm.SetCondition(libcnd.Condition{Type: api.ConditionFailed, Status: "True"})
+
+		pipeline := []*planapi.Step{
+			{Task: planapi.Task{Name: PhaseCreateSnapshots}},
+			{Task: planapi.Task{Name: api.PhaseCompleted}},
+		}
+		m.Reset(vm, pipeline)
+
+		Expect(vm.Phase).To(Equal(api.PhaseStarted))
+		Expect(vm.Error).To(BeNil())
+		Expect(vm.Pipeline).To(Equal(pipeline))
+		Expect(vm.HasCondition(api.ConditionCanceled)).To(BeFalse())
+		Expect(vm.HasCondition(api.ConditionFailed)).To(BeFalse())
+	})
+
+	It("should preserve EC2-specific behavior (no DisksCopied reset)", func() {
+		m := newMigrator()
+		vm := &planapi.VMStatus{
+			VM: planapi.VM{Ref: ref.Ref{ID: "i-789"}},
+		}
+		vm.Phase = PhaseWaitForVolumes
+		vm.DisksCopied = true
+
+		pipeline := []*planapi.Step{
+			{Task: planapi.Task{Name: PhaseCreateSnapshots}},
+		}
+		m.Reset(vm, pipeline)
+
+		Expect(vm.Phase).To(Equal(api.PhaseStarted))
+		Expect(vm.DisksCopied).To(BeTrue(), "EC2 Reset does not clear DisksCopied")
+	})
+})
 
 var _ = Describe("EC2 Itinerary", func() {
 	newMigrator := func() *Migrator {

--- a/pkg/provider/ec2/controller/migrator/lifecycle.go
+++ b/pkg/provider/ec2/controller/migrator/lifecycle.go
@@ -34,14 +34,14 @@ func (r *Migrator) Status(vm planapi.VM) *planapi.VMStatus {
 }
 
 // Reset re-initializes a VM's migration status for retry after failure or cancellation.
-// Replaces pipeline, resets phase to first in itinerary, clears errors and timestamps.
+// EC2 has a single cold itinerary (always starts with PhaseStarted), never sets
+// DisksCopied or Warm, and does not support resume-conversion — so this is a
+// minimal reset without the warm/resume logic in BaseMigrator.Reset.
 func (r *Migrator) Reset(vm *planapi.VMStatus, pipeline []*planapi.Step) {
 	vm.DeleteCondition(api.ConditionCanceled, api.ConditionFailed)
 	vm.MarkReset()
 	vm.Pipeline = pipeline
-	itr := r.Itinerary(vm.VM)
-	step, _ := itr.First()
-	vm.Phase = step.Name
+	vm.Phase = api.PhaseStarted
 	vm.Error = nil
 
 	r.log.V(1).Info("VM status reset", "vm", vm.Name)


### PR DESCRIPTION
Reduce code duplication introduced by PR #7810 resume-conversion feature by extracting shared patterns into reusable helpers:

- Unify GetGuestConversionPod into GetConversionPod with a filterOutMigrationLabel parameter; remove duplicated pod-lookup
- Extract listDiskPVCsByUUID helper from getPVCs and validateResumePVCsByUUID to share list+filter+sort logic
- Extract ensureStaleObjectDeleted to encapsulate the "check DeletionTimestamp, wait or force-delete" pattern used by deleteStaleConversionWorkloads for both pods and CRs
- Simplify EC2 Reset() by using api.PhaseStarted directly instead of allocating an itinerary to discover the constant first phase