### PR TITLE
fix(populator): use correct units for default resource quantities

### DIFF
--- a/pkg/settings/populator.go
+++ b/pkg/settings/populator.go
@@ -15,10 +15,10 @@ const (
 )
 
 var (
-	DefaultPopulatorContainerLimitsCpu      = resource.NewQuantity(1000, resource.DecimalSI)
-	DefaultPopulatorContainerLimitsMemory   = resource.NewQuantity(1024, resource.BinarySI)
-	DefaultPopulatorContainerRequestsCpu    = resource.NewQuantity(100, resource.DecimalSI)
-	DefaultPopulatorContainerRequestsMemory = resource.NewQuantity(512, resource.BinarySI)
+	DefaultPopulatorContainerLimitsCpu      = resource.NewMilliQuantity(1000, resource.DecimalSI)
+	DefaultPopulatorContainerLimitsMemory   = resource.NewQuantity(1<<30, resource.BinarySI)
+	DefaultPopulatorContainerRequestsCpu    = resource.NewMilliQuantity(100, resource.DecimalSI)
+	DefaultPopulatorContainerRequestsMemory = resource.NewQuantity(512<<20, resource.BinarySI)
 )
 
 type Populator struct {


### PR DESCRIPTION
## Summary
- Follow-up to #7812 fixing a units bug flagged by CodeRabbit review.
- `resource.NewQuantity(1000, DecimalSI)` sets the value to 1000 whole CPU cores, not 1000 millicores as intended — same issue for memory, where `NewQuantity(512, BinarySI)` set 512 bytes instead of 512Mi.
- Switched CPU defaults to `NewMilliQuantity` and memory defaults to byte-shifted literals (`1<<30` = 1Gi, `512<<20` = 512Mi) so the actual defaults match the documented `1000m` / `1Gi` / `100m` / `512Mi`.

## Test plan
- [x] Verified on a live OpenShift cluster: before the fix, a populate pod created via `forklift-volume-populator-controller` showed `limits.cpu: "1k"` (1000 cores). After the fix, the same flow produces `limits.cpu: "1"` (1000m = 1 core), matching intent.
- [x] `go build ./pkg/settings/... ./cmd/populator-controller/...` passes.