### PR TITLE
MTV-5871 | Decouple xcopyUsed/vibVersion scraping from progress

### DIFF
--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -951,26 +951,6 @@ func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolum
 		c.parseAndRecordCompletion(bodyStr, pvc, cr)
 	}
 
-	// Pick the right progress regex for the populator type.
-	var importRegExp *regexp.Regexp
-	if populatorKind == api.VSphereXcopyVolumePopulatorKind {
-		importRegExp = regexp.MustCompile(`vsphere_xcopy_volume_populator_progress\{[^}]*owner_uid="` + string(pvc.UID) + `"[^}]*\} (\d+\.?\d*)`)
-	} else {
-		importRegExp = regexp.MustCompile("progress\\{ownerUID=\"" + string(pvc.UID) + "\"\\} (\\d+\\.?\\d*)")
-	}
-
-	match := importRegExp.FindStringSubmatch(bodyStr)
-	if match == nil {
-		klog.V(5).Info("Failed to find matches, regex: ", importRegExp)
-		return nil
-	}
-
-	progress, err := strconv.ParseFloat(string(match[1]), 64)
-	if err != nil {
-		klog.V(5).Info("Could not convert progress: ", err)
-		return err
-	}
-
 	gvr := schema.GroupVersionResource{
 		Group:    *pvc.Spec.DataSourceRef.APIGroup,
 		Version:  "v1beta1",
@@ -983,36 +963,61 @@ func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolum
 		return err
 	}
 
-	err = updatePopulatorProgress(int64(progress), latestPopulator)
-	if err != nil {
-		klog.V(5).Info("Failed to update progress: ", err)
-		return err
+	dirty := false
+	var progress float64
+
+	// Pick the right progress regex for the populator type.
+	// Best-effort: a miss or parse/write failure here is logged and skipped, and must
+	// not prevent the independent xcopyUsed/vibVersion scrapes below from being applied.
+	var importRegExp *regexp.Regexp
+	if populatorKind == api.VSphereXcopyVolumePopulatorKind {
+		importRegExp = regexp.MustCompile(`vsphere_xcopy_volume_populator_progress\{[^}]*owner_uid="` + string(pvc.UID) + `"[^}]*\} (\d+\.?\d*)`)
+	} else {
+		importRegExp = regexp.MustCompile("progress\\{ownerUID=\"" + string(pvc.UID) + "\"\\} (\\d+\\.?\\d*)")
 	}
 
+	if match := importRegExp.FindStringSubmatch(bodyStr); match == nil {
+		klog.V(5).Info("Failed to find matches, regex: ", importRegExp)
+	} else if p, perr := strconv.ParseFloat(match[1], 64); perr != nil {
+		klog.V(5).Info("Could not convert progress: ", perr)
+	} else {
+		progress = p
+		if err := updatePopulatorProgress(int64(progress), latestPopulator); err != nil {
+			klog.V(5).Info("Failed to update progress: ", err)
+		} else {
+			dirty = true
+		}
+	}
+
+	// xcopyUsed / vibVersion: best-effort, independent of progress above so that a
+	// failure/miss on either side never blocks the other from reaching the CR.
 	if populatorKind == api.VSphereXcopyVolumePopulatorKind {
 		xcopyRegExp := regexp.MustCompile(`vsphere_xcopy_volume_populator_xcopy_used\{[^}]*owner_uid="` + string(pvc.UID) + `"[^}]*\} (\d+)`)
-		xcopyMatch := xcopyRegExp.FindStringSubmatch(string(body))
-		if xcopyMatch != nil {
+		if xcopyMatch := xcopyRegExp.FindStringSubmatch(bodyStr); xcopyMatch != nil {
 			if err := unstructured.SetNestedField(latestPopulator.Object, xcopyMatch[1], "status", "xcopyUsed"); err != nil {
 				klog.V(5).Info("Failed to update xcopyUsed: ", err)
-				return err
+			} else {
+				dirty = true
 			}
 		}
 
 		vibVerRegExp := regexp.MustCompile(`vsphere_xcopy_volume_populator_vib_version\{[^}]*owner_uid="` + string(pvc.UID) + `"[^}]*\} (\d+)`)
-		vibVerLine := vibVerRegExp.FindString(bodyStr)
-		if vibVerLine != "" {
+		if vibVerLine := vibVerRegExp.FindString(bodyStr); vibVerLine != "" {
 			if vibVersion := extractLabel(vibVerLine, "version"); vibVersion != "" {
 				if err := unstructured.SetNestedField(latestPopulator.Object, vibVersion, "status", "vibVersion"); err != nil {
 					klog.V(5).Info("Failed to update vibVersion: ", err)
-					return err
+				} else {
+					dirty = true
 				}
 			}
 		}
 	}
 
-	_, err = c.dynamicClient.Resource(gvr).Namespace(pvc.Namespace).Update(context.TODO(), latestPopulator, metav1.UpdateOptions{})
-	if err != nil {
+	if !dirty {
+		return nil
+	}
+
+	if _, err := c.dynamicClient.Resource(gvr).Namespace(pvc.Namespace).Update(context.TODO(), latestPopulator, metav1.UpdateOptions{}); err != nil {
 		klog.V(5).Info("Failed to update CR ", err)
 		return err
 	}


### PR DESCRIPTION
## Summary
- PR #7443 fixed the `xcopyUsed` metric regex, but the scrape remained structurally coupled to progress: any miss/error in the progress regex, parse, or CR-field update returned early and skipped the `xcopyUsed`/`vibVersion` scrapes for that cycle. Conversely, a failure writing `xcopyUsed` skipped the final `Update()` call, dropping an already-scraped progress value too.
- Makes progress, `xcopyUsed`, and `vibVersion` independent, best-effort scrapes in `updateProgress`: each is logged and skipped on failure rather than aborting the whole function, so a hiccup in one never blocks the others. A `dirty` flag ensures the CR is only updated when something new was actually scraped, and any field not touched this cycle naturally keeps its last persisted value.

## Test plan
- [x] `go build ./pkg/lib-volume-populator/...`
- [x] `go test ./pkg/lib-volume-populator/...`
- [x] Verified live on a cluster: ran a fresh XCOPY-offload migration (`vsphere` → `host`, ONTAP/Trident target) with the built image; observed the `VSphereXcopyVolumePopulator` CR reach `status.xcopyUsed=1` on a scrape cycle where `status.progress` was still empty, confirming the two scrapes are no longer coupled. Migration completed `DiskTransfer` successfully with `xcopyUsed: "1"` propagated onto the Plan's task annotations.