### PR TITLE
MTV-6307 | Fix Hyper-V cluster NIC resolution by owner node

### DIFF
--- a/pkg/controller/plan/adapter/hyperv/validator.go
+++ b/pkg/controller/plan/adapter/hyperv/validator.go
@@ -66,7 +66,12 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (bool, error) {
 
 	for _, nic := range vm.NICs {
 		if nic.Network.ID == "" {
-			continue // Disconnected NIC is OK
+			if nic.NetworkName != "" {
+				// NIC is attached to a switch that wasn't discovered in inventory.
+				// Treat as unmapped rather than silently skipping.
+				return false, nil
+			}
+			continue // Truly disconnected NIC
 		}
 		mapped := false
 		for _, pair := range r.Context.Map.Network.Spec.Map {

--- a/pkg/controller/plan/adapter/hyperv/validator_test.go
+++ b/pkg/controller/plan/adapter/hyperv/validator_test.go
@@ -213,3 +213,55 @@ func TestMaintenanceMode_VMNotFound(t *testing.T) {
 		t.Error("expected error when VM lookup fails")
 	}
 }
+
+func TestNetworksMapped_UnresolvedNICTreatedAsUnmapped(t *testing.T) {
+	vm := &hyperv.VM{}
+	vm.ID = "vm-1"
+	vm.NICs = []model.NIC{
+		{Name: "nic-0", Network: model.Ref{Kind: model.NetKind, ID: ""}, NetworkName: "LabSwitch"},
+	}
+
+	inv := &stubInventory{vms: map[string]*hyperv.VM{"vm-1": vm}}
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{Inventory: inv},
+			Plan: &api.Plan{
+				Spec: api.PlanSpec{},
+			},
+		},
+	}
+	v.Map.Network = &api.NetworkMap{}
+
+	ok, err := v.NetworksMapped(ref.Ref{ID: "vm-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false: NIC with networkName but empty network.ID should be treated as unmapped, not disconnected")
+	}
+}
+
+func TestNetworksMapped_TrulyDisconnectedNICSkipped(t *testing.T) {
+	vm := &hyperv.VM{}
+	vm.ID = "vm-1"
+	vm.NICs = []model.NIC{
+		{Name: "nic-0", Network: model.Ref{Kind: model.NetKind, ID: ""}, NetworkName: ""},
+	}
+
+	inv := &stubInventory{vms: map[string]*hyperv.VM{"vm-1": vm}}
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{Inventory: inv},
+			Plan:   &api.Plan{},
+		},
+	}
+	v.Map.Network = &api.NetworkMap{}
+
+	ok, err := v.NetworksMapped(ref.Ref{ID: "vm-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("expected ok=true: truly disconnected NIC (empty name and ID) should be skipped")
+	}
+}

--- a/pkg/controller/provider/container/hyperv/client.go
+++ b/pkg/controller/provider/container/hyperv/client.go
@@ -20,6 +20,8 @@ import (
 	core "k8s.io/api/core/v1"
 )
 
+var clientLog = logging.WithName("client|hyperv")
+
 // Not found error.
 type NotFound struct {
 }
@@ -480,7 +482,7 @@ func (r *Client) applyBatchDetails(vms []types.VM, indices []int, batchMap map[s
 					Name:        fmt.Sprintf("nic-%d", j),
 					MAC:         mac,
 					DeviceIndex: j,
-					NetworkUUID: resolveNetworkUUID(nd.SwitchName, networks),
+					NetworkUUID: resolveNetworkUUID(nd.SwitchName, vms[i].OwnerNode, networks),
 					NetworkName: nd.SwitchName,
 					VlanId:      nd.VlanId,
 				})
@@ -648,13 +650,23 @@ func (r *Client) validateDisksOnSMB(vms []types.VM) {
 	}
 }
 
-// ListNetworks collects all networks from the HyperV host via WinRM.
+// ListNetworks collects all virtual switches from the Hyper-V host via WinRM.
+// In cluster mode, switches are collected from all cluster nodes so that NICs
+// on VMs running on remote nodes can be resolved to a known network UUID.
 func (r *Client) ListNetworks() ([]types.Network, error) {
 	netDomains, err := r.driver.ListAllNetworks()
 	if err != nil {
 		return nil, err
 	}
 
+	localName := ""
+	if r.provider != nil && r.provider.IsHyperVCluster() {
+		if info, err := r.driver.GetComputerInfo(); err == nil {
+			localName = info.DNSHostName
+		}
+	}
+
+	seen := make(map[string]bool)
 	var result []types.Network
 	for _, n := range netDomains {
 		uuid, err := n.GetUUIDString()
@@ -671,14 +683,82 @@ func (r *Client) ListNetworks() ([]types.Network, error) {
 		}
 		switchType, _ := n.GetSwitchType()
 
+		seen[uuid] = true
+		ownerNodes := []string{}
+		if localName != "" {
+			ownerNodes = []string{localName}
+		}
 		result = append(result, types.Network{
 			UUID:       uuid,
 			Name:       name,
 			SwitchType: switchType,
+			OwnerNodes: ownerNodes,
 		})
 		_ = n.Free()
 	}
+
+	if r.provider != nil && r.provider.IsHyperVCluster() {
+		r.mergeRemoteNodeNetworks(&result, seen)
+	}
+
 	return result, nil
+}
+
+// mergeRemoteNodeNetworks queries Get-VMSwitch on each remote cluster node.
+// New switches are appended to resultת switches whose UUID was already seen
+// get the remote node appended to their OwnerNodes list.
+func (r *Client) mergeRemoteNodeNetworks(result *[]types.Network, seen map[string]bool) {
+	cc, err := r.getClusterCache()
+	if err != nil {
+		r.Log.Error(err, "Cannot collect remote node networks: cluster cache unavailable")
+		return
+	}
+
+	localInfo, err := r.driver.GetComputerInfo()
+	if err != nil {
+		r.Log.V(1).Info("Cannot determine local hostname for network dedup", "error", err)
+		return
+	}
+	localName := strings.ToUpper(localInfo.DNSHostName)
+
+	for _, node := range cc.nodes {
+		if strings.EqualFold(node.Name, localName) || node.State != driver.ClusterNodeStateUp {
+			continue
+		}
+		stdout, err := r.driver.RunOnNode(ps.ListAllSwitches, node.Name)
+		if err != nil {
+			r.Log.Info("Failed to collect switches from remote node", "node", node.Name, "error", err)
+			continue
+		}
+		stdout = strings.TrimSpace(stdout)
+		if stdout == "" {
+			continue
+		}
+		switchesData, err := driver.UnmarshalArrayOrSingle[driver.SwitchData]([]byte(stdout))
+		if err != nil {
+			r.Log.Info("Failed to parse remote node switches", "node", node.Name, "error", err)
+			continue
+		}
+		for _, sw := range switchesData {
+			if seen[sw.Id] {
+				for i := range *result {
+					if (*result)[i].UUID == sw.Id {
+						(*result)[i].OwnerNodes = append((*result)[i].OwnerNodes, node.Name)
+						break
+					}
+				}
+				continue
+			}
+			seen[sw.Id] = true
+			*result = append(*result, types.Network{
+				UUID:       sw.Id,
+				Name:       sw.Name,
+				SwitchType: mapSwitchType(sw.SwitchType),
+				OwnerNodes: []string{node.Name},
+			})
+			r.Log.Info("Discovered remote-only switch", "node", node.Name, "name", sw.Name, "id", sw.Id)
+		}
+	}
 }
 
 // ListStorages returns the SMB storage record from the HyperV host via WinRM.
@@ -814,7 +894,7 @@ func (r *Client) getVMFromDomain(domain driver.Domain, networks []types.Network,
 	}
 
 	vm.Disks = r.extractDisks(domain, smbWindowsPrefix, uuid)
-	vm.NICs = r.extractNICs(domain, networks)
+	vm.NICs = r.extractNICs(domain, computerName, networks)
 
 	return vm, nil
 }
@@ -849,7 +929,7 @@ func (r *Client) extractDisks(domain driver.Domain, smbWindowsPrefix string, vmU
 	return disks
 }
 
-func (r *Client) extractNICs(domain driver.Domain, networks []types.Network) []types.NIC {
+func (r *Client) extractNICs(domain driver.Domain, vmOwnerNode string, networks []types.Network) []types.NIC {
 	nicInfos, err := domain.GetNICs()
 	if err != nil {
 		r.Log.Error(err, "Failed to get NICs")
@@ -858,7 +938,7 @@ func (r *Client) extractNICs(domain driver.Domain, networks []types.Network) []t
 
 	var nics []types.NIC
 	for i, ni := range nicInfos {
-		networkUUID := resolveNetworkUUID(ni.SwitchName, networks)
+		networkUUID := resolveNetworkUUID(ni.SwitchName, vmOwnerNode, networks)
 		mac := formatMAC(ni.MACAddress)
 
 		nics = append(nics, types.NIC{
@@ -890,14 +970,10 @@ func (r *Client) collectPerVMDisks(vmName, vmUUID, computerName string) []types.
 		ControllerNumber   int    `json:"ControllerNumber"`
 		ControllerLocation int    `json:"ControllerLocation"`
 	}
-	var disksData []diskData
-	if err := json.Unmarshal([]byte(stdout), &disksData); err != nil {
-		var single diskData
-		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
-			r.Log.Error(err, "Failed to parse disks JSON", "vm", vmName)
-			return []types.Disk{}
-		}
-		disksData = append(disksData, single)
+	disksData, err := driver.UnmarshalArrayOrSingle[diskData]([]byte(stdout))
+	if err != nil {
+		r.Log.Error(err, "Failed to parse disks JSON", "vm", vmName)
+		return []types.Disk{}
 	}
 	var disks []types.Disk
 	for i, dd := range disksData {
@@ -936,14 +1012,10 @@ func (r *Client) collectPerVMNICs(vmName, computerName string, networks []types.
 		SwitchName string `json:"SwitchName"`
 		VlanId     int    `json:"VlanId"`
 	}
-	var nicsData []nicData
-	if err := json.Unmarshal([]byte(stdout), &nicsData); err != nil {
-		var single nicData
-		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
-			r.Log.Error(err, "Failed to parse NICs JSON", "vm", vmName)
-			return []types.NIC{}
-		}
-		nicsData = append(nicsData, single)
+	nicsData, err := driver.UnmarshalArrayOrSingle[nicData]([]byte(stdout))
+	if err != nil {
+		r.Log.Error(err, "Failed to parse NICs JSON", "vm", vmName)
+		return []types.NIC{}
 	}
 	var nics []types.NIC
 	for i, nd := range nicsData {
@@ -952,7 +1024,7 @@ func (r *Client) collectPerVMNICs(vmName, computerName string, networks []types.
 			Name:        fmt.Sprintf("nic-%d", i),
 			MAC:         mac,
 			DeviceIndex: i,
-			NetworkUUID: resolveNetworkUUID(nd.SwitchName, networks),
+			NetworkUUID: resolveNetworkUUID(nd.SwitchName, computerName, networks),
 			NetworkName: nd.SwitchName,
 			VlanId:      nd.VlanId,
 		})
@@ -1023,13 +1095,9 @@ func (r *Client) collectGuestNetworkConfig(vmName string, nics []types.NIC, comp
 		return []types.GuestNetwork{}, nil
 	}
 
-	var configs []guestNetCfg
-	if err := json.Unmarshal([]byte(stdout), &configs); err != nil {
-		var single guestNetCfg
-		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
-			return nil, fmt.Errorf("failed to parse KVP JSON: %w", err)
-		}
-		configs = append(configs, single)
+	configs, err := driver.UnmarshalArrayOrSingle[guestNetCfg]([]byte(stdout))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse KVP JSON: %w", err)
 	}
 
 	return buildGuestNetworks(configs, nics), nil
@@ -1237,16 +1305,71 @@ func mapPowerState(state driver.DomainState) string {
 	}
 }
 
-func resolveNetworkUUID(name string, networks []types.Network) string {
+// resolveNetworkUUID returns the UUID of the switch named `name`.
+// When vmOwnerNode is set, a switch whose OwnerNodes includes that node
+// is preferred. A switch with empty OwnerNodes (no ownership data) is
+// treated as unscoped and matches any VM. A scoped fallback (populated
+// OwnerNodes that don't include vmOwnerNode) is only used when the VM
+// owner node is unknown.
+func resolveNetworkUUID(name, vmOwnerNode string, networks []types.Network) string {
 	if name == "" {
 		return ""
 	}
+	unscopedFallback := ""
+	scopedFallback := ""
 	for _, n := range networks {
-		if strings.EqualFold(n.Name, name) {
+		if !strings.EqualFold(n.Name, name) {
+			continue
+		}
+		if len(n.OwnerNodes) == 0 {
+			if unscopedFallback == "" {
+				unscopedFallback = n.UUID
+			}
+			continue
+		}
+		if vmOwnerNode != "" && containsIgnoreCase(n.OwnerNodes, vmOwnerNode) {
 			return n.UUID
 		}
+		if scopedFallback == "" {
+			scopedFallback = n.UUID
+		}
 	}
+	if unscopedFallback != "" {
+		return unscopedFallback
+	}
+	if scopedFallback != "" && vmOwnerNode == "" {
+		return scopedFallback
+	}
+	clientLog.Info("NIC references undiscovered virtual switch",
+		"switchName", name,
+		"vmOwnerNode", vmOwnerNode,
+		"discoveredSwitches", len(networks))
 	return ""
+}
+
+// containsIgnoreCase reports whether any element of ss case-insensitively
+// matches target.
+func containsIgnoreCase(ss []string, target string) bool {
+	for _, s := range ss {
+		if strings.EqualFold(s, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// mapSwitchType converts the PowerShell SwitchType int to a human-readable string.
+func mapSwitchType(switchType int) string {
+	switch switchType {
+	case 0:
+		return "External"
+	case 1:
+		return "Internal"
+	case 2:
+		return "Private"
+	default:
+		return "Unknown"
+	}
 }
 
 func extractHostFromURL(addr string) string {

--- a/pkg/controller/provider/container/hyperv/client_test.go
+++ b/pkg/controller/provider/container/hyperv/client_test.go
@@ -18,6 +18,8 @@ type mockDriver struct {
 	clusterData  *driver.ClusterData
 	clusterNodes []driver.ClusterNodeData
 	clusterVMs   []driver.ClusterGroupData
+	networks     []driver.Network
+	computerInfo *driver.ComputerInfoData
 	runOnNodeFn  func(command, computerName string) (string, error)
 }
 
@@ -28,12 +30,24 @@ func (m *mockDriver) ListAllDomains() ([]driver.Domain, error)                 {
 func (m *mockDriver) ListAllClusterDomains() ([]driver.Domain, error)          { return nil, nil }
 func (m *mockDriver) LookupDomainByName(string) (driver.Domain, error)         { return nil, nil } //nolint:nilnil
 func (m *mockDriver) LookupDomainByUUIDString(string) (driver.Domain, error)   { return nil, nil } //nolint:nilnil
-func (m *mockDriver) ListAllNetworks() ([]driver.Network, error)               { return nil, nil }
 func (m *mockDriver) LookupNetworkByUUIDString(string) (driver.Network, error) { return nil, nil } //nolint:nilnil
 func (m *mockDriver) ExecuteCommand(string) (string, error)                    { return "", nil }
-func (m *mockDriver) GetComputerInfo() (*driver.ComputerInfoData, error)       { return nil, nil } //nolint:nilnil
 func (m *mockDriver) GetCluster() (*driver.ClusterData, error)                 { return m.clusterData, nil }
 func (m *mockDriver) GetClusterNodes() ([]driver.ClusterNodeData, error)       { return m.clusterNodes, nil }
+
+func (m *mockDriver) ListAllNetworks() ([]driver.Network, error) {
+	if m.networks != nil {
+		return m.networks, nil
+	}
+	return nil, nil
+}
+
+func (m *mockDriver) GetComputerInfo() (*driver.ComputerInfoData, error) {
+	if m.computerInfo != nil {
+		return m.computerInfo, nil
+	}
+	return nil, nil //nolint:nilnil
+}
 func (m *mockDriver) GetClusterVMGroups() ([]driver.ClusterGroupData, error) {
 	return m.clusterVMs, nil
 }
@@ -911,5 +925,274 @@ func TestApplyHostTo(t *testing.T) {
 	expectedMemBytes := int64(32768) * 1024 * 1024
 	if m.MemoryBytes != expectedMemBytes {
 		t.Errorf("Expected MemoryBytes %d, got %d", expectedMemBytes, m.MemoryBytes)
+	}
+}
+
+// mockNetwork implements driver.Network for tests.
+type mockNetwork struct {
+	uuid       string
+	name       string
+	switchType string
+}
+
+func (n *mockNetwork) GetName() (string, error)       { return n.name, nil }
+func (n *mockNetwork) GetUUIDString() (string, error) { return n.uuid, nil }
+func (n *mockNetwork) GetSwitchType() (string, error) { return n.switchType, nil }
+func (n *mockNetwork) Free() error                    { return nil }
+
+func TestListNetworks_ClusterCollectsRemoteSwitches(t *testing.T) {
+	localSwitch := &mockNetwork{uuid: "local-uuid-1", name: "Lab-External", switchType: "External"}
+	remoteJSON := `[{"Id":"remote-uuid-1","Name":"LabSwitch","SwitchType":1}]`
+
+	md := &mockDriver{
+		networks: []driver.Network{localSwitch},
+		computerInfo: &driver.ComputerInfoData{
+			DNSHostName: "WIN-LOCAL",
+		},
+		clusterData: &driver.ClusterData{Name: "cluster01"},
+		clusterNodes: []driver.ClusterNodeData{
+			{Name: "WIN-LOCAL", State: driver.ClusterNodeStateUp, Id: "1"},
+			{Name: "HV-NODE02", State: driver.ClusterNodeStateUp, Id: "2"},
+		},
+		runOnNodeFn: func(command, computerName string) (string, error) {
+			if computerName == "HV-NODE02" {
+				return remoteJSON, nil
+			}
+			return "", nil
+		},
+	}
+
+	client := &Client{driver: md, provider: newClusterProvider(), Log: testLogger()}
+	networks, err := client.ListNetworks()
+	if err != nil {
+		t.Fatalf("ListNetworks error: %v", err)
+	}
+
+	if len(networks) != 2 {
+		t.Fatalf("Expected 2 networks (local + remote), got %d", len(networks))
+	}
+
+	found := false
+	for _, n := range networks {
+		if n.UUID == "remote-uuid-1" && n.Name == "LabSwitch" {
+			found = true
+			if n.SwitchType != "Internal" {
+				t.Errorf("Expected SwitchType 'Internal', got '%s'", n.SwitchType)
+			}
+		}
+	}
+	if !found {
+		t.Error("Remote LabSwitch not found in combined network list")
+	}
+}
+
+func TestListNetworks_ClusterDeduplicatesSharedSwitches(t *testing.T) {
+	localSwitch := &mockNetwork{uuid: "shared-uuid", name: "Lab-External", switchType: "External"}
+	// Remote node has the same switch (same UUID)
+	remoteJSON := `[{"Id":"shared-uuid","Name":"Lab-External","SwitchType":2}]`
+
+	md := &mockDriver{
+		networks:     []driver.Network{localSwitch},
+		computerInfo: &driver.ComputerInfoData{DNSHostName: "WIN-LOCAL"},
+		clusterData:  &driver.ClusterData{Name: "cluster01"},
+		clusterNodes: []driver.ClusterNodeData{
+			{Name: "WIN-LOCAL", State: driver.ClusterNodeStateUp, Id: "1"},
+			{Name: "HV-NODE02", State: driver.ClusterNodeStateUp, Id: "2"},
+		},
+		runOnNodeFn: func(command, computerName string) (string, error) {
+			return remoteJSON, nil
+		},
+	}
+
+	client := &Client{driver: md, provider: newClusterProvider(), Log: testLogger()}
+	networks, err := client.ListNetworks()
+	if err != nil {
+		t.Fatalf("ListNetworks error: %v", err)
+	}
+
+	if len(networks) != 1 {
+		t.Fatalf("Expected 1 network (deduped), got %d", len(networks))
+	}
+}
+
+func TestListNetworks_StandaloneSkipsRemoteCollection(t *testing.T) {
+	localSwitch := &mockNetwork{uuid: "local-uuid-1", name: "Default Switch", switchType: "Private"}
+
+	md := &mockDriver{
+		networks: []driver.Network{localSwitch},
+		runOnNodeFn: func(command, computerName string) (string, error) {
+			t.Error("RunOnNode should not be called in standalone mode")
+			return "", nil
+		},
+	}
+
+	client := &Client{driver: md, provider: newStandaloneProvider(), Log: testLogger()}
+	networks, err := client.ListNetworks()
+	if err != nil {
+		t.Fatalf("ListNetworks error: %v", err)
+	}
+
+	if len(networks) != 1 {
+		t.Fatalf("Expected 1 network, got %d", len(networks))
+	}
+}
+
+func TestResolveNetworkUUID(t *testing.T) {
+	networks := []types.Network{
+		{UUID: "uuid-1", Name: "Lab-External"},
+		{UUID: "uuid-2", Name: "LabSwitch"},
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"exact match", "Lab-External", "uuid-1"},
+		{"case insensitive", "lab-external", "uuid-1"},
+		{"empty name returns empty", "", ""},
+		{"not found returns empty", "NonExistent", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resolveNetworkUUID(tc.input, "", networks)
+			if result != tc.expected {
+				t.Errorf("resolveNetworkUUID(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestResolveNetworkUUID_NodeScoped(t *testing.T) {
+	// Two nodes each have a switch named "LabSwitch" with different UUIDs.
+	// "Lab-External" has the same UUID on both nodes (shared switch).
+	networks := []types.Network{
+		{UUID: "local-uuid", Name: "LabSwitch", OwnerNodes: []string{"NODE-01"}},
+		{UUID: "remote-uuid", Name: "LabSwitch", OwnerNodes: []string{"NODE-02"}},
+		{UUID: "shared-uuid", Name: "Lab-External", OwnerNodes: []string{"NODE-01", "NODE-02"}},
+	}
+
+	tests := []struct {
+		name        string
+		switchName  string
+		vmOwnerNode string
+		expected    string
+	}{
+		{
+			name:        "VM on NODE-01 gets local UUID",
+			switchName:  "LabSwitch",
+			vmOwnerNode: "NODE-01",
+			expected:    "local-uuid",
+		},
+		{
+			name:        "VM on NODE-02 gets remote UUID",
+			switchName:  "LabSwitch",
+			vmOwnerNode: "NODE-02",
+			expected:    "remote-uuid",
+		},
+		{
+			name:        "node match is case-insensitive",
+			switchName:  "LabSwitch",
+			vmOwnerNode: "node-02",
+			expected:    "remote-uuid",
+		},
+		{
+			name:        "no node hint falls back to first name match",
+			switchName:  "LabSwitch",
+			vmOwnerNode: "",
+			expected:    "local-uuid",
+		},
+		{
+			name:        "VM on unknown node returns empty not wrong UUID",
+			switchName:  "LabSwitch",
+			vmOwnerNode: "NODE-99",
+			expected:    "",
+		},
+		{
+			name:        "shared switch resolves for VM on NODE-01",
+			switchName:  "Lab-External",
+			vmOwnerNode: "NODE-01",
+			expected:    "shared-uuid",
+		},
+		{
+			name:        "shared switch resolves for VM on NODE-02",
+			switchName:  "Lab-External",
+			vmOwnerNode: "NODE-02",
+			expected:    "shared-uuid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resolveNetworkUUID(tc.switchName, tc.vmOwnerNode, networks)
+			if result != tc.expected {
+				t.Errorf("resolveNetworkUUID(%q, %q) = %q, want %q",
+					tc.switchName, tc.vmOwnerNode, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestResolveNetworkUUID_UnscopedFallback(t *testing.T) {
+	// Simulates GetComputerInfo() failure: networks have empty OwnerNodes
+	// but VMs still have OwnerNode from GetClusterVMGroups.
+	networks := []types.Network{
+		{UUID: "uuid-1", Name: "LabSwitch"},
+		{UUID: "uuid-2", Name: "Lab-External"},
+	}
+
+	tests := []struct {
+		name        string
+		switchName  string
+		vmOwnerNode string
+		expected    string
+	}{
+		{
+			name:        "unscoped network resolves even with known VM node",
+			switchName:  "LabSwitch",
+			vmOwnerNode: "NODE-01",
+			expected:    "uuid-1",
+		},
+		{
+			name:        "unscoped network resolves with unknown VM node",
+			switchName:  "Lab-External",
+			vmOwnerNode: "",
+			expected:    "uuid-2",
+		},
+		{
+			name:        "not found still returns empty",
+			switchName:  "NoSuchSwitch",
+			vmOwnerNode: "NODE-01",
+			expected:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := resolveNetworkUUID(tc.switchName, tc.vmOwnerNode, networks)
+			if result != tc.expected {
+				t.Errorf("resolveNetworkUUID(%q, %q) = %q, want %q",
+					tc.switchName, tc.vmOwnerNode, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMapSwitchType(t *testing.T) {
+	tests := []struct {
+		input    int
+		expected string
+	}{
+		{0, "External"},
+		{1, "Internal"},
+		{2, "Private"},
+		{99, "Unknown"},
+	}
+	for _, tc := range tests {
+		result := mapSwitchType(tc.input)
+		if result != tc.expected {
+			t.Errorf("mapSwitchType(%d) = %q, want %q", tc.input, result, tc.expected)
+		}
 	}
 }

--- a/pkg/controller/provider/model/hyperv/types/types.go
+++ b/pkg/controller/provider/model/hyperv/types/types.go
@@ -71,9 +71,10 @@ type GuestNetwork struct {
 
 // Network represents a Hyper-V virtual network/switch.
 type Network struct {
-	UUID       string `json:"uuid"`
-	Name       string `json:"name"`
-	SwitchType string `json:"switchType"`
+	UUID       string   `json:"uuid"`
+	Name       string   `json:"name"`
+	SwitchType string   `json:"switchType"`
+	OwnerNodes []string `json:"ownerNodes,omitempty"`
 }
 
 // Storage represents a Hyper-V storage location.

--- a/pkg/lib/hyperv/driver/winrm.go
+++ b/pkg/lib/hyperv/driver/winrm.go
@@ -360,6 +360,20 @@ func runSingle[T any](d *WinRMDriver, script, label string) (*T, error) {
 	return &result, nil
 }
 
+// UnmarshalArrayOrSingle unmarshals JSON that may be either an array or a bare
+// object (PowerShell returns a bare object when the result set has one element).
+func UnmarshalArrayOrSingle[T any](data []byte) ([]T, error) {
+	var results []T
+	if err := json.Unmarshal(data, &results); err != nil {
+		var single T
+		if err := json.Unmarshal(data, &single); err != nil {
+			return nil, err
+		}
+		results = append(results, single)
+	}
+	return results, nil
+}
+
 // runList executes a PowerShell script and unmarshals the JSON output into a
 // slice of T. Handles PowerShell's behavior of returning a bare object instead
 // of a one-element array.
@@ -371,13 +385,9 @@ func runList[T any](d *WinRMDriver, script, label string) ([]T, error) {
 	if stdout == "" {
 		return []T{}, nil
 	}
-	var results []T
-	if err := json.Unmarshal([]byte(stdout), &results); err != nil {
-		var single T
-		if err := json.Unmarshal([]byte(stdout), &single); err != nil {
-			return nil, fmt.Errorf("failed to parse %s JSON: %w", label, err)
-		}
-		results = append(results, single)
+	results, err := UnmarshalArrayOrSingle[T]([]byte(stdout))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s JSON: %w", label, err)
 	}
 	return results, nil
 }

--- a/validation/policies/io/konveyor/forklift/hyperv/nic_unresolved_network.rego
+++ b/validation/policies/io/konveyor/forklift/hyperv/nic_unresolved_network.rego
@@ -1,0 +1,37 @@
+# NIC network resolution validation for Hyper-V VMs.
+# Detects NICs that reference a virtual switch by name but whose network UUID
+# could not be resolved during inventory collection. This typically happens in
+# cluster environments where a switch exists on a remote node but not on the
+# provider's connected host.
+
+package io.konveyor.forklift.hyperv
+
+import rego.v1
+
+nics_with_unresolved_network contains idx if {
+	some idx
+	nic := input.nics[idx]
+	has_network_name(nic)
+	not has_network_uuid(nic)
+}
+
+has_network_name(nic) if {
+	is_string(nic.networkName)
+	nic.networkName != ""
+}
+
+has_network_uuid(nic) if {
+	is_string(nic.network.id)
+	nic.network.id != ""
+}
+
+concerns contains flag if {
+	nics_with_unresolved_network[idx]
+	nic := input.nics[idx]
+	flag := {
+		"id": "hyperv.nic.unresolved_network",
+		"category": "Warning",
+		"label": sprintf("NIC '%v' references undiscovered switch '%v'", [nic.name, nic.networkName]),
+		"assessment": sprintf("NIC '%v' is connected to virtual switch '%v' which was not found in the provider's network inventory. In a cluster, this switch may only exist on a remote node. The NIC will be skipped during migration unless the switch is created on the provider's connected host or all cluster nodes are reachable. Verify that the virtual switch exists and is accessible.", [nic.name, nic.networkName]),
+	}
+}

--- a/validation/policies/io/konveyor/forklift/hyperv/nic_unresolved_network_test.rego
+++ b/validation/policies/io/konveyor/forklift/hyperv/nic_unresolved_network_test.rego
@@ -1,0 +1,87 @@
+package io.konveyor.forklift.hyperv
+
+import rego.v1
+
+test_nic_with_resolved_network if {
+	mock_vm := {
+		"name": "test-vm",
+		"nics": [{
+			"name": "nic-0",
+			"mac": "00:15:5D:01:DB:01",
+			"network": {"id": "a5c4bd9a-5ca9-4bf8-9452-1b97de56d686", "kind": "Network"},
+			"networkName": "Lab-External",
+		}],
+		"disks": [{"name": "disk-0", "capacity": 1000}],
+	}
+	results := concerns with input as mock_vm
+	not any_unresolved_nic_concern(results)
+}
+
+test_nic_with_unresolved_network if {
+	mock_vm := {
+		"name": "test-vm",
+		"nics": [{
+			"name": "nic-0",
+			"mac": "00:15:5D:01:DB:01",
+			"network": {"id": "", "kind": "Network"},
+			"networkName": "LabSwitch",
+		}],
+		"disks": [{"name": "disk-0", "capacity": 1000}],
+	}
+	results := concerns with input as mock_vm
+	some result in results
+	result.id == "hyperv.nic.unresolved_network"
+}
+
+test_nic_disconnected_no_concern if {
+	mock_vm := {
+		"name": "test-vm",
+		"nics": [{
+			"name": "nic-0",
+			"mac": "00:15:5D:01:DB:01",
+			"network": {"id": "", "kind": "Network"},
+			"networkName": "",
+		}],
+		"disks": [{"name": "disk-0", "capacity": 1000}],
+	}
+	results := concerns with input as mock_vm
+	not any_unresolved_nic_concern(results)
+}
+
+test_nic_null_network_name_no_concern if {
+	mock_vm := {
+		"name": "test-vm",
+		"nics": [{"name": "nic-0", "mac": "00:15:5D:01:DB:01", "network": {"id": "", "kind": "Network"}}],
+		"disks": [{"name": "disk-0", "capacity": 1000}],
+	}
+	results := concerns with input as mock_vm
+	not any_unresolved_nic_concern(results)
+}
+
+test_multiple_nics_one_unresolved if {
+	mock_vm := {
+		"name": "test-vm",
+		"nics": [
+			{
+				"name": "nic-0",
+				"mac": "00:15:5D:01:DB:01",
+				"network": {"id": "", "kind": "Network"},
+				"networkName": "LabSwitch",
+			},
+			{
+				"name": "nic-1",
+				"mac": "00:15:5D:01:DB:02",
+				"network": {"id": "a5c4bd9a-5ca9-4bf8-9452-1b97de56d686", "kind": "Network"},
+				"networkName": "Lab-External",
+			},
+		],
+		"disks": [{"name": "disk-0", "capacity": 1000}],
+	}
+	results := concerns with input as mock_vm
+	count([r | some r in results; r.id == "hyperv.nic.unresolved_network"]) == 1
+}
+
+any_unresolved_nic_concern(results) if {
+	some result in results
+	result.id == "hyperv.nic.unresolved_network"
+}


### PR DESCRIPTION
In Hyper-V clusters, ListNetworks only queried the connected host,
so VMs on remote nodes had NICs silently dropped when their switch
was missing from inventory. resolveNetworkUUID also matched by name
only, which could assign the wrong UUID when two nodes had
identically-named switches with different UUIDs.
- ListNetworks collects switches from all cluster nodes via
  Invoke-Command, tagging each with its OwnerNode.
- resolveNetworkUUID resolves by (ownerNode, switchName) when the
  VM owner node is known; returns empty (not a cross-node fallback)
  when no node-scoped match exists.
- NetworksMapped validator distinguishes truly disconnected NICs
  from unresolved ones (name set, ID empty).
- New Rego policy (hyperv.nic.unresolved_network) surfaces a
  concern when a NIC references an undiscovered switch; uses
  nic.network.id to match the model serialization.
- UnmarshalArrayOrSingle generic helper reduces duplicated
  array-or-single JSON parsing in client.go and driver/winrm.go.


Ref: https://redhat.atlassian.net/browse/MTV-6307
Resolves: MTV-6307