### PR TITLE
MTV-5866 | Add timezone field to migration plan spec

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -2456,6 +2456,10 @@ spec:
                 - "off"
                 - auto
                 type: string
+              timezone:
+                description: Timezone specifies the IANA timezone (e.g., "America/New_York")
+                  to set on target VMs. Overrides the auto-detected guest timezone.
+                type: string
               transferNetwork:
                 description: The network attachment definition that should be used
                   for disk transfer.

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -353,6 +353,13 @@ type PlanSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=on;off;auto
 	TargetPowerState plan.TargetPowerState `json:"targetPowerState,omitempty"`
+	// Timezone specifies the IANA timezone (e.g., "America/New_York", "Europe/Rome") to set
+	// on the target VM's clock. When set, this overrides any timezone detected from the source
+	// provider. When empty, the timezone is determined by the source provider's inventory data
+	// (vSphere uses the ESXi host timezone, oVirt uses the VM timezone, others leave it unset).
+	// Uses standard tz database names: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+	// +optional
+	Timezone string `json:"timezone,omitempty"`
 	// RunPreflightInspection controls whether an inspection step on VM base disks is performed before starting the first disk transfer. Applies only to warm migrations from VMWare.
 	// - true (default): Inspection step runs before transferring any disks and may fail if it detects the migration would fail.
 	// - false: No inspection is performed before disk transfer.

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -729,7 +729,7 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 		r.mapCPU(vmRef, vm, object)
 		r.mapMemory(vm, object)
 	}
-	r.mapClock(host, object)
+	r.mapClock(vm, host, object)
 	r.mapInput(object)
 	r.mapTpm(vm, object)
 	err = r.mapNetworks(vm, object)
@@ -889,12 +889,16 @@ func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {
 	object.Template.Spec.Domain.Devices.Inputs = []cnv.Input{tablet}
 }
 
-func (r *Builder) mapClock(host *model.Host, object *cnv.VirtualMachineSpec) {
-	if host.Timezone != "" {
+func (r *Builder) mapClock(vm *model.VM, host *model.Host, object *cnv.VirtualMachineSpec) {
+	timezone := vm.Timezone
+	if timezone == "" {
+		timezone = host.Timezone
+	}
+	if timezone != "" {
 		if object.Template.Spec.Domain.Clock == nil {
 			object.Template.Spec.Domain.Clock = &cnv.Clock{}
 		}
-		tz := cnv.ClockOffsetTimezone(host.Timezone)
+		tz := cnv.ClockOffsetTimezone(timezone)
 		object.Template.Spec.Domain.Clock.ClockOffset.Timezone = &tz
 	}
 }

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -3048,6 +3048,14 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus, sortVolumesByLibvirt bool) 
 		return
 	}
 
+	if r.Plan.Spec.Timezone != "" {
+		if object.Spec.Template.Spec.Domain.Clock == nil {
+			object.Spec.Template.Spec.Domain.Clock = &cnv.Clock{}
+		}
+		tz := cnv.ClockOffsetTimezone(r.Plan.Spec.Timezone)
+		object.Spec.Template.Spec.Domain.Clock.ClockOffset.Timezone = &tz
+	}
+
 	return
 }
 

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
+	_ "time/tzdata"
 
 	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -118,6 +120,7 @@ const (
 	// datastore lacks NAS export details in inventory (required for MTV annotations).
 	NetAppShiftDatastoreNASMissing = "NetAppShiftDatastoreNASMissing"
 	ConversionResumable            = "ConversionResumable"
+	TimezoneNotValid               = "TimezoneNotValid"
 )
 
 // Categories
@@ -187,6 +190,8 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 	if err = r.validateTargetNamespace(plan); err != nil {
 		return err
 	}
+
+	r.validateTimezone(plan)
 
 	if err = r.validateNetworkMap(plan); err != nil {
 		return err
@@ -506,6 +511,33 @@ func (r *Reconciler) validateTargetNamespace(plan *api.Plan) (err error) {
 		plan.Status.SetCondition(newCnd)
 	}
 	return
+}
+
+func (r *Reconciler) validateTimezone(plan *api.Plan) {
+	if plan.Spec.Timezone == "" {
+		return
+	}
+	// "Local" is accepted by time.LoadLocation but is not a valid IANA timezone name.
+	if plan.Spec.Timezone == "Local" {
+		plan.Status.SetCondition(libcnd.Condition{
+			Type:     TimezoneNotValid,
+			Status:   True,
+			Category: Critical,
+			Reason:   NotValid,
+			Message:  fmt.Sprintf("Timezone %q is not a valid IANA timezone name.", plan.Spec.Timezone),
+		})
+		return
+	}
+	_, err := time.LoadLocation(plan.Spec.Timezone)
+	if err != nil {
+		plan.Status.SetCondition(libcnd.Condition{
+			Type:     TimezoneNotValid,
+			Status:   True,
+			Category: Critical,
+			Reason:   NotValid,
+			Message:  fmt.Sprintf("Timezone %q is not a valid IANA timezone name.", plan.Spec.Timezone),
+		})
+	}
 }
 
 // Validate unsupported User Defined Network configurations in the destination namespace.

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -735,6 +735,57 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 	})
 })
 
+var _ = ginkgo.Describe("validateTimezone", func() {
+	var reconciler *Reconciler
+
+	ginkgo.BeforeEach(func() {
+		reconciler = &Reconciler{
+			base.Reconciler{},
+			nil,
+		}
+	})
+
+	ginkgo.It("should not set condition when timezone is empty", func() {
+		plan := &api.Plan{}
+		plan.Spec.Timezone = ""
+		reconciler.validateTimezone(plan)
+		gomega.Expect(plan.Status.HasCondition(TimezoneNotValid)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should not set condition for valid IANA timezone", func() {
+		plan := &api.Plan{}
+		plan.Spec.Timezone = "America/New_York"
+		reconciler.validateTimezone(plan)
+		gomega.Expect(plan.Status.HasCondition(TimezoneNotValid)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should not set condition for UTC", func() {
+		plan := &api.Plan{}
+		plan.Spec.Timezone = "UTC"
+		reconciler.validateTimezone(plan)
+		gomega.Expect(plan.Status.HasCondition(TimezoneNotValid)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should set condition for invalid timezone", func() {
+		plan := &api.Plan{}
+		plan.Spec.Timezone = "Foo/Bar"
+		reconciler.validateTimezone(plan)
+		gomega.Expect(plan.Status.HasCondition(TimezoneNotValid)).To(gomega.BeTrue())
+		cnd := plan.Status.FindCondition(TimezoneNotValid)
+		gomega.Expect(cnd.Category).To(gomega.Equal(Critical))
+		gomega.Expect(cnd.Message).To(gomega.ContainSubstring("Foo/Bar"))
+	})
+
+	ginkgo.It("should reject the special Local value", func() {
+		plan := &api.Plan{}
+		plan.Spec.Timezone = "Local"
+		reconciler.validateTimezone(plan)
+		gomega.Expect(plan.Status.HasCondition(TimezoneNotValid)).To(gomega.BeTrue())
+		cnd := plan.Status.FindCondition(TimezoneNotValid)
+		gomega.Expect(cnd.Message).To(gomega.ContainSubstring("Local"))
+	})
+})
+
 var _ = ginkgo.Describe("vmUsesVddk", func() {
 	var (
 		reconciler *Reconciler

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -157,6 +157,7 @@ const (
 	fGuestDisk                = "guest.disk"
 	fGuestIpStack             = "guest.ipStack"
 	fHostName                 = "guest.hostName"
+	fGuestTimezone            = "guest.timeZone"
 	// fToolsStatus is deprecated since vSphere API 4.0; use fToolsRunningStatus instead
 	fToolsStatus        = "guest.toolsStatus"
 	fToolsRunningStatus = "guest.toolsRunningStatus"
@@ -1098,6 +1099,7 @@ func (r *Collector) vmPathSet() []string {
 		fChangeTracking,
 		fGuestIpStack,
 		fHostName,
+		fGuestTimezone,
 		fToolsStatus,
 		fToolsRunningStatus,
 		fToolsVersionStatus,

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -892,6 +892,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				v.model.ToolsRunningStatus = fmt.Sprint(p.Val)
 			case fToolsVersionStatus:
 				v.model.ToolsVersionStatus = fmt.Sprint(p.Val)
+			case fGuestTimezone:
+				if s, cast := p.Val.(string); cast {
+					v.model.Timezone = s
+				}
 			case fTpmPresent:
 				if b, cast := p.Val.(bool); cast {
 					v.model.TpmEnabled = b

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -358,6 +358,7 @@ type VM struct {
 	ToolsStatus              string             `sql:""`
 	ToolsRunningStatus       string             `sql:""`
 	ToolsVersionStatus       string             `sql:""`
+	Timezone                 string             `sql:""`
 	DiskEnableUuid           bool               `sql:""`
 	NestedHVEnabled          bool               `sql:""`
 	CustomDef                []CustomFieldDef   `sql:""`

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -304,6 +304,7 @@ type VM struct {
 	// Note: vSphere reports version as "toolsVersionStatus2"; we keep the Go field
 	// name ToolsVersionStatus for continuity while serializing as toolsVersionStatus2.
 	ToolsVersionStatus string                   `json:"toolsVersionStatus2"`
+	Timezone           string                   `json:"timezone"`
 	DiskEnableUuid     bool                     `json:"diskEnableUuid"`
 	NestedHVEnabled    bool                     `json:"nestedHVEnabled"`
 	CustomDef          []model.CustomFieldDef   `json:"customDef"`
@@ -357,6 +358,7 @@ func (r *VM) With(m *model.VM) {
 	r.ToolsStatus = m.ToolsStatus
 	r.ToolsRunningStatus = m.ToolsRunningStatus
 	r.ToolsVersionStatus = m.ToolsVersionStatus
+	r.Timezone = m.Timezone
 	r.DiskEnableUuid = m.DiskEnableUuid
 	r.NestedHVEnabled = m.NestedHVEnabled
 	r.CustomDef = m.CustomDef


### PR DESCRIPTION
  ## Links
  - Jira: https://redhat.atlassian.net/browse/MTV-5866
  - VIRTSTRAT: https://redhat.atlassian.net/browse/VIRTSTRAT-667
  - Console plugin PR: https://github.com/kubev2v/forklift-console-plugin/pull/2643
  
  ## Description
  Adds a `timezone` field to the Plan CRD spec allowing users to specify an IANA timezone
  for target VMs. When set, the timezone overrides any source provider default and is applied
  to the KubeVirt VM clock before first boot — no VM restart required. 
  
  - **PlanSpec:** New `Timezone string` field with `json:"timezone,omitempty"`
  - **kubevirt.go:** Applies timezone override after provider-specific builder settings
  - **validation.go:** Validates timezone using `time.LoadLocation()` with embedded `time/tzdata`
    for minimal container support
    
  ## Testing
  - Tested on OpenShift lab: migrated VM from VMware to OpenShift Virtualization
  - Confirmed timezone persists on the target VM after migration
  - Validated that invalid timezone names produce a `TimezoneNotValid` condition
