### PR TITLE
MTV-2522 | Fix Windows network config scripts for variable DNS

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config-registry.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config-registry.ps1.tmpl
@@ -1,7 +1,7 @@
 # Configures static IP on Windows network interfaces via registry.
 # Registry writes don't depend on RPC or DHCP Client service.
 # Changes take effect after reboot.
-# Input format: MAC:ip:IP,Gateway,Prefix,DNS1,DNS2 (entries separated by '_')
+# Input format: MAC:ip:IP,Gateway,Prefix,DNS1[,DNS2,...,DNSn] (entries separated by '_')
 
 $inputString = "{{.InputString}}"
 $adapterWaitMinutes = 5
@@ -55,13 +55,23 @@ $adapterConfigs = @{}
 Write-Host "[INFO] Parsing $totalEntries entries..."
 
 foreach ($entry in $entries) {
-    if ($entry -match "^([0-9A-Fa-f:\-]+):ip:([^,]+),([^,]+),([^,]+),([^,]+),([^,]*)$") {
+    if ($entry -match "^([0-9A-Fa-f:\-]+):ip:(.+)$") {
         $mac = $matches[1].ToUpper().Replace(":", "-")
-        $ip = $matches[2]
-        $gw = $matches[3]
-        $prefix = [int]$matches[4]
-        $dns1 = $matches[5]
-        $dns2 = $matches[6]
+        $fields = $matches[2].Split(",")
+
+        if ($fields.Count -lt 4) {
+            Write-Warning "[ERROR] Not enough fields (need at least IP,GW,Prefix,DNS1): '$entry'"
+            continue
+        }
+
+        $ip = $fields[0]
+        $gw = $fields[1]
+        $prefix = [int]$fields[2]
+        $dnsServers = @($fields[3..($fields.Count - 1)] | Where-Object { $_ -ne "" })
+        if ($dnsServers.Count -eq 0) {
+            Write-Warning "[ERROR] No DNS servers provided for entry: '$entry'"
+            continue
+        }
         $mask = Convert-PrefixToMask $prefix
 
         if (-not $adapterConfigs.ContainsKey($mac)) {
@@ -69,8 +79,7 @@ foreach ($entry in $entries) {
                 IPs = @()
                 Masks = @()
                 Gateway = $gw
-                DNS1 = $dns1
-                DNS2 = $dns2
+                DNSServers = $dnsServers
             }
         }
 
@@ -78,7 +87,7 @@ foreach ($entry in $entries) {
         $adapterConfigs[$mac].Masks += $mask
     } else {
         Write-Warning "[ERROR] Invalid input format: '$entry'"
-        Write-Warning "[ERROR] Expected: MAC:ip:IP,Gateway,Prefix,DNS1,DNS2"
+        Write-Warning "[ERROR] Expected: MAC:ip:IP,Gateway,Prefix,DNS1[,DNS2,...,DNSn]"
     }
 }
 
@@ -91,7 +100,7 @@ foreach ($mac in $adapterConfigs.Keys) {
     Write-Host "--- Adapter MAC=$mac ---"
     Write-Host "[INFO] IPs: $($config.IPs -join ', ')"
     Write-Host "[INFO] Masks: $($config.Masks -join ', ')"
-    Write-Host "[INFO] GW=$($config.Gateway) DNS=$($config.DNS1),$($config.DNS2)"
+    Write-Host "[INFO] GW=$($config.Gateway) DNS=$($config.DNSServers -join ',')"
 
     $adapter = Find-AdapterByMAC $mac
     if ($adapter -eq $null) {
@@ -117,11 +126,10 @@ foreach ($mac in $adapterConfigs.Keys) {
         Set-ItemProperty -Path $regPath -Name "DefaultGateway" -Value @($config.Gateway) -Type MultiString
         Set-ItemProperty -Path $regPath -Name "DefaultGatewayMetric" -Value @("0") -Type MultiString
 
-        $dnsServers = $config.DNS1
-        if ($config.DNS2 -ne "") { $dnsServers = "$($config.DNS1),$($config.DNS2)" }
-        Set-ItemProperty -Path $regPath -Name "NameServer" -Value $dnsServers -Type String
+        $dnsString = $config.DNSServers -join ","
+        Set-ItemProperty -Path $regPath -Name "NameServer" -Value $dnsString -Type String
 
-        Write-Host "[OK] Registry updated: IPs=($($config.IPs -join ', ')) GW=$($config.Gateway) DNS=$dnsServers"
+        Write-Host "[OK] Registry updated: IPs=($($config.IPs -join ', ')) GW=$($config.Gateway) DNS=$dnsString"
         $successCount++
     } catch {
         Write-Error "[FAIL] Registry write failed for MAC=$mac at ${regPath}: $_"

--- a/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-network-config.ps1.tmpl
@@ -1,11 +1,12 @@
 #This script configures static IP settings on legacy Windows network interfaces
 #based on input that maps MAC addresses to IP configuration details.
 #Input string will be added to the script while creating the virt-v2v pod
-#Input string format: MAC:ip:IP,Gateway,Prefix,DNS1,DNS2
+#Input string format: MAC:ip:IP,Gateway,Prefix,DNS1[,DNS2,...,DNSn]
 
 # Input string
 $inputString = "{{.InputString}}"
-
+$adapterWaitSeconds = 60
+$adapterPollInterval = 5
 
 # Lookup table avoids [Convert]::ToInt32() which is blocked in Constrained Language Mode
 $PrefixToMaskTable = @(
@@ -24,57 +25,104 @@ function Convert-PrefixToMask($prefix) {
     return $PrefixToMaskTable[[int]$prefix]
 }
 
-# Split entries by '_'
-$entries = $inputString.Split("_")
+function Find-AdapterByMAC($mac) {
+    $startTime = Get-Date
+    $deadline = $startTime.AddSeconds($adapterWaitSeconds)
+    Write-Host "Waiting for adapter with MAC $mac...`n"
 
-# Extract parts
-foreach ($entry in $entries) {
-    if ($entry -match "^([0-9A-Fa-f:\-]+):ip:([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)$") {
-        $mac = $matches[1]
-        $mac = $mac.ToUpper()
-        $mac = $mac.Replace(":", "-")
-        $ip = $matches[2]
-        $gw = $matches[3]
-        $prefix = [int]$matches[4]
-        $dns1 = $matches[5]
-        $dns2 = $matches[6]
-        $mask = Convert-PrefixToMask $prefix
-
-        Write-Host "Searching for MAC: $mac`n"
-
+    while ((Get-Date) -lt $deadline) {
         $adapters = Get-WmiObject Win32_NetworkAdapter
-        $adapter = $null
-
         foreach ($a in $adapters) {
             if ($a.MACAddress -and $a.NetConnectionID) {
                 $aMac = $a.MACAddress.ToUpper().Replace(":", "-")
                 if ($aMac -eq $mac) {
-                    $adapter = $a
-                    break
+                    $elapsed = [int]((Get-Date) - $startTime).TotalSeconds
+                    Write-Host "Found adapter '$($a.NetConnectionID)' after ${elapsed}s`n"
+                    return $a
                 }
             }
         }
+        Start-Sleep -Seconds $adapterPollInterval
+    }
+    return $null
+}
+
+# Split entries by '_'
+$entries = $inputString.Split("_")
+$failCount = 0
+
+# Extract parts: MAC:ip:IP,Gateway,Prefix,DNS1[,DNS2,...,DNSn]
+foreach ($entry in $entries) {
+    if ($entry -match "^([0-9A-Fa-f:\-]+):ip:(.+)$") {
+        $mac = $matches[1].ToUpper().Replace(":", "-")
+        $fields = $matches[2].Split(",")
+
+        if ($fields.Count -lt 4) {
+            Write-Warning "Not enough fields for entry (need at least IP,GW,Prefix,DNS1): '$entry'`n"
+            $failCount++
+            continue
+        }
+
+        $ip = $fields[0]
+        $gw = $fields[1]
+        $prefix = [int]$fields[2]
+        $dnsServers = @($fields[3..($fields.Count - 1)] | Where-Object { $_ -ne "" })
+        if ($dnsServers.Count -eq 0) {
+            Write-Warning "No DNS servers provided for entry: '$entry'`n"
+            $failCount++
+            continue
+        }
+        $mask = Convert-PrefixToMask $prefix
+
+        $adapter = Find-AdapterByMAC $mac
 
         if ($adapter -eq $null) {
-            Write-Warning "Adapter with MAC $mac not found!`n"
-            exit 1
+            Write-Warning "Adapter with MAC $mac not found after waiting ${adapterWaitSeconds}s`n"
+            $failCount++
+            continue
         }
 
         $iface = $adapter.NetConnectionID
         Write-Host "Using interface: $iface`n"
 
-       # Use cmd /c instead of COM objects (blocked in Constrained Language Mode)
-       cmd /c "netsh interface ip set address name=`"$iface`" static $ip $mask $gw" 2>&1 | Out-Null
+        # Use cmd /c instead of COM objects (blocked in Constrained Language Mode)
+        $cmdFailed = $false
 
-       cmd /c "netsh interface ip set dns name=`"$iface`" static $dns1" 2>&1 | Out-Null
-        
-        if ($dns2 -ne "") {
-            cmd /c "netsh interface ip add dns name=`"$iface`" $dns2 index=2" 2>&1 | Out-Null
-        } 
-        
-        Write-Host "IP configuration applied`n"
+        cmd /c "netsh interface ip set address name=`"$iface`" static $ip $mask $gw" 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to set IP address on $iface (exit code $LASTEXITCODE)`n"
+            $cmdFailed = $true
+        }
+
+        # Set first DNS as primary, add remaining as alternates
+        cmd /c "netsh interface ip set dns name=`"$iface`" static $($dnsServers[0])" 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to set primary DNS on $iface (exit code $LASTEXITCODE)`n"
+            $cmdFailed = $true
+        }
+        for ($i = 1; $i -lt $dnsServers.Count; $i++) {
+            $idx = $i + 1
+            cmd /c "netsh interface ip add dns name=`"$iface`" $($dnsServers[$i]) index=$idx" 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "Failed to add DNS $($dnsServers[$i]) on $iface (exit code $LASTEXITCODE)`n"
+                $cmdFailed = $true
+            }
+        }
+
+        if ($cmdFailed) {
+            Write-Warning "One or more netsh commands failed for $iface`n"
+            $failCount++
+        } else {
+            Write-Host "IP configuration applied (DNS servers: $($dnsServers.Count))`n"
+        }
     }
     else {
-        Write-Warning "Input string format is invalid`n"
+        Write-Warning "Input string format is invalid: '$entry'`n"
+        $failCount++
     }
+}
+
+if ($failCount -gt 0) {
+    Write-Warning "$failCount adapter(s) failed to configure`n"
+    exit 1
 }


### PR DESCRIPTION
Both PowerShell firstboot scripts (legacy netsh and registry) used a regex hardcoded for exactly 2 DNS servers. VMs with 3+ DNS entries caused the pattern to fail, silently skipping network configuration.

Replace the rigid regex with field splitting to accept any number of DNS servers. Additionally in the legacy script: replace the immediate exit 1 on missing adapters with continue so remaining adapters still get configured.
Ref: https://redhat.atlassian.net/browse/MTV-2522
Resolves: MTV-2522