### PR TITLE
MTV-6335 | Fix extra-v2v-conf and vddk-conf not mounted in Conversion CR pods

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -3535,7 +3535,7 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 
 	extraConfigMapExists := len(Settings.Migration.VirtV2vExtraConfConfigMap) > 0
 	if extraConfigMapExists {
-		volumes = append(volumes, core.Volume{
+		extraV2vConfVol := core.Volume{
 			Name: ExtraV2vConf,
 			VolumeSource: core.VolumeSource{
 				ConfigMap: &core.ConfigMapVolumeSource{
@@ -3544,21 +3544,16 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 					},
 				},
 			},
-		})
+		}
+		extraV2vConfMount := core.VolumeMount{
+			Name:      ExtraV2vConf,
+			MountPath: fmt.Sprintf("/mnt/%s", ExtraV2vConf),
+		}
+		volumes = append(volumes, extraV2vConfVol)
+		mounts = append(mounts, extraV2vConfMount)
+		extraVolumes = append(extraVolumes, extraV2vConfVol)
+		extraMounts = append(extraMounts, extraV2vConfMount)
 	}
-	if vddkConfigmap != nil {
-		volumes = append(volumes, core.Volume{
-			Name: VddkConf,
-			VolumeSource: core.VolumeSource{
-				ConfigMap: &core.ConfigMapVolumeSource{
-					LocalObjectReference: core.LocalObjectReference{
-						Name: vddkConfigmap.Name,
-					},
-				},
-			},
-		})
-	}
-
 	switch r.Source.Provider.Type() {
 	case api.Ova, api.HyperV:
 		var pvc *core.PersistentVolumeClaim
@@ -3616,21 +3611,25 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 				MountPath: "/opt",
 			},
 		)
-		if extraConfigMapExists {
-			mounts = append(mounts,
-				core.VolumeMount{
-					Name:      ExtraV2vConf,
-					MountPath: fmt.Sprintf("/mnt/%s", ExtraV2vConf),
-				},
-			)
-		}
 		if vddkConfigmap != nil {
-			mounts = append(mounts,
-				core.VolumeMount{
-					Name:      VddkConf,
-					MountPath: fmt.Sprintf("/mnt/%s", VddkConf),
+			vddkConfVol := core.Volume{
+				Name: VddkConf,
+				VolumeSource: core.VolumeSource{
+					ConfigMap: &core.ConfigMapVolumeSource{
+						LocalObjectReference: core.LocalObjectReference{
+							Name: vddkConfigmap.Name,
+						},
+					},
 				},
-			)
+			}
+			vddkConfMount := core.VolumeMount{
+				Name:      VddkConf,
+				MountPath: fmt.Sprintf("/mnt/%s", VddkConf),
+			}
+			volumes = append(volumes, vddkConfVol)
+			mounts = append(mounts, vddkConfMount)
+			extraVolumes = append(extraVolumes, vddkConfVol)
+			extraMounts = append(extraMounts, vddkConfMount)
 		}
 	}
 


### PR DESCRIPTION
 The extra-v2v-conf and vddk-conf ConfigMap volumes were added to volumes/mounts but not to extraVolumes/extraMounts in podVolumeMounts. When UseConversionCR is enabled (default), EnsureConversion filters
 non-PVC volumes while populating the the Conversion CR. Since these ConfigMap volumes were missing from extraVolumes, they were silently dropped from the final pod spec, causing:
    

- extra-v2v-conf: "No such file or directory" when referenced via  VIRT_V2V_EXTRA_ARGS (-io vddk-config=/mnt/extra-v2v-conf/...)
-  vddk-conf: VDDK AIO optimization silently not applied even when useVddkAioOptimization is enabled on the provider
    
Resolves: https://redhat.atlassian.net/browse/MTV-6335