### PR TITLE
fix(hyperv): query VM power state on owner node in cluster mode

### DIFF
--- a/pkg/controller/plan/adapter/hyperv/client.go
+++ b/pkg/controller/plan/adapter/hyperv/client.go
@@ -3,6 +3,7 @@ package hyperv
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
@@ -68,13 +69,71 @@ func (r *Client) PowerState(vmRef ref.Ref) (planapi.VMPowerState, error) {
 		return planapi.VMPowerStateUnknown, err
 	}
 
-	switch vm.PowerState {
-	case model.PowerStateOn:
+	drv, err := r.connect()
+	if err != nil {
+		log.Info("WinRM connect failed, falling back to inventory cache", "vm", vm.Name, "error", err)
+		return r.powerStateFromInventory(vm), nil
+	}
+
+	// In cluster mode the VM may reside on a different node than the
+	// provider entry-point. Route the Get-VM query to the owner node.
+	if r.Source.Provider.IsHyperVCluster() && vm.Host != "" {
+		cmd := ps.BuildCommand(ps.GetVMState, vm.Name)
+		out, err := drv.RunOnNode(cmd, vm.Host)
+		if err != nil {
+			log.Info("RunOnNode Get-VM failed, falling back to inventory cache",
+				"vm", vm.Name, "node", vm.Host, "error", err)
+			return r.powerStateFromInventory(vm), nil
+		}
+		return r.parseStateString(out), nil
+	}
+
+	domain, err := drv.LookupDomainByName(vm.Name)
+	if err != nil {
+		log.Info("VM not found via WinRM, falling back to inventory cache", "vm", vm.Name, "error", err)
+		return r.powerStateFromInventory(vm), nil
+	}
+	defer func() { _ = domain.Free() }()
+
+	state, _, err := domain.GetState()
+	if err != nil {
+		log.Info("Failed to get VM state via WinRM, falling back to inventory cache", "vm", vm.Name, "error", err)
+		return r.powerStateFromInventory(vm), nil
+	}
+
+	switch state {
+	case driver.DOMAIN_RUNNING:
 		return planapi.VMPowerStateOn, nil
-	case model.PowerStateOff:
+	case driver.DOMAIN_SHUTOFF:
 		return planapi.VMPowerStateOff, nil
 	default:
 		return planapi.VMPowerStateUnknown, nil
+	}
+}
+
+// parseStateString maps the textual output of PowerShell's VM State property
+// (e.g. "Off", "Running") to the plan VMPowerState enum.
+func (r *Client) parseStateString(raw string) planapi.VMPowerState {
+	s := strings.TrimSpace(strings.ToLower(raw))
+	switch {
+	case strings.Contains(s, "off"):
+		return planapi.VMPowerStateOff
+	case strings.Contains(s, "running"):
+		return planapi.VMPowerStateOn
+	default:
+		log.Info("Unrecognised VM state string from WinRM", "raw", raw)
+		return planapi.VMPowerStateUnknown
+	}
+}
+
+func (r *Client) powerStateFromInventory(vm *hyperv.VM) planapi.VMPowerState {
+	switch vm.PowerState {
+	case model.PowerStateOn:
+		return planapi.VMPowerStateOn
+	case model.PowerStateOff:
+		return planapi.VMPowerStateOff
+	default:
+		return planapi.VMPowerStateUnknown
 	}
 }
 

--- a/pkg/controller/plan/adapter/hyperv/client_test.go
+++ b/pkg/controller/plan/adapter/hyperv/client_test.go
@@ -1,0 +1,58 @@
+package hyperv
+
+import (
+	"testing"
+
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
+)
+
+func TestParseStateString(t *testing.T) {
+	c := &Client{}
+	tests := []struct {
+		name     string
+		raw      string
+		expected planapi.VMPowerState
+	}{
+		{"off lowercase", "Off", planapi.VMPowerStateOff},
+		{"off with whitespace", "  Off\r\n", planapi.VMPowerStateOff},
+		{"running", "Running", planapi.VMPowerStateOn},
+		{"running with whitespace", "\n Running \n", planapi.VMPowerStateOn},
+		{"unknown state", "Paused", planapi.VMPowerStateUnknown},
+		{"empty string", "", planapi.VMPowerStateUnknown},
+		{"shutoff variant", "TurnedOff", planapi.VMPowerStateOff},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := c.parseStateString(tc.raw)
+			if got != tc.expected {
+				t.Errorf("parseStateString(%q) = %q, want %q", tc.raw, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestPowerStateFromInventory(t *testing.T) {
+	c := &Client{}
+	tests := []struct {
+		name     string
+		state    string
+		expected planapi.VMPowerState
+	}{
+		{"on", model.PowerStateOn, planapi.VMPowerStateOn},
+		{"off", model.PowerStateOff, planapi.VMPowerStateOff},
+		{"paused", model.PowerStatePaused, planapi.VMPowerStateUnknown},
+		{"empty", "", planapi.VMPowerStateUnknown},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vm := &hyperv.VM{PowerState: tc.state}
+			got := c.powerStateFromInventory(vm)
+			if got != tc.expected {
+				t.Errorf("powerStateFromInventory(state=%q) = %q, want %q",
+					tc.state, got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/lib/hyperv/powershell/scripts.go
+++ b/pkg/lib/hyperv/powershell/scripts.go
@@ -56,6 +56,10 @@ const (
 	// Parameters: vmId
 	GetVMByID = `Get-VM -Id '%s' | Select-Object Id, Name, State, ProcessorCount, MemoryStartup, Generation | ConvertTo-Json`
 
+	// GetVMState returns the power state of a VM as a string (e.g. "Running", "Off").
+	// Parameters: vmName
+	GetVMState = `Get-VM -Name '%s' | Select-Object -ExpandProperty State`
+
 	// StopVM forcefully stops a VM
 	// Parameters: vmName
 	StopVM = `Stop-VM -Name '%s' -Force -Confirm:$false`


### PR DESCRIPTION
PowerState() was always querying the provider entry-point host via LookupDomainByName, which fails in cluster mode when the VM resides on a different node. This caused Get-VM to return "VM not found", falling back to the stale inventory cache and leaving migrations stuck at WaitForPowerOff indefinitely.

Route the Get-VM query to vm.Host via RunOnNode when IsHyperVCluster() is true, mirroring what PowerOff() already does. Single-host mode is untouched — the original LookupDomainByName path remains the default.

Resolves: none