### PR TITLE
MTV-6322 | Fix StorageMap entry order affecting CSI/xcopy resolution

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -472,13 +472,37 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 	return
 }
 
-// buildDatastoreMap builds a map of storage mappings keyed by source datastore ID
-func (r *Builder) buildDatastoreMap() (map[string]*api.StoragePair, error) {
+type copyMethod string
+
+const (
+	copyMethodVDDK  copyMethod = "vddk"
+	copyMethodXcopy copyMethod = "xcopy"
+	copyMethodCsi   copyMethod = "csi"
+)
+
+// Shift destinations classify as vddk since Shift is identified by the destination StorageClass, not an offload plugin.
+func storagePairCopyMethod(pair *api.StoragePair) copyMethod {
+	if pair.OffloadPlugin != nil {
+		if pair.OffloadPlugin.VSphereXcopyPluginConfig != nil {
+			return copyMethodXcopy
+		}
+		if pair.OffloadPlugin.CsiVolumeImport != nil {
+			return copyMethodCsi
+		}
+	}
+	return copyMethodVDDK
+}
+
+// buildDatastoreMap builds a map of storage mappings keyed by source datastore ID, restricted to entries matching method.
+func (r *Builder) buildDatastoreMap(method copyMethod) (map[string]*api.StoragePair, error) {
 	dsMap := make(map[string]*api.StoragePair)
 	dsMapIn := r.Context.Map.Storage.Spec.Map
 
 	for i := range dsMapIn {
 		mapped := &dsMapIn[i]
+		if storagePairCopyMethod(mapped) != method {
+			continue
+		}
 		ref := mapped.Source
 		ds := &model.Datastore{}
 		err := r.Source.Inventory.Find(ds, ref)
@@ -550,7 +574,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 	canUseInstanceUUID := r.canUseInstanceUUID()
 
 	// Build datastore map for more efficient lookups
-	dsMap, err := r.buildDatastoreMap()
+	dsMap, err := r.buildDatastoreMap(copyMethodVDDK)
 	if err != nil {
 		return
 	}
@@ -1411,47 +1435,14 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 	sortedDisks := vm.SortedDisksAsVmware()
 
 	dsMapIn := r.Context.Map.Storage.Spec.Map
+	xcopyDsMap, dsErr := r.buildDatastoreMap(copyMethodXcopy)
+	if dsErr != nil {
+		return nil, dsErr
+	}
 	naaPrefixes := loadNAAPrefixes(r.Client)
 	dsNaaMap := make(map[string]string)
 
-	// Pre-pass: resolve RDM disks by NAA vendor prefix.
-	// Builds a map from disk index to the storage map entry whose offload
-	// plugin matches the RDM's vendor. Disks that fail NAA resolution are
-	// left out and will fall back to datastore-based matching in the main loop.
-	rdmMapped := make(map[int]*api.StoragePair)
-	for diskIndex, disk := range sortedDisks {
-		if !disk.RDM || disk.DeviceName == "" {
-			continue
-		}
-		rdmVendor, matched := vendorFromNAA(disk.DeviceName, naaPrefixes)
-		if !matched {
-			r.Log.Info("RDM disk NAA prefix not recognized, falling back to datastore matching",
-				"diskKey", disk.Key, "deviceName", disk.DeviceName)
-			continue
-		}
-		candidates := findStorageMapEntriesForVendor(dsMapIn, rdmVendor)
-		switch len(candidates) {
-		case 0:
-			r.Log.Info("No storage map entry found for RDM vendor, falling back to datastore matching",
-				"diskKey", disk.Key, "vendor", rdmVendor)
-		case 1:
-			rdmMapped[diskIndex] = candidates[0]
-			r.Log.Info("RDM disk resolved to storage vendor by NAA",
-				"diskKey", disk.Key, "deviceName", disk.DeviceName,
-				"vendor", rdmVendor, "storageClass", candidates[0].Destination.StorageClass)
-		default:
-			entry, disambigErr := disambiguateRDMByNAA(r.Source.Inventory, candidates, disk.DeviceName, naaPrefixes)
-			if disambigErr != nil {
-				r.Log.Info("RDM NAA disambiguation failed, falling back to datastore matching",
-					"diskKey", disk.Key, "vendor", rdmVendor, "error", disambigErr)
-			} else {
-				rdmMapped[diskIndex] = entry
-				r.Log.Info("RDM disk resolved to storage vendor by NAA",
-					"diskKey", disk.Key, "deviceName", disk.DeviceName,
-					"vendor", rdmVendor, "storageClass", entry.Destination.StorageClass)
-			}
-		}
-	}
+	resolved := resolvePassthroughDisksByVendor(sortedDisks, dsMapIn, r.Source.Inventory, naaPrefixes, offloadKindXcopy, r.Log)
 
 	for i := range dsMapIn {
 		mapped := &dsMapIn[i]
@@ -1466,14 +1457,17 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 		pvblock := core.PersistentVolumeBlock
 		for diskIndex, disk := range sortedDisks {
 			var effectiveMapped *api.StoragePair
-			if disk.RDM && disk.DeviceName != "" {
-				if entry, ok := rdmMapped[diskIndex]; ok {
+			if passthroughIdentifier(disk) != "" {
+				if entry, ok := resolved[diskIndex]; ok {
 					if mapped != entry {
 						continue
 					}
 					effectiveMapped = entry
-				} else if disk.Datastore.ID == ds.ID {
-					effectiveMapped = mapped
+				} else if entry, ok := xcopyDsMap[disk.Datastore.ID]; ok { // datastore fallback is xcopy-only; csi entries are never guessed at here
+					if mapped != entry {
+						continue
+					}
+					effectiveMapped = entry
 					r.Log.Info("RDM disk matched by datastore fallback",
 						"diskKey", disk.Key, "deviceName", disk.DeviceName,
 						"datastoreID", ds.ID)
@@ -1497,12 +1491,10 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 			}
 
 			{
-				// For RDM disks, look up the NAA from the resolved storage map entry's
-				// source datastore (not the outer-loop ds) since the RDM may be on a
-				// different array. Use the storage map ref directly as a synthetic
-				// Datastore to ensure the correct cache key and vSphere query.
+				// Use the resolved entry's source datastore (not the outer-loop ds) because
+				// the disk's LUN may be on a different array.
 				naaDS := ds
-				if disk.RDM && disk.DeviceName != "" {
+				if passthroughIdentifier(disk) != "" {
 					naaDS = &model.Datastore{}
 					naaDS.ID = effectiveMapped.Source.ID
 					naaDS.Name = effectiveMapped.Source.Name
@@ -2613,18 +2605,27 @@ func (r *Builder) CsiImportPVCs(vmRef ref.Ref, pvcLabels map[string]string) (pvc
 		vm.RemoveSharedDisks()
 	}
 
-	dsMap, err := r.buildDatastoreMap()
+	csiDsMap, err := r.buildDatastoreMap(copyMethodCsi)
 	if err != nil {
 		return
 	}
+	if len(csiDsMap) == 0 {
+		return nil, nil
+	}
 
 	disks := vm.SortedDisksAsVmware()
+	dsMapIn := r.Map.Storage.Spec.Map
+	naaPrefixes := loadNAAPrefixes(r.Client)
+	resolved := resolvePassthroughDisksByVendor(disks, dsMapIn, r.Source.Inventory, naaPrefixes, offloadKindCsi, r.Log)
+	maps.Copy(resolved, resolveVVolDisksByDatastore(disks, csiDsMap))
+
 	for diskIndex, disk := range disks {
-		mapped, found := dsMap[disk.Datastore.ID]
+		mapped, found := resolved[diskIndex]
 		if !found {
-			continue
-		}
-		if mapped.OffloadPlugin == nil || mapped.OffloadPlugin.CsiVolumeImport == nil {
+			if passthroughIdentifier(disk) != "" {
+				r.Log.Info("RDM disk has no recognized vendor for CSI import; deferring to xcopy/populator handling",
+					"diskKey", disk.Key, "deviceName", disk.DeviceName, "datastoreID", disk.Datastore.ID)
+			}
 			continue
 		}
 
@@ -2659,7 +2660,7 @@ func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) (pvcs
 		vm.RemoveSharedDisks()
 	}
 
-	dsMap, err := r.buildDatastoreMap()
+	dsMap, err := r.buildDatastoreMap(copyMethodVDDK)
 	if err != nil {
 		return
 	}

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -1589,6 +1589,102 @@ var _ = DescribeTable("instance UUID check", func(cdiVersion string, expected bo
 	Entry("should not use instance UUIDs on 4.18.5", "4.18.5", false),
 )
 
+var _ = Describe("buildDatastoreMap", func() {
+	It("does not error when two entries of the same copy method map to the same datastore", func() {
+		builder := createBuilder()
+		builder.Source.Inventory = &mockInventory{ds: model.Datastore{Resource: model.Resource{ID: "ds-1"}}}
+		builder.Map.Storage = &v1beta1.StorageMap{
+			Spec: v1beta1.StorageMapSpec{
+				Map: []v1beta1.StoragePair{
+					{
+						Source:      ref.Ref{ID: "ds-1"},
+						Destination: v1beta1.DestinationStorage{StorageClass: "sc-a"},
+						OffloadPlugin: &v1beta1.OffloadPlugin{
+							VSphereXcopyPluginConfig: &v1beta1.VSphereXcopyPluginConfig{StorageVendorProduct: "vendor-a", SecretRef: "secret-a"},
+						},
+					},
+					{
+						Source:      ref.Ref{ID: "ds-1"},
+						Destination: v1beta1.DestinationStorage{StorageClass: "sc-b"},
+						OffloadPlugin: &v1beta1.OffloadPlugin{
+							VSphereXcopyPluginConfig: &v1beta1.VSphereXcopyPluginConfig{StorageVendorProduct: "vendor-b", SecretRef: "secret-b"},
+						},
+					},
+				},
+			},
+		}
+
+		xcopyMap, err := builder.buildDatastoreMap(copyMethodXcopy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(xcopyMap).To(HaveLen(1))
+	})
+
+	It("does not error when different copy methods map to the same datastore", func() {
+		builder := createBuilder()
+		builder.Source.Inventory = &mockInventory{ds: model.Datastore{Resource: model.Resource{ID: "ds-1"}}}
+		builder.Map.Storage = &v1beta1.StorageMap{
+			Spec: v1beta1.StorageMapSpec{
+				Map: []v1beta1.StoragePair{
+					{
+						Source:      ref.Ref{ID: "ds-1"},
+						Destination: v1beta1.DestinationStorage{StorageClass: "sc-xcopy"},
+						OffloadPlugin: &v1beta1.OffloadPlugin{
+							VSphereXcopyPluginConfig: &v1beta1.VSphereXcopyPluginConfig{StorageVendorProduct: "vendor-a", SecretRef: "secret-a"},
+						},
+					},
+					{
+						Source:      ref.Ref{ID: "ds-1"},
+						Destination: v1beta1.DestinationStorage{StorageClass: "sc-csi"},
+						OffloadPlugin: &v1beta1.OffloadPlugin{
+							CsiVolumeImport: &v1beta1.CsiVolumeImport{StorageVendorProduct: "vendor-a", SecretRef: "secret-a"},
+						},
+					},
+				},
+			},
+		}
+
+		xcopyMap, err := builder.buildDatastoreMap(copyMethodXcopy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(xcopyMap).To(HaveLen(1))
+
+		csiMap, err := builder.buildDatastoreMap(copyMethodCsi)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(csiMap).To(HaveLen(1))
+	})
+})
+
+var _ = Describe("CsiImportPVCs", func() {
+	It("defers an RDM disk with an unrecognized vendor instead of guessing via datastore matching", func() {
+		builder := createBuilder()
+		vm := model.VM{
+			VM1: model.VM1{
+				VM0: model.VM0{ID: "vm-1", Name: "vm"},
+				Disks: []vsphere.Disk{
+					{Key: 4000, RDM: true, DeviceName: "naa.6999999999999999", Datastore: vsphere.Ref{ID: "ds-1"}},
+				},
+			},
+		}
+		builder.Source.Inventory = &mockInventory{ds: model.Datastore{Resource: model.Resource{ID: "ds-1"}}, vm: vm}
+		builder.Map.Storage = &v1beta1.StorageMap{
+			Spec: v1beta1.StorageMapSpec{
+				Map: []v1beta1.StoragePair{
+					{
+						Source:      ref.Ref{ID: "ds-1"},
+						Destination: v1beta1.DestinationStorage{StorageClass: "ontap-sc"},
+						OffloadPlugin: &v1beta1.OffloadPlugin{
+							CsiVolumeImport: &v1beta1.CsiVolumeImport{StorageVendorProduct: v1beta1.StorageVendorProductOntap, SecretRef: "ontap-secret"},
+						},
+					},
+				},
+			},
+		}
+
+		pvcs, err := builder.CsiImportPVCs(ref.Ref{ID: "vm-1"}, map[string]string{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvcs).To(BeEmpty())
+	})
+})
+
 //nolint:errcheck
 func createBuilder(objs ...runtime.Object) *Builder {
 	scheme := runtime.NewScheme()

--- a/pkg/controller/plan/adapter/vsphere/rdm_storage.go
+++ b/pkg/controller/plan/adapter/vsphere/rdm_storage.go
@@ -9,7 +9,9 @@ import (
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
 	"github.com/kubev2v/forklift/pkg/settings"
 	core "k8s.io/api/core/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -126,20 +128,80 @@ func vendorFromNAA(deviceName string, prefixes []naaVendorEntry) (api.StorageVen
 	return "", false
 }
 
-// findStorageMapEntriesForVendor searches the storage map for all entries whose
-// offload plugin matches the given vendor.
-func findStorageMapEntriesForVendor(storageMap []api.StoragePair, vendor api.StorageVendorProduct) []*api.StoragePair {
+type passthroughOffloadKind int
+
+const (
+	offloadKindXcopy passthroughOffloadKind = iota
+	offloadKindCsi
+)
+
+func findStorageMapEntriesForVendor(storageMap []api.StoragePair, vendor api.StorageVendorProduct, kind passthroughOffloadKind) []*api.StoragePair {
 	var matches []*api.StoragePair
 	for i := range storageMap {
 		entry := &storageMap[i]
-		if entry.OffloadPlugin == nil || entry.OffloadPlugin.VSphereXcopyPluginConfig == nil {
+		if entry.OffloadPlugin == nil {
 			continue
 		}
-		if entry.OffloadPlugin.VSphereXcopyPluginConfig.StorageVendorProduct == vendor {
-			matches = append(matches, entry)
+		switch kind {
+		case offloadKindXcopy:
+			if cfg := entry.OffloadPlugin.VSphereXcopyPluginConfig; cfg != nil && cfg.StorageVendorProduct == vendor {
+				matches = append(matches, entry)
+			}
+		case offloadKindCsi:
+			if cfg := entry.OffloadPlugin.CsiVolumeImport; cfg != nil && cfg.StorageVendorProduct == vendor {
+				matches = append(matches, entry)
+			}
 		}
 	}
 	return matches
+}
+
+func passthroughIdentifier(disk vsphere.Disk) string {
+	if disk.RDM && disk.DeviceName != "" {
+		return disk.DeviceName
+	}
+	return ""
+}
+
+// Unresolved disks (not passthrough, unrecognized vendor, ambiguous) are omitted;
+// callers fall back to datastore-ID matching for those.
+func resolvePassthroughDisksByVendor(
+	sortedDisks []vsphere.Disk,
+	dsMapIn []api.StoragePair,
+	inventory datastoreFinder,
+	naaPrefixes []naaVendorEntry,
+	kind passthroughOffloadKind,
+	log logging.LevelLogger,
+) map[int]*api.StoragePair {
+	resolved := make(map[int]*api.StoragePair)
+	for diskIndex, disk := range sortedDisks {
+		identifier := passthroughIdentifier(disk)
+		if identifier == "" {
+			continue
+		}
+		vendor, matched := vendorFromNAA(identifier, naaPrefixes)
+		if !matched {
+			log.Info("RDM disk NAA prefix not recognized, leaving unresolved for this copy method",
+				"diskKey", disk.Key, "identifier", identifier, "kind", kind)
+			continue
+		}
+		candidates := findStorageMapEntriesForVendor(dsMapIn, vendor, kind)
+		switch len(candidates) {
+		case 0:
+			log.Info("no storage map entry found for vendor of this kind, leaving unresolved for this copy method",
+				"diskKey", disk.Key, "vendor", vendor, "kind", kind)
+		case 1:
+			resolved[diskIndex] = candidates[0]
+		default:
+			if entry, err := disambiguateRDMByNAA(inventory, candidates, identifier, naaPrefixes); err == nil {
+				resolved[diskIndex] = entry
+			} else {
+				log.Info("NAA disambiguation failed, leaving unresolved for this copy method",
+					"diskKey", disk.Key, "vendor", vendor, "kind", kind, "error", err)
+			}
+		}
+	}
+	return resolved
 }
 
 // datastoreFinder can look up a Datastore by ref. Satisfied by web.Client.

--- a/pkg/controller/plan/adapter/vsphere/rdm_storage_test.go
+++ b/pkg/controller/plan/adapter/vsphere/rdm_storage_test.go
@@ -5,6 +5,7 @@ import (
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -130,7 +131,7 @@ var _ = Describe("RDM storage resolution", func() {
 
 		It("should find a single matching entry", func() {
 			storageMap := []api.StoragePair{pureEntry, powerMaxEntry}
-			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPowerMax)
+			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPowerMax, offloadKindXcopy)
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].OffloadPlugin.VSphereXcopyPluginConfig.SecretRef).To(Equal("powermax-secret"))
 			Expect(result[0].Destination.StorageClass).To(Equal("powermax-sc"))
@@ -138,7 +139,7 @@ var _ = Describe("RDM storage resolution", func() {
 
 		It("should return empty when no entry matches", func() {
 			storageMap := []api.StoragePair{pureEntry}
-			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPowerMax)
+			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPowerMax, offloadKindXcopy)
 			Expect(result).To(BeEmpty())
 		})
 
@@ -146,13 +147,13 @@ var _ = Describe("RDM storage resolution", func() {
 			secondPure := pureEntry
 			secondPure.Destination = api.DestinationStorage{StorageClass: "pure-sc-2"}
 			storageMap := []api.StoragePair{pureEntry, secondPure, powerMaxEntry}
-			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPureFlashArray)
+			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPureFlashArray, offloadKindXcopy)
 			Expect(result).To(HaveLen(2))
 		})
 
 		It("should skip entries without offload plugin", func() {
 			storageMap := []api.StoragePair{noOffloadEntry, powerMaxEntry}
-			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPowerMax)
+			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPowerMax, offloadKindXcopy)
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Destination.StorageClass).To(Equal("powermax-sc"))
 		})
@@ -162,9 +163,50 @@ var _ = Describe("RDM storage resolution", func() {
 				OffloadPlugin: &api.OffloadPlugin{},
 			}
 			storageMap := []api.StoragePair{nilConfigEntry, pureEntry}
-			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPureFlashArray)
+			result := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductPureFlashArray, offloadKindXcopy)
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Destination.StorageClass).To(Equal("pure-sc"))
+		})
+
+		It("should only match entries of the requested kind, even for the same vendor", func() {
+			ontapCsiEntry := api.StoragePair{
+				Source:      ref.Ref{ID: "ds-1"},
+				Destination: api.DestinationStorage{StorageClass: "ontap-csi-sc"},
+				OffloadPlugin: &api.OffloadPlugin{
+					CsiVolumeImport: &api.CsiVolumeImport{
+						StorageVendorProduct: api.StorageVendorProductOntap,
+						SecretRef:            "ontap-secret",
+					},
+				},
+			}
+			ontapXcopyEntry := api.StoragePair{
+				Source:      ref.Ref{ID: "ds-1"},
+				Destination: api.DestinationStorage{StorageClass: "ontap-xcopy-sc"},
+				OffloadPlugin: &api.OffloadPlugin{
+					VSphereXcopyPluginConfig: &api.VSphereXcopyPluginConfig{
+						StorageVendorProduct: api.StorageVendorProductOntap,
+						SecretRef:            "ontap-secret",
+					},
+				},
+			}
+
+			// CSI-only entry first, xcopy-only entry second.
+			storageMap := []api.StoragePair{ontapCsiEntry, ontapXcopyEntry}
+			csiResult := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductOntap, offloadKindCsi)
+			Expect(csiResult).To(HaveLen(1))
+			Expect(csiResult[0].Destination.StorageClass).To(Equal("ontap-csi-sc"))
+			xcopyResult := findStorageMapEntriesForVendor(storageMap, api.StorageVendorProductOntap, offloadKindXcopy)
+			Expect(xcopyResult).To(HaveLen(1))
+			Expect(xcopyResult[0].Destination.StorageClass).To(Equal("ontap-xcopy-sc"))
+
+			// Order flipped: xcopy-only entry first, CSI-only entry second — identical results.
+			flipped := []api.StoragePair{ontapXcopyEntry, ontapCsiEntry}
+			csiResultFlipped := findStorageMapEntriesForVendor(flipped, api.StorageVendorProductOntap, offloadKindCsi)
+			Expect(csiResultFlipped).To(HaveLen(1))
+			Expect(csiResultFlipped[0].Destination.StorageClass).To(Equal("ontap-csi-sc"))
+			xcopyResultFlipped := findStorageMapEntriesForVendor(flipped, api.StorageVendorProductOntap, offloadKindXcopy)
+			Expect(xcopyResultFlipped).To(HaveLen(1))
+			Expect(xcopyResultFlipped[0].Destination.StorageClass).To(Equal("ontap-xcopy-sc"))
 		})
 	})
 
@@ -344,6 +386,106 @@ var _ = Describe("RDM storage resolution", func() {
 			result, err := disambiguateRDMByNAA(inv, candidates, "naa.6000097000011111000000000000099", naaVendorPrefixes)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Destination.StorageClass).To(Equal("powermax-1-sc"))
+		})
+	})
+
+	Context("resolvePassthroughDisksByVendor", func() {
+		ontapCsiEntry := api.StoragePair{
+			Source:      ref.Ref{ID: "ds-1"},
+			Destination: api.DestinationStorage{StorageClass: "ontap-csi-sc"},
+			OffloadPlugin: &api.OffloadPlugin{
+				CsiVolumeImport: &api.CsiVolumeImport{
+					StorageVendorProduct: api.StorageVendorProductOntap,
+					SecretRef:            "ontap-secret",
+				},
+			},
+		}
+		ontapXcopyEntry := api.StoragePair{
+			Source:      ref.Ref{ID: "ds-1"},
+			Destination: api.DestinationStorage{StorageClass: "ontap-xcopy-sc"},
+			OffloadPlugin: &api.OffloadPlugin{
+				VSphereXcopyPluginConfig: &api.VSphereXcopyPluginConfig{
+					StorageVendorProduct: api.StorageVendorProductOntap,
+					SecretRef:            "ontap-secret",
+				},
+			},
+		}
+		rdmDisk := vsphere.Disk{Key: 2000, RDM: true, DeviceName: "naa.600a0980123456789abcdef0"}
+		vmdkDisk := vsphere.Disk{Key: 2003}
+		unrecognizedVendorRDM := vsphere.Disk{Key: 2004, RDM: true, DeviceName: "naa.6999999999999999"}
+
+		It("resolves an RDM disk to the single matching CSI-kind entry", func() {
+			storageMap := []api.StoragePair{ontapCsiEntry, ontapXcopyEntry}
+			resolved := resolvePassthroughDisksByVendor(
+				[]vsphere.Disk{rdmDisk}, storageMap, &dsInventory{}, naaVendorPrefixes, offloadKindCsi, builderLog)
+			Expect(resolved).To(HaveKey(0))
+			Expect(resolved[0].Destination.StorageClass).To(Equal("ontap-csi-sc"))
+		})
+
+		It("resolves the same RDM disk to the xcopy-kind entry when asked for xcopy", func() {
+			storageMap := []api.StoragePair{ontapCsiEntry, ontapXcopyEntry}
+			resolved := resolvePassthroughDisksByVendor(
+				[]vsphere.Disk{rdmDisk}, storageMap, &dsInventory{}, naaVendorPrefixes, offloadKindXcopy, builderLog)
+			Expect(resolved).To(HaveKey(0))
+			Expect(resolved[0].Destination.StorageClass).To(Equal("ontap-xcopy-sc"))
+		})
+
+		It("resolves identically regardless of entry order (MTV-6322 regression)", func() {
+			flipped := []api.StoragePair{ontapXcopyEntry, ontapCsiEntry}
+			resolved := resolvePassthroughDisksByVendor(
+				[]vsphere.Disk{rdmDisk}, flipped, &dsInventory{}, naaVendorPrefixes, offloadKindCsi, builderLog)
+			Expect(resolved).To(HaveKey(0))
+			Expect(resolved[0].Destination.StorageClass).To(Equal("ontap-csi-sc"))
+		})
+
+		It("falls back (omits the disk) when the vendor prefix isn't recognized", func() {
+			storageMap := []api.StoragePair{ontapCsiEntry}
+			resolved := resolvePassthroughDisksByVendor(
+				[]vsphere.Disk{unrecognizedVendorRDM}, storageMap, &dsInventory{}, naaVendorPrefixes, offloadKindCsi, builderLog)
+			Expect(resolved).NotTo(HaveKey(0))
+		})
+
+		It("falls back when the vendor is recognized but no entry of the requested kind exists", func() {
+			storageMap := []api.StoragePair{ontapXcopyEntry}
+			resolved := resolvePassthroughDisksByVendor(
+				[]vsphere.Disk{rdmDisk}, storageMap, &dsInventory{}, naaVendorPrefixes, offloadKindCsi, builderLog)
+			Expect(resolved).NotTo(HaveKey(0))
+		})
+
+		It("disambiguates two same-kind, same-vendor candidates by NAA array match", func() {
+			inv := &dsInventory{
+				datastores: map[string]model.Datastore{
+					"ds-pm1": {BackingDevicesNames: []string{"naa.6000097000011111000000000000001"}},
+					"ds-pm2": {BackingDevicesNames: []string{"naa.6000097000022222000000000000001"}},
+				},
+			}
+			powerMaxEntry1 := api.StoragePair{
+				Source:      ref.Ref{ID: "ds-pm1"},
+				Destination: api.DestinationStorage{StorageClass: "powermax-1-sc"},
+				OffloadPlugin: &api.OffloadPlugin{
+					VSphereXcopyPluginConfig: &api.VSphereXcopyPluginConfig{StorageVendorProduct: api.StorageVendorProductPowerMax, SecretRef: "pm1-secret"},
+				},
+			}
+			powerMaxEntry2 := api.StoragePair{
+				Source:      ref.Ref{ID: "ds-pm2"},
+				Destination: api.DestinationStorage{StorageClass: "powermax-2-sc"},
+				OffloadPlugin: &api.OffloadPlugin{
+					VSphereXcopyPluginConfig: &api.VSphereXcopyPluginConfig{StorageVendorProduct: api.StorageVendorProductPowerMax, SecretRef: "pm2-secret"},
+				},
+			}
+			disk := vsphere.Disk{Key: 3000, RDM: true, DeviceName: "naa.6000097000022222000000000000099"}
+			storageMap := []api.StoragePair{powerMaxEntry1, powerMaxEntry2}
+			resolved := resolvePassthroughDisksByVendor(
+				[]vsphere.Disk{disk}, storageMap, inv, naaVendorPrefixes, offloadKindXcopy, builderLog)
+			Expect(resolved).To(HaveKey(0))
+			Expect(resolved[0].Destination.StorageClass).To(Equal("powermax-2-sc"))
+		})
+
+		It("never resolves a plain VMDK disk", func() {
+			storageMap := []api.StoragePair{ontapCsiEntry, ontapXcopyEntry}
+			resolved := resolvePassthroughDisksByVendor(
+				[]vsphere.Disk{vmdkDisk}, storageMap, &dsInventory{}, naaVendorPrefixes, offloadKindCsi, builderLog)
+			Expect(resolved).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/controller/plan/adapter/vsphere/vvol_storage.go
+++ b/pkg/controller/plan/adapter/vsphere/vvol_storage.go
@@ -1,0 +1,19 @@
+package vsphere
+
+import (
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+)
+
+func resolveVVolDisksByDatastore(disks []vsphere.Disk, dsMap map[string]*api.StoragePair) map[int]*api.StoragePair {
+	resolved := make(map[int]*api.StoragePair)
+	for diskIndex, disk := range disks {
+		if disk.VVolID == "" {
+			continue
+		}
+		if entry, found := dsMap[disk.Datastore.ID]; found {
+			resolved[diskIndex] = entry
+		}
+	}
+	return resolved
+}


### PR DESCRIPTION
## Summary

- `CsiImportPVCs` resolved each disk's storage-map entry via `buildDatastoreMap`, which keyed a single map by source datastore ID and silently overwrote earlier entries sharing that ID.
- When a `StorageMap` legitimately lists the same datastore twice — one entry with `csiVolumeImport` for RDM disks, one with `vsphereXcopyConfig` for VMDKs — the outcome for CSI-eligible disks depended on which entry was listed last in `spec.map`. `csiVolumeImport` before `vsphereXcopyConfig` lost the CSI entry and the migration failed (MTV-6322).
- `buildDatastoreMap` now takes a `copyMethod` (`vddk`, `xcopy`, or `csi`), classified from each entry's `OffloadPlugin`, and only returns entries of that method. `CsiImportPVCs` and `PopulatorVolumes` each build their own method-scoped map from an independent pass over `spec.map`, so a `csiVolumeImport` entry and a `vsphereXcopyConfig` entry sharing a source datastore land in separate maps regardless of order — the reported order-dependence is gone by construction.
- Also bundled in while touching this path:
  - Extended the existing vendor/NAA-based RDM resolution (previously xcopy-only) to CSI via a shared, kind-aware `resolvePassthroughDisksByVendor`, so RDMs resolve consistently between the two copy methods.
  - Narrowed `CsiImportPVCs`' prior datastore-ID fallback — which matched *any* disk on a CSI-mapped datastore, including plain VMDKs that should never get a CSI PVC — to VVol disks specifically, via `resolveVVolDisksByDatastore`.
- An RDM disk whose NAA can't be matched to a known vendor is **not** guessed at via CSI datastore-ID matching: a `csiVolumeImport` entry is tied to a specific vendor's plugin/secret, so blindly matching by datastore risks picking the wrong vendor's target when a datastore hosts RDMs from more than one array. Such disks are left unresolved by `CsiImportPVCs` (logged) and fall through to `PopulatorVolumes`, which still has its own xcopy datastore-ID fallback.
- `DataVolumes` and `NetAppShiftPVCs` both request `vddk`-classified entries and keep filtering shift vs. plain VDDK downstream via the destination `StorageClass`, so shift behavior is unchanged.

## Out of scope / deferred

Two entries of the *same* copy method mapping to the *same* source datastore (e.g. two `xcopy` entries both sourced from the same datastore) are intentionally **not** rejected by this PR. Deciding whether that shape should be a hard validation error, or handled some other way, is a separate ambiguity-handling question still under discussion — deferred to a follow-up. Behavior for that specific case (last-write-wins) is unchanged from before this fix.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/controller/plan/...`
- [x] Unit test covering the exact reported scenario: a `StorageMap` with one `csiVolumeImport` and one `vsphereXcopyConfig` entry sourced from the same datastore resolves both correctly, independent of list order.
- [x] Unit test covering an RDM disk with an unrecognized vendor: `CsiImportPVCs` defers it (no PVC, no error) instead of guessing via datastore matching.
