### PR TITLE
MTV-6366 | Cache the NetApp Shift SC resolution

### DIFF
--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -9764,6 +9764,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              netAppShiftDestination:
+                description: |-
+                  NetAppShiftDestination indicates whether the plan's storage map resolves to a NetApp
+                  Shift/Trident destination StorageClass.
+                type: boolean
               observedGeneration:
                 description: The most recent generation observed by the controller.
                 format: int64

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -9764,6 +9764,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              netAppShiftDestination:
+                description: |-
+                  NetAppShiftDestination indicates whether the plan's storage map resolves to a NetApp
+                  Shift/Trident destination StorageClass.
+                type: boolean
               observedGeneration:
                 description: The most recent generation observed by the controller.
                 format: int64

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -3644,6 +3644,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              netAppShiftDestination:
+                description: |-
+                  NetAppShiftDestination indicates whether the plan's storage map resolves to a NetApp
+                  Shift/Trident destination StorageClass.
+                type: boolean
               observedGeneration:
                 description: The most recent generation observed by the controller.
                 format: int64

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -412,6 +412,10 @@ type PlanStatus struct {
 	// The most recent generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// NetAppShiftDestination indicates whether the plan's storage map resolves to a NetApp
+	// Shift/Trident destination StorageClass.
+	// +optional
+	NetAppShiftDestination bool `json:"netAppShiftDestination,omitempty"`
 	// Migration
 	Migration plan.MigrationStatus `json:"migration,omitempty"`
 }
@@ -446,12 +450,15 @@ func (p *Plan) IsWarm() bool {
 // just use virt-v2v directly to convert the vm while copying data over. In other
 // cases, we use CDI to transfer disks to the destination cluster and then use
 // virt-v2v-in-place to convert these disks after cutover.
-func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref, destinationClient k8sclient.Client) (bool, error) {
-	source := p.Referenced.Provider.Source
+//
+// Note: this is called once per VM from several places (adapters, scheduler, migrator,
+// kubevirt.go, migration.go) on every reconcile, so it must not perform any API/client calls itself.
+func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref) (bool, error) {
+	source := p.Provider.Source
 	if source == nil {
 		return false, liberr.New("Cannot analyze plan, source provider is missing.")
 	}
-	destination := p.Referenced.Provider.Destination
+	destination := p.Provider.Destination
 	if destination == nil {
 		return false, liberr.New("Cannot analyze plan, destination provider is missing.")
 	}
@@ -468,14 +475,8 @@ func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref, destinationClient k8sclien
 			p.Spec.SkipGuestConversion || p.Spec.Type == MigrationOnlyConversion {
 			return false, nil
 		}
-		if p.Map.Storage != nil {
-			hasNetAppShift, err := p.Map.Storage.HasNetAppShiftDestination(destinationClient)
-			if err != nil {
-				return false, err
-			}
-			if hasNetAppShift {
-				return false, nil
-			}
+		if p.HasNetAppShiftDestination() {
+			return false, nil
 		}
 		if p.IsUsingOffloadPlugin() {
 			return false, nil
@@ -486,6 +487,10 @@ func (p *Plan) ShouldUseV2vForTransfer(vmRef ref.Ref, destinationClient k8sclien
 	default:
 		return false, nil
 	}
+}
+
+func (p *Plan) HasNetAppShiftDestination() bool {
+	return p.Status.NetAppShiftDestination
 }
 
 func (r *Plan) DestinationHasUdnNetwork(client k8sclient.Client) bool {

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -562,7 +562,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 
 		storageClass := mapped.Destination.StorageClass
 		var dvSource cdi.DataVolumeSource
-		useV2vForTransfer, vErr := r.Context.Plan.ShouldUseV2vForTransfer(vmRef, r.Context.Destination.Client)
+		useV2vForTransfer, vErr := r.Plan.ShouldUseV2vForTransfer(vmRef)
 		if vErr != nil {
 			err = vErr
 			return

--- a/pkg/controller/plan/adapter/vsphere/client.go
+++ b/pkg/controller/plan/adapter/vsphere/client.go
@@ -432,7 +432,7 @@ func (r *Client) getTaskById(vmRef ref.Ref, taskId string, hosts util.HostsFunc)
 }
 
 func (r *Client) getClient(vm *model.VM, hosts util.HostsFunc) (client *vim25.Client, err error) {
-	if useV2vForTransfer, vErr := r.Plan.ShouldUseV2vForTransfer(ref.Ref{ID: vm.ID}, r.Destination.Client); vErr == nil && useV2vForTransfer {
+	if useV2vForTransfer, vErr := r.Plan.ShouldUseV2vForTransfer(ref.Ref{ID: vm.ID}); vErr == nil && useV2vForTransfer {
 		// when virt-v2v runs the migration, forklift-controller should interact only
 		// with the component that serves the SDK endpoint of the provider
 		client = r.client.Client

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -236,7 +236,7 @@ func (r *KubeVirt) resolveConversionResources(vm *plan.VMStatus, podType convctx
 			return
 		}
 
-		useV2v, v2vErr := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref, r.Destination.Client)
+		useV2v, v2vErr := r.Plan.ShouldUseV2vForTransfer(vm.Ref)
 		if v2vErr != nil {
 			err = v2vErr
 			return
@@ -355,7 +355,7 @@ func (r *KubeVirt) checkProviderReady(vmID string) (ready bool, err error) {
 // should use InPlace or Remote conversion based on the plan transfer mode
 // and PVC copy-offload annotations.
 func (r *KubeVirt) ResolveConversionType(vm *plan.VMStatus) (api.ConversionType, error) {
-	useV2v, err := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref, r.Destination.Client)
+	useV2v, err := r.Plan.ShouldUseV2vForTransfer(vm.Ref)
 	if err != nil {
 		return "", err
 	}
@@ -407,7 +407,8 @@ func (r *KubeVirt) EnsureConversion(vm *plan.VMStatus, conversionType api.Conver
 	maps.Copy(labels, resources.podConfig.PodLabels)
 
 	list := &api.ConversionList{}
-	err = r.Client.List(context.TODO(), list,
+	err = r.Client.List(
+		context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabels(labels),
 	)
@@ -419,7 +420,8 @@ func (r *KubeVirt) EnsureConversion(vm *plan.VMStatus, conversionType api.Conver
 		r.Log.Info(
 			"Conversion CR already exists.",
 			"conversion", path.Join(list.Items[0].Namespace, list.Items[0].Name),
-			"vm", vm.String())
+			"vm", vm.String(),
+		)
 		return r.checkProviderReady(vm.ID)
 	}
 
@@ -493,7 +495,8 @@ func (r *KubeVirt) EnsureConversion(vm *plan.VMStatus, conversionType api.Conver
 			sourceNS = r.Plan.Namespace
 		}
 		source := &core.Secret{}
-		if err = r.Client.Get(context.TODO(),
+		if err = r.Client.Get(
+			context.TODO(),
 			types.NamespacedName{Namespace: sourceNS, Name: vm.LUKS.Name}, source,
 		); err != nil {
 			err = liberr.Wrap(err)
@@ -532,7 +535,8 @@ func (r *KubeVirt) EnsureConversion(vm *plan.VMStatus, conversionType api.Conver
 		"Conversion CR created.",
 		"conversion", path.Join(conversion.Namespace, conversion.Name),
 		"type", string(conversionType),
-		"vm", vm.String())
+		"vm", vm.String(),
+	)
 	return
 }
 
@@ -557,7 +561,8 @@ func (r *KubeVirt) getConversionLabels(convType api.ConversionType, vmID, planID
 // all supplied labels. Returns nil (no error) when no match is found.
 func (r *KubeVirt) getConversion(labels map[string]string) (*api.Conversion, error) {
 	list := &api.ConversionList{}
-	if err := r.Client.List(context.TODO(), list,
+	if err := r.Client.List(
+		context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabels(labels),
 	); err != nil {
@@ -586,7 +591,8 @@ func (r *KubeVirt) buildConversion(planName, vmID string, labels map[string]stri
 // found its Spec is refreshed; otherwise the provided CR is created verbatim.
 func (r *KubeVirt) ensureConversion(cr *api.Conversion) (*api.Conversion, error) {
 	list := &api.ConversionList{}
-	if err := r.Client.List(context.TODO(), list,
+	if err := r.Client.List(
+		context.TODO(), list,
 		client.InNamespace(cr.Namespace),
 		client.MatchingLabels(cr.Labels),
 	); err != nil {
@@ -634,7 +640,8 @@ func (r *KubeVirt) ensureConversionSecret(cl client.Client, secret *core.Secret)
 		}
 	}
 	list := &core.SecretList{}
-	if err := cl.List(context.TODO(), list,
+	if err := cl.List(
+		context.TODO(), list,
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(lookupLabels),
 			Namespace:     secret.Namespace,
@@ -677,7 +684,8 @@ func (r *KubeVirt) GetGuestConversion(vm *plan.VMStatus) (*api.Conversion, error
 	}).Add(*typeReq)
 
 	list := &api.ConversionList{}
-	if err := r.List(context.TODO(), list,
+	if err := r.List(
+		context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabelsSelector{Selector: selector},
 	); err != nil {
@@ -728,7 +736,8 @@ func (r *KubeVirt) CreateDeepInspectionConversion(
 			sourceNS = r.Plan.Namespace
 		}
 		source := &core.Secret{}
-		if err = r.Client.Get(context.TODO(),
+		if err = r.Client.Get(
+			context.TODO(),
 			types.NamespacedName{Namespace: sourceNS, Name: vm.LUKS.Name}, source,
 		); err != nil {
 			return nil, liberr.Wrap(err)
@@ -812,7 +821,8 @@ func (r *KubeVirt) DeleteAllConversions(vm *plan.VMStatus) error {
 		convctx.LabelVM:   vm.Ref.ID,
 	}
 	list := &api.ConversionList{}
-	if err := r.Client.List(context.TODO(), list,
+	if err := r.Client.List(
+		context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabels(labels),
 	); err != nil {
@@ -842,7 +852,8 @@ func (r *KubeVirt) deleteConversionPod(cr *api.Conversion) error {
 		return nil
 	}
 	list := &core.PodList{}
-	if err := cl.List(context.TODO(), list,
+	if err := cl.List(
+		context.TODO(), list,
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(matchLabels),
 			Namespace:     cr.Spec.TargetNamespace,
@@ -889,7 +900,8 @@ func (r *KubeVirt) deleteConversionSecrets(cr *api.Conversion) error {
 		convctx.LabelConversionType: string(cr.Spec.Type),
 	}
 	list := &core.SecretList{}
-	if err := cl.List(context.TODO(), list,
+	if err := cl.List(
+		context.TODO(), list,
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(matchLabels),
 			Namespace:     cr.Spec.TargetNamespace,
@@ -911,7 +923,8 @@ func (r *KubeVirt) deleteConversionSecrets(cr *api.Conversion) error {
 		return nil
 	}
 	v2vList := &core.SecretList{}
-	if err := r.Destination.Client.List(context.TODO(), v2vList,
+	if err := r.Destination.Client.List(
+		context.TODO(), v2vList,
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(map[string]string{
 				convctx.LabelVM: vmID,
@@ -958,7 +971,8 @@ func (r *KubeVirt) CancelConversion(vm *plan.VMStatus) error {
 		convctx.LabelVM:   vm.Ref.ID,
 	}
 	list := &api.ConversionList{}
-	err := r.Client.List(context.TODO(), list,
+	err := r.Client.List(
+		context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabels(labels),
 	)
@@ -1213,7 +1227,8 @@ func (r *KubeVirt) EnsureGuestInspectionPod(vm *plan.VMStatus, step *plan.Step) 
 	err = convbuilder.EnsureVirtV2vPod(
 		r.Destination.Client, r.Log, vm,
 		res.volumes, res.mounts, res.devices,
-		res.secret, convctx.VirtV2vInspectionPod, false, res.podConfig)
+		res.secret, convctx.VirtV2vInspectionPod, false, res.podConfig,
+	)
 	if err != nil {
 		return
 	}
@@ -1317,7 +1332,8 @@ func (r *KubeVirt) ListVMs() ([]VirtualMachine, error) {
 			list,
 			VirtualMachine{
 				VirtualMachine: vm,
-			})
+			},
+		)
 	}
 	dvList := &cdi.DataVolumeList{}
 	err = r.Destination.Client.List(
@@ -1347,7 +1363,8 @@ func (r *KubeVirt) ListVMs() ([]VirtualMachine, error) {
 					ExtendedDataVolume{
 						DataVolume: dv,
 						PVC:        pvc,
-					})
+					},
+				)
 			}
 		}
 	}
@@ -1362,7 +1379,8 @@ func (r *KubeVirt) EnsureNamespace() error {
 		r.Log.Info(
 			"Created namespace.",
 			"import",
-			r.Plan.Spec.TargetNamespace)
+			r.Plan.Spec.TargetNamespace,
+		)
 	}
 	return err
 }
@@ -1389,7 +1407,8 @@ func (r *KubeVirt) EnsureExtraV2vConfConfigMap() error {
 		r.Log.Info(
 			"Created config map for extra configuration for virt-v2v.",
 			"target namespace",
-			r.Plan.Spec.TargetNamespace)
+			r.Plan.Spec.TargetNamespace,
+		)
 	}
 	return err
 }
@@ -1439,7 +1458,8 @@ func (r *KubeVirt) EnsureCustomizationScriptsConfigMap() error {
 		r.Log.V(4).Info(
 			"Ensured ConfigMap for customization scripts in target namespace.",
 			"configMap namespace", configMapNamespace,
-			"target namespace", r.Plan.Spec.TargetNamespace)
+			"target namespace", r.Plan.Spec.TargetNamespace,
+		)
 	}
 	return err
 }
@@ -1558,7 +1578,8 @@ func (r *KubeVirt) DeleteDataVolumes(vm *plan.VMStatus) (err error) {
 			"dv",
 			path.Join(dv.Namespace, dv.Name),
 			"vm",
-			vm.String())
+			vm.String(),
+		)
 		err = r.Destination.Client.Delete(context.TODO(), dv.DataVolume)
 		if err != nil {
 			return
@@ -1583,9 +1604,11 @@ func (r *KubeVirt) DeleteImporterPods(pvc *core.PersistentVolumeClaim) (err erro
 				"pod",
 				path.Join(
 					pod.Namespace,
-					pod.Name),
+					pod.Name,
+				),
 				"pvc",
-				pvc.Name)
+				pvc.Name,
+			)
 			continue
 		}
 		r.Log.Info(
@@ -1593,9 +1616,11 @@ func (r *KubeVirt) DeleteImporterPods(pvc *core.PersistentVolumeClaim) (err erro
 			"pod",
 			path.Join(
 				pod.Namespace,
-				pod.Name),
+				pod.Name,
+			),
 			"pvc",
-			pvc.Name)
+			pvc.Name,
+		)
 	}
 	return
 }
@@ -1628,7 +1653,9 @@ func (r *KubeVirt) DeleteJobs(vm *plan.VMStatus) (err error) {
 				"job",
 				path.Join(
 					job.Namespace,
-					job.Name))
+					job.Name,
+				),
+			)
 			continue
 		}
 
@@ -1661,7 +1688,9 @@ func (r *KubeVirt) DeleteJobs(vm *plan.VMStatus) (err error) {
 					"pod",
 					path.Join(
 						pod.Namespace,
-						pod.Name))
+						pod.Name,
+					),
+				)
 				continue
 			}
 		}
@@ -1698,9 +1727,11 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) error {
 			"vm",
 			path.Join(
 				virtualMachine.Namespace,
-				virtualMachine.Name),
+				virtualMachine.Name,
+			),
 			"source",
-			vm.String())
+			vm.String(),
+		)
 	} else {
 		virtualMachine = &vms.Items[0]
 	}
@@ -1714,7 +1745,8 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) error {
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(r.vmLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
-		})
+		},
+	)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -1822,9 +1854,11 @@ func (r *KubeVirt) DeleteVM(vm *plan.VMStatus) (err error) {
 				"vm",
 				path.Join(
 					object.Namespace,
-					object.Name),
+					object.Name,
+				),
 				"source",
-				vm.String())
+				vm.String(),
+			)
 		}
 	}
 	return
@@ -1885,7 +1919,8 @@ func (r *KubeVirt) EnsureDataVolumes(vm *plan.VMStatus, dataVolumes []cdi.DataVo
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(r.vmLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
-		})
+		},
+	)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -1902,7 +1937,8 @@ func (r *KubeVirt) EnsureDataVolumes(vm *plan.VMStatus, dataVolumes []cdi.DataVo
 				"dv",
 				path.Join(
 					dv.Namespace,
-					dv.Name),
+					dv.Name,
+				),
 				"vm",
 				vm.String())
 		}
@@ -1977,7 +2013,9 @@ func (r *KubeVirt) ensureVddkConfigMap() (configMap *core.ConfigMap, err error) 
 			"configmap",
 			path.Join(
 				configMap.Namespace,
-				configMap.Name))
+				configMap.Name,
+			),
+		)
 	} else {
 		configMap = newConfigMap
 		err = r.Destination.Client.Create(context.TODO(), configMap)
@@ -1990,7 +2028,9 @@ func (r *KubeVirt) ensureVddkConfigMap() (configMap *core.ConfigMap, err error) 
 			"configmap",
 			path.Join(
 				configMap.Namespace,
-				configMap.Name))
+				configMap.Name,
+			),
+		)
 	}
 	return
 }
@@ -2027,7 +2067,8 @@ func (r *KubeVirt) getDVs(vm *plan.VMStatus) (edvs []ExtendedDataVolume, err err
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(r.vmAllButMigrationLabels(vm.Ref)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
-		})
+		},
+	)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -2309,7 +2350,8 @@ func (r *KubeVirt) GetGuestConversionPod(vm *plan.VMStatus) (pod *core.Pod, err 
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(r.conversionLabels(vm.Ref, false)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
-		})
+		},
+	)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -2481,7 +2523,8 @@ func (r *KubeVirt) DeleteDeepInspectionPods(vm *plan.VMStatus) error {
 		convctx.LabelConversionType: string(api.DeepInspection),
 	}
 	list := &core.PodList{}
-	if err := r.List(context.TODO(), list,
+	if err := r.List(
+		context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabels(matchLabels),
 	); err != nil {
@@ -2552,9 +2595,11 @@ func (r *KubeVirt) DeleteObject(object client.Object, vm *plan.VMStatus, message
 			objType,
 			path.Join(
 				object.GetNamespace(),
-				object.GetName()),
+				object.GetName(),
+			),
 			"vm",
-			vm.String())
+			vm.String(),
+		)
 	}
 	return
 }
@@ -2648,7 +2693,8 @@ func (r *KubeVirt) DeletePopulatorPods(vm *plan.VMStatus) (err error) {
 			r.Log.Info(
 				"WARNING: FEATURE_RETAIN_POPULATOR_PODS is enabled but DeleteVmOnFailMigration is also set;"+
 					" on failure the PVCs will be deleted and Kubernetes GC will remove the populator pods via OwnerReference.",
-				"vm", vm.String())
+				"vm", vm.String(),
+			)
 		}
 		r.Log.Info("Retaining populator pods (feature flag enabled).", "vm", vm.String())
 		return
@@ -2757,7 +2803,8 @@ func (r *KubeVirt) getGeneratedName(vm *plan.VMStatus) string {
 			r.Plan.Name,
 			vm.ID,
 		},
-		"-") + "-"
+		"-",
+	) + "-"
 }
 
 // Return the generated name for a specific VM and plan.
@@ -2987,7 +3034,8 @@ func (r *KubeVirt) getVirtualMachineInstanceType(instanceTypeName string) (kind 
 	err = r.Destination.Client.Get(
 		context.TODO(),
 		client.ObjectKey{Name: instanceTypeName, Namespace: r.Plan.Spec.TargetNamespace},
-		virtualMachineInstancetype)
+		virtualMachineInstancetype,
+	)
 	if err != nil {
 		return
 	}
@@ -3000,7 +3048,8 @@ func (r *KubeVirt) getVirtualMachineClusterInstanceType(vm *plan.VMStatus, insta
 	err = r.Destination.Client.Get(
 		context.TODO(),
 		client.ObjectKey{Name: instanceTypeName},
-		virtualMachineClusterInstancetype)
+		virtualMachineClusterInstancetype,
+	)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			r.Log.Info("could not find instance type for destination VM.",
@@ -3059,7 +3108,8 @@ func (r *KubeVirt) getVirtualMachinePreference(preferenceName string) (name, kin
 	err = r.Destination.Client.Get(
 		context.TODO(),
 		client.ObjectKey{Name: preferenceName, Namespace: r.Plan.Spec.TargetNamespace},
-		virtualMachinePreference)
+		virtualMachinePreference,
+	)
 	if err != nil {
 		return
 	}
@@ -3071,7 +3121,8 @@ func (r *KubeVirt) getVirtualMachineClusterPreference(vm *plan.VMStatus, prefere
 	err = r.Destination.Client.Get(
 		context.TODO(),
 		client.ObjectKey{Name: preferenceName},
-		virtualMachineClusterPreference)
+		virtualMachineClusterPreference,
+	)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			r.Log.Info("could not find instance type preference for destination VM.",
@@ -3236,7 +3287,8 @@ func (r *KubeVirt) findTemplate(vm *plan.VMStatus) (tmpl *template.Template, err
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(templateLabels),
 			Namespace:     "openshift",
-		})
+		},
+	)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -3372,7 +3424,8 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 				"volume",
 				v.Name,
 				"pvc",
-				v.PersistentVolumeClaim.ClaimName)
+				v.PersistentVolumeClaim.ClaimName,
+			)
 			continue
 		}
 		vol := core.Volume{
@@ -3475,14 +3528,16 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 		extraVolumes = append(extraVolumes, providerVol)
 		extraMounts = append(extraMounts, providerMount)
 	case api.VSphere:
-		mounts = append(mounts,
+		mounts = append(
+			mounts,
 			core.VolumeMount{
 				Name:      VddkVolumeName,
 				MountPath: "/opt",
 			},
 		)
 		if extraConfigMapExists {
-			mounts = append(mounts,
+			mounts = append(
+				mounts,
 				core.VolumeMount{
 					Name:      ExtraV2vConf,
 					MountPath: fmt.Sprintf("/mnt/%s", ExtraV2vConf),
@@ -3490,7 +3545,8 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 			)
 		}
 		if vddkConfigmap != nil {
-			mounts = append(mounts,
+			mounts = append(
+				mounts,
 				core.VolumeMount{
 					Name:      VddkConf,
 					MountPath: fmt.Sprintf("/mnt/%s", VddkConf),
@@ -3522,7 +3578,8 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 		if !exists {
 			err = liberr.New(
 				fmt.Sprintf("CustomizationScripts ConfigMap %s not found in namespace %s",
-					volumeConfigMapName, r.Plan.Spec.TargetNamespace))
+					volumeConfigMapName, r.Plan.Spec.TargetNamespace),
+			)
 			return
 		}
 		scriptsVol := core.Volume{
@@ -3651,9 +3708,11 @@ func (r *KubeVirt) ensureConfigMap(vmRef ref.Ref) (configMap *core.ConfigMap, er
 			"configMap",
 			path.Join(
 				configMap.Namespace,
-				configMap.Name),
+				configMap.Name,
+			),
 			"vm",
-			vmRef.String())
+			vmRef.String(),
+		)
 	}
 
 	return
@@ -3670,7 +3729,8 @@ func (r *KubeVirt) configMap(vmRef ref.Ref) (object *core.ConfigMap, err error) 
 					r.Plan.Name,
 					vmRef.ID,
 				},
-				"-") + "-",
+				"-",
+			) + "-",
 		},
 		BinaryData: make(map[string][]byte),
 	}
@@ -3742,9 +3802,11 @@ func (r *KubeVirt) ensureSecret(vmRef ref.Ref, setSecretData func(*core.Secret) 
 			"secret",
 			path.Join(
 				secret.Namespace,
-				secret.Name),
+				secret.Name,
+			),
 			"vm",
-			vmRef.String())
+			vmRef.String(),
+		)
 	} else {
 		secret = newSecret
 		err = r.Destination.Client.Create(context.TODO(), secret)
@@ -3757,9 +3819,11 @@ func (r *KubeVirt) ensureSecret(vmRef ref.Ref, setSecretData func(*core.Secret) 
 			"secret",
 			path.Join(
 				secret.Namespace,
-				secret.Name),
+				secret.Name,
+			),
 			"vm",
-			vmRef.String())
+			vmRef.String(),
+		)
 	}
 
 	return
@@ -3776,7 +3840,8 @@ func (r *KubeVirt) secret(vmRef ref.Ref, setSecretData func(*core.Secret) error,
 					r.Plan.Name,
 					vmRef.ID,
 				},
-				"-") + "-",
+				"-",
+			) + "-",
 		},
 	}
 	err = setSecretData(secret)
@@ -3935,7 +4000,8 @@ func (r *KubeVirt) setTransferNetwork(annotations map[string]string) (err error)
 			} else {
 				err = liberr.New(
 					"Transfer network default route is not a valid IP address.",
-					"route", route)
+					"route", route,
+				)
 				return
 			}
 		}
@@ -4061,7 +4127,8 @@ func (r *KubeVirt) EnsurePersistentVolume(vmRef ref.Ref, persistentVolumes []cor
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(r.vmLabels(vmRef)),
 			Namespace:     r.Plan.Spec.TargetNamespace,
-		})
+		},
+	)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -4087,7 +4154,8 @@ func (r *KubeVirt) EnsurePersistentVolume(vmRef ref.Ref, persistentVolumes []cor
 				"pv",
 				path.Join(
 					pv.Namespace,
-					pv.Name),
+					pv.Name,
+				),
 				"vm",
 				vmRef.String())
 		}
@@ -4477,7 +4545,8 @@ func (r *KubeVirt) EnsurePersistentVolumeClaim(vmRef ref.Ref, persistentVolumeCl
 				"pvc",
 				path.Join(
 					pvc.Namespace,
-					pvc.Name),
+					pvc.Name,
+				),
 				"vmRef",
 				vmRef.String())
 		}

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -117,7 +117,8 @@ func (r *Migration) Run() (reQ time.Duration, err error) {
 				if !r.Source.Provider.Status.HasCondition(libcnd.Ready) {
 					r.Log.Info(
 						"VM not found in inventory but source provider is not ready, will retry.",
-						"vm", vm.String())
+						"vm", vm.String(),
+					)
 					return
 				}
 				vm.SetCondition(libcnd.Condition{
@@ -207,7 +208,8 @@ func (r *Migration) begin() (err error) {
 			Category: api.CategoryAdvisory,
 			Message:  "The plan is EXECUTING.",
 			Durable:  true,
-		})
+		},
+	)
 	err = r.kubevirt.EnsureNamespace()
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -255,12 +257,14 @@ func (r *Migration) begin() (err error) {
 			log.Info(
 				"Pipeline reset.",
 				"vm",
-				vm.String())
+				vm.String(),
+			)
 		} else {
 			log.Info(
 				"Pipeline preserved.",
 				"vm",
-				vm.String())
+				vm.String(),
+			)
 		}
 		list = append(list, status)
 	}
@@ -528,7 +532,8 @@ func (r *Migration) removeLastWarmSnapshot(vm *plan.VMStatus) {
 		r.Log.Error(
 			err,
 			"Failed to clean up warm migration snapshots.",
-			"vm", vm)
+			"vm", vm,
+		)
 	}
 }
 
@@ -714,12 +719,14 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				Reason:   UserRequested,
 				Message:  "The migration has been canceled.",
 				Durable:  true,
-			})
+			},
+		)
 		vm.Phase = api.PhaseCompleted
 		r.Log.Info(
 			"Migration [CANCELED]",
 			"vm",
-			vm.String())
+			vm.String(),
+		)
 		return
 	}
 
@@ -728,11 +735,13 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 		"vm",
 		vm.String(),
 		"phase",
-		vm.Phase)
+		vm.Phase,
+	)
 	r.Log.V(2).Info(
 		"Migrating VM (definition).",
 		"vm",
-		vm)
+		vm,
+	)
 
 	// delegate to a provider-specific implementation of a phase
 	// if one exists, otherwise run through the default implementation.
@@ -970,7 +979,8 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 						err = r.Destination.Client.Get(
 							context.TODO(),
 							types.NamespacedName{Namespace: pvc.Namespace, Name: owner.Name},
-							dataVolume)
+							dataVolume,
+						)
 						if err != nil {
 							r.Log.Error(err, "error getting matching DataVolume for PVC", "pvc", pvc.Name)
 							return
@@ -1124,7 +1134,8 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				if len(pod.Status.ContainerStatuses) > 0 {
 					cs := pod.Status.ContainerStatuses[0]
 					if cs.State.Terminated != nil {
-						logFields = append(logFields,
+						logFields = append(
+							logFields,
 							"exitCode", cs.State.Terminated.ExitCode,
 							"terminationReason", cs.State.Terminated.Reason,
 							"terminationMessage", cs.State.Terminated.Message,
@@ -1511,7 +1522,8 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 
 				if cr == nil {
 					_, err = r.kubevirt.CreateDeepInspectionConversion(
-						vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID))
+						vm, snapshotMoref, r.Plan.Name, string(r.Plan.UID),
+					)
 					if err != nil {
 						step.AddError(err.Error())
 						err = nil
@@ -1599,16 +1611,20 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			r.Log.Info(
 				"Migration [COMPLETED]",
 				"vm",
-				vm.String())
+				vm.String(),
+			)
 		default:
 			r.Log.Info(
 				"Phase unknown.",
 				"vm",
-				vm)
+				vm,
+			)
 			vm.AddError(
 				fmt.Sprintf(
 					"Phase [%s] unknown",
-					vm.Phase))
+					vm.Phase,
+				),
+			)
 			vm.Phase = api.PhaseCompleted
 		}
 	}
@@ -1635,7 +1651,8 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				Category: api.CategoryAdvisory,
 				Message:  "The VM migration has SUCCEEDED.",
 				Durable:  true,
-			})
+			},
+		)
 		_ = r.cleanup(vm, func(err error) bool {
 			if err != nil {
 				r.Log.Error(err, "Cleanup after successful VM migration.", "vm", vm.String())
@@ -1659,7 +1676,8 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 				Category: api.CategoryAdvisory,
 				Message:  "The VM migration has FAILED.",
 				Durable:  true,
-			})
+			},
+		)
 	}
 
 	return
@@ -1704,7 +1722,8 @@ func (r *Migration) end() (completed bool, err error) {
 				Category: api.CategoryAdvisory,
 				Message:  "The plan execution has FAILED.",
 				Durable:  true,
-			})
+			},
+		)
 	} else if succeeded > 0 {
 		// if the migration didn't fail and at least one VM succeeded,
 		// then the migration succeeded.
@@ -1717,7 +1736,8 @@ func (r *Migration) end() (completed bool, err error) {
 				Category: api.CategoryAdvisory,
 				Message:  "The plan execution has SUCCEEDED.",
 				Durable:  true,
-			})
+			},
+		)
 	} else {
 		// if there were no failures or successes, but
 		// all the VMs are complete, then the migration must
@@ -1730,7 +1750,8 @@ func (r *Migration) end() (completed bool, err error) {
 				Category: api.CategoryAdvisory,
 				Message:  "The plan execution has been CANCELED.",
 				Durable:  true,
-			})
+			},
+		)
 	}
 
 	completed = true
@@ -1810,7 +1831,8 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 						"vm",
 						vm.String(),
 						"dv",
-						path.Join(dv.Namespace, dv.Name))
+						path.Join(dv.Namespace, dv.Name),
+					)
 					continue
 				}
 				snapshot := dv.Spec.Checkpoints[len(dv.Spec.Checkpoints)-1].Current
@@ -1870,7 +1892,8 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 							"vm",
 							vm.String(),
 							"dv",
-							path.Join(dv.Namespace, dv.Name))
+							path.Join(dv.Namespace, dv.Name),
+						)
 						continue
 					}
 					err = r.Destination.Client.Get(context.TODO(), types.NamespacedName{
@@ -1889,7 +1912,8 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 								"vm",
 								vm.String(),
 								"dv",
-								path.Join(dv.Namespace, dv.Name))
+								path.Join(dv.Namespace, dv.Name),
+							)
 							continue
 						}
 					}
@@ -1903,7 +1927,8 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 						"vm",
 						vm.String(),
 						"dv",
-						path.Join(dv.Namespace, dv.Name))
+						path.Join(dv.Namespace, dv.Name),
+					)
 					continue
 				}
 
@@ -1913,7 +1938,8 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 						"vm",
 						vm.String(),
 						"dv",
-						path.Join(dv.Namespace, dv.Name))
+						path.Join(dv.Namespace, dv.Name),
+					)
 					continue
 				}
 
@@ -2007,7 +2033,7 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 			break
 		}
 
-		useV2vForTransfer, err := r.Context.Plan.ShouldUseV2vForTransfer(vm.Ref, r.Destination.Client)
+		useV2vForTransfer, err := r.Plan.ShouldUseV2vForTransfer(vm.Ref)
 		switch {
 		case err != nil:
 			return liberr.Wrap(err)

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -81,7 +81,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Progress:    libitr.Progress{Total: 1},
 						Phase:       api.StepPending,
 					},
-				})
+				},
+			)
 		case api.PhasePreHook:
 			pipeline = append(
 				pipeline,
@@ -92,7 +93,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Progress:    libitr.Progress{Total: 1},
 						Phase:       api.StepPending,
 					},
-				})
+				},
+			)
 		case api.PhaseAllocateDisks, api.PhaseCopyDisks, api.PhaseCopyDisksVirtV2V, api.PhaseConvertOpenstackSnapshot:
 			tasks, pErr := r.builder.Tasks(vm.Ref)
 			if pErr != nil {
@@ -136,7 +138,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Phase: api.StepPending,
 					},
 					Tasks: tasks,
-				})
+				},
+			)
 		case api.PhaseFinalize:
 			tasks, pErr := r.builder.Tasks(vm.Ref)
 			if pErr != nil {
@@ -161,7 +164,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						},
 					},
 					Tasks: tasks,
-				})
+				},
+			)
 		case api.PhaseConvertGuest:
 			pipeline = append(
 				pipeline,
@@ -172,7 +176,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Progress:    libitr.Progress{Total: 1},
 						Phase:       api.StepPending,
 					},
-				})
+				},
+			)
 		case api.PhasePostHook:
 			pipeline = append(
 				pipeline,
@@ -183,7 +188,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Progress:    libitr.Progress{Total: 1},
 						Phase:       api.StepPending,
 					},
-				})
+				},
+			)
 		case api.PhaseCreateVM:
 			pipeline = append(
 				pipeline,
@@ -194,7 +200,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Phase:       api.StepPending,
 						Progress:    libitr.Progress{Total: 1},
 					},
-				})
+				},
+			)
 		case api.PhaseWaitForGuestReboots:
 			pipeline = append(
 				pipeline,
@@ -205,7 +212,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Phase:       api.StepPending,
 						Progress:    libitr.Progress{Total: 1},
 					},
-				})
+				},
+			)
 		case api.PhasePreflightInspection:
 			pipeline = append(
 				pipeline,
@@ -216,7 +224,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Phase:       api.StepPending,
 						Progress:    libitr.Progress{Total: 1},
 					},
-				})
+				},
+			)
 		case api.PhaseWaitForFinalSnapshotRemoval:
 			pipeline = append(
 				pipeline,
@@ -227,7 +236,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 						Phase:       api.StepPending,
 						Progress:    libitr.Progress{Total: 1},
 					},
-				})
+				},
+			)
 		}
 		next, done, _ := itinerary.Next(step.Name)
 		if !done {
@@ -245,7 +255,8 @@ func (r *BaseMigrator) Pipeline(vm plan.VM) (pipeline []*plan.Step, err error) {
 	r.Log.V(2).Info(
 		"Pipeline built.",
 		"vm",
-		vm.String())
+		vm.String(),
+	)
 	return
 }
 
@@ -411,7 +422,7 @@ type BasePredicate struct {
 
 // Evaluate predicate flags.
 func (r *BasePredicate) Evaluate(flag libitr.Flag) (allowed bool, err error) {
-	useV2vForTransfer, vErr := r.context.Plan.ShouldUseV2vForTransfer(r.vm.Ref, r.context.Destination.Client)
+	useV2vForTransfer, vErr := r.context.Plan.ShouldUseV2vForTransfer(r.vm.Ref)
 	if vErr != nil {
 		err = vErr
 		return

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -248,7 +248,7 @@ func (r *Scheduler) migratesSharedDisks(vmStatus *plan.VMStatus) bool {
 }
 
 func (r *Scheduler) cost(vm *model.VM, vmStatus *plan.VMStatus) int {
-	useV2vForTransfer, _ := r.Plan.ShouldUseV2vForTransfer(vmStatus.Ref, r.Destination.Client)
+	useV2vForTransfer, _ := r.Plan.ShouldUseV2vForTransfer(vmStatus.Ref)
 	if useV2vForTransfer || r.Plan.IsUsingOffloadPlugin() {
 		switch vmStatus.Phase {
 		case CreateVM, PostHook, Completed:

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -376,7 +376,7 @@ func (r *Reconciler) ensureSecretForProvider(plan *api.Plan) error {
 // and returns whether the plan uses Shift storage so callers can pass the flag forward.
 func (r *Reconciler) validateNetAppShift(ctx *plancontext.Context) (err error) {
 	plan := ctx.Plan
-	src := plan.Referenced.Provider.Source
+	src := plan.Provider.Source
 	if src == nil || src.Type() != api.VSphere || plan.Map.Storage == nil {
 		return nil
 	}
@@ -384,6 +384,7 @@ func (r *Reconciler) validateNetAppShift(ctx *plancontext.Context) (err error) {
 	if err != nil {
 		return liberr.Wrap(err, "check NetApp Shift storage")
 	}
+	plan.Status.NetAppShiftDestination = shift
 	if !shift {
 		return nil
 	}
@@ -1003,17 +1004,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 	source := plan.Referenced.Provider.Source
 	checkMixedUsage := source != nil && source.Type() == api.VSphere && settings.Settings.Features.CopyOffload
 	planUsesOffload := checkMixedUsage && plan.IsUsingOffloadPlugin()
-	netAppShift := false
-	var err error
-	if source != nil && source.Type() == api.VSphere && plan.Map.Storage != nil {
-		netAppShift, err = plan.Map.Storage.HasNetAppShiftDestination(ctx.Destination.Client)
-		if err != nil {
-			return liberr.Wrap(err, "check NetApp Shift storage")
-		}
-	}
-	if err != nil {
-		return liberr.Wrap(err, "check NetApp Shift storage")
-	}
+	netAppShift := plan.HasNetAppShiftDestination()
 
 	// Referenced VMs.
 	for i := range plan.Spec.VMs {


### PR DESCRIPTION
Issue: the netapp shift resolution was called multiple times per VM and per plan reconcile which was very wasteful. Cache the result and only call the resolution once per plan reconcile.

Resolves: MTV-6366