### PR TITLE
MTV-5701 | Warn when vmkfstools may exceed hostd-tmp memory

### DIFF
--- a/pkg/controller/plan/hostdtmp.go
+++ b/pkg/controller/plan/hostdtmp.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
-	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web"
 	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
@@ -16,37 +15,37 @@ import (
 const (
 	HostdTmpMemoryLow = "HostdTmpMemoryLow"
 
-	// Default ESXi hostd-tmp memory limit. Concurrent vmkfstools can exceed this;
-	// see cmd/vsphere-copy-offload-populator/vmkfstools-wrapper/tweak-esxi-mem.sh.
-	defaultHostdTmpMB = 500
-
-	// Planned XCOPY disks per host at/above this count risks hostd-tmp pressure.
+	// Default ESXi hostd-tmp limit (~500MB). See tweak-esxi-mem.sh in the populator.
+	defaultHostdTmpMB         = 500
 	hostdTmpDiskWarnThreshold = 10
 )
 
-// validateHostdTmpMemory sets a non-blocking warning when a VSphere XCOPY plan
-// has enough disks per ESXi host that concurrent vmkfstools may exceed the
-// default hostd-tmp memory limit (~500MB).
+func shouldWarnHostdTmp(plannedDisks int) bool {
+	return plannedDisks >= hostdTmpDiskWarnThreshold
+}
+
+// validateHostdTmpMemory warns when an XCOPY plan may push concurrent vmkfstools
+// past the default ESXi hostd-tmp memory limit (~500MB).
 func (r *Reconciler) validateHostdTmpMemory(plan *api.Plan) error {
 	plan.Status.DeleteCondition(HostdTmpMemoryLow)
 
-	if plan.Referenced.Provider.Source == nil || plan.Referenced.Provider.Source.Type() != api.VSphere {
+	if plan.Provider.Source == nil || plan.Provider.Source.Type() != api.VSphere {
 		return nil
 	}
-	if !settings.Settings.Features.CopyOffload || !r.planUsesVSphereXcopyPopulator(plan) {
+	if !settings.Settings.CopyOffload || !r.planUsesVSphereXcopyPopulator(plan) {
 		return nil
 	}
-	if plan.Referenced.Map.Storage == nil {
+	if plan.Map.Storage == nil {
 		return nil
 	}
 
-	inventory, err := web.NewClient(plan.Referenced.Provider.Source)
+	inventory, err := web.NewClient(plan.Provider.Source)
 	if err != nil {
 		r.Log.V(1).Info("Skipping hostd-tmp check", "error", err)
 		return nil
 	}
 
-	diskCountByHost := map[string]int{}
+	disksByHost := map[string]int{}
 	for i := range plan.Spec.VMs {
 		vmRef := &plan.Spec.VMs[i].Ref
 		if vmRef.NotSet() {
@@ -57,7 +56,6 @@ func (r *Reconciler) validateHostdTmpMemory(plan *api.Plan) error {
 			if errors.As(vErr, &web.NotFoundError{}) || errors.As(vErr, &web.RefNotUniqueError{}) {
 				continue
 			}
-			r.Log.V(1).Info("Skipping hostd-tmp check for VM", "vm", vmRef.String(), "error", vErr)
 			continue
 		}
 		vm, ok := v.(*vsphere.VM)
@@ -65,29 +63,20 @@ func (r *Reconciler) validateHostdTmpMemory(plan *api.Plan) error {
 			continue
 		}
 		for _, disk := range vm.Disks {
-			mapping, found := plan.Referenced.Map.Storage.FindStorage(disk.Datastore.ID)
-			if found && mapping.OffloadPlugin != nil && mapping.OffloadPlugin.VSphereXcopyPluginConfig != nil {
-				diskCountByHost[vm.Host]++
+			m, found := plan.Map.Storage.FindStorage(disk.Datastore.ID)
+			if found && m.OffloadPlugin != nil && m.OffloadPlugin.VSphereXcopyPluginConfig != nil {
+				disksByHost[vm.Host]++
 			}
 		}
 	}
 
-	var items []string
-	var details []string
-	for hostID, planned := range diskCountByHost {
-		if planned < hostdTmpDiskWarnThreshold {
-			continue
+	var hosts []string
+	for hostID, n := range disksByHost {
+		if shouldWarnHostdTmp(n) {
+			hosts = append(hosts, fmt.Sprintf("%s (%d disks)", hostID, n))
 		}
-		name := hostID
-		host := &vsphere.Host{}
-		if fErr := inventory.Find(host, ref.Ref{ID: hostID}); fErr == nil && host.Name != "" {
-			name = host.Name
-		}
-		items = append(items, hostID)
-		details = append(details, fmt.Sprintf("%s (%d XCOPY disks)", name, planned))
 	}
-
-	if len(items) == 0 {
+	if len(hosts) == 0 {
 		return nil
 	}
 
@@ -97,10 +86,10 @@ func (r *Reconciler) validateHostdTmpMemory(plan *api.Plan) error {
 		Reason:   NotValid,
 		Category: Warn,
 		Message: fmt.Sprintf(
-			"Concurrent vmkfstools for this copy-offload migration may exceed the default ESXi hostd-tmp memory limit (~%dMB) on: %s. "+
-				"Raise hostd-tmp (e.g. run vmkfstools-wrapper/tweak-esxi-mem.sh 2048 on those hosts) before migrating.",
-			defaultHostdTmpMB, strings.Join(details, ", ")),
-		Items: items,
+			"Concurrent vmkfstools may exceed ESXi hostd-tmp (~%dMB) on: %s. "+
+				"Raise hostd-tmp (e.g. tweak-esxi-mem.sh 2048) before migrating.",
+			defaultHostdTmpMB, strings.Join(hosts, ", ")),
+		Items: hosts,
 	})
 	return nil
 }

--- a/pkg/controller/plan/hostdtmp.go
+++ b/pkg/controller/plan/hostdtmp.go
@@ -1,0 +1,106 @@
+package plan
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web"
+	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
+	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
+	"github.com/kubev2v/forklift/pkg/settings"
+)
+
+const (
+	HostdTmpMemoryLow = "HostdTmpMemoryLow"
+
+	// Default ESXi hostd-tmp memory limit. Concurrent vmkfstools can exceed this;
+	// see cmd/vsphere-copy-offload-populator/vmkfstools-wrapper/tweak-esxi-mem.sh.
+	defaultHostdTmpMB = 500
+
+	// Planned XCOPY disks per host at/above this count risks hostd-tmp pressure.
+	hostdTmpDiskWarnThreshold = 10
+)
+
+// validateHostdTmpMemory sets a non-blocking warning when a VSphere XCOPY plan
+// has enough disks per ESXi host that concurrent vmkfstools may exceed the
+// default hostd-tmp memory limit (~500MB).
+func (r *Reconciler) validateHostdTmpMemory(plan *api.Plan) error {
+	plan.Status.DeleteCondition(HostdTmpMemoryLow)
+
+	if plan.Referenced.Provider.Source == nil || plan.Referenced.Provider.Source.Type() != api.VSphere {
+		return nil
+	}
+	if !settings.Settings.Features.CopyOffload || !r.planUsesVSphereXcopyPopulator(plan) {
+		return nil
+	}
+	if plan.Referenced.Map.Storage == nil {
+		return nil
+	}
+
+	inventory, err := web.NewClient(plan.Referenced.Provider.Source)
+	if err != nil {
+		r.Log.V(1).Info("Skipping hostd-tmp check", "error", err)
+		return nil
+	}
+
+	diskCountByHost := map[string]int{}
+	for i := range plan.Spec.VMs {
+		vmRef := &plan.Spec.VMs[i].Ref
+		if vmRef.NotSet() {
+			continue
+		}
+		v, vErr := inventory.VM(vmRef)
+		if vErr != nil {
+			if errors.As(vErr, &web.NotFoundError{}) || errors.As(vErr, &web.RefNotUniqueError{}) {
+				continue
+			}
+			r.Log.V(1).Info("Skipping hostd-tmp check for VM", "vm", vmRef.String(), "error", vErr)
+			continue
+		}
+		vm, ok := v.(*vsphere.VM)
+		if !ok || vm.Host == "" {
+			continue
+		}
+		for _, disk := range vm.Disks {
+			mapping, found := plan.Referenced.Map.Storage.FindStorage(disk.Datastore.ID)
+			if found && mapping.OffloadPlugin != nil && mapping.OffloadPlugin.VSphereXcopyPluginConfig != nil {
+				diskCountByHost[vm.Host]++
+			}
+		}
+	}
+
+	var items []string
+	var details []string
+	for hostID, planned := range diskCountByHost {
+		if planned < hostdTmpDiskWarnThreshold {
+			continue
+		}
+		name := hostID
+		host := &vsphere.Host{}
+		if fErr := inventory.Find(host, ref.Ref{ID: hostID}); fErr == nil && host.Name != "" {
+			name = host.Name
+		}
+		items = append(items, hostID)
+		details = append(details, fmt.Sprintf("%s (%d XCOPY disks)", name, planned))
+	}
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	plan.Status.SetCondition(libcnd.Condition{
+		Type:     HostdTmpMemoryLow,
+		Status:   True,
+		Reason:   NotValid,
+		Category: Warn,
+		Message: fmt.Sprintf(
+			"Concurrent vmkfstools for this copy-offload migration may exceed the default ESXi hostd-tmp memory limit (~%dMB) on: %s. "+
+				"Raise hostd-tmp (e.g. run vmkfstools-wrapper/tweak-esxi-mem.sh 2048 on those hosts) before migrating.",
+			defaultHostdTmpMB, strings.Join(details, ", ")),
+		Items: items,
+	})
+	return nil
+}

--- a/pkg/controller/plan/hostdtmp.go
+++ b/pkg/controller/plan/hostdtmp.go
@@ -14,18 +14,29 @@ import (
 
 const (
 	HostdTmpMemoryLow = "HostdTmpMemoryLow"
-
-	// Default ESXi hostd-tmp limit (~500MB). See tweak-esxi-mem.sh in the populator.
-	defaultHostdTmpMB         = 500
-	hostdTmpDiskWarnThreshold = 10
 )
 
-func shouldWarnHostdTmp(plannedDisks int) bool {
-	return plannedDisks >= hostdTmpDiskWarnThreshold
+func shouldWarnHostdTmp(plannedDisks, maxInFlight int) bool {
+	if maxInFlight <= 0 {
+		return false
+	}
+	return plannedDisks >= maxInFlight
+}
+
+// xcopyRuntimeHosts returns ESXi host IDs where vmkfstools for an XCOPY disk may run.
+// Dedicated migration hosts from the storage map take precedence over the VM host.
+func xcopyRuntimeHosts(vm *vsphere.VM, config *api.VSphereXcopyPluginConfig) []string {
+	if config != nil && len(config.DedicatedMigrationHosts) > 0 {
+		return config.DedicatedMigrationHosts
+	}
+	if vm.Host != "" {
+		return []string{vm.Host}
+	}
+	return nil
 }
 
 // validateHostdTmpMemory warns when an XCOPY plan may push concurrent vmkfstools
-// past the default ESXi hostd-tmp memory limit (~500MB).
+// past the ESXi hostd-tmp memory limit on a migration host.
 func (r *Reconciler) validateHostdTmpMemory(plan *api.Plan) error {
 	plan.Status.DeleteCondition(HostdTmpMemoryLow)
 
@@ -45,6 +56,7 @@ func (r *Reconciler) validateHostdTmpMemory(plan *api.Plan) error {
 		return nil
 	}
 
+	maxInFlight := settings.Settings.MaxInFlight
 	disksByHost := map[string]int{}
 	for i := range plan.Spec.VMs {
 		vmRef := &plan.Spec.VMs[i].Ref
@@ -59,21 +71,26 @@ func (r *Reconciler) validateHostdTmpMemory(plan *api.Plan) error {
 			continue
 		}
 		vm, ok := v.(*vsphere.VM)
-		if !ok || vm.Host == "" {
+		if !ok {
 			continue
 		}
 		for _, disk := range vm.Disks {
 			m, found := plan.Map.Storage.FindStorage(disk.Datastore.ID)
-			if found && m.OffloadPlugin != nil && m.OffloadPlugin.VSphereXcopyPluginConfig != nil {
-				disksByHost[vm.Host]++
+			if !found || m.OffloadPlugin == nil || m.OffloadPlugin.VSphereXcopyPluginConfig == nil {
+				continue
+			}
+			for _, hostID := range xcopyRuntimeHosts(vm, m.OffloadPlugin.VSphereXcopyPluginConfig) {
+				disksByHost[hostID]++
 			}
 		}
 	}
 
 	var hosts []string
+	var items []string
 	for hostID, n := range disksByHost {
-		if shouldWarnHostdTmp(n) {
+		if shouldWarnHostdTmp(n, maxInFlight) {
 			hosts = append(hosts, fmt.Sprintf("%s (%d disks)", hostID, n))
+			items = append(items, hostID)
 		}
 	}
 	if len(hosts) == 0 {
@@ -86,10 +103,10 @@ func (r *Reconciler) validateHostdTmpMemory(plan *api.Plan) error {
 		Reason:   NotValid,
 		Category: Warn,
 		Message: fmt.Sprintf(
-			"Concurrent vmkfstools may exceed ESXi hostd-tmp (~%dMB) on: %s. "+
-				"Raise hostd-tmp (e.g. tweak-esxi-mem.sh 2048) before migrating.",
-			defaultHostdTmpMB, strings.Join(hosts, ", ")),
-		Items: hosts,
+			"Concurrent vmkfstools may exceed ESXi hostd-tmp memory on: %s. "+
+				"Raise hostd-tmp if needed (see tweak-esxi-mem.sh in vsphere-copy-offload-populator).",
+			strings.Join(hosts, ", ")),
+		Items: items,
 	})
 	return nil
 }

--- a/pkg/controller/plan/hostdtmp_test.go
+++ b/pkg/controller/plan/hostdtmp_test.go
@@ -3,13 +3,37 @@ package plan
 import (
 	"testing"
 
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
 	"github.com/onsi/gomega"
 )
 
 func TestShouldWarnHostdTmp(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	g.Expect(shouldWarnHostdTmp(9)).To(gomega.BeFalse())
-	g.Expect(shouldWarnHostdTmp(10)).To(gomega.BeTrue())
-	g.Expect(shouldWarnHostdTmp(25)).To(gomega.BeTrue())
+	for _, tc := range []struct {
+		planned, maxInFlight int
+		want                 bool
+	}{
+		{9, 10, false},
+		{10, 10, true},
+		{25, 10, true},
+		{19, 20, false},
+		{20, 20, true},
+		{10, 0, false},
+	} {
+		g.Expect(shouldWarnHostdTmp(tc.planned, tc.maxInFlight)).
+			To(gomega.Equal(tc.want), "planned=%d maxInFlight=%d", tc.planned, tc.maxInFlight)
+	}
+}
+
+func TestXcopyRuntimeHosts(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	vm := &vsphere.VM{VM1: vsphere.VM1{Host: "vm-host"}}
+
+	g.Expect(xcopyRuntimeHosts(vm, nil)).To(gomega.Equal([]string{"vm-host"}))
+	g.Expect(xcopyRuntimeHosts(&vsphere.VM{}, nil)).To(gomega.BeEmpty())
+	g.Expect(xcopyRuntimeHosts(vm, &api.VSphereXcopyPluginConfig{
+		DedicatedMigrationHosts: []string{"dedicated-a", "dedicated-b"},
+	})).To(gomega.Equal([]string{"dedicated-a", "dedicated-b"}))
 }

--- a/pkg/controller/plan/hostdtmp_test.go
+++ b/pkg/controller/plan/hostdtmp_test.go
@@ -1,0 +1,16 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestHostdTmpDiskWarnThreshold(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	g.Expect(defaultHostdTmpMB).To(gomega.Equal(500))
+	g.Expect(hostdTmpDiskWarnThreshold).To(gomega.Equal(10))
+	g.Expect(10 >= hostdTmpDiskWarnThreshold).To(gomega.BeTrue())
+	g.Expect(9 >= hostdTmpDiskWarnThreshold).To(gomega.BeFalse())
+}

--- a/pkg/controller/plan/hostdtmp_test.go
+++ b/pkg/controller/plan/hostdtmp_test.go
@@ -6,11 +6,10 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func TestHostdTmpDiskWarnThreshold(t *testing.T) {
+func TestShouldWarnHostdTmp(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	g.Expect(defaultHostdTmpMB).To(gomega.Equal(500))
-	g.Expect(hostdTmpDiskWarnThreshold).To(gomega.Equal(10))
-	g.Expect(10 >= hostdTmpDiskWarnThreshold).To(gomega.BeTrue())
-	g.Expect(9 >= hostdTmpDiskWarnThreshold).To(gomega.BeFalse())
+	g.Expect(shouldWarnHostdTmp(9)).To(gomega.BeFalse())
+	g.Expect(shouldWarnHostdTmp(10)).To(gomega.BeTrue())
+	g.Expect(shouldWarnHostdTmp(25)).To(gomega.BeTrue())
 }

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -272,7 +272,7 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 		return err
 	}
 
-	// Warn when concurrent vmkfstools may exceed ESXi hostd-tmp memory (~500MB)
+	// Warn when concurrent vmkfstools may exceed ESXi hostd-tmp memory
 	if err = r.validateHostdTmpMemory(plan); err != nil {
 		return err
 	}

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -272,6 +272,11 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 		return err
 	}
 
+	// Warn when concurrent vmkfstools may exceed ESXi hostd-tmp memory (~500MB)
+	if err = r.validateHostdTmpMemory(plan); err != nil {
+		return err
+	}
+
 	// Validate conversion temp storage configuration
 	if err = r.validateConversionTempStorage(plan); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Adds a non-blocking plan Warn (`HostdTmpMemoryLow`) for VSphere copy-offload (XCOPY) plans when an ESXi host has ≥10 planned XCOPY disks.
- Points operators at raising `hostd-tmp` (default ~500MB) via `vmkfstools-wrapper/tweak-esxi-mem.sh`, matching the populator troubleshooting guidance.
- Same style as the MTV-5700 Disk.MaxLUN preflight warning.

## Test plan
- [ ] Unit: `go test ./pkg/controller/plan/ -run TestHostdTmp`
- [ ] Create an XCOPY plan with a host that has ≥10 XCOPY-mapped disks → expect `HostdTmpMemoryLow` Warn on the Plan
- [ ] Same plan with fewer than 10 disks on each host → no `HostdTmpMemoryLow` condition
- [ ] Non-XCOPY / non-vSphere plan → no condition

Resolves: MTV-5701

Made with [Cursor](https://cursor.com)