### PR TITLE
MTV-6301 | fix(metrics): re-emit xcopy per-disk metrics from forklift-controller

### DIFF
--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/vsphere_xcopy_volumepopulator.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/vsphere_xcopy_volumepopulator.go
@@ -44,6 +44,20 @@ type VSphereXcopyVolumePopulatorStatus struct {
 	XcopyUsed string `json:"xcopyUsed,omitempty"`
 	// +optional
 	VibVersion string `json:"vibVersion,omitempty"`
+	// +optional
+	CopyDurationSeconds string `json:"copyDurationSeconds,omitempty"`
+	// +optional
+	Result string `json:"result,omitempty"`
+	// +optional
+	StorageVendor string `json:"storageVendor,omitempty"`
+	// +optional
+	CloneMethod string `json:"cloneMethod,omitempty"`
+	// +optional
+	StorageProtocol string `json:"storageProtocol,omitempty"`
+	// +optional
+	ProvisionedBytes string `json:"provisionedBytes,omitempty"`
+	// +optional
+	AllocatedBytes string `json:"allocatedBytes,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -10696,7 +10696,21 @@ spec:
             type: object
           status:
             properties:
+              allocatedBytes:
+                type: string
+              cloneMethod:
+                type: string
+              copyDurationSeconds:
+                type: string
               progress:
+                type: string
+              provisionedBytes:
+                type: string
+              result:
+                type: string
+              storageProtocol:
+                type: string
+              storageVendor:
                 type: string
               vibVersion:
                 type: string

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -10696,7 +10696,21 @@ spec:
             type: object
           status:
             properties:
+              allocatedBytes:
+                type: string
+              cloneMethod:
+                type: string
+              copyDurationSeconds:
+                type: string
               progress:
+                type: string
+              provisionedBytes:
+                type: string
+              result:
+                type: string
+              storageProtocol:
+                type: string
+              storageVendor:
                 type: string
               vibVersion:
                 type: string

--- a/operator/config/crd/bases/forklift.konveyor.io_vspherexcopyvolumepopulators.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_vspherexcopyvolumepopulators.yaml
@@ -69,7 +69,21 @@ spec:
             type: object
           status:
             properties:
+              allocatedBytes:
+                type: string
+              cloneMethod:
+                type: string
+              copyDurationSeconds:
+                type: string
               progress:
+                type: string
+              provisionedBytes:
+                type: string
+              result:
+                type: string
+              storageProtocol:
+                type: string
+              storageVendor:
                 type: string
               vibVersion:
                 type: string

--- a/pkg/apis/forklift/v1beta1/vsphere_xcopy_volumepopulator.go
+++ b/pkg/apis/forklift/v1beta1/vsphere_xcopy_volumepopulator.go
@@ -44,6 +44,20 @@ type VSphereXcopyVolumePopulatorStatus struct {
 	XcopyUsed string `json:"xcopyUsed,omitempty"`
 	// +optional
 	VibVersion string `json:"vibVersion,omitempty"`
+	// +optional
+	CopyDurationSeconds string `json:"copyDurationSeconds,omitempty"`
+	// +optional
+	Result string `json:"result,omitempty"`
+	// +optional
+	StorageVendor string `json:"storageVendor,omitempty"`
+	// +optional
+	CloneMethod string `json:"cloneMethod,omitempty"`
+	// +optional
+	StorageProtocol string `json:"storageProtocol,omitempty"`
+	// +optional
+	ProvisionedBytes string `json:"provisionedBytes,omitempty"`
+	// +optional
+	AllocatedBytes string `json:"allocatedBytes,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -89,6 +89,7 @@ func Add(mgr manager.Manager) error {
 
 	// Gather migration metrics
 	metrics.RecordMigrationMetrics(mgr.GetClient())
+	metrics.RecordXcopyMetrics(mgr.GetClient())
 
 	return nil
 }

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1912,8 +1912,19 @@ func (r *Builder) PopulatorOffloadInfo(pvc *core.PersistentVolumeClaim) (map[str
 		return nil, err
 	}
 	info := make(map[string]string)
-	if populatorCr.Status.XcopyUsed != "" {
-		info["xcopyUsed"] = populatorCr.Status.XcopyUsed
+	for key, value := range map[string]string{
+		"xcopyUsed":           populatorCr.Status.XcopyUsed,
+		"copyDurationSeconds": populatorCr.Status.CopyDurationSeconds,
+		"result":              populatorCr.Status.Result,
+		"storageVendor":       populatorCr.Status.StorageVendor,
+		"cloneMethod":         populatorCr.Status.CloneMethod,
+		"storageProtocol":     populatorCr.Status.StorageProtocol,
+		"provisionedBytes":    populatorCr.Status.ProvisionedBytes,
+		"allocatedBytes":      populatorCr.Status.AllocatedBytes,
+	} {
+		if value != "" {
+			info[key] = value
+		}
 	}
 	return info, nil
 }

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -1225,6 +1225,56 @@ var _ = Describe("PopulatorOffloadInfo", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should return all completion metric fields when set", func() {
+		populatorCr := &v1beta1.VSphereXcopyVolumePopulator{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "test-pop",
+				Namespace: "test",
+				Labels: map[string]string{
+					"migration": "123",
+					"vmdkKey":   "2000",
+					"vmID":      "vm-1",
+				},
+			},
+			Spec: v1beta1.VSphereXcopyVolumePopulatorSpec{
+				VmId: "vm-1",
+			},
+			Status: v1beta1.VSphereXcopyVolumePopulatorStatus{
+				Progress:            "100",
+				XcopyUsed:           "1",
+				CopyDurationSeconds: "42.5",
+				Result:              "success",
+				StorageVendor:       "ontap",
+				CloneMethod:         "vib",
+				StorageProtocol:     "iscsi",
+				ProvisionedBytes:    "1.073741824e+10",
+				AllocatedBytes:      "5.36870912e+09",
+			},
+		}
+		builder := createBuilder(populatorCr)
+		pvc := &core.PersistentVolumeClaim{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "test-pvc",
+				Namespace: "test",
+				Labels: map[string]string{
+					"vmdkKey": "2000",
+					"vmID":    "vm-1",
+				},
+			},
+		}
+
+		info, err := builder.PopulatorOffloadInfo(pvc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info).To(HaveKeyWithValue("xcopyUsed", "1"))
+		Expect(info).To(HaveKeyWithValue("copyDurationSeconds", "42.5"))
+		Expect(info).To(HaveKeyWithValue("result", "success"))
+		Expect(info).To(HaveKeyWithValue("storageVendor", "ontap"))
+		Expect(info).To(HaveKeyWithValue("cloneMethod", "vib"))
+		Expect(info).To(HaveKeyWithValue("storageProtocol", "iscsi"))
+		Expect(info).To(HaveKeyWithValue("provisionedBytes", "1.073741824e+10"))
+		Expect(info).To(HaveKeyWithValue("allocatedBytes", "5.36870912e+09"))
+	})
+
 	It("should return xcopyUsed=0 when xcopy was not used", func() {
 		populatorCr := &v1beta1.VSphereXcopyVolumePopulator{
 			ObjectMeta: meta.ObjectMeta{

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -947,8 +947,9 @@ func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolum
 	bodyStr := string(body)
 
 	// For xcopy populator: detect completion metrics from the scraped body.
+	var completion *completionData
 	if populatorKind == api.VSphereXcopyVolumePopulatorKind && !c.metrics.isCompletionRecorded(pvc.UID) {
-		c.parseAndRecordCompletion(bodyStr, pvc, cr)
+		completion = c.parseAndRecordCompletion(bodyStr, pvc, cr)
 	}
 
 	gvr := schema.GroupVersionResource{
@@ -1013,6 +1014,31 @@ func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolum
 		}
 	}
 
+	if completion != nil {
+		for field, value := range map[string]string{
+			"copyDurationSeconds": completion.duration,
+			"result":              completion.result,
+			"storageVendor":       completion.vendor,
+			"cloneMethod":         completion.method,
+			"storageProtocol":     completion.protocol,
+			"provisionedBytes":    completion.provisionedBytes,
+			"allocatedBytes":      completion.allocatedBytes,
+		} {
+			if value != "" {
+				if err := unstructured.SetNestedField(latestPopulator.Object, value, "status", field); err != nil {
+					klog.V(5).Info("Failed to update ", field, ": ", err)
+				} else {
+					dirty = true
+				}
+			}
+		}
+		if err := unstructured.SetNestedField(latestPopulator.Object, "true", "metadata", "labels", "forklift.konveyor.io/offload-completed"); err != nil {
+			klog.V(5).Info("Failed to set offload-completed label: ", err)
+		} else {
+			dirty = true
+		}
+	}
+
 	if !dirty {
 		return nil
 	}
@@ -1029,16 +1055,28 @@ func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolum
 	return nil
 }
 
+type completionData struct {
+	result           string
+	vendor           string
+	method           string
+	xcopy            string
+	protocol         string
+	duration         string
+	provisionedBytes string
+	allocatedBytes   string
+}
+
 // parseAndRecordCompletion extracts completion metrics from the populator pod's /metrics output.
 // The presence of copy_duration_seconds signals that the copy finished (success or failure).
-func (c *controller) parseAndRecordCompletion(body string, pvc *corev1.PersistentVolumeClaim, cr *unstructured.Unstructured) {
+// Returns the parsed data so the caller can persist it to the CR, or nil if no completion detected.
+func (c *controller) parseAndRecordCompletion(body string, pvc *corev1.PersistentVolumeClaim, cr *unstructured.Unstructured) *completionData {
 	ownerUID := string(pvc.UID)
 
 	// Use copy_duration_seconds as the completion signal — emitted on both success and failure.
 	durationRegex := regexp.MustCompile(`vsphere_xcopy_volume_populator_copy_duration_seconds\{[^}]*owner_uid="` + ownerUID + `"[^}]*\} ([0-9.]+)`)
 	durationMatch := durationRegex.FindStringSubmatch(body)
 	if durationMatch == nil {
-		return
+		return nil
 	}
 
 	duration, _ := strconv.ParseFloat(durationMatch[1], 64)
@@ -1047,13 +1085,16 @@ func (c *controller) parseAndRecordCompletion(body string, pvc *corev1.Persisten
 
 	// Parse source disk bytes by type
 	var provisionedBytes, allocatedBytes float64
+	var provisionedBytesStr, allocatedBytesStr string
 	provisionedRegex := regexp.MustCompile(`vsphere_xcopy_volume_populator_source_disk_bytes\{[^}]*owner_uid="` + ownerUID + `"[^}]*type="provisioned"[^}]*\} ([0-9.e+]+)`)
 	if m := provisionedRegex.FindStringSubmatch(body); m != nil {
 		provisionedBytes, _ = strconv.ParseFloat(m[1], 64)
+		provisionedBytesStr = fmt.Sprintf("%g", provisionedBytes)
 	}
 	allocatedRegex := regexp.MustCompile(`vsphere_xcopy_volume_populator_source_disk_bytes\{[^}]*owner_uid="` + ownerUID + `"[^}]*type="datastore_allocated"[^}]*\} ([0-9.e+]+)`)
 	if m := allocatedRegex.FindStringSubmatch(body); m != nil {
 		allocatedBytes, _ = strconv.ParseFloat(m[1], 64)
+		allocatedBytesStr = fmt.Sprintf("%g", allocatedBytes)
 	}
 
 	// Parse labels from the duration metric line
@@ -1065,6 +1106,17 @@ func (c *controller) parseAndRecordCompletion(body string, pvc *corev1.Persisten
 	protocol := extractLabel(durationLine, "storage_protocol")
 
 	c.metrics.recordCompletionFromScrape(pvc.UID, result, migration, ownerUID, vendor, method, xcopy, protocol, duration, provisionedBytes, allocatedBytes)
+
+	return &completionData{
+		result:           result,
+		vendor:           vendor,
+		method:           method,
+		xcopy:            xcopy,
+		protocol:         protocol,
+		duration:         durationMatch[1],
+		provisionedBytes: provisionedBytesStr,
+		allocatedBytes:   allocatedBytesStr,
+	}
 }
 
 // extractLabel extracts a label value from a Prometheus metric line.

--- a/pkg/monitoring/metrics/forklift-controller/metrics.go
+++ b/pkg/monitoring/metrics/forklift-controller/metrics.go
@@ -168,4 +168,54 @@ var (
 			"target",
 		},
 	)
+
+	// 'result' - [success, failure]
+	// 'migration' - [Migration UID]
+	// 'owner_uid' - [PVC UID]
+	// 'storage_vendor' - [ontap, powermax, ...]
+	// 'clone_method' - [vib, vddk]
+	// 'xcopy_used' - [0, 1]
+	// 'storage_protocol' - [iscsi, fc, nfs]
+	// 'vib_version' - [VIB version string, "unknown"]
+	xcopyDurationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "mtv_vsphere_xcopy_volume_populator_copy_duration_seconds",
+		Help: "Duration of copy-offload operation in seconds per disk",
+	},
+		[]string{
+			"result",
+			"migration",
+			"owner_uid",
+			"storage_vendor",
+			"clone_method",
+			"xcopy_used",
+			"storage_protocol",
+			"vib_version",
+		},
+	)
+
+	// 'result' - [success, failure]
+	// 'migration' - [Migration UID]
+	// 'owner_uid' - [PVC UID]
+	// 'storage_vendor' - [ontap, powermax, ...]
+	// 'clone_method' - [vib, vddk]
+	// 'xcopy_used' - [0, 1]
+	// 'storage_protocol' - [iscsi, fc, nfs]
+	// 'vib_version' - [VIB version string, "unknown"]
+	// 'type' - [provisioned, datastore_allocated]
+	xcopySourceDiskBytesGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "mtv_vsphere_xcopy_volume_populator_source_disk_bytes",
+		Help: "Source disk size in bytes per disk. type=provisioned is guest-visible size; type=datastore_allocated is actual data on datastore",
+	},
+		[]string{
+			"result",
+			"migration",
+			"owner_uid",
+			"storage_vendor",
+			"clone_method",
+			"xcopy_used",
+			"storage_protocol",
+			"vib_version",
+			"type",
+		},
+	)
 )

--- a/pkg/monitoring/metrics/forklift-controller/xcopy_metrics.go
+++ b/pkg/monitoring/metrics/forklift-controller/xcopy_metrics.go
@@ -1,0 +1,105 @@
+package forklift_controller
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var processedXcopyCompletions = make(map[string]struct{})
+
+func RecordXcopyMetrics(c client.Client) {
+	go func() {
+		for {
+			time.Sleep(10 * time.Second)
+
+			populators := api.VSphereXcopyVolumePopulatorList{}
+			err := c.List(context.TODO(), &populators, client.MatchingLabels{"forklift.konveyor.io/offload-completed": "true"})
+			if err != nil {
+				klog.Errorf("Metrics xcopy populators list error: %v", err)
+				continue
+			}
+
+			for _, p := range populators.Items {
+				if p.Status.Result == "" {
+					continue
+				}
+
+				key := string(p.UID)
+				if _, exists := processedXcopyCompletions[key]; exists {
+					continue
+				}
+
+				migration := p.Labels["migration"]
+				ownerUID := ""
+				if len(p.OwnerReferences) > 0 {
+					ownerUID = string(p.OwnerReferences[0].UID)
+				}
+
+				result := p.Status.Result
+				vendor := p.Status.StorageVendor
+				method := p.Status.CloneMethod
+				xcopy := p.Status.XcopyUsed
+				protocol := p.Status.StorageProtocol
+				vibVersion := p.Status.VibVersion
+
+				if p.Status.CopyDurationSeconds != "" {
+					duration, err := strconv.ParseFloat(p.Status.CopyDurationSeconds, 64)
+					if err == nil {
+						xcopyDurationGauge.With(prometheus.Labels{
+							"result":           result,
+							"migration":        migration,
+							"owner_uid":        ownerUID,
+							"storage_vendor":   vendor,
+							"clone_method":     method,
+							"xcopy_used":       xcopy,
+							"storage_protocol": protocol,
+							"vib_version":      vibVersion,
+						}).Set(duration)
+					}
+				}
+
+				if p.Status.ProvisionedBytes != "" {
+					prov, err := strconv.ParseFloat(p.Status.ProvisionedBytes, 64)
+					if err == nil && prov > 0 {
+						xcopySourceDiskBytesGauge.With(prometheus.Labels{
+							"result":           result,
+							"migration":        migration,
+							"owner_uid":        ownerUID,
+							"storage_vendor":   vendor,
+							"clone_method":     method,
+							"xcopy_used":       xcopy,
+							"storage_protocol": protocol,
+							"vib_version":      vibVersion,
+							"type":             "provisioned",
+						}).Set(prov)
+					}
+				}
+
+				if p.Status.AllocatedBytes != "" {
+					alloc, err := strconv.ParseFloat(p.Status.AllocatedBytes, 64)
+					if err == nil && alloc > 0 {
+						xcopySourceDiskBytesGauge.With(prometheus.Labels{
+							"result":           result,
+							"migration":        migration,
+							"owner_uid":        ownerUID,
+							"storage_vendor":   vendor,
+							"clone_method":     method,
+							"xcopy_used":       xcopy,
+							"storage_protocol": protocol,
+							"vib_version":      vibVersion,
+							"type":             "datastore_allocated",
+						}).Set(alloc)
+					}
+				}
+
+				processedXcopyCompletions[key] = struct{}{}
+			}
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- Prometheus only scrapes the forklift-controller (:2112), not the populator-controller (:8082). Copy-offload completion metrics were invisible.
- Added 7 status fields to VSphereXcopyVolumePopulatorStatus to carry completion data (duration, result, vendor, method, protocol, bytes) from populator-controller to the CR.
- Forklift-controller now polls VSphereXcopyVolumePopulator CRs every 10s and emits per-disk `mtv_vsphere_xcopy_volume_populator_copy_duration_seconds` and `mtv_vsphere_xcopy_volume_populator_source_disk_bytes` gauges for all terminal states.

## Test plan
- [x] Unit test for `PopulatorOffloadInfo` covering all new status fields
- [x] `go build ./...` passes
- [x] End-to-end validated on cluster: manually patched CR status, confirmed metrics appear on `:2112/metrics`

Resolve: MTV-6301

🤖 Generated with [Claude Code](https://claude.com/claude-code)