### PR TITLE
MTV-6119 | Fix nil-pointer panic when source provider is deleted

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -594,7 +594,7 @@ func (r *Reconciler) validateNetworkMap(plan *api.Plan) (err error) {
 	}
 	// Check if we are preserving static IPs and give warning if we are mapping to Pod Network.
 	// The Pod network has different subnet than the source provider so the VMs might not be accessible.
-	if plan.Referenced.Provider.Source.SupportsPreserveStaticIps() && plan.Spec.PreserveStaticIPs {
+	if plan.Provider.Source != nil && plan.Provider.Source.SupportsPreserveStaticIps() && plan.Spec.PreserveStaticIPs {
 		var hasMappingToPodNetwork bool
 		for _, networkMap := range mp.Spec.Map {
 			if networkMap.Destination.Type == Pod {


### PR DESCRIPTION
The controller panicked with a nil-pointer dereference in plan validation
when the source provider was deleted while a plan referenced it. The
SupportsPreserveStaticIps() call was made without checking if
Provider.Source was nil.

Add a nil guard before calling SupportsPreserveStaticIps().

Resolves: MTV-6119