### PR TITLE
MTV-6225 | Propagate NAA affinity label to intermediate prime PVC

### DIFF
--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -83,7 +83,8 @@ const (
 
 	qemuGroup = 107
 
-	labelSourceHost = api.LabelSourceHost
+	labelSourceHost  = api.LabelSourceHost
+	labelTemplateNAA = "volume.csi.k8s.io/affinity-source-naa"
 )
 
 type empty struct{}
@@ -718,7 +719,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 			// If PVC' doesn't exist yet, create it
 			if pvcPrime == nil {
 				pvcPrimeLabels := make(map[string]string)
-				for _, key := range []string{"migration", "plan", "vmID"} {
+				for _, key := range []string{"migration", "plan", "vmID", labelTemplateNAA} {
 					if val, ok := pvc.Labels[key]; ok {
 						pvcPrimeLabels[key] = val
 					}


### PR DESCRIPTION
## Summary
- The `volume.csi.k8s.io/affinity-source-naa` label set on the target PVC for xcopy-offload migrations (`pkg/controller/plan/adapter/vsphere/builder.go`) was not being copied to the intermediate "prime" PVC created by the volume-populator machinery, so CSI drivers that use it for source/destination co-location (e.g. Dell CSM, used by PowerStore) couldn't see it on the prime PVC that actually triggers volume creation.
- Extends the existing allow-list of labels copied from the target PVC to the prime PVC (`migration`, `plan`, `vmID`) to also include `volume.csi.k8s.io/affinity-source-naa`, copied only when present on the source PVC.

Jira: https://redhat.atlassian.net/browse/MTV-6225

## Test plan
- [x] Deployed a build with the fix to a live OCP cluster's `forklift-volume-populator-controller` deployment
- [x] Ran an xcopy-offload migration and confirmed the prime PVC (`prime-<uid>`) now carries `volume.csi.k8s.io/affinity-source-naa` matching the target disk PVC
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)