### PR TITLE
fix(sioc): a bug with default values of vsphere storage io control

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -734,13 +734,23 @@ func applyNasDatastoreNfsInfo(info types.NasDatastoreInfo, ds *model.Datastore) 
 
 func applyIormConfiguration(info *types.StorageIORMInfo, ds *model.Datastore) {
 	ds.IORMEnabled = info.Enabled
-	ds.IORMCongestionThreshold = info.CongestionThreshold
+	// vSphere returns 0 when SIOC is disabled/unconfigured; downstream requires 5-100ms range, default 30ms
+	threshold := info.CongestionThreshold
+	if threshold < 5 {
+		threshold = 30
+	} else if threshold > 100 {
+		threshold = 100
+	}
+	ds.IORMCongestionThreshold = threshold
 	ds.IORMCongestionThresholdMode = model.IORMThresholdModeAutomatic
 	if model.IORMThresholdMode(info.CongestionThresholdMode) == model.IORMThresholdModeManual {
 		ds.IORMCongestionThresholdMode = model.IORMThresholdModeManual
 	}
+	// vSphere returns 0 when SIOC is disabled; valid range 50-100, default 90
 	pct := info.PercentOfPeakThroughput
-	if pct > 100 {
+	if pct < 50 {
+		pct = 90
+	} else if pct > 100 {
 		pct = 100
 	}
 	ds.IORMPercentOfPeakThroughput = pct


### PR DESCRIPTION
When IORMEnabled is false and SIOC has never been configured on the datastore, vSphere returns the zero value for CongestionThreshold.
The documented valid range (5–100ms) only applies when SIOC is actively enabled. The default 30ms.

There is a need to clamp it to avoid unexpected 0 values

Sources:
  - vSphere 7.0 - Set Storage I/O Control Threshold Value (https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/7-0/vsphere-resource-management/managing-storage-i-o-resources/set-storage-i-o-control-threshold-value-flex.html)
  - VMware KB - Setting the congestion Threshold Value
  (https://knowledge.broadcom.com/external/article/323063/setting-the-congestion-threshold-value-f.html)
  - govmomi StorageIORMInfo type

Signed-off-by: Igor Troyanovsky <itroyano@redhat.com>

Assisted-by: Claude 4.6
