### PR TITLE
MTV-6252 | Import OCP virtiofs PVC exports as CDI archives

### DIFF
--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -124,12 +124,12 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *v1.Secret, configMap *v1.Co
 		dataVolume.Annotations[planbase.AnnDiskSource] = fmt.Sprintf("%s/%s", pvc.Namespace, pvc.Name)
 		dataVolume.Annotations[planbase.AnnDiskIndex] = fmt.Sprintf("%d", diskIndex)
 
-		url := getExportURL(volume.Formats)
-		if url == "" {
+		url, contentType, ok := selectExportFormat(volume.Formats)
+		if !ok {
 			return nil, liberr.Wrap(fmt.Errorf("failed to get export URL, available formats: %v", volume.Formats))
 		}
-		storageClassName := storageMap[*pvc.Spec.StorageClassName].StorageClass
-		dataVolume.Spec = *createDataVolumeSpec(size, storageClassName, url, configMap.Name, secret.Name)
+		destStorage := storageMap[*pvc.Spec.StorageClassName]
+		dataVolume.Spec = *createDataVolumeSpec(size, destStorage, url, configMap.Name, secret.Name, contentType, pvc)
 
 		err = r.Destination.Client.Create(context.TODO(), dataVolume, &client.CreateOptions{})
 		if err != nil {
@@ -145,14 +145,24 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *v1.Secret, configMap *v1.Co
 	return dataVolumes, nil
 }
 
-func getExportURL(virtualMachineExportVolumeFormat []export.VirtualMachineExportVolumeFormat) (url string) {
-	for _, format := range virtualMachineExportVolumeFormat {
-		if format.Format == export.KubeVirtGz || format.Format == export.ArchiveGz {
-			return format.Url
+// selectExportFormat prefers a kubevirt disk image export when available.
+// Virtiofs / filesystem PVC volumes only expose ArchiveGz (tar.gz); those must be
+// imported with CDI contentType=archive so the destination PVC gets extracted files
+// rather than a disk.img.
+func selectExportFormat(formats []export.VirtualMachineExportVolumeFormat) (url string, contentType cdi.DataVolumeContentType, ok bool) {
+	var archiveURL string
+	for _, format := range formats {
+		switch format.Format {
+		case export.KubeVirtGz:
+			return format.Url, cdi.DataVolumeKubeVirt, true
+		case export.ArchiveGz:
+			archiveURL = format.Url
 		}
 	}
-
-	return ""
+	if archiveURL != "" {
+		return archiveURL, cdi.DataVolumeArchive, true
+	}
+	return "", "", false
 }
 
 // PodEnvironment implements base.Builder
@@ -640,8 +650,15 @@ func (r *Builder) getSourceVmFromDefinition(vmRef ref.Ref) (*cnv.VirtualMachine,
 	return nil, liberr.New("failed to find vm in manifest")
 }
 
-func createDataVolumeSpec(size resource.Quantity, storageClassName, url, configMap, secret string) *cdi.DataVolumeSpec {
-	return &cdi.DataVolumeSpec{
+func createDataVolumeSpec(
+	size resource.Quantity,
+	destStorage v1beta1.DestinationStorage,
+	url, configMap, secret string,
+	contentType cdi.DataVolumeContentType,
+	sourcePVC *core.PersistentVolumeClaim,
+) *cdi.DataVolumeSpec {
+	storageClassName := destStorage.StorageClass
+	spec := &cdi.DataVolumeSpec{
 		Source: &cdi.DataVolumeSource{
 			HTTP: &cdi.DataVolumeSourceHTTP{
 				URL:                url,
@@ -658,6 +675,29 @@ func createDataVolumeSpec(size resource.Quantity, storageClassName, url, configM
 			StorageClassName: &storageClassName,
 		},
 	}
+
+	if contentType == cdi.DataVolumeArchive {
+		// Archive imports expand a tar.gz into a Filesystem PVC (virtiofs / shared FS volumes).
+		spec.ContentType = cdi.DataVolumeArchive
+		fsMode := core.PersistentVolumeFilesystem
+		spec.Storage.VolumeMode = &fsMode
+	}
+
+	if destStorage.VolumeMode != "" {
+		volumeMode := destStorage.VolumeMode
+		spec.Storage.VolumeMode = &volumeMode
+	} else if contentType != cdi.DataVolumeArchive && sourcePVC != nil && sourcePVC.Spec.VolumeMode != nil {
+		volumeMode := *sourcePVC.Spec.VolumeMode
+		spec.Storage.VolumeMode = &volumeMode
+	}
+
+	if destStorage.AccessMode != "" {
+		spec.Storage.AccessModes = []core.PersistentVolumeAccessMode{destStorage.AccessMode}
+	} else if sourcePVC != nil && len(sourcePVC.Spec.AccessModes) > 0 {
+		spec.Storage.AccessModes = append([]core.PersistentVolumeAccessMode(nil), sourcePVC.Spec.AccessModes...)
+	}
+
+	return spec
 }
 
 func (r *Builder) SupportsVolumePopulators() bool {

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -681,12 +681,10 @@ func createDataVolumeSpec(
 		spec.ContentType = cdi.DataVolumeArchive
 		fsMode := core.PersistentVolumeFilesystem
 		spec.Storage.VolumeMode = &fsMode
-	}
-
-	if destStorage.VolumeMode != "" {
+	} else if destStorage.VolumeMode != "" {
 		volumeMode := destStorage.VolumeMode
 		spec.Storage.VolumeMode = &volumeMode
-	} else if contentType != cdi.DataVolumeArchive && sourcePVC != nil && sourcePVC.Spec.VolumeMode != nil {
+	} else if sourcePVC != nil && sourcePVC.Spec.VolumeMode != nil {
 		volumeMode := *sourcePVC.Spec.VolumeMode
 		spec.Storage.VolumeMode = &volumeMode
 	}

--- a/pkg/controller/plan/adapter/ocp/builder_test.go
+++ b/pkg/controller/plan/adapter/ocp/builder_test.go
@@ -470,3 +470,101 @@ func TestDataVolumes_ArchiveExportSetsContentType(t *testing.T) {
 		t.Errorf("expected source access modes preserved, got %#v", dv.Spec.Storage.AccessModes)
 	}
 }
+
+func TestDataVolumes_ArchiveExportKeepsFilesystemWithBlockDestination(t *testing.T) {
+	const (
+		ns      = "src-ns"
+		vmName  = "test-vm"
+		pvcName = "virtiofs-pvc"
+		scName  = "source-sc"
+	)
+
+	scheme := runtime.NewScheme()
+	_ = core.AddToScheme(scheme)
+	_ = export.AddToScheme(scheme)
+	_ = cdi.AddToScheme(scheme)
+
+	ocpType := api.OpenShift
+	storageClass := scName
+	fsMode := core.PersistentVolumeFilesystem
+	srcClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
+		&export.VirtualMachineExport{
+			ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: ns},
+			Status: &export.VirtualMachineExportStatus{
+				Links: &export.VirtualMachineExportLinks{
+					External: &export.VirtualMachineExportLink{
+						Cert: "cert",
+						Volumes: []export.VirtualMachineExportVolume{{
+							Name: pvcName,
+							Formats: []export.VirtualMachineExportVolumeFormat{
+								{Format: export.ArchiveGz, Url: "https://export.example/fs.tar.gz"},
+							},
+						}},
+					},
+				},
+			},
+		},
+		&core.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: core.PersistentVolumeClaimSpec{
+				StorageClassName: &storageClass,
+				VolumeMode:       &fsMode,
+				Resources: core.VolumeResourceRequirements{
+					Requests: core.ResourceList{core.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		},
+	).Build()
+	dstClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	plan := &api.Plan{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-plan"},
+		Spec:       api.PlanSpec{TargetNamespace: "target-ns"},
+	}
+	plan.Provider.Source = &api.Provider{Spec: api.ProviderSpec{Type: &ocpType}}
+	builder := &Builder{
+		Context: &plancontext.Context{
+			Plan: plan,
+			Map: struct {
+				Network *api.NetworkMap
+				Storage *api.StorageMap
+			}{
+				Storage: &api.StorageMap{
+					Spec: api.StorageMapSpec{
+						Map: []api.StoragePair{{
+							Source: ref.Ref{Name: scName},
+							Destination: api.DestinationStorage{
+								StorageClass: "dest-sc",
+								VolumeMode:   core.PersistentVolumeBlock,
+							},
+						}},
+					},
+				},
+			},
+			Destination: plancontext.Destination{Client: dstClient},
+			Log:         logging.WithName("ocp-builder-test"),
+		},
+		sourceClient: srcClient,
+	}
+
+	dvs, err := builder.DataVolumes(
+		ref.Ref{ID: "vm-1", Name: vmName, Namespace: ns},
+		&core.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret"}},
+		&core.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm"}},
+		&cdi.DataVolume{ObjectMeta: metav1.ObjectMeta{Namespace: "target-ns", Annotations: map[string]string{}}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dvs) != 1 {
+		t.Fatalf("expected 1 DataVolume, got %d", len(dvs))
+	}
+	dv := dvs[0]
+	if dv.Spec.ContentType != cdi.DataVolumeArchive {
+		t.Errorf("expected contentType archive, got %q", dv.Spec.ContentType)
+	}
+	if dv.Spec.Storage == nil || dv.Spec.Storage.VolumeMode == nil || *dv.Spec.Storage.VolumeMode != core.PersistentVolumeFilesystem {
+		t.Errorf("expected Filesystem volume mode for archive import, got %#v", dv.Spec.Storage)
+	}
+}

--- a/pkg/controller/plan/adapter/ocp/builder_test.go
+++ b/pkg/controller/plan/adapter/ocp/builder_test.go
@@ -325,3 +325,148 @@ func TestDataVolumes_PVCNameTemplate(t *testing.T) {
 		}
 	})
 }
+
+func TestSelectExportFormat(t *testing.T) {
+	t.Run("prefers kubevirt gzip over archive", func(t *testing.T) {
+		url, contentType, ok := selectExportFormat([]export.VirtualMachineExportVolumeFormat{
+			{Format: export.ArchiveGz, Url: "https://export.example/disk.tar.gz"},
+			{Format: export.KubeVirtGz, Url: "https://export.example/disk.gz"},
+		})
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if url != "https://export.example/disk.gz" {
+			t.Errorf("expected kubevirt url, got %q", url)
+		}
+		if contentType != cdi.DataVolumeKubeVirt {
+			t.Errorf("expected kubevirt content type, got %q", contentType)
+		}
+	})
+
+	t.Run("uses archive when only tar.gz is available", func(t *testing.T) {
+		url, contentType, ok := selectExportFormat([]export.VirtualMachineExportVolumeFormat{
+			{Format: export.ArchiveGz, Url: "https://export.example/fs.tar.gz"},
+			{Format: export.Dir, Url: "https://export.example/fs/"},
+		})
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if url != "https://export.example/fs.tar.gz" {
+			t.Errorf("expected archive url, got %q", url)
+		}
+		if contentType != cdi.DataVolumeArchive {
+			t.Errorf("expected archive content type, got %q", contentType)
+		}
+	})
+
+	t.Run("returns false when no supported format", func(t *testing.T) {
+		_, _, ok := selectExportFormat([]export.VirtualMachineExportVolumeFormat{
+			{Format: export.Dir, Url: "https://export.example/fs/"},
+		})
+		if ok {
+			t.Fatal("expected not ok")
+		}
+	})
+}
+
+func TestDataVolumes_ArchiveExportSetsContentType(t *testing.T) {
+	const (
+		ns      = "src-ns"
+		vmName  = "test-vm"
+		pvcName = "virtiofs-pvc"
+		scName  = "source-sc"
+	)
+
+	scheme := runtime.NewScheme()
+	_ = core.AddToScheme(scheme)
+	_ = export.AddToScheme(scheme)
+	_ = cdi.AddToScheme(scheme)
+
+	ocpType := api.OpenShift
+	storageClass := scName
+	fsMode := core.PersistentVolumeFilesystem
+	srcClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
+		&export.VirtualMachineExport{
+			ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: ns},
+			Status: &export.VirtualMachineExportStatus{
+				Links: &export.VirtualMachineExportLinks{
+					External: &export.VirtualMachineExportLink{
+						Cert: "cert",
+						Volumes: []export.VirtualMachineExportVolume{{
+							Name: pvcName,
+							Formats: []export.VirtualMachineExportVolumeFormat{
+								{Format: export.ArchiveGz, Url: "https://export.example/fs.tar.gz"},
+							},
+						}},
+					},
+				},
+			},
+		},
+		&core.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: core.PersistentVolumeClaimSpec{
+				StorageClassName: &storageClass,
+				VolumeMode:       &fsMode,
+				AccessModes:      []core.PersistentVolumeAccessMode{core.ReadWriteMany},
+				Resources: core.VolumeResourceRequirements{
+					Requests: core.ResourceList{core.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		},
+	).Build()
+	dstClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	plan := &api.Plan{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-plan"},
+		Spec:       api.PlanSpec{TargetNamespace: "target-ns"},
+	}
+	plan.Provider.Source = &api.Provider{Spec: api.ProviderSpec{Type: &ocpType}}
+	builder := &Builder{
+		Context: &plancontext.Context{
+			Plan: plan,
+			Map: struct {
+				Network *api.NetworkMap
+				Storage *api.StorageMap
+			}{
+				Storage: &api.StorageMap{
+					Spec: api.StorageMapSpec{
+						Map: []api.StoragePair{{
+							Source:      ref.Ref{Name: scName},
+							Destination: api.DestinationStorage{StorageClass: "dest-sc"},
+						}},
+					},
+				},
+			},
+			Destination: plancontext.Destination{Client: dstClient},
+			Log:         logging.WithName("ocp-builder-test"),
+		},
+		sourceClient: srcClient,
+	}
+
+	dvs, err := builder.DataVolumes(
+		ref.Ref{ID: "vm-1", Name: vmName, Namespace: ns},
+		&core.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret"}},
+		&core.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm"}},
+		&cdi.DataVolume{ObjectMeta: metav1.ObjectMeta{Namespace: "target-ns", Annotations: map[string]string{}}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dvs) != 1 {
+		t.Fatalf("expected 1 DataVolume, got %d", len(dvs))
+	}
+	dv := dvs[0]
+	if dv.Spec.ContentType != cdi.DataVolumeArchive {
+		t.Errorf("expected contentType archive, got %q", dv.Spec.ContentType)
+	}
+	if dv.Spec.Source == nil || dv.Spec.Source.HTTP == nil || dv.Spec.Source.HTTP.URL != "https://export.example/fs.tar.gz" {
+		t.Errorf("expected archive export URL, got %#v", dv.Spec.Source)
+	}
+	if dv.Spec.Storage == nil || dv.Spec.Storage.VolumeMode == nil || *dv.Spec.Storage.VolumeMode != core.PersistentVolumeFilesystem {
+		t.Errorf("expected Filesystem volume mode, got %#v", dv.Spec.Storage)
+	}
+	if len(dv.Spec.Storage.AccessModes) != 1 || dv.Spec.Storage.AccessModes[0] != core.ReadWriteMany {
+		t.Errorf("expected source access modes preserved, got %#v", dv.Spec.Storage.AccessModes)
+	}
+}


### PR DESCRIPTION
Virtiofs volumes only expose ArchiveGz. Set CDI contentType=archive so cold OCP→OCP migration copies filesystem PVCs correctly.

Ref: https://redhat.atlassian.net/browse/MTV-6252
Resolves: MTV-6252