### PR TITLE
MTV-6377 | Remove duplicate NAD validation and fix NAD pool reuse

### DIFF
--- a/pkg/controller/plan/adapter/base/network.go
+++ b/pkg/controller/plan/adapter/base/network.go
@@ -42,16 +42,28 @@ func NewNADPool() *NADPool {
 	}
 }
 
+func nadKey(dest api.DestinationNetwork) string {
+	if dest.Namespace == "" {
+		return dest.Name
+	}
+	return dest.Namespace + "/" + dest.Name
+}
+
 // Allocate picks the first Multus NAD not yet used on this VM.
 // pairsForSource are pre-filtered by source network (matched by ID or
 // name), so every pair shares the same source. Only pass Multus pairs;
 // for mixed-type routing use AllocateNetwork.
 func (p *NADPool) Allocate(pairsForSource []api.NetworkPair) (api.NetworkPair, bool) {
+	if len(pairsForSource) == 0 {
+		return api.NetworkPair{}, false
+	}
+
+	if len(pairsForSource) == 1 {
+		return pairsForSource[0], true
+	}
+
 	for _, pair := range pairsForSource {
-		key := pair.Destination.Namespace + "/" + pair.Destination.Name
-		if pair.Destination.Namespace == "" {
-			key = pair.Destination.Name
-		}
+		key := nadKey(pair.Destination)
 		if !p.used[key] {
 			p.used[key] = true
 			return pair, true
@@ -75,32 +87,27 @@ func AllocateNetwork(pool *NADPool, pairsForSource []api.NetworkPair) (api.Netwo
 	return pool.Allocate(nadPairs)
 }
 
-// ValidateNetworkDuplicates checks whether more than one NIC resolves to the
-// pod network or more than one NIC resolves to the same Multus NAD name.
-// With NAD pool mapping, duplicate NADs are only flagged when the pool for a
-// source network is exhausted (NIC count exceeds available NADs).
-func ValidateNetworkDuplicates(nicRefs []ref.Ref, networkMap *api.NetworkMap) (foundNadDup bool, foundPodDup bool) {
+// ValidatePodNetworkDuplicates reports whether more than one NIC resolves
+// to the pod network. Duplicate Multus NAD assignments are allowed.
+func ValidatePodNetworkDuplicates(nicRefs []ref.Ref, networkMap *api.NetworkMap) bool {
 	if networkMap == nil {
-		return
+		return false
 	}
 
 	pool := NewNADPool()
 	podCount := 0
-
 	for _, nicRef := range nicRefs {
-		pairsForSource := FindAllMappingsForNICRef(nicRef, networkMap)
-		pair, allocated := AllocateNetwork(pool, pairsForSource)
-		if !allocated {
-			if len(pairsForSource) > 0 {
-				foundNadDup = true
-			}
+		pairs := FindAllMappingsForNICRef(nicRef, networkMap)
+		if len(pairs) == 0 {
+			continue
+		}
+		pair, ok := AllocateNetwork(pool, pairs)
+		if !ok {
 			continue
 		}
 		if pair.Destination.Type == Pod {
 			podCount++
 		}
 	}
-
-	foundPodDup = podCount > 1
-	return
+	return podCount > 1
 }

--- a/pkg/controller/plan/adapter/base/network_test.go
+++ b/pkg/controller/plan/adapter/base/network_test.go
@@ -7,94 +7,94 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 )
 
-func TestValidateNetworkDuplicates_NilNetworkMap(t *testing.T) {
-	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nil, nil)
-	if foundNadDup || foundPodDup {
-		t.Errorf("nil map should return (false, false), got (%v, %v)", foundNadDup, foundPodDup)
+func TestValidatePodNetworkDuplicates_NilNetworkMap(t *testing.T) {
+	if ValidatePodNetworkDuplicates(nil, nil) {
+		t.Error("nil map should return false")
 	}
 }
 
-func TestValidateNetworkDuplicates_NoNICs(t *testing.T) {
+func TestValidatePodNetworkDuplicates_NoNICs(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{}}}
-	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nil, nm)
-	if foundNadDup || foundPodDup {
-		t.Errorf("empty NIC list should find no duplicates, got (%v, %v)", foundNadDup, foundPodDup)
+	if ValidatePodNetworkDuplicates(nil, nm) {
+		t.Error("empty NIC list should find no duplicates")
 	}
 }
 
-func TestValidateNetworkDuplicates_SinglePod(t *testing.T) {
+func TestValidatePodNetworkDuplicates_SinglePod(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{Type: "pod"}}, Destination: api.DestinationNetwork{Type: Pod}},
 	}}}
 	nicRefs := []ref.Ref{{Type: "pod"}}
-	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
-	if foundNadDup || foundPodDup {
-		t.Errorf("single pod NIC should find no duplicates, got (%v, %v)", foundNadDup, foundPodDup)
+	if ValidatePodNetworkDuplicates(nicRefs, nm) {
+		t.Error("single pod NIC should find no duplicates")
 	}
 }
 
-func TestValidateNetworkDuplicates_DuplicatePod(t *testing.T) {
+func TestValidatePodNetworkDuplicates_DuplicatePod(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{Type: "pod"}}, Destination: api.DestinationNetwork{Type: Pod}},
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
 	}}}
 	nicRefs := []ref.Ref{{Type: "pod"}, {ID: "net-1"}}
-	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
-	if foundNadDup {
-		t.Errorf("no NAD duplicates expected, got foundNadDup=true")
-	}
-	if !foundPodDup {
-		t.Errorf("two NICs mapped to pod should detect duplicate, got foundPodDup=false")
+	if !ValidatePodNetworkDuplicates(nicRefs, nm) {
+		t.Error("two NICs mapped to pod should detect duplicate")
 	}
 }
 
-func TestValidateNetworkDuplicates_DuplicateNAD_ByID(t *testing.T) {
+func TestValidatePodNetworkDuplicates_SameNADAllowed(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
 	}}}
 	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}}
-	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
-	if !foundNadDup {
-		t.Errorf("duplicate NAD (same source ID) should be detected, got foundNadDup=false")
-	}
-	if foundPodDup {
-		t.Errorf("no pod mapping, foundPodDup should be false, got true")
+	if ValidatePodNetworkDuplicates(nicRefs, nm) {
+		t.Error("duplicate NAD on same source should not be flagged")
 	}
 }
 
-func TestValidateNetworkDuplicates_DuplicateNAD_ByNameNamespace(t *testing.T) {
-	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{Namespace: "ns", Name: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{Namespace: "ns", Name: "net-2"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
-	}}}
-	nicRefs := []ref.Ref{{Namespace: "ns", Name: "net-1"}, {Namespace: "ns", Name: "net-2"}}
-	foundNadDup, _ := ValidateNetworkDuplicates(nicRefs, nm)
-	if !foundNadDup {
-		t.Errorf("two NIC refs mapped to same NAD should be detected, got foundNadDup=false")
-	}
-}
-
-func TestValidateNetworkDuplicates_DistinctNADs(t *testing.T) {
+func TestValidatePodNetworkDuplicates_DistinctNADs(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-2"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
 	}}}
 	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-2"}}
-	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
-	if foundNadDup || foundPodDup {
-		t.Errorf("distinct NADs should find no duplicates, got (%v, %v)", foundNadDup, foundPodDup)
+	if ValidatePodNetworkDuplicates(nicRefs, nm) {
+		t.Error("distinct NADs should find no pod duplicates")
 	}
 }
 
-func TestValidateNetworkDuplicates_UnmappedNICIgnored(t *testing.T) {
+func TestValidatePodNetworkDuplicates_UnmappedNICIgnored(t *testing.T) {
 	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
 	}}}
 	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-999"}}
-	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
-	if foundNadDup || foundPodDup {
-		t.Errorf("unmapped NIC should be ignored, got (%v, %v)", foundNadDup, foundPodDup)
+	if ValidatePodNetworkDuplicates(nicRefs, nm) {
+		t.Error("unmapped NIC should be ignored")
 	}
+}
+
+func TestValidatePodNetworkDuplicates_MultusBeforePod(t *testing.T) {
+	t.Run("single NIC with Multus then Pod resolves to pod without duplicate", func(t *testing.T) {
+		nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+			{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+			{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
+		}}}
+		nicRefs := []ref.Ref{{ID: "net-1"}}
+		if ValidatePodNetworkDuplicates(nicRefs, nm) {
+			t.Error("single NIC resolving to pod should not flag duplicate")
+		}
+	})
+
+	t.Run("two NICs resolving to pod triggers VMMultiplePodNetworkMappings", func(t *testing.T) {
+		nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
+			{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+			{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
+			{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-2"}}, Destination: api.DestinationNetwork{Type: Pod}},
+		}}}
+		nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-2"}}
+		if !ValidatePodNetworkDuplicates(nicRefs, nm) {
+			t.Error("two NICs mapped to pod should detect duplicate (VMMultiplePodNetworkMappings)")
+		}
+	})
 }
 
 // --- FindAllMappingsForNICRef ---
@@ -161,20 +161,39 @@ func TestNADPool_Allocate_DistinctNADs(t *testing.T) {
 	}
 }
 
-func TestNADPool_Allocate_PoolExhausted(t *testing.T) {
+func TestNADPool_Allocate_SameNADReused(t *testing.T) {
 	pairsForSource := []api.NetworkPair{
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
 	}
 	pool := NewNADPool()
 
+	pair1, allocated1 := pool.Allocate(pairsForSource)
+	pair2, allocated2 := pool.Allocate(pairsForSource)
+
+	if !allocated1 || !allocated2 {
+		t.Fatal("both allocations should succeed when reusing the same NAD")
+	}
+	if pair1.Destination.Name != "nad-a" || pair2.Destination.Name != "nad-a" {
+		t.Errorf("expected same NAD nad-a, got %s and %s", pair1.Destination.Name, pair2.Destination.Name)
+	}
+}
+
+func TestNADPool_Allocate_PoolDistinctThenExhausted(t *testing.T) {
+	pairsForSource := []api.NetworkPair{
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
+		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
+	}
+	pool := NewNADPool()
+
 	_, allocated1 := pool.Allocate(pairsForSource)
 	_, allocated2 := pool.Allocate(pairsForSource)
+	_, allocated3 := pool.Allocate(pairsForSource)
 
-	if !allocated1 {
-		t.Error("first allocation should succeed")
+	if !allocated1 || !allocated2 {
+		t.Fatal("first two allocations should succeed")
 	}
-	if allocated2 {
-		t.Error("second allocation should fail (pool exhausted)")
+	if allocated3 {
+		t.Error("third allocation should fail when pool is exhausted")
 	}
 }
 
@@ -235,58 +254,5 @@ func TestNADPool_Allocate_IndependentNetworks(t *testing.T) {
 	}
 	if pair1.Destination.Name != "nad-a" || pair2.Destination.Name != "nad-b" {
 		t.Errorf("unexpected assignments: %s, %s", pair1.Destination.Name, pair2.Destination.Name)
-	}
-}
-
-// --- ValidateNetworkDuplicates with NAD pool ---
-
-func TestValidateNetworkDuplicates_1toN_NoDuplicate(t *testing.T) {
-	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
-	}}}
-	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}}
-	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
-	if foundNadDup {
-		t.Error("with 2 NADs for 2 NICs, should not flag duplicate")
-	}
-	if foundPodDup {
-		t.Error("no pod mapping, should not flag pod duplicate")
-	}
-}
-
-func TestValidateNetworkDuplicates_1toN_PoolExhausted(t *testing.T) {
-	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
-	}}}
-	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}, {ID: "net-1"}}
-	foundNadDup, _ := ValidateNetworkDuplicates(nicRefs, nm)
-	if !foundNadDup {
-		t.Error("3 NICs with only 2 NADs should flag duplicate")
-	}
-}
-
-func TestValidateNetworkDuplicates_1toN_MixedNetworks(t *testing.T) {
-	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-b"}},
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-2"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-c"}},
-	}}}
-	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}, {ID: "net-2"}}
-	foundNadDup, foundPodDup := ValidateNetworkDuplicates(nicRefs, nm)
-	if foundNadDup || foundPodDup {
-		t.Errorf("sufficient NADs for all NICs, should find no duplicates, got (%v, %v)", foundNadDup, foundPodDup)
-	}
-}
-
-func TestValidateNetworkDuplicates_BackwardCompat_SingleRow(t *testing.T) {
-	nm := &api.NetworkMap{Spec: api.NetworkMapSpec{Map: []api.NetworkPair{
-		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"}},
-	}}}
-	nicRefs := []ref.Ref{{ID: "net-1"}, {ID: "net-1"}}
-	foundNadDup, _ := ValidateNetworkDuplicates(nicRefs, nm)
-	if !foundNadDup {
-		t.Error("single-row map with 2 NICs should still flag duplicate (backward compatible)")
 	}
 }

--- a/pkg/controller/plan/adapter/ocp/validator_test.go
+++ b/pkg/controller/plan/adapter/ocp/validator_test.go
@@ -146,12 +146,8 @@ func TestNICNetworkRefs_NoDuplicates(t *testing.T) {
 		t.Fatalf("expected 2 NIC refs, got %d", len(nicRefs))
 	}
 
-	foundNadDup, foundPodDup := planbase.ValidateNetworkDuplicates(nicRefs, plan.Referenced.Map.Network)
-	if foundNadDup {
-		t.Errorf("expected no NAD duplicates, got foundNadDup=true")
-	}
-	if foundPodDup {
-		t.Errorf("expected no pod duplicates, got foundPodDup=true")
+	if planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network) {
+		t.Errorf("expected no pod duplicates")
 	}
 }
 
@@ -197,9 +193,8 @@ func TestNICNetworkRefs_TwoNICsSameNAD(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	foundNadDup, _ := planbase.ValidateNetworkDuplicates(nicRefs, plan.Referenced.Map.Network)
-	if !foundNadDup {
-		t.Errorf("expected NAD duplicate detected, got foundNadDup=false")
+	if planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network) {
+		t.Errorf("expected no pod duplicate when two NICs map to same NAD")
 	}
 }
 
@@ -241,9 +236,8 @@ func TestNICNetworkRefs_TwoNICsSameSourceNetwork(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	foundNadDup, _ := planbase.ValidateNetworkDuplicates(nicRefs, plan.Referenced.Map.Network)
-	if !foundNadDup {
-		t.Errorf("expected NAD duplicate detected (two NICs on same source network), got foundNadDup=false")
+	if planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network) {
+		t.Errorf("expected no pod duplicate when two NICs on same source map to same NAD")
 	}
 }
 
@@ -288,9 +282,8 @@ func TestNICNetworkRefs_VMOnlyUsesOneOfDuplicateMappings(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	foundNadDup, _ := planbase.ValidateNetworkDuplicates(nicRefs, plan.Referenced.Map.Network)
-	if foundNadDup {
-		t.Errorf("expected no NAD duplicate (VM only uses one of the duplicate mappings), got foundNadDup=true")
+	if planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network) {
+		t.Errorf("expected no pod duplicate (VM only uses one of the duplicate mappings)")
 	}
 }
 
@@ -339,12 +332,8 @@ func TestNICNetworkRefs_PodAndMultus(t *testing.T) {
 		t.Fatalf("expected 2 NIC refs (pod + multus), got %d", len(nicRefs))
 	}
 
-	foundNadDup, foundPodDup := planbase.ValidateNetworkDuplicates(nicRefs, plan.Referenced.Map.Network)
-	if foundNadDup {
-		t.Errorf("expected no NAD duplicate (single multus NAD), got foundNadDup=true")
-	}
-	if foundPodDup {
-		t.Errorf("expected no pod duplicate (single pod network), got foundPodDup=true")
+	if planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network) {
+		t.Errorf("expected no pod duplicate (single pod network and single multus NAD)")
 	}
 }
 

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -394,7 +394,7 @@ var _ = Describe("vsphere validation tests", func() {
 		)
 	})
 
-	Describe("NICNetworkRefs + ValidateNetworkDuplicates", func() {
+	Describe("NICNetworkRefs + ValidatePodNetworkDuplicates", func() {
 		It("should return no refs for VM with no NICs", func() {
 			plan := createPlan()
 			ctx := plancontext.Context{
@@ -452,12 +452,11 @@ var _ = Describe("vsphere validation tests", func() {
 			validator := &Validator{Context: &ctx}
 			nicRefs, err := validator.NICNetworkRefs(ref.Ref{Name: "test"})
 			Expect(err).NotTo(HaveOccurred())
-			foundNadDup, foundPodDup := planbase.ValidateNetworkDuplicates(nicRefs, plan.Map.Network)
-			Expect(foundNadDup).To(BeFalse())
+			foundPodDup := planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network)
 			Expect(foundPodDup).To(BeFalse())
 		})
 
-		It("should detect duplicate when two NICs on same source network map to same NAD", func() {
+		It("should allow two NICs on same source network mapped to same NAD", func() {
 			plan := createPlan()
 			plan.Map.Network = &v1beta1.NetworkMap{
 				Spec: v1beta1.NetworkMapSpec{
@@ -490,11 +489,11 @@ var _ = Describe("vsphere validation tests", func() {
 			validator := &Validator{Context: &ctx}
 			nicRefs, err := validator.NICNetworkRefs(ref.Ref{Name: "test"})
 			Expect(err).NotTo(HaveOccurred())
-			foundNadDup, _ := planbase.ValidateNetworkDuplicates(nicRefs, plan.Map.Network)
-			Expect(foundNadDup).To(BeTrue())
+			foundPodDup := planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network)
+			Expect(foundPodDup).To(BeFalse())
 		})
 
-		It("should detect duplicate when two different source networks map to same NAD", func() {
+		It("should allow two different source networks mapped to same NAD", func() {
 			plan := createPlan()
 			plan.Map.Network = &v1beta1.NetworkMap{
 				Spec: v1beta1.NetworkMapSpec{
@@ -535,11 +534,11 @@ var _ = Describe("vsphere validation tests", func() {
 			validator := &Validator{Context: &ctx}
 			nicRefs, err := validator.NICNetworkRefs(ref.Ref{Name: "test"})
 			Expect(err).NotTo(HaveOccurred())
-			foundNadDup, _ := planbase.ValidateNetworkDuplicates(nicRefs, plan.Map.Network)
-			Expect(foundNadDup).To(BeTrue())
+			foundPodDup := planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network)
+			Expect(foundPodDup).To(BeFalse())
 		})
 
-		It("should detect multiple pod networks via foundPodDup", func() {
+		It("should detect multiple pod networks", func() {
 			plan := createPlan()
 			plan.Map.Network = &v1beta1.NetworkMap{
 				Spec: v1beta1.NetworkMapSpec{
@@ -577,8 +576,7 @@ var _ = Describe("vsphere validation tests", func() {
 			validator := &Validator{Context: &ctx}
 			nicRefs, err := validator.NICNetworkRefs(ref.Ref{Name: "test"})
 			Expect(err).NotTo(HaveOccurred())
-			foundNadDup, foundPodDup := planbase.ValidateNetworkDuplicates(nicRefs, plan.Map.Network)
-			Expect(foundNadDup).To(BeFalse())
+			foundPodDup := planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network)
 			Expect(foundPodDup).To(BeTrue()) // two NICs mapped to pod
 		})
 

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -64,7 +64,6 @@ const (
 	VMStorageNotMapped              = "VMStorageNotMapped"
 	VMStorageNotSupported           = "VMStorageNotSupported"
 	VMMultiplePodNetworkMappings    = "VMMultiplePodNetworkMappings"
-	VMDuplicateNADMappings          = "VMDuplicateNADMappings"
 	VMMissingGuestIPs               = "VMMissingGuestIPs"
 	VMIpNotMatchingUdnSubnet        = "VMIpNotMatchingUdnSubnet"
 	VMMissingChangedBlockTracking   = "VMMissingChangedBlockTracking"
@@ -802,14 +801,6 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 		Message:  "VM has more than one interface mapped to the pod network.",
 		Items:    []string{},
 	}
-	duplicateNADMappings := libcnd.Condition{
-		Type:     VMDuplicateNADMappings,
-		Status:   True,
-		Reason:   NotValid,
-		Category: api.CategoryCritical,
-		Message:  "Multiple VM NICs mapped to the same Multus NAD. Add additional NetworkMap entries with different destination NADs for the same source network.",
-		Items:    []string{},
-	}
 	missingStaticIPs := libcnd.Condition{
 		Type:     VMMissingGuestIPs,
 		Status:   True,
@@ -1144,12 +1135,8 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			if nErr != nil {
 				return nErr
 			}
-			foundNadDup, foundPodDup := planbase.ValidateNetworkDuplicates(nicRefs, plan.Referenced.Map.Network)
-			if foundPodDup {
+			if planbase.ValidatePodNetworkDuplicates(nicRefs, plan.Map.Network) {
 				multiplePodNetworkMappings.Items = append(multiplePodNetworkMappings.Items, ref.String())
-			}
-			if foundNadDup {
-				duplicateNADMappings.Items = append(duplicateNADMappings.Items, ref.String())
 			}
 		}
 		if plan.Referenced.Map.Storage != nil {
@@ -1403,9 +1390,6 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 	}
 	if len(multiplePodNetworkMappings.Items) > 0 {
 		plan.Status.SetCondition(multiplePodNetworkMappings)
-	}
-	if len(duplicateNADMappings.Items) > 0 {
-		plan.Status.SetCondition(duplicateNADMappings)
 	}
 	if len(missingStaticIPs.Items) > 0 {
 		plan.Status.SetCondition(missingStaticIPs)


### PR DESCRIPTION
MTV-6377 reported that MTV-3075 blocks valid migrations when multiple NICs map to the same Multus NAD. The ticket suggested narrowing the validation to allow reuse only for linux-bridge NADs while keeping the OVN-specific block.

Cluster testing on OCP Virt 5.0 / CNV 5.0 showed both linux-bridge and OVN-Kubernetes NADs support multiple NICs on the same attachment, each receiving a distinct IP. The validation was therefore removed entirely rather than partially relaxed by CNI type.

Test run logs added to jira ticket.

Ref: https://redhat.atlassian.net/browse/MTV-6377
Resolves: MTV-6377