### PR TITLE
MTV-6364 | Extend and fix vmware removal scripts

### DIFF
--- a/docs/9100_cleanup_vmware.md
+++ b/docs/9100_cleanup_vmware.md
@@ -256,12 +256,21 @@ HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\vmtoolsd.exe
 ### Directories (`$VMwareDirs`)
 
 ```
-%ProgramFiles%\VMware
-%ProgramFiles%\Common Files\VMware
+%ProgramW6432%\VMware
+%CommonProgramW6432%\VMware
 %ProgramFiles(x86)%\VMware
-%ProgramFiles(x86)%\Common Files\VMware
+%CommonProgramFiles(x86)%\VMware
 %ProgramData%\VMware
 ```
+
+The real (64-bit) paths are resolved via `%ProgramW6432%` /
+`%CommonProgramW6432%`, not `%ProgramFiles%` / `%CommonProgramFiles%`.
+The firstboot mechanism runs this script under a 32-bit PowerShell
+(WOW64), where `%ProgramFiles%` is silently redirected to
+`...\Program Files (x86)` — same idea as the `Sysnative` trick used for
+`System32`, just for `Program Files`. Using the redirected variable here
+meant the real `C:\Program Files\VMware` and
+`C:\Program Files\Common Files\VMware` were never actually targeted.
 
 ...plus wildcarded temp folders (`$VMwareTempDirPatterns`, Phase 6 step 2):
 

--- a/docs/9100_cleanup_vmware.md
+++ b/docs/9100_cleanup_vmware.md
@@ -49,7 +49,10 @@ bookkeeping, so VMware would keep reappearing in "Programs and Features" /
 1. Scans the `Uninstall` registry key (and `WOW6432Node`) for any entry
    whose `DisplayName` matches `VMware`.
 2. For each match, extracts the MSI product code and runs
-   `msiexec /x {ProductCode} /qn /norestart`.
+   `msiexec /x {ProductCode} /qn /norestart` with a bounded 10-minute wait
+   (this runs unattended on firstboot, so a stuck msiexec must not hang the
+   rest of the script) and accepts exit codes `0`, `1641`, and `3010` as
+   success (the latter two mean "succeeded, reboot required").
 3. Force-deletes the Add/Remove Programs key afterwards regardless of
    whether msiexec succeeded.
 4. Cleans orphaned **Windows Installer product registrations** (drives
@@ -64,7 +67,9 @@ bookkeeping, so VMware would keep reappearing in "Programs and Features" /
 
 1. Looks up every name in `$VMwareServices` (see below) via `Get-Service`.
 2. Also scans all services for a `DisplayName`/`Name`/`PathName` matching
-   VMware, catching anything not on the static list.
+   VMware, catching anything not on the static list — except `pvscsi`,
+   which is explicitly excluded even if this broad match would otherwise
+   catch it (see the note under "Services" below).
 3. For each match: `sc.exe stop`, wait 2s, force-kill if still running,
    then `sc.exe config ... start= disabled`.
 4. Services are **not deleted yet** — that's Phase 4.
@@ -74,8 +79,9 @@ bookkeeping, so VMware would keep reappearing in "Programs and Features" /
 1. Prefers `Get-WindowsDriver -Online` (locale-independent — works
    regardless of display language), matching `ProviderName = VMware` or
    `OriginalFileName` against known VMware `.inf` basenames (derived from
-   `$VMwareDriverFiles`, plus `vm3d.inf` added explicitly). The `.inf`-name
-   match exists because post-Broadcom-acquisition packages get republished
+   `$VMwareDriverFiles`, plus `vm3d.inf` added explicitly), excluding
+   `pvscsi.inf` even though its provider is VMware. The
+   `.inf`-name match exists because post-Broadcom-acquisition packages get republished
    as `Provider Name: Broadcom Inc.` — matching "Broadcom" alone would be
    unsafe since unrelated Broadcom hardware exists.
 2. Falls back to parsing `pnputil /enum-drivers` text output if
@@ -98,7 +104,8 @@ bookkeeping, so VMware would keep reappearing in "Programs and Features" /
    `ROOT\VMware` (ROOT-enumerated software devices that can lack a VMware
    name entirely).
 4. For each device: `Disable-PnpDevice`, then `pnputil /remove-device` if
-   supported by the OS.
+   supported by the OS (exit code `3010` = reboot-required success, not a
+   failure).
 5. Ghost devices (`Status = Unknown`) that survive both are removed via
    `CM_Uninstall_DevNode` — the same API Device Manager's "Uninstall
    device" uses.
@@ -126,9 +133,14 @@ already deleted in Phase 3).
    auto-generated `Services\<name>` key per entry in `$VMwareServices`.
 2. Deletes the `VMware Host Open` value under `RegisteredApplications`.
 3. Sweeps stray **COM registrations** under `CLSID`/`TypeLib` (native and
-   `WOW6432Node`) for GUID subtrees mentioning `VMware`, up to 3 levels
-   deep. Uses the .NET registry API directly instead of spawning `reg.exe`
-   per GUID — these keys can each have tens of thousands of subkeys.
+   `WOW6432Node`): a GUID subtree is deleted only when its COM server
+   module (`InprocServer32`/`LocalServer32`'s default value, or
+   `TypeLib`'s `win32`/`win64` default value) resolves to a VMware install
+   path or a known VMware module name — not when "VMware" merely appears
+   somewhere else in the subtree, which could delete an unrelated
+   component's entire registration. Uses the .NET registry API directly
+   instead of spawning `reg.exe` per GUID — these keys can each have tens
+   of thousands of subkeys.
 4. Sweeps `Installer\Folders` for value **names** containing `VMware`
    (records folders an MSI wrote to; not reliably pruned by `msiexec /x`).
 5. Sweeps `Run`/`RunOnce` autostart entries for any value whose name or
@@ -183,7 +195,7 @@ DriverStore residuals left for manual follow-up.
 
 ```
 VGAuthService, VM3DService, VMTools, vmvss, GISvc, vmhgfs, vmmemctl,
-vmrawdsk, vnetWFP, vnetflt, vsepflt, vmci, vmxnet3, vmxnet3ndis6, pvscsi,
+vmrawdsk, vnetWFP, vnetflt, vsepflt, vmci, vmxnet3, vmxnet3ndis6,
 vmusbmouse, vmmouse, vm3dmp, vm3dmp-debug, vm3dmp-stats, vm3dmp_loader,
 vsock, efifw, svga_wddm, vmaudio, vgauth, cblauncher, vmwtimeprovider,
 vmstatsprovider, vmupgradehelper, vmwefifw,
@@ -192,14 +204,29 @@ vmware, vmx86, VMwareCertService
 ```
 
 Notes: `vnetflt` is the legacy predecessor of `vnetWFP` and can be left
-behind by a Tools installer bug, BSODing alongside `vsepflt` if not
-removed. `vgauth`/`cblauncher` are legacy alternate names (no-op if
-absent). `vm3dservice` is the service behind `vm3dservice.exe` (already in
+behind by a Tools installer bug alongside `vsepflt`; both are removed
+normally like any other service. `vgauth`/`cblauncher` are legacy alternate
+names (no-op if absent). `vm3dservice` is the service behind `vm3dservice.exe` (already in
 `$VMwareSystemFiles`) — without it, deleting the file alone leaves an
 orphaned service definition. `vmxnet`, `vmx_svga`, `vmkbd`, `vmdesched`,
 `vmdebug`, `vmware` are legacy pre-WDDM names; `vmx86`/`VMwareCertService`
 are newer names checked defensively. Each also gets its own
 `Services\<name>` registry key removed in Phase 5.
+
+**`pvscsi` is deliberately never touched** (not stopped, not deleted,
+not swept by the broad `DisplayName`/`PathName` match, and its driver
+package is skipped even though its `ProviderName` is VMware). virt-v2v
+is supposed to have already replaced the VMware Paravirtual SCSI
+controller with VirtIO by the time this script runs, making `pvscsi` an
+inert leftover — but that swap isn't guaranteed for every guest OS
+virt-v2v doesn't fully recognize (e.g. an early Windows Server 2025
+Insider Build image). On such a guest, `pvscsi` can still be the live
+boot-critical storage driver; deleting its service/file there pulls the
+disk driver Windows is actually booting from out from under it,
+bricking the boot volume with `INACCESSIBLE_BOOT_DEVICE`. Leaving it
+installed is simpler and safer than trying to detect the swap per-guest.
+`verify_vmware_cleanup.ps1` mirrors this and doesn't check for its
+absence either.
 
 ### Explicit registry keys (`$VMwareRegistryKeys`)
 
@@ -250,11 +277,14 @@ HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\vmtoolsd.exe
 
 ```
 vmci.sys, vmmouse.sys, vmrawdsk.sys, vmhgfs.sys, vmusbmouse.sys,
-pvscsi.sys, vmxnet3.sys, vm3dmp.sys, vm3dmp-debug.sys, vm3dmp-stats.sys,
+vmxnet3.sys, vm3dmp.sys, vm3dmp-debug.sys, vm3dmp-stats.sys,
 vm3dmp_loader.sys, vsock.sys, vmmemctl.sys, vsepflt.sys, vnetWFP.sys,
 vnetflt.sys, svga_wddm.sys, efifw.sys, vmaudio.sys,
 vmx_svga.sys, vmkbd.sys, vmdesched.sys
 ```
+
+(`pvscsi.sys` intentionally excluded — see the `pvscsi` note under
+"Services" above.)
 
 Each `.sys` name is also converted to a matching `.inf` basename for the
 Phase 2 driver-package match (plus `vm3d.inf` added explicitly).
@@ -302,8 +332,18 @@ vm3dum_10.dll, vm3dum_10-debug.dll, vm3dum_10-stats.dll, vm3dum_loader.dll
 
 Kept in sync with this script's data lists so it can confirm nothing was
 missed. It also runs `DISM /Online /Cleanup-Image /CheckHealth` at the
-end, since Phase 6 no longer force-deletes `DriverStore` folders — that
-check catches any resulting (or unrelated) component-store corruption.
+end (via `$Sys32\Dism.exe`, not the bare command, so a 32-bit PowerShell
+host doesn't silently invoke the 32-bit DISM against a 64-bit image),
+since Phase 6 no longer force-deletes `DriverStore` folders — that check
+catches any resulting (or unrelated) component-store corruption.
 `sfc /scannow` was deliberately left out: it can take 10-20+ minutes on a
 real VM, disproportionate to what this script verifies; run it manually
-if `DISM /CheckHealth` flags corruption.
+if `DISM /CheckHealth` flags corruption. It also reports (informational,
+non-failing) any `VMware`-named entry left in Windows Update's driver
+package history — it deliberately doesn't match the generic `Broadcom`
+vendor name there, since that would also flag unrelated Broadcom NIC/
+storage drivers that have nothing to do with VMware Tools. Like
+`9100_cleanup_vmware.ps1`, it never checks for `pvscsi`'s
+absence (service, file, driver-store package, or the registry sweep) -
+it's deliberately left installed, so flagging it would be a false
+failure.

--- a/docs/9100_cleanup_vmware.md
+++ b/docs/9100_cleanup_vmware.md
@@ -1,0 +1,309 @@
+# VMware Removal Script — `9100_cleanup_vmware.ps1`
+
+Fully removes VMware Tools and its leftovers from a Windows guest in one
+pass. Run **as Administrator**, typically after a physical/`p2v` migration
+or a botched VMware Tools uninstall, when Add/Remove Programs and manual
+driver removal aren't enough.
+
+## Usage
+
+```powershell
+# From an elevated PowerShell prompt
+.\9100_cleanup_vmware.ps1
+```
+
+- Writes a timestamped log next to the script: `cleanup_vmware.log`.
+- Safe to re-run — every phase checks whether its target exists before
+  acting.
+- A reboot is recommended afterwards; a few locked driver files may be
+  scheduled for delete-on-reboot instead of removed immediately.
+- Pair with `verify_vmware_cleanup.ps1` to confirm nothing was missed, and
+  `syntax_check.ps1` to lint both scripts before running them on a real box.
+
+## Why phase order matters
+
+Components depend on each other, so removing them out of order lets
+Windows re-create or veto something already "cleaned":
+
+1. **Services are quiesced first** (Phase 1), before drivers/devices/files
+   are touched.
+2. **Drivers before devices** (Phase 2 before Phase 3): `vmci` is a PnP bus
+   enumerator that can re-assert its device mid-removal, and a driver still
+   in the driver store can get re-selected on a PnP rescan.
+3. **Service definitions are deleted last** (Phase 4, after devices are
+   gone) — deleting a service too early can interfere with the
+   device-removal APIs in Phase 3.
+4. **`vmci` is force-deleted mid-flow** (start of Phase 3): stopped/disabled
+   in Phase 1 like everything else, but only fully deleted right before
+   device removal so it can't re-assert its bus device — then excluded
+   from the Phase 4 list.
+
+## Script flow (phase by phase)
+
+### Phase 0 — VMware Tools MSI uninstall
+
+Manual file/service/driver deletion never updates Windows Installer's own
+bookkeeping, so VMware would keep reappearing in "Programs and Features" /
+`Get-Package` forever. This phase uninstalls it properly first:
+
+1. Scans the `Uninstall` registry key (and `WOW6432Node`) for any entry
+   whose `DisplayName` matches `VMware`.
+2. For each match, extracts the MSI product code and runs
+   `msiexec /x {ProductCode} /qn /norestart`.
+3. Force-deletes the Add/Remove Programs key afterwards regardless of
+   whether msiexec succeeded.
+4. Cleans orphaned **Windows Installer product registrations** (drives
+   `Get-Package`/`Win32_Product` visibility independently of the Uninstall
+   key), across every SID under `UserData`, not just SYSTEM.
+5. Cleans orphaned **Windows Installer Components ownership entries**
+   (`UserData\<SID>\Components\<ComponentGuid>`) — since a component can be
+   shared by multiple products, only the matching value is deleted, and the
+   parent key only once it has no owners left.
+
+### Phase 1 — Stop and disable VMware services
+
+1. Looks up every name in `$VMwareServices` (see below) via `Get-Service`.
+2. Also scans all services for a `DisplayName`/`Name`/`PathName` matching
+   VMware, catching anything not on the static list.
+3. For each match: `sc.exe stop`, wait 2s, force-kill if still running,
+   then `sc.exe config ... start= disabled`.
+4. Services are **not deleted yet** — that's Phase 4.
+
+### Phase 2 — Remove VMware driver packages
+
+1. Prefers `Get-WindowsDriver -Online` (locale-independent — works
+   regardless of display language), matching `ProviderName = VMware` or
+   `OriginalFileName` against known VMware `.inf` basenames (derived from
+   `$VMwareDriverFiles`, plus `vm3d.inf` added explicitly). The `.inf`-name
+   match exists because post-Broadcom-acquisition packages get republished
+   as `Provider Name: Broadcom Inc.` — matching "Broadcom" alone would be
+   unsafe since unrelated Broadcom hardware exists.
+2. Falls back to parsing `pnputil /enum-drivers` text output if
+   `Get-WindowsDriver` is unavailable (English-only, so this fallback finds
+   nothing on a non-English OS).
+3. Removes each match with `pnputil /delete-driver <inf> /uninstall /force`.
+
+### Phase 3 — Disable and remove VMware PnP devices
+
+1. Force-stops and deletes the `vmci` service outright (see phase-order
+   notes above), then drops it from the pending Phase 4 list.
+2. Strips the VMware SVGA class coinstaller (`vm3dc003.dll`) from
+   `CoDeviceInstallers` for the Display-adapters class GUID — only the
+   matching entry, not the whole `REG_MULTI_SZ` value. A stale coinstaller
+   can veto removal of every device in that class.
+3. Enumerates PnP devices by `Manufacturer`/`FriendlyName` = VMware,
+   VMware's PCI vendor ID (`VEN_15AD`), its USB vendor ID (`VID_0E0F` —
+   catches the USB composite parent of the VMware USB mouse, which doesn't
+   say VMware itself), or an instance ID starting `ROOT\VMWVMCI`/
+   `ROOT\VMware` (ROOT-enumerated software devices that can lack a VMware
+   name entirely).
+4. For each device: `Disable-PnpDevice`, then `pnputil /remove-device` if
+   supported by the OS.
+5. Ghost devices (`Status = Unknown`) that survive both are removed via
+   `CM_Uninstall_DevNode` — the same API Device Manager's "Uninstall
+   device" uses.
+6. If that also fails, `Clear-GhostDeviceReferences` cleans secondary
+   registry locations before a raw delete of the `Enum\<InstanceId>` key:
+   - Deletes the class driver binding key pointed to by the device's
+     `Driver` value.
+   - Deletes any `DeviceClasses` interface registration whose
+     `DeviceInstance` matches this device.
+   - `DeviceContainers` references are only **logged**, not deleted — a
+     container can be shared by sibling functions of a composite device.
+
+   Leftover references in these locations are a suspected cause of
+   Windows resynthesizing a fresh `Unknown` Enum entry for an
+   already-deleted device.
+
+### Phase 4 — Delete VMware service definitions
+
+Runs `sc.exe delete` on every service collected in Phase 1 (minus `vmci`,
+already deleted in Phase 3).
+
+### Phase 5 — Remove VMware registry entries
+
+1. Deletes every key in `$VMwareRegistryKeys` (see below), plus one
+   auto-generated `Services\<name>` key per entry in `$VMwareServices`.
+2. Deletes the `VMware Host Open` value under `RegisteredApplications`.
+3. Sweeps stray **COM registrations** under `CLSID`/`TypeLib` (native and
+   `WOW6432Node`) for GUID subtrees mentioning `VMware`, up to 3 levels
+   deep. Uses the .NET registry API directly instead of spawning `reg.exe`
+   per GUID — these keys can each have tens of thousands of subkeys.
+4. Sweeps `Installer\Folders` for value **names** containing `VMware`
+   (records folders an MSI wrote to; not reliably pruned by `msiexec /x`).
+5. Sweeps `Run`/`RunOnce` autostart entries for any value whose name or
+   data mentions `VMware`.
+6. Sweeps `Control\Video\{GUID}\Video` for adapter nodes with a VMware
+   `DeviceDesc` or a `Service` starting `vm3dmp` — separate from the
+   `vm3dmp_loader` service key already deleted in step 1.
+
+All key/value deletions go through `reg.exe` (not the PowerShell registry
+provider) to avoid WOW64 redirection.
+
+### Phase 6 — Remove VMware files and folders
+
+1. Recursively removes every directory in `$VMwareDirs` (see below).
+2. Recursively removes folders matching `$VMwareTempDirPatterns`
+   (`vmware-*` under `%SystemRoot%\Temp` and `%TEMP%`) — one folder per
+   account that's ever run Tools, not just SYSTEM.
+3. Recursively removes `AppData\{Local,Roaming,LocalLow}\VMware` under
+   every user profile in `C:\Users`, including hidden ones like `Default`.
+4. Deletes individual driver files (`$VMwareDriverFiles`), system
+   DLLs/EXEs (`$VMwareSystemFiles`), and their 32-bit counterparts
+   (`$VMwareSysWOW64Files`).
+5. **Reports** (does not delete) any `DriverStore\FileRepository`
+   subfolder matching the VMware name pattern (Hyper-V's own `vm*` folders
+   are excluded). This store is tracked by Component-Based Servicing;
+   `pnputil /delete-driver` (Phase 2) is the supported removal path, and
+   force-deleting a folder directly risks CBS inconsistency that can
+   surface as `sfc`/`DISM /CheckHealth` corruption later. Anything pnputil
+   didn't remove is only logged (`driverStoreResidual`) for manual
+   follow-up.
+
+Every removal in this phase (except the DriverStore report) goes through a
+shared helper: tries `Remove-Item`, falls back to `cmd /c rd`/`del`, and
+for files still locked by a loaded driver, schedules deletion on next boot
+via `MoveFileEx(..., MOVEFILE_DELAY_UNTIL_REBOOT)`.
+
+### Phase 7 — Remove VMware scheduled tasks
+
+Finds and `Unregister-ScheduledTask`s any task whose name or path mentions
+`VMware`/`vmtools`.
+
+### Summary
+
+Logs and prints final counts for: MSI products uninstalled, MSI Components
+removed, driver packages removed, services deleted, stray COM keys removed,
+registry keys deleted (+ errors), files/dirs removed (+ errors), and
+DriverStore residuals left for manual follow-up.
+
+## Reference data (what's matched/removed)
+
+### Services (`$VMwareServices`)
+
+```
+VGAuthService, VM3DService, VMTools, vmvss, GISvc, vmhgfs, vmmemctl,
+vmrawdsk, vnetWFP, vnetflt, vsepflt, vmci, vmxnet3, vmxnet3ndis6, pvscsi,
+vmusbmouse, vmmouse, vm3dmp, vm3dmp-debug, vm3dmp-stats, vm3dmp_loader,
+vsock, efifw, svga_wddm, vmaudio, vgauth, cblauncher, vmwtimeprovider,
+vmstatsprovider, vmupgradehelper, vmwefifw,
+VMCISockets, vm3dservice, vmxnet, vmx_svga, vmkbd, vmdesched, vmdebug,
+vmware, vmx86, VMwareCertService
+```
+
+Notes: `vnetflt` is the legacy predecessor of `vnetWFP` and can be left
+behind by a Tools installer bug, BSODing alongside `vsepflt` if not
+removed. `vgauth`/`cblauncher` are legacy alternate names (no-op if
+absent). `vm3dservice` is the service behind `vm3dservice.exe` (already in
+`$VMwareSystemFiles`) — without it, deleting the file alone leaves an
+orphaned service definition. `vmxnet`, `vmx_svga`, `vmkbd`, `vmdesched`,
+`vmdebug`, `vmware` are legacy pre-WDDM names; `vmx86`/`VMwareCertService`
+are newer names checked defensively. Each also gets its own
+`Services\<name>` registry key removed in Phase 5.
+
+### Explicit registry keys (`$VMwareRegistryKeys`)
+
+Keys not derivable from the service list — mostly shell/COM integration
+("Open with VMware Host") and event log source registrations:
+
+```
+HKLM\SOFTWARE\Clients\StartmenuInternet\VMWAREHOSTOPEN.EXE
+HKLM\SOFTWARE\Classes\Applications\VMwareHostOpen.exe
+HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocFile
+HKLM\SOFTWARE\Classes\VMwareHostOpen.AssocURL
+HKLM\SOFTWARE\VMware, Inc.
+HKLM\SOFTWARE\Classes\CLSID\{C73DA087-EDDB-4a7c-B216-8EF8A3B92C7B}
+HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\vmwTimeProvider
+HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmtools
+HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\vmStatsProvider
+HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMUpgradeHelper
+HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VGAuth
+HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMware Tools
+HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP
+HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetflt
+HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt
+HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vmci
+HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\vmtoolsd.exe
+```
+
+### Directories (`$VMwareDirs`)
+
+```
+%ProgramFiles%\VMware
+%ProgramFiles%\Common Files\VMware
+%ProgramFiles(x86)%\VMware
+%ProgramFiles(x86)%\Common Files\VMware
+%ProgramData%\VMware
+```
+
+...plus wildcarded temp folders (`$VMwareTempDirPatterns`, Phase 6 step 2):
+
+```
+%SystemRoot%\Temp\vmware-*
+%TEMP%\vmware-*
+```
+
+...plus `AppData\{Local,Roaming,LocalLow}\VMware` under every user profile
+(Phase 6, step 3).
+
+### Driver files (`$VMwareDriverFiles`, in `drivers`)
+
+```
+vmci.sys, vmmouse.sys, vmrawdsk.sys, vmhgfs.sys, vmusbmouse.sys,
+pvscsi.sys, vmxnet3.sys, vm3dmp.sys, vm3dmp-debug.sys, vm3dmp-stats.sys,
+vm3dmp_loader.sys, vsock.sys, vmmemctl.sys, vsepflt.sys, vnetWFP.sys,
+vnetflt.sys, svga_wddm.sys, efifw.sys, vmaudio.sys,
+vmx_svga.sys, vmkbd.sys, vmdesched.sys
+```
+
+Each `.sys` name is also converted to a matching `.inf` basename for the
+Phase 2 driver-package match (plus `vm3d.inf` added explicitly).
+
+### System files (`$VMwareSystemFiles`, in `System32`)
+
+```
+vmGuestLib.dll, vmhgfs.dll, vm3dgl64.dll, vm3dver.dll,
+vmGuestLibJava.dll, VMWSU.DLL, vm3dc003.dll,
+vm3ddevapi64.dll, vm3ddevapi64-debug.dll, vm3ddevapi64-release.dll,
+vm3ddevapi64-stats.dll, vm3dglhelper64.dll,
+vm3dum64.dll, vm3dum64-debug.dll, vm3dum64-stats.dll,
+vm3dum64_10.dll, vm3dum64_10-debug.dll, vm3dum64_10-stats.dll,
+vm3dum64_loader.dll, vm3dservice.exe
+```
+
+### 32-bit system files (`$VMwareSysWOW64Files`, in `SysWOW64`)
+
+```
+vmGuestLib.dll, vmGuestLibJava.dll,
+vm3ddevapi.dll, vm3ddevapi-debug.dll, vm3ddevapi-release.dll,
+vm3ddevapi-stats.dll, vm3dgl.dll, vm3dglhelper.dll, vm3dservice.exe,
+vm3dum.dll, vm3dum-debug.dll, vm3dum-stats.dll,
+vm3dum_10.dll, vm3dum_10-debug.dll, vm3dum_10-stats.dll, vm3dum_loader.dll
+```
+
+## Other design notes
+
+- **WOW64-safe paths throughout:** file paths resolve via `Sysnative`
+  instead of `System32`, and registry reads/writes go through `reg.exe`
+  rather than the PowerShell provider, to avoid WOW64 redirection hiding
+  the 64-bit view.
+- **Idempotent by construction:** almost every action checks whether its
+  target exists before touching it, so re-running is safe.
+- **Locale-independent where it matters:** Phase 2 prefers
+  `Get-WindowsDriver` over `pnputil`'s English-only text output.
+- **DriverStore is reported, not force-deleted:** only
+  `pnputil /delete-driver` (Phase 2) is a supported removal path; leftover
+  folders are logged for manual follow-up instead.
+- **Ghost-device cleanup goes beyond the `Enum` key:** Phase 3 also clears
+  the class driver binding and `DeviceClasses` registration, and reports
+  (without deleting) any `DeviceContainers` reference — see Phase 3 step 6.
+
+## `verify_vmware_cleanup.ps1`
+
+Kept in sync with this script's data lists so it can confirm nothing was
+missed. It also runs `DISM /Online /Cleanup-Image /CheckHealth` at the
+end, since Phase 6 no longer force-deletes `DriverStore` folders — that
+check catches any resulting (or unrelated) component-store corruption.
+`sfc /scannow` was deliberately left out: it can take 10-20+ minutes on a
+real VM, disproportionate to what this script verifies; run it manually
+if `DISM /CheckHealth` flags corruption.

--- a/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.ps1
@@ -111,11 +111,15 @@ $VMwareRegistryKeys = @(
     'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\vmtoolsd.exe'
 )
 
+# This script runs under a 32-bit PowerShell on firstboot (WOW64), where
+# $env:ProgramFiles gets silently redirected to "...Program Files (x86)" -
+# so it can't be used to reach the real 64-bit folder. $env:ProgramW6432 /
+# CommonProgramW6432 are the unambiguous, non-redirected equivalents.
 $VMwareDirs = @(
-    "$env:ProgramFiles\VMware",
-    "$env:ProgramFiles\Common Files\VMware",
+    "$env:ProgramW6432\VMware",
+    "$env:CommonProgramW6432\VMware",
     "${env:ProgramFiles(x86)}\VMware",
-    "${env:ProgramFiles(x86)}\Common Files\VMware",
+    "${env:CommonProgramFiles(x86)}\VMware",
     "$env:ProgramData\VMware"
 )
 

--- a/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.ps1
@@ -5,8 +5,7 @@
 
 $ErrorActionPreference = 'Continue'
 
-# Schedule-for-reboot helper via MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT).
-# Used as last resort when a file is locked (e.g. loaded driver).
+# Schedules a locked file for deletion on next reboot (last resort).
 Add-Type @"
 using System;
 using System.Runtime.InteropServices;
@@ -17,9 +16,8 @@ public static class LockedFileDeleter {
     public const int MOVEFILE_DELAY_UNTIL_REBOOT = 0x4;
 }
 
-// CM_Uninstall_DevNode: same API Device Manager's "Uninstall device"
-// uses to remove a ghost/non-present device. Safer than deleting the
-// CurrentControlSet\Enum key by hand, which can corrupt the PnP database.
+// CM_Uninstall_DevNode: same API Device Manager uses to remove a
+// device. Safer than deleting the Enum registry key by hand.
 public static class CfgMgr {
     public const uint CM_LOCATE_DEVNODE_PHANTOM = 0x00000001;
     public const uint CR_SUCCESS = 0x00000000;
@@ -48,8 +46,8 @@ function Remove-GhostDevNode {
 # ===================================================================
 # WOW64-safe path resolution
 # ===================================================================
-# Use Sysnative (not System32) in case this runs as a 32-bit process,
-# where System32 would otherwise be redirected to SysWOW64.
+# Sysnative avoids System32 being redirected to SysWOW64 if this runs
+# as a 32-bit process.
 $Sysnative = Join-Path $env:SystemRoot 'Sysnative'
 if (Test-Path $Sysnative) {
     $Sys32   = $Sysnative
@@ -71,11 +69,15 @@ $VMwareServices = @(
     'vmci', 'vmxnet3', 'vmxnet3ndis6', 'pvscsi',
     'vmusbmouse', 'vmmouse',
     'vm3dmp', 'vm3dmp-debug', 'vm3dmp-stats', 'vm3dmp_loader',
-    # vgauth/cblauncher are alternate/legacy names alongside
-    # VGAuthService/CbLauncher - a no-op if not present.
+    # vgauth/cblauncher: legacy alternate names, no-op if absent.
     'vsock', 'efifw', 'svga_wddm', 'vmaudio', 'vgauth', 'cblauncher',
     'vmwtimeprovider', 'vmstatsprovider', 'vmupgradehelper',
-    'vmwefifw'
+    'vmwefifw',
+    # vm3dservice backs the vm3dservice.exe in $VMwareSystemFiles below.
+    # The rest are newer (vmx86, VMwareCertService) or legacy pre-WDDM
+    # names from older Tools builds.
+    'VMCISockets', 'vm3dservice', 'vmxnet', 'vmx_svga', 'vmkbd',
+    'vmdesched', 'vmdebug', 'vmware', 'vmx86', 'VMwareCertService'
 )
 
 # Registry keys that are NOT auto-derived from service names.
@@ -95,7 +97,9 @@ $VMwareRegistryKeys = @(
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetflt',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt',
-    'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vmci'
+    'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vmci',
+    # App Paths entry for vmtoolsd.exe - orphaned once the exe is gone.
+    'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\vmtoolsd.exe'
 )
 
 $VMwareDirs = @(
@@ -103,8 +107,14 @@ $VMwareDirs = @(
     "$env:ProgramFiles\Common Files\VMware",
     "${env:ProgramFiles(x86)}\VMware",
     "${env:ProgramFiles(x86)}\Common Files\VMware",
-    "$env:ProgramData\VMware",
-    "$env:SystemRoot\Temp\vmware-SYSTEM"
+    "$env:ProgramData\VMware"
+)
+
+# Handled separately from $VMwareDirs: Tools creates one
+# "vmware-<account>" temp folder per account that's run it.
+$VMwareTempDirPatterns = @(
+    "$env:SystemRoot\Temp\vmware-*",
+    "$env:TEMP\vmware-*"
 )
 
 $VMwareDriverFiles = @(
@@ -112,11 +122,12 @@ $VMwareDriverFiles = @(
     'vmusbmouse.sys', 'pvscsi.sys', 'vmxnet3.sys',
     'vm3dmp.sys', 'vm3dmp-debug.sys', 'vm3dmp-stats.sys', 'vm3dmp_loader.sys',
     'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys',
-    # vnetflt: pre-10.2.5 predecessor of vnetWFP for the Tools
-    # "NetworkIntrospection" feature. A Tools installer bug can leave
-    # it behind and BSOD alongside the newer vsepflt driver.
+    # vnetflt: legacy predecessor of vnetWFP, can be left behind by a
+    # Tools installer bug and BSOD alongside vsepflt.
     'vnetflt.sys',
-    'svga_wddm.sys', 'efifw.sys', 'vmaudio.sys'
+    'svga_wddm.sys', 'efifw.sys', 'vmaudio.sys',
+    # Legacy pre-WDDM driver files.
+    'vmx_svga.sys', 'vmkbd.sys', 'vmdesched.sys'
 )
 
 $VMwareSystemFiles = @(
@@ -143,7 +154,7 @@ $VMwareSysWOW64Files = @(
     'vm3dum_loader.dll'
 )
 
-# DriverStore dirs matching this pattern are VMware; Hyper-V dirs
+# DriverStore dirs matching this pattern are VMware, Hyper-V dirs
 # (vmbus, vmgid, vmgen*, vmstor*, vms3cap, vmbk*) are excluded.
 $DriverStorePattern = '^vm(3d|ci|hgfs|mouse|rawdsk|memctl|xnet|ware|tools|vss|usb)'
 
@@ -162,8 +173,7 @@ function Log {
     Add-Content -Path $LogFile -Value $line
 }
 
-# Delete a registry key tree. Uses reg.exe (not PowerShell) to avoid
-# WOW64 redirection.
+# Delete a registry key tree via reg.exe (avoids WOW64 redirection).
 function Delete-RegKey {
     param([string]$KeyPath)
     & $RegExe query $KeyPath /ve 2>&1 | Out-Null
@@ -214,9 +224,8 @@ function Get-RegValue {
     return $null
 }
 
-# Remove a file or directory with logging and counter updates.
-# Falls back to cmd /c rd/del, then schedules locked files for
-# deletion on reboot via MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT).
+# Removes a file/dir, falling back to cmd /c rd/del, then scheduling
+# locked files for deletion on reboot.
 function Remove-PathItem {
     param([string]$Path, [switch]$Recurse)
     if (-not (Test-Path $Path)) { return }
@@ -239,12 +248,11 @@ function Remove-PathItem {
         return
     }
     # File is locked (e.g. loaded driver) - schedule for reboot deletion.
-    # Resolve Sysnative back to System32 so the kernel can find the file.
     if (-not $Recurse) {
+        # Resolve back to System32 so the kernel can find the file.
         $kernelPath = $Path -replace '(?i)\\Sysnative\\', '\System32\'
-        # Must pass [NullString]::Value, not $null - PowerShell marshals a
-        # bare $null as "", which MoveFileEx treats as "rename to empty
-        # path" (fails) instead of "delete on reboot".
+        # [NullString]::Value, not $null - PowerShell marshals bare $null
+        # as "", which MoveFileEx treats as a failing rename instead of delete.
         $ok = [LockedFileDeleter]::MoveFileEx($kernelPath, [NullString]::Value,
                 [LockedFileDeleter]::MOVEFILE_DELAY_UNTIL_REBOOT)
         if ($ok) {
@@ -269,17 +277,13 @@ Log "[INFO] Sys32=$Sys32  PnpUtil=$PnpUtil  RegExe=$RegExe"
 # -------------------------------------------------------------------
 # PHASE 0: Uninstall VMware Tools via Windows Installer (MSI)
 # -------------------------------------------------------------------
-# VMware Tools is an MSI product. Manually deleting its files/services/
-# drivers (Phases 1-6) never touches Windows Installer's own bookkeeping,
-# so it would keep showing up in Programs and Features forever. Uninstall
-# it properly first, then force-delete the registry remnants if msiexec
-# can't fully clean up (e.g. the payload was already removed by a
-# previous partial run).
+# Uninstall via MSI first so it doesn't linger in Programs and Features,
+# then force-delete any registry remnants msiexec leaves behind.
 Log ''
 Log '  PHASE 0: VMware Tools MSI Uninstall'
 Log '---------------------------------------------------------------'
 
-# Declared here since Phase 0 is the first phase to call Delete-RegKey/Value.
+# Counters used by Delete-RegKey/Value, first called below.
 $regDeleted = 0
 $regErrors  = 0
 $msiRemoved = 0
@@ -328,16 +332,14 @@ if (-not $vmwareUninstallKeys) {
             Log "[WARNING] No product code found for $($entry.DisplayName) - forcing registry cleanup"
         }
 
-        # Guarantee the Add/Remove Programs entry is gone even if msiexec
-        # left it behind (e.g. payload already missing).
+        # Ensure the Add/Remove Programs entry is gone even if msiexec left it.
         Delete-RegKey $entry.KeyPath
     }
 }
 
-# Clean orphaned Windows Installer product registrations - these drive
-# Get-Package/Win32_Product visibility independently of the Uninstall key
-# above and can survive even a clean msiexec /x. Enumerate every SID
-# under UserData rather than hardcoding S-1-5-18 (SYSTEM).
+# Clean orphaned Windows Installer product registrations (drive
+# Get-Package/Win32_Product visibility; can survive a clean msiexec /x).
+# Enumerate every SID under UserData rather than hardcoding SYSTEM.
 $UserDataRoot = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData'
 $productsRoots = @('HKLM\SOFTWARE\Classes\Installer\Products')
 foreach ($sidKey in (Get-RegSubKeyPaths $UserDataRoot)) {
@@ -356,13 +358,10 @@ foreach ($productsRoot in $productsRoots) {
 
 Log "[INFO] VMware MSI products uninstalled via msiexec: $msiRemoved"
 
-# Clean orphaned Windows Installer "Components" ownership entries. Every
-# file/registry-key a product installs is tracked under
-# UserData\<SID>\Components\<ComponentGuid>, keyed by the owning
-# product's packed ProductCode (value data = install path). A clean
-# msiexec /x removes these automatically; the registry fallback above
-# doesn't. A component can be shared by multiple products, so delete
-# only the matching value, then remove the key once it has no owners left.
+# Clean orphaned Windows Installer "Components" ownership entries
+# (UserData\<SID>\Components\<ComponentGuid>), not handled by the
+# registry fallback above. A component can be shared by multiple
+# products, so only delete the matching value, then the key if empty.
 function Get-RegDataMatches {
     param([string]$KeyPath, [string]$Pattern)
     $out = & $RegExe query $KeyPath /f $Pattern /d /s 2>&1 | Out-String
@@ -394,14 +393,12 @@ foreach ($sidKey in (Get-RegSubKeyPaths $UserDataRoot)) {
 Log "[INFO] Orphaned Windows Installer Components entries removed: $componentsRemoved"
 
 # -------------------------------------------------------------------
-# PHASE 1: Stop and disable VMware services (quiesce before touching
-# drivers/devices below)
+# PHASE 1: Stop and disable VMware services
 # -------------------------------------------------------------------
-# Phase order matters: quiesce services first, remove driver packages
-# before PnP device instances, and only delete service definitions last
-# (Phase 4, after devices are gone). Otherwise: vmci (a PnP bus
-# enumerator) can keep re-asserting its bus device during removal, and
-# drivers still in the driver store can get re-selected on a PnP rescan.
+# Phase order matters: quiesce services, then drivers, then devices,
+# and only delete service definitions last (Phase 4). Otherwise vmci
+# (a PnP bus enumerator) can re-assert its device, and drivers still in
+# the driver store can get re-selected on a PnP rescan.
 Log ''
 Log '  PHASE 1: Stop and Disable VMware Services'
 Log '---------------------------------------------------------------'
@@ -451,42 +448,66 @@ if ($servicesToRemove.Count -eq 0) {
 }
 
 # -------------------------------------------------------------------
-# PHASE 2: Remove VMware driver packages (pnputil) - before PnP
-# device instances, see Phase 1 rationale above.
+# PHASE 2: Remove VMware driver packages (pnputil)
 # -------------------------------------------------------------------
 Log ''
 Log '  PHASE 2: VMware Driver Packages'
 Log '---------------------------------------------------------------'
 
-# Post-Broadcom-acquisition, VMware driver packages are republished with
-# "Provider Name: Broadcom Inc." instead of "VMware, Inc.", though the
-# .inf filename is unchanged. Matching "Broadcom" alone would be unsafe
-# (unrelated Broadcom NICs/RAID controllers exist), so anchor on known
-# VMware .inf basenames derived from $VMwareDriverFiles instead.
-# vm3d.inf (SVGA 3D setup package) has no matching .sys of its own
-# (the binary is vm3dmp.sys, already in that list), so add it explicitly.
+# Post-Broadcom-acquisition, some VMware driver packages are republished
+# as "Provider Name: Broadcom Inc.", but the .inf filename is unchanged.
+# Matching "Broadcom" alone would be unsafe (unrelated Broadcom hardware
+# exists), so match known VMware .inf basenames instead. vm3d.inf has no
+# matching .sys (its binary is vm3dmp.sys), so it's added explicitly.
 $VMwareExtraInfNames = @('vm3d.inf')
 $VMwareInfNames = ((($VMwareDriverFiles | ForEach-Object { $_ -replace '\.sys$', '.inf' }) + $VMwareExtraInfNames) |
     ForEach-Object { [regex]::Escape($_) }) -join '|'
 
-$pnpOutput = & $PnpUtil /enum-drivers 2>&1 | Out-String
-$driverBlocks = $pnpOutput -split '(?=Published Name)' |
-    Where-Object {
-        $_ -match 'VMware' -or
-        $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
-    }
+# Get-WindowsDriver returns structured fields, so it works regardless of
+# display language. pnputil's text output is English-only, so it's only
+# a fallback below.
+$publishedNames = $null
+try {
+    $publishedNames = @(
+        Get-WindowsDriver -Online -ErrorAction Stop |
+            Where-Object {
+                $_.ProviderName -match 'VMware' -or
+                $_.OriginalFileName -match "(?i)($VMwareInfNames)"
+            } |
+            ForEach-Object { $_.Driver }
+    )
+    Log "[INFO] Get-WindowsDriver identified $($publishedNames.Count) VMware driver package(s)"
+} catch {
+    Log "[WARNING] Get-WindowsDriver unavailable ($_) - falling back to pnputil text parsing (English output only)"
+}
 
 $drvRemoved = 0
-if ($driverBlocks.Count -eq 0) {
-    Log '[INFO] No VMware driver packages found in driver store.'
-} else {
-    Log "[INFO] Found $($driverBlocks.Count) VMware driver package(s)"
-    foreach ($block in $driverBlocks) {
-        $inf = if ($block -match 'Published Name\s*:\s*(\S+)') { $Matches[1] } else { '(unknown)' }
+if ($null -ne $publishedNames) {
+    foreach ($inf in $publishedNames) {
         Log "[DRIVER] Removing $inf ..."
         $result = & $PnpUtil /delete-driver "$inf" /uninstall /force 2>&1 | Out-String
         Log "  $result"
         $drvRemoved++
+    }
+} else {
+    $pnpOutput = & $PnpUtil /enum-drivers 2>&1 | Out-String
+    $driverBlocks = $pnpOutput -split '(?=Published Name)' |
+        Where-Object {
+            $_ -match 'VMware' -or
+            $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
+        }
+
+    if ($driverBlocks.Count -eq 0) {
+        Log '[INFO] No VMware driver packages found in driver store.'
+    } else {
+        Log "[INFO] Found $($driverBlocks.Count) VMware driver package(s)"
+        foreach ($block in $driverBlocks) {
+            $inf = if ($block -match 'Published Name\s*:\s*(\S+)') { $Matches[1] } else { '(unknown)' }
+            Log "[DRIVER] Removing $inf ..."
+            $result = & $PnpUtil /delete-driver "$inf" /uninstall /force 2>&1 | Out-String
+            Log "  $result"
+            $drvRemoved++
+        }
     }
 }
 
@@ -497,19 +518,16 @@ Log ''
 Log '  PHASE 3: VMware PnP Devices'
 Log '---------------------------------------------------------------'
 
-# vmci is a PnP bus enumerator and can keep re-asserting its bus device
-# during removal below - Phase 1 only stopped/disabled it, so delete it
-# outright here, immediately before device removal. Remove it from the
-# pending Phase 4 list so that phase doesn't warn it's already gone.
+# vmci is a PnP bus enumerator that can keep re-asserting its device, so
+# delete it outright now, right before device removal. Drop it from the
+# Phase 4 list since it's already gone.
 & sc.exe stop vmci 2>&1 | Out-Null
 & sc.exe delete vmci 2>&1 | Out-Null
 $servicesToRemove = @($servicesToRemove | Where-Object { $_.Name -ne 'vmci' })
 
-# vm3d.inf registers a class coinstaller (vm3dc003.dll) under the
-# Display-adapters class GUID. A class coinstaller runs for every
-# device in that class and can veto removal for any of them, so strip
-# only the matching entry - never the whole REG_MULTI_SZ value, since
-# other legitimate coinstallers may share it.
+# vm3d.inf registers a class coinstaller (vm3dc003.dll) that runs for
+# every display device and can veto removal, so strip only that entry -
+# other legitimate coinstallers may share the same REG_MULTI_SZ value.
 $displayClassGuid = '{4d36e968-e325-11ce-bfc1-08002be10318}'
 $coDevKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\CoDeviceInstallers'
 $coDevProp = Get-ItemProperty -Path $coDevKey -Name $displayClassGuid -ErrorAction SilentlyContinue
@@ -526,11 +544,85 @@ $vmDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
         $_.Manufacturer -match 'VMware' -or
         $_.FriendlyName -match 'VMware' -or
         $_.InstanceId -match 'VEN_15AD' -or
-        # VMware's USB vendor ID - catches the generic "USB Composite
-        # Device"/"USB Input Device" parent of the VMware USB mouse,
-        # which never says VMware in its own description.
-        $_.InstanceId -match 'VID_0E0F'
+        # VMware's USB vendor ID - catches the "USB Composite Device"
+        # parent of the VMware USB mouse, which doesn't say VMware itself.
+        $_.InstanceId -match 'VID_0E0F' -or
+        # ROOT-enumerated software devices (e.g. ROOT\VMWVMCIHOSTDEV\0000)
+        # that can lack a VMware Manufacturer/FriendlyName entirely.
+        $_.InstanceId -match '^ROOT\\(VMWVMCI|VMware)'
     }
+
+# Builds an InstanceId -> [DeviceClasses key path] lookup in one pass,
+# using the .NET registry API instead of reg.exe. DeviceClasses can hold
+# thousands of entries, and this runs once per ghost device below, so a
+# fresh reg.exe scan per call would mean tens of thousands of process
+# spawns - one cached in-process scan avoids that.
+function Get-DeviceClassesInstanceMap {
+    $map = @{}
+    $hklm64 = [Microsoft.Win32.RegistryKey]::OpenBaseKey('LocalMachine', 'Registry64')
+    $root = $hklm64.OpenSubKey('SYSTEM\CurrentControlSet\Control\DeviceClasses')
+    if (-not $root) { return $map }
+    foreach ($ifaceGuidName in $root.GetSubKeyNames()) {
+        $ifaceGuidKey = $root.OpenSubKey($ifaceGuidName)
+        if (-not $ifaceGuidKey) { continue }
+        foreach ($instName in $ifaceGuidKey.GetSubKeyNames()) {
+            $instKey = $ifaceGuidKey.OpenSubKey($instName)
+            if ($instKey) {
+                $devInst = $instKey.GetValue('DeviceInstance')
+                if ($devInst) {
+                    if (-not $map.ContainsKey($devInst)) {
+                        $map[$devInst] = New-Object System.Collections.Generic.List[string]
+                    }
+                    $map[$devInst].Add("HKLM\SYSTEM\CurrentControlSet\Control\DeviceClasses\$ifaceGuidName\$instName")
+                }
+                $instKey.Close()
+            }
+        }
+        $ifaceGuidKey.Close()
+    }
+    $root.Close()
+    return $map
+}
+
+# Cleans stale references to a ghost device that the raw Enum key
+# delete below doesn't touch: its class-specific driver binding and its
+# DeviceClasses interface registration(s). Leftovers here are a
+# suspected cause of Windows resynthesizing a fresh "Unknown" Enum entry
+# for an already-deleted device. DeviceContainers is only reported, not
+# deleted - it can be shared by sibling functions of a composite device.
+# Must run BEFORE the Enum key delete - it's the source of the "Driver"
+# pointer used below.
+function Clear-GhostDeviceReferences {
+    param([string]$InstanceId)
+
+    # The Enum key's "Driver" value ("{ClassGUID}\NNNN") points to its
+    # class driver binding key - the only way to find it, since that key
+    # has no value pointing back.
+    $enumKey = "HKLM\SYSTEM\CurrentControlSet\Enum\$InstanceId"
+    $driverBinding = Get-RegValue $enumKey 'Driver'
+    if ($driverBinding) {
+        $bindingKey = "HKLM\SYSTEM\CurrentControlSet\Control\Class\$driverBinding"
+        Delete-RegKey $bindingKey
+        Log "[INFO] Cleared class driver binding for $InstanceId ($bindingKey)"
+    }
+
+    # Built once, lazily, and reused across calls - see
+    # Get-DeviceClassesInstanceMap above.
+    if (-not $script:deviceClassesMap) {
+        $script:deviceClassesMap = Get-DeviceClassesInstanceMap
+    }
+    if ($script:deviceClassesMap.ContainsKey($InstanceId)) {
+        foreach ($ifaceInstanceKey in $script:deviceClassesMap[$InstanceId]) {
+            Delete-RegKey $ifaceInstanceKey
+            Log "[INFO] Cleared DeviceClasses interface registration for $InstanceId ($ifaceInstanceKey)"
+        }
+    }
+
+    $containerHits = Get-RegDataMatches 'HKLM\SYSTEM\CurrentControlSet\Control\DeviceContainers' $InstanceId
+    foreach ($hit in $containerHits) {
+        Log "[WARNING] DeviceContainers still references $InstanceId (not removed - may be shared with another device): $($hit.KeyPath)\$($hit.ValueName)"
+    }
+}
 
 if (-not $vmDevices -or $vmDevices.Count -eq 0) {
     Log '[INFO] No VMware PnP devices found.'
@@ -561,11 +653,9 @@ if (-not $vmDevices -or $vmDevices.Count -eq 0) {
             }
         }
 
-        # Ghost devices (Status=Unknown) commonly survive both
-        # Disable-PnpDevice and pnputil /remove-device (which also
-        # doesn't exist pre-Windows 10 2004/Server 2022). Try
-        # CM_Uninstall_DevNode next; fall back to a raw registry
-        # delete only as a last resort.
+        # Ghost devices (Status=Unknown) often survive Disable-PnpDevice
+        # and pnputil /remove-device (also missing pre-2004/Server 2022).
+        # Try CM_Uninstall_DevNode, then raw registry delete as last resort.
         if (-not $removed -and $dev.Status -eq 'Unknown') {
             if (Remove-GhostDevNode -InstanceId $dev.InstanceId) {
                 Log "[REMOVED] $($dev.FriendlyName) (CM_Uninstall_DevNode)"
@@ -574,6 +664,7 @@ if (-not $vmDevices -or $vmDevices.Count -eq 0) {
         }
 
         if (-not $removed -and $dev.Status -eq 'Unknown') {
+            Clear-GhostDeviceReferences -InstanceId $dev.InstanceId
             $enumKey = "HKLM\SYSTEM\CurrentControlSet\Enum\$($dev.InstanceId)"
             & $RegExe delete $enumKey /f 2>&1 | Out-Null
             if ($LASTEXITCODE -eq 0) {
@@ -624,12 +715,10 @@ foreach ($key in $allRegKeys) {
 Delete-RegValue 'HKLM\SOFTWARE\RegisteredApplications' 'VMware Host Open'
 
 # --- Stray COM registrations (CLSID/TypeLib) ---
-# VMware Tools registers several COM components under CLSID/TypeLib
-# GUIDs that vary across Tools builds, so hardcoding them doesn't scale.
-# CLSID/TypeLib can each have tens of thousands of subkeys, so this uses
-# the .NET registry API directly (64-bit view) instead of spawning
-# reg.exe per GUID or recursively text-dumping the whole subtree
-# (both far too slow - minutes vs. seconds).
+# VMware Tools registers COM components under CLSID/TypeLib GUIDs that
+# vary across builds, so they can't be hardcoded. CLSID/TypeLib can each
+# have tens of thousands of subkeys, so this scans in-process via .NET
+# instead of spawning reg.exe per GUID (minutes vs. seconds).
 function Test-RegValueContainsVMware {
     param([Microsoft.Win32.RegistryKey]$Key)
     if (-not $Key) { return $false }
@@ -640,9 +729,8 @@ function Test-RegValueContainsVMware {
     return $false
 }
 
-# Bounded-depth recursive scan. CLSID's path sits one level down
-# (InprocServer32/LocalServer32), TypeLib's two levels down
-# (e.g. {GUID}\1.0\0\win64) - depth 3 covers both cheaply.
+# Bounded-depth recursive scan: CLSID's path is one level down,
+# TypeLib's is two levels down - depth 3 covers both.
 function Test-KeyTreeContainsVMware {
     param([Microsoft.Win32.RegistryKey]$Key, [int]$Depth = 3)
     if (-not $Key) { return $false }
@@ -691,11 +779,9 @@ foreach ($root in $comRoots) {
 Log "[INFO] Stray VMware COM (CLSID/TypeLib) registrations removed: $comRemoved"
 
 # --- Installer\Folders stale path references ---
-# Windows Installer records every folder a per-machine MSI product wrote
-# to under Installer\Folders (the folder path is the value NAME, e.g.
-# "C:\ProgramData\VMware\VMware VGAuth\msgCatalog\"). Not reliably
-# pruned by msiexec /x, so sweep it directly. This key is WOW64-shared,
-# so there's no separate WOW6432Node copy to check.
+# Records every folder an MSI product wrote to, keyed by folder path as
+# the value NAME. Not reliably pruned by msiexec /x, so swept directly.
+# This key is WOW64-shared - no separate WOW6432Node copy exists.
 $foldersKeyPS = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\Folders'
 $foldersProps = Get-ItemProperty -Path $foldersKeyPS -ErrorAction SilentlyContinue
 if ($foldersProps) {
@@ -710,8 +796,8 @@ if ($foldersProps) {
 }
 
 # --- Run/RunOnce autostart entries ---
-# e.g. "VMware VM3DService Process" under Run - a harmless but visible
-# leftover once the target .exe is gone.
+# e.g. "VMware VM3DService Process" - a harmless leftover once the
+# target .exe is gone.
 function Remove-VMwareRunEntries {
     param([string]$KeyPath)
     $psPath = $KeyPath -replace '^HKLM\\', 'HKLM:\'
@@ -735,9 +821,8 @@ foreach ($runKey in @(
 )) { Remove-VMwareRunEntries $runKey }
 
 # --- SVGA 3D display adapter "software device" node ---
-# HKLM\SYSTEM\CurrentControlSet\Control\Video\{GUID}\Video holds a
-# separate DeviceDesc/Service registration from the vm3dmp_loader
-# service key already deleted above.
+# Control\Video\{GUID}\Video holds a separate registration from the
+# vm3dmp_loader service key already deleted above.
 $videoRoot = 'HKLM\SYSTEM\CurrentControlSet\Control\Video'
 foreach ($guidKey in (Get-RegSubKeyPaths $videoRoot)) {
     $desc = Get-RegValue "$guidKey\Video" 'DeviceDesc'
@@ -761,8 +846,16 @@ foreach ($dir in $VMwareDirs) {
     Remove-PathItem $dir -Recurse
 }
 
-# Per-user VMware AppData folders - not covered by $VMwareDirs since
-# the path depends on each profile under \Users.
+foreach ($pattern in $VMwareTempDirPatterns) {
+    $parent = Split-Path $pattern -Parent
+    $leaf   = Split-Path $pattern -Leaf
+    if (Test-Path $parent) {
+        Get-ChildItem -Path $parent -Directory -Filter $leaf -ErrorAction SilentlyContinue |
+            ForEach-Object { Remove-PathItem $_.FullName -Recurse }
+    }
+}
+
+# Per-user AppData folders - path depends on each profile under \Users.
 $usersRoot = Join-Path $env:SystemDrive 'Users'
 if (Test-Path $usersRoot) {
     # -Force: C:\Users\Default is hidden and would otherwise be skipped.
@@ -783,12 +876,20 @@ foreach ($f in $allFiles) {
     Remove-PathItem $f
 }
 
-# DriverStore leftovers
+# DriverStore leftovers - report only, don't delete directly.
+# DriverStore\FileRepository is tracked by Component-Based Servicing;
+# force-deleting a folder here can leave that bookkeeping inconsistent
+# and surface as DISM /CheckHealth corruption later. Anything pnputil
+# didn't remove in Phase 2 is logged here for manual follow-up instead.
+$driverStoreResidual = 0
 $driverStore = Join-Path $Sys32 'DriverStore\FileRepository'
 if (Test-Path $driverStore) {
     Get-ChildItem -Path $driverStore -Directory -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -match $DriverStorePattern } |
-        ForEach-Object { Remove-PathItem $_.FullName -Recurse }
+        ForEach-Object {
+            Log "[WARNING] Residual DriverStore folder (not removed - use pnputil /delete-driver or investigate manually): $($_.FullName)"
+            $driverStoreResidual++
+        }
 }
 
 # -------------------------------------------------------------------
@@ -831,5 +932,6 @@ Log "  Registry keys deleted:   $regDeleted"
 Log "  Registry errors:         $regErrors"
 Log "  Files/dirs removed:      $fileDeleted"
 Log "  File removal errors:     $fileErrors"
+Log "  DriverStore residuals (not removed, need follow-up): $driverStoreResidual"
 Log "  Log: $LogFile"
 Log '==============================================================='

--- a/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.ps1
@@ -5,12 +5,51 @@
 
 $ErrorActionPreference = 'Continue'
 
+# Schedule-for-reboot helper via MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT).
+# Used as last resort when a file is locked (e.g. loaded driver).
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class LockedFileDeleter {
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool MoveFileEx(
+        string lpExistingFileName, string lpNewFileName, int dwFlags);
+    public const int MOVEFILE_DELAY_UNTIL_REBOOT = 0x4;
+}
+
+// CM_Uninstall_DevNode: same API Device Manager's "Uninstall device"
+// uses to remove a ghost/non-present device. Safer than deleting the
+// CurrentControlSet\Enum key by hand, which can corrupt the PnP database.
+public static class CfgMgr {
+    public const uint CM_LOCATE_DEVNODE_PHANTOM = 0x00000001;
+    public const uint CR_SUCCESS = 0x00000000;
+
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode, SetLastError = true,
+        EntryPoint = "CM_Locate_DevNodeW")]
+    public static extern uint CM_Locate_DevNode(
+        out uint pdnDevInst, string pDeviceID, uint ulFlags);
+
+    [DllImport("cfgmgr32.dll", SetLastError = true,
+        EntryPoint = "CM_Uninstall_DevNode")]
+    public static extern uint CM_Uninstall_DevNode(uint dnDevInst, uint ulFlags);
+}
+"@
+
+# Removes a ghost/non-present device instance. Returns $true on success.
+function Remove-GhostDevNode {
+    param([string]$InstanceId)
+    $devInst = 0
+    $cr = [CfgMgr]::CM_Locate_DevNode([ref]$devInst, $InstanceId, [CfgMgr]::CM_LOCATE_DEVNODE_PHANTOM)
+    if ($cr -ne [CfgMgr]::CR_SUCCESS) { return $false }
+    $cr2 = [CfgMgr]::CM_Uninstall_DevNode($devInst, 0)
+    return ($cr2 -eq [CfgMgr]::CR_SUCCESS)
+}
+
 # ===================================================================
 # WOW64-safe path resolution
 # ===================================================================
-# The firstboot service may run as a 32-bit (WOW64) process where
-# System32 is redirected to SysWOW64.  Sysnative escapes back to the
-# real 64-bit System32.
+# Use Sysnative (not System32) in case this runs as a 32-bit process,
+# where System32 would otherwise be redirected to SysWOW64.
 $Sysnative = Join-Path $env:SystemRoot 'Sysnative'
 if (Test-Path $Sysnative) {
     $Sys32   = $Sysnative
@@ -28,10 +67,15 @@ $RegExe  = Join-Path $Sys32 'reg.exe'
 
 $VMwareServices = @(
     'VGAuthService', 'VM3DService', 'VMTools', 'vmvss', 'GISvc',
-    'vmhgfs', 'vmmemctl', 'vmrawdsk', 'vnetWFP', 'vsepflt',
+    'vmhgfs', 'vmmemctl', 'vmrawdsk', 'vnetWFP', 'vnetflt', 'vsepflt',
     'vmci', 'vmxnet3', 'vmxnet3ndis6', 'pvscsi',
     'vmusbmouse', 'vmmouse',
-    'vm3dmp', 'vm3dmp-debug', 'vm3dmp-stats', 'vm3dmp_loader'
+    'vm3dmp', 'vm3dmp-debug', 'vm3dmp-stats', 'vm3dmp_loader',
+    # vgauth/cblauncher are alternate/legacy names alongside
+    # VGAuthService/CbLauncher - a no-op if not present.
+    'vsock', 'efifw', 'svga_wddm', 'vmaudio', 'vgauth', 'cblauncher',
+    'vmwtimeprovider', 'vmstatsprovider', 'vmupgradehelper',
+    'vmwefifw'
 )
 
 # Registry keys that are NOT auto-derived from service names.
@@ -49,6 +93,7 @@ $VMwareRegistryKeys = @(
     'HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VGAuth',
     'HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMware Tools',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP',
+    'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetflt',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vmci'
 )
@@ -66,7 +111,12 @@ $VMwareDriverFiles = @(
     'vmci.sys', 'vmmouse.sys', 'vmrawdsk.sys', 'vmhgfs.sys',
     'vmusbmouse.sys', 'pvscsi.sys', 'vmxnet3.sys',
     'vm3dmp.sys', 'vm3dmp-debug.sys', 'vm3dmp-stats.sys', 'vm3dmp_loader.sys',
-    'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys'
+    'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys',
+    # vnetflt: pre-10.2.5 predecessor of vnetWFP for the Tools
+    # "NetworkIntrospection" feature. A Tools installer bug can leave
+    # it behind and BSOD alongside the newer vsepflt driver.
+    'vnetflt.sys',
+    'svga_wddm.sys', 'efifw.sys', 'vmaudio.sys'
 )
 
 $VMwareSystemFiles = @(
@@ -112,8 +162,8 @@ function Log {
     Add-Content -Path $LogFile -Value $line
 }
 
-# Delete a registry key tree via reg.exe.
-# Uses reg.exe query (not PowerShell Test-Path) to avoid WOW64 redirection.
+# Delete a registry key tree. Uses reg.exe (not PowerShell) to avoid
+# WOW64 redirection.
 function Delete-RegKey {
     param([string]$KeyPath)
     & $RegExe query $KeyPath /ve 2>&1 | Out-Null
@@ -143,8 +193,30 @@ function Delete-RegValue {
     }
 }
 
+# List immediate subkey paths of a key (WOW64-safe).
+function Get-RegSubKeyPaths {
+    param([string]$KeyPath)
+    $out = & $RegExe query $KeyPath 2>&1
+    if ($LASTEXITCODE -ne 0) { return @() }
+    $out |
+        Where-Object { $_ -match '^HKEY_LOCAL_MACHINE\\' } |
+        ForEach-Object { ($_ -replace '^HKEY_LOCAL_MACHINE\\', 'HKLM\').Trim() } |
+        Where-Object { $_ -ne $KeyPath }
+}
+
+# Read a single string value from a key via reg.exe.
+function Get-RegValue {
+    param([string]$KeyPath, [string]$ValueName)
+    $out = & $RegExe query $KeyPath /v $ValueName 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { return $null }
+    $m = [regex]::Match($out, [regex]::Escape($ValueName) + '\s+REG_\w+\s+(.+)')
+    if ($m.Success) { return $m.Groups[1].Value.Trim() }
+    return $null
+}
+
 # Remove a file or directory with logging and counter updates.
-# For directories, falls back to cmd /c rd if Remove-Item leaves remnants.
+# Falls back to cmd /c rd/del, then schedules locked files for
+# deletion on reboot via MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT).
 function Remove-PathItem {
     param([string]$Path, [switch]$Recurse)
     if (-not (Test-Path $Path)) { return }
@@ -161,13 +233,28 @@ function Remove-PathItem {
             & cmd.exe /c del /f /q "$Path" 2>&1 | Out-Null
         }
     }
-    if (Test-Path $Path) {
-        Log "[WARNING] Could not remove: $Path"
-        $script:fileErrors++
-    } else {
+    if (-not (Test-Path $Path)) {
         Log "[DEL] $Path"
         $script:fileDeleted++
+        return
     }
+    # File is locked (e.g. loaded driver) - schedule for reboot deletion.
+    # Resolve Sysnative back to System32 so the kernel can find the file.
+    if (-not $Recurse) {
+        $kernelPath = $Path -replace '(?i)\\Sysnative\\', '\System32\'
+        # Must pass [NullString]::Value, not $null - PowerShell marshals a
+        # bare $null as "", which MoveFileEx treats as "rename to empty
+        # path" (fails) instead of "delete on reboot".
+        $ok = [LockedFileDeleter]::MoveFileEx($kernelPath, [NullString]::Value,
+                [LockedFileDeleter]::MOVEFILE_DELAY_UNTIL_REBOOT)
+        if ($ok) {
+            Log "[DEL-REBOOT] $Path (scheduled for deletion on reboot)"
+            $script:fileDeleted++
+            return
+        }
+    }
+    Log "[WARNING] Could not remove: $Path"
+    $script:fileErrors++
 }
 
 # ===================================================================
@@ -180,91 +267,143 @@ Log '==============================================================='
 Log "[INFO] Sys32=$Sys32  PnpUtil=$PnpUtil  RegExe=$RegExe"
 
 # -------------------------------------------------------------------
-# PHASE 1: Disable and remove VMware PnP devices
+# PHASE 0: Uninstall VMware Tools via Windows Installer (MSI)
 # -------------------------------------------------------------------
+# VMware Tools is an MSI product. Manually deleting its files/services/
+# drivers (Phases 1-6) never touches Windows Installer's own bookkeeping,
+# so it would keep showing up in Programs and Features forever. Uninstall
+# it properly first, then force-delete the registry remnants if msiexec
+# can't fully clean up (e.g. the payload was already removed by a
+# previous partial run).
 Log ''
-Log '  PHASE 1: VMware PnP Devices'
+Log '  PHASE 0: VMware Tools MSI Uninstall'
 Log '---------------------------------------------------------------'
 
-$vmDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
-    Where-Object {
-        $_.Manufacturer -match 'VMware' -or
-        $_.FriendlyName -match 'VMware' -or
-        $_.InstanceId -match 'VEN_15AD'
+# Declared here since Phase 0 is the first phase to call Delete-RegKey/Value.
+$regDeleted = 0
+$regErrors  = 0
+$msiRemoved = 0
+$UninstallRoots = @(
+    'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+    'HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$vmwareUninstallKeys = foreach ($root in $UninstallRoots) {
+    foreach ($sub in (Get-RegSubKeyPaths $root)) {
+        $displayName = Get-RegValue $sub 'DisplayName'
+        if ($displayName -match 'VMware') {
+            [PSCustomObject]@{
+                KeyPath         = $sub
+                DisplayName     = $displayName
+                UninstallString = Get-RegValue $sub 'UninstallString'
+            }
+        }
     }
+}
 
-if (-not $vmDevices -or $vmDevices.Count -eq 0) {
-    Log '[INFO] No VMware PnP devices found.'
+if (-not $vmwareUninstallKeys) {
+    Log '[INFO] No VMware entries in Add/Remove Programs.'
 } else {
-    Log "[INFO] Found $($vmDevices.Count) VMware PnP device(s)"
+    foreach ($entry in $vmwareUninstallKeys) {
+        $productCode = $null
+        if ($entry.KeyPath -match '(\{[0-9A-Fa-f\-]{36}\})$') { $productCode = $Matches[1] }
+        elseif ($entry.UninstallString -match '(\{[0-9A-Fa-f\-]{36}\})') { $productCode = $Matches[1] }
 
-    $pnpHelp = & $PnpUtil /? 2>&1 | Out-String
-    $hasRemoveDevice = $pnpHelp -match '/remove-device'
-
-    foreach ($dev in $vmDevices) {
-        Log "[DEVICE] $($dev.FriendlyName) [$($dev.InstanceId)] Status=$($dev.Status)"
-
-        if ($dev.Status -ne 'Unknown') {
+        if ($productCode) {
+            Log "[MSI] Uninstalling $($entry.DisplayName) $productCode ..."
             try {
-                Disable-PnpDevice -InstanceId $dev.InstanceId -Confirm:$false -ErrorAction Stop
-                Log "[DISABLED] $($dev.FriendlyName)"
-            } catch {
-                Log "[WARNING] Could not disable: $($dev.FriendlyName) - $_"
-            }
-        }
-
-        if ($hasRemoveDevice) {
-            & $PnpUtil /remove-device "$($dev.InstanceId)" 2>&1 | Out-Null
-            if ($LASTEXITCODE -eq 0) {
-                Log "[REMOVED] $($dev.FriendlyName)"
-            }
-        }
-    }
-
-    if (-not $hasRemoveDevice) {
-        Log '[INFO] pnputil /remove-device not available - removing ghost devices via registry.'
-        foreach ($dev in $vmDevices) {
-            if ($dev.Status -eq 'Unknown') {
-                $enumKey = "HKLM\SYSTEM\CurrentControlSet\Enum\$($dev.InstanceId)"
-                & $RegExe delete $enumKey /f 2>&1 | Out-Null
-                if ($LASTEXITCODE -eq 0) {
-                    Log "[DEL ENUM] $($dev.FriendlyName)"
+                $p = Start-Process -FilePath 'msiexec.exe' `
+                    -ArgumentList "/x $productCode /qn /norestart" `
+                    -Wait -PassThru -ErrorAction Stop
+                if ($p.ExitCode -eq 0) {
+                    Log "[SUCCESS] msiexec removed $($entry.DisplayName)"
+                    $msiRemoved++
+                } else {
+                    Log "[WARNING] msiexec exited $($p.ExitCode) for $($entry.DisplayName) - forcing registry cleanup"
                 }
+            } catch {
+                Log "[WARNING] msiexec failed to launch for $($entry.DisplayName): $_"
             }
+        } else {
+            Log "[WARNING] No product code found for $($entry.DisplayName) - forcing registry cleanup"
+        }
+
+        # Guarantee the Add/Remove Programs entry is gone even if msiexec
+        # left it behind (e.g. payload already missing).
+        Delete-RegKey $entry.KeyPath
+    }
+}
+
+# Clean orphaned Windows Installer product registrations - these drive
+# Get-Package/Win32_Product visibility independently of the Uninstall key
+# above and can survive even a clean msiexec /x. Enumerate every SID
+# under UserData rather than hardcoding S-1-5-18 (SYSTEM).
+$UserDataRoot = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData'
+$productsRoots = @('HKLM\SOFTWARE\Classes\Installer\Products')
+foreach ($sidKey in (Get-RegSubKeyPaths $UserDataRoot)) {
+    $productsRoots += "$sidKey\Products"
+}
+
+foreach ($productsRoot in $productsRoots) {
+    foreach ($sub in (Get-RegSubKeyPaths $productsRoot)) {
+        $name = Get-RegValue $sub 'ProductName'
+        if (-not $name) { $name = Get-RegValue "$sub\InstallProperties" 'DisplayName' }
+        if ($name -match 'VMware') {
+            Delete-RegKey $sub
         }
     }
 }
 
-# -------------------------------------------------------------------
-# PHASE 2: Remove VMware driver packages (pnputil)
-# -------------------------------------------------------------------
-Log ''
-Log '  PHASE 2: VMware Driver Packages'
-Log '---------------------------------------------------------------'
+Log "[INFO] VMware MSI products uninstalled via msiexec: $msiRemoved"
 
-$pnpOutput = & $PnpUtil /enum-drivers 2>&1 | Out-String
-$driverBlocks = $pnpOutput -split '(?=Published Name)' |
-    Where-Object { $_ -match 'VMware|Broadcom.*vmx' }
-
-$drvRemoved = 0
-if ($driverBlocks.Count -eq 0) {
-    Log '[INFO] No VMware driver packages found in driver store.'
-} else {
-    Log "[INFO] Found $($driverBlocks.Count) VMware driver package(s)"
-    foreach ($block in $driverBlocks) {
-        $inf = if ($block -match 'Published Name\s*:\s*(\S+)') { $Matches[1] } else { '(unknown)' }
-        Log "[DRIVER] Removing $inf ..."
-        $result = & $PnpUtil /delete-driver "$inf" /uninstall /force 2>&1 | Out-String
-        Log "  $result"
-        $drvRemoved++
+# Clean orphaned Windows Installer "Components" ownership entries. Every
+# file/registry-key a product installs is tracked under
+# UserData\<SID>\Components\<ComponentGuid>, keyed by the owning
+# product's packed ProductCode (value data = install path). A clean
+# msiexec /x removes these automatically; the registry fallback above
+# doesn't. A component can be shared by multiple products, so delete
+# only the matching value, then remove the key once it has no owners left.
+function Get-RegDataMatches {
+    param([string]$KeyPath, [string]$Pattern)
+    $out = & $RegExe query $KeyPath /f $Pattern /d /s 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { return @() }
+    $results = New-Object System.Collections.Generic.List[object]
+    $currentKey = $null
+    foreach ($line in ($out -split "`r?`n")) {
+        if ($line -match '^HKEY_LOCAL_MACHINE\\(.+)$') {
+            $currentKey = "HKLM\$($Matches[1])"
+        } elseif ($currentKey -and $line -match '^\s+(\S+)\s+REG_\w+\s+.*') {
+            $results.Add([PSCustomObject]@{ KeyPath = $currentKey; ValueName = $Matches[1] })
+        }
     }
+    return $results
 }
 
+$componentsRemoved = 0
+foreach ($sidKey in (Get-RegSubKeyPaths $UserDataRoot)) {
+    $componentsRoot = "$sidKey\Components"
+    foreach ($hit in (Get-RegDataMatches $componentsRoot 'VMware')) {
+        Delete-RegValue $hit.KeyPath $hit.ValueName
+        $componentsRemoved++
+        $remaining = & $RegExe query $hit.KeyPath 2>&1 | Out-String
+        if ($LASTEXITCODE -eq 0 -and $remaining -notmatch 'REG_') {
+            Delete-RegKey $hit.KeyPath
+        }
+    }
+}
+Log "[INFO] Orphaned Windows Installer Components entries removed: $componentsRemoved"
+
 # -------------------------------------------------------------------
-# PHASE 3: Stop, disable, and delete VMware services
+# PHASE 1: Stop and disable VMware services (quiesce before touching
+# drivers/devices below)
 # -------------------------------------------------------------------
+# Phase order matters: quiesce services first, remove driver packages
+# before PnP device instances, and only delete service definitions last
+# (Phase 4, after devices are gone). Otherwise: vmci (a PnP bus
+# enumerator) can keep re-asserting its bus device during removal, and
+# drivers still in the driver store can get re-selected on a PnP rescan.
 Log ''
-Log '  PHASE 3: VMware Services'
+Log '  PHASE 1: Stop and Disable VMware Services'
 Log '---------------------------------------------------------------'
 
 $svcDeleted = 0
@@ -296,7 +435,7 @@ if ($servicesToRemove.Count -eq 0) {
 } else {
     Log "[INFO] Found $($servicesToRemove.Count) VMware-related service(s)"
     foreach ($svc in $servicesToRemove) {
-        Log "[SERVICE] Processing $($svc.Name) ($($svc.DisplayName)) - Status: $($svc.Status)"
+        Log "[SERVICE] Stopping/disabling $($svc.Name) ($($svc.DisplayName)) - Status: $($svc.Status)"
 
         & sc.exe stop "$($svc.Name)" 2>&1 | Out-Null
         Start-Sleep -Seconds 2
@@ -308,6 +447,153 @@ if ($servicesToRemove.Count -eq 0) {
         }
 
         & sc.exe config "$($svc.Name)" start= disabled 2>&1 | Out-Null
+    }
+}
+
+# -------------------------------------------------------------------
+# PHASE 2: Remove VMware driver packages (pnputil) - before PnP
+# device instances, see Phase 1 rationale above.
+# -------------------------------------------------------------------
+Log ''
+Log '  PHASE 2: VMware Driver Packages'
+Log '---------------------------------------------------------------'
+
+# Post-Broadcom-acquisition, VMware driver packages are republished with
+# "Provider Name: Broadcom Inc." instead of "VMware, Inc.", though the
+# .inf filename is unchanged. Matching "Broadcom" alone would be unsafe
+# (unrelated Broadcom NICs/RAID controllers exist), so anchor on known
+# VMware .inf basenames derived from $VMwareDriverFiles instead.
+# vm3d.inf (SVGA 3D setup package) has no matching .sys of its own
+# (the binary is vm3dmp.sys, already in that list), so add it explicitly.
+$VMwareExtraInfNames = @('vm3d.inf')
+$VMwareInfNames = ((($VMwareDriverFiles | ForEach-Object { $_ -replace '\.sys$', '.inf' }) + $VMwareExtraInfNames) |
+    ForEach-Object { [regex]::Escape($_) }) -join '|'
+
+$pnpOutput = & $PnpUtil /enum-drivers 2>&1 | Out-String
+$driverBlocks = $pnpOutput -split '(?=Published Name)' |
+    Where-Object {
+        $_ -match 'VMware' -or
+        $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
+    }
+
+$drvRemoved = 0
+if ($driverBlocks.Count -eq 0) {
+    Log '[INFO] No VMware driver packages found in driver store.'
+} else {
+    Log "[INFO] Found $($driverBlocks.Count) VMware driver package(s)"
+    foreach ($block in $driverBlocks) {
+        $inf = if ($block -match 'Published Name\s*:\s*(\S+)') { $Matches[1] } else { '(unknown)' }
+        Log "[DRIVER] Removing $inf ..."
+        $result = & $PnpUtil /delete-driver "$inf" /uninstall /force 2>&1 | Out-String
+        Log "  $result"
+        $drvRemoved++
+    }
+}
+
+# -------------------------------------------------------------------
+# PHASE 3: Disable and remove VMware PnP devices
+# -------------------------------------------------------------------
+Log ''
+Log '  PHASE 3: VMware PnP Devices'
+Log '---------------------------------------------------------------'
+
+# vmci is a PnP bus enumerator and can keep re-asserting its bus device
+# during removal below - Phase 1 only stopped/disabled it, so delete it
+# outright here, immediately before device removal. Remove it from the
+# pending Phase 4 list so that phase doesn't warn it's already gone.
+& sc.exe stop vmci 2>&1 | Out-Null
+& sc.exe delete vmci 2>&1 | Out-Null
+$servicesToRemove = @($servicesToRemove | Where-Object { $_.Name -ne 'vmci' })
+
+# vm3d.inf registers a class coinstaller (vm3dc003.dll) under the
+# Display-adapters class GUID. A class coinstaller runs for every
+# device in that class and can veto removal for any of them, so strip
+# only the matching entry - never the whole REG_MULTI_SZ value, since
+# other legitimate coinstallers may share it.
+$displayClassGuid = '{4d36e968-e325-11ce-bfc1-08002be10318}'
+$coDevKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\CoDeviceInstallers'
+$coDevProp = Get-ItemProperty -Path $coDevKey -Name $displayClassGuid -ErrorAction SilentlyContinue
+if ($coDevProp -and $coDevProp.$displayClassGuid) {
+    $filtered = @($coDevProp.$displayClassGuid | Where-Object { $_ -notmatch 'vm3dc003' })
+    if ($filtered.Count -ne @($coDevProp.$displayClassGuid).Count) {
+        Set-ItemProperty -Path $coDevKey -Name $displayClassGuid -Value $filtered -Type MultiString
+        Log '[INFO] Cleared VMware SVGA class coinstaller registration (vm3dc003)'
+    }
+}
+
+$vmDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
+    Where-Object {
+        $_.Manufacturer -match 'VMware' -or
+        $_.FriendlyName -match 'VMware' -or
+        $_.InstanceId -match 'VEN_15AD' -or
+        # VMware's USB vendor ID - catches the generic "USB Composite
+        # Device"/"USB Input Device" parent of the VMware USB mouse,
+        # which never says VMware in its own description.
+        $_.InstanceId -match 'VID_0E0F'
+    }
+
+if (-not $vmDevices -or $vmDevices.Count -eq 0) {
+    Log '[INFO] No VMware PnP devices found.'
+} else {
+    Log "[INFO] Found $($vmDevices.Count) VMware PnP device(s)"
+
+    $pnpHelp = & $PnpUtil /? 2>&1 | Out-String
+    $hasRemoveDevice = $pnpHelp -match '/remove-device'
+
+    foreach ($dev in $vmDevices) {
+        Log "[DEVICE] $($dev.FriendlyName) [$($dev.InstanceId)] Status=$($dev.Status)"
+
+        if ($dev.Status -ne 'Unknown') {
+            try {
+                Disable-PnpDevice -InstanceId $dev.InstanceId -Confirm:$false -ErrorAction Stop
+                Log "[DISABLED] $($dev.FriendlyName)"
+            } catch {
+                Log "[WARNING] Could not disable: $($dev.FriendlyName) - $_"
+            }
+        }
+
+        $removed = $false
+        if ($hasRemoveDevice) {
+            & $PnpUtil /remove-device "$($dev.InstanceId)" 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Log "[REMOVED] $($dev.FriendlyName)"
+                $removed = $true
+            }
+        }
+
+        # Ghost devices (Status=Unknown) commonly survive both
+        # Disable-PnpDevice and pnputil /remove-device (which also
+        # doesn't exist pre-Windows 10 2004/Server 2022). Try
+        # CM_Uninstall_DevNode next; fall back to a raw registry
+        # delete only as a last resort.
+        if (-not $removed -and $dev.Status -eq 'Unknown') {
+            if (Remove-GhostDevNode -InstanceId $dev.InstanceId) {
+                Log "[REMOVED] $($dev.FriendlyName) (CM_Uninstall_DevNode)"
+                $removed = $true
+            }
+        }
+
+        if (-not $removed -and $dev.Status -eq 'Unknown') {
+            $enumKey = "HKLM\SYSTEM\CurrentControlSet\Enum\$($dev.InstanceId)"
+            & $RegExe delete $enumKey /f 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Log "[DEL ENUM] $($dev.FriendlyName) (registry fallback)"
+            }
+        }
+    }
+}
+
+# -------------------------------------------------------------------
+# PHASE 4: Delete VMware service definitions (devices are gone now)
+# -------------------------------------------------------------------
+Log ''
+Log '  PHASE 4: Delete VMware Services'
+Log '---------------------------------------------------------------'
+
+if ($servicesToRemove.Count -eq 0) {
+    Log '[INFO] No VMware-related services to delete.'
+} else {
+    foreach ($svc in $servicesToRemove) {
         $scResult = & sc.exe delete "$($svc.Name)" 2>&1 | Out-String
         if ($LASTEXITCODE -eq 0) {
             Log "[SUCCESS] Deleted service: $($svc.Name)"
@@ -319,14 +605,11 @@ if ($servicesToRemove.Count -eq 0) {
 }
 
 # -------------------------------------------------------------------
-# PHASE 4: Remove VMware registry entries
+# PHASE 5: Remove VMware registry entries
 # -------------------------------------------------------------------
 Log ''
-Log '  PHASE 4: VMware Registry Entries'
+Log '  PHASE 5: VMware Registry Entries'
 Log '---------------------------------------------------------------'
-
-$regDeleted = 0
-$regErrors  = 0
 
 # Auto-generate service registry keys from $VMwareServices
 $serviceRegKeys = $VMwareServices | ForEach-Object {
@@ -340,11 +623,135 @@ foreach ($key in $allRegKeys) {
 
 Delete-RegValue 'HKLM\SOFTWARE\RegisteredApplications' 'VMware Host Open'
 
+# --- Stray COM registrations (CLSID/TypeLib) ---
+# VMware Tools registers several COM components under CLSID/TypeLib
+# GUIDs that vary across Tools builds, so hardcoding them doesn't scale.
+# CLSID/TypeLib can each have tens of thousands of subkeys, so this uses
+# the .NET registry API directly (64-bit view) instead of spawning
+# reg.exe per GUID or recursively text-dumping the whole subtree
+# (both far too slow - minutes vs. seconds).
+function Test-RegValueContainsVMware {
+    param([Microsoft.Win32.RegistryKey]$Key)
+    if (-not $Key) { return $false }
+    foreach ($valName in $Key.GetValueNames()) {
+        $v = $Key.GetValue($valName)
+        if ($v -and "$v" -match 'VMware') { return $true }
+    }
+    return $false
+}
+
+# Bounded-depth recursive scan. CLSID's path sits one level down
+# (InprocServer32/LocalServer32), TypeLib's two levels down
+# (e.g. {GUID}\1.0\0\win64) - depth 3 covers both cheaply.
+function Test-KeyTreeContainsVMware {
+    param([Microsoft.Win32.RegistryKey]$Key, [int]$Depth = 3)
+    if (-not $Key) { return $false }
+    if (Test-RegValueContainsVMware $Key) { return $true }
+    if ($Depth -le 0) { return $false }
+    foreach ($childName in $Key.GetSubKeyNames()) {
+        $child = $Key.OpenSubKey($childName)
+        if ($child) {
+            $found = Test-KeyTreeContainsVMware $child ($Depth - 1)
+            $child.Close()
+            if ($found) { return $true }
+        }
+    }
+    return $false
+}
+
+function Get-VMwareStrayComKeys {
+    param([string]$SubPath, [string]$RootPathForLog)
+    $hklm64 = [Microsoft.Win32.RegistryKey]::OpenBaseKey('LocalMachine', 'Registry64')
+    $root = $hklm64.OpenSubKey($SubPath)
+    if (-not $root) { return @() }
+    $stray = @()
+    foreach ($guidName in $root.GetSubKeyNames()) {
+        $guidKey = $root.OpenSubKey($guidName)
+        if (-not $guidKey) { continue }
+        if (Test-KeyTreeContainsVMware $guidKey) { $stray += "$RootPathForLog\$guidName" }
+        $guidKey.Close()
+    }
+    $root.Close()
+    return $stray
+}
+
+$comRoots = @(
+    @{ SubPath = 'SOFTWARE\Classes\CLSID';               LogPath = 'HKLM\SOFTWARE\Classes\CLSID' },
+    @{ SubPath = 'SOFTWARE\Classes\WOW6432Node\CLSID';   LogPath = 'HKLM\SOFTWARE\Classes\WOW6432Node\CLSID' },
+    @{ SubPath = 'SOFTWARE\Classes\TypeLib';             LogPath = 'HKLM\SOFTWARE\Classes\TypeLib' },
+    @{ SubPath = 'SOFTWARE\Classes\WOW6432Node\TypeLib'; LogPath = 'HKLM\SOFTWARE\Classes\WOW6432Node\TypeLib' }
+)
+$comRemoved = 0
+foreach ($root in $comRoots) {
+    foreach ($strayKey in (Get-VMwareStrayComKeys $root.SubPath $root.LogPath)) {
+        Delete-RegKey $strayKey
+        $comRemoved++
+    }
+}
+Log "[INFO] Stray VMware COM (CLSID/TypeLib) registrations removed: $comRemoved"
+
+# --- Installer\Folders stale path references ---
+# Windows Installer records every folder a per-machine MSI product wrote
+# to under Installer\Folders (the folder path is the value NAME, e.g.
+# "C:\ProgramData\VMware\VMware VGAuth\msgCatalog\"). Not reliably
+# pruned by msiexec /x, so sweep it directly. This key is WOW64-shared,
+# so there's no separate WOW6432Node copy to check.
+$foldersKeyPS = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\Folders'
+$foldersProps = Get-ItemProperty -Path $foldersKeyPS -ErrorAction SilentlyContinue
+if ($foldersProps) {
+    $vmwareFolderNames = $foldersProps.PSObject.Properties |
+        Where-Object { $_.Name -notmatch '^PS(Path|ParentPath|ChildName|Drive|Provider)$' -and $_.Name -match 'VMware' } |
+        ForEach-Object { $_.Name }
+    foreach ($n in $vmwareFolderNames) {
+        Remove-ItemProperty -Path $foldersKeyPS -Name $n -Force -ErrorAction SilentlyContinue
+        Log "[DEL VAL] Installer\Folders\$n"
+        $regDeleted++
+    }
+}
+
+# --- Run/RunOnce autostart entries ---
+# e.g. "VMware VM3DService Process" under Run - a harmless but visible
+# leftover once the target .exe is gone.
+function Remove-VMwareRunEntries {
+    param([string]$KeyPath)
+    $psPath = $KeyPath -replace '^HKLM\\', 'HKLM:\'
+    $props = Get-ItemProperty -Path $psPath -ErrorAction SilentlyContinue
+    if (-not $props) { return }
+    $names = $props.PSObject.Properties |
+        Where-Object { $_.Name -notmatch '^PS(Path|ParentPath|ChildName|Drive|Provider)$' } |
+        Where-Object { $_.Name -match 'VMware' -or "$($_.Value)" -match 'VMware' } |
+        ForEach-Object { $_.Name }
+    foreach ($n in $names) {
+        Remove-ItemProperty -Path $psPath -Name $n -Force -ErrorAction SilentlyContinue
+        Log "[DEL VAL] $KeyPath\$n"
+        $script:regDeleted++
+    }
+}
+foreach ($runKey in @(
+    'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run',
+    'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce',
+    'HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run',
+    'HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\RunOnce'
+)) { Remove-VMwareRunEntries $runKey }
+
+# --- SVGA 3D display adapter "software device" node ---
+# HKLM\SYSTEM\CurrentControlSet\Control\Video\{GUID}\Video holds a
+# separate DeviceDesc/Service registration from the vm3dmp_loader
+# service key already deleted above.
+$videoRoot = 'HKLM\SYSTEM\CurrentControlSet\Control\Video'
+foreach ($guidKey in (Get-RegSubKeyPaths $videoRoot)) {
+    $desc = Get-RegValue "$guidKey\Video" 'DeviceDesc'
+    $svc  = Get-RegValue "$guidKey\Video" 'Service'
+    if ($desc -match 'VMware' -or $svc -match '^vm3dmp') {
+        Delete-RegKey $guidKey
+    }
+}
+
 # -------------------------------------------------------------------
-# PHASE 5: Remove VMware files and folders
+# PHASE 6: Remove VMware files and folders
 # -------------------------------------------------------------------
 Log ''
-Log '  PHASE 5: VMware Files and Folders'
+Log '  PHASE 6: VMware Files and Folders'
 Log '---------------------------------------------------------------'
 
 $fileDeleted = 0
@@ -352,6 +759,19 @@ $fileErrors  = 0
 
 foreach ($dir in $VMwareDirs) {
     Remove-PathItem $dir -Recurse
+}
+
+# Per-user VMware AppData folders - not covered by $VMwareDirs since
+# the path depends on each profile under \Users.
+$usersRoot = Join-Path $env:SystemDrive 'Users'
+if (Test-Path $usersRoot) {
+    # -Force: C:\Users\Default is hidden and would otherwise be skipped.
+    Get-ChildItem -Path $usersRoot -Directory -Force -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            foreach ($sub in @('AppData\Local\VMware', 'AppData\Roaming\VMware', 'AppData\LocalLow\VMware')) {
+                Remove-PathItem (Join-Path $_.FullName $sub) -Recurse
+            }
+        }
 }
 
 $SysWOW64 = Join-Path $env:SystemRoot 'SysWOW64'
@@ -372,10 +792,10 @@ if (Test-Path $driverStore) {
 }
 
 # -------------------------------------------------------------------
-# PHASE 6: Remove VMware scheduled tasks
+# PHASE 7: Remove VMware scheduled tasks
 # -------------------------------------------------------------------
 Log ''
-Log '  PHASE 6: VMware Scheduled Tasks'
+Log '  PHASE 7: VMware Scheduled Tasks'
 Log '---------------------------------------------------------------'
 
 $vmTasks = Get-ScheduledTask -ErrorAction SilentlyContinue |
@@ -402,8 +822,11 @@ Log ''
 Log '==============================================================='
 Log '  VMware Cleanup Complete'
 Log '==============================================================='
+Log "  MSI products uninstalled: $msiRemoved"
+Log "  MSI Components removed:  $componentsRemoved"
 Log "  Driver packages removed: $drvRemoved"
 Log "  Services deleted:        $svcDeleted"
+Log "  Stray COM keys removed:  $comRemoved"
 Log "  Registry keys deleted:   $regDeleted"
 Log "  Registry errors:         $regErrors"
 Log "  Files/dirs removed:      $fileDeleted"

--- a/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9100_cleanup_vmware.ps1
@@ -60,22 +60,31 @@ $PnpUtil = Join-Path $Sys32 'pnputil.exe'
 $RegExe  = Join-Path $Sys32 'reg.exe'
 
 # ===================================================================
-# Data declarations — single source of truth
+# Data declarations - single source of truth
 # ===================================================================
 
+# pvscsi is deliberately NOT in this list. On at least one guest OS
+# (a Windows Server 2025 Insider Build image) it turned out to still be
+# the live boot-critical storage controller driver post-conversion -
+# deleting its service/file pulled the disk driver Windows was actually
+# booting from out from under it, bricking the boot volume (Stop code
+# INACCESSIBLE_BOOT_DEVICE). virt-v2v is supposed to have already
+# switched the boot controller to VirtIO by the time this script runs,
+# but that isn't guaranteed for every guest OS it doesn't fully
+# recognize. Leaving pvscsi installed (inert, cosmetic leftover on
+# guests where the VirtIO swap did happen) is simpler and safer than
+# risking the boot device, so every phase below explicitly excludes it.
 $VMwareServices = @(
     'VGAuthService', 'VM3DService', 'VMTools', 'vmvss', 'GISvc',
     'vmhgfs', 'vmmemctl', 'vmrawdsk', 'vnetWFP', 'vnetflt', 'vsepflt',
-    'vmci', 'vmxnet3', 'vmxnet3ndis6', 'pvscsi',
+    'vmci', 'vmxnet3', 'vmxnet3ndis6',
     'vmusbmouse', 'vmmouse',
     'vm3dmp', 'vm3dmp-debug', 'vm3dmp-stats', 'vm3dmp_loader',
     # vgauth/cblauncher: legacy alternate names, no-op if absent.
     'vsock', 'efifw', 'svga_wddm', 'vmaudio', 'vgauth', 'cblauncher',
     'vmwtimeprovider', 'vmstatsprovider', 'vmupgradehelper',
     'vmwefifw',
-    # vm3dservice backs the vm3dservice.exe in $VMwareSystemFiles below.
-    # The rest are newer (vmx86, VMwareCertService) or legacy pre-WDDM
-    # names from older Tools builds.
+    # vm3dservice backs vm3dservice.exe below; rest are newer/legacy names.
     'VMCISockets', 'vm3dservice', 'vmxnet', 'vmx_svga', 'vmkbd',
     'vmdesched', 'vmdebug', 'vmware', 'vmx86', 'VMwareCertService'
 )
@@ -117,14 +126,12 @@ $VMwareTempDirPatterns = @(
     "$env:TEMP\vmware-*"
 )
 
+# pvscsi.sys intentionally excluded - see the $VMwareServices comment above.
 $VMwareDriverFiles = @(
     'vmci.sys', 'vmmouse.sys', 'vmrawdsk.sys', 'vmhgfs.sys',
-    'vmusbmouse.sys', 'pvscsi.sys', 'vmxnet3.sys',
+    'vmusbmouse.sys', 'vmxnet3.sys',
     'vm3dmp.sys', 'vm3dmp-debug.sys', 'vm3dmp-stats.sys', 'vm3dmp_loader.sys',
-    'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys',
-    # vnetflt: legacy predecessor of vnetWFP, can be left behind by a
-    # Tools installer bug and BSOD alongside vsepflt.
-    'vnetflt.sys',
+    'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys', 'vnetflt.sys',
     'svga_wddm.sys', 'efifw.sys', 'vmaudio.sys',
     # Legacy pre-WDDM driver files.
     'vmx_svga.sys', 'vmkbd.sys', 'vmdesched.sys'
@@ -224,6 +231,24 @@ function Get-RegValue {
     return $null
 }
 
+# .NET registry reads used for in-process tree scans (DeviceClasses,
+# CLSID/TypeLib). These throw a terminating SecurityException/
+# UnauthorizedAccessException on a restricted-ACL key, which neither
+# $ErrorActionPreference value suppresses - swallow it here so one
+# unreadable key doesn't abort the whole scan.
+function Get-SafeSubKeyNames {
+    param([Microsoft.Win32.RegistryKey]$Key)
+    try { return $Key.GetSubKeyNames() } catch { return @() }
+}
+function Open-SafeSubKey {
+    param([Microsoft.Win32.RegistryKey]$Key, [string]$Name)
+    try { return $Key.OpenSubKey($Name) } catch { return $null }
+}
+function Get-SafeRegValue {
+    param([Microsoft.Win32.RegistryKey]$Key, [string]$Name)
+    try { return $Key.GetValue($Name) } catch { return $null }
+}
+
 # Removes a file/dir, falling back to cmd /c rd/del, then scheduling
 # locked files for deletion on reboot.
 function Remove-PathItem {
@@ -316,10 +341,17 @@ if (-not $vmwareUninstallKeys) {
         if ($productCode) {
             Log "[MSI] Uninstalling $($entry.DisplayName) $productCode ..."
             try {
+                # Bounded wait (10 min): this runs unattended on firstboot, so
+                # a stuck msiexec (e.g. blocked on the Installer mutex) must
+                # not hang Phases 1-7 forever. 3010/1641 mean success with a
+                # reboot pending, not failure.
                 $p = Start-Process -FilePath 'msiexec.exe' `
                     -ArgumentList "/x $productCode /qn /norestart" `
-                    -Wait -PassThru -ErrorAction Stop
-                if ($p.ExitCode -eq 0) {
+                    -PassThru -ErrorAction Stop
+                if (-not $p.WaitForExit(600000)) {
+                    Log "[WARNING] msiexec timed out for $($entry.DisplayName) - killing and forcing registry cleanup"
+                    Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+                } elseif ($p.ExitCode -in 0, 1641, 3010) {
                     Log "[SUCCESS] msiexec removed $($entry.DisplayName)"
                     $msiRemoved++
                 } else {
@@ -337,9 +369,8 @@ if (-not $vmwareUninstallKeys) {
     }
 }
 
-# Clean orphaned Windows Installer product registrations (drive
-# Get-Package/Win32_Product visibility; can survive a clean msiexec /x).
-# Enumerate every SID under UserData rather than hardcoding SYSTEM.
+# Clean orphaned Windows Installer product registrations (drives
+# Get-Package/Win32_Product visibility) across every SID under UserData.
 $UserDataRoot = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData'
 $productsRoots = @('HKLM\SOFTWARE\Classes\Installer\Products')
 foreach ($sidKey in (Get-RegSubKeyPaths $UserDataRoot)) {
@@ -359,9 +390,8 @@ foreach ($productsRoot in $productsRoots) {
 Log "[INFO] VMware MSI products uninstalled via msiexec: $msiRemoved"
 
 # Clean orphaned Windows Installer "Components" ownership entries
-# (UserData\<SID>\Components\<ComponentGuid>), not handled by the
-# registry fallback above. A component can be shared by multiple
-# products, so only delete the matching value, then the key if empty.
+# (UserData\<SID>\Components\<ComponentGuid>) - only the matching value
+# is deleted (shared by products), then the key if empty.
 function Get-RegDataMatches {
     param([string]$KeyPath, [string]$Pattern)
     $out = & $RegExe query $KeyPath /f $Pattern /d /s 2>&1 | Out-String
@@ -395,10 +425,9 @@ Log "[INFO] Orphaned Windows Installer Components entries removed: $componentsRe
 # -------------------------------------------------------------------
 # PHASE 1: Stop and disable VMware services
 # -------------------------------------------------------------------
-# Phase order matters: quiesce services, then drivers, then devices,
-# and only delete service definitions last (Phase 4). Otherwise vmci
-# (a PnP bus enumerator) can re-assert its device, and drivers still in
-# the driver store can get re-selected on a PnP rescan.
+# Order matters: quiesce services, then drivers, then devices; delete
+# service definitions last (Phase 4) - otherwise vmci can re-assert its
+# device and stale drivers can get re-selected on a PnP rescan.
 Log ''
 Log '  PHASE 1: Stop and Disable VMware Services'
 Log '---------------------------------------------------------------'
@@ -424,6 +453,11 @@ if ($vmwareCim) {
         if ($svc) { $servicesToRemove += $svc }
     }
 }
+
+# pvscsi would otherwise get swept in by the broad "VMware in
+# DisplayName" match above - excluded here too so it's never touched
+# regardless of which path found it (see $VMwareServices comment).
+$servicesToRemove = $servicesToRemove | Where-Object { $_.Name -notin @('pvscsi') }
 
 $servicesToRemove = $servicesToRemove | Sort-Object -Property Name -Unique
 
@@ -454,11 +488,9 @@ Log ''
 Log '  PHASE 2: VMware Driver Packages'
 Log '---------------------------------------------------------------'
 
-# Post-Broadcom-acquisition, some VMware driver packages are republished
-# as "Provider Name: Broadcom Inc.", but the .inf filename is unchanged.
-# Matching "Broadcom" alone would be unsafe (unrelated Broadcom hardware
-# exists), so match known VMware .inf basenames instead. vm3d.inf has no
-# matching .sys (its binary is vm3dmp.sys), so it's added explicitly.
+# Some packages are republished as "Broadcom Inc." post-acquisition, but
+# keep the same .inf name - match known VMware .inf basenames instead of
+# the ambiguous "Broadcom" text. vm3d.inf (binary vm3dmp.sys) added explicitly.
 $VMwareExtraInfNames = @('vm3d.inf')
 $VMwareInfNames = ((($VMwareDriverFiles | ForEach-Object { $_ -replace '\.sys$', '.inf' }) + $VMwareExtraInfNames) |
     ForEach-Object { [regex]::Escape($_) }) -join '|'
@@ -466,13 +498,20 @@ $VMwareInfNames = ((($VMwareDriverFiles | ForEach-Object { $_ -replace '\.sys$',
 # Get-WindowsDriver returns structured fields, so it works regardless of
 # display language. pnputil's text output is English-only, so it's only
 # a fallback below.
+# pvscsi excluded here too - a generic "ProviderName -match VMware"
+# match would otherwise still catch its driver package even though the
+# service/file are deliberately left alone (see $VMwareServices comment
+# in the data declarations above).
 $publishedNames = $null
 try {
     $publishedNames = @(
         Get-WindowsDriver -Online -ErrorAction Stop |
             Where-Object {
-                $_.ProviderName -match 'VMware' -or
-                $_.OriginalFileName -match "(?i)($VMwareInfNames)"
+                $_.OriginalFileName -notmatch '(?i)^pvscsi\.inf$' -and
+                (
+                    $_.ProviderName -match 'VMware' -or
+                    $_.OriginalFileName -match "(?i)($VMwareInfNames)"
+                )
             } |
             ForEach-Object { $_.Driver }
     )
@@ -493,8 +532,11 @@ if ($null -ne $publishedNames) {
     $pnpOutput = & $PnpUtil /enum-drivers 2>&1 | Out-String
     $driverBlocks = $pnpOutput -split '(?=Published Name)' |
         Where-Object {
-            $_ -match 'VMware' -or
-            $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
+            $_ -notmatch '(?i)Original Name:\s*pvscsi\.inf\b' -and
+            (
+                $_ -match 'VMware' -or
+                $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
+            )
         }
 
     if ($driverBlocks.Count -eq 0) {
@@ -518,16 +560,14 @@ Log ''
 Log '  PHASE 3: VMware PnP Devices'
 Log '---------------------------------------------------------------'
 
-# vmci is a PnP bus enumerator that can keep re-asserting its device, so
-# delete it outright now, right before device removal. Drop it from the
-# Phase 4 list since it's already gone.
+# vmci can re-assert its device if left running, so delete it outright
+# now and drop it from the Phase 4 list.
 & sc.exe stop vmci 2>&1 | Out-Null
 & sc.exe delete vmci 2>&1 | Out-Null
 $servicesToRemove = @($servicesToRemove | Where-Object { $_.Name -ne 'vmci' })
 
-# vm3d.inf registers a class coinstaller (vm3dc003.dll) that runs for
-# every display device and can veto removal, so strip only that entry -
-# other legitimate coinstallers may share the same REG_MULTI_SZ value.
+# vm3dc003.dll is a class coinstaller that can veto removal of any
+# display device; strip only this entry from the shared REG_MULTI_SZ value.
 $displayClassGuid = '{4d36e968-e325-11ce-bfc1-08002be10318}'
 $coDevKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\CoDeviceInstallers'
 $coDevProp = Get-ItemProperty -Path $coDevKey -Name $displayClassGuid -ErrorAction SilentlyContinue
@@ -552,23 +592,22 @@ $vmDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
         $_.InstanceId -match '^ROOT\\(VMWVMCI|VMware)'
     }
 
-# Builds an InstanceId -> [DeviceClasses key path] lookup in one pass,
-# using the .NET registry API instead of reg.exe. DeviceClasses can hold
-# thousands of entries, and this runs once per ghost device below, so a
-# fresh reg.exe scan per call would mean tens of thousands of process
-# spawns - one cached in-process scan avoids that.
+# Builds an InstanceId -> DeviceClasses key lookup in one .NET pass,
+# avoiding a reg.exe scan per ghost device (would mean thousands of spawns).
+# DeviceClasses entries often carry restrictive ACLs, so every read below
+# goes through the Get-Safe*/Open-Safe* helpers above.
 function Get-DeviceClassesInstanceMap {
     $map = @{}
     $hklm64 = [Microsoft.Win32.RegistryKey]::OpenBaseKey('LocalMachine', 'Registry64')
     $root = $hklm64.OpenSubKey('SYSTEM\CurrentControlSet\Control\DeviceClasses')
     if (-not $root) { return $map }
-    foreach ($ifaceGuidName in $root.GetSubKeyNames()) {
-        $ifaceGuidKey = $root.OpenSubKey($ifaceGuidName)
+    foreach ($ifaceGuidName in (Get-SafeSubKeyNames $root)) {
+        $ifaceGuidKey = Open-SafeSubKey $root $ifaceGuidName
         if (-not $ifaceGuidKey) { continue }
-        foreach ($instName in $ifaceGuidKey.GetSubKeyNames()) {
-            $instKey = $ifaceGuidKey.OpenSubKey($instName)
+        foreach ($instName in (Get-SafeSubKeyNames $ifaceGuidKey)) {
+            $instKey = Open-SafeSubKey $ifaceGuidKey $instName
             if ($instKey) {
-                $devInst = $instKey.GetValue('DeviceInstance')
+                $devInst = Get-SafeRegValue $instKey 'DeviceInstance'
                 if ($devInst) {
                     if (-not $map.ContainsKey($devInst)) {
                         $map[$devInst] = New-Object System.Collections.Generic.List[string]
@@ -584,14 +623,10 @@ function Get-DeviceClassesInstanceMap {
     return $map
 }
 
-# Cleans stale references to a ghost device that the raw Enum key
-# delete below doesn't touch: its class-specific driver binding and its
-# DeviceClasses interface registration(s). Leftovers here are a
-# suspected cause of Windows resynthesizing a fresh "Unknown" Enum entry
-# for an already-deleted device. DeviceContainers is only reported, not
-# deleted - it can be shared by sibling functions of a composite device.
-# Must run BEFORE the Enum key delete - it's the source of the "Driver"
-# pointer used below.
+# Cleans a ghost device's class driver binding and DeviceClasses
+# registration - leftovers here can make Windows resynthesize a fresh
+# ghost Enum entry. DeviceContainers is only reported, not deleted
+# (may be shared). Must run BEFORE the Enum key delete below.
 function Clear-GhostDeviceReferences {
     param([string]$InstanceId)
 
@@ -647,15 +682,15 @@ if (-not $vmDevices -or $vmDevices.Count -eq 0) {
         $removed = $false
         if ($hasRemoveDevice) {
             & $PnpUtil /remove-device "$($dev.InstanceId)" 2>&1 | Out-Null
-            if ($LASTEXITCODE -eq 0) {
+            # 3010 = ERROR_SUCCESS_REBOOT_REQUIRED - removed, not a failure.
+            if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 3010) {
                 Log "[REMOVED] $($dev.FriendlyName)"
                 $removed = $true
             }
         }
 
-        # Ghost devices (Status=Unknown) often survive Disable-PnpDevice
-        # and pnputil /remove-device (also missing pre-2004/Server 2022).
-        # Try CM_Uninstall_DevNode, then raw registry delete as last resort.
+        # Ghost devices often survive the above; try CM_Uninstall_DevNode,
+        # then raw registry delete as last resort.
         if (-not $removed -and $dev.Status -eq 'Unknown') {
             if (Remove-GhostDevNode -InstanceId $dev.InstanceId) {
                 Log "[REMOVED] $($dev.FriendlyName) (CM_Uninstall_DevNode)"
@@ -715,48 +750,50 @@ foreach ($key in $allRegKeys) {
 Delete-RegValue 'HKLM\SOFTWARE\RegisteredApplications' 'VMware Host Open'
 
 # --- Stray COM registrations (CLSID/TypeLib) ---
-# VMware Tools registers COM components under CLSID/TypeLib GUIDs that
-# vary across builds, so they can't be hardcoded. CLSID/TypeLib can each
-# have tens of thousands of subkeys, so this scans in-process via .NET
-# instead of spawning reg.exe per GUID (minutes vs. seconds).
-function Test-RegValueContainsVMware {
-    param([Microsoft.Win32.RegistryKey]$Key)
-    if (-not $Key) { return $false }
-    foreach ($valName in $Key.GetValueNames()) {
-        $v = $Key.GetValue($valName)
-        if ($v -and "$v" -match 'VMware') { return $true }
-    }
-    return $false
-}
+# GUIDs vary per Tools build, so scan in-process via .NET rather than
+# spawning reg.exe per GUID across tens of thousands of subkeys.
+# Ownership is decided by the COM server module path/name (InprocServer32/
+# LocalServer32/win32/win64's default value), not by "VMware" appearing
+# anywhere in the subtree - a free-text match would also delete an
+# unrelated component that merely references a VMware path/DLL in some
+# other value, and this deletion isn't reversible on the migrated guest.
+$VMwareComServerPattern = '(?i)(\\Program Files( \(x86\))?\\(Common Files\\)?VMware\\|\\vm3d|\\vmGuestLib|\\vmhgfs|VMWSU\.DLL)'
 
-# Bounded-depth recursive scan: CLSID's path is one level down,
-# TypeLib's is two levels down - depth 3 covers both.
-function Test-KeyTreeContainsVMware {
+# CLSID's server path is one level down (InprocServer32/LocalServer32);
+# TypeLib's is three levels down (version\lcid\win32|win64) - depth 3
+# covers both while still only matching those specific named subkeys.
+function Test-KeyTreeHasVMwareComServer {
     param([Microsoft.Win32.RegistryKey]$Key, [int]$Depth = 3)
-    if (-not $Key) { return $false }
-    if (Test-RegValueContainsVMware $Key) { return $true }
-    if ($Depth -le 0) { return $false }
-    foreach ($childName in $Key.GetSubKeyNames()) {
-        $child = $Key.OpenSubKey($childName)
-        if ($child) {
-            $found = Test-KeyTreeContainsVMware $child ($Depth - 1)
-            $child.Close()
-            if ($found) { return $true }
+    if (-not $Key -or $Depth -le 0) { return $false }
+    foreach ($childName in (Get-SafeSubKeyNames $Key)) {
+        $child = Open-SafeSubKey $Key $childName
+        if (-not $child) { continue }
+        if ($childName -in @('InprocServer32', 'LocalServer32', 'win32', 'win64')) {
+            $modulePath = Get-SafeRegValue $child ''
+            if ($modulePath -and "$modulePath" -match $VMwareComServerPattern) {
+                $child.Close()
+                return $true
+            }
         }
+        if (Test-KeyTreeHasVMwareComServer $child ($Depth - 1)) {
+            $child.Close()
+            return $true
+        }
+        $child.Close()
     }
     return $false
 }
 
-function Get-VMwareStrayComKeys {
+function Get-VMwareStrayComKey {
     param([string]$SubPath, [string]$RootPathForLog)
     $hklm64 = [Microsoft.Win32.RegistryKey]::OpenBaseKey('LocalMachine', 'Registry64')
     $root = $hklm64.OpenSubKey($SubPath)
     if (-not $root) { return @() }
     $stray = @()
-    foreach ($guidName in $root.GetSubKeyNames()) {
-        $guidKey = $root.OpenSubKey($guidName)
+    foreach ($guidName in (Get-SafeSubKeyNames $root)) {
+        $guidKey = Open-SafeSubKey $root $guidName
         if (-not $guidKey) { continue }
-        if (Test-KeyTreeContainsVMware $guidKey) { $stray += "$RootPathForLog\$guidName" }
+        if (Test-KeyTreeHasVMwareComServer $guidKey) { $stray += "$RootPathForLog\$guidName" }
         $guidKey.Close()
     }
     $root.Close()
@@ -771,7 +808,7 @@ $comRoots = @(
 )
 $comRemoved = 0
 foreach ($root in $comRoots) {
-    foreach ($strayKey in (Get-VMwareStrayComKeys $root.SubPath $root.LogPath)) {
+    foreach ($strayKey in (Get-VMwareStrayComKey $root.SubPath $root.LogPath)) {
         Delete-RegKey $strayKey
         $comRemoved++
     }
@@ -779,9 +816,8 @@ foreach ($root in $comRoots) {
 Log "[INFO] Stray VMware COM (CLSID/TypeLib) registrations removed: $comRemoved"
 
 # --- Installer\Folders stale path references ---
-# Records every folder an MSI product wrote to, keyed by folder path as
-# the value NAME. Not reliably pruned by msiexec /x, so swept directly.
-# This key is WOW64-shared - no separate WOW6432Node copy exists.
+# Value NAME is the folder path an MSI wrote to; not reliably pruned by
+# msiexec /x. WOW64-shared, no separate WOW6432Node copy.
 $foldersKeyPS = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\Folders'
 $foldersProps = Get-ItemProperty -Path $foldersKeyPS -ErrorAction SilentlyContinue
 if ($foldersProps) {
@@ -876,11 +912,9 @@ foreach ($f in $allFiles) {
     Remove-PathItem $f
 }
 
-# DriverStore leftovers - report only, don't delete directly.
-# DriverStore\FileRepository is tracked by Component-Based Servicing;
-# force-deleting a folder here can leave that bookkeeping inconsistent
-# and surface as DISM /CheckHealth corruption later. Anything pnputil
-# didn't remove in Phase 2 is logged here for manual follow-up instead.
+# DriverStore leftovers - report only. Force-deleting risks CBS
+# bookkeeping inconsistency (DISM /CheckHealth corruption); log for
+# manual pnputil follow-up instead.
 $driverStoreResidual = 0
 $driverStore = Join-Path $Sys32 'DriverStore\FileRepository'
 if (Test-Path $driverStore) {

--- a/pkg/virt-v2v/customize/scripts/windows/verify_vmware_cleanup.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/verify_vmware_cleanup.ps1
@@ -28,14 +28,14 @@ $VMwareServices = @(
     'vmci', 'vmxnet3', 'vmxnet3ndis6', 'pvscsi',
     'vmusbmouse', 'vmmouse',
     'vm3dmp', 'vm3dmp-debug', 'vm3dmp-stats', 'vm3dmp_loader',
-    # Additional short names from vmware-cleanup-tool's canonical
-    # component list (vmware_components.txt) - mirrors 9100_cleanup_vmware.ps1.
+    # Additional short names - mirrors 9100_cleanup_vmware.ps1.
     'vsock', 'efifw', 'svga_wddm', 'vmaudio', 'vgauth', 'cblauncher',
     'vmwtimeprovider', 'vmstatsprovider', 'vmupgradehelper',
-    # vmwefifw: real on-disk service key name for the EFI firmware
-    # component - found via a broad post-cleanup sweep on all 3 test
-    # VMs. Mirrors 9100_cleanup_vmware.ps1.
-    'vmwefifw'
+    # vmwefifw: on-disk service name for the EFI firmware component.
+    'vmwefifw',
+    # Legacy/newer names - mirrors 9100_cleanup_vmware.ps1.
+    'VMCISockets', 'vm3dservice', 'vmxnet', 'vmx_svga', 'vmkbd',
+    'vmdesched', 'vmdebug', 'vmware', 'vmx86', 'VMwareCertService'
 )
 
 # Registry keys checked via reg.exe (avoids WOW64 redirection on SOFTWARE hive).
@@ -55,7 +55,9 @@ $RegKeysToCheck = @(
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetflt',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt',
-    'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vmci'
+    'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vmci',
+    # App Paths entry for vmtoolsd.exe - mirrors 9100_cleanup_vmware.ps1.
+    'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\vmtoolsd.exe'
 )
 
 $VMwareDirs = @(
@@ -66,6 +68,12 @@ $VMwareDirs = @(
     "$env:ProgramData\VMware"
 )
 
+# Wildcarded temp folders - one "vmware-<account>" folder per account.
+$VMwareTempDirPatterns = @(
+    "$env:SystemRoot\Temp\vmware-*",
+    "$env:TEMP\vmware-*"
+)
+
 $VMwareDriverFiles = @(
     'vmci.sys', 'vmmouse.sys', 'vmrawdsk.sys', 'vmhgfs.sys',
     'vmusbmouse.sys', 'pvscsi.sys', 'vmxnet3.sys',
@@ -73,8 +81,13 @@ $VMwareDriverFiles = @(
     'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys',
     'vnetflt.sys',
     # svga_wddm/efifw/vmaudio - mirrors 9100_cleanup_vmware.ps1.
-    'svga_wddm.sys', 'efifw.sys', 'vmaudio.sys'
+    'svga_wddm.sys', 'efifw.sys', 'vmaudio.sys',
+    # Legacy pre-WDDM driver files.
+    'vmx_svga.sys', 'vmkbd.sys', 'vmdesched.sys'
 )
+
+# DriverStore dirs matching this pattern are VMware (Hyper-V's own dirs excluded).
+$DriverStorePattern = '^vm(3d|ci|hgfs|mouse|rawdsk|memctl|xnet|ware|tools|vss|usb)'
 
 $VMwareSystemFiles = @(
     'vmGuestLib.dll', 'vmhgfs.dll', 'vm3dgl64.dll', 'vm3dver.dll',
@@ -119,8 +132,7 @@ function Test-RegKey {
     return ($LASTEXITCODE -eq 0)
 }
 
-# List immediate subkey paths of a key via reg.exe (WOW64-safe - mirrors
-# 9100_cleanup_vmware.ps1).
+# List immediate subkey paths via reg.exe (WOW64-safe).
 function Get-RegSubKeyPaths {
     param([string]$KeyPath)
     $out = & $RegExe query $KeyPath 2>&1
@@ -200,9 +212,7 @@ if (-not $vmwareUninstallKeys) {
     }
 }
 
-# Enumerate every SID under UserData rather than hardcoding S-1-5-18
-# (SYSTEM) - per-machine installs land there, but we don't want to
-# silently miss a registration under an unexpected context.
+# Enumerate every SID under UserData rather than hardcoding SYSTEM.
 $UserDataRoot = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData'
 $productsRoots = @('HKLM\SOFTWARE\Classes\Installer\Products')
 foreach ($sidKey in (Get-RegSubKeyPaths $UserDataRoot)) {
@@ -224,12 +234,8 @@ if (-not $vmwareInstallerProducts) {
     }
 }
 
-# Windows Installer "Components" ownership map - one entry per
-# installed file/registry key, keyed by ComponentGuid with a value
-# named after the owning product's packed ProductCode. Only cleaned
-# automatically by a successful msiexec /x; survives the registry
-# fallback in 9100_cleanup_vmware.ps1's Phase 0 if not explicitly
-# swept (mirrors that script's Components cleanup).
+# Windows Installer "Components" ownership map - only cleaned
+# automatically by a successful msiexec /x. Mirrors 9100_cleanup_vmware.ps1.
 function Get-RegDataMatches {
     param([string]$KeyPath, [string]$Pattern)
     $out = & $RegExe query $KeyPath /f $Pattern /d /s 2>&1 | Out-String
@@ -261,32 +267,69 @@ if (-not $vmwareComponentHits) {
 Write-Host ""
 Write-Host "--- Driver Packages ---"
 
-# Mirrors 9100_cleanup_vmware.ps1: post Broadcom/VMware acquisition,
-# VMware's driver packages get republished with "Provider Name:
-# Broadcom Inc." instead of "VMware, Inc.", but the Original Name
-# (.inf filename) stays the same. Anchor on the known VMware .inf
-# basenames rather than the ambiguous "Broadcom" text, since Broadcom
-# also makes plenty of unrelated physical NICs/RAID controllers.
-# vm3d.inf (the SVGA 3D "setup" package) has no .sys of its own - the
-# binary is vm3dmp.sys, already in $VMwareDriverFiles - so it can't be
-# derived from that list and is listed explicitly.
+# Post-Broadcom-acquisition, packages can be republished as "Broadcom
+# Inc." but keep the same .inf filename, so match known VMware .inf
+# basenames rather than the ambiguous "Broadcom" text. vm3d.inf has no
+# matching .sys (its binary is vm3dmp.sys), so it's listed explicitly.
 $VMwareExtraInfNames = @('vm3d.inf')
 $VMwareInfNames = ((($VMwareDriverFiles | ForEach-Object { $_ -replace '\.sys$', '.inf' }) + $VMwareExtraInfNames) |
     ForEach-Object { [regex]::Escape($_) }) -join '|'
 
-$pnpOutput = & $PnpUtil /enum-drivers 2>&1 | Out-String
-$driverBlocks = $pnpOutput -split '(?=Published Name)' |
-    Where-Object {
-        $_ -match 'VMware' -or
-        $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
-    }
+# Get-WindowsDriver is locale-independent; pnputil's text fields are English-only.
+$publishedNames = $null
+try {
+    $publishedNames = @(
+        Get-WindowsDriver -Online -ErrorAction Stop |
+            Where-Object {
+                $_.ProviderName -match 'VMware' -or
+                $_.OriginalFileName -match "(?i)($VMwareInfNames)"
+            } |
+            ForEach-Object { $_.Driver }
+    )
+} catch {
+    Write-Host "  (Get-WindowsDriver unavailable ($_) - falling back to pnputil text parsing)"
+}
 
-if ($driverBlocks.Count -eq 0) {
-    Check-Pass "No VMware driver packages in driver store"
+if ($null -ne $publishedNames) {
+    if ($publishedNames.Count -eq 0) {
+        Check-Pass "No VMware driver packages in driver store"
+    } else {
+        foreach ($inf in $publishedNames) {
+            Check-Fail "VMware driver package still in store: $inf"
+        }
+    }
 } else {
-    foreach ($block in $driverBlocks) {
-        $inf = if ($block -match 'Published Name\s*:\s*(\S+)') { $Matches[1] } else { '(unknown)' }
-        Check-Fail "VMware driver package still in store: $inf"
+    $pnpOutput = & $PnpUtil /enum-drivers 2>&1 | Out-String
+    $driverBlocks = $pnpOutput -split '(?=Published Name)' |
+        Where-Object {
+            $_ -match 'VMware' -or
+            $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
+        }
+
+    if ($driverBlocks.Count -eq 0) {
+        Check-Pass "No VMware driver packages in driver store"
+    } else {
+        foreach ($block in $driverBlocks) {
+            $inf = if ($block -match 'Published Name\s*:\s*(\S+)') { $Matches[1] } else { '(unknown)' }
+            Check-Fail "VMware driver package still in store: $inf"
+        }
+    }
+}
+
+# DriverStore\FileRepository residuals. 9100_cleanup_vmware.ps1's Phase 6
+# doesn't force-delete these (unsupported, risks CBS inconsistency) - it
+# only logs them. Surfaced here too for the reviewer.
+$Sys32ForDriverStore = if (Test-Path (Join-Path $env:SystemRoot 'Sysnative')) { Join-Path $env:SystemRoot 'Sysnative' } else { Join-Path $env:SystemRoot 'System32' }
+$driverStorePath = Join-Path $Sys32ForDriverStore 'DriverStore\FileRepository'
+if (Test-Path $driverStorePath) {
+    $driverStoreResiduals = Get-ChildItem -Path $driverStorePath -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match $DriverStorePattern }
+    if (-not $driverStoreResiduals) {
+        Check-Pass "No residual VMware folders in DriverStore\FileRepository"
+    } else {
+        foreach ($residual in $driverStoreResiduals) {
+            Check-Warn "Residual DriverStore folder (needs manual pnputil cleanup): $($residual.FullName)"
+        }
     }
 }
 
@@ -301,10 +344,11 @@ $vmDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
         $_.Manufacturer -match 'VMware' -or
         $_.FriendlyName -match 'VMware' -or
         $_.InstanceId -match 'VEN_15AD' -or
-        # VMware's USB vendor ID - catches the USB composite PARENT of
-        # "VMware USB Pointing Device", whose own description doesn't
-        # say VMware. Mirrors 9100_cleanup_vmware.ps1.
-        $_.InstanceId -match 'VID_0E0F'
+        # VMware's USB vendor ID - catches the USB composite parent of
+        # "VMware USB Pointing Device", which doesn't say VMware itself.
+        $_.InstanceId -match 'VID_0E0F' -or
+        # ROOT-enumerated software devices (e.g. ROOT\VMWVMCIHOSTDEV\0000).
+        $_.InstanceId -match '^ROOT\\(VMWVMCI|VMware)'
     }
 
 if (-not $vmDevices -or $vmDevices.Count -eq 0) {
@@ -315,6 +359,65 @@ if (-not $vmDevices -or $vmDevices.Count -eq 0) {
             Check-Warn "Ghost VMware device: $($d.FriendlyName) [$($d.InstanceId)]"
         } else {
             Check-Fail "Active VMware device: $($d.FriendlyName) [$($d.InstanceId)] Status=$($d.Status)"
+        }
+    }
+}
+
+# Builds an InstanceId -> [DeviceClasses key path] lookup in one pass via
+# .NET instead of reg.exe (mirrors 9100_cleanup_vmware.ps1). DeviceClasses
+# can hold thousands of entries - walking it per device via reg.exe would
+# mean tens of thousands of process spawns.
+function Get-DeviceClassesInstanceMap {
+    $map = @{}
+    $hklm64 = [Microsoft.Win32.RegistryKey]::OpenBaseKey('LocalMachine', 'Registry64')
+    $root = $hklm64.OpenSubKey('SYSTEM\CurrentControlSet\Control\DeviceClasses')
+    if (-not $root) { return $map }
+    foreach ($ifaceGuidName in $root.GetSubKeyNames()) {
+        $ifaceGuidKey = $root.OpenSubKey($ifaceGuidName)
+        if (-not $ifaceGuidKey) { continue }
+        foreach ($instName in $ifaceGuidKey.GetSubKeyNames()) {
+            $instKey = $ifaceGuidKey.OpenSubKey($instName)
+            if ($instKey) {
+                $devInst = $instKey.GetValue('DeviceInstance')
+                if ($devInst) {
+                    if (-not $map.ContainsKey($devInst)) {
+                        $map[$devInst] = New-Object System.Collections.Generic.List[string]
+                    }
+                    $map[$devInst].Add("HKLM\SYSTEM\CurrentControlSet\Control\DeviceClasses\$ifaceGuidName\$instName")
+                }
+                $instKey.Close()
+            }
+        }
+        $ifaceGuidKey.Close()
+    }
+    $root.Close()
+    return $map
+}
+
+# For any device still present, also check the secondary registry
+# locations Clear-GhostDeviceReferences targets - a stale entry there is
+# a suspected cause of Windows resynthesizing a ghost Enum entry.
+if ($vmDevices -and $vmDevices.Count -gt 0) {
+    $deviceClassesMap = Get-DeviceClassesInstanceMap
+    foreach ($d in $vmDevices) {
+        # Enum key's "Driver" value points at its class driver binding key.
+        $driverBinding = Get-RegValue "HKLM\SYSTEM\CurrentControlSet\Enum\$($d.InstanceId)" 'Driver'
+        if ($driverBinding) {
+            $bindingKey = "HKLM\SYSTEM\CurrentControlSet\Control\Class\$driverBinding"
+            if (Test-RegKey $bindingKey) {
+                Check-Fail "Class driver binding still references $($d.InstanceId): $bindingKey"
+            }
+        }
+
+        if ($deviceClassesMap.ContainsKey($d.InstanceId)) {
+            foreach ($ifaceInstanceKey in $deviceClassesMap[$d.InstanceId]) {
+                Check-Fail "DeviceClasses interface registration still references $($d.InstanceId): $ifaceInstanceKey"
+            }
+        }
+
+        $containerHits = Get-RegDataMatches 'HKLM\SYSTEM\CurrentControlSet\Control\DeviceContainers' $d.InstanceId
+        foreach ($hit in $containerHits) {
+            Check-Warn "DeviceContainers still references $($d.InstanceId) (may be shared with another device): $($hit.KeyPath)\$($hit.ValueName)"
         }
     }
 }
@@ -361,10 +464,8 @@ if ($strayKeys.Count -eq 0) {
 }
 
 # Stray COM registrations (CLSID/TypeLib) - mirrors 9100_cleanup_vmware.ps1.
-# Uses the .NET registry API directly (in-process, forced to the 64-bit
-# view) rather than "reg query /s" - CLSID/TypeLib can each have tens
-# of thousands of subkeys, and recursively dumping/parsing the entire
-# subtree as text took several minutes in testing.
+# Uses .NET directly rather than "reg query /s" - CLSID/TypeLib can each
+# have tens of thousands of subkeys, and text-parsing took minutes.
 Write-Host ""
 Write-Host "--- COM registrations (CLSID/TypeLib) ---"
 function Test-RegValueContainsVMware {
@@ -378,9 +479,7 @@ function Test-RegValueContainsVMware {
 }
 
 # Bounded-depth recursive scan - mirrors 9100_cleanup_vmware.ps1. CLSID's
-# implementation path normally sits one level down (InprocServer32/
-# LocalServer32), but TypeLib's path values sit two levels down (e.g.
-# {GUID}\1.0\0\win64) - a fixed depth of 3 comfortably covers both.
+# path is one level down, TypeLib's is two - depth 3 covers both.
 function Test-KeyTreeContainsVMware {
     param([Microsoft.Win32.RegistryKey]$Key, [int]$Depth = 3)
     if (-not $Key) { return $false }
@@ -431,9 +530,7 @@ if ($strayComTotal -eq 0) {
 }
 
 # Installer\Folders stale path references (value NAME is the folder
-# path, e.g. "C:\ProgramData\VMware\VMware VGAuth\msgCatalog\"). This
-# key is WOW64-shared (non-redirected), so there's no separate
-# WOW6432Node copy to also check.
+# path). WOW64-shared, so no separate WOW6432Node copy exists.
 Write-Host ""
 Write-Host "--- Installer Folders ---"
 $foldersProps = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\Folders' -ErrorAction SilentlyContinue
@@ -496,10 +593,8 @@ if (-not $strayVideoKeys) {
     }
 }
 
-# SVGA 3D class coinstaller (vm3dc003) under the Display-adapters class
-# GUID's CoDeviceInstallers value - can silently veto removal of ANY
-# display device (not just VMware's own) if left behind. Mirrors the
-# fix in 9100_cleanup_vmware.ps1's Phase 3.
+# SVGA 3D class coinstaller (vm3dc003) can silently veto removal of any
+# display device if left behind. Mirrors 9100_cleanup_vmware.ps1 Phase 3.
 $displayClassGuid = '{4d36e968-e325-11ce-bfc1-08002be10318}'
 $coDevProp = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CoDeviceInstallers' -Name $displayClassGuid -ErrorAction SilentlyContinue
 if ($coDevProp -and (@($coDevProp.$displayClassGuid) -match 'vm3dc003')) {
@@ -522,9 +617,7 @@ foreach ($dir in $VMwareDirs) {
     }
 }
 
-# Per-user VMware AppData folders - mirrors 9100_cleanup_vmware.ps1's
-# Phase 6 sweep. Path depends on each profile under \Users, so
-# enumerate rather than hardcode.
+# Per-user AppData folders - path depends on each profile under \Users.
 $usersRoot = Join-Path $env:SystemDrive 'Users'
 $staleUserDirs = @()
 if (Test-Path $usersRoot) {
@@ -542,6 +635,25 @@ if ($staleUserDirs.Count -eq 0) {
 } else {
     foreach ($d in $staleUserDirs) {
         Check-Fail "VMware AppData folder still exists: $d"
+    }
+}
+
+# Wildcarded temp folders - mirrors 9100_cleanup_vmware.ps1's Phase 6
+# sweep of vmware-<account> folders (not just vmware-SYSTEM).
+$staleTempDirs = @()
+foreach ($pattern in $VMwareTempDirPatterns) {
+    $parent = Split-Path $pattern -Parent
+    $leaf   = Split-Path $pattern -Leaf
+    if (Test-Path $parent) {
+        Get-ChildItem -Path $parent -Directory -Filter $leaf -ErrorAction SilentlyContinue |
+            ForEach-Object { $staleTempDirs += $_.FullName }
+    }
+}
+if ($staleTempDirs.Count -eq 0) {
+    Check-Pass "No VMware temp folders (vmware-*)"
+} else {
+    foreach ($d in $staleTempDirs) {
+        Check-Fail "VMware temp folder still exists: $d"
     }
 }
 
@@ -576,17 +688,38 @@ if (-not $vmTasks -or $vmTasks.Count -eq 0) {
 }
 
 # -------------------------------------------------------------------
-# 8. Windows Update Agent driver-install history (msu provider)
+# 8. Component store integrity (DISM CheckHealth)
+# -------------------------------------------------------------------
+# Catches component-store corruption, e.g. from DriverStore residuals
+# that 9100_cleanup_vmware.ps1's Phase 6 deliberately doesn't force-delete.
+# `sfc /scannow` is intentionally skipped here - it can take 10-20+
+# minutes, disproportionate to this check; run it manually if DISM flags
+# corruption. DISM's output is English-only; non-English falls through
+# to a WARN with the raw text.
+Write-Host ""
+Write-Host "--- Component Store Integrity ---"
+
+Write-Host "  Running DISM /Online /Cleanup-Image /CheckHealth..."
+$dismOutput = & DISM.exe /Online /Cleanup-Image /CheckHealth 2>&1 | Out-String
+$dismNormalized = ($dismOutput.ToLowerInvariant() -replace '[^a-z]', '')
+if ($dismNormalized -match 'nocomponentstorecorruptiondetected') {
+    Check-Pass "DISM /CheckHealth: no component store corruption detected"
+} elseif ($dismNormalized -match 'isrepairable') {
+    Check-Warn "DISM /CheckHealth: component store corruption detected (repairable) - run DISM /Online /Cleanup-Image /RestoreHealth"
+} elseif ($dismNormalized -match 'isnotrepairable') {
+    Check-Fail "DISM /CheckHealth: component store corruption detected (NOT repairable) - review $env:windir\Logs\DISM\dism.log"
+} else {
+    Check-Warn "DISM /CheckHealth: could not parse result (non-English output?) - raw: $($dismOutput.Trim())"
+}
+
+# -------------------------------------------------------------------
+# 9. Windows Update Agent driver-install history (msu provider)
 # -------------------------------------------------------------------
 # Informational only (WARN, never FAIL). Since the Broadcom/VMware
-# acquisition, driver packages like vmci.inf get delivered/tracked via
-# Windows Update Agent and show up under Get-Package -ProviderName msu
-# (e.g. "Broadcom Inc. - System - 9.8.30.0"). This is just WU's own
-# local install-history bookkeeping - there is no supported API or
-# registry location to remove a stale entry from it, and its presence
-# does not mean the corresponding driver/service is still active (the
-# actual driver-store/service/file checks above are authoritative for
-# that). We still surface it so a reviewer isn't surprised by it later.
+# acquisition, driver packages can show up under
+# Get-Package -ProviderName msu. This is just WU's own install-history
+# bookkeeping with no supported removal path, and doesn't mean the
+# driver/service is still active - surfaced so it isn't a surprise later.
 Write-Host ""
 Write-Host "--- Windows Update Driver History (informational) ---"
 

--- a/pkg/virt-v2v/customize/scripts/windows/verify_vmware_cleanup.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/verify_vmware_cleanup.ps1
@@ -24,10 +24,18 @@ $RegExe  = Join-Path $Sys32 'reg.exe'
 
 $VMwareServices = @(
     'VGAuthService', 'VM3DService', 'VMTools', 'vmvss', 'GISvc',
-    'vmhgfs', 'vmmemctl', 'vmrawdsk', 'vnetWFP', 'vsepflt',
+    'vmhgfs', 'vmmemctl', 'vmrawdsk', 'vnetWFP', 'vnetflt', 'vsepflt',
     'vmci', 'vmxnet3', 'vmxnet3ndis6', 'pvscsi',
     'vmusbmouse', 'vmmouse',
-    'vm3dmp', 'vm3dmp-debug', 'vm3dmp-stats', 'vm3dmp_loader'
+    'vm3dmp', 'vm3dmp-debug', 'vm3dmp-stats', 'vm3dmp_loader',
+    # Additional short names from vmware-cleanup-tool's canonical
+    # component list (vmware_components.txt) - mirrors 9100_cleanup_vmware.ps1.
+    'vsock', 'efifw', 'svga_wddm', 'vmaudio', 'vgauth', 'cblauncher',
+    'vmwtimeprovider', 'vmstatsprovider', 'vmupgradehelper',
+    # vmwefifw: real on-disk service key name for the EFI firmware
+    # component - found via a broad post-cleanup sweep on all 3 test
+    # VMs. Mirrors 9100_cleanup_vmware.ps1.
+    'vmwefifw'
 )
 
 # Registry keys checked via reg.exe (avoids WOW64 redirection on SOFTWARE hive).
@@ -45,6 +53,7 @@ $RegKeysToCheck = @(
     'HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VGAuth',
     'HKLM\SYSTEM\CurrentControlSet\Services\Eventlog\Application\VMware Tools',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetWFP',
+    'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vnetflt',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vsepflt',
     'HKLM\SYSTEM\CurrentControlSet\services\eventLog\System\vmci'
 )
@@ -61,7 +70,10 @@ $VMwareDriverFiles = @(
     'vmci.sys', 'vmmouse.sys', 'vmrawdsk.sys', 'vmhgfs.sys',
     'vmusbmouse.sys', 'pvscsi.sys', 'vmxnet3.sys',
     'vm3dmp.sys', 'vm3dmp-debug.sys', 'vm3dmp-stats.sys', 'vm3dmp_loader.sys',
-    'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys'
+    'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys',
+    'vnetflt.sys',
+    # svga_wddm/efifw/vmaudio - mirrors 9100_cleanup_vmware.ps1.
+    'svga_wddm.sys', 'efifw.sys', 'vmaudio.sys'
 )
 
 $VMwareSystemFiles = @(
@@ -89,7 +101,7 @@ $VMwareSysWOW64Files = @(
 )
 
 # Excludes Hyper-V services (vmbus, vmgid, vmgen*, etc.)
-$SweepPattern = '^(vm(3d|ci|hgfs|mouse|rawdsk|memctl|xnet|ware|tools|vss|usb)|VGAuth|pvscsi|vsepflt|vnetWFP|GISvc)'
+$SweepPattern = '^(vm(3d|ci|hgfs|mouse|rawdsk|memctl|xnet|ware|tools|vss|usb)|VGAuth|pvscsi|vsepflt|vnetWFP|vnetflt|GISvc)'
 
 # ===================================================================
 # Helpers
@@ -105,6 +117,28 @@ function Test-RegKey {
     param([string]$KeyPath)
     & $RegExe query $KeyPath /ve 2>&1 | Out-Null
     return ($LASTEXITCODE -eq 0)
+}
+
+# List immediate subkey paths of a key via reg.exe (WOW64-safe - mirrors
+# 9100_cleanup_vmware.ps1).
+function Get-RegSubKeyPaths {
+    param([string]$KeyPath)
+    $out = & $RegExe query $KeyPath 2>&1
+    if ($LASTEXITCODE -ne 0) { return @() }
+    $out |
+        Where-Object { $_ -match '^HKEY_LOCAL_MACHINE\\' } |
+        ForEach-Object { ($_ -replace '^HKEY_LOCAL_MACHINE\\', 'HKLM\').Trim() } |
+        Where-Object { $_ -ne $KeyPath }
+}
+
+# Read a single string value from a key via reg.exe.
+function Get-RegValue {
+    param([string]$KeyPath, [string]$ValueName)
+    $out = & $RegExe query $KeyPath /v $ValueName 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { return $null }
+    $m = [regex]::Match($out, [regex]::Escape($ValueName) + '\s+REG_\w+\s+(.+)')
+    if ($m.Success) { return $m.Groups[1].Value.Trim() }
+    return $null
 }
 
 # ===================================================================
@@ -143,14 +177,109 @@ if ($foundServices.Count -eq 0) {
 }
 
 # -------------------------------------------------------------------
-# 2. Driver packages (pnputil)
+# 2. VMware Tools MSI / Add-Remove Programs
+# -------------------------------------------------------------------
+Write-Host ""
+Write-Host "--- MSI / Add-Remove Programs ---"
+
+$UninstallRoots = @(
+    'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+    'HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+$vmwareUninstallKeys = foreach ($root in $UninstallRoots) {
+    foreach ($sub in (Get-RegSubKeyPaths $root)) {
+        $displayName = Get-RegValue $sub 'DisplayName'
+        if ($displayName -match 'VMware') { "$sub ($displayName)" }
+    }
+}
+if (-not $vmwareUninstallKeys) {
+    Check-Pass "No VMware entries in Add/Remove Programs"
+} else {
+    foreach ($k in $vmwareUninstallKeys) {
+        Check-Fail "Add/Remove Programs entry still present: $k"
+    }
+}
+
+# Enumerate every SID under UserData rather than hardcoding S-1-5-18
+# (SYSTEM) - per-machine installs land there, but we don't want to
+# silently miss a registration under an unexpected context.
+$UserDataRoot = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData'
+$productsRoots = @('HKLM\SOFTWARE\Classes\Installer\Products')
+foreach ($sidKey in (Get-RegSubKeyPaths $UserDataRoot)) {
+    $productsRoots += "$sidKey\Products"
+}
+
+$vmwareInstallerProducts = foreach ($productsRoot in $productsRoots) {
+    foreach ($sub in (Get-RegSubKeyPaths $productsRoot)) {
+        $name = Get-RegValue $sub 'ProductName'
+        if (-not $name) { $name = Get-RegValue "$sub\InstallProperties" 'DisplayName' }
+        if ($name -match 'VMware') { "$sub ($name)" }
+    }
+}
+if (-not $vmwareInstallerProducts) {
+    Check-Pass "No orphaned VMware Windows Installer product registrations"
+} else {
+    foreach ($p in $vmwareInstallerProducts) {
+        Check-Fail "Windows Installer product registration still present: $p"
+    }
+}
+
+# Windows Installer "Components" ownership map - one entry per
+# installed file/registry key, keyed by ComponentGuid with a value
+# named after the owning product's packed ProductCode. Only cleaned
+# automatically by a successful msiexec /x; survives the registry
+# fallback in 9100_cleanup_vmware.ps1's Phase 0 if not explicitly
+# swept (mirrors that script's Components cleanup).
+function Get-RegDataMatches {
+    param([string]$KeyPath, [string]$Pattern)
+    $out = & $RegExe query $KeyPath /f $Pattern /d /s 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { return @() }
+    $results = New-Object System.Collections.Generic.List[object]
+    $currentKey = $null
+    foreach ($line in ($out -split "`r?`n")) {
+        if ($line -match '^HKEY_LOCAL_MACHINE\\(.+)$') {
+            $currentKey = "HKLM\$($Matches[1])"
+        } elseif ($currentKey -and $line -match '^\s+(\S+)\s+REG_\w+\s+.*') {
+            $results.Add([PSCustomObject]@{ KeyPath = $currentKey; ValueName = $Matches[1] })
+        }
+    }
+    return $results
+}
+
+$vmwareComponentHits = foreach ($sidKey in (Get-RegSubKeyPaths $UserDataRoot)) {
+    Get-RegDataMatches "$sidKey\Components" 'VMware'
+}
+if (-not $vmwareComponentHits) {
+    Check-Pass "No orphaned VMware Windows Installer Components entries"
+} else {
+    Check-Fail "$(@($vmwareComponentHits).Count) orphaned Windows Installer Components entries still reference VMware (e.g. $($vmwareComponentHits[0].KeyPath))"
+}
+
+# -------------------------------------------------------------------
+# 3. Driver packages (pnputil)
 # -------------------------------------------------------------------
 Write-Host ""
 Write-Host "--- Driver Packages ---"
 
+# Mirrors 9100_cleanup_vmware.ps1: post Broadcom/VMware acquisition,
+# VMware's driver packages get republished with "Provider Name:
+# Broadcom Inc." instead of "VMware, Inc.", but the Original Name
+# (.inf filename) stays the same. Anchor on the known VMware .inf
+# basenames rather than the ambiguous "Broadcom" text, since Broadcom
+# also makes plenty of unrelated physical NICs/RAID controllers.
+# vm3d.inf (the SVGA 3D "setup" package) has no .sys of its own - the
+# binary is vm3dmp.sys, already in $VMwareDriverFiles - so it can't be
+# derived from that list and is listed explicitly.
+$VMwareExtraInfNames = @('vm3d.inf')
+$VMwareInfNames = ((($VMwareDriverFiles | ForEach-Object { $_ -replace '\.sys$', '.inf' }) + $VMwareExtraInfNames) |
+    ForEach-Object { [regex]::Escape($_) }) -join '|'
+
 $pnpOutput = & $PnpUtil /enum-drivers 2>&1 | Out-String
 $driverBlocks = $pnpOutput -split '(?=Published Name)' |
-    Where-Object { $_ -match 'VMware|Broadcom.*vmx' }
+    Where-Object {
+        $_ -match 'VMware' -or
+        $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
+    }
 
 if ($driverBlocks.Count -eq 0) {
     Check-Pass "No VMware driver packages in driver store"
@@ -162,7 +291,7 @@ if ($driverBlocks.Count -eq 0) {
 }
 
 # -------------------------------------------------------------------
-# 3. PnP devices
+# 4. PnP devices
 # -------------------------------------------------------------------
 Write-Host ""
 Write-Host "--- PnP Devices ---"
@@ -171,7 +300,11 @@ $vmDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
     Where-Object {
         $_.Manufacturer -match 'VMware' -or
         $_.FriendlyName -match 'VMware' -or
-        $_.InstanceId -match 'VEN_15AD'
+        $_.InstanceId -match 'VEN_15AD' -or
+        # VMware's USB vendor ID - catches the USB composite PARENT of
+        # "VMware USB Pointing Device", whose own description doesn't
+        # say VMware. Mirrors 9100_cleanup_vmware.ps1.
+        $_.InstanceId -match 'VID_0E0F'
     }
 
 if (-not $vmDevices -or $vmDevices.Count -eq 0) {
@@ -187,7 +320,7 @@ if (-not $vmDevices -or $vmDevices.Count -eq 0) {
 }
 
 # -------------------------------------------------------------------
-# 4. Registry
+# 5. Registry
 # -------------------------------------------------------------------
 Write-Host ""
 Write-Host "--- Registry ---"
@@ -227,8 +360,156 @@ if ($strayKeys.Count -eq 0) {
     }
 }
 
+# Stray COM registrations (CLSID/TypeLib) - mirrors 9100_cleanup_vmware.ps1.
+# Uses the .NET registry API directly (in-process, forced to the 64-bit
+# view) rather than "reg query /s" - CLSID/TypeLib can each have tens
+# of thousands of subkeys, and recursively dumping/parsing the entire
+# subtree as text took several minutes in testing.
+Write-Host ""
+Write-Host "--- COM registrations (CLSID/TypeLib) ---"
+function Test-RegValueContainsVMware {
+    param([Microsoft.Win32.RegistryKey]$Key)
+    if (-not $Key) { return $false }
+    foreach ($valName in $Key.GetValueNames()) {
+        $v = $Key.GetValue($valName)
+        if ($v -and "$v" -match 'VMware') { return $true }
+    }
+    return $false
+}
+
+# Bounded-depth recursive scan - mirrors 9100_cleanup_vmware.ps1. CLSID's
+# implementation path normally sits one level down (InprocServer32/
+# LocalServer32), but TypeLib's path values sit two levels down (e.g.
+# {GUID}\1.0\0\win64) - a fixed depth of 3 comfortably covers both.
+function Test-KeyTreeContainsVMware {
+    param([Microsoft.Win32.RegistryKey]$Key, [int]$Depth = 3)
+    if (-not $Key) { return $false }
+    if (Test-RegValueContainsVMware $Key) { return $true }
+    if ($Depth -le 0) { return $false }
+    foreach ($childName in $Key.GetSubKeyNames()) {
+        $child = $Key.OpenSubKey($childName)
+        if ($child) {
+            $found = Test-KeyTreeContainsVMware $child ($Depth - 1)
+            $child.Close()
+            if ($found) { return $true }
+        }
+    }
+    return $false
+}
+
+function Get-VMwareStrayComKeys {
+    param([string]$SubPath, [string]$RootPathForLog)
+    $hklm64 = [Microsoft.Win32.RegistryKey]::OpenBaseKey('LocalMachine', 'Registry64')
+    $root = $hklm64.OpenSubKey($SubPath)
+    if (-not $root) { return @() }
+    $stray = @()
+    foreach ($guidName in $root.GetSubKeyNames()) {
+        $guidKey = $root.OpenSubKey($guidName)
+        if (-not $guidKey) { continue }
+        if (Test-KeyTreeContainsVMware $guidKey) { $stray += "$RootPathForLog\$guidName" }
+        $guidKey.Close()
+    }
+    $root.Close()
+    return $stray
+}
+
+$comRoots = @(
+    @{ SubPath = 'SOFTWARE\Classes\CLSID';               LogPath = 'HKLM\SOFTWARE\Classes\CLSID' },
+    @{ SubPath = 'SOFTWARE\Classes\WOW6432Node\CLSID';   LogPath = 'HKLM\SOFTWARE\Classes\WOW6432Node\CLSID' },
+    @{ SubPath = 'SOFTWARE\Classes\TypeLib';             LogPath = 'HKLM\SOFTWARE\Classes\TypeLib' },
+    @{ SubPath = 'SOFTWARE\Classes\WOW6432Node\TypeLib'; LogPath = 'HKLM\SOFTWARE\Classes\WOW6432Node\TypeLib' }
+)
+$strayComTotal = 0
+foreach ($root in $comRoots) {
+    foreach ($strayKey in (Get-VMwareStrayComKeys $root.SubPath $root.LogPath)) {
+        Check-Fail "Stray VMware COM registration: $strayKey"
+        $strayComTotal++
+    }
+}
+if ($strayComTotal -eq 0) {
+    Check-Pass "No stray VMware COM (CLSID/TypeLib) registrations"
+}
+
+# Installer\Folders stale path references (value NAME is the folder
+# path, e.g. "C:\ProgramData\VMware\VMware VGAuth\msgCatalog\"). This
+# key is WOW64-shared (non-redirected), so there's no separate
+# WOW6432Node copy to also check.
+Write-Host ""
+Write-Host "--- Installer Folders ---"
+$foldersProps = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\Folders' -ErrorAction SilentlyContinue
+$vmwareFolderNames = @()
+if ($foldersProps) {
+    $vmwareFolderNames = $foldersProps.PSObject.Properties |
+        Where-Object { $_.Name -notmatch '^PS(Path|ParentPath|ChildName|Drive|Provider)$' -and $_.Name -match 'VMware' } |
+        ForEach-Object { $_.Name }
+}
+if ($vmwareFolderNames.Count -eq 0) {
+    Check-Pass "No VMware entries in Installer\Folders"
+} else {
+    foreach ($n in $vmwareFolderNames) {
+        Check-Fail "Installer\Folders entry still present: $n"
+    }
+}
+
+# Run/RunOnce autostart entries (e.g. "VMware VM3DService Process").
+Write-Host ""
+Write-Host "--- Run / RunOnce autostart entries ---"
+function Get-VMwareRunEntryNames {
+    param([string]$PsKeyPath)
+    $props = Get-ItemProperty -Path $PsKeyPath -ErrorAction SilentlyContinue
+    if (-not $props) { return @() }
+    $props.PSObject.Properties |
+        Where-Object { $_.Name -notmatch '^PS(Path|ParentPath|ChildName|Drive|Provider)$' } |
+        Where-Object { $_.Name -match 'VMware' -or "$($_.Value)" -match 'VMware' } |
+        ForEach-Object { "$PsKeyPath\$($_.Name)" }
+}
+$runKeys = @(
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run',
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce',
+    'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run',
+    'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\RunOnce'
+)
+$staleRunEntries = foreach ($rk in $runKeys) { Get-VMwareRunEntryNames $rk }
+if (-not $staleRunEntries) {
+    Check-Pass "No VMware Run/RunOnce autostart entries"
+} else {
+    foreach ($e in $staleRunEntries) {
+        Check-Fail "Run/RunOnce entry still present: $e"
+    }
+}
+
+# SVGA 3D display adapter "software device" node - separate from the
+# vm3dmp_loader service key already checked above.
+Write-Host ""
+Write-Host "--- Display adapter (Control\Video) ---"
+$videoRoot = 'HKLM\SYSTEM\CurrentControlSet\Control\Video'
+$strayVideoKeys = foreach ($guidKey in (Get-RegSubKeyPaths $videoRoot)) {
+    $desc = Get-RegValue "$guidKey\Video" 'DeviceDesc'
+    $svc  = Get-RegValue "$guidKey\Video" 'Service'
+    if ($desc -match 'VMware' -or $svc -match '^vm3dmp') { $guidKey }
+}
+if (-not $strayVideoKeys) {
+    Check-Pass "No VMware display adapter registration under Control\Video"
+} else {
+    foreach ($k in $strayVideoKeys) {
+        Check-Fail "VMware display adapter registration still present: $k"
+    }
+}
+
+# SVGA 3D class coinstaller (vm3dc003) under the Display-adapters class
+# GUID's CoDeviceInstallers value - can silently veto removal of ANY
+# display device (not just VMware's own) if left behind. Mirrors the
+# fix in 9100_cleanup_vmware.ps1's Phase 3.
+$displayClassGuid = '{4d36e968-e325-11ce-bfc1-08002be10318}'
+$coDevProp = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CoDeviceInstallers' -Name $displayClassGuid -ErrorAction SilentlyContinue
+if ($coDevProp -and (@($coDevProp.$displayClassGuid) -match 'vm3dc003')) {
+    Check-Fail "VMware SVGA class coinstaller (vm3dc003) still registered under CoDeviceInstallers"
+} else {
+    Check-Pass "No VMware SVGA class coinstaller registration"
+}
+
 # -------------------------------------------------------------------
-# 5. Files on disk
+# 6. Files on disk
 # -------------------------------------------------------------------
 Write-Host ""
 Write-Host "--- Files ---"
@@ -238,6 +519,29 @@ foreach ($dir in $VMwareDirs) {
         Check-Fail "VMware directory still exists: $dir"
     } else {
         Check-Pass "Gone: $dir"
+    }
+}
+
+# Per-user VMware AppData folders - mirrors 9100_cleanup_vmware.ps1's
+# Phase 6 sweep. Path depends on each profile under \Users, so
+# enumerate rather than hardcode.
+$usersRoot = Join-Path $env:SystemDrive 'Users'
+$staleUserDirs = @()
+if (Test-Path $usersRoot) {
+    # -Force: C:\Users\Default is hidden and would otherwise be skipped.
+    Get-ChildItem -Path $usersRoot -Directory -Force -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            foreach ($sub in @('AppData\Local\VMware', 'AppData\Roaming\VMware', 'AppData\LocalLow\VMware')) {
+                $p = Join-Path $_.FullName $sub
+                if (Test-Path $p) { $staleUserDirs += $p }
+            }
+        }
+}
+if ($staleUserDirs.Count -eq 0) {
+    Check-Pass "No per-user VMware AppData folders"
+} else {
+    foreach ($d in $staleUserDirs) {
+        Check-Fail "VMware AppData folder still exists: $d"
     }
 }
 
@@ -255,7 +559,7 @@ foreach ($f in $allFiles) {
 }
 
 # -------------------------------------------------------------------
-# 6. Scheduled tasks
+# 7. Scheduled tasks
 # -------------------------------------------------------------------
 Write-Host ""
 Write-Host "--- Scheduled Tasks ---"
@@ -269,6 +573,37 @@ if (-not $vmTasks -or $vmTasks.Count -eq 0) {
     foreach ($t in $vmTasks) {
         Check-Fail "VMware scheduled task: $($t.TaskPath)$($t.TaskName)"
     }
+}
+
+# -------------------------------------------------------------------
+# 8. Windows Update Agent driver-install history (msu provider)
+# -------------------------------------------------------------------
+# Informational only (WARN, never FAIL). Since the Broadcom/VMware
+# acquisition, driver packages like vmci.inf get delivered/tracked via
+# Windows Update Agent and show up under Get-Package -ProviderName msu
+# (e.g. "Broadcom Inc. - System - 9.8.30.0"). This is just WU's own
+# local install-history bookkeeping - there is no supported API or
+# registry location to remove a stale entry from it, and its presence
+# does not mean the corresponding driver/service is still active (the
+# actual driver-store/service/file checks above are authoritative for
+# that). We still surface it so a reviewer isn't surprised by it later.
+Write-Host ""
+Write-Host "--- Windows Update Driver History (informational) ---"
+
+$msuEntries = $null
+try {
+    $msuEntries = Get-Package -ProviderName msu -ErrorAction Stop |
+        Where-Object { $_.Name -match 'VMware|Broadcom' }
+} catch {
+    Write-Host "  (Get-Package msu provider unavailable on this system - skipped)"
+}
+
+if ($null -ne $msuEntries -and $msuEntries) {
+    foreach ($e in $msuEntries) {
+        Check-Warn "WU package history still references: $($e.Name) (Status=$($e.Status)) - expected residue, no supported removal path"
+    }
+} elseif ($null -ne $msuEntries) {
+    Check-Pass "No VMware/Broadcom entries in Windows Update package history"
 }
 
 # -------------------------------------------------------------------

--- a/pkg/virt-v2v/customize/scripts/windows/verify_vmware_cleanup.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/verify_vmware_cleanup.ps1
@@ -19,13 +19,16 @@ $PnpUtil = Join-Path $Sys32 'pnputil.exe'
 $RegExe  = Join-Path $Sys32 'reg.exe'
 
 # ===================================================================
-# Data declarations — kept in sync with 9100_cleanup_vmware.ps1
+# Data declarations - kept in sync with 9100_cleanup_vmware.ps1
 # ===================================================================
 
+# pvscsi intentionally excluded here too - 9100_cleanup_vmware.ps1
+# deliberately leaves it installed (see its $VMwareServices comment),
+# so checking for its absence would be a false failure.
 $VMwareServices = @(
     'VGAuthService', 'VM3DService', 'VMTools', 'vmvss', 'GISvc',
     'vmhgfs', 'vmmemctl', 'vmrawdsk', 'vnetWFP', 'vnetflt', 'vsepflt',
-    'vmci', 'vmxnet3', 'vmxnet3ndis6', 'pvscsi',
+    'vmci', 'vmxnet3', 'vmxnet3ndis6',
     'vmusbmouse', 'vmmouse',
     'vm3dmp', 'vm3dmp-debug', 'vm3dmp-stats', 'vm3dmp_loader',
     # Additional short names - mirrors 9100_cleanup_vmware.ps1.
@@ -76,10 +79,9 @@ $VMwareTempDirPatterns = @(
 
 $VMwareDriverFiles = @(
     'vmci.sys', 'vmmouse.sys', 'vmrawdsk.sys', 'vmhgfs.sys',
-    'vmusbmouse.sys', 'pvscsi.sys', 'vmxnet3.sys',
+    'vmusbmouse.sys', 'vmxnet3.sys',
     'vm3dmp.sys', 'vm3dmp-debug.sys', 'vm3dmp-stats.sys', 'vm3dmp_loader.sys',
-    'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys',
-    'vnetflt.sys',
+    'vsock.sys', 'vmmemctl.sys', 'vsepflt.sys', 'vnetWFP.sys', 'vnetflt.sys',
     # svga_wddm/efifw/vmaudio - mirrors 9100_cleanup_vmware.ps1.
     'svga_wddm.sys', 'efifw.sys', 'vmaudio.sys',
     # Legacy pre-WDDM driver files.
@@ -113,8 +115,9 @@ $VMwareSysWOW64Files = @(
     'vm3dum_loader.dll'
 )
 
-# Excludes Hyper-V services (vmbus, vmgid, vmgen*, etc.)
-$SweepPattern = '^(vm(3d|ci|hgfs|mouse|rawdsk|memctl|xnet|ware|tools|vss|usb)|VGAuth|pvscsi|vsepflt|vnetWFP|vnetflt|GISvc)'
+# Excludes Hyper-V services (vmbus, vmgid, vmgen*, etc.). pvscsi excluded
+# too - it's deliberately left installed by 9100_cleanup_vmware.ps1.
+$SweepPattern = '^(vm(3d|ci|hgfs|mouse|rawdsk|memctl|xnet|ware|tools|vss|usb)|VGAuth|vsepflt|vnetWFP|vnetflt|GISvc)'
 
 # ===================================================================
 # Helpers
@@ -151,6 +154,25 @@ function Get-RegValue {
     $m = [regex]::Match($out, [regex]::Escape($ValueName) + '\s+REG_\w+\s+(.+)')
     if ($m.Success) { return $m.Groups[1].Value.Trim() }
     return $null
+}
+
+# .NET registry reads used for in-process tree scans (DeviceClasses,
+# CLSID/TypeLib). These throw a terminating SecurityException/
+# UnauthorizedAccessException on a restricted-ACL key, which neither
+# $ErrorActionPreference value suppresses - swallow it here so one
+# unreadable key doesn't abort the rest of the checks (and the final
+# RESULTS/exit code below).
+function Get-SafeSubKeyNames {
+    param([Microsoft.Win32.RegistryKey]$Key)
+    try { return $Key.GetSubKeyNames() } catch { return @() }
+}
+function Open-SafeSubKey {
+    param([Microsoft.Win32.RegistryKey]$Key, [string]$Name)
+    try { return $Key.OpenSubKey($Name) } catch { return $null }
+}
+function Get-SafeRegValue {
+    param([Microsoft.Win32.RegistryKey]$Key, [string]$Name)
+    try { return $Key.GetValue($Name) } catch { return $null }
 }
 
 # ===================================================================
@@ -276,13 +298,18 @@ $VMwareInfNames = ((($VMwareDriverFiles | ForEach-Object { $_ -replace '\.sys$',
     ForEach-Object { [regex]::Escape($_) }) -join '|'
 
 # Get-WindowsDriver is locale-independent; pnputil's text fields are English-only.
+# pvscsi excluded - 9100_cleanup_vmware.ps1 deliberately leaves its
+# driver package alone, so it staying in the store isn't a failure.
 $publishedNames = $null
 try {
     $publishedNames = @(
         Get-WindowsDriver -Online -ErrorAction Stop |
             Where-Object {
-                $_.ProviderName -match 'VMware' -or
-                $_.OriginalFileName -match "(?i)($VMwareInfNames)"
+                $_.OriginalFileName -notmatch '(?i)^pvscsi\.inf$' -and
+                (
+                    $_.ProviderName -match 'VMware' -or
+                    $_.OriginalFileName -match "(?i)($VMwareInfNames)"
+                )
             } |
             ForEach-Object { $_.Driver }
     )
@@ -302,8 +329,11 @@ if ($null -ne $publishedNames) {
     $pnpOutput = & $PnpUtil /enum-drivers 2>&1 | Out-String
     $driverBlocks = $pnpOutput -split '(?=Published Name)' |
         Where-Object {
-            $_ -match 'VMware' -or
-            $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
+            $_ -notmatch '(?i)Original Name:\s*pvscsi\.inf\b' -and
+            (
+                $_ -match 'VMware' -or
+                $_ -match "(?i)Original Name:\s*($VMwareInfNames)\b"
+            )
         }
 
     if ($driverBlocks.Count -eq 0) {
@@ -366,19 +396,21 @@ if (-not $vmDevices -or $vmDevices.Count -eq 0) {
 # Builds an InstanceId -> [DeviceClasses key path] lookup in one pass via
 # .NET instead of reg.exe (mirrors 9100_cleanup_vmware.ps1). DeviceClasses
 # can hold thousands of entries - walking it per device via reg.exe would
-# mean tens of thousands of process spawns.
+# mean tens of thousands of process spawns. DeviceClasses entries often
+# carry restrictive ACLs, so every read below goes through the
+# Get-Safe*/Open-Safe* helpers above.
 function Get-DeviceClassesInstanceMap {
     $map = @{}
     $hklm64 = [Microsoft.Win32.RegistryKey]::OpenBaseKey('LocalMachine', 'Registry64')
     $root = $hklm64.OpenSubKey('SYSTEM\CurrentControlSet\Control\DeviceClasses')
     if (-not $root) { return $map }
-    foreach ($ifaceGuidName in $root.GetSubKeyNames()) {
-        $ifaceGuidKey = $root.OpenSubKey($ifaceGuidName)
+    foreach ($ifaceGuidName in (Get-SafeSubKeyNames $root)) {
+        $ifaceGuidKey = Open-SafeSubKey $root $ifaceGuidName
         if (-not $ifaceGuidKey) { continue }
-        foreach ($instName in $ifaceGuidKey.GetSubKeyNames()) {
-            $instKey = $ifaceGuidKey.OpenSubKey($instName)
+        foreach ($instName in (Get-SafeSubKeyNames $ifaceGuidKey)) {
+            $instKey = Open-SafeSubKey $ifaceGuidKey $instName
             if ($instKey) {
-                $devInst = $instKey.GetValue('DeviceInstance')
+                $devInst = Get-SafeRegValue $instKey 'DeviceInstance'
                 if ($devInst) {
                     if (-not $map.ContainsKey($devInst)) {
                         $map[$devInst] = New-Object System.Collections.Generic.List[string]
@@ -466,46 +498,47 @@ if ($strayKeys.Count -eq 0) {
 # Stray COM registrations (CLSID/TypeLib) - mirrors 9100_cleanup_vmware.ps1.
 # Uses .NET directly rather than "reg query /s" - CLSID/TypeLib can each
 # have tens of thousands of subkeys, and text-parsing took minutes.
+# Ownership is decided by the COM server module path/name, not by "VMware"
+# appearing anywhere in the subtree - see 9100_cleanup_vmware.ps1 for why.
 Write-Host ""
 Write-Host "--- COM registrations (CLSID/TypeLib) ---"
-function Test-RegValueContainsVMware {
-    param([Microsoft.Win32.RegistryKey]$Key)
-    if (-not $Key) { return $false }
-    foreach ($valName in $Key.GetValueNames()) {
-        $v = $Key.GetValue($valName)
-        if ($v -and "$v" -match 'VMware') { return $true }
-    }
-    return $false
-}
+$VMwareComServerPattern = '(?i)(\\Program Files( \(x86\))?\\(Common Files\\)?VMware\\|\\vm3d|\\vmGuestLib|\\vmhgfs|VMWSU\.DLL)'
 
-# Bounded-depth recursive scan - mirrors 9100_cleanup_vmware.ps1. CLSID's
-# path is one level down, TypeLib's is two - depth 3 covers both.
-function Test-KeyTreeContainsVMware {
+# CLSID's server path is one level down (InprocServer32/LocalServer32);
+# TypeLib's is three levels down (version\lcid\win32|win64) - depth 3
+# covers both while still only matching those specific named subkeys.
+function Test-KeyTreeHasVMwareComServer {
     param([Microsoft.Win32.RegistryKey]$Key, [int]$Depth = 3)
-    if (-not $Key) { return $false }
-    if (Test-RegValueContainsVMware $Key) { return $true }
-    if ($Depth -le 0) { return $false }
-    foreach ($childName in $Key.GetSubKeyNames()) {
-        $child = $Key.OpenSubKey($childName)
-        if ($child) {
-            $found = Test-KeyTreeContainsVMware $child ($Depth - 1)
-            $child.Close()
-            if ($found) { return $true }
+    if (-not $Key -or $Depth -le 0) { return $false }
+    foreach ($childName in (Get-SafeSubKeyNames $Key)) {
+        $child = Open-SafeSubKey $Key $childName
+        if (-not $child) { continue }
+        if ($childName -in @('InprocServer32', 'LocalServer32', 'win32', 'win64')) {
+            $modulePath = Get-SafeRegValue $child ''
+            if ($modulePath -and "$modulePath" -match $VMwareComServerPattern) {
+                $child.Close()
+                return $true
+            }
         }
+        if (Test-KeyTreeHasVMwareComServer $child ($Depth - 1)) {
+            $child.Close()
+            return $true
+        }
+        $child.Close()
     }
     return $false
 }
 
-function Get-VMwareStrayComKeys {
+function Get-VMwareStrayComKey {
     param([string]$SubPath, [string]$RootPathForLog)
     $hklm64 = [Microsoft.Win32.RegistryKey]::OpenBaseKey('LocalMachine', 'Registry64')
     $root = $hklm64.OpenSubKey($SubPath)
     if (-not $root) { return @() }
     $stray = @()
-    foreach ($guidName in $root.GetSubKeyNames()) {
-        $guidKey = $root.OpenSubKey($guidName)
+    foreach ($guidName in (Get-SafeSubKeyNames $root)) {
+        $guidKey = Open-SafeSubKey $root $guidName
         if (-not $guidKey) { continue }
-        if (Test-KeyTreeContainsVMware $guidKey) { $stray += "$RootPathForLog\$guidName" }
+        if (Test-KeyTreeHasVMwareComServer $guidKey) { $stray += "$RootPathForLog\$guidName" }
         $guidKey.Close()
     }
     $root.Close()
@@ -520,7 +553,7 @@ $comRoots = @(
 )
 $strayComTotal = 0
 foreach ($root in $comRoots) {
-    foreach ($strayKey in (Get-VMwareStrayComKeys $root.SubPath $root.LogPath)) {
+    foreach ($strayKey in (Get-VMwareStrayComKey $root.SubPath $root.LogPath)) {
         Check-Fail "Stray VMware COM registration: $strayKey"
         $strayComTotal++
     }
@@ -700,7 +733,11 @@ Write-Host ""
 Write-Host "--- Component Store Integrity ---"
 
 Write-Host "  Running DISM /Online /Cleanup-Image /CheckHealth..."
-$dismOutput = & DISM.exe /Online /Cleanup-Image /CheckHealth 2>&1 | Out-String
+# Bare "DISM.exe" resolves via WOW64 to the 32-bit SysWOW64 copy on a
+# 32-bit PowerShell host, which can't service a running 64-bit image -
+# $Sys32 (Sysnative on WOW64) forces the real 64-bit DISM.
+$DismExe = Join-Path $Sys32 'Dism.exe'
+$dismOutput = & $DismExe /Online /Cleanup-Image /CheckHealth 2>&1 | Out-String
 $dismNormalized = ($dismOutput.ToLowerInvariant() -replace '[^a-z]', '')
 if ($dismNormalized -match 'nocomponentstorecorruptiondetected') {
     Check-Pass "DISM /CheckHealth: no component store corruption detected"
@@ -723,20 +760,26 @@ if ($dismNormalized -match 'nocomponentstorecorruptiondetected') {
 Write-Host ""
 Write-Host "--- Windows Update Driver History (informational) ---"
 
+# Only match "VMware" by name - the generic "Broadcom" vendor name would
+# also flag unrelated Broadcom NIC/storage drivers that have nothing to do
+# with VMware Tools, and Get-Package's Name field has no VMware-specific
+# text to disambiguate a republished VMware driver from those.
 $msuEntries = $null
+$msuAvailable = $false
 try {
     $msuEntries = Get-Package -ProviderName msu -ErrorAction Stop |
-        Where-Object { $_.Name -match 'VMware|Broadcom' }
+        Where-Object { $_.Name -match 'VMware' }
+    $msuAvailable = $true
 } catch {
     Write-Host "  (Get-Package msu provider unavailable on this system - skipped)"
 }
 
-if ($null -ne $msuEntries -and $msuEntries) {
+if ($msuEntries) {
     foreach ($e in $msuEntries) {
         Check-Warn "WU package history still references: $($e.Name) (Status=$($e.Status)) - expected residue, no supported removal path"
     }
-} elseif ($null -ne $msuEntries) {
-    Check-Pass "No VMware/Broadcom entries in Windows Update package history"
+} elseif ($msuAvailable) {
+    Check-Pass "No VMware entries in Windows Update package history"
 }
 
 # -------------------------------------------------------------------

--- a/pkg/virt-v2v/customize/scripts/windows/verify_vmware_cleanup.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/verify_vmware_cleanup.ps1
@@ -63,11 +63,15 @@ $RegKeysToCheck = @(
     'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\vmtoolsd.exe'
 )
 
+# This script runs under a 32-bit PowerShell on firstboot (WOW64), where
+# $env:ProgramFiles gets silently redirected to "...Program Files (x86)" -
+# so it can't be used to reach the real 64-bit folder. $env:ProgramW6432 /
+# CommonProgramW6432 are the unambiguous, non-redirected equivalents.
 $VMwareDirs = @(
-    "$env:ProgramFiles\VMware",
-    "$env:ProgramFiles\Common Files\VMware",
+    "$env:ProgramW6432\VMware",
+    "$env:CommonProgramW6432\VMware",
     "${env:ProgramFiles(x86)}\VMware",
-    "${env:ProgramFiles(x86)}\Common Files\VMware",
+    "${env:CommonProgramFiles(x86)}\VMware",
     "$env:ProgramData\VMware"
 )
 


### PR DESCRIPTION
added missing parts:
- check and remove MSI entries
- check and validate MSU entries
- check and remove class installer products (backup to MSI removal)
- check and remove broadcom renamed entries/drivers in a safe way
- check and remove control sets
- check and remove class registrations
- push current control set enum removal to a fallback option so we don't corrupt the database
- check and remove CLSID and TypeLib stale COM registrations
- check and remove stale autostart entries
- check and remove current control set video entry for vm3dmp
- expand removal of vmware directories and files across users
- reorder the phases so we hit less locks
- expand file checks with wildcards
- use windows get driver first as that is language agnostic, failover to pnputil
- check and remove ghost devices 
- add dism corruption health check
- fix 64 vs 32 bit resolution problem
- don't fail on ACL access errors

Resolves: MTV-6364