### PR TITLE
MTV-6403 | set Memory.Guest instead of Resources.Requests in mapMemory

### DIFF
--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -291,9 +291,7 @@ func (r *Builder) mapMemory(vm *model.VM, object *cnv.VirtualMachineSpec, usesIn
 		return
 	}
 	memory := resource.NewQuantity(int64(vm.MemoryMB)*1024*1024, resource.BinarySI)
-	object.Template.Spec.Domain.Resources.Requests = core.ResourceList{
-		core.ResourceMemory: *memory,
-	}
+	object.Template.Spec.Domain.Memory = &cnv.Memory{Guest: memory}
 }
 
 func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) (dvs []cdi.DataVolume, err error) {

--- a/pkg/controller/plan/adapter/hyperv/builder_test.go
+++ b/pkg/controller/plan/adapter/hyperv/builder_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	hyperv "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
+	cnv "kubevirt.io/api/core/v1"
 )
 
 func TestBuildNICKeys(t *testing.T) {
@@ -83,6 +85,41 @@ func TestBuildNICKeys(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMapMemory(t *testing.T) {
+	r := &Builder{}
+	vm := &model.VM{}
+	vm.MemoryMB = 2048
+	object := &cnv.VirtualMachineSpec{
+		Template: &cnv.VirtualMachineInstanceTemplateSpec{},
+	}
+
+	r.mapMemory(vm, object, false)
+
+	if object.Template.Spec.Domain.Memory == nil || object.Template.Spec.Domain.Memory.Guest == nil {
+		t.Fatalf("expected Memory.Guest to be set, got nil")
+	}
+	expected := int64(2048) * 1024 * 1024
+	actual := object.Template.Spec.Domain.Memory.Guest.Value()
+	if actual != expected {
+		t.Errorf("Memory.Guest = %d, want %d", actual, expected)
+	}
+}
+
+func TestMapMemoryUsesInstanceType(t *testing.T) {
+	r := &Builder{}
+	vm := &model.VM{}
+	vm.MemoryMB = 2048
+	object := &cnv.VirtualMachineSpec{
+		Template: &cnv.VirtualMachineInstanceTemplateSpec{},
+	}
+
+	r.mapMemory(vm, object, true)
+
+	if object.Template.Spec.Domain.Memory != nil {
+		t.Errorf("expected Memory to be nil when usesInstanceType is true, got %+v", object.Template.Spec.Domain.Memory)
 	}
 }
 


### PR DESCRIPTION
The Hyper-V builder was the only provider adapter setting Resources.Requests[memory] instead of Memory.Guest on the KubeVirt VM spec. This caused KubeVirt to derive guest memory from the resource request, resulting in incorrect memory allocation (e.g., 2048MB source VM becoming 4GB on destination).

Align with vSphere, OVirt, OVA, and OpenStack adapters which all set Memory.Guest directly.

Adds unit tests covering mapMemory for both the direct-memory and usesInstanceType code paths.

Ref: https://redhat.atlassian.net/browse/MTV-6403
Resolves: MTV-6403