### PR TITLE
MTV-6404 | normalize Hyper-V MAC addresses to lowercase

### DIFF
--- a/pkg/controller/provider/container/hyperv/client.go
+++ b/pkg/controller/provider/container/hyperv/client.go
@@ -1035,7 +1035,7 @@ func (r *Client) collectPerVMNICs(vmName, computerName string, networks []types.
 func formatMAC(mac string) string {
 	mac = strings.ReplaceAll(mac, "-", "")
 	mac = strings.ReplaceAll(mac, ":", "")
-	mac = strings.ToUpper(mac)
+	mac = strings.ToLower(mac)
 	if len(mac) == 12 {
 		return fmt.Sprintf("%s:%s:%s:%s:%s:%s",
 			mac[0:2], mac[2:4], mac[4:6], mac[6:8], mac[8:10], mac[10:12])

--- a/pkg/controller/provider/container/hyperv/client_test.go
+++ b/pkg/controller/provider/container/hyperv/client_test.go
@@ -268,7 +268,7 @@ func TestApplyBatchDetails(t *testing.T) {
 		t.Errorf("vm-linux-01: expected prefix length 24, got %d", vms[0].GuestNetworks[0].PrefixLength)
 	}
 	// MAC should be normalized to colon-separated format
-	expectedMAC := "00:15:5D:01:01:01"
+	expectedMAC := "00:15:5d:01:01:01"
 	if vms[0].GuestNetworks[0].MAC != expectedMAC {
 		t.Errorf("vm-linux-01: expected MAC '%s', got '%s'", expectedMAC, vms[0].GuestNetworks[0].MAC)
 	}
@@ -380,8 +380,8 @@ func TestApplyBatchDetails_ClusterModeBuildDisksAndNICs(t *testing.T) {
 	if len(vms[0].NICs) != 1 {
 		t.Fatalf("Expected 1 NIC, got %d", len(vms[0].NICs))
 	}
-	if vms[0].NICs[0].MAC != "00:15:5D:01:01:01" {
-		t.Errorf("Expected normalized MAC '00:15:5D:01:01:01', got '%s'", vms[0].NICs[0].MAC)
+	if vms[0].NICs[0].MAC != "00:15:5d:01:01:01" {
+		t.Errorf("Expected normalized MAC '00:15:5d:01:01:01', got '%s'", vms[0].NICs[0].MAC)
 	}
 	if vms[0].NICs[0].NetworkUUID != "switch-uuid-1" {
 		t.Errorf("Expected NetworkUUID 'switch-uuid-1', got '%s'", vms[0].NICs[0].NetworkUUID)
@@ -541,10 +541,10 @@ func TestFormatMAC(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"00155D010101", "00:15:5D:01:01:01"},
-		{"00-15-5D-01-01-01", "00:15:5D:01:01:01"},
-		{"00:15:5D:01:01:01", "00:15:5D:01:01:01"},
-		{"short", "SHORT"},
+		{"00155D010101", "00:15:5d:01:01:01"},
+		{"00-15-5D-01-01-01", "00:15:5d:01:01:01"},
+		{"00:15:5D:01:01:01", "00:15:5d:01:01:01"},
+		{"short", "short"},
 	}
 
 	for _, tc := range tests {
@@ -823,7 +823,7 @@ func TestBuildGuestNetworks(t *testing.T) {
 	if ipv4.IP != "192.168.1.10" {
 		t.Errorf("Expected IPv4 '192.168.1.10', got '%s'", ipv4.IP)
 	}
-	if ipv4.MAC != "00:15:5D:01:01:01" {
+	if ipv4.MAC != "00:15:5d:01:01:01" {
 		t.Errorf("Expected normalized MAC, got '%s'", ipv4.MAC)
 	}
 	if ipv4.Origin != "Dhcp" {
@@ -856,7 +856,7 @@ func TestBuildGuestNetworks_DashedMAC(t *testing.T) {
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 result, got %d", len(result))
 	}
-	if result[0].MAC != "00:15:5D:01:01:01" {
+	if result[0].MAC != "00:15:5d:01:01:01" {
 		t.Errorf("Expected colon-separated MAC from dashed input, got '%s'", result[0].MAC)
 	}
 }


### PR DESCRIPTION
The Hyper-V inventory provider normalizes MAC addresses to uppercase via formatMAC() which calls strings.ToUpper(). This uppercase MAC flows unchanged through the entire pipeline: inventory model → mapMacStaticIPs() builder → V2V_staticIPs environment variable → macToIP file → network_config_util.sh → udev rules. The resulting udev rule uses uppercase:

  ATTR{address}=="00:15:5D:A0:A3:14",NAME="eth1"

But the Linux kernel reports MACs in lowercase via sysfs (/sys/class/net/*/address), and udev's ATTR{address}== matching is case-sensitive. The uppercase rule never matches, and NIC names are not preserved after migration (e.g., eth1 becomes enp2s0).

While MTV-5530 (PR #6418) added systemd .link files as an alternative NIC naming mechanism for Guests with NM, that fix has limitations:
- Only generates .link files when an NM connection profile exists and lacks a mac-address= entry — NICs that don't meet both conditions still rely on udev rules
- Does not generate .link files for older guests (RHEL7)
- Does not fix the udev rules themselves — the uppercase MAC in 70-persistent-net.rules remains broken as a fallback
- Any Linux guest not using NetworkManager profiles (e.g., minimal installs, containers, older distros) has no .link safety net

This fix changes formatMAC() from strings.ToUpper() to strings.ToLower(), aligning with the vSphere provider convention. All downstream consumers receive lowercase MACs that match the kernel's sysfs output. Safe for Windows guests — Windows network commands are case-insensitive, and the vSphere provider has used lowercase for all guests including Windows without issues.

Ref: https://redhat.atlassian.net/browse/MTV-6404
Resolves: MTV-6404