### PR TITLE
MTV-6420 | allow Host Ready unless ESXi overallStatus is red

### DIFF
--- a/pkg/controller/host/handler/vsphere/handler.go
+++ b/pkg/controller/host/handler/vsphere/handler.go
@@ -55,7 +55,7 @@ func (r *Handler) Created(e libweb.Event) {
 func (r *Handler) Updated(e libweb.Event) {
 	if host, cast := e.Resource.(*vsphere.Host); cast {
 		updated := e.Updated.(*vsphere.Host)
-		if updated.Path != host.Path || updated.InMaintenanceMode != host.InMaintenanceMode {
+		if updated.Path != host.Path || updated.InMaintenanceMode != host.InMaintenanceMode || updated.Status != host.Status {
 			r.changed(host, updated)
 		}
 	}

--- a/pkg/controller/host/validation.go
+++ b/pkg/controller/host/validation.go
@@ -30,6 +30,7 @@ const (
 	ConnectionTestFailed    = "ConnectionTestFailed"
 	InMaintenance           = "InMaintenance"
 	NotHealthy              = "NotHealthy"
+	HostStatusNotGreen      = "HostStatusNotGreen"
 )
 
 // Categories
@@ -295,17 +296,7 @@ func (r *Reconciler) testConnection(host *api.Host) (err error) {
 				},
 			)
 		}
-		if hostModel.Status != "green" {
-			host.Status.SetCondition(
-				libcnd.Condition{
-					Type:     NotHealthy,
-					Status:   True,
-					Reason:   StateEvaluated,
-					Category: Critical,
-					Message:  "Host status not 'green'.",
-				},
-			)
-		}
+		setOverallStatusConditions(host, hostModel.Status)
 		secret.Data["thumbprint"] = []byte(hostModel.Thumbprint)
 		h := adapter.EsxHost{
 			Secret: secret,
@@ -350,4 +341,32 @@ func (r *Reconciler) testConnection(host *api.Host) (err error) {
 	}
 
 	return
+}
+
+// setOverallStatusConditions maps vSphere HostSystem.overallStatus onto Host
+// conditions. Only red blocks Ready (Critical NotHealthy), any non-green value
+// is surfaced as a Warn concern.
+func setOverallStatusConditions(host *api.Host, overallStatus string) {
+	if overallStatus != "green" {
+		host.Status.SetCondition(
+			libcnd.Condition{
+				Type:     HostStatusNotGreen,
+				Status:   True,
+				Reason:   StateEvaluated,
+				Category: Warn,
+				Message:  fmt.Sprintf("Host overallStatus is %q (expected green).", overallStatus),
+			},
+		)
+	}
+	if overallStatus == "red" {
+		host.Status.SetCondition(
+			libcnd.Condition{
+				Type:     NotHealthy,
+				Status:   True,
+				Reason:   StateEvaluated,
+				Category: Critical,
+				Message:  "Host overallStatus is red.",
+			},
+		)
+	}
 }

--- a/pkg/controller/host/validation_test.go
+++ b/pkg/controller/host/validation_test.go
@@ -1,0 +1,75 @@
+package host
+
+import (
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+)
+
+func TestSetOverallStatusConditions(t *testing.T) {
+	cases := []struct {
+		name           string
+		overallStatus  string
+		wantNotGreen   bool
+		wantNotHealthy bool
+		wantBlocker    bool
+	}{
+		{
+			name:          "green",
+			overallStatus: "green",
+		},
+		{
+			name:          "yellow",
+			overallStatus: "yellow",
+			wantNotGreen:  true,
+		},
+		{
+			name:          "gray",
+			overallStatus: "gray",
+			wantNotGreen:  true,
+		},
+		{
+			name:           "red",
+			overallStatus:  "red",
+			wantNotGreen:   true,
+			wantNotHealthy: true,
+			wantBlocker:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host := &api.Host{}
+			setOverallStatusConditions(host, tc.overallStatus)
+
+			if got := host.Status.HasCondition(HostStatusNotGreen); got != tc.wantNotGreen {
+				t.Errorf("HostStatusNotGreen = %v, want %v", got, tc.wantNotGreen)
+			}
+			if got := host.Status.HasCondition(NotHealthy); got != tc.wantNotHealthy {
+				t.Errorf("NotHealthy = %v, want %v", got, tc.wantNotHealthy)
+			}
+			if got := host.Status.HasBlockerCondition(); got != tc.wantBlocker {
+				t.Errorf("HasBlockerCondition = %v, want %v", got, tc.wantBlocker)
+			}
+
+			if tc.wantNotGreen {
+				cnd := host.Status.FindCondition(HostStatusNotGreen)
+				if cnd == nil {
+					t.Fatal("expected HostStatusNotGreen condition")
+				}
+				if cnd.Category != Warn {
+					t.Errorf("HostStatusNotGreen category = %q, want %q", cnd.Category, Warn)
+				}
+			}
+			if tc.wantNotHealthy {
+				cnd := host.Status.FindCondition(NotHealthy)
+				if cnd == nil {
+					t.Fatal("expected NotHealthy condition")
+				}
+				if cnd.Category != Critical {
+					t.Errorf("NotHealthy category = %q, want %q", cnd.Category, Critical)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Treat yellow/gray host overallStatus as a Warn concern instead of blocking migration-network Host CRs. Keep NotHealthy Critical only for red. Reconcile Hosts when inventory overallStatus changes.

Ref: https://redhat.atlassian.net/browse/MTV-6420
Resolves: MTV-6420

Epic: https://redhat.atlassian.net/browse/MTV-6415
RFE: https://redhat.atlassian.net/browse/MTV-5820