### PR TITLE
chore(automation): Bundle SHA reference update for 2-12

### DIFF
--- a/build/forklift-operator-bundle/Containerfile-downstream
+++ b/build/forklift-operator-bundle/Containerfile-downstream
@@ -41,7 +41,7 @@ ARG UI_PLUGIN_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-con
 
 ARG VALIDATION_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-validation-rhel9@sha256:c632f1d24b690705eea268a14d7e6702565d452d7bfa2cf7a2166642e1848ade"
 
-ARG VIRT_V2V_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel10@sha256:66f358d30608c019d1e706f59dee6c2879da7e9020aa8700f89ff7827d100ae5"
+ARG VIRT_V2V_IMAGE="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel10@sha256:595e5f44267d5ed249613287ae669ca23d0233d15cf2f8943f94d2594abf97ea"
 
 ARG VIRT_V2V_IMAGE_RHEL9="registry.redhat.io/migration-toolkit-virtualization/mtv-virt-v2v-rhel9@sha256:9445e2288ec04d0d97bff97bb59275c51920f4209f7a43c14189424a89c17066"
 


### PR DESCRIPTION
This PR updates the SHA references in Containerfile-downstream files based on the latest snapshot for version 2-12.

## Changes
- Updated SHA references in all Containerfile-downstream files
- Generated from latest snapshot: forklift-operator-2-12-20260816-111717-000

## Automated Update
This PR was created automatically by the mtv-releng update script.