### PR TITLE
[release-2.12] MTV-6308 | Centralize ResolveTargetVmName across all adapters (#7892)

### DIFF
--- a/pkg/controller/plan/adapter/base/template.go
+++ b/pkg/controller/plan/adapter/base/template.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/controller/plan/util"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	"github.com/kubev2v/forklift/pkg/templateutil"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
@@ -57,4 +59,64 @@ func ValidatePVCNameTemplate(templateStr string, testData interface{}) (string, 
 	}
 
 	return result, nil
+}
+
+// ResolveTargetVmName returns the DNS1123-safe target VM name.
+// Resolution order (first non-empty wins):
+//  1. spec.vms[].targetName  — explicit user override
+//  2. status.migration.vms[].newName — assigned during a previous migration run
+//  3. util.ChangeVmName(vmName) — automatic sanitization when vmName is not a valid DNS1123 label
+//  4. vmName as-is
+func ResolveTargetVmName(p *api.Plan, vmID, vmName string) string {
+	if name := planOverrideName(p, vmID); name != "" {
+		return name
+	}
+	if errs := k8svalidation.IsDNS1123Label(vmName); len(errs) > 0 {
+		if hasAlphanumeric(vmName) {
+			return util.ChangeVmName(vmName)
+		}
+		return vmIDFallbackName(vmID)
+	}
+	return vmName
+}
+
+// planOverrideName checks the plan for an explicit target name (spec.targetName
+// or status.newName) for the given vmID.
+func planOverrideName(p *api.Plan, vmID string) string {
+	if p == nil {
+		return ""
+	}
+	for i := range p.Spec.VMs {
+		if p.Spec.VMs[i].ID == vmID {
+			if name := strings.TrimSpace(p.Spec.VMs[i].TargetName); name != "" {
+				return name
+			}
+			break
+		}
+	}
+	for _, vmStatus := range p.Status.Migration.VMs {
+		if vmStatus.ID == vmID && vmStatus.NewName != "" {
+			return vmStatus.NewName
+		}
+	}
+	return ""
+}
+
+// hasAlphanumeric reports whether s contains at least one ASCII letter or digit.
+// When false, ChangeVmName would strip all characters and produce a random suffix.
+func hasAlphanumeric(s string) bool {
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			return true
+		}
+	}
+	return false
+}
+
+// vmIDFallbackName produces a deterministic DNS1123-safe name from a VM ID.
+func vmIDFallbackName(vmID string) string {
+	if hasAlphanumeric(vmID) {
+		return util.ChangeVmName(vmID)
+	}
+	return "vm-0000"
 }

--- a/pkg/controller/plan/adapter/base/template_test.go
+++ b/pkg/controller/plan/adapter/base/template_test.go
@@ -1,0 +1,133 @@
+package base
+
+import (
+	"testing"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestResolveTargetVmName(t *testing.T) {
+	const vmID = "358ce831-f790-4ad9-8ee0-ee272b0ecac4"
+
+	t.Run("nil plan returns vmName as-is when valid", func(t *testing.T) {
+		got := ResolveTargetVmName(nil, vmID, "valid-name")
+		if got != "valid-name" {
+			t.Fatalf("got %q, want valid-name", got)
+		}
+	})
+
+	t.Run("sanitizes invalid DNS1123 name", func(t *testing.T) {
+		p := &api.Plan{}
+		got := ResolveTargetVmName(p, vmID, "rhel9-node_2")
+		if got != "rhel9-node-2" {
+			t.Fatalf("got %q, want rhel9-node-2", got)
+		}
+	})
+
+	t.Run("spec targetName wins over sanitization and is trimmed", func(t *testing.T) {
+		p := &api.Plan{
+			Spec: api.PlanSpec{
+				VMs: []planapi.VM{{
+					Ref:        ref.Ref{ID: vmID},
+					TargetName: "  custom-target  ",
+				}},
+			},
+		}
+		got := ResolveTargetVmName(p, vmID, "rhel9-node_2")
+		if got != "custom-target" {
+			t.Fatalf("got %q, want %q (leading/trailing spaces must be trimmed)", got, "custom-target")
+		}
+	})
+
+	t.Run("status newName wins over sanitization", func(t *testing.T) {
+		p := &api.Plan{}
+		p.Status.Migration.VMs = []*planapi.VMStatus{
+			{VM: planapi.VM{Ref: ref.Ref{ID: vmID}}, NewName: "migrated-name"},
+		}
+		got := ResolveTargetVmName(p, vmID, "rhel9-node_2")
+		if got != "migrated-name" {
+			t.Fatalf("got %q, want migrated-name", got)
+		}
+	})
+
+	t.Run("spec targetName wins over status newName", func(t *testing.T) {
+		p := &api.Plan{
+			Spec: api.PlanSpec{
+				VMs: []planapi.VM{{
+					Ref:        ref.Ref{ID: vmID},
+					TargetName: "explicit-target",
+				}},
+			},
+		}
+		p.Status.Migration.VMs = []*planapi.VMStatus{
+			{VM: planapi.VM{Ref: ref.Ref{ID: vmID}}, NewName: "migrated-name"},
+		}
+		got := ResolveTargetVmName(p, vmID, "rhel9-node_2")
+		if got != "explicit-target" {
+			t.Fatalf("got %q, want explicit-target", got)
+		}
+	})
+
+	t.Run("valid name returned as-is", func(t *testing.T) {
+		p := &api.Plan{}
+		got := ResolveTargetVmName(p, vmID, "already-valid")
+		if got != "already-valid" {
+			t.Fatalf("got %q, want already-valid", got)
+		}
+	})
+
+	t.Run("whitespace-only targetName falls through to sanitization", func(t *testing.T) {
+		p := &api.Plan{
+			Spec: api.PlanSpec{
+				VMs: []planapi.VM{{
+					Ref:        ref.Ref{ID: vmID},
+					TargetName: "   ",
+				}},
+			},
+		}
+		got := ResolveTargetVmName(p, vmID, "rhel9-node_2")
+		if got != "rhel9-node-2" {
+			t.Fatalf("got %q, want rhel9-node-2", got)
+		}
+	})
+
+	t.Run("mismatched vmID falls through to sanitization", func(t *testing.T) {
+		p := &api.Plan{
+			Spec: api.PlanSpec{
+				VMs: []planapi.VM{{
+					Ref:        ref.Ref{ID: "other-id"},
+					TargetName: "should-not-match",
+				}},
+			},
+		}
+		got := ResolveTargetVmName(p, vmID, "My_VM+Name")
+		if got != "my-vm-name" {
+			t.Fatalf("got %q, want my-vm-name", got)
+		}
+	})
+
+	t.Run("all-invalid name produces deterministic fallback from vmID", func(t *testing.T) {
+		p := &api.Plan{}
+		otherID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+		got1 := ResolveTargetVmName(p, vmID, "...")
+		got2 := ResolveTargetVmName(p, vmID, "...")
+		gotOther := ResolveTargetVmName(p, otherID, "...")
+
+		if got1 != got2 {
+			t.Fatalf("non-deterministic: first call %q, second call %q", got1, got2)
+		}
+		if got1 == "" || got1 == "..." {
+			t.Fatalf("expected a valid fallback name, got %q", got1)
+		}
+		if got1 == gotOther {
+			t.Fatalf("different vmIDs should produce different fallbacks: %q == %q", got1, gotOther)
+		}
+		if errs := k8svalidation.IsDNS1123Label(got1); len(errs) > 0 {
+			t.Fatalf("fallback %q is not a valid DNS1123 label: %v", got1, errs)
+		}
+	})
+}

--- a/pkg/controller/plan/adapter/hyperv/validator.go
+++ b/pkg/controller/plan/adapter/hyperv/validator.go
@@ -254,12 +254,15 @@ func (r *Validator) PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (bool
 		return false, liberr.Wrap(err, "vm", vmRef.String())
 	}
 
+	targetVmName := planbase.ResolveTargetVmName(r.Plan, vm.ID, vm.Name)
+
 	// Validate template produces valid k8s labels for each disk
 	for i, disk := range vm.Disks {
 		testData := map[string]interface{}{
-			"VmName":    vm.Name,
-			"DiskIndex": i,
-			"DiskId":    disk.ID,
+			"VmName":       vm.Name,
+			"TargetVmName": targetVmName,
+			"DiskIndex":    i,
+			"DiskId":       disk.ID,
 		}
 		_, err := planbase.ValidatePVCNameTemplate(pvcNameTemplate, testData)
 		if err != nil {

--- a/pkg/controller/plan/adapter/hyperv/validator_test.go
+++ b/pkg/controller/plan/adapter/hyperv/validator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
@@ -263,5 +264,44 @@ func TestNetworksMapped_TrulyDisconnectedNICSkipped(t *testing.T) {
 	}
 	if !ok {
 		t.Error("expected ok=true: truly disconnected NIC (empty name and ID) should be skipped")
+	}
+}
+
+func TestPVCNameTemplate_UsesInventoryVMIdentity(t *testing.T) {
+	lookupID := "lookup-ref-id"
+	inventoryID := "358ce831-f790-4ad9-8ee0-ee272b0ecac4"
+	inventoryName := "rhel9-node_2"
+
+	vm := &hyperv.VM{}
+	vm.ID = inventoryID
+	vm.Name = inventoryName
+	vm.Disks = []model.Disk{
+		{Base: model.Base{ID: inventoryID + "-disk-0"}, Capacity: 16 * 1024 * 1024 * 1024},
+	}
+
+	inv := &stubInventory{vms: map[string]*hyperv.VM{lookupID: vm}}
+
+	plan := &api.Plan{}
+	plan.Name = "test-plan"
+	plan.Spec.VMs = []planapi.VM{{
+		Ref:        ref.Ref{ID: inventoryID},
+		TargetName: "my-custom-target",
+	}}
+
+	v := &Validator{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{Inventory: inv},
+			Plan:   plan,
+		},
+	}
+
+	tmpl := `{{if eq .TargetVmName "my-custom-target"}}ok-{{.DiskIndex}}{{else}}INVALID{{end}}`
+
+	ok, err := v.PVCNameTemplate(ref.Ref{ID: lookupID}, tmpl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("expected ok=true: PVC name template should be valid when TargetVmName resolves to spec.targetName")
 	}
 }

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -405,16 +405,7 @@ func (r *Validator) PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (ok b
 		return
 	}
 
-	// Get target VM name (either from VM status NewName or source VM name)
-	targetVmName := vmRef.Name
-	if r.Plan != nil && r.Plan.Status.Migration.VMs != nil {
-		for _, vmStatus := range r.Plan.Status.Migration.VMs {
-			if vmStatus.ID == vmRef.ID && vmStatus.NewName != "" {
-				targetVmName = vmStatus.NewName
-				break
-			}
-		}
-	}
+	targetVmName := planbase.ResolveTargetVmName(r.Plan, vmRef.ID, vmRef.Name)
 
 	// Test template with sample data for each disk
 	diskIndex := 0

--- a/pkg/controller/plan/adapter/ocp/validator_test.go
+++ b/pkg/controller/plan/adapter/ocp/validator_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	cnv "kubevirt.io/api/core/v1"
@@ -346,5 +348,55 @@ func TestNICNetworkRefs_VMNotFound(t *testing.T) {
 	_, err := validator.NICNetworkRefs(ref.Ref{Name: "nonexistent", Namespace: "test-ns"})
 	if err == nil {
 		t.Errorf("expected error for missing VM, got nil")
+	}
+}
+
+func TestPVCNameTemplate_UsesSpecTargetName(t *testing.T) {
+	vm := &cnv.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "source-vm", Namespace: "test-ns"},
+		Spec: cnv.VirtualMachineSpec{
+			Template: &cnv.VirtualMachineInstanceTemplateSpec{
+				Spec: cnv.VirtualMachineInstanceSpec{
+					Volumes: []cnv.Volume{
+						{Name: "vol-0", VolumeSource: cnv.VolumeSource{
+							PersistentVolumeClaim: &cnv.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "src-pvc"},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+	client := newFakeClient(vm).Build()
+
+	plan := &api.Plan{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-plan"},
+		Spec: api.PlanSpec{
+			VMs: []planapi.VM{{
+				Ref:        ref.Ref{ID: "vm-id", Name: "source-vm", Namespace: "test-ns"},
+				TargetName: "my-target",
+			}},
+		},
+	}
+
+	validator := &Validator{
+		log:          logging.WithName("test").WithValues("test", "pvc-template"),
+		sourceClient: client,
+		Context:      &plancontext.Context{Plan: plan},
+	}
+
+	// Template that only produces a valid name when .TargetVmName == "my-target".
+	tmpl := `{{if eq .TargetVmName "my-target"}}ok-{{.DiskIndex}}{{else}}INVALID{{end}}`
+
+	ok, err := validator.PVCNameTemplate(
+		ref.Ref{ID: "vm-id", Name: "source-vm", Namespace: "test-ns"},
+		tmpl,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("expected ok=true: validator should resolve spec.targetName via ResolveTargetVmName")
 	}
 }

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -2126,8 +2126,11 @@ func (r *Builder) setColdMigrationDefaultPVCName(objectMeta *metav1.ObjectMeta, 
 		rootDiskIndex = utils.GetBootDiskNumber(planVM.RootDisk)
 	}
 
+	targetVmName := planbase.ResolveTargetVmName(r.Plan, vm.ID, vm.Name)
+
 	templateData := api.VSpherePVCNameTemplateData{
-		VmName:         r.getPlanVMSafeName(vm),
+		VmName:         vm.Name,
+		TargetVmName:   targetVmName,
 		PlanName:       r.Plan.Name,
 		DiskIndex:      diskIndex,
 		RootDiskIndex:  rootDiskIndex,

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strings"
 
 	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -13,7 +12,6 @@ import (
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	planbase "github.com/kubev2v/forklift/pkg/controller/plan/adapter/base"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
-	"github.com/kubev2v/forklift/pkg/controller/plan/util"
 	ocpmodel "github.com/kubev2v/forklift/pkg/controller/provider/model/ocp"
 	"github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
@@ -134,8 +132,7 @@ func (r *Validator) PVCNameTemplate(vmRef ref.Ref, pvcNameTemplate string) (ok b
 		return true, nil
 	}
 
-	// Get target VM name (either from TargetName field or cleaned VM name)
-	targetVmName := r.getPlanVMTargetName(vm)
+	targetVmName := planbase.ResolveTargetVmName(r.Plan, vm.ID, vm.Name)
 
 	for i, disk := range vm.Disks {
 		testData := api.VSpherePVCNameTemplateData{
@@ -580,21 +577,6 @@ func (r *Validator) getPlanVM(vm *model.VM) *plan.VM {
 		}
 	}
 	return nil
-}
-
-// getPlanVMTargetName returns the target VM name, either by using the TargetName field if present,
-// or by cleaning the VM name to make it DNS1123 compatible
-func (r *Validator) getPlanVMTargetName(vm *model.VM) string {
-	// Get plan VM from spec.vms and use the TargetName field if present
-	planVM := r.getPlanVM(vm)
-	if planVM != nil {
-		if name := strings.TrimSpace(planVM.TargetName); name != "" {
-			return name
-		}
-	}
-
-	// Otherwise, clean the VM name
-	return util.ChangeVmName(vm.Name)
 }
 
 // Validate that VM has no pre-existing snapshots for warm migration


### PR DESCRIPTION
Backport: https://github.com/kubev2v/forklift/pull/7892


ResolveTargetVmName in base/template.go only checked status.migration.vms[].newName, so each adapter re-implemented spec.vms[].targetName lookup with divergent logic. The Hyper-V validator used vmRef.ID instead of the inventory vm.ID, which could miss the targetName match when IDs differed. The OCP validator ignored spec.targetName entirely, causing the validator and builder to evaluate PVC name templates with different TargetVmName values.

- ResolveTargetVmName now resolves in order: spec.targetName, status.newName, DNS1123 sanitization, vmName as-is.
- Plan lookup extracted into planOverrideName helper.
- All-invalid VM names produce a deterministic fallback from vmID.
- Hyper-V validator uses inventory vm.ID instead of vmRef.ID.
- OCP validator replaced local resolution with ResolveTargetVmName.
- vSphere validator/builder removed duplicated getPlanVMTargetName and inline DNS1123 check.

Ref: https://redhat.atlassian.net/browse/MTV-6308
Resolves: MTV-6308