### PR TITLE
MTV-6400 | Assign disk serial number on every migrated VM

### DIFF
--- a/pkg/controller/plan/adapter/base/disk_serial.go
+++ b/pkg/controller/plan/adapter/base/disk_serial.go
@@ -1,0 +1,45 @@
+package base
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const MaxDiskSerialLength = 20
+
+// DiskSerial returns a serial number for a KubeVirt disk device.
+// If sourceID is non-empty it is sanitized and truncated to
+// MaxDiskSerialLength. Otherwise a deterministic 20-character hex
+// serial is derived from vmID and diskKey.
+func DiskSerial(sourceID, vmID string, diskKey int) string {
+	if s := sanitizeSerial(sourceID); s != "" {
+		return truncate(s, MaxDiskSerialLength)
+	}
+	return generateSerial(vmID, diskKey)
+}
+
+// sanitizeSerial removes characters that are unsafe for QEMU/libvirt
+// disk serials, keeping only alphanumerics and hyphens.
+func sanitizeSerial(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func generateSerial(vmID string, diskKey int) string {
+	h := sha256.Sum256(fmt.Appendf(nil, "%s:%d", vmID, diskKey))
+	return hex.EncodeToString(h[:])[:MaxDiskSerialLength]
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen]
+}

--- a/pkg/controller/plan/adapter/base/disk_serial_test.go
+++ b/pkg/controller/plan/adapter/base/disk_serial_test.go
@@ -1,0 +1,92 @@
+package base
+
+import (
+	"testing"
+)
+
+func TestDiskSerial_UsesSourceID(t *testing.T) {
+	serial := DiskSerial("6000C29a-1234-5678-abcd-000000000001", "vm-42", 0)
+	if len(serial) > MaxDiskSerialLength {
+		t.Errorf("serial too long: %d > %d", len(serial), MaxDiskSerialLength)
+	}
+	// Hyphens preserved, then truncated to 20 — matches what QEMU would
+	// produce from the raw UUID, keeping /dev/disk/by-id/ stable.
+	if serial != "6000C29a-1234-5678-a" {
+		t.Errorf("unexpected serial: %q", serial)
+	}
+}
+
+func TestDiskSerial_SourceIDShort(t *testing.T) {
+	serial := DiskSerial("disk-123", "vm-42", 0)
+	if serial != "disk-123" {
+		t.Errorf("expected %q, got %q", "disk-123", serial)
+	}
+}
+
+func TestDiskSerial_FallbackWhenEmpty(t *testing.T) {
+	serial := DiskSerial("", "vm-42", 0)
+	if len(serial) != MaxDiskSerialLength {
+		t.Errorf("fallback serial length: %d, want %d", len(serial), MaxDiskSerialLength)
+	}
+	// Deterministic: same inputs → same output
+	serial2 := DiskSerial("", "vm-42", 0)
+	if serial != serial2 {
+		t.Errorf("fallback not deterministic: %q vs %q", serial, serial2)
+	}
+}
+
+func TestDiskSerial_FallbackWhenSourceIDSanitizesToEmpty(t *testing.T) {
+	got := DiskSerial("@@@", "vm-42", 0)
+	want := DiskSerial("", "vm-42", 0)
+	if got != want {
+		t.Errorf("sanitized-empty fallback = %q, want %q", got, want)
+	}
+}
+
+func TestDiskSerial_FallbackDiffersByDiskKey(t *testing.T) {
+	s0 := DiskSerial("", "vm-42", 0)
+	s1 := DiskSerial("", "vm-42", 1)
+	if s0 == s1 {
+		t.Error("fallback should differ by disk key")
+	}
+}
+
+func TestDiskSerial_FallbackDiffersByVM(t *testing.T) {
+	s1 := DiskSerial("", "vm-1", 0)
+	s2 := DiskSerial("", "vm-2", 0)
+	if s1 == s2 {
+		t.Error("fallback should differ by VM ID")
+	}
+}
+
+func TestSanitizeSerial(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"uuid preserves hyphens", "6000C29a-1234-5678-abcd-000000000001", "6000C29a-1234-5678-abcd-000000000001"},
+		{"plain alphanumeric", "abc123", "abc123"},
+		{"special chars stripped", "disk@#$%^&*()", "disk"},
+		{"empty", "", ""},
+		{"spaces stripped", "disk 01", "disk01"},
+		{"braces stripped", "{12345678-abcd}", "12345678-abcd"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeSerial(tt.input)
+			if got != tt.expected {
+				t.Errorf("sanitizeSerial(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if truncate("abcdef", 3) != "abc" {
+		t.Error("truncate failed")
+	}
+	if truncate("abc", 10) != "abc" {
+		t.Error("truncate should not pad")
+	}
+}

--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -101,6 +101,7 @@ func (r *Builder) mapDisks(vm *model.VM, pvcs []*core.PersistentVolumeClaim, obj
 					Bus: cnv.DiskBusVirtio,
 				},
 			},
+			Serial: planbase.DiskSerial(disk.ID, vm.ID, i),
 		})
 	}
 	object.Template.Spec.Volumes = kVolumes

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -453,7 +453,7 @@ func (r *Builder) mapDisks(vm *model.Workload, persistentVolumeClaims []*core.Pe
 
 	var bootOrderSet bool
 	var imagePVC *core.PersistentVolumeClaim
-	for _, pvc := range persistentVolumeClaims {
+	for diskIdx, pvc := range persistentVolumeClaims {
 		// Handle loopvar https://go.dev/wiki/LoopvarExperiment
 		pvc := pvc
 
@@ -520,6 +520,7 @@ func (r *Builder) mapDisks(vm *model.Workload, persistentVolumeClaims []*core.Pe
 						Bus: cnv.DiskBus(bus),
 					},
 				},
+				Serial: planbase.DiskSerial(pvc.Annotations[planbase.AnnDiskSource], vm.ID, diskIdx),
 			}
 		default:
 			r.Log.Info("image disk format not supported", "format", image.DiskFormat)

--- a/pkg/controller/plan/adapter/ovfbase/builder.go
+++ b/pkg/controller/plan/adapter/ovfbase/builder.go
@@ -394,6 +394,7 @@ func (r *Builder) mapDisks(vm *model.VM, persistentVolumeClaims []*core.Persiste
 					Bus: Virtio,
 				},
 			},
+			Serial: planbase.DiskSerial(disk.DiskId, vm.ID, i),
 		}
 		kVolumes = append(kVolumes, volume)
 		kDisks = append(kDisks, kubevirtDisk)

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -1100,14 +1100,7 @@ func (r *Builder) mapDisks(vm *model.VM, vmRef ref.Ref, persistentVolumeClaims [
 				kubevirtDisk.ErrorPolicy = ptr.To(cnv.DiskErrorPolicyReport)
 			}
 		}
-		// Disk serial numbers are only presented to the source guest if
-		// the disk is connected with SCSI and disk.EnableUUID is set to
-		// TRUE, so only save the serial number for those disks. If the
-		// destination VM is configured with VirtIO or SATA, the resulting
-		// serial number will be truncated to 20 characters.
-		if vm.DiskEnableUuid && cnv.DiskBus(disk.Bus) == cnv.DiskBusSCSI {
-			kubevirtDisk.Serial = disk.Serial
-		}
+		kubevirtDisk.Serial = planbase.DiskSerial(disk.Serial, vm.ID, int(disk.Key))
 		kVolumes = append(kVolumes, volume)
 		kDisks = append(kDisks, kubevirtDisk)
 	}


### PR DESCRIPTION
 Add a shared DiskSerial helper that truncates the provider's disk
  UUID to 20 characters (virtio-blk limit) or falls back to a
  deterministic sha256-based serial from vmID+diskKey.  Hyphens are
  preserved so the truncated value matches what QEMU derives from the
  raw UUID, keeping /dev/disk/by-id/ references stable.
  
  vSphere: remove the DiskEnableUuid && SCSI guard so every disk gets
  a serial from backing.Uuid, not just SCSI disks with EnableUUID=TRUE.
  Hyper-V, OpenStack, OVF/OVA: set serial from the disk/volume ID.
  oVirt: unchanged (already sets Serial: da.Disk.ID).
  
  Ref: https://redhat.atlassian.net/browse/MTV-6400
  Resolves: MTV-6400