### PR TITLE
MTV-6393 | Retry transient block device errors before virt-v2v conversion

### DIFF
--- a/pkg/virt-v2v/conversion/disk.go
+++ b/pkg/virt-v2v/conversion/disk.go
@@ -1,10 +1,14 @@
 package conversion
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"syscall"
+	"time"
 
 	"github.com/kubev2v/forklift/pkg/virt-v2v/config"
 	"github.com/kubev2v/forklift/pkg/virt-v2v/utils"
@@ -14,6 +18,11 @@ const (
 	Letters       = "abcdefghijklmnopqrstuvwxyz"
 	LettersLength = len(Letters)
 )
+
+type blockDevOpener func(path string) error
+type sleepFunc func(time.Duration)
+
+const blockDevMaxAttempts = 10
 
 type Disk struct {
 	// The path to the connected disk
@@ -31,6 +40,11 @@ func NewDisk(cfg *config.AppConfig, diskPath string) (*Disk, error) {
 		isBlockDev = false
 		diskPath = filepath.Join(diskPath, "disk.img")
 	}
+	if isBlockDev {
+		if err := waitForBlockDevice(diskPath); err != nil {
+			return nil, err
+		}
+	}
 	disk := Disk{
 		Path:       diskPath,
 		IsBlockDev: isBlockDev,
@@ -44,6 +58,50 @@ func NewDisk(cfg *config.AppConfig, diskPath string) (*Disk, error) {
 	disk.Link = link
 
 	return &disk, nil
+}
+
+// waitForBlockDevice polls the block device until it is ready, retrying
+// transient errors (ENXIO, ENOENT, EIO) with exponential backoff. Permanent
+// errors fail immediately.
+func waitForBlockDevice(path string) error {
+	return waitForBlockDeviceWith(path, blockDevMaxAttempts, func(p string) error {
+		f, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		return f.Close()
+	}, time.Sleep)
+}
+
+func waitForBlockDeviceWith(path string, maxAttempts int, open blockDevOpener, sleep sleepFunc) error {
+	backoff := 500 * time.Millisecond
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err := open(path)
+		if err == nil {
+			if attempt > 1 {
+				fmt.Printf("Block device %s ready after %d attempts\n", path, attempt)
+			}
+			return nil
+		}
+		lastErr = err
+		if !isTransientBlockDevErr(err) {
+			return fmt.Errorf("block device %s: %w", path, err)
+		}
+		fmt.Printf("Block device %s not ready (attempt %d/%d): %v\n", path, attempt, maxAttempts, err)
+		if attempt < maxAttempts {
+			sleep(backoff)
+			backoff = min(backoff*2, 30*time.Second)
+		}
+	}
+	return fmt.Errorf("block device %s not ready after %d attempts: %w", path, maxAttempts, lastErr)
+}
+
+func isTransientBlockDevErr(err error) bool {
+	return errors.Is(err, syscall.ENXIO) ||
+		errors.Is(err, syscall.ENOENT) ||
+		errors.Is(err, syscall.EIO)
 }
 
 func (d *Disk) getDiskName() string {

--- a/pkg/virt-v2v/conversion/disk_test.go
+++ b/pkg/virt-v2v/conversion/disk_test.go
@@ -1,8 +1,9 @@
-// Generated-by: Claude
 package conversion
 
 import (
 	"errors"
+	"syscall"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -238,6 +239,93 @@ var _ = Describe("Disks", func() {
 			Entry("disk 51 -> sdaz", "/dev/block51", "/var/tmp/v2v/vm-sdaz"),
 			Entry("disk 52 -> sdba", "/dev/block52", "/var/tmp/v2v/vm-sdba"),
 		)
+	})
+
+	Describe("waitForBlockDeviceWith", func() {
+		noSleep := func(_ time.Duration) {}
+
+		It("succeeds on first attempt", func() {
+			calls := 0
+			err := waitForBlockDeviceWith("/dev/block0", 3, func(_ string) error {
+				calls++
+				return nil
+			}, noSleep)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(calls).To(Equal(1))
+		})
+
+		It("retries transient ENXIO then succeeds", func() {
+			calls := 0
+			err := waitForBlockDeviceWith("/dev/block0", 3, func(_ string) error {
+				calls++
+				if calls <= 2 {
+					return syscall.ENXIO
+				}
+				return nil
+			}, noSleep)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(calls).To(Equal(3))
+		})
+
+		It("retries transient ENOENT then succeeds", func() {
+			calls := 0
+			err := waitForBlockDeviceWith("/dev/block0", 3, func(_ string) error {
+				calls++
+				if calls == 1 {
+					return syscall.ENOENT
+				}
+				return nil
+			}, noSleep)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(calls).To(Equal(2))
+		})
+
+		It("retries transient EIO then succeeds", func() {
+			calls := 0
+			err := waitForBlockDeviceWith("/dev/block0", 3, func(_ string) error {
+				calls++
+				if calls == 1 {
+					return syscall.EIO
+				}
+				return nil
+			}, noSleep)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(calls).To(Equal(2))
+		})
+
+		It("fails immediately on permanent error (EPERM)", func() {
+			calls := 0
+			err := waitForBlockDeviceWith("/dev/block0", 3, func(_ string) error {
+				calls++
+				return syscall.EPERM
+			}, noSleep)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("block device /dev/block0"))
+			Expect(calls).To(Equal(1))
+		})
+
+		It("wraps last error after exhausting retries", func() {
+			err := waitForBlockDeviceWith("/dev/block0", 3, func(_ string) error {
+				return syscall.ENXIO
+			}, noSleep)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not ready after 3 attempts"))
+			Expect(errors.Is(err, syscall.ENXIO)).To(BeTrue())
+		})
+
+		It("uses correct backoff sequence", func() {
+			var delays []time.Duration
+			spy := func(d time.Duration) { delays = append(delays, d) }
+			_ = waitForBlockDeviceWith("/dev/block0", 5, func(_ string) error {
+				return syscall.ENXIO
+			}, spy)
+			Expect(delays).To(Equal([]time.Duration{
+				500 * time.Millisecond,
+				1 * time.Second,
+				2 * time.Second,
+				4 * time.Second,
+			}))
+		})
 	})
 
 })


### PR DESCRIPTION
NVMe/TCP namespace rescans can race with PVC attach/detach, causing ENXIO when virt-v2v opens a block device immediately after pod start. Add waitForBlockDevice() with exponential backoff (500ms→30s, 10 attempts) that retries ENXIO/ENOENT/EIO and fails fast on permanent errors like EPERM.

https://redhat.atlassian.net/browse/MTV-6393