### PR TITLE
Allow selecting the conversion pod seccomp profile on any cluster

### DIFF
--- a/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -832,6 +832,17 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              virt_v2v_seccomp_profile:
+                description: Seccomp profile for the conversion pods, as a Localhost
+                  profile name resolved by the kubelet under its seccomp profile root
+                  (for example "profiles/unshare.json"). The conversion appliance
+                  runs passt, which calls unshare(CLONE_NEWUSER) and then mount, umount2
+                  and pivot_root; a runtime's default profile denies those. Unlike
+                  Unconfined, a Localhost profile keeps syscall filtering enabled
+                  and is admitted by the baseline and restricted Pod Security Standards.
+                  Optional. When empty, OpenShift clusters use profiles/unshare.json
+                  as before and all others use the runtime default.
+                type: string
               virt_v2v_smp:
                 description: Number of virtual CPUs for the virt-v2v conversion appliance.
                 format: int32

--- a/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2
@@ -270,6 +270,10 @@ spec:
           value: "{{ virt_v2v_container_requests_cpu }}"
         - name: VIRT_V2V_CONTAINER_REQUESTS_MEMORY
           value: "{{ virt_v2v_container_requests_memory }}"
+{% if virt_v2v_seccomp_profile is defined and virt_v2v_seccomp_profile %}
+        - name: VIRT_V2V_SECCOMP_PROFILE
+          value: "{{ virt_v2v_seccomp_profile }}"
+{% endif %}
         - name: HOOKS_CONTAINER_LIMITS_CPU
           value: "{{ hooks_container_limits_cpu }}"
         - name: HOOKS_CONTAINER_LIMITS_MEMORY

--- a/pkg/apis/forklift/v1beta1/forkliftcontroller.go
+++ b/pkg/apis/forklift/v1beta1/forkliftcontroller.go
@@ -715,6 +715,10 @@ type ForkliftControllerSpec struct {
 	// +kubebuilder:validation:Enum="true";"false"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	VirtV2VDontRequestKVM string `json:"virt_v2v_dont_request_kvm,omitempty"`
+	// Seccomp profile for the conversion pods, as a Localhost profile name resolved by the kubelet under its seccomp profile root (for example "profiles/unshare.json"). The conversion appliance runs passt, which calls unshare(CLONE_NEWUSER) and then mount, umount2 and pivot_root; a runtime's default profile denies those. Unlike Unconfined, a Localhost profile keeps syscall filtering enabled and is admitted by the baseline and restricted Pod Security Standards. Optional. When empty, OpenShift clusters use profiles/unshare.json as before and all others use the runtime default.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	VirtV2VSeccompProfile string `json:"virt_v2v_seccomp_profile,omitempty"`
 	// Additional arguments for virt-v2v conversion. Optional. If left empty, the operator automatically sets this from the environment.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}

--- a/pkg/controller/conversion/builder.go
+++ b/pkg/controller/conversion/builder.go
@@ -138,14 +138,7 @@ func (b *Builder) GetVirtV2vPodSpec(vm *plan.VMStatus, volumes []core.Volume, vo
 		maps.Copy(annotations, cfg.TransferNetworkAnnotations)
 	}
 
-	seccompProfile := core.SeccompProfile{Type: core.SeccompProfileTypeRuntimeDefault}
-	if settings.Settings.OpenShift {
-		unshare := "profiles/unshare.json"
-		seccompProfile = core.SeccompProfile{
-			Type:             core.SeccompProfileTypeLocalhost,
-			LocalhostProfile: &unshare,
-		}
-	}
+	seccompProfile := conversionSeccompProfile()
 
 	podLabels := make(map[string]string)
 	if cfg.PodLabels != nil {
@@ -319,14 +312,7 @@ func (b *Builder) GetDeepInspectionPodSpec(volumes []core.Volume, volumeMounts [
 		maps.Copy(annotations, cfg.PodAnnotations)
 	}
 
-	seccompProfile := core.SeccompProfile{Type: core.SeccompProfileTypeRuntimeDefault}
-	if settings.Settings.OpenShift {
-		unshare := "profiles/unshare.json"
-		seccompProfile = core.SeccompProfile{
-			Type:             core.SeccompProfileTypeLocalhost,
-			LocalhostProfile: &unshare,
-		}
-	}
+	seccompProfile := conversionSeccompProfile()
 
 	podLabels := make(map[string]string)
 	if cfg.PodLabels != nil {
@@ -391,6 +377,30 @@ func (b *Builder) GetDeepInspectionPodSpec(volumes []core.Volume, volumeMounts [
 	SetKvmOnPodSpec(&pod.Spec, cfg.RequestKVM)
 
 	return pod, nil
+}
+
+// conversionSeccompProfile returns the seccomp profile for a conversion pod.
+//
+// The conversion appliance starts passt for its network, and passt calls
+// clone(CLONE_NEWUSER), which a container runtime's default seccomp profile
+// denies without CAP_SYS_ADMIN. OpenShift ships a profile permitting that
+// syscall, so it has always been selected there. VIRT_V2V_SECCOMP_PROFILE lets
+// any cluster that provides an equivalent node-level profile name it, which
+// keeps syscall filtering enabled and, unlike Unconfined, is admitted by the
+// baseline and restricted Pod Security Standards. Unset preserves the previous
+// behaviour exactly.
+func conversionSeccompProfile() core.SeccompProfile {
+	profile := settings.Settings.Migration.VirtV2vSeccompProfile
+	if profile == "" && settings.Settings.OpenShift {
+		profile = "profiles/unshare.json"
+	}
+	if profile != "" {
+		return core.SeccompProfile{
+			Type:             core.SeccompProfileTypeLocalhost,
+			LocalhostProfile: &profile,
+		}
+	}
+	return core.SeccompProfile{Type: core.SeccompProfileTypeRuntimeDefault}
 }
 
 func vddkVolumeInList(volumes []core.Volume) bool {

--- a/pkg/controller/conversion/builder_test.go
+++ b/pkg/controller/conversion/builder_test.go
@@ -1,0 +1,69 @@
+package conversion
+
+import (
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/settings"
+	core "k8s.io/api/core/v1"
+)
+
+func TestConversionSeccompProfile(t *testing.T) {
+	tests := []struct {
+		name             string
+		setting          string
+		openShift        bool
+		wantType         core.SeccompProfileType
+		wantLocalhostRef string
+	}{
+		{
+			name:     "unset on kubernetes keeps the runtime default",
+			wantType: core.SeccompProfileTypeRuntimeDefault,
+		},
+		{
+			name:             "unset on openshift keeps the unshare profile",
+			openShift:        true,
+			wantType:         core.SeccompProfileTypeLocalhost,
+			wantLocalhostRef: "profiles/unshare.json",
+		},
+		{
+			name:             "setting selects a localhost profile on kubernetes",
+			setting:          "profiles/unshare.json",
+			wantType:         core.SeccompProfileTypeLocalhost,
+			wantLocalhostRef: "profiles/unshare.json",
+		},
+		{
+			name:             "setting overrides the openshift default",
+			setting:          "profiles/custom.json",
+			openShift:        true,
+			wantType:         core.SeccompProfileTypeLocalhost,
+			wantLocalhostRef: "profiles/custom.json",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			savedProfile := settings.Settings.Migration.VirtV2vSeccompProfile
+			savedOpenShift := settings.Settings.OpenShift
+			defer func() {
+				settings.Settings.Migration.VirtV2vSeccompProfile = savedProfile
+				settings.Settings.OpenShift = savedOpenShift
+			}()
+			settings.Settings.Migration.VirtV2vSeccompProfile = tc.setting
+			settings.Settings.OpenShift = tc.openShift
+
+			profile := conversionSeccompProfile()
+			if profile.Type != tc.wantType {
+				t.Errorf("type = %v, want %v", profile.Type, tc.wantType)
+			}
+			switch {
+			case tc.wantLocalhostRef == "":
+				if profile.LocalhostProfile != nil {
+					t.Errorf("LocalhostProfile = %q, want nil", *profile.LocalhostProfile)
+				}
+			case profile.LocalhostProfile == nil:
+				t.Errorf("LocalhostProfile = nil, want %q", tc.wantLocalhostRef)
+			case *profile.LocalhostProfile != tc.wantLocalhostRef:
+				t.Errorf("LocalhostProfile = %q, want %q", *profile.LocalhostProfile, tc.wantLocalhostRef)
+			}
+		})
+	}
+}

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -46,6 +46,7 @@ const (
 	VirtV2vContainerLimitsMemory           = "VIRT_V2V_CONTAINER_LIMITS_MEMORY"
 	VirtV2vContainerRequestsCpu            = "VIRT_V2V_CONTAINER_REQUESTS_CPU"
 	VirtV2vContainerRequestsMemory         = "VIRT_V2V_CONTAINER_REQUESTS_MEMORY"
+	VirtV2vSeccompProfile                  = "VIRT_V2V_SECCOMP_PROFILE"
 	HooksContainerLimitsCpu                = "HOOKS_CONTAINER_LIMITS_CPU"
 	HooksContainerLimitsMemory             = "HOOKS_CONTAINER_LIMITS_MEMORY"
 	HooksContainerRequestsCpu              = "HOOKS_CONTAINER_REQUESTS_CPU"
@@ -149,14 +150,18 @@ type Migration struct {
 	VirtV2vContainerLimitsMemory   string
 	VirtV2vContainerRequestsCpu    string
 	VirtV2vContainerRequestsMemory string
-	HooksContainerLimitsCpu        string
-	HooksContainerLimitsMemory     string
-	HooksContainerRequestsCpu      string
-	HooksContainerRequestsMemory   string
-	OvaContainerLimitsCpu          string
-	OvaContainerLimitsMemory       string
-	OvaContainerRequestsCpu        string
-	OvaContainerRequestsMemory     string
+	// Seccomp profile for the virt-v2v conversion pod. When set, the pod uses a
+	// Localhost profile of this name, resolved by the kubelet under its seccomp
+	// profile root. Empty keeps the built-in behaviour.
+	VirtV2vSeccompProfile        string
+	HooksContainerLimitsCpu      string
+	HooksContainerLimitsMemory   string
+	HooksContainerRequestsCpu    string
+	HooksContainerRequestsMemory string
+	OvaContainerLimitsCpu        string
+	OvaContainerLimitsMemory     string
+	OvaContainerRequestsCpu      string
+	OvaContainerRequestsMemory   string
 	// VDDK image for guest conversion
 	VddkImage string
 	// TlsConnectionTimeout is the timeout for TLS connections in seconds
@@ -340,6 +345,9 @@ func (r *Migration) Load() (err error) {
 		r.VirtV2vContainerRequestsMemory = val
 	} else {
 		r.VirtV2vContainerRequestsMemory = "1Gi"
+	}
+	if val, found := os.LookupEnv(VirtV2vSeccompProfile); found {
+		r.VirtV2vSeccompProfile = val
 	}
 	if val, found := os.LookupEnv(HooksContainerLimitsCpu); found {
 		r.HooksContainerLimitsCpu = val


### PR DESCRIPTION
## Problem

The conversion appliance runs `passt`, which sandboxes itself into fresh namespaces unconditionally: `unshare(CLONE_NEWUSER)` ([`isolation.c:340`](https://passt.top/passt/plain/isolation.c)), then `mount`, `pivot_root` and `umount2`. A container runtime's default seccomp profile permits the first three only under `CAP_SYS_ADMIN` and omits `pivot_root` entirely, and the conversion pod drops all capabilities — so on a cluster that gets `RuntimeDefault`, conversion fails with:

```
passt ... Couldn't create user namespace: Operation not permitted
```

`CAP_SYS_ADMIN` is not actually required: passt makes those calls inside the user namespace it has just created, and only the seccomp filter, which is not namespace-aware, stands in the way. This matches the root cause you identified in #1445: *"The root cause of this issue is in the passt using the `unshare(2)` syscall."*

Forklift already solves this — `GetVirtV2vPodSpec` and `GetDeepInspectionPodSpec` request the Localhost profile `profiles/unshare.json` — but the branch is gated on `settings.Settings.OpenShift`, which is autodetected from the presence of the `route.openshift.io` API group. A plain Kubernetes cluster therefore always gets `RuntimeDefault`, with no way to opt in. #4491 has been open since January with reporters on RKE2, Harvester and Talos, and `k8s_cluster: "false"` is not a workaround because it also switches on Routes, SCCs and the other OpenShift-only resources.

## Change

Adds `VIRT_V2V_SECCOMP_PROFILE`, exposed as `virt_v2v_seccomp_profile` on `ForkliftController`, so a cluster that provides an equivalent node-level profile can name it. Precedence is: explicit setting → OpenShift default → runtime default.

**Unset preserves today's behaviour exactly** — OpenShift still selects `profiles/unshare.json`, every other cluster still gets `RuntimeDefault`. Nothing changes for any existing user.

The two duplicated profile blocks in the conversion and deep-inspection builders are replaced by one shared helper, so this is a small net simplification of `builder.go`.

Why a Localhost profile rather than `Unconfined`: both `baseline` and `restricted` Pod Security Standards accept `seccompProfile.type: Localhost` ([`check_seccompProfile_restricted.go`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/pod-security-admission/policy/check_seccompProfile_restricted.go)), so with a profile in place the conversion pod is admitted by a `restricted` namespace with no other change — nothing else in the pod spec violates either profile. `Unconfined` would remove filtering wholesale and is forbidden by both.

A cluster operator supplies the profile the same way an OpenShift admin does today (Forklift has never shipped `unshare.json` itself); on Talos, for instance, it is a `machine.seccompProfiles` entry, which lands under the kubelet's seccomp root and is addressed as `profiles/unshare.json`.

## Files

- `pkg/settings/migration.go` — const, field and loader, following `VIRT_V2V_DONT_REQUEST_KVM`
- `pkg/controller/conversion/builder.go` — shared `conversionSeccompProfile()` helper replacing both blocks
- `pkg/controller/conversion/builder_test.go` — precedence table (unset/k8s, unset/OpenShift, set/k8s, set overriding OpenShift)
- `pkg/apis/forklift/v1beta1/forkliftcontroller.go` — the CR field
- `operator/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml` — regenerated with `make manifests`
- `operator/roles/forkliftcontroller/templates/controller/deployment-controller.yml.j2` — env var, emitted only when set

`go build ./pkg/...` and the new test pass; `gofmt` clean.

## Notes

Draft because the profile contents are still being validated against a live conversion on our side — the four syscalls above are read from `passt`'s source and containerd's default profile, so a run may show the set needs to be wider. The code change is independent of that and does not encode any particular profile.

Happy to reshape this if you would rather see it per-`Conversion` via `PodSettings` (beside `NodeSelector` / `RequestKVM`) than as a controller-level setting; a controller-level knob seemed right because the profile is a node property rather than a per-migration choice.

Closes #4491.
