### PR TITLE
MTV-6454 | Copy source PVC labels onto prime PVC for xcopy

### DIFF
--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -67,6 +67,7 @@ const (
 	populatorPodPrefix      = "populate"
 	populatorPodVolumeName  = "target"
 	populatorPvcPrefix      = "prime"
+	csiLabelPrefix          = "volume.csi.k8s.io/"
 	populatedFromAnnoSuffix = "populated-from"
 	annSelectedNode         = "volume.kubernetes.io/selected-node"
 	controllerNameSuffix    = "populator"
@@ -85,6 +86,8 @@ const (
 
 	labelSourceHost = api.LabelSourceHost
 )
+
+var primePVCMigrationLabelKeys = []string{"migration", "plan", "vmID"}
 
 type empty struct{}
 
@@ -485,6 +488,26 @@ func (c *controller) runWorker() {
 	}
 }
 
+// primePVCLabelsFromSource returns labels to apply to the prime PVC: plan/migration
+// metadata plus CSI affinity labels required for co-located provisioning.
+func primePVCLabelsFromSource(source map[string]string) map[string]string {
+	if len(source) == 0 {
+		return nil
+	}
+	labels := make(map[string]string)
+	for _, key := range primePVCMigrationLabelKeys {
+		if val, ok := source[key]; ok {
+			labels[key] = val
+		}
+	}
+	for key, val := range source {
+		if strings.HasPrefix(key, csiLabelPrefix) {
+			labels[key] = val
+		}
+	}
+	return labels
+}
+
 func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName string) error {
 	var err error
 
@@ -717,12 +740,9 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 
 			// If PVC' doesn't exist yet, create it
 			if pvcPrime == nil {
-				// Copy all source PVC labels so CSI drivers (e.g. affinity-source-naa)
-				// see the same metadata on the object they actually provision.
-				pvcPrimeLabels := make(map[string]string, len(pvc.Labels))
-				for key, val := range pvc.Labels {
-					pvcPrimeLabels[key] = val
-				}
+				// Copy plan/migration labels and CSI affinity labels (e.g. affinity-source-naa)
+				// so drivers co-locate the prime volume without duplicating provider identity labels.
+				pvcPrimeLabels := primePVCLabelsFromSource(pvc.Labels)
 				pvcPrime = &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      pvcPrimeName,

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -717,11 +717,11 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 
 			// If PVC' doesn't exist yet, create it
 			if pvcPrime == nil {
-				pvcPrimeLabels := make(map[string]string)
-				for _, key := range []string{"migration", "plan", "vmID"} {
-					if val, ok := pvc.Labels[key]; ok {
-						pvcPrimeLabels[key] = val
-					}
+				// Copy all source PVC labels so CSI drivers (e.g. affinity-source-naa)
+				// see the same metadata on the object they actually provision.
+				pvcPrimeLabels := make(map[string]string, len(pvc.Labels))
+				for key, val := range pvc.Labels {
+					pvcPrimeLabels[key] = val
 				}
 				pvcPrime = &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/lib-volume-populator/populator-machinery/controller_test.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller_test.go
@@ -165,6 +165,18 @@ func isThrottled(recorder *record.FakeRecorder) bool {
 	}
 }
 
+// createdPrimePVCLabels returns the labels of the prime PVC created via the fake kubeClient, or nil if none was created.
+func createdPrimePVCLabels(fakeClient *fake.Clientset) map[string]string {
+	for _, action := range fakeClient.Actions() {
+		if action.GetVerb() == "create" && action.GetResource().Resource == "persistentvolumeclaims" {
+			obj := action.(interface{ GetObject() runtime.Object }).GetObject()
+			pvc := obj.(*corev1.PersistentVolumeClaim)
+			return pvc.Labels
+		}
+	}
+	return nil
+}
+
 // createdPodLabels returns the labels of the pod created via the fake kubeClient, or nil if none was created.
 func createdPodLabels(fakeClient *fake.Clientset) map[string]string {
 	for _, action := range fakeClient.Actions() {
@@ -308,6 +320,36 @@ func TestThrottle_Mixed_WithMigrationHost_ThrottlesOnMigrationHost(t *testing.T)
 	}
 	if !isThrottled(recorder) {
 		t.Error("expected throttle on dedicated-host even though sourceHost is free")
+	}
+}
+
+// Prime PVC inherits all labels from the source PVC (e.g. CSI affinity-source-naa).
+func TestPrimePVC_InheritsSourceLabels(t *testing.T) {
+	const naaLabel = "volume.csi.k8s.io/affinity-source-naa"
+	pvc := makePVC("pvc-1", "test-ns", "cr-1", "test-sc")
+	pvc.Labels = map[string]string{
+		"migration": "migration-uid",
+		"plan":      "plan-uid",
+		"vmID":      "vm-1",
+		"vmdkKey":   "42",
+		naaLabel:    "eui.b4f2d1234567890",
+	}
+	cr := makeCR("cr-1", "test-ns", "source-host", "")
+
+	c, fakeClient, _ := buildController(t, 10, nil, []*corev1.PersistentVolumeClaim{pvc}, []*unstructured.Unstructured{cr})
+
+	err := c.syncPvc(context.Background(), "test-ns/pvc-1", "test-ns", "pvc-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	labels := createdPrimePVCLabels(fakeClient)
+	if labels == nil {
+		t.Fatal("expected prime PVC to be created")
+	}
+	for key, want := range pvc.Labels {
+		if got := labels[key]; got != want {
+			t.Errorf("prime PVC label %q = %q, want %q", key, got, want)
+		}
 	}
 }
 

--- a/pkg/lib-volume-populator/populator-machinery/controller_test.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller_test.go
@@ -165,13 +165,15 @@ func isThrottled(recorder *record.FakeRecorder) bool {
 	}
 }
 
-// createdPrimePVCLabels returns the labels of the prime PVC created via the fake kubeClient, or nil if none was created.
-func createdPrimePVCLabels(fakeClient *fake.Clientset) map[string]string {
+// createdPrimePVCLabels returns the labels of the named prime PVC create action, or nil if not found.
+func createdPrimePVCLabels(fakeClient *fake.Clientset, namespace, name string) map[string]string {
 	for _, action := range fakeClient.Actions() {
 		if action.GetVerb() == "create" && action.GetResource().Resource == "persistentvolumeclaims" {
 			obj := action.(interface{ GetObject() runtime.Object }).GetObject()
 			pvc := obj.(*corev1.PersistentVolumeClaim)
-			return pvc.Labels
+			if pvc.Namespace == namespace && pvc.Name == name {
+				return pvc.Labels
+			}
 		}
 	}
 	return nil
@@ -323,8 +325,8 @@ func TestThrottle_Mixed_WithMigrationHost_ThrottlesOnMigrationHost(t *testing.T)
 	}
 }
 
-// Prime PVC inherits all labels from the source PVC (e.g. CSI affinity-source-naa).
-func TestPrimePVC_InheritsSourceLabels(t *testing.T) {
+// Prime PVC inherits plan/migration labels and CSI affinity labels from the source PVC.
+func TestPrimePVC_InheritsCSIAffinityAndPlanLabels(t *testing.T) {
 	const naaLabel = "volume.csi.k8s.io/affinity-source-naa"
 	pvc := makePVC("pvc-1", "test-ns", "cr-1", "test-sc")
 	pvc.Labels = map[string]string{
@@ -342,14 +344,19 @@ func TestPrimePVC_InheritsSourceLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	labels := createdPrimePVCLabels(fakeClient)
+	primeName := "prime-" + string(pvc.UID)
+	labels := createdPrimePVCLabels(fakeClient, "test-ns", primeName)
 	if labels == nil {
-		t.Fatal("expected prime PVC to be created")
+		t.Fatalf("expected prime PVC %q to be created in namespace %q", primeName, "test-ns")
 	}
-	for key, want := range pvc.Labels {
+	for _, key := range []string{"migration", "plan", "vmID", naaLabel} {
+		want := pvc.Labels[key]
 		if got := labels[key]; got != want {
 			t.Errorf("prime PVC label %q = %q, want %q", key, got, want)
 		}
+	}
+	if _, ok := labels["vmdkKey"]; ok {
+		t.Errorf("prime PVC should not inherit provider identity label %q", "vmdkKey")
 	}
 }
 


### PR DESCRIPTION
The volume populator creates a prime PVC that the CSI driver actually provisions. Only migration/plan/vmID labels were copied, so CSI affinity labels (volume.csi.k8s.io/affinity-source-naa) never reached volume creation and co-location failed for PowerStore/PowerFlex/ONTAP xcopy.

Copy csi affinity labels when creating the prime PVC and add a unit test verifying affinity-source-naa propagation.

Ref: https://redhat.atlassian.net/browse/MTV-6454
Resolves: MTV-6454