### PR TITLE
MTV-6511 | Split Custom Field Definitions from VM table in inventory to dedicated table

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -2880,32 +2880,44 @@ func (r *Builder) SourceVMLabelsAndAnnotations(vmRef ref.Ref, tagMapping *api.Ta
 
 	// Custom attributes to annotations
 	annotationOriginalKeys := make(map[string]string)
+	customDefs := []model.CustomFieldDef{}
+	err = r.Source.Inventory.List(&customDefs, web.Param{
+		Key:   web.DetailParam,
+		Value: "all",
+	})
+	if err != nil {
+		err = liberr.Wrap(err, "custom field definitions")
+		return
+	}
+	customDefByKey := make(map[int32]model.CustomFieldDef, len(customDefs))
+	for _, def := range customDefs {
+		customDefByKey[def.Key] = def
+	}
 	for _, cv := range vm.CustomValues {
-		for _, def := range vm.CustomDef {
-			if def.Key == cv.Key {
-				originalName := def.Name
-				sanitizedName := sanitizeForK8sMetadata(originalName)
-				if sanitizedName == "" {
-					break
-				}
-				if sanitizedName != originalName {
-					sanitizationReport[fmt.Sprintf("customAttribute.name.%s", originalName)] = sanitizedName
-				}
-
-				key := fmt.Sprintf("vsphere.forklift.konveyor.io/%s", sanitizedName)
-				if existingOriginal, exists := annotationOriginalKeys[key]; exists {
-					r.Log.Info("Custom attribute key collision, later attribute overwrites earlier",
-						"sanitizedKey", key,
-						"previousAttribute", existingOriginal,
-						"currentAttribute", originalName)
-					sanitizationReport[fmt.Sprintf("customAttribute.collision.%s", sanitizedName)] = fmt.Sprintf("%s overwrites %s", originalName, existingOriginal)
-				}
-				annotationOriginalKeys[key] = originalName
-
-				annotations[key] = cv.Value
-				break
-			}
+		def, ok := customDefByKey[cv.Key]
+		if !ok {
+			continue
 		}
+		originalName := def.Name
+		sanitizedName := sanitizeForK8sMetadata(originalName)
+		if sanitizedName == "" {
+			continue
+		}
+		if sanitizedName != originalName {
+			sanitizationReport[fmt.Sprintf("customAttribute.name.%s", originalName)] = sanitizedName
+		}
+
+		key := fmt.Sprintf("vsphere.forklift.konveyor.io/%s", sanitizedName)
+		if existingOriginal, exists := annotationOriginalKeys[key]; exists {
+			r.Log.Info("Custom attribute key collision, later attribute overwrites earlier",
+				"sanitizedKey", key,
+				"previousAttribute", existingOriginal,
+				"currentAttribute", originalName)
+			sanitizationReport[fmt.Sprintf("customAttribute.collision.%s", sanitizedName)] = fmt.Sprintf("%s overwrites %s", originalName, existingOriginal)
+		}
+		annotationOriginalKeys[key] = originalName
+
+		annotations[key] = cv.Value
 	}
 
 	return

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -541,16 +541,18 @@ var _ = Describe("vSphere builder", func() {
 				VM1: model.VM1{
 					VM0: model.VM0{ID: "vm-1", Name: "test-vm"},
 				},
-				CustomDef: []vsphere.CustomFieldDef{
-					{Key: 100, Name: "app-name"},
-					{Key: 101, Name: "app-version"},
-				},
 				CustomValues: []vsphere.CustomFieldValue{
 					{Key: 100, Value: "my-application"},
 					{Key: 101, Value: "v1.2.3"},
 				},
 			}
-			builder.Source.Inventory = &mockInventory{vm: vm}
+			builder.Source.Inventory = &mockInventory{
+				vm: vm,
+				customDefs: []model.CustomFieldDef{
+					{Key: 100, Name: "app-name"},
+					{Key: 101, Name: "app-version"},
+				},
+			}
 
 			labels, annotations, _, err := builder.SourceVMLabelsAndAnnotations(ref.Ref{ID: "vm-1"}, nil)
 
@@ -614,14 +616,16 @@ var _ = Describe("vSphere builder", func() {
 				Tags: []vsphere.Tag{
 					{Name: "owner", Description: "platform-team"},
 				},
-				CustomDef: []vsphere.CustomFieldDef{
-					{Key: 100, Name: "app-name"},
-				},
 				CustomValues: []vsphere.CustomFieldValue{
 					{Key: 100, Value: "my-application"},
 				},
 			}
-			builder.Source.Inventory = &mockInventory{vm: vm}
+			builder.Source.Inventory = &mockInventory{
+				vm: vm,
+				customDefs: []model.CustomFieldDef{
+					{Key: 100, Name: "app-name"},
+				},
+			}
 
 			labels, annotations, _, err := builder.SourceVMLabelsAndAnnotations(ref.Ref{ID: "vm-1"}, nil)
 
@@ -642,14 +646,16 @@ var _ = Describe("vSphere builder", func() {
 					{Name: "owner", Description: "platform-team"},
 					{Name: "environment", Description: "production"},
 				},
-				CustomDef: []vsphere.CustomFieldDef{
-					{Key: 100, Name: "app-name"},
-				},
 				CustomValues: []vsphere.CustomFieldValue{
 					{Key: 100, Value: "my-application"},
 				},
 			}
-			builder.Source.Inventory = &mockInventory{vm: vm}
+			builder.Source.Inventory = &mockInventory{
+				vm: vm,
+				customDefs: []model.CustomFieldDef{
+					{Key: 100, Name: "app-name"},
+				},
+			}
 
 			tagMapping := &v1beta1.TagMapping{
 				Disabled: true,
@@ -715,14 +721,16 @@ var _ = Describe("vSphere builder", func() {
 				VM1: model.VM1{
 					VM0: model.VM0{ID: "vm-1", Name: "test-vm"},
 				},
-				CustomDef: []vsphere.CustomFieldDef{
-					{Key: 100, Name: "invalid attr name"},
-				},
 				CustomValues: []vsphere.CustomFieldValue{
 					{Key: 100, Value: "some-value"},
 				},
 			}
-			builder.Source.Inventory = &mockInventory{vm: vm}
+			builder.Source.Inventory = &mockInventory{
+				vm: vm,
+				customDefs: []model.CustomFieldDef{
+					{Key: 100, Name: "invalid attr name"},
+				},
+			}
 
 			_, annotations, sanitizationReport, err := builder.SourceVMLabelsAndAnnotations(ref.Ref{ID: "vm-1"}, nil)
 
@@ -739,16 +747,18 @@ var _ = Describe("vSphere builder", func() {
 				VM1: model.VM1{
 					VM0: model.VM0{ID: "vm-1", Name: "test-vm"},
 				},
-				CustomDef: []vsphere.CustomFieldDef{
-					{Key: 100, Name: "!@#$"},
-					{Key: 101, Name: "valid-attr"},
-				},
 				CustomValues: []vsphere.CustomFieldValue{
 					{Key: 100, Value: "should-be-skipped"},
 					{Key: 101, Value: "kept"},
 				},
 			}
-			builder.Source.Inventory = &mockInventory{vm: vm}
+			builder.Source.Inventory = &mockInventory{
+				vm: vm,
+				customDefs: []model.CustomFieldDef{
+					{Key: 100, Name: "!@#$"},
+					{Key: 101, Name: "valid-attr"},
+				},
+			}
 
 			_, annotations, _, err := builder.SourceVMLabelsAndAnnotations(ref.Ref{ID: "vm-1"}, nil)
 

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -23,9 +23,10 @@ var ErrNotImplemented = errors.New("not implemented")
 
 // Mock inventory struct and methods for testing
 type mockInventory struct {
-	ds       model.Datastore
-	vm       model.VM
-	networks map[string]model.Network // keyed by ID
+	ds         model.Datastore
+	vm         model.VM
+	networks   map[string]model.Network // keyed by ID
+	customDefs []model.CustomFieldDef   // global custom field definitions
 }
 
 // defaultVM returns a VM with sensible defaults for testing
@@ -131,6 +132,10 @@ func (m *mockInventory) Host(ref *ref.Ref) (interface{}, error) {
 }
 
 func (m *mockInventory) List(list interface{}, param ...web.Param) error {
+	switch v := list.(type) {
+	case *[]model.CustomFieldDef:
+		*v = m.customDefs
+	}
 	return nil
 }
 

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -1282,6 +1282,10 @@ func (r Collector) applyEnter(tx *libmodel.Tx, u types.ObjectUpdate) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	err = r.upsertCustomFieldDefs(tx, u)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
 
 	return nil
 }
@@ -1301,6 +1305,40 @@ func (r Collector) applyModify(tx *libmodel.Tx, u types.ObjectUpdate) error {
 	err = tx.Update(m)
 	if err != nil {
 		return liberr.Wrap(err)
+	}
+	err = r.upsertCustomFieldDefs(tx, u)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+
+	return nil
+}
+
+// Upsert the custom field definitions reported on a VirtualMachine update
+// into the provider-global CustomFieldDef table. The same global definition
+// set is reported per-VM, so inserting by key naturally de-duplicates it.
+func (r Collector) upsertCustomFieldDefs(tx *libmodel.Tx, u types.ObjectUpdate) (err error) {
+	if u.Obj.Type != VirtualMachine {
+		return nil
+	}
+	for _, p := range u.ChangeSet {
+		if p.Name != fAvailableField {
+			continue
+		}
+		customFields, ok := p.Val.(types.ArrayOfCustomFieldDef)
+		if !ok {
+			continue
+		}
+		for _, f := range customFields.CustomFieldDef {
+			def := &model.CustomFieldDef{
+				Name:              f.Name,
+				Key:               f.Key,
+				ManagedObjectType: f.ManagedObjectType,
+			}
+			if err = tx.Insert(def); err != nil {
+				return liberr.Wrap(err)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -1098,19 +1098,6 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 						SortNICsByGuestNetworkOrder(&v.model)
 					}
 				}
-			case fAvailableField:
-				if customFields, cast := p.Val.(types.ArrayOfCustomFieldDef); cast {
-					customDef := []model.CustomFieldDef{}
-					for _, f := range customFields.CustomFieldDef {
-						customDef = append(customDef, model.CustomFieldDef{
-							Name:              f.Name,
-							Key:               f.Key,
-							ManagedObjectType: f.ManagedObjectType,
-						})
-					}
-
-					v.model.CustomDef = customDef
-				}
 			case fCustomValue:
 				customValues := []model.CustomFieldValue{}
 				switch cv := p.Val.(type) {

--- a/pkg/controller/provider/container/vsphere/model_test.go
+++ b/pkg/controller/provider/container/vsphere/model_test.go
@@ -1,10 +1,12 @@
 package vsphere
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -626,21 +628,12 @@ func TestVmAdapter_getDiskGuestInfo(t *testing.T) {
 func TestVmAdapter_Apply_CustomFields(t *testing.T) {
 	tests := []struct {
 		name              string
-		preExistingDef    []model.CustomFieldDef
 		preExistingValues []model.CustomFieldValue
-		availableFieldVal interface{}
 		customValueVal    interface{}
-		expectedDef       []model.CustomFieldDef
 		expectedValues    []model.CustomFieldValue
 	}{
 		{
-			name: "populates CustomDef and CustomValues from scratch",
-			availableFieldVal: types.ArrayOfCustomFieldDef{
-				CustomFieldDef: []types.CustomFieldDef{
-					{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
-					{Name: "env", Key: 200, ManagedObjectType: ""},
-				},
-			},
+			name: "populates CustomValues from scratch",
 			customValueVal: types.ArrayOfCustomFieldValue{
 				CustomFieldValue: []types.BaseCustomFieldValue{
 					&types.CustomFieldStringValue{
@@ -653,24 +646,10 @@ func TestVmAdapter_Apply_CustomFields(t *testing.T) {
 					},
 				},
 			},
-			expectedDef: []model.CustomFieldDef{
-				{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
-				{Name: "env", Key: 200, ManagedObjectType: ""},
-			},
 			expectedValues: []model.CustomFieldValue{
 				{Key: 100, Value: "alice"},
 				{Key: 200, Value: "production"},
 			},
-		},
-		{
-			name: "clears CustomDef when vSphere reports empty availableField",
-			preExistingDef: []model.CustomFieldDef{
-				{Name: "stale", Key: 999},
-			},
-			availableFieldVal: types.ArrayOfCustomFieldDef{
-				CustomFieldDef: []types.CustomFieldDef{},
-			},
-			expectedDef: []model.CustomFieldDef{},
 		},
 		{
 			name: "clears CustomValues when vSphere reports empty customValue (ArrayOf)",
@@ -708,19 +687,11 @@ func TestVmAdapter_Apply_CustomFields(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			v := &VmAdapter{
 				model: model.VM{
-					CustomDef:    tt.preExistingDef,
 					CustomValues: tt.preExistingValues,
 				},
 			}
 
 			changeSet := []types.PropertyChange{}
-			if tt.availableFieldVal != nil {
-				changeSet = append(changeSet, types.PropertyChange{
-					Op:   Assign,
-					Name: fAvailableField,
-					Val:  tt.availableFieldVal,
-				})
-			}
 			if tt.customValueVal != nil {
 				changeSet = append(changeSet, types.PropertyChange{
 					Op:   Assign,
@@ -733,17 +704,101 @@ func TestVmAdapter_Apply_CustomFields(t *testing.T) {
 				ChangeSet: changeSet,
 			})
 
-			if tt.expectedDef != nil {
-				if !reflect.DeepEqual(v.model.CustomDef, tt.expectedDef) {
-					t.Errorf("CustomDef mismatch\ngot:  %+v\nwant: %+v", v.model.CustomDef, tt.expectedDef)
-				}
-			}
 			if tt.expectedValues != nil {
 				if !reflect.DeepEqual(v.model.CustomValues, tt.expectedValues) {
 					t.Errorf("CustomValues mismatch\ngot:  %+v\nwant: %+v", v.model.CustomValues, tt.expectedValues)
 				}
 			}
 		})
+	}
+}
+
+func newTestInventoryDB(t *testing.T) libmodel.DB {
+	t.Helper()
+	db := libmodel.New(filepath.Join(t.TempDir(), "test.db"), &model.CustomFieldDef{})
+	if err := db.Open(true); err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close(true) })
+	return db
+}
+
+func TestUpsertCustomFieldDefs(t *testing.T) {
+	adapter := Collector{}
+	db := newTestInventoryDB(t)
+	defs := []types.CustomFieldDef{
+		{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
+		{Name: "env", Key: 200, ManagedObjectType: ""},
+	}
+	u := types.ObjectUpdate{
+		Obj: types.ManagedObjectReference{Type: "VirtualMachine"},
+		ChangeSet: []types.PropertyChange{
+			{
+				Op:   Assign,
+				Name: fAvailableField,
+				Val: types.ArrayOfCustomFieldDef{
+					CustomFieldDef: defs,
+				},
+			},
+		},
+	}
+
+	err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, u)
+	})
+	if err != nil {
+		t.Fatalf("upsertCustomFieldDefs returned error: %v", err)
+	}
+
+	list := []model.CustomFieldDef{}
+	err = db.List(&list, libmodel.ListOptions{Detail: libmodel.MaxDetail})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != len(defs) {
+		t.Fatalf("expected %d defs upserted, got %d", len(defs), len(list))
+	}
+	byKey := make(map[int32]model.CustomFieldDef, len(list))
+	for _, d := range list {
+		byKey[d.Key] = d
+	}
+	for _, f := range defs {
+		got, ok := byKey[f.Key]
+		if !ok {
+			t.Errorf("expected def with key %d to be present", f.Key)
+			continue
+		}
+		expected := model.CustomFieldDef{
+			Name:              f.Name,
+			Key:               f.Key,
+			ManagedObjectType: f.ManagedObjectType,
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("def %d mismatch\ngot:  %+v\nwant: %+v", f.Key, got, expected)
+		}
+	}
+}
+
+func TestUpsertCustomFieldDefsSkipsNonVM(t *testing.T) {
+	adapter := Collector{}
+	db := newTestInventoryDB(t)
+
+	err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, types.ObjectUpdate{
+			Obj: types.ManagedObjectReference{Type: "HostSystem"},
+		})
+	})
+	if err != nil {
+		t.Fatalf("upsertCustomFieldDefs returned unexpected error: %v", err)
+	}
+
+	list := []model.CustomFieldDef{}
+	err = db.List(&list, libmodel.ListOptions{Detail: libmodel.MaxDetail})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected no defs for non-VM object, got %d", len(list))
 	}
 }
 

--- a/pkg/controller/provider/model/vsphere/doc.go
+++ b/pkg/controller/provider/model/vsphere/doc.go
@@ -15,6 +15,7 @@ func All() []interface{} {
 		&Network{},
 		&Datastore{},
 		&Host{},
+		&CustomFieldDef{},
 		&VM{},
 	}
 }

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -1,6 +1,8 @@
 package vsphere
 
 import (
+	"strconv"
+
 	"github.com/kubev2v/forklift/pkg/controller/provider/model/base"
 	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
 )
@@ -360,7 +362,6 @@ type VM struct {
 	ToolsVersionStatus       string             `sql:""`
 	DiskEnableUuid           bool               `sql:""`
 	NestedHVEnabled          bool               `sql:""`
-	CustomDef                []CustomFieldDef   `sql:""`
 	CustomValues             []CustomFieldValue `sql:""`
 	Tags                     []Tag              `sql:""`
 	ConsolidationNeeded      bool               `sql:""`
@@ -479,8 +480,13 @@ type DiskMountPoint struct {
 
 type CustomFieldDef struct {
 	Name              string `json:"name"`
-	Key               int32  `json:"key"`
+	Key               int32  `json:"key" sql:"pk"`
 	ManagedObjectType string `json:"managedObjectType,omitempty"`
+}
+
+// Get the primary key.
+func (m *CustomFieldDef) Pk() string {
+	return strconv.Itoa(int(m.Key))
 }
 
 type CustomFieldValue struct {

--- a/pkg/controller/provider/web/vsphere/client.go
+++ b/pkg/controller/provider/web/vsphere/client.go
@@ -57,6 +57,11 @@ func (r *Resolver) Path(resource interface{}, id string) (path string, err error
 		r.ID = id
 		r.Link(provider)
 		path = r.SelfLink
+	case *CustomFieldDef:
+		r := CustomFieldDef{}
+		r.ID = id
+		r.Link(provider)
+		path = r.SelfLink
 	case *VM:
 		r := VM{}
 		r.ID = id

--- a/pkg/controller/provider/web/vsphere/customfielddef.go
+++ b/pkg/controller/provider/web/vsphere/customfielddef.go
@@ -1,0 +1,140 @@
+package vsphere
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+)
+
+// Routes.
+const (
+	CustomFieldDefParam      = "customfielddef"
+	CustomFieldDefCollection = "customfielddefs"
+	CustomFieldDefsRoot      = ProviderRoot + "/" + CustomFieldDefCollection
+	CustomFieldDefRoot       = CustomFieldDefsRoot + "/:" + CustomFieldDefParam
+)
+
+// Custom field definition handler.
+type CustomFieldDefHandler struct {
+	Handler
+}
+
+// Add routes to the `gin` router.
+func (h *CustomFieldDefHandler) AddRoutes(e *gin.Engine) {
+	e.GET(CustomFieldDefsRoot, h.List)
+	e.GET(CustomFieldDefsRoot+"/", h.List)
+	e.GET(CustomFieldDefRoot, h.Get)
+}
+
+// List resources in a REST collection.
+func (h *CustomFieldDefHandler) List(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	defer func() {
+		if err != nil {
+			log.Trace(
+				err,
+				"url",
+				ctx.Request.URL)
+			ctx.Status(http.StatusInternalServerError)
+		}
+	}()
+	db := h.Collector.DB()
+	list := []model.CustomFieldDef{}
+	err = db.List(&list, h.ListOptions(ctx))
+	if err != nil {
+		return
+	}
+	content := []interface{}{}
+	for _, m := range list {
+		r := &CustomFieldDef{}
+		r.With(&m)
+		r.Link(h.Provider)
+		content = append(content, r.Content(h.Detail))
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// Get a specific REST resource.
+func (h *CustomFieldDefHandler) Get(ctx *gin.Context) {
+	status, err := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	key, err := strconv.ParseInt(ctx.Param(CustomFieldDefParam), 10, 32)
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	m := &model.CustomFieldDef{
+		Key: int32(key),
+	}
+	db := h.Collector.DB()
+	err = db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r := &CustomFieldDef{}
+	r.With(m)
+	r.Link(h.Provider)
+	content := r.Content(model.MaxDetail)
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+// REST Resource.
+type CustomFieldDef struct {
+	SelfLink          string `json:"selfLink"`
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Key               int32  `json:"key"`
+	ManagedObjectType string `json:"managedObjectType,omitempty"`
+}
+
+// Build the resource using the model.
+func (r *CustomFieldDef) With(m *model.CustomFieldDef) {
+	r.ID = strconv.Itoa(int(m.Key))
+	r.Name = m.Name
+	r.Key = m.Key
+	r.ManagedObjectType = m.ManagedObjectType
+}
+
+// Build self link (URI).
+func (r *CustomFieldDef) Link(p *api.Provider) {
+	r.SelfLink = base.Link(
+		CustomFieldDefRoot,
+		base.Params{
+			base.ProviderParam:  string(p.UID),
+			CustomFieldDefParam: r.ID,
+		})
+}
+
+// As content.
+func (r *CustomFieldDef) Content(detail int) interface{} {
+	return r
+}

--- a/pkg/controller/provider/web/vsphere/customfielddef_test.go
+++ b/pkg/controller/provider/web/vsphere/customfielddef_test.go
@@ -1,0 +1,39 @@
+package vsphere
+
+import (
+	"testing"
+
+	model "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+)
+
+func TestCustomFieldDefWith(t *testing.T) {
+	m := &model.CustomFieldDef{
+		Name:              "app-name",
+		Key:               100,
+		ManagedObjectType: "VirtualMachine",
+	}
+	var r CustomFieldDef
+	r.With(m)
+
+	if r.ID != "100" {
+		t.Errorf("ID = %q, want %q", r.ID, "100")
+	}
+	if r.Key != 100 {
+		t.Errorf("Key = %d, want 100", r.Key)
+	}
+	if r.Name != "app-name" {
+		t.Errorf("Name = %q, want %q", r.Name, "app-name")
+	}
+	if r.ManagedObjectType != "VirtualMachine" {
+		t.Errorf("ManagedObjectType = %q, want %q", r.ManagedObjectType, "VirtualMachine")
+	}
+}
+
+func TestCustomFieldDefRouteConstants(t *testing.T) {
+	if CustomFieldDefsRoot != ProviderRoot+"/"+CustomFieldDefCollection {
+		t.Errorf("CustomFieldDefsRoot = %q, want %q", CustomFieldDefsRoot, ProviderRoot+"/"+CustomFieldDefCollection)
+	}
+	if CustomFieldDefRoot != CustomFieldDefsRoot+"/:"+CustomFieldDefParam {
+		t.Errorf("CustomFieldDefRoot = %q, want %q", CustomFieldDefRoot, CustomFieldDefsRoot+"/:"+CustomFieldDefParam)
+	}
+}

--- a/pkg/controller/provider/web/vsphere/doc.go
+++ b/pkg/controller/provider/web/vsphere/doc.go
@@ -56,6 +56,11 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 				base.Handler{Container: container},
 			},
 		},
+		&CustomFieldDefHandler{
+			Handler: Handler{
+				base.Handler{Container: container},
+			},
+		},
 		&VMHandler{
 			Handler: Handler{
 				base.Handler{Container: container},

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -306,7 +306,6 @@ type VM struct {
 	ToolsVersionStatus string                   `json:"toolsVersionStatus2"`
 	DiskEnableUuid     bool                     `json:"diskEnableUuid"`
 	NestedHVEnabled    bool                     `json:"nestedHVEnabled"`
-	CustomDef          []model.CustomFieldDef   `json:"customDef"`
 	CustomValues       []model.CustomFieldValue `json:"customValues"`
 	Tags               []model.Tag              `json:"tags"`
 }
@@ -359,7 +358,6 @@ func (r *VM) With(m *model.VM) {
 	r.ToolsVersionStatus = m.ToolsVersionStatus
 	r.DiskEnableUuid = m.DiskEnableUuid
 	r.NestedHVEnabled = m.NestedHVEnabled
-	r.CustomDef = m.CustomDef
 	r.CustomValues = m.CustomValues
 	r.Tags = m.Tags
 	r.ConsolidationNeeded = m.ConsolidationNeeded


### PR DESCRIPTION
An issue was found in using forklift to move VMs from vSphere where there was a large amount of custom value definitions. It resulted in a very large inventory database as well as very high memory consumption of the inventory container when the plans were reconciling.

This was due to the entire custom value definition being added to each VM in the VM table. In the test case there were over 1200 custom value definitions where all were used, but most VMs only used a few each. In that case about 95% of the entire inventory DB was the custom value definitions.

Originally, I thought to make the changes entirely within the inventory so the consumer did not need to be changed where at the time of the data being committed to the database, the custom value definitions were for each VM would be pruned to only the values that VM had defined. But when an incremental change is made where a value is added to a VM, the definitions are not resent and it would have resulted in annotations being excluded until the next time the pod was restarted.

Instead, I opted to move the custom value definitions into a separate database table and endpoint and have the consumer merge the data together.

This allows for the data in the DB to be reduced from n (VMs) to 1 as well as the amount of data passed by each of the calls to the inventory will be reduced by the size of the custom value definition at the expense of 1 additional call per VM to collect the custom value definitions. 

Ref: https://redhat.atlassian.net/browse/MTV-6511