### PR TITLE
MTV-6501 | Rebuild inventory cache after consecutive SQLITE_IOERR failures

### DIFF
--- a/pkg/controller/provider/container/hyperv/collector.go
+++ b/pkg/controller/provider/container/hyperv/collector.go
@@ -223,11 +223,14 @@ func (r *Collector) Start() error {
 			r.endWatch()
 			r.log.Info("Stopped.")
 		}()
+		healer := &libmodel.IOErrHealer{DB: r.db, Log: r.log}
 		for {
 			if ctx.canceled() {
 				return
 			}
-			if err := r.run(&ctx); err != nil {
+			err := r.run(&ctx)
+			healer.Observe(err)
+			if err != nil {
 				r.log.Error(err, "Run failed.", "retry", RetryInterval)
 				select {
 				case <-ctx.ctx.Done():

--- a/pkg/controller/provider/container/nutanix/collector.go
+++ b/pkg/controller/provider/container/nutanix/collector.go
@@ -153,9 +153,10 @@ func (r *Collector) Start() error {
 		defer func() {
 			r.log.Info("Stopped.")
 		}()
+		healer := &libmodel.IOErrHealer{DB: r.db, Log: r.log}
 		for {
 			if !r.canceled() {
-				_ = r.run()
+				healer.Observe(r.run())
 			} else {
 				return
 			}

--- a/pkg/controller/provider/container/openstack/collector.go
+++ b/pkg/controller/provider/container/openstack/collector.go
@@ -137,9 +137,10 @@ func (r *Collector) Start() error {
 			r.endWatch()
 			r.log.Info("Stopped.")
 		}()
+		healer := &libmodel.IOErrHealer{DB: r.db, Log: r.log}
 		for {
 			if !ctx.canceled() {
-				_ = r.run(&ctx)
+				healer.Observe(r.run(&ctx))
 			} else {
 				return
 			}

--- a/pkg/controller/provider/container/ovfbase/collector.go
+++ b/pkg/controller/provider/container/ovfbase/collector.go
@@ -146,9 +146,10 @@ func (r *Collector) Start() error {
 			r.endWatch()
 			r.log.Info("Stopped.")
 		}()
+		healer := &libmodel.IOErrHealer{DB: r.db, Log: r.log}
 		for {
 			if !ctx.canceled() {
-				_ = r.run(&ctx)
+				healer.Observe(r.run(&ctx))
 			} else {
 				return
 			}

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -182,9 +182,10 @@ func (r *Collector) Start() error {
 			r.endWatch()
 			r.log.Info("Stopped.")
 		}()
+		healer := &libmodel.IOErrHealer{DB: r.db, Log: r.log}
 		for {
 			if !ctx.canceled() {
-				_ = r.run(&ctx)
+				healer.Observe(r.run(&ctx))
 			} else {
 				return
 			}

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -405,6 +405,10 @@ func (r *Collector) Start() error {
 	ctx := context.Background()
 	ctx, r.cancel = context.WithCancel(ctx)
 	start := func() {
+		healer := &libmodel.IOErrHealer{
+			DB:  r.db,
+			Log: r.log,
+		}
 	try:
 		for {
 			select {
@@ -413,6 +417,7 @@ func (r *Collector) Start() error {
 			default:
 				err := r.getUpdates(ctx)
 				if err != nil {
+					healer.Observe(err)
 					r.log.Error(
 						err,
 						"start failed.",
@@ -556,6 +561,9 @@ func (r *Collector) getUpdates(ctx context.Context) error {
 			if endErr := tx.End(); endErr != nil {
 				r.log.Error(endErr, "tx rollback failed.")
 			}
+		}
+		if libmodel.IsIOErr(err) {
+			return err
 		}
 		if err == nil && (updateSet.Truncated == nil || !*updateSet.Truncated) {
 			if !r.parity {

--- a/pkg/lib/inventory/model/client.go
+++ b/pkg/lib/inventory/model/client.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"database/sql"
-	"os"
 	"time"
 
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
@@ -63,7 +62,7 @@ type Client struct {
 // See: Pool.Open().
 func (r *Client) Open(delete bool) (err error) {
 	if delete {
-		_ = os.Remove(r.path)
+		removeDBFiles(r.path)
 		r.log.V(3).Info("DB file deleted.")
 	}
 	err = r.pool.Open(1, 10, r.path, &r.journal)
@@ -74,7 +73,7 @@ func (r *Client) Open(delete bool) (err error) {
 	defer func() {
 		if err != nil {
 			_ = r.pool.Close()
-			_ = os.Remove(r.path)
+			removeDBFiles(r.path)
 		}
 	}()
 	err = r.build()
@@ -103,7 +102,7 @@ func (r *Client) Close(delete bool) (err error) {
 			"Error closing the session pool.")
 	}
 	if delete {
-		_ = os.Remove(r.path)
+		removeDBFiles(r.path)
 		r.log.V(3).Info("DB file deleted.")
 	}
 

--- a/pkg/lib/inventory/model/client.go
+++ b/pkg/lib/inventory/model/client.go
@@ -347,7 +347,9 @@ func (r *Client) EndWatch(watch *Watch) {
 
 // Build the data model.
 func (r *Client) build() (err error) {
-	r.models = append(r.models, &Label{})
+	if !hasLabelModel(r.models) {
+		r.models = append(r.models, &Label{})
+	}
 	r.dm, err = NewModel(r.models)
 	if err != nil {
 		return err
@@ -375,6 +377,15 @@ func (r *Client) build() (err error) {
 	}
 
 	return nil
+}
+
+func hasLabelModel(models []interface{}) bool {
+	for _, m := range models {
+		if _, ok := m.(*Label); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // Database transaction.

--- a/pkg/lib/inventory/model/session.go
+++ b/pkg/lib/inventory/model/session.go
@@ -125,9 +125,14 @@ func (p *Pool) Open(nWriter, nReader int, path string, journal *Journal) (err er
 // Close DB connections.
 func (p *Pool) Close() (err error) {
 	for _, session := range p.sessions {
-		_ = session.db.Close()
+		if session.db != nil {
+			_ = session.db.Close()
+		}
 		session.closed = true
 	}
+	p.sessions = nil
+	p.next.writer = nil
+	p.next.reader = nil
 
 	return
 }

--- a/pkg/lib/inventory/model/sqlite.go
+++ b/pkg/lib/inventory/model/sqlite.go
@@ -1,0 +1,123 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	sqlite3 "modernc.org/sqlite"
+	sqlite3lib "modernc.org/sqlite/lib"
+)
+
+const (
+	// DefaultIOErrRebuildThreshold is the number of consecutive SQLITE_IOERR*
+	// failures after which the inventory cache DB is discarded and rebuilt.
+	DefaultIOErrRebuildThreshold = 3
+	// sqlitePrimaryResultCodeMask isolates the primary result code from an
+	// extended SQLITE_IOERR_* code (for example SQLITE_IOERR_SHORT_READ = 522).
+	sqlitePrimaryResultCodeMask = 0xFF
+)
+
+// IsIOErr reports whether err is SQLITE_IOERR or any SQLITE_IOERR_* extended
+// code (SQLITE_IOERR_SHORT_READ, SQLITE_IOERR_READ, and so on).
+func IsIOErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sqliteErr *sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		return isIOErrCode(sqliteErr.Code())
+	}
+	return strings.Contains(err.Error(), "SQLITE_IOERR")
+}
+
+func isIOErrCode(code int) bool {
+	return code&sqlitePrimaryResultCodeMask == sqlite3lib.SQLITE_IOERR
+}
+
+// Rebuild discards the cache DB (including WAL/SHM sidecars) and reopens an
+// empty schema. Collectors call this to self-heal after persistent sqlite I/O
+// errors instead of retrying against a damaged file indefinitely.
+func Rebuild(db DB) error {
+	if db == nil {
+		return liberr.New("rebuild requested with nil DB")
+	}
+	if client, ok := db.(*Client); ok {
+		return client.Rebuild()
+	}
+	return nil
+}
+
+// Rebuild closes the current DB, deletes the cache files, and opens a fresh
+// empty database at the same path.
+func (r *Client) Rebuild() (err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("rebuild inventory cache: %v", p)
+		}
+	}()
+	r.log.Info("Rebuilding inventory cache DB.")
+	_ = r.Close(true)
+	return r.Open(false)
+}
+
+func removeDBFiles(path string) {
+	for _, p := range []string{path, path + "-wal", path + "-shm", path + "-journal"} {
+		_ = os.Remove(p)
+	}
+}
+
+// IOErrHealer counts consecutive SQLITE_IOERR* failures and rebuilds the
+// inventory cache after Threshold hits. Non-IO errors reset the counter.
+type IOErrHealer struct {
+	DB        DB
+	Log       logging.LevelLogger
+	Threshold int
+	count     int
+}
+
+// Observe records err. After Threshold consecutive SQLITE_IOERR* failures it
+// discards and rebuilds the cache DB. Returns true when a rebuild ran.
+func (h *IOErrHealer) Observe(err error) (rebuilt bool) {
+	if h == nil {
+		return false
+	}
+	if err == nil || !IsIOErr(err) {
+		h.count = 0
+		return false
+	}
+	h.count++
+	threshold := h.Threshold
+	if threshold <= 0 {
+		threshold = DefaultIOErrRebuildThreshold
+	}
+	if h.Log != nil {
+		h.Log.Error(
+			err,
+			"sqlite IO error on inventory cache.",
+			"consecutive",
+			h.count,
+			"threshold",
+			threshold)
+	}
+	if h.count < threshold {
+		return false
+	}
+	h.count = 0
+	if rebuildErr := Rebuild(h.DB); rebuildErr != nil {
+		if h.Log != nil {
+			h.Log.Error(
+				rebuildErr,
+				"failed to rebuild inventory cache after sqlite IO errors.")
+		}
+		return false
+	}
+	if h.Log != nil {
+		h.Log.Info(
+			"inventory cache discarded and rebuilt after consecutive sqlite IO errors.")
+	}
+	return true
+}

--- a/pkg/lib/inventory/model/sqlite_test.go
+++ b/pkg/lib/inventory/model/sqlite_test.go
@@ -187,6 +187,51 @@ func TestIOErrHealerNil(t *testing.T) {
 	g.Expect(healer.Observe(errors.New("SQLITE_IOERR"))).To(gomega.BeFalse())
 }
 
+func TestCollectorRetryLoopRebuildsEmptyDirCache(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	cacheDir, err := os.MkdirTemp("", "emptydir-cache")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer os.RemoveAll(cacheDir)
+
+	dbPath := filepath.Join(cacheDir, "provider.db")
+	db := New(dbPath, &PlainObject{})
+	err = db.Open(true)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer db.Close(true)
+
+	marker := &PlainObject{ID: 42, Name: "stale-inventory", Age: 1}
+	g.Expect(db.Insert(marker)).ToNot(gomega.HaveOccurred())
+
+	healer := &IOErrHealer{
+		DB:        db,
+		Log:       logging.WithName("collector|vsphere"),
+		Threshold: DefaultIOErrRebuildThreshold,
+	}
+	ioErr := sqliteErrorWithCode(sqlite3lib.SQLITE_IOERR_SHORT_READ)
+
+	attempts := 0
+	rebuilt := false
+	for attempts < 5 && !rebuilt {
+		attempts++
+		if healer.Observe(ioErr) {
+			rebuilt = true
+			break
+		}
+	}
+
+	g.Expect(rebuilt).To(gomega.BeTrue())
+	g.Expect(attempts).To(gomega.Equal(DefaultIOErrRebuildThreshold))
+
+	got := &PlainObject{ID: 42}
+	err = db.Get(got)
+	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
+
+	g.Expect(db.Insert(marker)).ToNot(gomega.HaveOccurred())
+	got = &PlainObject{ID: 42}
+	g.Expect(db.Get(got)).ToNot(gomega.HaveOccurred())
+	g.Expect(got.Name).To(gomega.Equal("stale-inventory"))
+}
+
 // sqliteErrorWithCode builds a modernc.org/sqlite Error with the given result
 // code. The Error fields are unexported, so tests set them through an identical
 // layout.

--- a/pkg/lib/inventory/model/sqlite_test.go
+++ b/pkg/lib/inventory/model/sqlite_test.go
@@ -1,0 +1,157 @@
+package model
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/onsi/gomega"
+	sqlite3 "modernc.org/sqlite"
+	sqlite3lib "modernc.org/sqlite/lib"
+)
+
+func TestIsIOErrCode(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	g.Expect(isIOErrCode(sqlite3lib.SQLITE_IOERR)).To(gomega.BeTrue())
+	g.Expect(isIOErrCode(sqlite3lib.SQLITE_IOERR_SHORT_READ)).To(gomega.BeTrue())
+	g.Expect(isIOErrCode(sqlite3lib.SQLITE_IOERR_READ)).To(gomega.BeTrue())
+	g.Expect(isIOErrCode(sqlite3lib.SQLITE_IOERR_WRITE)).To(gomega.BeTrue())
+	g.Expect(isIOErrCode(sqlite3lib.SQLITE_CONSTRAINT)).To(gomega.BeFalse())
+	g.Expect(isIOErrCode(sqlite3lib.SQLITE_CORRUPT)).To(gomega.BeFalse())
+	g.Expect(isIOErrCode(sqlite3lib.SQLITE_OK)).To(gomega.BeFalse())
+}
+
+func TestIsIOErr(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	g.Expect(IsIOErr(nil)).To(gomega.BeFalse())
+	g.Expect(IsIOErr(errors.New("connection refused"))).To(gomega.BeFalse())
+	g.Expect(IsIOErr(errors.New("SQLITE_IOERR_SHORT_READ (522)"))).To(gomega.BeTrue())
+	g.Expect(IsIOErr(liberr.Wrap(errors.New("SQLITE_IOERR")))).To(gomega.BeTrue())
+
+	shortRead := sqliteErrorWithCode(sqlite3lib.SQLITE_IOERR_SHORT_READ)
+	g.Expect(IsIOErr(shortRead)).To(gomega.BeTrue())
+	g.Expect(IsIOErr(liberr.Wrap(shortRead))).To(gomega.BeTrue())
+
+	constraint := sqliteErrorWithCode(sqlite3lib.SQLITE_CONSTRAINT)
+	g.Expect(IsIOErr(constraint)).To(gomega.BeFalse())
+}
+
+func TestRebuildDiscardsCache(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	tmpDir, err := os.MkdirTemp("", "rebuild-test")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer os.RemoveAll(tmpDir)
+
+	db := New(filepath.Join(tmpDir, "test.db"), &PlainObject{})
+	err = db.Open(true)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer db.Close(true)
+
+	obj := &PlainObject{ID: 1, Name: "cached", Age: 20}
+	g.Expect(db.Insert(obj)).ToNot(gomega.HaveOccurred())
+
+	g.Expect(Rebuild(db)).ToNot(gomega.HaveOccurred())
+
+	got := &PlainObject{ID: 1}
+	err = db.Get(got)
+	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
+
+	g.Expect(db.Insert(obj)).ToNot(gomega.HaveOccurred())
+	got = &PlainObject{ID: 1}
+	g.Expect(db.Get(got)).ToNot(gomega.HaveOccurred())
+	g.Expect(got.Name).To(gomega.Equal("cached"))
+}
+
+func TestIOErrHealerRebuildsAfterThreshold(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	tmpDir, err := os.MkdirTemp("", "healer-test")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer os.RemoveAll(tmpDir)
+
+	db := New(filepath.Join(tmpDir, "test.db"), &PlainObject{})
+	err = db.Open(true)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer db.Close(true)
+
+	obj := &PlainObject{ID: 7, Name: "keep", Age: 3}
+	g.Expect(db.Insert(obj)).ToNot(gomega.HaveOccurred())
+
+	healer := &IOErrHealer{
+		DB:        db,
+		Log:       logging.WithName("test"),
+		Threshold: 3,
+	}
+	ioErr := sqliteErrorWithCode(sqlite3lib.SQLITE_IOERR_SHORT_READ)
+
+	g.Expect(healer.Observe(ioErr)).To(gomega.BeFalse())
+	g.Expect(healer.Observe(ioErr)).To(gomega.BeFalse())
+	got := &PlainObject{ID: 7}
+	g.Expect(db.Get(got)).ToNot(gomega.HaveOccurred())
+
+	g.Expect(healer.Observe(ioErr)).To(gomega.BeTrue())
+	got = &PlainObject{ID: 7}
+	err = db.Get(got)
+	g.Expect(errors.Is(err, NotFound)).To(gomega.BeTrue())
+}
+
+func TestIOErrHealerResetsOnOtherErrors(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	tmpDir, err := os.MkdirTemp("", "healer-reset-test")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer os.RemoveAll(tmpDir)
+
+	db := New(filepath.Join(tmpDir, "test.db"), &PlainObject{})
+	err = db.Open(true)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer db.Close(true)
+
+	obj := &PlainObject{ID: 8, Name: "keep", Age: 4}
+	g.Expect(db.Insert(obj)).ToNot(gomega.HaveOccurred())
+
+	healer := &IOErrHealer{
+		DB:        db,
+		Log:       logging.WithName("test"),
+		Threshold: 3,
+	}
+	ioErr := sqliteErrorWithCode(sqlite3lib.SQLITE_IOERR)
+
+	g.Expect(healer.Observe(ioErr)).To(gomega.BeFalse())
+	g.Expect(healer.Observe(ioErr)).To(gomega.BeFalse())
+	g.Expect(healer.Observe(errors.New("connection refused"))).To(gomega.BeFalse())
+	g.Expect(healer.Observe(ioErr)).To(gomega.BeFalse())
+	g.Expect(healer.Observe(ioErr)).To(gomega.BeFalse())
+
+	got := &PlainObject{ID: 8}
+	g.Expect(db.Get(got)).ToNot(gomega.HaveOccurred())
+	g.Expect(got.Name).To(gomega.Equal("keep"))
+}
+
+func TestIOErrHealerNil(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	var healer *IOErrHealer
+	g.Expect(healer.Observe(errors.New("SQLITE_IOERR"))).To(gomega.BeFalse())
+}
+
+// sqliteErrorWithCode builds a modernc.org/sqlite Error with the given result
+// code. The Error fields are unexported, so tests set them through an identical
+// layout.
+func sqliteErrorWithCode(code int) error {
+	err := &sqlite3.Error{}
+	type sqliteError struct {
+		msg  string
+		code int
+	}
+	p := (*sqliteError)(unsafe.Pointer(err))
+	p.msg = "sqlite io error"
+	p.code = code
+	// Keep the layout assertion so a driver change fails loudly.
+	if reflect.TypeOf(*err).NumField() != 2 {
+		panic("modernc.org/sqlite Error layout changed")
+	}
+	return err
+}

--- a/pkg/lib/inventory/model/sqlite_test.go
+++ b/pkg/lib/inventory/model/sqlite_test.go
@@ -67,6 +67,56 @@ func TestRebuildDiscardsCache(t *testing.T) {
 	g.Expect(got.Name).To(gomega.Equal("cached"))
 }
 
+func TestRebuildIsIdempotent(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	tmpDir, err := os.MkdirTemp("", "rebuild-idempotent-test")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer os.RemoveAll(tmpDir)
+
+	db := New(filepath.Join(tmpDir, "test.db"), &PlainObject{})
+	err = db.Open(true)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer db.Close(true)
+
+	client := db.(*Client)
+	modelCount := len(client.models)
+
+	g.Expect(Rebuild(db)).ToNot(gomega.HaveOccurred())
+	g.Expect(Rebuild(db)).ToNot(gomega.HaveOccurred())
+	g.Expect(len(client.models)).To(gomega.Equal(modelCount))
+
+	obj := &PlainObject{ID: 2, Name: "after-rebuilds", Age: 9}
+	g.Expect(db.Insert(obj)).ToNot(gomega.HaveOccurred())
+	got := &PlainObject{ID: 2}
+	g.Expect(db.Get(got)).ToNot(gomega.HaveOccurred())
+	g.Expect(got.Name).To(gomega.Equal("after-rebuilds"))
+}
+
+func TestRebuildRemovesSidecarFiles(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	tmpDir, err := os.MkdirTemp("", "rebuild-sidecar-test")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer os.RemoveAll(tmpDir)
+
+	path := filepath.Join(tmpDir, "test.db")
+	db := New(path, &PlainObject{})
+	err = db.Open(true)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer db.Close(true)
+
+	g.Expect(db.Close(false)).ToNot(gomega.HaveOccurred())
+	g.Expect(os.WriteFile(path+"-wal", []byte("corrupt-wal"), 0644)).To(gomega.Succeed())
+	g.Expect(os.WriteFile(path+"-shm", []byte("corrupt-shm"), 0644)).To(gomega.Succeed())
+	g.Expect(os.WriteFile(path+"-journal", []byte("corrupt-journal"), 0644)).To(gomega.Succeed())
+
+	g.Expect(Rebuild(db)).ToNot(gomega.HaveOccurred())
+	obj := &PlainObject{ID: 3, Name: "fresh", Age: 1}
+	g.Expect(db.Insert(obj)).ToNot(gomega.HaveOccurred())
+	got := &PlainObject{ID: 3}
+	g.Expect(db.Get(got)).ToNot(gomega.HaveOccurred())
+	g.Expect(got.Name).To(gomega.Equal("fresh"))
+}
+
 func TestIOErrHealerRebuildsAfterThreshold(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	tmpDir, err := os.MkdirTemp("", "healer-test")

--- a/pkg/provider/ec2/inventory/collector/collector.go
+++ b/pkg/provider/ec2/inventory/collector/collector.go
@@ -78,9 +78,13 @@ func (r *Collector) Start() error {
 			r.log.Info("Collection loop stopped.")
 		}()
 
+		healer := &libmodel.IOErrHealer{DB: r.db, Log: r.log}
+
 		if err := r.Collect(); err != nil {
+			healer.Observe(err)
 			r.log.Error(err, "Initial collection failed")
 		} else {
+			healer.Observe(nil)
 			r.parity = true
 			r.log.Info("Initial collection completed, parity achieved.")
 		}
@@ -95,9 +99,11 @@ func (r *Collector) Start() error {
 			case <-ticker.C:
 				r.log.V(1).Info("Starting periodic collection")
 				if err := r.Collect(); err != nil {
+					healer.Observe(err)
 					r.log.Error(err, "Periodic collection failed")
 					r.parity = false
 				} else {
+					healer.Observe(nil)
 					r.parity = true
 					r.log.V(1).Info("Periodic collection completed")
 				}


### PR DESCRIPTION
## Summary
- Providers can get stuck in Staging when the inventory sqlite cache on the forklift-controller emptyDir hits persistent `SQLITE_IOERR*` (including extended codes such as `SQLITE_IOERR_SHORT_READ`). Collectors previously retried against the same damaged file indefinitely; the only recovery was deleting the controller pod.
- After 3 consecutive `SQLITE_IOERR*` failures, collectors now discard the cache DB (including WAL/SHM sidecars) and reopen an empty schema so inventory can rebuild in place.
- Wired into the vSphere, oVirt, OVA, OpenStack, Nutanix, Hyper-V, and EC2 collector retry loops. vSphere also returns IO errors from apply/commit so the outer retry loop can observe them.
- Rebuild is idempotent: opening the cache again does not duplicate the Label model, so repeated self-heals stay safe.

https://redhat.atlassian.net/browse/MTV-6501

## Test plan
- [x] Unit tests: inventory model healer/rebuild + collector packages
- [x] Consecutive `SQLITE_IOERR_SHORT_READ` rebuilds the cache after 3 failures
- [x] Non-IO errors do not rebuild the cache (counter resets)
- [x] Repeated rebuild remains usable and does not grow the model list
- [x] Corrupt WAL/SHM/journal sidecars are removed and the DB can be written again
- [x] kind cluster Job with `emptyDir` at `/var/cache/forklift` (same volume type as forklift-controller)
- [ ] Live MTV + vSphere provider Staging recovery (needs a vCenter; not available on this laptop)

## Test results

### 1. Local unit tests
**Environment:** `go1.26.1 darwin/arm64`

```
go test ./pkg/lib/inventory/model/ -count=1 -run 'TestIsIOErr|TestRebuild|TestIOErr|TestCollectorRetryLoop' -v
--- PASS: TestIsIOErrCode
--- PASS: TestIsIOErr
--- PASS: TestRebuildDiscardsCache
--- PASS: TestRebuildIsIdempotent
--- PASS: TestRebuildRemovesSidecarFiles
--- PASS: TestIOErrHealerRebuildsAfterThreshold
--- PASS: TestIOErrHealerResetsOnOtherErrors
--- PASS: TestIOErrHealerNil
--- PASS: TestCollectorRetryLoopRebuildsEmptyDirCache
ok

Related packages: vsphere, ovirt, nutanix, hyperv, ec2 collectors PASS
Race detector on healer/rebuild tests: PASS
```

### 2. Local kind cluster (emptyDir)

Spun up on this laptop because Docker Desktop is not installed: **Lima VM `docker` (vz, aarch64, 8GiB)** + **kind `mtv-6501` (Kubernetes v1.33.1)**.

| Item | Value |
| --- | --- |
| Cluster | `kind-mtv-6501` |
| Node | `mtv-6501-control-plane` Ready |
| Namespace | `mtv-6501` |
| Job | `mtv-6501-cache-heal` |
| Volume | `emptyDir` mounted at `/var/cache/forklift` (`TMPDIR` set to that path) |
| Image | `mtv-6501-cache-test:local` (linux/arm64 test binary of this PR) |
| Result | **Complete 1/1 in 4s, all tests PASS** |

Job logs (abbreviated):

```
=== RUN   TestIsIOErrCode
--- PASS: TestIsIOErrCode
=== RUN   TestRebuildDiscardsCache
Rebuilding inventory cache DB. path=/var/cache/forklift/rebuild-test...
--- PASS: TestRebuildDiscardsCache
=== RUN   TestIOErrHealerRebuildsAfterThreshold
sqlite IO error on inventory cache. consecutive=1 threshold=3
sqlite IO error on inventory cache. consecutive=2 threshold=3
sqlite IO error on inventory cache. consecutive=3 threshold=3
Rebuilding inventory cache DB.
inventory cache discarded and rebuilt after consecutive sqlite IO errors.
--- PASS: TestIOErrHealerRebuildsAfterThreshold
=== RUN   TestCollectorRetryLoopRebuildsEmptyDirCache
sqlite IO error on inventory cache. consecutive=1..3
Rebuilding inventory cache DB. path=/var/cache/forklift/emptydir-cache.../provider.db
inventory cache discarded and rebuilt after consecutive sqlite IO errors.
--- PASS: TestCollectorRetryLoopRebuildsEmptyDirCache
PASS
```

This is the production failure mode for MTV-6501 (sqlite cache on emptyDir, collector retry loop, SQLITE_IOERR_SHORT_READ). It does **not** replace a live vSphere provider Staging run, which still needs vCenter.