### PR TITLE
MTV-6500 | Handle IPv6 duplicate persistent routes after migration

### DIFF
--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes-registry.ps1
@@ -22,6 +22,7 @@ function Convert-PrefixToMask($prefix) {
 # Remove a persistent route using both Remove-NetRoute and route.exe as fallback.
 # Remove-NetRoute -PolicyStore PersistentStore can silently fail on some Windows versions,
 # so we always also invoke route.exe to guarantee the persistent store entry is gone.
+# route.exe only supports IPv4; IPv6 routes rely on Remove-NetRoute alone.
 function Remove-PersistentRoute($route) {
     try {
         Remove-NetRoute -DestinationPrefix $route.DestinationPrefix -NextHop $route.NextHop `
@@ -29,9 +30,10 @@ function Remove-PersistentRoute($route) {
     } catch {
         Write-Host "      Remove-NetRoute failed: $($_.Exception.Message)" -ForegroundColor Red
     }
-    $parts = $route.DestinationPrefix.Split("/")
-    $prefixLen = [int]$parts[1]
-    if ($prefixLen -le 32) {
+    # route.exe fallback is IPv4 only
+    if ($route.AddressFamily -eq "IPv4") {
+        $parts = $route.DestinationPrefix.Split("/")
+        $prefixLen = [int]$parts[1]
         $network = $parts[0]
         $netmask = Convert-PrefixToMask $prefixLen
         $result = cmd /c "route delete $network mask $netmask $($route.NextHop) IF $($route.InterfaceIndex)" 2>&1
@@ -49,10 +51,8 @@ try {
     Exit 1
 }
 
-$routes = $routes | Where-Object { $_.AddressFamily -eq "IPv4" }
-
-# Step 1: Preserve ALL default gateways (0.0.0.0/0) with their interface indexes
-$defaultGateways = $routes | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" }
+# Step 1: Preserve ALL default gateways (0.0.0.0/0 and ::/0) with their interface indexes
+$defaultGateways = $routes | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" -or $_.DestinationPrefix -eq "::/0" }
 Write-Host "Found $($defaultGateways.Count) default gateway(s) to preserve:" -ForegroundColor Cyan
 foreach ($gw in $defaultGateways) {
     Write-Host "  Gateway: $($gw.NextHop) on Interface $($gw.InterfaceIndex) with metric $($gw.RouteMetric)" -ForegroundColor Cyan
@@ -70,8 +70,14 @@ $groupedRoutes = $routes | Group-Object {
 } | Where-Object { $_.Count -gt 1 }
 
 # Separate default gateway duplicates from other duplicates
-$gatewayDuplicates = $groupedRoutes | Where-Object { $_.Name.Trim().StartsWith("0.0.0.0/0-") }
-$nonGatewayDuplicates = $groupedRoutes | Where-Object { -not $_.Name.Trim().StartsWith("0.0.0.0/0-") }
+$gatewayDuplicates = $groupedRoutes | Where-Object {
+    $n = $_.Name.Trim()
+    $n.StartsWith("0.0.0.0/0-") -or $n.StartsWith("::/0-")
+}
+$nonGatewayDuplicates = $groupedRoutes | Where-Object {
+    $n = $_.Name.Trim()
+    -not ($n.StartsWith("0.0.0.0/0-") -or $n.StartsWith("::/0-"))
+}
 
 Write-Host "Found $($gatewayDuplicates.Count) duplicate default gateway groups" -ForegroundColor Cyan
 Write-Host "Found $($nonGatewayDuplicates.Count) duplicate non-gateway route groups" -ForegroundColor Cyan
@@ -114,18 +120,15 @@ if (-not $groupedRoutes) {
             Write-Host "    Deleted: $($route.DestinationPrefix) via $($route.NextHop) on IF $($route.InterfaceIndex)" -ForegroundColor Red
         }
         
-        # Check if the chosen interface already has this gateway via its IP
-        # configuration (DefaultGateway registry, set by the network-configure
-        # script). If so, skip the PersistentStore re-add to avoid creating a
-        # duplicate persistent entry from a different source.
-        $ipCfg = Get-NetIPConfiguration -InterfaceIndex $toKeep.InterfaceIndex -ErrorAction SilentlyContinue
-        $alreadyHasGateway = $false
-        if ($ipCfg -and $ipCfg.IPv4DefaultGateway) {
-            $alreadyHasGateway = $ipCfg.IPv4DefaultGateway.NextHop -contains $gateway
-        }
+        # After deleting all duplicates, verify if a persistent route still
+        # exists for this destination. We must check the PersistentStore directly
+        # rather than Get-NetIPConfiguration, which reflects active (non-persistent)
+        # routes and would falsely indicate the gateway exists.
+        $existingPersistent = Get-NetRoute -DestinationPrefix $dest -InterfaceIndex $toKeep.InterfaceIndex `
+            -PolicyStore PersistentStore -ErrorAction SilentlyContinue | Where-Object { $_.NextHop -eq $gateway }
 
-        if ($alreadyHasGateway) {
-            Write-Host "    Skipping re-add: IF $($toKeep.InterfaceIndex) already has gateway $gateway via DefaultGateway" -ForegroundColor Green
+        if ($existingPersistent) {
+            Write-Host "    Skipping re-add: persistent route already exists for $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
         } else {
             # Re-add only ONE instance (preserve the first interface)
             $reAddSucceeded = $false
@@ -137,15 +140,11 @@ if (-not $groupedRoutes) {
                 Write-Host "      PolicyStore method failed: $($_.Exception.Message)" -ForegroundColor Yellow
             }
             
-            # Fallback to route.exe if PolicyStore failed
-            if (-not $reAddSucceeded) {
+            # Fallback to route.exe if PolicyStore failed (IPv4 only)
+            if (-not $reAddSucceeded -and $dest -eq "0.0.0.0/0") {
                 try {
-                    $parts = $dest.Split("/")
-                    $network = $parts[0]
-                    $prefix = [int]$parts[1]
-                    $netmask = Convert-PrefixToMask $prefix
                     $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
-                    $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
+                    $command = "route -p ADD 0.0.0.0 MASK 0.0.0.0 $gateway IF $($toKeep.InterfaceIndex) $metricStr"
                     Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
                     cmd /c $command
                     if ($LASTEXITCODE -ne 0) {
@@ -155,6 +154,36 @@ if (-not $groupedRoutes) {
                     }
                 } catch {
                     Write-Host "      route.exe also failed: $($_.Exception.Message)" -ForegroundColor Red
+                }
+            }
+
+            # Fallback for IPv6: use netsh or New-NetRoute without PolicyStore
+            if (-not $reAddSucceeded -and $dest -eq "::/0") {
+                try {
+                    $metricVal = if ($null -ne $metric) { [int]$metric } else { 256 }
+                    # First try "set route" (modifies existing active route to be persistent)
+                    $netshCmd = "netsh interface ipv6 set route ::/0 interface=$($toKeep.InterfaceIndex) nexthop=$gateway metric=$metricVal store=persistent publish=Yes"
+                    Write-Host "      Trying netsh set: $netshCmd" -ForegroundColor Gray
+                    cmd /c $netshCmd 2>&1
+                    if ($LASTEXITCODE -ne 0) {
+                        # "set route" failed, try removing active then re-adding fresh
+                        Write-Host "      netsh set failed, removing active route and re-adding..." -ForegroundColor Yellow
+                        cmd /c "netsh interface ipv6 delete route ::/0 interface=$($toKeep.InterfaceIndex) nexthop=$gateway" 2>&1
+                        $addCmd = "netsh interface ipv6 add route ::/0 interface=$($toKeep.InterfaceIndex) nexthop=$gateway metric=$metricVal store=persistent publish=Yes"
+                        Write-Host "      Trying netsh add: $addCmd" -ForegroundColor Gray
+                        cmd /c $addCmd 2>&1
+                        if ($LASTEXITCODE -ne 0) {
+                            # Last resort: New-NetRoute without PolicyStore
+                            New-NetRoute -DestinationPrefix "::/0" -InterfaceIndex $toKeep.InterfaceIndex -NextHop $gateway -RouteMetric $metricVal -ErrorAction Stop
+                            Write-Host "    Re-added with New-NetRoute (active): ::/0 via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                        } else {
+                            Write-Host "    Re-added with netsh add: ::/0 via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                        }
+                    } else {
+                        Write-Host "    Made persistent with netsh set: ::/0 via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                    }
+                } catch {
+                    Write-Host "      IPv6 route re-add failed: $($_.Exception.Message)" -ForegroundColor Red
                 }
             }
         }
@@ -179,17 +208,13 @@ if (-not $groupedRoutes) {
         $gateway = $toKeep.NextHop
         $metric = $toKeep.RouteMetric
         $interfaceIndex = $toKeep.InterfaceIndex
+        $isIPv4 = $toKeep.AddressFamily -eq "IPv4"
 
         $parts = $dest.Split("/")
         if ($parts.Count -ne 2) {
             Write-Host "  Invalid destination prefix format: $dest" -ForegroundColor Red
             continue
         }
-
-        $network = $parts[0]
-        $prefix = [int]$parts[1]
-        $netmask = Convert-PrefixToMask $prefix
-        $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
 
         # Delete all matching routes
         foreach ($route in $group.Group) {
@@ -208,8 +233,12 @@ if (-not $groupedRoutes) {
             Write-Host "  New-NetRoute failed: $($_.Exception.Message), falling back to route.exe " -ForegroundColor Yellow
         }
 
-        # Fallback to route.exe if New-NetRoute failed
-        if (-not $reAddSucceeded) {
+        # Fallback to route.exe if New-NetRoute failed (IPv4 only)
+        if (-not $reAddSucceeded -and $isIPv4) {
+            $network = $parts[0]
+            $prefix = [int]$parts[1]
+            $netmask = Convert-PrefixToMask $prefix
+            $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
             $command = "route -p ADD $network MASK $netmask $gateway IF $interfaceIndex"
             if ($metricStr -ne "") {
                 $command += " $metricStr"
@@ -231,8 +260,8 @@ if (-not $groupedRoutes) {
 
 # Step 3: Remove persistent routes bound to interfaces that no longer exist (stale after migration)
 Write-Host "Removing stale persistent routes on dead interfaces..." -ForegroundColor Yellow
-# Re-read persistent routes after Step 2 cleanup
-$allPersistent = Get-NetRoute -PolicyStore PersistentStore -AddressFamily IPv4 -ErrorAction SilentlyContinue
+# Re-read persistent routes after Step 2 cleanup (both IPv4 and IPv6)
+$allPersistent = Get-NetRoute -PolicyStore PersistentStore -ErrorAction SilentlyContinue
 # Collect interface indexes that are actually present on this machine (including hidden adapters like loopback)
 $activeIndexes = @(Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue | ForEach-Object { $_.InterfaceIndex })
 if ($activeIndexes.Count -eq 0) {
@@ -257,14 +286,18 @@ if ($activeIndexes.Count -eq 0) {
 # Step 4: Configure default gateways at NIC/IP configuration level via registry
 Write-Host "Configuring default gateways at interface level (Registry)..." -ForegroundColor Cyan
 
-# Get current default gateways after cleanup
-$currentDefaultGateways = Get-NetRoute -PolicyStore PersistentStore -AddressFamily IPv4 | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" }
+# Get current default gateways after cleanup (both IPv4 and IPv6)
+$currentDefaultGateways = Get-NetRoute -PolicyStore PersistentStore | Where-Object {
+    $_.DestinationPrefix -eq "0.0.0.0/0" -or $_.DestinationPrefix -eq "::/0"
+}
 Write-Host "Configuring $($currentDefaultGateways.Count) remaining default gateway(s)..." -ForegroundColor Cyan
 
 foreach ($gateway in $currentDefaultGateways) {
     $nextHop = $gateway.NextHop
     $interfaceIndex = $gateway.InterfaceIndex
     $metric = $gateway.RouteMetric
+    $isIPv4 = $gateway.AddressFamily -eq "IPv4"
+    $family = if ($isIPv4) { "IPv4" } else { "IPv6" }
 
     # Check if interface still exists
     $interface = Get-NetAdapter | Where-Object { $_.InterfaceIndex -eq $interfaceIndex } -ErrorAction SilentlyContinue
@@ -274,45 +307,64 @@ foreach ($gateway in $currentDefaultGateways) {
     }
 
     $interfaceAlias = $interface.Name
-    $guid = $interface.InterfaceGuid
-    Write-Host "  Processing Interface $interfaceIndex ($interfaceAlias) - Gateway $nextHop" -ForegroundColor Yellow
+    Write-Host "  Processing Interface $interfaceIndex ($interfaceAlias) - $family Gateway $nextHop" -ForegroundColor Yellow
 
-    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$guid"
-    if (-not (Test-Path $regPath)) {
-        Write-Host "    Registry path not found: $regPath" -ForegroundColor Red
-        continue
-    }
+    if ($isIPv4) {
+        # IPv4: use Tcpip registry path
+        $guid = $interface.InterfaceGuid
+        $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$guid"
+        if (-not (Test-Path $regPath)) {
+            Write-Host "    Registry path not found: $regPath" -ForegroundColor Red
+            continue
+        }
 
-    $regGateways = (Get-ItemProperty -Path $regPath -Name "DefaultGateway" -ErrorAction SilentlyContinue).DefaultGateway
-    $gwList = @()
-    if ($null -ne $regGateways) {
-        $gwList = @($regGateways)
-    }
-    if ($gwList -contains $nextHop) {
-        Write-Host "    Interface already has gateway $nextHop in registry DefaultGateway, removing from PersistentRoutes only" -ForegroundColor Green
-        $persistKey = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\PersistentRoutes"
-        if (Test-Path $persistKey) {
-            $routeKeyPrefix = "0.0.0.0,0.0.0.0,$nextHop,"
-            $props = Get-Item -Path $persistKey | Select-Object -ExpandProperty Property
-            foreach ($p in $props) {
-                if ($p.StartsWith($routeKeyPrefix)) {
-                    try {
-                        Remove-ItemProperty -Path $persistKey -Name $p -ErrorAction Stop
-                        Write-Host "    Removed PersistentRoutes entry: $p" -ForegroundColor Green
-                    } catch {
-                        Write-Host "    Failed to remove PersistentRoutes entry '$p': $($_.Exception.Message)" -ForegroundColor Red
+        $regGateways = (Get-ItemProperty -Path $regPath -Name "DefaultGateway" -ErrorAction SilentlyContinue).DefaultGateway
+        $gwList = @()
+        if ($null -ne $regGateways) {
+            $gwList = @($regGateways)
+        }
+        if ($gwList -contains $nextHop) {
+            Write-Host "    Interface already has gateway $nextHop in registry DefaultGateway, removing from PersistentRoutes only" -ForegroundColor Green
+            $persistKey = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\PersistentRoutes"
+            if (Test-Path $persistKey) {
+                $routeKeyPrefix = "0.0.0.0,0.0.0.0,$nextHop,"
+                $props = Get-Item -Path $persistKey | Select-Object -ExpandProperty Property
+                foreach ($p in $props) {
+                    if ($p.StartsWith($routeKeyPrefix)) {
+                        try {
+                            Remove-ItemProperty -Path $persistKey -Name $p -ErrorAction Stop
+                            Write-Host "    Removed PersistentRoutes entry: $p" -ForegroundColor Green
+                        } catch {
+                            Write-Host "    Failed to remove PersistentRoutes entry '$p': $($_.Exception.Message)" -ForegroundColor Red
+                        }
                     }
                 }
             }
+            continue
         }
-        continue
+
+        $merged = ($gwList + @($nextHop)) | Select-Object -Unique
+        Write-Host "    Setting DefaultGateway=$($merged -join ',') in registry" -ForegroundColor Yellow
+        Set-ItemProperty -Path $regPath -Name "DefaultGateway" -Value $merged -Type MultiString
+        Write-Host "    [OK] Gateway written to registry for $interfaceAlias" -ForegroundColor Green
+    } else {
+        # IPv6: Tcpip registry is IPv4-only, use New-NetRoute cmdlet
+        $ipCfg = Get-NetIPConfiguration -InterfaceIndex $interfaceIndex -ErrorAction SilentlyContinue
+        $alreadyHas = $false
+        if ($ipCfg -and $ipCfg.IPv6DefaultGateway) {
+            $alreadyHas = $ipCfg.IPv6DefaultGateway.NextHop -contains $nextHop
+        }
+        if ($alreadyHas) {
+            Write-Host "    Interface already has IPv6 gateway $nextHop" -ForegroundColor Green
+        } else {
+            try {
+                New-NetRoute -DestinationPrefix "::/0" -InterfaceIndex $interfaceIndex -NextHop $nextHop -RouteMetric $metric -ErrorAction Stop
+                Write-Host "    Configured IPv6 gateway: $nextHop on $interfaceAlias" -ForegroundColor Green
+            } catch {
+                Write-Host "    Failed to configure IPv6 gateway: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
     }
-
-    $merged = ($gwList + @($nextHop)) | Select-Object -Unique
-    Write-Host "    Setting DefaultGateway=$($merged -join ',') in registry" -ForegroundColor Yellow
-    Set-ItemProperty -Path $regPath -Name "DefaultGateway" -Value $merged -Type MultiString
-    Write-Host "    [OK] Gateway written to registry for $interfaceAlias" -ForegroundColor Green
-
 }
 
 Write-Host "Persistent route cleanup completed!" -ForegroundColor Green

--- a/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
+++ b/pkg/virt-v2v/customize/scripts/windows/9999-remove_duplicate_persistent_routes.ps1
@@ -22,6 +22,7 @@ function Convert-PrefixToMask($prefix) {
 # Remove a persistent route using both Remove-NetRoute and route.exe as fallback.
 # Remove-NetRoute -PolicyStore PersistentStore can silently fail on some Windows versions,
 # so we always also invoke route.exe to guarantee the persistent store entry is gone.
+# route.exe only supports IPv4, IPv6 routes rely on Remove-NetRoute alone.
 function Remove-PersistentRoute($route) {
     try {
         Remove-NetRoute -DestinationPrefix $route.DestinationPrefix -NextHop $route.NextHop `
@@ -29,9 +30,10 @@ function Remove-PersistentRoute($route) {
     } catch {
         Write-Host "      Remove-NetRoute failed: $($_.Exception.Message)" -ForegroundColor Red
     }
-    $parts = $route.DestinationPrefix.Split("/")
-    $prefixLen = [int]$parts[1]
-    if ($prefixLen -le 32) {
+    # route.exe fallback is IPv4 only
+    if ($route.AddressFamily -eq "IPv4") {
+        $parts = $route.DestinationPrefix.Split("/")
+        $prefixLen = [int]$parts[1]
         $network = $parts[0]
         $netmask = Convert-PrefixToMask $prefixLen
         $result = cmd /c "route delete $network mask $netmask $($route.NextHop) IF $($route.InterfaceIndex)" 2>&1
@@ -49,10 +51,8 @@ try {
     Exit 1
 }
 
-$routes = $routes | Where-Object { $_.AddressFamily -eq "IPv4" }
-
-# Step 1: Preserve ALL default gateways (0.0.0.0/0) with their interface indexes
-$defaultGateways = $routes | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" }
+# Step 1: Preserve ALL default gateways (0.0.0.0/0 and ::/0) with their interface indexes
+$defaultGateways = $routes | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" -or $_.DestinationPrefix -eq "::/0" }
 Write-Host "Found $($defaultGateways.Count) default gateway(s) to preserve:" -ForegroundColor Cyan
 foreach ($gw in $defaultGateways) {
     Write-Host "  Gateway: $($gw.NextHop) on Interface $($gw.InterfaceIndex) with metric $($gw.RouteMetric)" -ForegroundColor Cyan
@@ -67,8 +67,14 @@ $groupedRoutes = $routes | Group-Object {
 } | Where-Object { $_.Count -gt 1 }
 
 # Separate default gateway duplicates from other duplicates
-$gatewayDuplicates = $groupedRoutes | Where-Object { $_.Name.Trim().StartsWith("0.0.0.0/0-") }
-$nonGatewayDuplicates = $groupedRoutes | Where-Object { -not $_.Name.Trim().StartsWith("0.0.0.0/0-") }
+$gatewayDuplicates = $groupedRoutes | Where-Object {
+    $n = $_.Name.Trim()
+    $n.StartsWith("0.0.0.0/0-") -or $n.StartsWith("::/0-")
+}
+$nonGatewayDuplicates = $groupedRoutes | Where-Object {
+    $n = $_.Name.Trim()
+    -not ($n.StartsWith("0.0.0.0/0-") -or $n.StartsWith("::/0-"))
+}
 
 Write-Host "Found $($gatewayDuplicates.Count) duplicate default gateway groups" -ForegroundColor Cyan
 Write-Host "Found $($nonGatewayDuplicates.Count) duplicate non-gateway route groups" -ForegroundColor Cyan
@@ -111,18 +117,15 @@ if (-not $groupedRoutes) {
             Write-Host "    Deleted: $($route.DestinationPrefix) via $($route.NextHop) on IF $($route.InterfaceIndex)" -ForegroundColor Red
         }
         
-        # Check if the chosen interface already has this gateway via its IP
-        # configuration (DefaultGateway registry, set by the network-configure
-        # script). If so, skip the PersistentStore re-add to avoid creating a
-        # duplicate persistent entry from a different source.
-        $ipCfg = Get-NetIPConfiguration -InterfaceIndex $toKeep.InterfaceIndex -ErrorAction SilentlyContinue
-        $alreadyHasGateway = $false
-        if ($ipCfg -and $ipCfg.IPv4DefaultGateway) {
-            $alreadyHasGateway = $ipCfg.IPv4DefaultGateway.NextHop -contains $gateway
-        }
+        # After deleting all duplicates, verify if a persistent route still
+        # exists for this destination. We must check the PersistentStore directly
+        # rather than Get-NetIPConfiguration, which reflects active (non-persistent)
+        # routes and would falsely indicate the gateway exists.
+        $existingPersistent = Get-NetRoute -DestinationPrefix $dest -InterfaceIndex $toKeep.InterfaceIndex `
+            -PolicyStore PersistentStore -ErrorAction SilentlyContinue | Where-Object { $_.NextHop -eq $gateway }
 
-        if ($alreadyHasGateway) {
-            Write-Host "    Skipping re-add: IF $($toKeep.InterfaceIndex) already has gateway $gateway via DefaultGateway" -ForegroundColor Green
+        if ($existingPersistent) {
+            Write-Host "    Skipping re-add: persistent route already exists for $dest via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
         } else {
             # Re-add only ONE instance (preserve the first interface)
             $reAddSucceeded = $false
@@ -134,15 +137,11 @@ if (-not $groupedRoutes) {
                 Write-Host "      PolicyStore method failed: $($_.Exception.Message)" -ForegroundColor Yellow
             }
             
-            # Fallback to route.exe if PolicyStore failed
-            if (-not $reAddSucceeded) {
+            # Fallback to route.exe if PolicyStore failed (IPv4 only)
+            if (-not $reAddSucceeded -and $dest -eq "0.0.0.0/0") {
                 try {
-                    $parts = $dest.Split("/")
-                    $network = $parts[0]
-                    $prefix = [int]$parts[1]
-                    $netmask = Convert-PrefixToMask $prefix
                     $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
-                    $command = "route -p ADD $network MASK $netmask $gateway IF $($toKeep.InterfaceIndex) $metricStr"
+                    $command = "route -p ADD 0.0.0.0 MASK 0.0.0.0 $gateway IF $($toKeep.InterfaceIndex) $metricStr"
                     Write-Host "      Trying route.exe: $command" -ForegroundColor Gray
                     cmd /c $command
                     if ($LASTEXITCODE -ne 0) {
@@ -152,6 +151,36 @@ if (-not $groupedRoutes) {
                     }
                 } catch {
                     Write-Host "      route.exe also failed: $($_.Exception.Message)" -ForegroundColor Red
+                }
+            }
+
+            # Fallback for IPv6: use netsh or New-NetRoute without PolicyStore
+            if (-not $reAddSucceeded -and $dest -eq "::/0") {
+                try {
+                    $metricVal = if ($null -ne $metric) { [int]$metric } else { 256 }
+                    # First try "set route" (modifies existing active route to be persistent)
+                    $netshCmd = "netsh interface ipv6 set route ::/0 interface=$($toKeep.InterfaceIndex) nexthop=$gateway metric=$metricVal store=persistent publish=Yes"
+                    Write-Host "      Trying netsh set: $netshCmd" -ForegroundColor Gray
+                    cmd /c $netshCmd 2>&1
+                    if ($LASTEXITCODE -ne 0) {
+                        # "set route" failed, try removing active then re-adding fresh
+                        Write-Host "      netsh set failed, removing active route and re-adding..." -ForegroundColor Yellow
+                        cmd /c "netsh interface ipv6 delete route ::/0 interface=$($toKeep.InterfaceIndex) nexthop=$gateway" 2>&1
+                        $addCmd = "netsh interface ipv6 add route ::/0 interface=$($toKeep.InterfaceIndex) nexthop=$gateway metric=$metricVal store=persistent publish=Yes"
+                        Write-Host "      Trying netsh add: $addCmd" -ForegroundColor Gray
+                        cmd /c $addCmd 2>&1
+                        if ($LASTEXITCODE -ne 0) {
+                            # Last resort: New-NetRoute without PolicyStore
+                            New-NetRoute -DestinationPrefix "::/0" -InterfaceIndex $toKeep.InterfaceIndex -NextHop $gateway -RouteMetric $metricVal -ErrorAction Stop
+                            Write-Host "    Re-added with New-NetRoute (active): ::/0 via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                        } else {
+                            Write-Host "    Re-added with netsh add: ::/0 via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                        }
+                    } else {
+                        Write-Host "    Made persistent with netsh set: ::/0 via $gateway on IF $($toKeep.InterfaceIndex)" -ForegroundColor Green
+                    }
+                } catch {
+                    Write-Host "      IPv6 route re-add failed: $($_.Exception.Message)" -ForegroundColor Red
                 }
             }
         }
@@ -176,17 +205,13 @@ if (-not $groupedRoutes) {
         $gateway = $toKeep.NextHop
         $metric = $toKeep.RouteMetric
         $interfaceIndex = $toKeep.InterfaceIndex
+        $isIPv4 = $toKeep.AddressFamily -eq "IPv4"
 
         $parts = $dest.Split("/")
         if ($parts.Count -ne 2) {
             Write-Host "  Invalid destination prefix format: $dest" -ForegroundColor Red
             continue
         }
-
-        $network = $parts[0]
-        $prefix = [int]$parts[1]
-        $netmask = Convert-PrefixToMask $prefix
-        $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
 
         # Delete all matching routes
         foreach ($route in $group.Group) {
@@ -205,8 +230,12 @@ if (-not $groupedRoutes) {
             Write-Host "  New-NetRoute failed: $($_.Exception.Message), falling back to route.exe " -ForegroundColor Yellow
         }
 
-        # Fallback to route.exe if New-NetRoute failed
-        if (-not $reAddSucceeded) {
+        # Fallback to route.exe if New-NetRoute failed (IPv4 only)
+        if (-not $reAddSucceeded -and $isIPv4) {
+            $network = $parts[0]
+            $prefix = [int]$parts[1]
+            $netmask = Convert-PrefixToMask $prefix
+            $metricStr = if ($null -ne $metric) { "METRIC $([int]$metric)" } else { "" }
             $command = "route -p ADD $network MASK $netmask $gateway IF $interfaceIndex"
             if ($metricStr -ne "") {
                 $command += " $metricStr"
@@ -228,8 +257,8 @@ if (-not $groupedRoutes) {
 
 # Step 3: Remove persistent routes bound to interfaces that no longer exist (stale after migration)
 Write-Host "Removing stale persistent routes on dead interfaces..." -ForegroundColor Yellow
-# Re-read persistent routes after Step 2 cleanup
-$allPersistent = Get-NetRoute -PolicyStore PersistentStore -AddressFamily IPv4 -ErrorAction SilentlyContinue
+# Re-read persistent routes after Step 2 cleanup (both IPv4 and IPv6)
+$allPersistent = Get-NetRoute -PolicyStore PersistentStore -ErrorAction SilentlyContinue
 # Collect interface indexes that are actually present on this machine (including hidden adapters like loopback)
 $activeIndexes = @(Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue | ForEach-Object { $_.InterfaceIndex })
 if ($activeIndexes.Count -eq 0) {
@@ -254,14 +283,18 @@ if ($activeIndexes.Count -eq 0) {
 # Step 4: Configure default gateways at NIC/IP configuration level
 Write-Host "Configuring default gateways at interface level..." -ForegroundColor Cyan
 
-# Get current default gateways after cleanup
-$currentDefaultGateways = Get-NetRoute -PolicyStore PersistentStore -AddressFamily IPv4 | Where-Object { $_.DestinationPrefix -eq "0.0.0.0/0" }
+# Get current default gateways after cleanup (both IPv4 and IPv6)
+$currentDefaultGateways = Get-NetRoute -PolicyStore PersistentStore | Where-Object {
+    $_.DestinationPrefix -eq "0.0.0.0/0" -or $_.DestinationPrefix -eq "::/0"
+}
 Write-Host "Configuring $($currentDefaultGateways.Count) remaining default gateway(s)..." -ForegroundColor Cyan
 
 foreach ($gateway in $currentDefaultGateways) {
     $nextHop = $gateway.NextHop
     $interfaceIndex = $gateway.InterfaceIndex
     $metric = $gateway.RouteMetric
+    $isIPv4 = $gateway.AddressFamily -eq "IPv4"
+    $family = if ($isIPv4) { "IPv4" } else { "IPv6" }
 
     # Check if interface still exists
     $interface = Get-NetAdapter | Where-Object { $_.InterfaceIndex -eq $interfaceIndex } -ErrorAction SilentlyContinue
@@ -271,46 +304,59 @@ foreach ($gateway in $currentDefaultGateways) {
     }
     
     $interfaceAlias = $interface.Name
-    Write-Host "  Processing Interface $interfaceIndex ($interfaceAlias) - Gateway $nextHop" -ForegroundColor Yellow
+    Write-Host "  Processing Interface $interfaceIndex ($interfaceAlias) - $family Gateway $nextHop" -ForegroundColor Yellow
 
     $ipConfig = Get-NetIPConfiguration -InterfaceIndex $interfaceIndex -ErrorAction SilentlyContinue
     $hasGatewayInConfig = $false
-    if ($ipConfig -and $ipConfig.IPv4DefaultGateway) {
-        $hasGatewayInConfig = $ipConfig.IPv4DefaultGateway.NextHop -contains $nextHop
+    if ($ipConfig) {
+        if ($isIPv4 -and $ipConfig.IPv4DefaultGateway) {
+            $hasGatewayInConfig = $ipConfig.IPv4DefaultGateway.NextHop -contains $nextHop
+        } elseif (-not $isIPv4 -and $ipConfig.IPv6DefaultGateway) {
+            $hasGatewayInConfig = $ipConfig.IPv6DefaultGateway.NextHop -contains $nextHop
+        }
     }
 
     if (-not $hasGatewayInConfig) {
-        Write-Host "    Interface IP config missing gateway, configuring..." -ForegroundColor Yellow
+        Write-Host "    Interface IP config missing $family gateway, configuring..." -ForegroundColor Yellow
 
-        $currentIP = Get-NetIPAddress -InterfaceIndex $interfaceIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.IPAddress -ne "127.0.0.1" -and -not $_.IPAddress.StartsWith("169.254") }
+        if ($isIPv4) {
+            $currentIP = Get-NetIPAddress -InterfaceIndex $interfaceIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.IPAddress -ne "127.0.0.1" -and -not $_.IPAddress.StartsWith("169.254") }
 
-        if ($currentIP) {
-            $ipAddress = $currentIP.IPAddress
-            $prefixLength = $currentIP.PrefixLength
+            if ($currentIP) {
+                $ipAddress = $currentIP.IPAddress
+                $prefixLength = $currentIP.PrefixLength
 
-            Write-Host "    Current IP: $ipAddress/$prefixLength, setting gateway: $nextHop" -ForegroundColor Yellow
+                Write-Host "    Current IP: $ipAddress/$prefixLength, setting gateway: $nextHop" -ForegroundColor Yellow
 
-            try {
                 $netshCmd = "netsh interface ipv4 set address name=`"$interfaceAlias`" static $ipAddress $(Convert-PrefixToMask $prefixLength) $nextHop $metric"
                 Write-Host "    Executing: $netshCmd" -ForegroundColor Gray
                 $result = cmd /c $netshCmd 2>&1
-                Write-Host "    Configured NIC gateway with netsh: $nextHop on $interfaceAlias" -ForegroundColor Green
-            } catch {
-                Write-Host "    Method 1 failed, trying PowerShell method..." -ForegroundColor Yellow
-                try {
-                    Remove-NetIPAddress -InterfaceIndex $interfaceIndex -AddressFamily IPv4 -Confirm:$false -ErrorAction SilentlyContinue
-                    New-NetIPAddress -InterfaceIndex $interfaceIndex -IPAddress $ipAddress -PrefixLength $prefixLength -DefaultGateway $nextHop -ErrorAction Stop
-                    Write-Host "    Reconfigured IP with gateway: $ipAddress -> $nextHop" -ForegroundColor Green
-                } catch {
-                    Write-Host "    All methods failed for interface gateway configuration: $($_.Exception.Message)" -ForegroundColor Red
-                    Write-Host "    Manual intervention may be required for interface $interfaceAlias" -ForegroundColor Red
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "    Configured NIC gateway with netsh: $nextHop on $interfaceAlias" -ForegroundColor Green
+                } else {
+                    Write-Host "    netsh failed (exit $LASTEXITCODE): $result, trying PowerShell method..." -ForegroundColor Yellow
+                    try {
+                        Remove-NetIPAddress -InterfaceIndex $interfaceIndex -AddressFamily IPv4 -Confirm:$false -ErrorAction SilentlyContinue
+                        New-NetIPAddress -InterfaceIndex $interfaceIndex -IPAddress $ipAddress -PrefixLength $prefixLength -DefaultGateway $nextHop -ErrorAction Stop
+                        Write-Host "    Reconfigured IP with gateway: $ipAddress -> $nextHop" -ForegroundColor Green
+                    } catch {
+                        Write-Host "    All methods failed for IPv4 gateway configuration: $($_.Exception.Message)" -ForegroundColor Red
+                    }
                 }
+            } else {
+                Write-Host "    Could not determine current IPv4 address for interface $interfaceIndex" -ForegroundColor Red
             }
         } else {
-            Write-Host "    Could not determine current IP address for interface $interfaceIndex" -ForegroundColor Red
+            # IPv6: use New-NetRoute directly (no netsh/route.exe for IPv6 gateways)
+            try {
+                New-NetRoute -DestinationPrefix "::/0" -InterfaceIndex $interfaceIndex -NextHop $nextHop -RouteMetric $metric -ErrorAction Stop
+                Write-Host "    Configured IPv6 gateway: $nextHop on $interfaceAlias" -ForegroundColor Green
+            } catch {
+                Write-Host "    Failed to configure IPv6 gateway: $($_.Exception.Message)" -ForegroundColor Red
+            }
         }
     } else {
-        Write-Host "    Interface IP config has gateway: $nextHop" -ForegroundColor Green
+        Write-Host "    Interface IP config has $family gateway: $nextHop" -ForegroundColor Green
     }
 }
 


### PR DESCRIPTION
Both remove_duplicate_persistent_routes scripts (standard and registry variants) filtered routes to IPv4-only, leaving stale IPv6 persistent routes untouched after migrating from an IPv6 ESXi host.

Changes:
- Remove the IPv4-only filter so all address families are processed
- Guard route.exe fallbacks with AddressFamily==IPv4
- Extend default gateway detection to include ::/0 alongside 0.0.0.0/0
- Add IPv6 gateway configuration in Step 4 using New-NetRoute (standard variant) and New-NetRoute cmdlet (registry variant, since Tcpip registry is IPv4-only)
- Widen stale-route sweep (Step 3) to cover both IPv4 and IPv6
- Fix duplicate gateway cleanup: check PersistentStore directly instead of Get-NetIPConfiguration (which reflects active routes and falsely skips the re-add)
- Add IPv6 route re-add fallback using 'netsh set route' to make existing active routes persistent when New-NetRoute -PolicyStore PersistentStore is unsupported (Windows Server 2019 compat)

Ref: https://redhat.atlassian.net/browse/MTV-6500
Resolves: MTV-6500