### PR TITLE
MTV-6508 | Fix Hyper-V template selection using VM guest OS

### DIFF
--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -36,6 +36,68 @@ const (
 	Ignored = "ignored"
 )
 
+// Template label keys
+const (
+	templateOSLabel       = "os.template.kubevirt.io/%s"
+	templateWorkloadLabel = "workload.template.kubevirt.io/server"
+	templateFlavorLabel   = "flavor.template.kubevirt.io/medium"
+	redHatGuestOS         = "red hat"
+	centosGuestOS         = "centos"
+	defaultTemplateOS     = "rhel8.1"
+)
+
+// mapHypervGuestOS maps Hyper-V guest OS name strings (from KVP exchange) to
+// KubeVirt template OS identifiers.
+func mapHypervGuestOS(guestOS string) string {
+	os := strings.ToLower(guestOS)
+	switch {
+	case strings.Contains(os, "windows server 2022"):
+		return "win2k22"
+	case strings.Contains(os, "windows server 2019"):
+		return "win2k19"
+	case strings.Contains(os, "windows server 2016"):
+		return "win2k16"
+	case strings.Contains(os, "windows server 2012 r2"):
+		return "win2k12r2"
+	case strings.Contains(os, "windows server 2012"):
+		return "win2k12r2"
+	case strings.Contains(os, "windows 11"):
+		return "win11"
+	case strings.Contains(os, "windows 10"):
+		return "win10"
+	case strings.Contains(os, "windows"):
+		return "win10"
+	case strings.Contains(os, redHatGuestOS) && (strings.Contains(os, " 9.") || strings.Contains(os, " 9 ") || strings.HasSuffix(os, " 9")):
+		return "rhel9.4"
+	case strings.Contains(os, redHatGuestOS) && (strings.Contains(os, " 8.") || strings.Contains(os, " 8 ") || strings.HasSuffix(os, " 8")):
+		return defaultTemplateOS
+	case strings.Contains(os, redHatGuestOS) && (strings.Contains(os, " 7.") || strings.Contains(os, " 7 ") || strings.HasSuffix(os, " 7")):
+		return "rhel7.7"
+	case strings.Contains(os, redHatGuestOS):
+		return defaultTemplateOS
+	case strings.Contains(os, centosGuestOS) && (strings.Contains(os, " 9.") || strings.Contains(os, " 9 ") || strings.HasSuffix(os, " 9")):
+		return "centos-stream9"
+	case strings.Contains(os, centosGuestOS) && (strings.Contains(os, " 8.") || strings.Contains(os, " 8 ") || strings.HasSuffix(os, " 8")):
+		return "centos8"
+	case strings.Contains(os, centosGuestOS) && (strings.Contains(os, " 7.") || strings.Contains(os, " 7 ") || strings.HasSuffix(os, " 7")):
+		return "centos7.0"
+	case strings.Contains(os, centosGuestOS):
+		return "centos7.0"
+	case strings.Contains(os, "ubuntu"):
+		return "ubuntu18.04"
+	case strings.Contains(os, "debian"):
+		return "debian10"
+	case strings.Contains(os, "fedora"):
+		return "fedora31"
+	case strings.Contains(os, "suse") || strings.Contains(os, "sles"):
+		return "opensuse15.0"
+	case strings.Contains(os, "linux"):
+		return defaultTemplateOS
+	default:
+		return defaultTemplateOS
+	}
+}
+
 type Builder struct {
 	*plancontext.Context
 }
@@ -385,8 +447,21 @@ func (r *Builder) Tasks(vmRef ref.Ref) (tasks []*plan.Task, err error) {
 	return
 }
 
-func (r *Builder) TemplateLabels(_ ref.Ref) (labels map[string]string, err error) {
+func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err error) {
+	vm := &model.VM{}
+	err = r.Source.Inventory.Find(vm, vmRef)
+	if err != nil {
+		err = liberr.Wrap(err, "vm", vmRef.String())
+		return
+	}
+
+	os := mapHypervGuestOS(vm.GuestOS)
+
 	labels = make(map[string]string)
+	labels[fmt.Sprintf(templateOSLabel, os)] = "true"
+	labels[templateWorkloadLabel] = "true"
+	labels[templateFlavorLabel] = "true"
+
 	return
 }
 

--- a/pkg/controller/plan/adapter/hyperv/builder_test.go
+++ b/pkg/controller/plan/adapter/hyperv/builder_test.go
@@ -1,6 +1,7 @@
 package hyperv
 
 import (
+	"fmt"
 	"testing"
 
 	hyperv "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
@@ -162,5 +163,89 @@ func TestBuildPairKey(t *testing.T) {
 					tc.networkID, tc.vlan, key, tc.expected)
 			}
 		})
+	}
+}
+
+func TestMapHypervGuestOS(t *testing.T) {
+	tests := []struct {
+		name     string
+		guestOS  string
+		expected string
+	}{
+		// Windows variants
+		{name: "Win Server 2022", guestOS: "Microsoft Windows Server 2022 Standard", expected: "win2k22"},
+		{name: "Win Server 2019", guestOS: "Microsoft Windows Server 2019 Datacenter", expected: "win2k19"},
+		{name: "Win Server 2016", guestOS: "Microsoft Windows Server 2016 Standard", expected: "win2k16"},
+		{name: "Win Server 2012 R2", guestOS: "Microsoft Windows Server 2012 R2 Datacenter", expected: "win2k12r2"},
+		{name: "Win Server 2012 (non-R2)", guestOS: "Microsoft Windows Server 2012 Datacenter", expected: "win2k12r2"},
+		{name: "Windows 11", guestOS: "Microsoft Windows 11 Enterprise", expected: "win11"},
+		{name: "Windows 10", guestOS: "Microsoft Windows 10 Pro", expected: "win10"},
+		{name: "Generic Windows", guestOS: "Microsoft Windows", expected: "win10"},
+
+		// RHEL variants - major version detection
+		{name: "RHEL 9.2", guestOS: "Red Hat Enterprise Linux 9.2 (Plow)", expected: "rhel9.4"},
+		{name: "RHEL 8.4", guestOS: "Red Hat Enterprise Linux 8.4 (Ootpa)", expected: defaultTemplateOS},
+		{name: "RHEL 7.9", guestOS: "Red Hat Enterprise Linux 7.9 (Maipo)", expected: "rhel7.7"},
+		{name: "RHEL 7 no minor", guestOS: "Red Hat Enterprise Linux 7", expected: "rhel7.7"},
+		{name: "RHEL 8 no minor", guestOS: "Red Hat Enterprise Linux 8", expected: defaultTemplateOS},
+		{name: "RHEL 9 no minor", guestOS: "Red Hat Enterprise Linux 9", expected: "rhel9.4"},
+		{name: "RHEL unknown version", guestOS: "Red Hat Enterprise Linux", expected: defaultTemplateOS},
+
+		// Version boundary: minor version must not confuse major detection
+		{name: "RHEL 7.9 not misidentified as 9", guestOS: "Red Hat Enterprise Linux 7.9", expected: "rhel7.7"},
+		{name: "RHEL 8.9 not misidentified as 9", guestOS: "Red Hat Enterprise Linux 8.9", expected: defaultTemplateOS},
+		{name: "CentOS 7.9 not misidentified as 9", guestOS: "CentOS Linux 7.9.2009 (Core)", expected: "centos7.0"},
+
+		// CentOS variants
+		{name: "CentOS Stream 9", guestOS: "CentOS Stream 9", expected: "centos-stream9"},
+		{name: "CentOS 8.5", guestOS: "CentOS Linux 8.5.2111", expected: "centos8"},
+		{name: "CentOS 7.6", guestOS: "CentOS Linux 7.6.1810 (Core)", expected: "centos7.0"},
+		{name: "CentOS generic", guestOS: "CentOS Linux", expected: "centos7.0"},
+
+		// Other Linux
+		{name: "Ubuntu", guestOS: "Ubuntu 22.04 LTS", expected: "ubuntu18.04"},
+		{name: "Debian", guestOS: "Debian GNU/Linux 11", expected: "debian10"},
+		{name: "Fedora", guestOS: "Fedora Linux 38", expected: "fedora31"},
+		{name: "SUSE", guestOS: "SUSE Linux Enterprise Server 15", expected: "opensuse15.0"},
+		{name: "SLES", guestOS: "SLES 12 SP5", expected: "opensuse15.0"},
+		{name: "Generic Linux", guestOS: "Some Linux Distribution", expected: defaultTemplateOS},
+
+		// Fallback
+		{name: "Unknown OS", guestOS: "FreeBSD 13", expected: defaultTemplateOS},
+		{name: "Empty string", guestOS: "", expected: defaultTemplateOS},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mapHypervGuestOS(tc.guestOS)
+			if result != tc.expected {
+				t.Errorf("mapHypervGuestOS(%q) = %q, want %q", tc.guestOS, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMapHypervGuestOS_TemplateLabels(t *testing.T) {
+	guestOS := "Red Hat Enterprise Linux 8.4 (Ootpa)"
+	os := mapHypervGuestOS(guestOS)
+
+	expectedLabels := map[string]string{
+		"os.template.kubevirt.io/" + os:        "true",
+		"workload.template.kubevirt.io/server": "true",
+		"flavor.template.kubevirt.io/medium":   "true",
+	}
+
+	labels := make(map[string]string)
+	labels[fmt.Sprintf(templateOSLabel, os)] = "true"
+	labels[templateWorkloadLabel] = "true"
+	labels[templateFlavorLabel] = "true"
+
+	if len(labels) != len(expectedLabels) {
+		t.Fatalf("expected %d labels, got %d", len(expectedLabels), len(labels))
+	}
+	for k, v := range expectedLabels {
+		if labels[k] != v {
+			t.Errorf("label %q = %q, want %q", k, labels[k], v)
+		}
 	}
 }


### PR DESCRIPTION
The Hyper-V builder's TemplateLabels() returned an empty label map, causing findTemplate() to match all KubeVirt templates and select the newest by creation time. This resulted in incorrect templates being applied (e.g. a RHEL 8 VM getting windows10-highperformance).

Populate TemplateLabels() by fetching the VM's GuestOS from inventory and mapping it to the corresponding KubeVirt template OS identifier (e.g. "rhel8.1", "win2k19") via a new mapHypervGuestOS() function.

Ref: https://redhat.atlassian.net/browse/MTV-6508
Resolves: MTV-6508