### PR TITLE
MTV-6524 | Skip MAC conflict checks for OCP migrations

### DIFF
--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -179,51 +179,10 @@ func (r *Validator) InvalidDiskSizes(vmRef ref.Ref) ([]string, error) {
 }
 
 func (r *Validator) MacConflicts(vmRef ref.Ref) ([]planbase.MacConflict, error) {
-	// Only check MAC conflicts for live migrations
-	// For cold migrations, the source VM is shut down, so no conflicts occur
-	if r.Plan.Spec.Type != api.MigrationLive {
-		r.log.V(1).Info("Skipping MAC conflict check for non-live migration",
-			"migrationType", r.Plan.Spec.Type, "vm", vmRef.String())
-		return []planbase.MacConflict{}, nil
-	}
-
-	r.log.Info("Checking MAC conflicts for live migration", "vm", vmRef.String())
-
-	// Get source VM using common helper
-	vm, err := planbase.FindSourceVM[inventory.VM](r.Source.Inventory, vmRef)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get destination VMs and extract their MACs using common helper
-	destinationVMs, err := planbase.GetDestinationVMsFromInventory(r.Destination.Inventory, web.Param{
-		Key:   web.DetailParam,
-		Value: "all",
-	})
-	if err != nil {
-		return nil, liberr.Wrap(err)
-	}
-
-	// Extract source VM MACs
-	var sourceMacs []string
-	if vm.Object.Spec.Template != nil {
-		for _, iface := range vm.Object.Spec.Template.Spec.Domain.Devices.Interfaces {
-			// Include all MACs, even empty ones - the helper function will handle filtering
-			sourceMacs = append(sourceMacs, iface.MacAddress)
-		}
-	}
-
-	// Use common helper to detect conflicts
-	conflicts := planbase.CheckMacConflicts(sourceMacs, destinationVMs)
-
-	if len(conflicts) > 0 {
-		r.log.Info("MAC conflicts detected for live migration",
-			"vm", vmRef.String(), "conflicts", len(conflicts))
-	} else {
-		r.log.V(1).Info("No MAC conflicts detected", "vm", vmRef.String())
-	}
-
-	return conflicts, nil
+	// OCP does not check MAC conflicts. The source VM is already off, or
+	// will be shut down after migration, so the MAC is not used on both
+	// sides. See MTV-6524.
+	return []planbase.MacConflict{}, nil
 }
 
 func (r *Validator) SharedDisks(vmRef ref.Ref, client k8sclient.Client) (ok bool, s string, s2 string, err error) {

--- a/pkg/controller/plan/adapter/ocp/validator_test.go
+++ b/pkg/controller/plan/adapter/ocp/validator_test.go
@@ -16,15 +16,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestMacConflicts_SkipsCheckForColdMigrations(t *testing.T) {
-	coldMigrationTypes := []api.MigrationType{
+func TestMacConflicts_SkipsCheck(t *testing.T) {
+	migrationTypes := []api.MigrationType{
 		api.MigrationCold,
 		"", // Default migration type
+		api.MigrationLive,
 	}
 
-	for _, migrationType := range coldMigrationTypes {
+	for _, migrationType := range migrationTypes {
 		t.Run("migration_type_"+string(migrationType), func(t *testing.T) {
-			// Create validator with cold migration type
 			validator := &Validator{
 				log: logging.WithName("test").WithValues("test", "mac-conflicts"),
 				Context: &plancontext.Context{
@@ -36,60 +36,20 @@ func TestMacConflicts_SkipsCheckForColdMigrations(t *testing.T) {
 				},
 			}
 
-			// Mock VM reference
 			vmRef := ref.Ref{
 				ID:        "test-vm-id",
 				Name:      "test-vm",
 				Namespace: "test-ns",
 			}
 
-			// Call MacConflicts - should return empty result without checking inventory
+			// Should return empty result without checking inventory
 			conflicts, err := validator.MacConflicts(vmRef)
 
-			// Should not error and should return empty conflicts
 			if err != nil {
-				t.Errorf("Cold migration should not error, got: %v", err)
+				t.Errorf("MAC conflict check should not error, got: %v", err)
 			}
 			if len(conflicts) != 0 {
-				t.Errorf("Cold migration should return no conflicts, got %d conflicts", len(conflicts))
-			}
-
-			t.Logf("✓ %s migration correctly skipped MAC conflict check", string(migrationType))
-		})
-	}
-}
-
-func TestMacConflicts_BehaviorDocumentation(t *testing.T) {
-	// This test documents the expected behavior without testing implementation details
-	testCases := []struct {
-		migrationType    api.MigrationType
-		description      string
-		expectsInventory bool
-	}{
-		{
-			migrationType:    api.MigrationCold,
-			description:      "Cold migration shuts down source VM, no MAC conflicts possible",
-			expectsInventory: false,
-		},
-		{
-			migrationType:    "",
-			description:      "Default migration is cold, no MAC conflicts possible",
-			expectsInventory: false,
-		},
-		{
-			migrationType:    api.MigrationLive,
-			description:      "Live migration keeps source VM running, MAC conflicts possible",
-			expectsInventory: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run("documents_"+string(tc.migrationType), func(t *testing.T) {
-			t.Logf("Migration type '%s': %s", tc.migrationType, tc.description)
-			if tc.expectsInventory {
-				t.Logf("  → Should check destination inventory for MAC conflicts")
-			} else {
-				t.Logf("  → Should skip MAC conflict check entirely")
+				t.Errorf("MAC conflict check should return no conflicts, got %d conflicts", len(conflicts))
 			}
 		})
 	}


### PR DESCRIPTION
OCP no longer validates source MACs against destination VMs. The source VM is already off, or will be shut down after migration, so the MAC is not used on both sides.

Test and test run logs in the ticket.

Ref: https://redhat.atlassian.net/browse/MTV-6524
Resolves: MTV-6524