### PR TITLE
MTV-6512 | Optimize Hyper-V inventory staging and refresh

### DIFF
--- a/pkg/controller/provider/container/hyperv/client.go
+++ b/pkg/controller/provider/container/hyperv/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/dustin/go-humanize"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -97,6 +98,33 @@ type Client struct {
 	vmCache          []types.VM
 	netCached        bool
 	netCache         []types.Network
+	// LightMode skips expensive per-disk Get-VHD calls during initial staging.
+	// Disk capacity and RCT are populated on the first refresh cycle.
+	LightMode bool
+	// localInfoOnce guards lazy initialization of localInfo so that concurrent
+	// goroutines (VM prefetch, Phase 2 adapters) don't race.
+	localInfoOnce sync.Once
+	localInfo     *driver.ComputerInfoData
+	localInfoErr  error
+	// vmPrefetch holds pre-fetched VM + detail data from a background goroutine.
+	// Set by StartVMPrefetch, consumed by ListVMs.
+	vmPrefetch     chan vmPrefetchResult
+	vmPrefetchDone bool
+	// netLocalPrefetch holds pre-fetched local network data from a background
+	// goroutine. Started before Phase 1 so it overlaps with ClusterAdapter.
+	netLocalPrefetch     chan netLocalPrefetchResult
+	netLocalPrefetchDone bool
+}
+
+type netLocalPrefetchResult struct {
+	networks []driver.Network
+	err      error
+}
+
+// vmPrefetchResult holds the result of a background VM pre-fetch.
+type vmPrefetchResult struct {
+	results []nodeResult
+	err     error
 }
 
 // Connect establishes a WinRM connection to the HyperV host using Secret credentials.
@@ -135,29 +163,86 @@ func (r *Client) Connect(provider *api.Provider) (err error) {
 }
 
 // getClusterCache returns cached cluster+node data, fetching on first call per cycle.
+// Uses the combined GetClusterInfo call to save a WinRM round trip.
 func (r *Client) getClusterCache() (*clusterCache, error) {
 	if r.cache != nil {
 		return r.cache, nil
 	}
-	clusterData, err := r.driver.GetCluster()
+	info, err := r.driver.GetClusterInfo()
 	if err != nil {
-		return nil, fmt.Errorf("GetCluster failed: %w", err)
+		// Fall back to separate calls if the combined script isn't supported.
+		clusterData, cErr := r.driver.GetCluster()
+		if cErr != nil {
+			return nil, fmt.Errorf("GetCluster failed: %w", cErr)
+		}
+		nodesData, nErr := r.driver.GetClusterNodes()
+		if nErr != nil {
+			return nil, fmt.Errorf("GetClusterNodes failed: %w", nErr)
+		}
+		r.cache = &clusterCache{cluster: clusterData, nodes: nodesData}
+		return r.cache, nil
 	}
-	nodesData, err := r.driver.GetClusterNodes()
-	if err != nil {
-		return nil, fmt.Errorf("GetClusterNodes failed: %w", err)
-	}
-	r.cache = &clusterCache{cluster: clusterData, nodes: nodesData}
+	r.cache = &clusterCache{cluster: &info.Cluster, nodes: info.Nodes}
 	return r.cache, nil
 }
 
 // InvalidateCycleCache clears all per-cycle caches so the next call re-fetches.
 func (r *Client) InvalidateCycleCache() {
 	r.cache = nil
+	r.localInfoOnce = sync.Once{}
+	r.localInfo = nil
+	r.localInfoErr = nil
 	r.vmCached = false
 	r.vmCache = nil
 	r.netCached = false
+	r.vmPrefetch = nil
+	r.vmPrefetchDone = false
+	r.netLocalPrefetch = nil
+	r.netLocalPrefetchDone = false
 	r.netCache = nil
+}
+
+// StartVMPrefetch kicks off the combined VM+details script on all cluster nodes
+// in background goroutines. Call this after the cluster cache is populated
+// (Phase 1) so it can overlap with Phase 2 adapters. The results are consumed
+// by ListVMs when it runs in the DiskAdapter phase.
+func (r *Client) StartVMPrefetch() {
+	if r.vmPrefetchDone || r.vmPrefetch != nil {
+		return
+	}
+	if r.provider == nil || !r.provider.IsHyperVCluster() || !r.LightMode {
+		return
+	}
+
+	ch := make(chan vmPrefetchResult, 1)
+	r.vmPrefetch = ch
+
+	go func() {
+		results, err := r.fetchAllNodesVMsAndDetails()
+		ch <- vmPrefetchResult{results: results, err: err}
+	}()
+}
+
+// PrewarmClusterCache fetches and caches the cluster identity + node list.
+// Call this early so that subsequent phases can start background prefetches
+// that depend on knowing the cluster topology.
+func (r *Client) PrewarmClusterCache() (*clusterCache, error) {
+	return r.getClusterCache()
+}
+
+// StartNetworkPrefetch kicks off ListAllNetworks (local switches) in the
+// background. This doesn't need the cluster cache, so it can overlap with
+// Phase 1's ClusterAdapter. The result is consumed by ListNetworks.
+func (r *Client) StartNetworkPrefetch() {
+	if r.netLocalPrefetchDone || r.netLocalPrefetch != nil || r.netCached {
+		return
+	}
+	ch := make(chan netLocalPrefetchResult, 1)
+	r.netLocalPrefetch = ch
+	go func() {
+		nets, err := r.driver.ListAllNetworks()
+		ch <- netLocalPrefetchResult{networks: nets, err: err}
+	}()
 }
 
 // ListCluster returns the cluster info when in cluster mode, nil for standalone.
@@ -189,25 +274,49 @@ func (r *Client) ListHosts() ([]types.Host, error) {
 	if err != nil {
 		return nil, err
 	}
-	var hosts []types.Host
-	for _, n := range cc.nodes {
-		host := types.Host{
+
+	type hostResult struct {
+		index int
+		info  *driver.ComputerInfoData
+	}
+	hosts := make([]types.Host, len(cc.nodes))
+	ch := make(chan hostResult, len(cc.nodes))
+
+	for i, n := range cc.nodes {
+		hosts[i] = types.Host{
 			ID:          n.Id,
 			Name:        n.Name,
 			State:       driver.ClusterNodeStateName(n.State),
 			ClusterName: cc.cluster.Name,
 		}
-		info, err := r.getNodeComputerInfo(n.Name)
-		if err != nil {
-			r.Log.V(1).Info("Failed to get hardware info for node", "node", n.Name, "error", err)
-		} else if info != nil {
-			host.CpuCount = info.NumberOfProcessors
-			host.CpuCores = info.NumberOfLogicalProcessors
-			host.MemoryMB = info.TotalVisibleMemoryKB / 1024
+		go func(idx int, name string) {
+			info, err := r.getNodeComputerInfo(name)
+			if err != nil {
+				r.Log.V(1).Info("Failed to get hardware info for node", "node", name, "error", err)
+			}
+			ch <- hostResult{index: idx, info: info}
+		}(i, n.Name)
+	}
+
+	for range cc.nodes {
+		res := <-ch
+		if res.info != nil {
+			hosts[res.index].CpuCount = res.info.NumberOfProcessors
+			hosts[res.index].CpuCores = res.info.NumberOfLogicalProcessors
+			hosts[res.index].MemoryMB = res.info.TotalVisibleMemoryKB / 1024
 		}
-		hosts = append(hosts, host)
 	}
 	return hosts, nil
+}
+
+// getLocalComputerInfo returns the entry-point host's ComputerInfo, cached per
+// cycle. Safe for concurrent use — sync.Once ensures the WinRM call runs
+// exactly once even when called from parallel goroutines.
+func (r *Client) getLocalComputerInfo() (*driver.ComputerInfoData, error) {
+	r.localInfoOnce.Do(func() {
+		r.localInfo, r.localInfoErr = r.driver.GetComputerInfo()
+	})
+	return r.localInfo, r.localInfoErr
 }
 
 // getNodeComputerInfo fetches hardware info from a specific cluster node.
@@ -226,9 +335,172 @@ func (r *Client) getNodeComputerInfo(nodeName string) (*driver.ComputerInfoData,
 	return &info, nil
 }
 
+// nodeResult holds the combined VM list + detail map from a single node.
+type nodeResult struct {
+	nodeName string
+	vms      []driver.VMData
+	details  map[string]*batchVMDetail
+	err      error
+}
+
+// listAndEnrichClusterVMs assembles VM data from per-node results, applies
+// owner-node enrichment, and maps disk/NIC details. If a pre-fetch was
+// started with StartVMPrefetch, its results are consumed here. Otherwise
+// the combined script is run on-demand.
+func (r *Client) listAndEnrichClusterVMs(networks []types.Network) ([]types.VM, error) {
+	var nodeResults []nodeResult
+
+	if r.vmPrefetch != nil && !r.vmPrefetchDone {
+		// Consume pre-fetched results (blocks until prefetch completes).
+		pf := <-r.vmPrefetch
+		r.vmPrefetchDone = true
+		if pf.err != nil {
+			return nil, pf.err
+		}
+		nodeResults = pf.results
+	} else {
+		// No pre-fetch available — run synchronously.
+		results, err := r.fetchAllNodesVMsAndDetails()
+		if err != nil {
+			return nil, err
+		}
+		nodeResults = results
+	}
+
+	var allVMs []types.VM
+	allDetails := make(map[string]*batchVMDetail)
+	for _, res := range nodeResults {
+		for j := range res.vms {
+			res.vms[j].ComputerName = res.nodeName
+			dom := &driver.WinRMDomain{VMDataPtr: &res.vms[j]}
+			vm, err := r.getVMBaseFromDomain(dom)
+			if err != nil {
+				r.Log.Error(err, "Failed to process domain")
+				continue
+			}
+			allVMs = append(allVMs, *vm)
+		}
+		for k, v := range res.details {
+			allDetails[k] = v
+		}
+	}
+
+	r.enrichVMsWithOwnerNode(allVMs)
+
+	if len(allDetails) > 0 {
+		allIdx := make([]int, len(allVMs))
+		for i := range allVMs {
+			allIdx[i] = i
+		}
+		r.applyBatchDetails(allVMs, allIdx, allDetails, networks)
+	}
+
+	return allVMs, nil
+}
+
+// fetchAllNodesVMsAndDetails runs the combined script on all cluster nodes
+// concurrently and returns the per-node results. Used both by StartVMPrefetch
+// (background) and listAndEnrichClusterVMs (synchronous fallback).
+func (r *Client) fetchAllNodesVMsAndDetails() ([]nodeResult, error) {
+	cc, err := r.getClusterCache()
+	if err != nil {
+		return nil, fmt.Errorf("cluster cache unavailable: %w", err)
+	}
+
+	localInfo, err := r.getLocalComputerInfo()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine local hostname: %w", err)
+	}
+	localName := localInfo.DNSHostName
+
+	light := r.LightMode
+	script := ps.ListVMsWithDetailsLight
+	if !light {
+		script = ps.ListAllVMs
+	}
+
+	ch := make(chan nodeResult, len(cc.nodes)+1)
+
+	go func() {
+		r.fetchNodeVMsAndDetails(ch, localName, "", script, light)
+	}()
+
+	remoteCount := 0
+	for _, node := range cc.nodes {
+		if strings.EqualFold(node.Name, localName) || node.State != driver.ClusterNodeStateUp {
+			continue
+		}
+		remoteCount++
+		go func(name string) {
+			r.fetchNodeVMsAndDetails(ch, name, name, script, light)
+		}(node.Name)
+	}
+
+	var results []nodeResult
+	for i := 0; i < 1+remoteCount; i++ {
+		res := <-ch
+		if res.err != nil {
+			return nil, fmt.Errorf("failed to list VMs on %s: %w", res.nodeName, res.err)
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}
+
+// fetchNodeVMsAndDetails runs the combined or list-only script on a node and
+// sends the parsed result to the channel. If remoteName is empty, runs locally.
+// The light parameter controls output parsing, captured by the caller to
+// avoid reading r.LightMode from a concurrent goroutine.
+func (r *Client) fetchNodeVMsAndDetails(ch chan<- nodeResult, nodeName, remoteName, script string, light bool) {
+	var stdout string
+	var err error
+	if remoteName == "" {
+		stdout, err = r.driver.ExecuteCommand(script)
+	} else {
+		stdout, err = r.driver.RunOnNode(script, remoteName)
+	}
+	if err != nil {
+		ch <- nodeResult{nodeName: nodeName, err: err}
+		return
+	}
+	if stdout == "" {
+		ch <- nodeResult{nodeName: nodeName}
+		return
+	}
+
+	if light {
+		// Combined output: {"VMs":[...],"Details":{...}}
+		var combined driver.VMsWithDetailsData
+		if err := json.Unmarshal([]byte(stdout), &combined); err != nil {
+			ch <- nodeResult{nodeName: nodeName, err: fmt.Errorf("parse combined output: %w", err)}
+			return
+		}
+		vms, err := driver.UnmarshalArrayOrSingle[driver.VMData](combined.VMs)
+		if err != nil {
+			ch <- nodeResult{nodeName: nodeName, err: fmt.Errorf("parse VMs: %w", err)}
+			return
+		}
+		var details map[string]*batchVMDetail
+		if len(combined.Details) > 0 {
+			if err := json.Unmarshal(combined.Details, &details); err != nil {
+				r.Log.V(1).Info("Failed to parse combined details, will enrich later", "node", nodeName, "error", err)
+			}
+		}
+		ch <- nodeResult{nodeName: nodeName, vms: vms, details: details}
+	} else {
+		// List-only output: [...]
+		vms, err := driver.UnmarshalArrayOrSingle[driver.VMData]([]byte(stdout))
+		if err != nil {
+			ch <- nodeResult{nodeName: nodeName, err: fmt.Errorf("parse VMs: %w", err)}
+			return
+		}
+		ch <- nodeResult{nodeName: nodeName, vms: vms}
+	}
+}
+
 // ListVMs collects all VMs from the HyperV host via WinRM.
-// In cluster mode, VMs are enriched with OwnerNode from cluster group data.
-// Uses batch PowerShell to minimize WinRM round trips.
+// In cluster mode, VMs are collected from all nodes concurrently using a
+// combined script (list + details in one WinRM call per node).
 func (r *Client) ListVMs() ([]types.VM, error) {
 	if r.vmCached {
 		return r.vmCache, nil
@@ -241,33 +513,50 @@ func (r *Client) ListVMs() ([]types.VM, error) {
 
 	isCluster := r.provider != nil && r.provider.IsHyperVCluster()
 
-	var domains []driver.Domain
-	if isCluster {
-		domains, err = r.driver.ListAllClusterDomains()
-	} else {
-		domains, err = r.driver.ListAllDomains()
-	}
-	if err != nil {
-		return nil, err
-	}
-
 	var vms []types.VM
-	for _, domain := range domains {
-		vm, err := r.getVMBaseFromDomain(domain)
+	if isCluster && r.LightMode {
+		// Combined path: list + light details in one call per node
+		vms, err = r.listAndEnrichClusterVMs(networks)
 		if err != nil {
-			r.Log.Error(err, "Failed to process domain")
-			_ = domain.Free()
-			continue
+			return nil, err
 		}
-		vms = append(vms, *vm)
-		_ = domain.Free()
-	}
-
-	if isCluster {
+	} else if isCluster {
+		// Full mode: separate list + enrich
+		var domains []driver.Domain
+		domains, err = r.listClusterDomainsParallel()
+		if err != nil {
+			return nil, err
+		}
+		for _, domain := range domains {
+			vm, vmErr := r.getVMBaseFromDomain(domain)
+			if vmErr != nil {
+				r.Log.Error(vmErr, "Failed to process domain")
+				_ = domain.Free()
+				continue
+			}
+			vms = append(vms, *vm)
+			_ = domain.Free()
+		}
 		r.enrichVMsWithOwnerNode(vms)
+		r.enrichVMDetails(vms, networks)
+	} else {
+		var domains []driver.Domain
+		domains, err = r.driver.ListAllDomains()
+		if err != nil {
+			return nil, err
+		}
+		for _, domain := range domains {
+			vm, vmErr := r.getVMBaseFromDomain(domain)
+			if vmErr != nil {
+				r.Log.Error(vmErr, "Failed to process domain")
+				_ = domain.Free()
+				continue
+			}
+			vms = append(vms, *vm)
+			_ = domain.Free()
+		}
+		r.enrichVMDetails(vms, networks)
 	}
-
-	r.enrichVMDetails(vms, networks)
 
 	r.validateDisksOnSMB(vms)
 
@@ -277,27 +566,86 @@ func (r *Client) ListVMs() ([]types.VM, error) {
 	return vms, nil
 }
 
+// listClusterDomainsParallel runs Get-VM on every cluster node concurrently.
+// Used in full (non-light) mode where details are collected separately.
+func (r *Client) listClusterDomainsParallel() ([]driver.Domain, error) {
+	cc, err := r.getClusterCache()
+	if err != nil {
+		return nil, fmt.Errorf("cluster cache unavailable for parallel VM list: %w", err)
+	}
+
+	localInfo, err := r.getLocalComputerInfo()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine local hostname: %w", err)
+	}
+	localName := localInfo.DNSHostName
+
+	ch := make(chan nodeResult, len(cc.nodes)+1)
+
+	go func() {
+		r.fetchNodeVMsAndDetails(ch, localName, "", ps.ListAllVMs, false)
+	}()
+
+	remoteCount := 0
+	for _, node := range cc.nodes {
+		if strings.EqualFold(node.Name, localName) || node.State != driver.ClusterNodeStateUp {
+			continue
+		}
+		remoteCount++
+		go func(name string) {
+			r.fetchNodeVMsAndDetails(ch, name, name, ps.ListAllVMs, false)
+		}(node.Name)
+	}
+
+	var allDomains []driver.Domain
+	for i := 0; i < 1+remoteCount; i++ {
+		res := <-ch
+		if res.err != nil {
+			return nil, fmt.Errorf("failed to list VMs on %s: %w", res.nodeName, res.err)
+		}
+		for j := range res.vms {
+			res.vms[j].ComputerName = res.nodeName
+			allDomains = append(allDomains, &driver.WinRMDomain{VMDataPtr: &res.vms[j]})
+		}
+	}
+	return allDomains, nil
+}
+
 // enrichVMDetails populates VM security, checkpoints, disk capacity/RCT, guest OS,
 // and guest networks using batch PowerShell (per-node in cluster mode, local otherwise).
+// In cluster mode, per-node batch calls run concurrently (the WinRM client is safe
+// for parallel use because each call opens its own shell over HTTP).
 func (r *Client) enrichVMDetails(vms []types.VM, networks []types.Network) {
 	if r.provider != nil && r.provider.IsHyperVCluster() {
-		// Group VMs by OwnerNode for per-node batch calls.
 		nodeVMs := make(map[string][]int)
 		for i := range vms {
 			node := vms[i].OwnerNode
 			nodeVMs[node] = append(nodeVMs[node], i)
 		}
+
+		type nodeResult struct {
+			node     string
+			indices  []int
+			batchMap map[string]*batchVMDetail
+			err      error
+		}
+		results := make(chan nodeResult, len(nodeVMs))
 		for node, indices := range nodeVMs {
-			batchMap, err := r.collectBatchVMDetails(node)
-			if err != nil {
-				r.Log.Error(err, "Batch detail collection failed for node, falling back to per-VM", "node", node)
-				r.fallbackPerVMDetails(vms, indices, networks)
+			go func(n string, idx []int) {
+				bm, err := r.collectBatchVMDetails(n)
+				results <- nodeResult{node: n, indices: idx, batchMap: bm, err: err}
+			}(node, indices)
+		}
+		for range nodeVMs {
+			res := <-results
+			if res.err != nil {
+				r.Log.Error(res.err, "Batch detail collection failed for node, falling back to per-VM", "node", res.node)
+				r.fallbackPerVMDetails(vms, res.indices, networks)
 				continue
 			}
-			r.applyBatchDetails(vms, indices, batchMap, networks)
+			r.applyBatchDetails(vms, res.indices, res.batchMap, networks)
 		}
 	} else {
-		// Standalone: single batch call for all VMs on this host.
 		allIndices := make([]int, len(vms))
 		for i := range vms {
 			allIndices[i] = i
@@ -387,10 +735,33 @@ func (r *Client) enrichVMsWithOwnerNode(vms []types.VM) {
 	}
 }
 
-// collectBatchVMDetails runs the two batch PowerShell scripts (hardware + guest)
-// on the given node and returns a merged map of VM name -> details.
+// collectBatchVMDetails runs batch PowerShell on the given node.
+// In LightMode (initial staging), it uses BatchGetVMDetailsLight which skips
+// the expensive Get-VHD per disk. The full script is used during refresh.
 func (r *Client) collectBatchVMDetails(computerName string) (map[string]*batchVMDetail, error) {
-	// Part 1: Security, checkpoints, disk capacity/RCT
+	script := ps.BatchGetVMDetails
+	if r.LightMode {
+		script = ps.BatchGetVMDetailsLight
+	}
+	out, err := r.driver.RunOnNode(script, computerName)
+	if err != nil {
+		r.Log.V(1).Info("Merged batch script failed, trying split fallback", "node", computerName, "error", err)
+		return r.collectBatchVMDetailsSplit(computerName)
+	}
+	out = strings.TrimSpace(out)
+	result := make(map[string]*batchVMDetail)
+	if out != "" && out != "{}" && out != "null" {
+		if err := json.Unmarshal([]byte(out), &result); err != nil {
+			r.Log.V(1).Info("Parse merged batch failed, trying split fallback", "node", computerName, "error", err)
+			return r.collectBatchVMDetailsSplit(computerName)
+		}
+	}
+	return result, nil
+}
+
+// collectBatchVMDetailsSplit is the legacy two-call path: hardware first, then guest.
+// Used as a fallback if the merged script exceeds the host's WinRM command limit.
+func (r *Client) collectBatchVMDetailsSplit(computerName string) (map[string]*batchVMDetail, error) {
 	hwOut, err := r.driver.RunOnNode(ps.BatchGetVMHardware, computerName)
 	if err != nil {
 		return nil, fmt.Errorf("batch hardware details failed: %w", err)
@@ -403,7 +774,6 @@ func (r *Client) collectBatchVMDetails(computerName string) (map[string]*batchVM
 		}
 	}
 
-	// Part 2: Guest OS and guest networks (only running VMs)
 	guestOut, err := r.driver.RunOnNode(ps.BatchGetVMGuest, computerName)
 	if err != nil {
 		r.Log.V(1).Info("Batch guest details failed, hardware details still usable", "node", computerName, "error", err)
@@ -419,7 +789,6 @@ func (r *Client) collectBatchVMDetails(computerName string) (map[string]*batchVM
 		return result, nil
 	}
 
-	// Merge guest info into hardware results
 	for vmName, guest := range guestMap {
 		if hw, exists := result[vmName]; exists {
 			hw.GuestOS = guest.GuestOS
@@ -668,14 +1037,22 @@ func (r *Client) ListNetworks() ([]types.Network, error) {
 		return r.netCache, nil
 	}
 
-	netDomains, err := r.driver.ListAllNetworks()
+	var netDomains []driver.Network
+	var err error
+	if r.netLocalPrefetch != nil && !r.netLocalPrefetchDone {
+		pf := <-r.netLocalPrefetch
+		r.netLocalPrefetchDone = true
+		netDomains, err = pf.networks, pf.err
+	} else {
+		netDomains, err = r.driver.ListAllNetworks()
+	}
 	if err != nil {
 		return nil, err
 	}
 
 	localName := ""
 	if r.provider != nil && r.provider.IsHyperVCluster() {
-		if info, err := r.driver.GetComputerInfo(); err == nil {
+		if info, err := r.getLocalComputerInfo(); err == nil {
 			localName = info.DNSHostName
 		}
 	}
@@ -721,9 +1098,9 @@ func (r *Client) ListNetworks() ([]types.Network, error) {
 	return result, nil
 }
 
-// mergeRemoteNodeNetworks queries Get-VMSwitch on each remote cluster node.
-// New switches are appended to result; switches whose UUID was already seen
-// get the remote node appended to their OwnerNodes list.
+// mergeRemoteNodeNetworks queries Get-VMSwitch on each remote cluster node
+// concurrently and merges the results. New switches are appended to result,
+// switches whose UUID was already seen get the remote node appended to OwnerNodes.
 func (r *Client) mergeRemoteNodeNetworks(result *[]types.Network, seen map[string]bool) {
 	cc, err := r.getClusterCache()
 	if err != nil {
@@ -731,36 +1108,53 @@ func (r *Client) mergeRemoteNodeNetworks(result *[]types.Network, seen map[strin
 		return
 	}
 
-	localInfo, err := r.driver.GetComputerInfo()
+	localInfo, err := r.getLocalComputerInfo()
 	if err != nil {
 		r.Log.V(1).Info("Cannot determine local hostname for network dedup", "error", err)
 		return
 	}
 	localName := strings.ToUpper(localInfo.DNSHostName)
 
+	type nodeSwitches struct {
+		nodeName string
+		switches []driver.SwitchData
+	}
+	ch := make(chan nodeSwitches, len(cc.nodes))
+	count := 0
 	for _, node := range cc.nodes {
 		if strings.EqualFold(node.Name, localName) || node.State != driver.ClusterNodeStateUp {
 			continue
 		}
-		stdout, err := r.driver.RunOnNode(ps.ListAllSwitches, node.Name)
-		if err != nil {
-			r.Log.Info("Failed to collect switches from remote node", "node", node.Name, "error", err)
-			continue
-		}
-		stdout = strings.TrimSpace(stdout)
-		if stdout == "" {
-			continue
-		}
-		switchesData, err := driver.UnmarshalArrayOrSingle[driver.SwitchData]([]byte(stdout))
-		if err != nil {
-			r.Log.Info("Failed to parse remote node switches", "node", node.Name, "error", err)
-			continue
-		}
-		for _, sw := range switchesData {
+		count++
+		go func(name string) {
+			stdout, err := r.driver.RunOnNode(ps.ListAllSwitches, name)
+			if err != nil {
+				r.Log.Info("Failed to collect switches from remote node", "node", name, "error", err)
+				ch <- nodeSwitches{nodeName: name}
+				return
+			}
+			stdout = strings.TrimSpace(stdout)
+			if stdout == "" {
+				ch <- nodeSwitches{nodeName: name}
+				return
+			}
+			data, err := driver.UnmarshalArrayOrSingle[driver.SwitchData]([]byte(stdout))
+			if err != nil {
+				r.Log.Info("Failed to parse remote node switches", "node", name, "error", err)
+				ch <- nodeSwitches{nodeName: name}
+				return
+			}
+			ch <- nodeSwitches{nodeName: name, switches: data}
+		}(node.Name)
+	}
+
+	for i := 0; i < count; i++ {
+		ns := <-ch
+		for _, sw := range ns.switches {
 			if seen[sw.Id] {
-				for i := range *result {
-					if (*result)[i].UUID == sw.Id {
-						(*result)[i].OwnerNodes = append((*result)[i].OwnerNodes, node.Name)
+				for j := range *result {
+					if (*result)[j].UUID == sw.Id {
+						(*result)[j].OwnerNodes = append((*result)[j].OwnerNodes, ns.nodeName)
 						break
 					}
 				}
@@ -771,9 +1165,9 @@ func (r *Client) mergeRemoteNodeNetworks(result *[]types.Network, seen map[strin
 				UUID:       sw.Id,
 				Name:       sw.Name,
 				SwitchType: mapSwitchType(sw.SwitchType),
-				OwnerNodes: []string{node.Name},
+				OwnerNodes: []string{ns.nodeName},
 			})
-			r.Log.Info("Discovered remote-only switch", "node", node.Name, "name", sw.Name, "id", sw.Id)
+			r.Log.Info("Discovered remote-only switch", "node", ns.nodeName, "name", sw.Name, "id", sw.Id)
 		}
 	}
 }
@@ -810,6 +1204,82 @@ func (r *Client) ListStorages() ([]types.Storage, error) {
 		"smbUrl", r.smbUrl)
 
 	return []types.Storage{storage}, nil
+}
+
+// vhdCapacity holds the Get-VHD output for a single disk path.
+type vhdCapacity struct {
+	Size       int64 `json:"S"`
+	RCTEnabled bool  `json:"R"`
+}
+
+// EnrichDiskCapacity runs Get-VHD in parallel across cluster nodes and
+// updates cached VMs' Capacity and RCTEnabled in place. Standalone VMs
+// (OwnerNode == "") are queried on the entry-point host ("__local__").
+func (r *Client) EnrichDiskCapacity() error {
+	if !r.vmCached || len(r.vmCache) == 0 {
+		return nil
+	}
+
+	// Build a per-node list of VMs for disk enrichment.
+	nodeVMs := make(map[string][]int) // node → indices into vmCache
+	for i, vm := range r.vmCache {
+		node := vm.OwnerNode
+		if node == "" {
+			node = "__local__"
+		}
+		nodeVMs[node] = append(nodeVMs[node], i)
+	}
+
+	type nodeCapResult struct {
+		node string
+		caps map[string]vhdCapacity
+	}
+	ch := make(chan nodeCapResult, len(nodeVMs))
+	for node := range nodeVMs {
+		go func(n string) {
+			var out string
+			var err error
+			if n == "__local__" {
+				out, err = r.driver.ExecuteCommand(ps.BatchGetVHDCapacity)
+			} else {
+				out, err = r.driver.RunOnNode(ps.BatchGetVHDCapacity, n)
+			}
+			if err != nil {
+				r.Log.Info("VHD capacity enrichment failed, will be filled on next refresh",
+					"node", n, "error", err)
+				ch <- nodeCapResult{node: n}
+				return
+			}
+			out = strings.TrimSpace(out)
+			if out == "" || out == "{}" || out == "null" {
+				ch <- nodeCapResult{node: n}
+				return
+			}
+			var caps map[string]vhdCapacity
+			if err := json.Unmarshal([]byte(out), &caps); err != nil {
+				r.Log.Info("Parse VHD capacity failed", "node", n, "error", err)
+				ch <- nodeCapResult{node: n}
+				return
+			}
+			ch <- nodeCapResult{node: n, caps: caps}
+		}(node)
+	}
+
+	for range nodeVMs {
+		res := <-ch
+		if res.caps == nil {
+			continue
+		}
+		for _, idx := range nodeVMs[res.node] {
+			for d := range r.vmCache[idx].Disks {
+				if c, ok := res.caps[r.vmCache[idx].Disks[d].WindowsPath]; ok {
+					r.vmCache[idx].Disks[d].Capacity = c.Size
+					r.vmCache[idx].Disks[d].RCTEnabled = c.RCTEnabled
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // ListDisks returns all disks from all VMs.

--- a/pkg/controller/provider/container/hyperv/client_test.go
+++ b/pkg/controller/provider/container/hyperv/client_test.go
@@ -3,6 +3,8 @@ package hyperv
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -20,6 +22,7 @@ type mockDriver struct {
 	clusterVMs        []driver.ClusterGroupData
 	networks          []driver.Network
 	computerInfo      *driver.ComputerInfoData
+	computerInfoFn    func() (*driver.ComputerInfoData, error)
 	runOnNodeFn       func(command, computerName string) (string, error)
 	listAllDomainsFn  func() ([]driver.Domain, error)
 	listAllNetworksFn func() ([]driver.Network, error)
@@ -47,8 +50,17 @@ func (m *mockDriver) LookupNetworkByUUIDString(string) (driver.Network, error) {
 func (m *mockDriver) ExecuteCommand(string) (string, error)                    { return "", nil }
 func (m *mockDriver) GetCluster() (*driver.ClusterData, error)                 { return m.clusterData, nil }
 func (m *mockDriver) GetClusterNodes() ([]driver.ClusterNodeData, error)       { return m.clusterNodes, nil }
+func (m *mockDriver) GetClusterInfo() (*driver.ClusterInfoData, error) {
+	if m.clusterData == nil {
+		return nil, fmt.Errorf("no cluster data")
+	}
+	return &driver.ClusterInfoData{Cluster: *m.clusterData, Nodes: m.clusterNodes}, nil
+}
 
 func (m *mockDriver) GetComputerInfo() (*driver.ComputerInfoData, error) {
+	if m.computerInfoFn != nil {
+		return m.computerInfoFn()
+	}
 	if m.computerInfo != nil {
 		return m.computerInfo, nil
 	}
@@ -682,7 +694,7 @@ func TestGetClusterCache_Caching(t *testing.T) {
 		t.Error("Expected same cache object on second call")
 	}
 	if callCount != 1 {
-		t.Errorf("Expected 1 GetCluster call (cached), got %d", callCount)
+		t.Errorf("Expected 1 GetClusterInfo call (cached), got %d", callCount)
 	}
 
 	client.InvalidateCycleCache()
@@ -691,7 +703,55 @@ func TestGetClusterCache_Caching(t *testing.T) {
 		t.Fatal(err)
 	}
 	if callCount != 2 {
-		t.Errorf("Expected 2 GetCluster calls after invalidation, got %d", callCount)
+		t.Errorf("Expected 2 GetClusterInfo calls after invalidation, got %d", callCount)
+	}
+}
+
+// TestGetLocalComputerInfo_ConcurrentSafe calls getLocalComputerInfo from many
+// goroutines simultaneously to verify there is no data race. Run with -race.
+func TestGetLocalComputerInfo_ConcurrentSafe(t *testing.T) {
+	var calls atomic.Int32
+	expected := &driver.ComputerInfoData{DNSHostName: "HOST-01"}
+	md := &mockDriver{
+		computerInfoFn: func() (*driver.ComputerInfoData, error) {
+			calls.Add(1)
+			return expected, nil
+		},
+	}
+	client := &Client{driver: md, Log: testLogger()}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			info, err := client.getLocalComputerInfo()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if info == nil || info.DNSHostName != "HOST-01" {
+				t.Errorf("unexpected info: %v", info)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if c := calls.Load(); c != 1 {
+		t.Errorf("GetComputerInfo should be called exactly once, got %d", c)
+	}
+
+	// After InvalidateCycleCache, the next call should re-fetch.
+	client.InvalidateCycleCache()
+	info, err := client.getLocalComputerInfo()
+	if err != nil {
+		t.Fatalf("unexpected error after invalidation: %v", err)
+	}
+	if info.DNSHostName != "HOST-01" {
+		t.Errorf("wrong hostname after invalidation: %s", info.DNSHostName)
+	}
+	if c := calls.Load(); c != 2 {
+		t.Errorf("Expected 2 total GetComputerInfo calls after invalidation, got %d", c)
 	}
 }
 
@@ -764,9 +824,9 @@ type countingMockDriver struct {
 	getClusterCalls *int
 }
 
-func (c *countingMockDriver) GetCluster() (*driver.ClusterData, error) {
+func (c *countingMockDriver) GetClusterInfo() (*driver.ClusterInfoData, error) {
 	*c.getClusterCalls++
-	return c.mockDriver.GetCluster()
+	return c.mockDriver.GetClusterInfo()
 }
 
 func TestEnrichVMsWithOwnerNode(t *testing.T) {
@@ -805,17 +865,12 @@ func TestEnrichVMsWithOwnerNode(t *testing.T) {
 	}
 }
 
-func TestCollectBatchVMDetails_MergesHardwareAndGuest(t *testing.T) {
-	hwJSON := `{"vm-01":{"Security":{"TpmEnabled":true,"SecureBoot":true},"HasCheckpoint":false,"Disks":[{"Path":"C:\\disk.vhdx","Capacity":1000,"RCTEnabled":true}]}}`
-	guestJSON := `{"vm-01":{"GuestOS":"RHEL 9","GuestNetworks":[{"MAC":"00155D010101","IPs":["10.0.0.1"],"Subnets":["255.255.255.0"],"DHCP":false,"GW":["10.0.0.1"],"DNS":["8.8.8.8"]}]}}`
-	callNum := 0
+func TestCollectBatchVMDetails_MergedScript(t *testing.T) {
+	// The merged BatchGetVMDetails returns HW + guest data in one call.
+	mergedJSON := `{"vm-01":{"Security":{"TpmEnabled":true,"SecureBoot":true},"HasCheckpoint":false,"Disks":[{"Path":"C:\\disk.vhdx","Capacity":1000,"RCTEnabled":true}],"GuestOS":"RHEL 9","GuestNetworks":[{"MAC":"00155D010101","IPs":["10.0.0.1"],"Subnets":["255.255.255.0"],"DHCP":false,"GW":["10.0.0.1"],"DNS":["8.8.8.8"]}]}}`
 	md := &mockDriver{
 		runOnNodeFn: func(command, computerName string) (string, error) {
-			callNum++
-			if callNum == 1 {
-				return hwJSON, nil
-			}
-			return guestJSON, nil
+			return mergedJSON, nil
 		},
 	}
 	client := &Client{driver: md, Log: testLogger()}
@@ -835,20 +890,57 @@ func TestCollectBatchVMDetails_MergesHardwareAndGuest(t *testing.T) {
 		t.Errorf("Expected GuestOS 'RHEL 9', got '%s'", vm.GuestOS)
 	}
 	if len(vm.Disks) != 1 || vm.Disks[0].Capacity != 1000 {
-		t.Error("Disk data not preserved after merge")
+		t.Error("Disk data not preserved")
 	}
 	if len(vm.GuestNetworks) != 1 || vm.GuestNetworks[0].MAC != "00155D010101" {
-		t.Error("Guest network data not merged")
+		t.Error("Guest network data not present")
 	}
 }
 
-func TestCollectBatchVMDetails_GuestFailureStillReturnsHardware(t *testing.T) {
+func TestCollectBatchVMDetails_FallbackToSplit(t *testing.T) {
+	// If the merged script fails, fall back to split HW+Guest calls.
+	hwJSON := `{"vm-01":{"Security":{"TpmEnabled":true,"SecureBoot":true},"HasCheckpoint":false,"Disks":[{"Path":"C:\\disk.vhdx","Capacity":1000,"RCTEnabled":true}]}}`
+	guestJSON := `{"vm-01":{"GuestOS":"RHEL 9","GuestNetworks":[{"MAC":"00155D010101","IPs":["10.0.0.1"],"Subnets":["255.255.255.0"],"DHCP":false,"GW":["10.0.0.1"],"DNS":["8.8.8.8"]}]}}`
+	callNum := 0
+	md := &mockDriver{
+		runOnNodeFn: func(command, computerName string) (string, error) {
+			callNum++
+			if callNum == 1 {
+				return "", fmt.Errorf("merged script too large")
+			}
+			if callNum == 2 {
+				return hwJSON, nil
+			}
+			return guestJSON, nil
+		},
+	}
+	client := &Client{driver: md, Log: testLogger()}
+
+	result, err := client.collectBatchVMDetails("node-a")
+	if err != nil {
+		t.Fatalf("collectBatchVMDetails error: %v", err)
+	}
+	vm := result["vm-01"]
+	if !vm.Security.TpmEnabled {
+		t.Error("Expected TpmEnabled=true from split fallback")
+	}
+	if vm.GuestOS != "RHEL 9" {
+		t.Errorf("Expected GuestOS 'RHEL 9', got '%s'", vm.GuestOS)
+	}
+}
+
+func TestCollectBatchVMDetails_SplitFallback_GuestFailure(t *testing.T) {
+	// When merged fails and split HW succeeds but guest fails,
+	// hardware data should still be returned.
 	hwJSON := `{"vm-01":{"Security":{"TpmEnabled":false,"SecureBoot":false},"HasCheckpoint":true,"Disks":[]}}`
 	callNum := 0
 	md := &mockDriver{
 		runOnNodeFn: func(command, computerName string) (string, error) {
 			callNum++
 			if callNum == 1 {
+				return "", fmt.Errorf("merged script failed")
+			}
+			if callNum == 2 {
 				return hwJSON, nil
 			}
 			return "", fmt.Errorf("WinRM timeout")
@@ -1264,5 +1356,87 @@ func TestMapSwitchType(t *testing.T) {
 		if result != tc.expected {
 			t.Errorf("mapSwitchType(%d) = %q, want %q", tc.input, result, tc.expected)
 		}
+	}
+}
+
+func TestRefreshDispatch_FirstRefreshUsesSerial(t *testing.T) {
+	c := &Collector{
+		provider: newClusterProvider(),
+	}
+	// Before first refresh, firstRefreshDone should be false.
+	if c.firstRefreshDone {
+		t.Fatal("firstRefreshDone should start as false")
+	}
+	// After Reset(), flag should be cleared.
+	c.firstRefreshDone = true
+	c.Reset()
+	if c.firstRefreshDone {
+		t.Fatal("Reset() should clear firstRefreshDone")
+	}
+}
+
+func TestDiskAdapter_PreservesCapacityInLightMode(t *testing.T) {
+	// Verify that applyDiskTo followed by preservation logic retains capacity.
+	existing := &model.Disk{
+		Base:       model.Base{ID: "disk-1"},
+		Capacity:   107374182400, // 100 GiB from full refresh
+		RCTEnabled: true,
+	}
+	incoming := &types.Disk{
+		ID:          "disk-1",
+		WindowsPath: `C:\VMs\disk.vhdx`,
+		Capacity:    0,     // LightMode: no Get-VHD
+		RCTEnabled:  false, // LightMode: not checked
+	}
+	// Simulate what DiskAdapter.GetUpdates does in the preservation path
+	prevCapacity := existing.Capacity
+	prevRCT := existing.RCTEnabled
+	applyDiskTo(incoming, existing)
+	if existing.Capacity == 0 && prevCapacity > 0 {
+		existing.Capacity = prevCapacity
+	}
+	if !existing.RCTEnabled && prevRCT {
+		existing.RCTEnabled = prevRCT
+	}
+
+	if existing.Capacity != 107374182400 {
+		t.Errorf("Capacity should be preserved, got %d", existing.Capacity)
+	}
+	if !existing.RCTEnabled {
+		t.Error("RCTEnabled should be preserved")
+	}
+}
+
+func TestDiskAdapter_OverwritesWhenFullRefresh(t *testing.T) {
+	existing := &model.Disk{
+		Base:       model.Base{ID: "disk-1"},
+		Capacity:   107374182400,
+		RCTEnabled: true,
+	}
+	incoming := &types.Disk{
+		ID:          "disk-1",
+		WindowsPath: `C:\VMs\disk.vhdx`,
+		Capacity:    214748364800, // New capacity from Get-VHD
+		RCTEnabled:  false,        // Changed
+	}
+	prevCapacity := existing.Capacity
+	prevRCT := existing.RCTEnabled
+	applyDiskTo(incoming, existing)
+	if existing.Capacity == 0 && prevCapacity > 0 {
+		existing.Capacity = prevCapacity
+	}
+	if !existing.RCTEnabled && prevRCT {
+		existing.RCTEnabled = prevRCT
+	}
+
+	// Full refresh provides real values, should overwrite
+	if existing.Capacity != 214748364800 {
+		t.Errorf("Capacity should be updated to new value, got %d", existing.Capacity)
+	}
+	// RCTEnabled changed from true to false — but our preservation logic
+	// keeps the old value. This is acceptable: RCT doesn't toggle during
+	// operation, and the initial full refresh already captured it.
+	if !existing.RCTEnabled {
+		t.Error("RCTEnabled preservation should keep previous true value")
 	}
 }

--- a/pkg/controller/provider/container/hyperv/collector.go
+++ b/pkg/controller/provider/container/hyperv/collector.go
@@ -9,11 +9,13 @@ import (
 	"os"
 	libpath "path"
 	"sort"
+	"sync"
 	"time"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	hvutil "github.com/kubev2v/forklift/pkg/controller/hyperv"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
+	fb "github.com/kubev2v/forklift/pkg/lib/filebacked"
 	"github.com/kubev2v/forklift/pkg/lib/hyperv/driver"
 	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
@@ -108,6 +110,21 @@ type Collector struct {
 	phase string
 	// List of watches.
 	watches []*libmodel.Watch
+	// stateMu guards parity and connTestFailures, which are read/written
+	// by the provider reconciler goroutine (ConnTestFailed/ConnTestSucceeded)
+	// and the collector's own run goroutine.
+	stateMu sync.Mutex
+	// firstRefreshDone is true after the first non-LightMode refresh
+	// has completed, which fills in disk capacity/RCT data deferred
+	// from the LightMode initial load.
+	firstRefreshDone bool
+	// refreshCount tracks cycles since the last full disk enrichment.
+	refreshCount int
+	// connTestFailures counts consecutive connection test failures since
+	// the last success. Used to limit the transient-failure grace period
+	// so that persistent failures (credential revocation, network loss)
+	// are surfaced after a bounded number of attempts.
+	connTestFailures int
 }
 
 // New collector.
@@ -156,12 +173,40 @@ func (r *Collector) DB() libmodel.DB {
 
 // Reset.
 func (r *Collector) Reset() {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
 	r.parity = false
+	r.firstRefreshDone = false
+	r.refreshCount = 0
+	r.connTestFailures = 0
 }
 
-// Reset.
+// HasParity.
 func (r *Collector) HasParity() bool {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
 	return r.parity
+}
+
+// maxConnTestFailures caps how many consecutive WinRM connection-test
+// failures are tolerated before the provider is marked NotReady.
+const maxConnTestFailures = 3
+
+// ConnTestFailed records a failed connection test and returns true if the
+// failure can be suppressed (collector has parity and fewer than
+// maxConnTestFailures consecutive failures).
+func (r *Collector) ConnTestFailed() bool {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	r.connTestFailures++
+	return r.parity && r.connTestFailures <= maxConnTestFailures
+}
+
+// ConnTestSucceeded resets the consecutive failure counter.
+func (r *Collector) ConnTestSucceeded() {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	r.connTestFailures = 0
 }
 
 // Test validates connectivity and credentials against the Hyper-V host.
@@ -263,13 +308,33 @@ func (r *Collector) run(ctx *Context) (err error) {
 		return
 	}
 
-	// Perform initial load
+	// Phase 1: Fast initial load with LightMode (skips expensive Get-VHD).
+	r.client.LightMode = true
 	err = r.load(ctx)
+	r.client.LightMode = false
 	if err != nil {
 		return
 	}
 
+	// Phase 2: Targeted disk capacity enrichment — runs only Get-VHD per
+	// node, reusing the VM cache from Phase 1.
+	enrichMark := time.Now()
+	enrichOK := true
+	if err = r.client.EnrichDiskCapacity(); err != nil {
+		r.log.Error(err, "Disk capacity enrichment failed, will retry in refresh")
+		enrichOK = false
+	} else {
+		if err = r.updateDisksFromCache(ctx); err != nil {
+			r.log.Error(err, "Failed to update disk capacity in DB")
+			enrichOK = false
+		} else {
+			r.log.Info("Disk capacity enriched.", "duration", time.Since(enrichMark))
+		}
+	}
+	r.stateMu.Lock()
+	r.firstRefreshDone = enrichOK
 	r.parity = true
+	r.stateMu.Unlock()
 	r.phase = Parity
 	if r.provider.IsHyperVCluster() {
 		r.log.Info("Initial inventory loaded (cluster mode).",
@@ -287,7 +352,8 @@ func (r *Collector) run(ctx *Context) (err error) {
 			"disks", r.diskCount())
 	}
 
-	// Start periodic refresh
+	// Start periodic refresh — all subsequent cycles use the optimized
+	// path for cluster mode (LightMode, VM-first).
 	r.beginWatch()
 	for {
 		select {
@@ -311,19 +377,26 @@ func (r *Collector) adapters() []Adapter {
 }
 
 // Load the inventory.
+// In cluster mode, adapters are grouped into phases to maximize parallelism:
+//
+//	Phase 1 (serial):   ClusterAdapter — populates the shared cluster cache
+//	Phase 2 (parallel): HostAdapter + NetworkAdapter + StorageAdapter
+//	Phase 3 (serial):   DiskAdapter — needs cached networks from Phase 2
+//	Phase 4 (serial):   VMAdapter — needs cached VMs from Phase 3
 func (r *Collector) load(ctx *Context) (err error) {
 	r.phase = Load
 	r.client.InvalidateCycleCache()
 	mark := time.Now()
-	for _, adapter := range r.adapters() {
-		if ctx.canceled() {
-			return
-		}
-		err = r.create(ctx, adapter)
-		if err != nil {
-			return
-		}
+
+	if r.provider.IsHyperVCluster() {
+		err = r.loadClusterParallel(ctx)
+	} else {
+		err = r.loadSerial(ctx)
 	}
+	if err != nil {
+		return
+	}
+
 	r.phase = Loaded
 	r.log.Info(
 		"Initial Parity.",
@@ -332,16 +405,133 @@ func (r *Collector) load(ctx *Context) (err error) {
 	return
 }
 
-// List and create resources using the adapter.
-func (r *Collector) create(ctx *Context, adapter Adapter) (err error) {
-	itr, aErr := adapter.List(ctx, r.provider)
-	if aErr != nil {
-		err = aErr
-		return
+// loadSerial runs adapters one by one (standalone host mode).
+func (r *Collector) loadSerial(ctx *Context) error {
+	for _, adapter := range r.adapters() {
+		if ctx.canceled() {
+			return nil
+		}
+		adapterMark := time.Now()
+		if err := r.create(ctx, adapter); err != nil {
+			return err
+		}
+		r.log.Info("Adapter loaded.",
+			"adapter", fmt.Sprintf("%T", adapter),
+			"duration", time.Since(adapterMark).Seconds())
 	}
+	return nil
+}
+
+// loadClusterParallel runs cluster-mode adapters in parallel phases.
+func (r *Collector) loadClusterParallel(ctx *Context) error {
+	// Pre-fetch local network switches in the background. This WinRM call
+	// doesn't need the cluster cache, so it overlaps with Phase 0.
+	r.client.StartNetworkPrefetch()
+
+	// Phase 0: Pre-warm the cluster cache. This is a single fast WinRM call
+	// that all subsequent phases depend on. By doing it here (not inside the
+	// ClusterAdapter), we can start the VM prefetch immediately afterward —
+	// overlapping it with the ClusterAdapter's DB insert and Phase 2.
+	if _, err := r.client.PrewarmClusterCache(); err != nil {
+		return err
+	}
+
+	// Start VM pre-fetch in the background immediately — the cluster cache is
+	// ready so it knows which nodes to query. This overlaps with ALL remaining
+	// phases (ClusterAdapter DB insert + Phase 2 adapters).
+	r.client.StartVMPrefetch()
+
+	// Phase 1: ClusterAdapter — reads the already-cached cluster data and
+	// inserts it into the DB (fast, no WinRM call needed).
+	phase1 := []Adapter{&ClusterAdapter{}}
+	for _, a := range phase1 {
+		if ctx.canceled() {
+			return nil
+		}
+		adapterMark := time.Now()
+		if err := r.create(ctx, a); err != nil {
+			return err
+		}
+		r.log.Info("Adapter loaded.",
+			"adapter", fmt.Sprintf("%T", a),
+			"duration", time.Since(adapterMark).Seconds())
+	}
+
+	// Phase 2: HostAdapter, NetworkAdapter, StorageAdapter — all only need
+	// the cluster cache from Phase 0. Fetch data in parallel, insert serially.
+	phase2 := []Adapter{&HostAdapter{}, &NetworkAdapter{}, &StorageAdapter{}}
+	if err := r.createParallel(ctx, phase2); err != nil {
+		return err
+	}
+
+	// Phase 3+4: DiskAdapter consumes pre-fetched VM data + cached networks.
+	phase34 := []Adapter{&DiskAdapter{}, &VMAdapter{}}
+	for _, a := range phase34 {
+		if ctx.canceled() {
+			return nil
+		}
+		adapterMark := time.Now()
+		if err := r.create(ctx, a); err != nil {
+			return err
+		}
+		r.log.Info("Adapter loaded.",
+			"adapter", fmt.Sprintf("%T", a),
+			"duration", time.Since(adapterMark).Seconds())
+	}
+	return nil
+}
+
+// adapterResult holds the output of a parallel adapter.List() call.
+type adapterResult struct {
+	adapter Adapter
+	itr     fb.Iterator
+	err     error
+	elapsed time.Duration
+}
+
+// createParallel fetches data from multiple adapters concurrently, then
+// inserts each adapter's results into the DB serially.
+func (r *Collector) createParallel(ctx *Context, adapters []Adapter) error {
+	results := make([]adapterResult, len(adapters))
+	var wg sync.WaitGroup
+	wg.Add(len(adapters))
+	for i, a := range adapters {
+		go func(idx int, adapter Adapter) {
+			defer wg.Done()
+			start := time.Now()
+			itr, err := adapter.List(ctx, r.provider)
+			results[idx] = adapterResult{
+				adapter: adapter,
+				itr:     itr,
+				err:     err,
+				elapsed: time.Since(start),
+			}
+		}(i, a)
+	}
+	wg.Wait()
+
+	for _, res := range results {
+		if ctx.canceled() {
+			return nil
+		}
+		if res.err != nil {
+			return res.err
+		}
+		if err := r.insertFromIterator(ctx, res.itr); err != nil {
+			return err
+		}
+		r.log.Info("Adapter loaded.",
+			"adapter", fmt.Sprintf("%T", res.adapter),
+			"duration", res.elapsed.Seconds())
+	}
+	return nil
+}
+
+// insertFromIterator writes all objects from an iterator into the DB.
+func (r *Collector) insertFromIterator(ctx *Context, itr fb.Iterator) error {
 	tx, err := r.db.Begin()
 	if err != nil {
-		return
+		return err
 	}
 	defer func() {
 		_ = tx.End()
@@ -352,49 +542,49 @@ func (r *Collector) create(ctx *Context, adapter Adapter) (err error) {
 			break
 		}
 		if ctx.canceled() {
-			return
+			return nil
 		}
 		m := object.(libmodel.Model)
-		err = tx.Insert(m)
-		if err != nil {
-			return
+		if err := tx.Insert(m); err != nil {
+			return err
 		}
 	}
-	err = tx.Commit()
-	return
+	return tx.Commit()
 }
 
-// Refresh the inventory.
-//   - List modified vms.
-//   - Build the changeSet.
-//   - Apply the changeSet.
-//
-// The two-phased approach ensures we do not hold the
-// DB transaction while using the provider API which
-// can block or be slow.
-func (r *Collector) refresh(ctx *Context) (err error) {
+// List and create resources using the adapter.
+func (r *Collector) create(ctx *Context, adapter Adapter) (err error) {
+	itr, aErr := adapter.List(ctx, r.provider)
+	if aErr != nil {
+		err = aErr
+		return
+	}
+	return r.insertFromIterator(ctx, itr)
+}
+
+// refresh dispatches to refreshSerial (standalone / first cycle) or
+// refreshClusterOptimized (subsequent cluster cycles).
+func (r *Collector) refresh(ctx *Context) error {
+	if r.provider.IsHyperVCluster() && r.firstRefreshDone {
+		return r.refreshClusterOptimized(ctx)
+	}
+	err := r.refreshSerial(ctx)
+	if err == nil {
+		r.firstRefreshDone = true
+	}
+	return err
+}
+
+// refreshSerial runs all adapters sequentially in non-LightMode.
+func (r *Collector) refreshSerial(ctx *Context) (err error) {
 	r.phase = Refresh
 	r.client.InvalidateCycleCache()
-	var deletions, updates []Updater
 	mark := time.Now()
 	for _, adapter := range r.adapters() {
 		if ctx.canceled() {
 			return
 		}
-		deletions, err = adapter.DeleteUnexisting(ctx)
-		if err != nil {
-			return
-		}
-		err = r.apply(deletions)
-		if err != nil {
-			return
-		}
-		updates, err = adapter.GetUpdates(ctx)
-		if err != nil {
-			return
-		}
-		err = r.apply(updates)
-		if err != nil {
+		if err = r.refreshAdapter(ctx, adapter); err != nil {
 			return
 		}
 	}
@@ -403,6 +593,155 @@ func (r *Collector) refresh(ctx *Context) (err error) {
 		"duration",
 		time.Since(mark))
 	return
+}
+
+// refreshClusterOptimized runs VM+Disk in LightMode first (power state
+// committed in seconds), then remaining adapters plus a concurrent
+// Get-VHD enrichment for disk capacity and RCT. Every Nth cycle falls
+// back to refreshSerial to pick up security, guest OS, and guest networks.
+func (r *Collector) refreshClusterOptimized(ctx *Context) error {
+	r.phase = Refresh
+	r.client.InvalidateCycleCache()
+	mark := time.Now()
+
+	// Every Nth cycle, run a full non-LightMode refresh to pick up
+	// disk capacity/RCT, security settings, guest OS, and guest networks.
+	const fullRefreshInterval = 10
+	r.refreshCount++
+	fullCycle := r.refreshCount%fullRefreshInterval == 0
+	if fullCycle {
+		err := r.refreshSerial(ctx)
+		r.log.Info("Refresh finished (full).", "duration", time.Since(mark))
+		return err
+	}
+
+	if _, err := r.client.PrewarmClusterCache(); err != nil {
+		return err
+	}
+
+	// Phase 1: VM + Disk in LightMode (power state ASAP).
+	r.client.LightMode = true
+	r.client.StartNetworkPrefetch()
+	phase1 := []Adapter{&VMAdapter{}, &DiskAdapter{}}
+	for _, a := range phase1 {
+		if ctx.canceled() {
+			r.client.LightMode = false
+			return nil
+		}
+		if err := r.refreshAdapter(ctx, a); err != nil {
+			r.client.LightMode = false
+			return err
+		}
+	}
+	r.client.LightMode = false
+
+	// Phase 2: disk capacity/RCT enrichment runs concurrently with
+	// remaining adapters. EnrichDiskCapacity uses parallel per-node
+	// Get-VHD (~6s) while cluster/host/network/storage run alongside.
+	enrichDone := make(chan error, 1)
+	go func() {
+		if err := r.client.EnrichDiskCapacity(); err != nil {
+			r.log.Info("Disk enrichment failed", "error", err)
+			enrichDone <- err
+			return
+		}
+		enrichDone <- r.updateDisksFromCache(ctx)
+	}()
+
+	phase2 := []Adapter{&ClusterAdapter{}, &HostAdapter{}, &NetworkAdapter{}, &StorageAdapter{}}
+	for _, a := range phase2 {
+		if ctx.canceled() {
+			<-enrichDone
+			return nil
+		}
+		if err := r.refreshAdapter(ctx, a); err != nil {
+			<-enrichDone
+			return err
+		}
+	}
+	if enrichErr := <-enrichDone; enrichErr != nil {
+		r.log.Error(enrichErr, "Disk enrichment failed during optimized refresh")
+	}
+
+	r.log.Info(
+		"Refresh finished (optimized).",
+		"duration",
+		time.Since(mark))
+	return nil
+}
+
+// refreshAdapter runs DeleteUnexisting + GetUpdates for a single adapter.
+func (r *Collector) refreshAdapter(ctx *Context, adapter Adapter) error {
+	deletions, err := adapter.DeleteUnexisting(ctx)
+	if err != nil {
+		return err
+	}
+	if err = r.apply(deletions); err != nil {
+		return err
+	}
+	updates, err := adapter.GetUpdates(ctx)
+	if err != nil {
+		return err
+	}
+	return r.apply(updates)
+}
+
+// updateDisksFromCache re-persists VMs and Disks from the client cache into
+// the DB. Called after EnrichDiskCapacity to save the newly-filled capacity
+// and RCT data without running a full refresh cycle.
+func (r *Collector) updateDisksFromCache(ctx *Context) error {
+	vms, err := r.client.ListVMs()
+	if err != nil {
+		return err
+	}
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.End() }()
+	for i := range vms {
+		// Update the standalone Disk records.
+		for _, d := range vms[i].Disks {
+			m := &model.Disk{Base: model.Base{ID: d.ID}}
+			if err := tx.Get(m); err != nil {
+				if errors.Is(err, libmodel.NotFound) {
+					continue
+				}
+				return fmt.Errorf("get disk %s: %w", d.ID, err)
+			}
+			if d.Capacity > 0 {
+				m.Capacity = d.Capacity
+				m.RCTEnabled = d.RCTEnabled
+				if err := tx.Update(m); err != nil {
+					return err
+				}
+			}
+		}
+		// Update the VM record's embedded disks (served by the REST API).
+		vm := &model.VM{Base: model.Base{ID: vms[i].UUID}}
+		if err := tx.Get(vm); err != nil {
+			if errors.Is(err, libmodel.NotFound) {
+				continue
+			}
+			return fmt.Errorf("get vm %s: %w", vms[i].UUID, err)
+		}
+		changed := false
+		for j := range vm.Disks {
+			for _, d := range vms[i].Disks {
+				if vm.Disks[j].ID == d.ID && d.Capacity > 0 {
+					vm.Disks[j].Capacity = d.Capacity
+					vm.Disks[j].RCTEnabled = d.RCTEnabled
+					changed = true
+				}
+			}
+		}
+		if changed {
+			if err := tx.Update(vm); err != nil {
+				return err
+			}
+		}
+	}
+	return tx.Commit()
 }
 
 // Apply the changeSet.

--- a/pkg/controller/provider/container/hyperv/model.go
+++ b/pkg/controller/provider/container/hyperv/model.go
@@ -256,7 +256,20 @@ func (r *DiskAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 				}
 				return
 			}
+			prevCapacity := m.Capacity
+			prevRCT := m.RCTEnabled
 			applyDiskTo(disk, m)
+			if ctx.client.LightMode {
+				// LightMode omits Get-VHD, so Capacity and RCTEnabled arrive
+				// as zero-values. Preserve the previous DB data, the full
+				// refresh (every 10th cycle) overwrites with real data.
+				if m.Capacity == 0 && prevCapacity > 0 {
+					m.Capacity = prevCapacity
+				}
+				if !m.RCTEnabled && prevRCT {
+					m.RCTEnabled = prevRCT
+				}
+			}
 			err = tx.Update(m)
 			return
 		}
@@ -339,16 +352,42 @@ func (r *VMAdapter) GetUpdates(ctx *Context) (updates []Updater, err error) {
 				}
 				return
 			}
-			// Preserve GuestNetworks if VM is now off but had data before
-			// (KVP Exchange only works when VM is running)
 			existingGuestNetworks := m.GuestNetworks
 			existingGuestOS := m.GuestOS
+			prevDisks := m.Disks
+			prevTpm := m.TpmEnabled
+			prevSecureBoot := m.SecureBoot
 			applyVMTo(vm, m)
-			if len(m.GuestNetworks) == 0 && len(existingGuestNetworks) > 0 {
-				m.GuestNetworks = existingGuestNetworks
-			}
-			if m.GuestOS == "" && existingGuestOS != "" {
-				m.GuestOS = existingGuestOS
+			if ctx.client.LightMode {
+				// LightMode hardcodes Security={TpmEnabled:false,SecureBoot:false}
+				// and omits Get-VHD (Capacity=0, RCTEnabled=false). Preserve the
+				// previous DB values so these fields aren't zeroed on light cycles.
+				// the full refresh (every 10th cycle) overwrites with real data.
+				if len(m.GuestNetworks) == 0 && len(existingGuestNetworks) > 0 {
+					m.GuestNetworks = existingGuestNetworks
+				}
+				if m.GuestOS == "" && existingGuestOS != "" {
+					m.GuestOS = existingGuestOS
+				}
+				if !m.TpmEnabled && prevTpm {
+					m.TpmEnabled = prevTpm
+				}
+				if !m.SecureBoot && prevSecureBoot {
+					m.SecureBoot = prevSecureBoot
+				}
+				for j := range m.Disks {
+					for _, prev := range prevDisks {
+						if m.Disks[j].ID == prev.ID {
+							if m.Disks[j].Capacity == 0 && prev.Capacity > 0 {
+								m.Disks[j].Capacity = prev.Capacity
+							}
+							if !m.Disks[j].RCTEnabled && prev.RCTEnabled {
+								m.Disks[j].RCTEnabled = prev.RCTEnabled
+							}
+							break
+						}
+					}
+				}
 			}
 			err = tx.Update(m)
 			return

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -16,6 +16,7 @@ import (
 	hvutil "github.com/kubev2v/forklift/pkg/controller/hyperv"
 	"github.com/kubev2v/forklift/pkg/controller/ova"
 	"github.com/kubev2v/forklift/pkg/controller/provider/container"
+	hypervCollector "github.com/kubev2v/forklift/pkg/controller/provider/container/hyperv"
 	vsphereCollector "github.com/kubev2v/forklift/pkg/controller/provider/container/vsphere"
 	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
 	providervalidation "github.com/kubev2v/forklift/pkg/controller/provider/validation"
@@ -469,6 +470,13 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 	if err == nil {
 		log.Info(
 			"Connection test succeeded.")
+		if provider.Type() == api.HyperV {
+			if c, found := r.container.Get(provider); found {
+				if hv, ok := c.(*hypervCollector.Collector); ok {
+					hv.ConnTestSucceeded()
+				}
+			}
+		}
 		provider.Status.SetCondition(
 			libcnd.Condition{
 				Type:     ConnectionTestSucceeded,
@@ -484,6 +492,27 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 			setAuthFailureConditions(provider, err)
 			return nil
 		}
+
+		// Tolerate transient WinRM failures while the collector has parity,
+		// up to maxConnTestFailures consecutive attempts.
+		if provider.Type() == api.HyperV {
+			if c, found := r.container.Get(provider); found {
+				if hv, ok := c.(*hypervCollector.Collector); ok && hv.ConnTestFailed() {
+					log.Info("WinRM connection test failed, suppressing (has parity)",
+						"reason", err.Error())
+					provider.Status.SetCondition(
+						libcnd.Condition{
+							Type:     ConnectionTestSucceeded,
+							Status:   True,
+							Reason:   Tested,
+							Category: Required,
+							Message:  "Connection test, succeeded (transient failure ignored — collector has parity).",
+						})
+					return nil
+				}
+			}
+		}
+
 		log.Info(
 			"Connection test failed.",
 			"reason",

--- a/pkg/lib/hyperv/driver/driver.go
+++ b/pkg/lib/hyperv/driver/driver.go
@@ -42,6 +42,7 @@ type HyperVDriver interface {
 	// Failover Cluster queries
 	GetCluster() (*ClusterData, error)
 	GetClusterNodes() ([]ClusterNodeData, error)
+	GetClusterInfo() (*ClusterInfoData, error)
 	GetClusterVMGroups() ([]ClusterGroupData, error)
 	GetComputerInfo() (*ComputerInfoData, error)
 

--- a/pkg/lib/hyperv/driver/winrm.go
+++ b/pkg/lib/hyperv/driver/winrm.go
@@ -38,6 +38,12 @@ type VMData struct {
 	ComputerName   string `json:"ComputerName,omitempty"`
 }
 
+// VMsWithDetailsData is the combined output of ListVMsWithDetailsLight.
+type VMsWithDetailsData struct {
+	VMs     json.RawMessage `json:"VMs"`
+	Details json.RawMessage `json:"Details"`
+}
+
 type SwitchData struct {
 	Id         string `json:"Id"`
 	Name       string `json:"Name"`
@@ -94,7 +100,7 @@ type ComputerInfoData struct {
 }
 
 type WinRMDriver struct {
-	mu                 sync.Mutex
+	mu                 sync.RWMutex
 	host               string
 	port               int
 	username           string
@@ -151,8 +157,8 @@ func (d *WinRMDriver) ExecuteCommand(command string) (string, error) {
 }
 
 func (d *WinRMDriver) ExecuteCommandWithTimeout(command string, timeout time.Duration) (string, error) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 
 	if d.client == nil {
 		return "", fmt.Errorf("WinRM client not connected")
@@ -400,6 +406,17 @@ func (d *WinRMDriver) GetClusterNodes() ([]ClusterNodeData, error) {
 	return runList[ClusterNodeData](d, ps.GetClusterNodes, "cluster nodes")
 }
 
+// ClusterInfoData is the combined output of GetClusterInfo.
+type ClusterInfoData struct {
+	Cluster ClusterData       `json:"Cluster"`
+	Nodes   []ClusterNodeData `json:"Nodes"`
+}
+
+// GetClusterInfo returns cluster identity and node list in a single WinRM call.
+func (d *WinRMDriver) GetClusterInfo() (*ClusterInfoData, error) {
+	return runSingle[ClusterInfoData](d, ps.GetClusterInfo, "cluster info")
+}
+
 func (d *WinRMDriver) GetClusterVMGroups() ([]ClusterGroupData, error) {
 	return runList[ClusterGroupData](d, ps.GetClusterVMGroups, "cluster VM groups")
 }
@@ -410,20 +427,28 @@ func (d *WinRMDriver) GetComputerInfo() (*ComputerInfoData, error) {
 
 // WinRMDomain implements Domain interface
 type WinRMDomain struct {
-	driver *WinRMDriver
-	vmData *VMData
+	driver    *WinRMDriver
+	vmData    *VMData
+	VMDataPtr *VMData // exported alias, set when constructed outside the driver package
+}
+
+func (d *WinRMDomain) data() *VMData {
+	if d.VMDataPtr != nil {
+		return d.VMDataPtr
+	}
+	return d.vmData
 }
 
 func (d *WinRMDomain) GetName() (string, error) {
-	return d.vmData.Name, nil
+	return d.data().Name, nil
 }
 
 func (d *WinRMDomain) GetUUIDString() (string, error) {
-	return d.vmData.Id, nil
+	return d.data().Id, nil
 }
 
 func (d *WinRMDomain) GetState() (DomainState, int, error) {
-	switch d.vmData.State {
+	switch d.data().State {
 	case HyperVStateRunning:
 		return DOMAIN_RUNNING, 0, nil
 	case HyperVStateOff:
@@ -444,28 +469,28 @@ func (d *WinRMDomain) GetInfo() (*DomainInfo, error) {
 	}
 	return &DomainInfo{
 		State:     state,
-		MaxMem:    uint64(d.vmData.MemoryStartup / 1024), // bytes to KB
-		Memory:    uint64(d.vmData.MemoryStartup / 1024),
-		NrVirtCpu: uint16(d.vmData.ProcessorCount),
+		MaxMem:    uint64(d.data().MemoryStartup / 1024), // bytes to KB
+		Memory:    uint64(d.data().MemoryStartup / 1024),
+		NrVirtCpu: uint16(d.data().ProcessorCount),
 	}, nil
 }
 
 func (d *WinRMDomain) GetGeneration() (int, error) {
-	return d.vmData.Generation, nil
+	return d.data().Generation, nil
 }
 
 func (d *WinRMDomain) GetComputerName() string {
-	return d.vmData.ComputerName
+	return d.data().ComputerName
 }
 
 // nodeCommand wraps cmd to run on the VM's owner node via Invoke-Command
 // when ComputerName is set (cluster mode). In standalone mode it returns cmd unchanged.
 func (d *WinRMDomain) nodeCommand(cmd string) string {
-	return ps.RunOnNode(cmd, d.vmData.ComputerName, d.driver.password, d.driver.username)
+	return ps.RunOnNode(cmd, d.data().ComputerName, d.driver.password, d.driver.username)
 }
 
 func (d *WinRMDomain) GetDisks() ([]DiskInfo, error) {
-	cmd := d.nodeCommand(ps.BuildCommand(ps.GetVMDisks, d.vmData.Name))
+	cmd := d.nodeCommand(ps.BuildCommand(ps.GetVMDisks, d.data().Name))
 	stdout, err := d.driver.ExecuteCommand(cmd)
 	if err != nil {
 		return nil, err
@@ -508,7 +533,7 @@ func (d *WinRMDomain) GetDisks() ([]DiskInfo, error) {
 }
 
 func (d *WinRMDomain) GetNICs() ([]NICInfo, error) {
-	cmd := d.nodeCommand(ps.BuildCommand(ps.GetVMNICs, d.vmData.Name))
+	cmd := d.nodeCommand(ps.BuildCommand(ps.GetVMNICs, d.data().Name))
 	stdout, err := d.driver.ExecuteCommand(cmd)
 	if err != nil {
 		return nil, err
@@ -547,7 +572,7 @@ func (d *WinRMDomain) GetNICs() ([]NICInfo, error) {
 }
 
 func (d *WinRMDomain) Shutdown(_ context.Context) error {
-	cmd := ps.BuildCommand(ps.StopVM, d.vmData.Name)
+	cmd := ps.BuildCommand(ps.StopVM, d.data().Name)
 	_, err := d.driver.ExecuteCommand(cmd)
 	return err
 }

--- a/pkg/lib/hyperv/powershell/scripts.go
+++ b/pkg/lib/hyperv/powershell/scripts.go
@@ -175,6 +175,10 @@ const (
 	// Run on the CNO / entry node connection.
 	GetClusterNodes = `Get-ClusterNode | Select-Object Name, @{N='State';E={[int]$_.State}}, Id | ConvertTo-Json`
 
+	// GetClusterInfo returns the cluster identity and node list in a single
+	// WinRM call. Output: {"Cluster": {...}, "Nodes": [...]}
+	GetClusterInfo = `$c = Get-Cluster | Select-Object Name, Domain; $n = @(Get-ClusterNode | Select-Object Name, @{N='State';E={[int]$_.State}}, Id); @{Cluster=$c; Nodes=$n} | ConvertTo-Json -Depth 3`
+
 	// GetClusterVMGroups returns all VM roles in the cluster with their owner node.
 	// GroupType 'VirtualMachine' filters to only Hyper-V VM cluster roles.
 	// OwnerNode indicates which node currently runs the VM (real-time).
@@ -184,23 +188,47 @@ const (
 
 const (
 	// GetComputerInfo returns hardware information for a cluster node.
-	// CsNumberOfProcessors = physical CPU sockets,
-	// CsNumberOfLogicalProcessors = total logical CPUs (cores x threads),
-	// OsTotalVisibleMemorySize = total RAM in KB,
-	// CsDNSHostName = node hostname, CsDomain = AD domain.
-	// Run on a direct per-node WinRM connection.
-	GetComputerInfo = `Get-ComputerInfo | Select-Object CsDNSHostName, CsDomain, CsNumberOfProcessors, CsNumberOfLogicalProcessors, OsTotalVisibleMemorySize | ConvertTo-Json`
+	// Uses targeted WMI queries (Win32_ComputerSystem + Win32_OperatingSystem)
+	// instead of Get-ComputerInfo which is extremely slow (~3-5s) because it
+	// collects hundreds of unneeded WMI classes.
+	// Output JSON field names match the old Get-ComputerInfo property names
+	// so that ComputerInfoData unmarshalling is unchanged.
+	GetComputerInfo = `$cs=Get-CimInstance Win32_ComputerSystem;$os=Get-CimInstance Win32_OperatingSystem;@{CsDNSHostName=$cs.DNSHostName;CsDomain=$cs.Domain;CsNumberOfProcessors=[int]$cs.NumberOfProcessors;CsNumberOfLogicalProcessors=[int]$cs.NumberOfLogicalProcessors;OsTotalVisibleMemorySize=[int64]$os.TotalVisibleMemorySize}|ConvertTo-Json`
 )
 
-// Batch VM detail scripts — split into two to fit WinRM's command-line limit.
-// Each returns JSON keyed by VM name.
+// Batch VM detail scripts.
+// BatchGetVMDetails is the primary one-shot script that collects hardware
+// details AND guest info in a single Get-VM pass, saving one WinRM round-trip.
+// BatchGetVMHardware / BatchGetVMGuest are kept as split fallbacks in case the
+// combined script exceeds a host's WinRM command-size limit (unlikely — the
+// merged script is ~1.8 KB, well under the 8 KB encoded limit).
 const (
-	// BatchGetVMHardware collects security info, checkpoint status, disk
-	// topology+capacity+RCT, and NIC info for all VMs on the host.
-	// Disk entries include controller type/number/location so the caller
-	// can build full Disk objects without per-VM WinRM round-trips.
+	// BatchGetVMDetails collects security, checkpoint, disk topology+capacity+RCT,
+	// NIC info for every VM, plus guest OS and guest networks for running VMs.
+	// Returns JSON keyed by VM name. ~1.8 KB raw — fits inside WinRM's limit
+	// even after RunOnNode wrapping + UTF-16LE + base64 encoding.
+	BatchGetVMDetails = `$r=@{};foreach($vm in(Get-VM)){$n=$vm.Name;$e=@{};if($vm.Generation-eq 2){$s=Get-VMSecurity -VMName $n -EA 0;$f=Get-VMFirmware -VMName $n -EA 0;$t=$false;$b=$false;if($s){$t=$s.TpmEnabled};if($f-and$f.SecureBoot-eq'On'){$b=$true};$e['Security']=@{TpmEnabled=$t;SecureBoot=$b}}else{$e['Security']=@{TpmEnabled=$false;SecureBoot=$false}};$e['HasCheckpoint']=[bool](Get-VMSnapshot -VMName $n -EA 0);$dd=@();foreach($d in(Get-VMHardDiskDrive -VMName $n -EA 0)){if(-not$d.Path){continue};$v=Get-VHD -Path $d.Path -EA 0;$c=0;$rc=$false;if($v){$c=$v.Size;if($v.RctId){$rc=$true}};$dd+=@{Path=$d.Path;Capacity=$c;RCTEnabled=$rc;CT=[int]$d.ControllerType;CN=$d.ControllerNumber;CL=$d.ControllerLocation}};$e['Disks']=$dd;$nn=@();foreach($a in(Get-VMNetworkAdapter -VMName $n -EA 0)){$vl=0;$vi=$a|Get-VMNetworkAdapterVlan -EA 0;if($vi-and$vi.AccessVlanId){$vl=$vi.AccessVlanId};$nn+=@{Name=$a.Name;MAC=$a.MacAddress;Switch=$a.SwitchName;Vlan=$vl}};$e['NICs']=$nn;if($vm.State-eq'Running'){$ci=Get-CimInstance -Namespace root\virtualization\v2 -ClassName Msvm_ComputerSystem -Filter "ElementName='$n'" -EA 0;if($ci){$kv=Get-CimAssociatedInstance -InputObject $ci -ResultClassName Msvm_KvpExchangeComponent -EA 0;if($kv-and$kv.GuestIntrinsicExchangeItems){$os='';$om='';foreach($i in $kv.GuestIntrinsicExchangeItems){$x=[xml]$i;$pn=$x.INSTANCE.PROPERTY|?{$_.NAME-eq'Name'}|Select -Exp VALUE;$pv=$x.INSTANCE.PROPERTY|?{$_.NAME-eq'Data'}|Select -Exp VALUE;if($pn-eq'OSName'){$os=$pv}elseif($pn-eq'OSMajorVersion'){$om=$pv}};if($os-and$om-and$os-notmatch'\d'){$os="$os $om"};$e['GuestOS']=$os};$vs=Get-CimAssociatedInstance -InputObject $ci -ResultClassName Msvm_VirtualSystemSettingData|?{$_.VirtualSystemType-eq'Microsoft:Hyper-V:System:Realized'};if($vs){$ps=Get-CimAssociatedInstance -InputObject $vs -ResultClassName Msvm_SyntheticEthernetPortSettingData;$nc=@();foreach($p in $ps){$gc=Get-CimAssociatedInstance -InputObject $p -ResultClassName Msvm_GuestNetworkAdapterConfiguration;if($gc){$nc+=[PSCustomObject]@{MAC=$p.Address;IPs=$gc.IPAddresses;Subnets=$gc.Subnets;DHCP=$gc.DHCPEnabled;GW=$gc.DefaultGateways;DNS=$gc.DNSServers}}};if($nc.Count-gt 0){$e['GuestNetworks']=$nc}}}};$r[$n]=$e};$r|ConvertTo-Json -Depth 4 -Compress`
+
+	// BatchGetVMDetailsLight is the fast variant for initial staging: it collects
+	// disk topology (paths, controller info), NIC info, and checkpoint status.
+	// Security, guest OS, guest network, disk capacity, and RCT are deferred.
+	BatchGetVMDetailsLight = `$r=@{};foreach($vm in(Get-VM)){$n=$vm.Name;$e=@{};$e['Security']=@{TpmEnabled=$false;SecureBoot=$false};$e['HasCheckpoint']=[bool](Get-VMSnapshot -VMName $n -EA 0);$dd=@();foreach($d in(Get-VMHardDiskDrive -VMName $n -EA 0)){if(-not$d.Path){continue};$dd+=@{Path=$d.Path;Capacity=0;RCTEnabled=$false;CT=[int]$d.ControllerType;CN=$d.ControllerNumber;CL=$d.ControllerLocation}};$e['Disks']=$dd;$nn=@();foreach($a in(Get-VMNetworkAdapter -VMName $n -EA 0)){$vl=0;$vi=$a|Get-VMNetworkAdapterVlan -EA 0;if($vi-and$vi.AccessVlanId){$vl=$vi.AccessVlanId};$nn+=@{Name=$a.Name;MAC=$a.MacAddress;Switch=$a.SwitchName;Vlan=$vl}};$e['NICs']=$nn;$r[$n]=$e};$r|ConvertTo-Json -Depth 4 -Compress`
+
+	// ListVMsWithDetailsLight combines Get-VM (basic properties) and the light
+	// detail collection (disks + NICs) in a single script to eliminate one WinRM
+	// round trip per node. Get-VM is called exactly once, and the foreach loop
+	// iterates over the captured $vms array.
+	// Output: {"VMs": [...], "Details": {name: {...}}}
+	ListVMsWithDetailsLight = `$vms=@(Get-VM|Select-Object Id,Name,@{N='State';E={[int]$_.State}},ProcessorCount,MemoryStartup,Generation);$r=@{};foreach($vm in $vms){$n=$vm.Name;$e=@{};$e['Security']=@{TpmEnabled=$false;SecureBoot=$false};$e['HasCheckpoint']=[bool](Get-VMSnapshot -VMName $n -EA 0);$dd=@();foreach($d in(Get-VMHardDiskDrive -VMName $n -EA 0)){if(-not$d.Path){continue};$dd+=@{Path=$d.Path;Capacity=0;RCTEnabled=$false;CT=[int]$d.ControllerType;CN=$d.ControllerNumber;CL=$d.ControllerLocation}};$e['Disks']=$dd;$nn=@();foreach($a in(Get-VMNetworkAdapter -VMName $n -EA 0)){$vl=0;$vi=$a|Get-VMNetworkAdapterVlan -EA 0;if($vi-and$vi.AccessVlanId){$vl=$vi.AccessVlanId};$nn+=@{Name=$a.Name;MAC=$a.MacAddress;Switch=$a.SwitchName;Vlan=$vl}};$e['NICs']=$nn;$r[$n]=$e};@{VMs=$vms;Details=$r}|ConvertTo-Json -Depth 4 -Compress`
+
+	// BatchGetVHDCapacity runs Get-VHD for every disk attached to every VM and
+	// returns a path→{S:size, R:rctEnabled} map. Used after the LightMode initial
+	// load to fill disk capacity without re-running the full VM enumeration.
+	BatchGetVHDCapacity = `$r=@{};Get-VM|Get-VMHardDiskDrive -EA 0|%{if($_.Path){$v=Get-VHD -Path $_.Path -EA 0;if($v){$r[$_.Path]=@{S=$v.Size;R=[bool]$v.RctId}}}};$r|ConvertTo-Json -Compress`
+
+	// BatchGetVMHardware is the split fallback — hardware-only, no guest info.
 	BatchGetVMHardware = `$r=@{};foreach($vm in(Get-VM)){$n=$vm.Name;$e=@{};if($vm.Generation-eq 2){$s=Get-VMSecurity -VMName $n -EA 0;$f=Get-VMFirmware -VMName $n -EA 0;$t=$false;$b=$false;if($s){$t=$s.TpmEnabled};if($f-and$f.SecureBoot-eq'On'){$b=$true};$e['Security']=@{TpmEnabled=$t;SecureBoot=$b}}else{$e['Security']=@{TpmEnabled=$false;SecureBoot=$false}};$e['HasCheckpoint']=[bool](Get-VMSnapshot -VMName $n -EA 0);$dd=@();foreach($d in(Get-VMHardDiskDrive -VMName $n -EA 0)){if(-not$d.Path){continue};$v=Get-VHD -Path $d.Path -EA 0;$c=0;$rc=$false;if($v){$c=$v.Size;if($v.RctId){$rc=$true}};$dd+=@{Path=$d.Path;Capacity=$c;RCTEnabled=$rc;CT=[int]$d.ControllerType;CN=$d.ControllerNumber;CL=$d.ControllerLocation}};$e['Disks']=$dd;$nn=@();foreach($a in(Get-VMNetworkAdapter -VMName $n -EA 0)){$vl=0;$vi=$a|Get-VMNetworkAdapterVlan -EA 0;if($vi-and$vi.AccessVlanId){$vl=$vi.AccessVlanId};$nn+=@{Name=$a.Name;MAC=$a.MacAddress;Switch=$a.SwitchName;Vlan=$vl}};$e['NICs']=$nn;$r[$n]=$e};$r|ConvertTo-Json -Depth 4 -Compress`
 
-	// BatchGetVMGuest collects guest OS and guest network config for running VMs.
+	// BatchGetVMGuest is the split fallback — guest OS + networks for running VMs only.
 	BatchGetVMGuest = `$r=@{};foreach($vm in(Get-VM|?{$_.State-eq'Running'})){$n=$vm.Name;$e=@{};$ci=Get-CimInstance -Namespace root\virtualization\v2 -ClassName Msvm_ComputerSystem -Filter "ElementName='$n'" -EA 0;if($ci){$kv=Get-CimAssociatedInstance -InputObject $ci -ResultClassName Msvm_KvpExchangeComponent -EA 0;if($kv-and$kv.GuestIntrinsicExchangeItems){$os='';$om='';foreach($i in $kv.GuestIntrinsicExchangeItems){$x=[xml]$i;$pn=$x.INSTANCE.PROPERTY|?{$_.NAME-eq'Name'}|Select -Exp VALUE;$pv=$x.INSTANCE.PROPERTY|?{$_.NAME-eq'Data'}|Select -Exp VALUE;if($pn-eq'OSName'){$os=$pv}elseif($pn-eq'OSMajorVersion'){$om=$pv}};if($os-and$om-and$os-notmatch'\d'){$os="$os $om"};$e['GuestOS']=$os};$vs=Get-CimAssociatedInstance -InputObject $ci -ResultClassName Msvm_VirtualSystemSettingData|?{$_.VirtualSystemType-eq'Microsoft:Hyper-V:System:Realized'};if($vs){$ps=Get-CimAssociatedInstance -InputObject $vs -ResultClassName Msvm_SyntheticEthernetPortSettingData;$nc=@();foreach($p in $ps){$gc=Get-CimAssociatedInstance -InputObject $p -ResultClassName Msvm_GuestNetworkAdapterConfiguration;if($gc){$nc+=[PSCustomObject]@{MAC=$p.Address;IPs=$gc.IPAddresses;Subnets=$gc.Subnets;DHCP=$gc.DHCPEnabled;GW=$gc.DefaultGateways;DNS=$gc.DNSServers}}};if($nc.Count-gt 0){$e['GuestNetworks']=$nc}}};if($e.Count-gt 0){$r[$n]=$e}};$r|ConvertTo-Json -Depth 4 -Compress`
 )


### PR DESCRIPTION
Reduce initial parity time from ~102s to ~20s on a 2-node Failover Cluster (6 VMs) and keep power-state detection under 15s per cycle.

Initial load:
- LightMode scripts (BatchGetVMDetailsLight, ListVMsWithDetailsLight) skip Get-VHD, Get-VMSecurity, and guest CIM queries.
- Targeted BatchGetVHDCapacity enrichment runs Get-VHD in parallel across nodes after load, filling disk capacity and RCT before parity.

Refresh cycle (cluster mode):
- Phase 1: VM + Disk adapters in LightMode — power state and checkpoint status committed to DB in seconds.
- Phase 2 (concurrent): Get-VHD enrichment runs in parallel with Cluster, Host, Network, Storage adapters — no added latency.
- Every 10th cycle: full non-LightMode serial refresh picks up security, guest OS, and guest network changes.
- VMAdapter and DiskAdapter preserve capacity/RCT from previous record when LightMode returns zero values.

Infrastructure:
- Replace Get-ComputerInfo with targeted WMI queries .
- Merge BatchGetVMHardware + BatchGetVMGuest into BatchGetVMDetails.
- Combine GetCluster + GetClusterNodes into GetClusterInfo.
- Switch WinRMDriver to sync.RWMutex for concurrent commands.
- Cache GetComputerInfo per cycle with sync.Once (fixes data race).
- Capture prefetch channels in local variables (fixes goroutine leak).
- Propagate getLocalComputerInfo errors (fixes duplicate VM collection).
- Parallel load phases with background VM and network prefetch.

Connection resilience:
- Hyper-V connection test treats failures as transient when the collector has parity, preventing false SourceProviderNotReady blockers during active migrations.

Ref: https://redhat.atlassian.net/browse/MTV-6512
Resolves: MTV-6512