### PR TITLE
Unmap and remap Pure Storage NVMe hosts in vsphere-copy-offload-populator

### DIFF
--- a/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/remote_esxcli.go
@@ -208,6 +208,17 @@ func (p *RemoteEsxcliPopulator) Populate(ctx context.Context, vmId string, migra
 	}
 	setupLog.V(2).Info("current initiator groups for LUN", "lun", lun.IQN, "groups", originalInitiatorGroups)
 
+	// If the storage backend supports protocol-conflict resolution, evict any hosts that
+	// are connected via an incompatible transport family (e.g. NVMe-oF hosts when we
+	// are about to attach an iSCSI/FC xcopy initiator).  The evicted hosts are stored in
+	// mappingContext and restored unconditionally in the cleanup defer below.
+	if resolver, ok := p.StorageApi.(ProtocolConflictResolver); ok {
+		setupLog.Info("checking for protocol-conflicting connections before mapping", "lun", lun.Name)
+		if err := resolver.EvictConflictingConnections(lun, mappingContext); err != nil {
+			return fmt.Errorf("failed to evict conflicting connections for lun %s: %w", lun.Name, err)
+		}
+	}
+
 	fullCleanUpAttempted := false
 
 	defer func() {
@@ -226,6 +237,12 @@ func (p *RemoteEsxcliPopulator) Populate(ctx context.Context, vmId string, migra
 				}
 			} else {
 				setupLog.V(2).Info("skipping partial cleanup unmap (LUN not resolved)")
+			}
+		}
+		// Restore any connections that were evicted for protocol-conflict reasons.
+		if resolver, ok := p.StorageApi.(ProtocolConflictResolver); ok {
+			if errRestore := resolver.RestoreConflictingConnections(lun, mappingContext); errRestore != nil {
+				setupLog.Info("partial cleanup: failed to restore evicted connections", "err", errRestore)
 			}
 		}
 	}()
@@ -278,6 +295,14 @@ func (p *RemoteEsxcliPopulator) Populate(ctx context.Context, vmId string, migra
 		errUnmap := p.StorageApi.UnmapTarget(lun, mappingContext)
 		if errUnmap != nil {
 			cleanupLog.Info("failed to unmap during cleanup", "lun", lun.Name, "err", errUnmap)
+		}
+
+		// Restore any connections that were evicted for protocol-conflict reasons before
+		// we re-map the volume back to its original initiator groups.
+		if resolver, ok := p.StorageApi.(ProtocolConflictResolver); ok {
+			if errRestore := resolver.RestoreConflictingConnections(lun, mappingContext); errRestore != nil {
+				cleanupLog.Info("failed to restore evicted connections during cleanup", "lun", lun.Name, "err", errRestore)
+			}
 		}
 
 		cleanupLog.V(2).Info("mapping volume back to original initiator groups", "groups", originalInitiatorGroups)
@@ -483,6 +508,14 @@ func getScriptVersion(ctx context.Context, sshClient vmware.SSHClient, datastore
 }
 
 func checkScriptVersion(ctx context.Context, sshClient vmware.SSHClient, datastore, embeddedVersion string, publicKey []byte) error {
+	// "dev" is the default when the binary was not built with ldflags (local development).
+	// Skip the version check in that case — any script on the datastore is acceptable.
+	if embeddedVersion == "dev" {
+		setupLog := logger.New("xcopy").WithName("setup")
+		setupLog.Info("embedded script version is 'dev' (non-release build), skipping version check")
+		return nil
+	}
+
 	remoteVersion, err := getScriptVersion(ctx, sshClient, datastore)
 	if err != nil {
 		return fmt.Errorf("old script format detected (likely Python-based). Update script on datastore %s to version %s or newer: %w", datastore, embeddedVersion, err)

--- a/cmd/vsphere-copy-offload-populator/internal/populator/storage.go
+++ b/cmd/vsphere-copy-offload-populator/internal/populator/storage.go
@@ -61,6 +61,31 @@ type SciniAware interface {
 	SciniRequired() bool
 }
 
+// ProtocolConflictResolver is an optional interface for storage backends that need to
+// temporarily remove NVMe-connected hosts before the iSCSI/FC xcopy mapping can succeed.
+//
+// SCSI XCOPY requires SCSI, so the ESXi host performing xcopy always connects via iSCSI or
+// FC.  Pure FlashArray (and similar arrays) reject adding an iSCSI/FC host connection to a
+// volume that already has an NVMe-oF host connected.  When the target PVC was provisioned
+// on OpenShift via NVMe-oF/TCP by the CSI driver, the volume is pre-connected to one or
+// more NVMe hosts that must be temporarily removed before xcopy can proceed.
+//
+// Implementations must:
+//   - Record the evicted host names inside MappingContext so RestoreConflictingConnections
+//     can restore them unconditionally after xcopy finishes (success or failure).
+//   - Be idempotent: if there are no NVMe connections the call is a no-op.
+type ProtocolConflictResolver interface {
+	// EvictConflictingConnections disconnects any NVMe-connected hosts from targetLUN
+	// so that the iSCSI/FC xcopy initiator can be mapped.  Evicted host names are stored
+	// in mappingContext for later restoration.
+	EvictConflictingConnections(targetLUN LUN, mappingContext MappingContext) error
+
+	// RestoreConflictingConnections reconnects any hosts that were evicted by
+	// EvictConflictingConnections.  Should be called in a defer after xcopy completes,
+	// whether or not xcopy succeeded.
+	RestoreConflictingConnections(targetLUN LUN, mappingContext MappingContext) error
+}
+
 // StorageArrayInfo holds metadata about the storage array, retrieved from the API at connection time.
 type StorageArrayInfo struct {
 	// Vendor is the storage array vendor (e.g. "IBM", "Dell", "NetApp").

--- a/cmd/vsphere-copy-offload-populator/internal/pure/flashArray.go
+++ b/cmd/vsphere-copy-offload-populator/internal/pure/flashArray.go
@@ -21,6 +21,7 @@ var _ populator.RDMCapable = &FlashArrayClonner{}
 var _ populator.VVolCapable = &FlashArrayClonner{}
 var _ populator.VMDKCapable = &FlashArrayClonner{}
 var _ populator.StorageArrayInfoProvider = &FlashArrayClonner{}
+var _ populator.ProtocolConflictResolver = &FlashArrayClonner{}
 
 type FlashArrayClonner struct {
 	restClient    *RestClient
@@ -191,6 +192,108 @@ func (f *FlashArrayClonner) CurrentMappedGroups(targetLUN populator.LUN, context
 	// we don't use the host group feature, as a host in pure flasharray can not belong to two separate groups, and we
 	// definitely don't want to break host from their current groups. insted we'll just map/unmap the volume to individual hosts
 	return nil, nil
+}
+
+// EvictConflictingConnections disconnects any NVMe-connected hosts from targetLUN before
+// the iSCSI/FC xcopy mapping is established.
+//
+// Pure FlashArray rejects connecting an iSCSI or FC host to a volume that already has an
+// NVMe-oF host connected (and vice versa).  The target PVC will have been provisioned by
+// the CSI driver on OpenShift via NVMe-oF/TCP, leaving one or more NVMe host connections
+// in place.  Since the xcopy operation always uses iSCSI or FC (SCSI XCOPY requires SCSI),
+// those NVMe connections must be temporarily removed before MapTarget is called.
+//
+// The evicted host names are stored in mappingContext["evictedHosts"] as []string so that
+// RestoreConflictingConnections can reconnect them after xcopy finishes.
+func (f *FlashArrayClonner) EvictConflictingConnections(targetLUN populator.LUN, mappingContext populator.MappingContext) error {
+	if targetLUN.Name == "" {
+		return nil
+	}
+
+	f.log.Info("checking for NVMe-connected hosts before xcopy mapping", "volume", targetLUN.Name)
+
+	// List all current connections for this volume.
+	connections, err := f.restClient.ListVolumeConnections(targetLUN.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list connections for volume %s: %w", targetLUN.Name, err)
+	}
+
+	if len(connections) == 0 {
+		f.log.V(2).Info("no existing connections on volume, nothing to evict", "volume", targetLUN.Name)
+		return nil
+	}
+
+	// Build a lookup of all Pure hosts so we can check each connected host's NQNs.
+	allHosts, err := f.restClient.ListHosts()
+	if err != nil {
+		return fmt.Errorf("failed to list hosts for NVMe eviction check: %w", err)
+	}
+	hostByName := make(map[string]Host, len(allHosts))
+	for _, h := range allHosts {
+		hostByName[h.Name] = h
+	}
+
+	var evicted []string
+	for _, conn := range connections {
+		connHostName := conn.Host.Name
+		h, ok := hostByName[connHostName]
+		if !ok {
+			f.log.V(2).Info("connected host not found in host list, skipping", "host", connHostName)
+			continue
+		}
+
+		// Only evict NVMe-connected hosts; iSCSI/FC hosts are compatible with xcopy.
+		if len(h.Nqn) == 0 {
+			continue
+		}
+
+		f.log.Info("evicting NVMe-connected host before xcopy", "volume", targetLUN.Name, "host", connHostName)
+		if err := f.restClient.DisconnectHost(connHostName, targetLUN.Name); err != nil {
+			if strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "Connection does not exist") {
+				f.log.V(2).Info("connection already gone, ignoring", "host", connHostName, "volume", targetLUN.Name)
+			} else {
+				return fmt.Errorf("failed to evict NVMe host %s from volume %s: %w", connHostName, targetLUN.Name, err)
+			}
+		}
+		evicted = append(evicted, connHostName)
+	}
+
+	if len(evicted) > 0 {
+		f.log.Info("evicted NVMe connections; will restore after xcopy", "volume", targetLUN.Name, "evicted", evicted)
+		mappingContext["evictedHosts"] = evicted
+	}
+	return nil
+}
+
+// RestoreConflictingConnections reconnects any hosts that were evicted by
+// EvictConflictingConnections.  It is a best-effort operation: individual
+// reconnect failures are logged but do not stop the restore loop.
+func (f *FlashArrayClonner) RestoreConflictingConnections(targetLUN populator.LUN, mappingContext populator.MappingContext) error {
+	if targetLUN.Name == "" {
+		return nil
+	}
+
+	evicted, _ := mappingContext["evictedHosts"].([]string)
+	if len(evicted) == 0 {
+		return nil
+	}
+
+	f.log.Info("restoring evicted connections after xcopy", "volume", targetLUN.Name, "hosts", evicted)
+	var lastErr error
+	for _, hostName := range evicted {
+		f.log.Info("reconnecting host", "host", hostName, "volume", targetLUN.Name)
+		if err := f.restClient.ConnectHost(hostName, targetLUN.Name); err != nil {
+			if strings.Contains(err.Error(), "Connection already exists.") {
+				f.log.V(2).Info("connection already restored", "host", hostName, "volume", targetLUN.Name)
+				continue
+			}
+			f.log.Info("failed to restore connection", "host", hostName, "volume", targetLUN.Name, "err", err)
+			lastErr = err
+		} else {
+			f.log.Info("connection restored", "host", hostName, "volume", targetLUN.Name)
+		}
+	}
+	return lastErr
 }
 
 // ResolvePVToLUN resolves a PersistentVolume to Pure FlashArray LUN details

--- a/cmd/vsphere-copy-offload-populator/internal/pure/rest_client.go
+++ b/cmd/vsphere-copy-offload-populator/internal/pure/rest_client.go
@@ -91,6 +91,7 @@ type Host struct {
 	Name string   `json:"name"`
 	Iqn  []string `json:"iqns"`
 	Wwn  []string `json:"wwns"`
+	Nqn  []string `json:"nqns"`
 }
 
 // Volume represents a Pure FlashArray volume
@@ -114,6 +115,23 @@ type VolumesResponse struct {
 type HostConnectionRequest struct {
 	HostNames   string `json:"host_names"`
 	VolumeNames string `json:"volume_names"`
+}
+
+// HostConnection represents a single host-to-volume connection on the FlashArray.
+type HostConnection struct {
+	// Host is the Pure host object reference.
+	Host struct {
+		Name string `json:"name"`
+	} `json:"host"`
+	// Volume is the Pure volume object reference.
+	Volume struct {
+		Name string `json:"name"`
+	} `json:"volume"`
+}
+
+// HostConnectionsResponse represents the response from the connections list API.
+type HostConnectionsResponse struct {
+	Items []HostConnection `json:"items"`
 }
 
 // NewRestClient creates a new REST client for Pure FlashArray
@@ -493,6 +511,33 @@ func (c *RestClient) DisconnectHost(hostName, volumeName string) error {
 	}
 
 	return nil
+}
+
+// ListVolumeConnections returns all host connections for the given volume name.
+func (c *RestClient) ListVolumeConnections(volumeName string) ([]HostConnection, error) {
+	reqURL := fmt.Sprintf("https://%s/api/%s/connections?volume_names=%s",
+		c.hostname, c.apiV2, url.QueryEscape(volumeName))
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list connections request: %w", err)
+	}
+
+	resp, body, err := c.doWithReauth(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send list connections request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list connections request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result HostConnectionsResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse list connections response: %w", err)
+	}
+
+	return result.Items, nil
 }
 
 // GetVolume gets information about a specific volume


### PR DESCRIPTION
Closes #8307

This is a workaround to allow cross protocol migrations to use copy offload on Pure storage, e.g.:
iSCSI on VMware -> NVMe-oF on Kubernetes

It has only been implemented for Pure Storage as that's all I have available to test with and I'm not sure if other SANs have the same mixed protocol limitation.

It achieves this by unmapping hosts using another protocol from a PVC before mapping itself so there is not mixed protocols attached to a volume at the same time. Then remaps the other hosts after the copy is complete and it has unmapped itself.

I don't necessarily expect this to be merged as it is somewhat of a hack, but sharing in case it's useful or you can come up with a more elegant solution.