### PR TITLE
MTV-6511 | Fixes performance regression from #8250

### DIFF
--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -304,6 +304,10 @@ type Collector struct {
 	// Cached missing privileges from the last check.
 	missingPrivs   *privilegeCheckResult
 	missingPrivsMu *sync.RWMutex
+	// Committed provider-global custom field definitions (keyed by field key)
+	// so repeated per-VM upserts can be skipped via in-memory comparison.
+	customFieldDefs   map[int32]model.CustomFieldDef
+	customFieldDefsMu *sync.RWMutex
 }
 
 // New collector.
@@ -314,12 +318,14 @@ func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) *Collector
 			provider.GetNamespace(),
 			provider.GetName()))
 	return &Collector{
-		url:            provider.Spec.URL,
-		provider:       provider,
-		secret:         secret,
-		db:             db,
-		log:            nlog,
-		missingPrivsMu: &sync.RWMutex{},
+		url:               provider.Spec.URL,
+		provider:          provider,
+		secret:            secret,
+		db:                db,
+		log:               nlog,
+		missingPrivsMu:    &sync.RWMutex{},
+		customFieldDefs:   map[int32]model.CustomFieldDef{},
+		customFieldDefsMu: &sync.RWMutex{},
 	}
 }
 
@@ -551,11 +557,13 @@ func (r *Collector) getUpdates(ctx context.Context) error {
 			err = tx.Commit()
 			if err != nil {
 				r.log.Error(err, "tx commit failed.")
+				r.resetCustomFieldDefs()
 			}
 		} else {
 			if endErr := tx.End(); endErr != nil {
 				r.log.Error(endErr, "tx rollback failed.")
 			}
+			r.resetCustomFieldDefs()
 		}
 		if err == nil && (updateSet.Truncated == nil || !*updateSet.Truncated) {
 			if !r.parity {
@@ -1271,7 +1279,7 @@ func (r *Collector) selectAdapter(u types.ObjectUpdate) (Adapter, bool) {
 }
 
 // Object created.
-func (r Collector) applyEnter(tx *libmodel.Tx, u types.ObjectUpdate) error {
+func (r *Collector) applyEnter(tx *libmodel.Tx, u types.ObjectUpdate) error {
 	adapter, selected := r.selectAdapter(u)
 	if !selected {
 		return nil
@@ -1291,7 +1299,7 @@ func (r Collector) applyEnter(tx *libmodel.Tx, u types.ObjectUpdate) error {
 }
 
 // Object modified.
-func (r Collector) applyModify(tx *libmodel.Tx, u types.ObjectUpdate) error {
+func (r *Collector) applyModify(tx *libmodel.Tx, u types.ObjectUpdate) error {
 	adapter, selected := r.selectAdapter(u)
 	if !selected {
 		return nil
@@ -1317,31 +1325,88 @@ func (r Collector) applyModify(tx *libmodel.Tx, u types.ObjectUpdate) error {
 // Upsert the custom field definitions reported on a VirtualMachine update
 // into the provider-global CustomFieldDef table. The same global definition
 // set is reported per-VM, so inserting by key naturally de-duplicates it.
-func (r Collector) upsertCustomFieldDefs(tx *libmodel.Tx, u types.ObjectUpdate) (err error) {
+//
+// The set of definitions is provider-global and identical for every VM, so it
+// is cached in memory. When the reported set matches the cache, the DB
+// upserts are skipped entirely, avoiding repeated inserts on every VM update.
+func (r *Collector) upsertCustomFieldDefs(tx *libmodel.Tx, u types.ObjectUpdate) (err error) {
 	if u.Obj.Type != VirtualMachine {
 		return nil
 	}
+	var reported []types.CustomFieldDef
 	for _, p := range u.ChangeSet {
 		if p.Name != fAvailableField {
 			continue
 		}
 		customFields, ok := p.Val.(types.ArrayOfCustomFieldDef)
 		if !ok {
-			continue
+			return nil
 		}
-		for _, f := range customFields.CustomFieldDef {
-			def := &model.CustomFieldDef{
-				Name:              f.Name,
-				Key:               f.Key,
-				ManagedObjectType: f.ManagedObjectType,
-			}
-			if err = tx.Insert(def); err != nil {
-				return liberr.Wrap(err)
-			}
+		reported = customFields.CustomFieldDef
+	}
+	if len(reported) == 0 {
+		return nil
+	}
+
+	incoming := make(map[int32]model.CustomFieldDef, len(reported))
+	for _, f := range reported {
+		incoming[f.Key] = model.CustomFieldDef{
+			Name:              f.Name,
+			Key:               f.Key,
+			ManagedObjectType: f.ManagedObjectType,
 		}
 	}
 
+	r.customFieldDefsMu.RLock()
+	equal := equalCustomFieldDefs(r.customFieldDefs, incoming)
+	r.customFieldDefsMu.RUnlock()
+	if equal {
+		return nil
+	}
+
+	for _, f := range reported {
+		def := &model.CustomFieldDef{
+			Name:              f.Name,
+			Key:               f.Key,
+			ManagedObjectType: f.ManagedObjectType,
+		}
+		if err = tx.Insert(def); err != nil {
+			return liberr.Wrap(err)
+		}
+	}
+
+	// The cache is updated in place. If the surrounding transaction is rolled
+	// back, resetCustomFieldDefs drops it so a later retry reinserts the defs
+	// rather than skipping them on a stale cache.
+	r.customFieldDefsMu.Lock()
+	r.customFieldDefs = incoming
+	r.customFieldDefsMu.Unlock()
+
 	return nil
+}
+
+// resetCustomFieldDefs drops the cached custom field definitions. It is called
+// when the transaction that updated them is rolled back, so that the cache
+// never reflects definitions that were not committed to the DB.
+func (r *Collector) resetCustomFieldDefs() {
+	r.customFieldDefsMu.Lock()
+	r.customFieldDefs = map[int32]model.CustomFieldDef{}
+	r.customFieldDefsMu.Unlock()
+}
+
+// equalCustomFieldDefs reports whether the two provider-global custom field
+// definition sets are identical.
+func equalCustomFieldDefs(a, b map[int32]model.CustomFieldDef) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || av != bv {
+			return false
+		}
+	}
+	return true
 }
 
 // Object deleted.

--- a/pkg/controller/provider/container/vsphere/model_test.go
+++ b/pkg/controller/provider/container/vsphere/model_test.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
@@ -723,8 +724,15 @@ func newTestInventoryDB(t *testing.T) libmodel.DB {
 	return db
 }
 
+func newTestCollector() *Collector {
+	return &Collector{
+		customFieldDefs:   map[int32]model.CustomFieldDef{},
+		customFieldDefsMu: &sync.RWMutex{},
+	}
+}
+
 func TestUpsertCustomFieldDefs(t *testing.T) {
-	adapter := Collector{}
+	adapter := newTestCollector()
 	db := newTestInventoryDB(t)
 	defs := []types.CustomFieldDef{
 		{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
@@ -780,7 +788,7 @@ func TestUpsertCustomFieldDefs(t *testing.T) {
 }
 
 func TestUpsertCustomFieldDefsSkipsNonVM(t *testing.T) {
-	adapter := Collector{}
+	adapter := newTestCollector()
 	db := newTestInventoryDB(t)
 
 	err := db.With(func(tx *libmodel.Tx) error {
@@ -799,6 +807,129 @@ func TestUpsertCustomFieldDefsSkipsNonVM(t *testing.T) {
 	}
 	if len(list) != 0 {
 		t.Errorf("expected no defs for non-VM object, got %d", len(list))
+	}
+}
+
+func TestUpsertCustomFieldDefsCaches(t *testing.T) {
+	adapter := newTestCollector()
+	db := newTestInventoryDB(t)
+
+	defs := []types.CustomFieldDef{
+		{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
+		{Name: "env", Key: 200, ManagedObjectType: ""},
+	}
+	update := func(defs []types.CustomFieldDef) types.ObjectUpdate {
+		return types.ObjectUpdate{
+			Obj: types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-1"},
+			ChangeSet: []types.PropertyChange{
+				{
+					Op:   Assign,
+					Name: fAvailableField,
+					Val:  types.ArrayOfCustomFieldDef{CustomFieldDef: defs},
+				},
+			},
+		}
+	}
+
+	countRows := func() int {
+		t.Helper()
+		list := []model.CustomFieldDef{}
+		if err := db.List(&list, libmodel.ListOptions{Detail: libmodel.MaxDetail}); err != nil {
+			t.Fatalf("List returned error: %v", err)
+		}
+		return len(list)
+	}
+
+	if err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, update(defs))
+	}); err != nil {
+		t.Fatalf("first upsert returned error: %v", err)
+	}
+	if got := countRows(); got != len(defs) {
+		t.Fatalf("expected %d rows after first upsert, got %d", len(defs), got)
+	}
+
+	// The same provider-global def set reported by a second VM should be
+	// skipped via the in-memory cache (no additional DB writes, no dup rows).
+	if err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, update(defs))
+	}); err != nil {
+		t.Fatalf("repeated upsert returned error: %v", err)
+	}
+	if got := countRows(); got != len(defs) {
+		t.Fatalf("expected %d rows after repeated upsert, got %d", len(defs), got)
+	}
+
+	// A changed def set should be reflected in the DB.
+	changed := []types.CustomFieldDef{
+		{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
+		{Name: "env-renamed", Key: 200, ManagedObjectType: ""},
+		{Name: "team", Key: 300, ManagedObjectType: "VirtualMachine"},
+	}
+	if err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, update(changed))
+	}); err != nil {
+		t.Fatalf("changed upsert returned error: %v", err)
+	}
+	if got := countRows(); got != len(changed) {
+		t.Fatalf("expected %d rows after changed upsert, got %d", len(changed), got)
+	}
+}
+
+func TestUpsertCustomFieldDefsRollbackRetriesIdentical(t *testing.T) {
+	adapter := newTestCollector()
+	db := newTestInventoryDB(t)
+
+	defs := []types.CustomFieldDef{
+		{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
+		{Name: "env", Key: 200, ManagedObjectType: ""},
+	}
+	u := types.ObjectUpdate{
+		Obj: types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-1"},
+		ChangeSet: []types.PropertyChange{
+			{
+				Op:   Assign,
+				Name: fAvailableField,
+				Val:  types.ArrayOfCustomFieldDef{CustomFieldDef: defs},
+			},
+		},
+	}
+
+	countRows := func() int {
+		t.Helper()
+		list := []model.CustomFieldDef{}
+		if err := db.List(&list, libmodel.ListOptions{Detail: libmodel.MaxDetail}); err != nil {
+			t.Fatalf("List returned error: %v", err)
+		}
+		return len(list)
+	}
+
+	// Stage the defs inside a transaction that is then rolled back.
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin returned error: %v", err)
+	}
+	if err := adapter.upsertCustomFieldDefs(tx, u); err != nil {
+		t.Fatalf("upsertCustomFieldDefs returned error: %v", err)
+	}
+	if err := tx.End(); err != nil {
+		t.Fatalf("rollback returned error: %v", err)
+	}
+	// The cache must not retain defs from the rolled-back transaction.
+	adapter.resetCustomFieldDefs()
+
+	if got := countRows(); got != 0 {
+		t.Fatalf("expected 0 rows after rollback, got %d", got)
+	}
+
+	// Retrying identical definitions after the rollback must reinsert them.
+	if err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, u)
+	}); err != nil {
+		t.Fatalf("retry upsert returned error: %v", err)
+	}
+	if got := countRows(); got != len(defs) {
+		t.Fatalf("expected %d rows after retry, got %d", len(defs), got)
 	}
 }
 


### PR DESCRIPTION
With the PR #8250 there was a performance regression that caused the initial inventory parsing to take 3-4 times longer due to heavier reliance on the database to process updates instead of only inserts.

This change caches the custom def fields into memory in the inventory application and then does a compare against that before attempting the database insert/update. This is especially impactful on the initial startup which attempts to insert/update the same custom def fields for each VM. 

Resolves: MTV-6511