### PR TITLE
MTV-6511 | Gate collection of custom attributes in vSphere inventory

### DIFF
--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/settings/inventory.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/settings/inventory.go
@@ -19,16 +19,17 @@ const (
 
 // Environment variables.
 const (
-	AllowedOrigins = "CORS_ALLOWED_ORIGINS"
-	WorkingDir     = "WORKING_DIR"
-	AuthRequired   = "AUTH_REQUIRED"
-	Host           = "API_HOST"
-	Namespace      = "POD_NAMESPACE"
-	Port           = "API_PORT"
-	Scheme         = "INVENTORY_SERVICE_SCHEME"
-	TLSCertificate = "API_TLS_CERTIFICATE"
-	TLSKey         = "API_TLS_KEY"
-	TLSCa          = "API_TLS_CA"
+	AllowedOrigins                = "CORS_ALLOWED_ORIGINS"
+	WorkingDir                    = "WORKING_DIR"
+	AuthRequired                  = "AUTH_REQUIRED"
+	Host                          = "API_HOST"
+	Namespace                     = "POD_NAMESPACE"
+	Port                          = "API_PORT"
+	Scheme                        = "INVENTORY_SERVICE_SCHEME"
+	TLSCertificate                = "API_TLS_CERTIFICATE"
+	TLSKey                        = "API_TLS_KEY"
+	TLSCa                         = "API_TLS_CA"
+	VsphereExcludedVMPropertiesEv = "INVENTORY_VSPHERE_EXCLUDED_VM_PROPERTIES"
 )
 
 // CORS
@@ -62,6 +63,9 @@ type Inventory struct {
 		// CA path
 		CA string
 	}
+	// vSphere VM properties to exclude from the PropertyCollector PathSet.
+	// Comma-separated vCenter property paths (e.g. "customValue,availableField").
+	VsphereExcludedVMProperties []string
 }
 
 // Load settings.
@@ -126,6 +130,16 @@ func (r *Inventory) Load() error {
 	} else {
 		if _, err := os.Stat(ServiceCAFile); !errors.Is(err, os.ErrNotExist) {
 			r.TLS.CA = ServiceCAFile
+		}
+	}
+	// vSphere excluded VM properties
+	r.VsphereExcludedVMProperties = []string{}
+	if s, found := os.LookupEnv(VsphereExcludedVMPropertiesEv); found {
+		for _, p := range strings.Split(s, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				r.VsphereExcludedVMProperties = append(r.VsphereExcludedVMProperties, p)
+			}
 		}
 	}
 

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -1068,6 +1068,21 @@ func (r *Collector) propertySpec() []types.PropertySpec {
 	}
 }
 
+// vmPropertyDenylist lists properties that can never be excluded from
+// the VM PathSet because they are required for migration to succeed.
+var vmPropertyDenylist = map[string]bool{
+	fName:            true,
+	fParent:          true,
+	fUUID:            true,
+	fDevices:         true,
+	fGuestNet:        true,
+	fGuestIpStack:    true,
+	fDatastore:       true,
+	fNetwork:         true,
+	fPowerState:      true,
+	fConnectionState: true,
+}
+
 func (r *Collector) vmPathSet() []string {
 	pathSet := []string{
 		fName,
@@ -1119,7 +1134,37 @@ func (r *Collector) vmPathSet() []string {
 	if majorVal > 6 || majorVal == 6 && minorVal >= 7 {
 		pathSet = append(pathSet, fTpmPresent)
 	}
-	return pathSet
+
+	return r.filterVmPathSet(pathSet)
+}
+
+// filterVmPathSet removes excluded properties from the PathSet. Properties
+// in the denylist are always preserved; a warning is logged if an operator
+// attempts to exclude one.
+func (r *Collector) filterVmPathSet(pathSet []string) []string {
+	excluded := settings.Settings.VsphereExcludedVMProperties
+	if len(excluded) == 0 {
+		return pathSet
+	}
+	exclusionSet := make(map[string]bool, len(excluded))
+	for _, p := range excluded {
+		exclusionSet[strings.TrimSpace(p)] = true
+	}
+	filtered := make([]string, 0, len(pathSet))
+	for _, p := range pathSet {
+		if !exclusionSet[p] {
+			filtered = append(filtered, p)
+			continue
+		}
+		if vmPropertyDenylist[p] {
+			if r.log != nil {
+				r.log.Info("ignoring exclusion of denylisted VM property", "property", p)
+			}
+			filtered = append(filtered, p)
+			continue
+		}
+	}
+	return filtered
 }
 
 // Apply updates.

--- a/pkg/controller/provider/container/vsphere/collector_test.go
+++ b/pkg/controller/provider/container/vsphere/collector_test.go
@@ -24,6 +24,7 @@ import (
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
 	libmodel "github.com/kubev2v/forklift/pkg/lib/inventory/model"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
+	"github.com/kubev2v/forklift/pkg/settings"
 )
 
 var _ = Describe("vSphere collector", func() {
@@ -46,6 +47,59 @@ var _ = Describe("vSphere collector", func() {
 		table.Entry("collect TPM from vSphere 6.7", "6.7", ContainElements(fTpmPresent)),
 		table.Entry("collect TPM from vSphere > 6.7", "7.0", ContainElements(fTpmPresent)),
 	)
+})
+
+var _ = Describe("vmPathSet exclusion", func() {
+	collector := Collector{}
+	url, _ := liburl.Parse("https://fake.com/sdk")
+	vimClient := &vim25.Client{
+		Client:         soap.NewClient(url, false),
+		ServiceContent: types.ServiceContent{},
+	}
+	collector.client = &govmomi.Client{
+		SessionManager: session.NewManager(vimClient),
+		Client:         vimClient,
+	}
+	collector.client.ServiceContent.About.ApiVersion = "7.0"
+
+	var savedExcluded []string
+
+	BeforeEach(func() {
+		savedExcluded = settings.Settings.VsphereExcludedVMProperties
+		settings.Settings.VsphereExcludedVMProperties = []string{}
+	})
+
+	AfterEach(func() {
+		settings.Settings.VsphereExcludedVMProperties = savedExcluded
+	})
+
+	It("should return the full pathSet when no exclusions are set", func() {
+		pathSet := collector.vmPathSet()
+		Expect(pathSet).To(ContainElements(fCustomValue, fAvailableField, fName, fDevices))
+	})
+
+	It("should exclude listed properties", func() {
+		settings.Settings.VsphereExcludedVMProperties = []string{fCustomValue, fAvailableField}
+		pathSet := collector.vmPathSet()
+		Expect(pathSet).NotTo(ContainElement(fCustomValue))
+		Expect(pathSet).NotTo(ContainElement(fAvailableField))
+	})
+
+	It("should preserve denylisted properties even when listed for exclusion", func() {
+		settings.Settings.VsphereExcludedVMProperties = []string{fName, fDevices, fGuestNet, fCustomValue}
+		pathSet := collector.vmPathSet()
+		Expect(pathSet).To(ContainElement(fName))
+		Expect(pathSet).To(ContainElement(fDevices))
+		Expect(pathSet).To(ContainElement(fGuestNet))
+		Expect(pathSet).NotTo(ContainElement(fCustomValue))
+	})
+
+	It("should ignore whitespace in exclusion entries", func() {
+		settings.Settings.VsphereExcludedVMProperties = []string{"  customValue  ", " availableField"}
+		pathSet := collector.vmPathSet()
+		Expect(pathSet).NotTo(ContainElement(fCustomValue))
+		Expect(pathSet).NotTo(ContainElement(fAvailableField))
+	})
 })
 
 var _ = Describe("apply", func() {

--- a/pkg/settings/inventory.go
+++ b/pkg/settings/inventory.go
@@ -19,16 +19,17 @@ const (
 
 // Environment variables.
 const (
-	AllowedOrigins = "CORS_ALLOWED_ORIGINS"
-	WorkingDir     = "WORKING_DIR"
-	AuthRequired   = "AUTH_REQUIRED"
-	Host           = "API_HOST"
-	Namespace      = "POD_NAMESPACE"
-	Port           = "API_PORT"
-	Scheme         = "INVENTORY_SERVICE_SCHEME"
-	TLSCertificate = "API_TLS_CERTIFICATE"
-	TLSKey         = "API_TLS_KEY"
-	TLSCa          = "API_TLS_CA"
+	AllowedOrigins                = "CORS_ALLOWED_ORIGINS"
+	WorkingDir                    = "WORKING_DIR"
+	AuthRequired                  = "AUTH_REQUIRED"
+	Host                          = "API_HOST"
+	Namespace                     = "POD_NAMESPACE"
+	Port                          = "API_PORT"
+	Scheme                        = "INVENTORY_SERVICE_SCHEME"
+	TLSCertificate                = "API_TLS_CERTIFICATE"
+	TLSKey                        = "API_TLS_KEY"
+	TLSCa                         = "API_TLS_CA"
+	VsphereExcludedVMPropertiesEv = "INVENTORY_VSPHERE_EXCLUDED_VM_PROPERTIES"
 )
 
 // CORS
@@ -62,6 +63,9 @@ type Inventory struct {
 		// CA path
 		CA string
 	}
+	// vSphere VM properties to exclude from the PropertyCollector PathSet.
+	// Comma-separated vCenter property paths (e.g. "customValue,availableField").
+	VsphereExcludedVMProperties []string
 }
 
 // Load settings.
@@ -126,6 +130,16 @@ func (r *Inventory) Load() error {
 	} else {
 		if _, err := os.Stat(ServiceCAFile); !errors.Is(err, os.ErrNotExist) {
 			r.TLS.CA = ServiceCAFile
+		}
+	}
+	// vSphere excluded VM properties
+	r.VsphereExcludedVMProperties = []string{}
+	if s, found := os.LookupEnv(VsphereExcludedVMPropertiesEv); found {
+		for _, p := range strings.Split(s, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				r.VsphereExcludedVMProperties = append(r.VsphereExcludedVMProperties, p)
+			}
 		}
 	}
 

--- a/pkg/settings/inventory_test.go
+++ b/pkg/settings/inventory_test.go
@@ -23,7 +23,21 @@ func TestInventoryLoad_SchemeNormalization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.unset {
-				_ = os.Unsetenv(Scheme)
+				prev, present := os.LookupEnv(Scheme)
+				t.Cleanup(func() {
+					if present {
+						if err := os.Setenv(Scheme, prev); err != nil {
+							t.Errorf("failed to restore env %s: %v", Scheme, err)
+						}
+					} else {
+						if err := os.Unsetenv(Scheme); err != nil {
+							t.Errorf("failed to unset env %s: %v", Scheme, err)
+						}
+					}
+				})
+				if err := os.Unsetenv(Scheme); err != nil {
+					t.Fatalf("failed to unset env %s: %v", Scheme, err)
+				}
 			} else {
 				t.Setenv(Scheme, tt.env)
 			}
@@ -33,6 +47,58 @@ func TestInventoryLoad_SchemeNormalization(t *testing.T) {
 			}
 			if inv.Scheme != tt.want {
 				t.Fatalf("Scheme = %q, want %q", inv.Scheme, tt.want)
+			}
+		})
+	}
+}
+
+func TestInventoryLoad_VsphereExcludedVMProperties(t *testing.T) {
+	tests := []struct {
+		name  string
+		env   string
+		unset bool
+		want  []string
+	}{
+		{"unset => empty slice", "", true, []string{}},
+		{"empty string => empty slice", "", false, []string{}},
+		{"whitespace string => empty slice", "   ,  ", false, []string{}},
+		{"single property", "customValue", false, []string{"customValue"}},
+		{"multiple properties comma separated", "customValue,availableField", false, []string{"customValue", "availableField"}},
+		{"with spaces around properties", " customValue , availableField ", false, []string{"customValue", "availableField"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unset {
+				prev, present := os.LookupEnv(VsphereExcludedVMPropertiesEv)
+				t.Cleanup(func() {
+					if present {
+						if err := os.Setenv(VsphereExcludedVMPropertiesEv, prev); err != nil {
+							t.Errorf("failed to restore env %s: %v", VsphereExcludedVMPropertiesEv, err)
+						}
+					} else {
+						if err := os.Unsetenv(VsphereExcludedVMPropertiesEv); err != nil {
+							t.Errorf("failed to unset env %s: %v", VsphereExcludedVMPropertiesEv, err)
+						}
+					}
+				})
+				if err := os.Unsetenv(VsphereExcludedVMPropertiesEv); err != nil {
+					t.Fatalf("failed to unset env %s: %v", VsphereExcludedVMPropertiesEv, err)
+				}
+			} else {
+				t.Setenv(VsphereExcludedVMPropertiesEv, tt.env)
+			}
+			var inv Inventory
+			if err := inv.Load(); err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if len(inv.VsphereExcludedVMProperties) != len(tt.want) {
+				t.Fatalf("VsphereExcludedVMProperties length = %d, want %d", len(inv.VsphereExcludedVMProperties), len(tt.want))
+			}
+			for i, v := range tt.want {
+				if inv.VsphereExcludedVMProperties[i] != v {
+					t.Fatalf("VsphereExcludedVMProperties[%d] = %q, want %q", i, inv.VsphereExcludedVMProperties[i], v)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Adds `INVENTORY_VSPHERE_EXCLUDED_VM_PROPERTIES` environment variable to allow operators to exclude specific VM properties (e.g. `customValue`, `availableField`) from the vSphere PropertyCollector `PathSet`.

## Key Changes
- Adds `VsphereExcludedVMProperties` to `pkg/settings/inventory.go` (`INVENTORY_VSPHERE_EXCLUDED_VM_PROPERTIES`).
- Adds `filterVmPathSet()` and critical property denylist enforcement to `pkg/controller/provider/container/vsphere/collector.go`.
- Related to PRs #8250 and #8367.
- Adds unit tests in `collector_test.go` and `inventory_test.go`.

Resolves: MTV-6511