### PR TITLE
MTV-6504 | Merge split offload plugins for same datastore

### DIFF
--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/mapping.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/mapping.go
@@ -80,11 +80,60 @@ type NetworkPair struct {
 }
 
 // OffloadPlugin is a storage plugin that acts on the storage allocation and copying
-// phase of the migration. There can be more than one available but currently only
-// one will be supported
+// phase of the migration. Both xcopy and CSI volume import may be configured together.
 type OffloadPlugin struct {
 	VSphereXcopyPluginConfig *VSphereXcopyPluginConfig `json:"vsphereXcopyConfig,omitempty"`
 	CsiVolumeImport          *CsiVolumeImport          `json:"csiVolumeImport,omitempty"`
+}
+
+// MergeOffloadPlugins combines two offload plugin configs. Order does not matter.
+func MergeOffloadPlugins(a, b *OffloadPlugin) *OffloadPlugin {
+	if a == nil && b == nil {
+		return nil
+	}
+	if a == nil {
+		return b.DeepCopy()
+	}
+	if b == nil {
+		return a.DeepCopy()
+	}
+	merged := a.DeepCopy()
+	if b.VSphereXcopyPluginConfig != nil {
+		merged.VSphereXcopyPluginConfig = b.VSphereXcopyPluginConfig.DeepCopy()
+	}
+	if b.CsiVolumeImport != nil {
+		merged.CsiVolumeImport = b.CsiVolumeImport.DeepCopy()
+	}
+	return merged
+}
+
+// MergeStoragePair combines two mappings for the same source datastore.
+// Destination fields from src override empty fields on dst; offload plugins are merged.
+func MergeStoragePair(dst, src StoragePair) StoragePair {
+	out := dst
+	if src.Source.ID != "" {
+		out.Source.ID = src.Source.ID
+	}
+	if src.Source.Name != "" {
+		out.Source.Name = src.Source.Name
+	}
+	if src.Source.Namespace != "" {
+		out.Source.Namespace = src.Source.Namespace
+	}
+	if src.Source.Type != "" {
+		out.Source.Type = src.Source.Type
+	}
+	if src.Destination.StorageClass != "" {
+		out.Destination.StorageClass = src.Destination.StorageClass
+	}
+	if src.Destination.AccessMode != "" {
+		out.Destination.AccessMode = src.Destination.AccessMode
+	}
+	if src.Destination.VolumeMode != "" {
+		out.Destination.VolumeMode = src.Destination.VolumeMode
+	}
+	out.OffloadPlugin = MergeOffloadPlugins(dst.OffloadPlugin, src.OffloadPlugin)
+	return out
 }
 
 // CsiVolumeImport uses the CSI driver's native import capability to migrate VVol/RDM disks.
@@ -330,24 +379,38 @@ type StorageMap struct {
 }
 
 // Find storage map for source ID.
+// When multiple map entries reference the same datastore, their offload plugin
+// configurations are merged so xcopy and CSI import can be supplied independently.
 func (r *StorageMap) FindStorage(storageID string) (pair StoragePair, found bool) {
-	for _, pair = range r.Spec.Map {
-		if pair.Source.ID == storageID {
-			found = true
-			break
+	for _, entry := range r.Spec.Map {
+		if entry.Source.ID != storageID {
+			continue
 		}
+		if !found {
+			pair = entry
+			found = true
+			continue
+		}
+		pair = MergeStoragePair(pair, entry)
 	}
 
 	return
 }
 
 // Find storage map for source Name.
+// When multiple map entries reference the same datastore name, their offload plugin
+// configurations are merged.
 func (r *StorageMap) FindStorageByName(storageName string) (pair StoragePair, found bool) {
-	for _, pair = range r.Spec.Map {
-		if pair.Source.Name == storageName {
-			found = true
-			break
+	for _, entry := range r.Spec.Map {
+		if entry.Source.Name != storageName {
+			continue
 		}
+		if !found {
+			pair = entry
+			found = true
+			continue
+		}
+		pair = MergeStoragePair(pair, entry)
 	}
 
 	return

--- a/pkg/apis/forklift/v1beta1/mapping.go
+++ b/pkg/apis/forklift/v1beta1/mapping.go
@@ -80,11 +80,60 @@ type NetworkPair struct {
 }
 
 // OffloadPlugin is a storage plugin that acts on the storage allocation and copying
-// phase of the migration. There can be more than one available but currently only
-// one will be supported
+// phase of the migration. Both xcopy and CSI volume import may be configured together.
 type OffloadPlugin struct {
 	VSphereXcopyPluginConfig *VSphereXcopyPluginConfig `json:"vsphereXcopyConfig,omitempty"`
 	CsiVolumeImport          *CsiVolumeImport          `json:"csiVolumeImport,omitempty"`
+}
+
+// MergeOffloadPlugins combines two offload plugin configs. Order does not matter.
+func MergeOffloadPlugins(a, b *OffloadPlugin) *OffloadPlugin {
+	if a == nil && b == nil {
+		return nil
+	}
+	if a == nil {
+		return b.DeepCopy()
+	}
+	if b == nil {
+		return a.DeepCopy()
+	}
+	merged := a.DeepCopy()
+	if b.VSphereXcopyPluginConfig != nil {
+		merged.VSphereXcopyPluginConfig = b.VSphereXcopyPluginConfig.DeepCopy()
+	}
+	if b.CsiVolumeImport != nil {
+		merged.CsiVolumeImport = b.CsiVolumeImport.DeepCopy()
+	}
+	return merged
+}
+
+// MergeStoragePair combines two mappings for the same source datastore.
+// Destination fields from src override empty fields on dst; offload plugins are merged.
+func MergeStoragePair(dst, src StoragePair) StoragePair {
+	out := dst
+	if src.Source.ID != "" {
+		out.Source.ID = src.Source.ID
+	}
+	if src.Source.Name != "" {
+		out.Source.Name = src.Source.Name
+	}
+	if src.Source.Namespace != "" {
+		out.Source.Namespace = src.Source.Namespace
+	}
+	if src.Source.Type != "" {
+		out.Source.Type = src.Source.Type
+	}
+	if src.Destination.StorageClass != "" {
+		out.Destination.StorageClass = src.Destination.StorageClass
+	}
+	if src.Destination.AccessMode != "" {
+		out.Destination.AccessMode = src.Destination.AccessMode
+	}
+	if src.Destination.VolumeMode != "" {
+		out.Destination.VolumeMode = src.Destination.VolumeMode
+	}
+	out.OffloadPlugin = MergeOffloadPlugins(dst.OffloadPlugin, src.OffloadPlugin)
+	return out
 }
 
 // CsiVolumeImport uses the CSI driver's native import capability to migrate VVol/RDM disks.
@@ -330,24 +379,38 @@ type StorageMap struct {
 }
 
 // Find storage map for source ID.
+// When multiple map entries reference the same datastore, their offload plugin
+// configurations are merged so xcopy and CSI import can be supplied independently.
 func (r *StorageMap) FindStorage(storageID string) (pair StoragePair, found bool) {
-	for _, pair = range r.Spec.Map {
-		if pair.Source.ID == storageID {
-			found = true
-			break
+	for _, entry := range r.Spec.Map {
+		if entry.Source.ID != storageID {
+			continue
 		}
+		if !found {
+			pair = entry
+			found = true
+			continue
+		}
+		pair = MergeStoragePair(pair, entry)
 	}
 
 	return
 }
 
 // Find storage map for source Name.
+// When multiple map entries reference the same datastore name, their offload plugin
+// configurations are merged.
 func (r *StorageMap) FindStorageByName(storageName string) (pair StoragePair, found bool) {
-	for _, pair = range r.Spec.Map {
-		if pair.Source.Name == storageName {
-			found = true
-			break
+	for _, entry := range r.Spec.Map {
+		if entry.Source.Name != storageName {
+			continue
 		}
+		if !found {
+			pair = entry
+			found = true
+			continue
+		}
+		pair = MergeStoragePair(pair, entry)
 	}
 
 	return

--- a/pkg/apis/forklift/v1beta1/mapping_test.go
+++ b/pkg/apis/forklift/v1beta1/mapping_test.go
@@ -1,0 +1,47 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+)
+
+func TestFindStorageMergesSplitOffloadPlugins(t *testing.T) {
+	sm := &StorageMap{
+		Spec: StorageMapSpec{
+			Map: []StoragePair{
+				{
+					Source:      ref.Ref{ID: "datastore-1"},
+					Destination: DestinationStorage{StorageClass: "sc-a"},
+					OffloadPlugin: &OffloadPlugin{
+						CsiVolumeImport: &CsiVolumeImport{
+							SecretRef:            "csi-secret",
+							StorageVendorProduct: StorageVendorProductPrimera3Par,
+						},
+					},
+				},
+				{
+					Source:      ref.Ref{ID: "datastore-1"},
+					Destination: DestinationStorage{StorageClass: "sc-a"},
+					OffloadPlugin: &OffloadPlugin{
+						VSphereXcopyPluginConfig: &VSphereXcopyPluginConfig{
+							SecretRef:            "xcopy-secret",
+							StorageVendorProduct: StorageVendorProductPrimera3Par,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pair, found := sm.FindStorage("datastore-1")
+	if !found {
+		t.Fatal("expected datastore mapping")
+	}
+	if pair.OffloadPlugin == nil || pair.OffloadPlugin.CsiVolumeImport == nil {
+		t.Fatal("expected CSI import config")
+	}
+	if pair.OffloadPlugin.VSphereXcopyPluginConfig == nil {
+		t.Fatal("expected xcopy config")
+	}
+}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -569,20 +569,28 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 	return
 }
 
-// buildDatastoreMap builds a map of storage mappings keyed by source datastore ID
+// buildDatastoreMap builds a map of storage mappings keyed by source datastore ID.
+// Duplicate entries for the same datastore are merged so split offload plugins
+// (xcopy in one entry, CSI import in another) work regardless of list order.
 func (r *Builder) buildDatastoreMap() (map[string]*api.StoragePair, error) {
 	dsMap := make(map[string]*api.StoragePair)
 	dsMapIn := r.Context.Map.Storage.Spec.Map
 
 	for i := range dsMapIn {
-		mapped := &dsMapIn[i]
+		mapped := dsMapIn[i]
 		ref := mapped.Source
 		ds := &model.Datastore{}
 		err := r.Source.Inventory.Find(ds, ref)
 		if err != nil {
 			return nil, liberr.Wrap(err)
 		}
-		dsMap[ds.ID] = mapped
+		if existing, ok := dsMap[ds.ID]; ok {
+			merged := api.MergeStoragePair(*existing, mapped)
+			dsMap[ds.ID] = &merged
+		} else {
+			copy := mapped
+			dsMap[ds.ID] = &copy
+		}
 	}
 
 	return dsMap, nil


### PR DESCRIPTION
FindStorage and buildDatastoreMap previously kept only one map entry per datastore, so xcopy and CSI import split across duplicate entries failed depending on list order. Merge offload plugin configs when resolving a datastore mapping.

Ref: https://redhat.atlassian.net/browse/MTV-6504
Resolves: MTV-6504