### PR TITLE
MTV-6512 | Fix data races, error handling, and cluster scaling

### DIFF
--- a/pkg/controller/provider/container/hyperv/client.go
+++ b/pkg/controller/provider/container/hyperv/client.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -37,6 +38,11 @@ const (
 	StorageNamePrefixSMB  = "SMB: "
 	StorageNameDefaultSMB = "hyperv-storage"
 )
+
+// longCommandTimeout is used for scripts that iterate all VMs on a node
+// (combined list+details, batch detail collection). With 80-100 VMs per
+// node, the default 60s is insufficient for WinRM to return the output.
+const longCommandTimeout = 5 * time.Minute
 
 const (
 	VMGenerationGen1 = 1
@@ -437,12 +443,18 @@ func (r *Client) fetchAllNodesVMsAndDetails() ([]nodeResult, error) {
 	}
 
 	var results []nodeResult
+	succeeded := 0
 	for i := 0; i < 1+remoteCount; i++ {
 		res := <-ch
 		if res.err != nil {
-			return nil, fmt.Errorf("failed to list VMs on %s: %w", res.nodeName, res.err)
+			r.Log.Error(res.err, "Failed to list VMs on node, skipping", "node", res.nodeName)
+			continue
 		}
+		succeeded++
 		results = append(results, res)
+	}
+	if succeeded == 0 {
+		return nil, fmt.Errorf("all cluster nodes failed to list VMs")
 	}
 	return results, nil
 }
@@ -455,9 +467,9 @@ func (r *Client) fetchNodeVMsAndDetails(ch chan<- nodeResult, nodeName, remoteNa
 	var stdout string
 	var err error
 	if remoteName == "" {
-		stdout, err = r.driver.ExecuteCommand(script)
+		stdout, err = r.driver.ExecuteCommandWithTimeout(script, longCommandTimeout)
 	} else {
-		stdout, err = r.driver.RunOnNode(script, remoteName)
+		stdout, err = r.driver.RunOnNodeWithTimeout(script, remoteName, longCommandTimeout)
 	}
 	if err != nil {
 		ch <- nodeResult{nodeName: nodeName, err: err}
@@ -598,15 +610,21 @@ func (r *Client) listClusterDomainsParallel() ([]driver.Domain, error) {
 	}
 
 	var allDomains []driver.Domain
+	succeeded := 0
 	for i := 0; i < 1+remoteCount; i++ {
 		res := <-ch
 		if res.err != nil {
-			return nil, fmt.Errorf("failed to list VMs on %s: %w", res.nodeName, res.err)
+			r.Log.Error(res.err, "Failed to list VMs on node, skipping", "node", res.nodeName)
+			continue
 		}
+		succeeded++
 		for j := range res.vms {
 			res.vms[j].ComputerName = res.nodeName
 			allDomains = append(allDomains, &driver.WinRMDomain{VMDataPtr: &res.vms[j]})
 		}
+	}
+	if succeeded == 0 {
+		return nil, fmt.Errorf("all cluster nodes failed to list VMs")
 	}
 	return allDomains, nil
 }
@@ -743,7 +761,7 @@ func (r *Client) collectBatchVMDetails(computerName string) (map[string]*batchVM
 	if r.LightMode {
 		script = ps.BatchGetVMDetailsLight
 	}
-	out, err := r.driver.RunOnNode(script, computerName)
+	out, err := r.driver.RunOnNodeWithTimeout(script, computerName, longCommandTimeout)
 	if err != nil {
 		r.Log.V(1).Info("Merged batch script failed, trying split fallback", "node", computerName, "error", err)
 		return r.collectBatchVMDetailsSplit(computerName)
@@ -762,7 +780,7 @@ func (r *Client) collectBatchVMDetails(computerName string) (map[string]*batchVM
 // collectBatchVMDetailsSplit is the legacy two-call path: hardware first, then guest.
 // Used as a fallback if the merged script exceeds the host's WinRM command limit.
 func (r *Client) collectBatchVMDetailsSplit(computerName string) (map[string]*batchVMDetail, error) {
-	hwOut, err := r.driver.RunOnNode(ps.BatchGetVMHardware, computerName)
+	hwOut, err := r.driver.RunOnNodeWithTimeout(ps.BatchGetVMHardware, computerName, longCommandTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("batch hardware details failed: %w", err)
 	}
@@ -774,7 +792,7 @@ func (r *Client) collectBatchVMDetailsSplit(computerName string) (map[string]*ba
 		}
 	}
 
-	guestOut, err := r.driver.RunOnNode(ps.BatchGetVMGuest, computerName)
+	guestOut, err := r.driver.RunOnNodeWithTimeout(ps.BatchGetVMGuest, computerName, longCommandTimeout)
 	if err != nil {
 		r.Log.V(1).Info("Batch guest details failed, hardware details still usable", "node", computerName, "error", err)
 		return result, nil
@@ -1240,9 +1258,9 @@ func (r *Client) EnrichDiskCapacity() error {
 			var out string
 			var err error
 			if n == "__local__" {
-				out, err = r.driver.ExecuteCommand(ps.BatchGetVHDCapacity)
+				out, err = r.driver.ExecuteCommandWithTimeout(ps.BatchGetVHDCapacity, longCommandTimeout)
 			} else {
-				out, err = r.driver.RunOnNode(ps.BatchGetVHDCapacity, n)
+				out, err = r.driver.RunOnNodeWithTimeout(ps.BatchGetVHDCapacity, n, longCommandTimeout)
 			}
 			if err != nil {
 				r.Log.Info("VHD capacity enrichment failed, will be filled on next refresh",

--- a/pkg/controller/provider/container/hyperv/client_test.go
+++ b/pkg/controller/provider/container/hyperv/client_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
@@ -48,8 +49,11 @@ func (m *mockDriver) ListAllNetworks() ([]driver.Network, error) {
 }
 func (m *mockDriver) LookupNetworkByUUIDString(string) (driver.Network, error) { return nil, nil } //nolint:nilnil
 func (m *mockDriver) ExecuteCommand(string) (string, error)                    { return "", nil }
-func (m *mockDriver) GetCluster() (*driver.ClusterData, error)                 { return m.clusterData, nil }
-func (m *mockDriver) GetClusterNodes() ([]driver.ClusterNodeData, error)       { return m.clusterNodes, nil }
+func (m *mockDriver) ExecuteCommandWithTimeout(cmd string, _ time.Duration) (string, error) {
+	return m.ExecuteCommand(cmd)
+}
+func (m *mockDriver) GetCluster() (*driver.ClusterData, error)           { return m.clusterData, nil }
+func (m *mockDriver) GetClusterNodes() ([]driver.ClusterNodeData, error) { return m.clusterNodes, nil }
 func (m *mockDriver) GetClusterInfo() (*driver.ClusterInfoData, error) {
 	if m.clusterData == nil {
 		return nil, fmt.Errorf("no cluster data")
@@ -74,6 +78,9 @@ func (m *mockDriver) RunOnNode(command, computerName string) (string, error) {
 		return m.runOnNodeFn(command, computerName)
 	}
 	return "", nil
+}
+func (m *mockDriver) RunOnNodeWithTimeout(command, computerName string, _ time.Duration) (string, error) {
+	return m.RunOnNode(command, computerName)
 }
 
 func newClusterProvider() *api.Provider {

--- a/pkg/lib/hyperv/driver/driver.go
+++ b/pkg/lib/hyperv/driver/driver.go
@@ -1,6 +1,9 @@
 package driver
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // DomainState represents VM power state
 type DomainState int
@@ -48,10 +51,12 @@ type HyperVDriver interface {
 
 	// Raw command execution
 	ExecuteCommand(command string) (string, error)
+	ExecuteCommandWithTimeout(command string, timeout time.Duration) (string, error)
 	// RunOnNode wraps a command to execute on a specific cluster node via
 	// Invoke-Command with explicit credentials. Returns the command output.
 	// If computerName is empty, executes locally.
 	RunOnNode(command, computerName string) (string, error)
+	RunOnNodeWithTimeout(command, computerName string, timeout time.Duration) (string, error)
 }
 
 // Domain represents a virtual machine

--- a/pkg/lib/hyperv/driver/winrm.go
+++ b/pkg/lib/hyperv/driver/winrm.go
@@ -195,6 +195,11 @@ func (d *WinRMDriver) RunOnNode(command, computerName string) (string, error) {
 	return d.ExecuteCommand(cmd)
 }
 
+func (d *WinRMDriver) RunOnNodeWithTimeout(command, computerName string, timeout time.Duration) (string, error) {
+	cmd := ps.RunOnNode(command, computerName, d.password, d.username)
+	return d.ExecuteCommandWithTimeout(cmd, timeout)
+}
+
 func utf16LEEncode(s string) []byte {
 	u16 := utf16.Encode([]rune(s))
 	encoded := make([]byte, len(u16)*2)

--- a/pkg/lib/hyperv/powershell/scripts.go
+++ b/pkg/lib/hyperv/powershell/scripts.go
@@ -18,12 +18,17 @@ func BuildCommand(template string, args ...string) string {
 
 // RunOnNode wraps cmd to run on a remote node via Invoke-Command -Credential.
 // If computerName is empty, returns cmd unchanged (runs on the connected host).
+// Bare usernames are auto-qualified with ".\" for PSCredential on remote nodes.
 func RunOnNode(cmd, computerName, password, username string) string {
 	if computerName == "" {
 		return cmd
 	}
+	credUser := username
+	if !strings.Contains(credUser, `\`) && !strings.Contains(credUser, "@") {
+		credUser = `.\` + credUser
+	}
 	escPass := strings.ReplaceAll(password, "'", "''")
-	escUser := strings.ReplaceAll(username, "'", "''")
+	escUser := strings.ReplaceAll(credUser, "'", "''")
 	escNode := strings.ReplaceAll(computerName, "'", "''")
 	return fmt.Sprintf(
 		"$pw = ConvertTo-SecureString '%s' -AsPlainText -Force; "+
@@ -60,7 +65,7 @@ const (
 	// Parameters: vmName
 	GetVMState = `Get-VM -Name '%s' | Select-Object -ExpandProperty State`
 
-	// StopVM forcefully stops a VM
+	// StopVM forcefully stops a VM.
 	// Parameters: vmName
 	StopVM = `Stop-VM -Name '%s' -Force -Confirm:$false`
 )


### PR DESCRIPTION
Address  Paychex findings cluster issues:

- Pass LightMode as parameter to goroutines instead of reading the Client field concurrently.
- Add stateMu to guard parity and connTestFailures across goroutines.
- Distinguish libmodel.NotFound from unexpected errors in updateDisksFromCache instead of swallowing all tx.Get failures.
- Gate VM/Disk field preservation on LightMode so full refreshes accept genuine false/zero values from the host.
- Auto-qualify bare usernames with ".\" for Invoke-Command PSCredential on domain-joined cluster nodes (MTV-6536).
- Skip failed cluster nodes instead of aborting the entire inventory.
- Increase WinRM timeout to 5 minutes for scripts that iterate all VMs on a node (80-100 VM nodes were hitting 60s deadline).

Ref: https://redhat.atlassian.net/browse/MTV-6512,
     https://redhat.atlassian.net/browse/MTV-6536
Resolves: MTV-6512, MTV-6536