### PR TITLE
MTV-6508 | Use virt-v2v inspection to determine Hyper-V VM template OS

### DIFF
--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -94,7 +94,7 @@ func mapHypervGuestOS(guestOS string) string {
 	case strings.Contains(os, "linux"):
 		return defaultTemplateOS
 	default:
-		return defaultTemplateOS
+		return ""
 	}
 }
 
@@ -448,14 +448,33 @@ func (r *Builder) Tasks(vmRef ref.Ref) (tasks []*plan.Task, err error) {
 }
 
 func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err error) {
-	vm := &model.VM{}
-	err = r.Source.Inventory.Find(vm, vmRef)
-	if err != nil {
-		err = liberr.Wrap(err, "vm", vmRef.String())
-		return
+	// Prefer the OS detected by virt-v2v inspection (set during conversion).
+	var os string
+	for _, vmConf := range r.Migration.Status.VMs {
+		if vmConf.ID == vmRef.ID {
+			os = mapOperatingSystemToTemplate(vmConf.OperatingSystem)
+			break
+		}
 	}
 
-	os := mapHypervGuestOS(vm.GuestOS)
+	// Fall back to inventory GuestOS from KVP Exchange (only available when
+	// the VM was running with Integration Services).
+	if os == "" {
+		vm := &model.VM{}
+		err = r.Source.Inventory.Find(vm, vmRef)
+		if err != nil {
+			err = liberr.Wrap(err, "vm", vmRef.String())
+			return
+		}
+		if vm.GuestOS != "" {
+			os = mapHypervGuestOS(vm.GuestOS)
+		}
+	}
+
+	if os == "" {
+		err = liberr.New("guest OS not detected, cannot determine template")
+		return
+	}
 
 	labels = make(map[string]string)
 	labels[fmt.Sprintf(templateOSLabel, os)] = "true"
@@ -463,6 +482,64 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 	labels[templateFlavorLabel] = "true"
 
 	return
+}
+
+func mapOperatingSystemToTemplate(operatingSystem string) string {
+	if operatingSystem == "" {
+		return ""
+	}
+	os := strings.ToLower(operatingSystem)
+	switch {
+	// Windows Server
+	case strings.Contains(os, "2022srvnext"):
+		return "win2k25"
+	case strings.Contains(os, "2019srvnext"):
+		return "win2k22"
+	case strings.Contains(os, "2019"):
+		return "win2k19"
+	case strings.Contains(os, "windows9server"):
+		return "win2k16"
+	case strings.Contains(os, "windows8server"):
+		return "win2k12r2"
+	case strings.Contains(os, "windows7server"):
+		return "win2k8r2"
+	// Windows desktop
+	case strings.Contains(os, "windows12"):
+		return "win11"
+	case strings.Contains(os, "windows11"):
+		return "win11"
+	case strings.Contains(os, "windows9") || strings.Contains(os, "windows10"):
+		return "win10"
+	case strings.Contains(os, "windows"):
+		return "win10"
+	// Linux distributions
+	case strings.Contains(os, "rhel10"):
+		return "rhel10.0"
+	case strings.Contains(os, "rhel9"):
+		return "rhel9.4"
+	case strings.Contains(os, "rhel8"):
+		return defaultTemplateOS
+	case strings.Contains(os, "rhel7"):
+		return "rhel7.7"
+	case strings.Contains(os, "centos9") || strings.Contains(os, "centosstream9"):
+		return "centos-stream9"
+	case strings.Contains(os, "centos8"):
+		return "centos8"
+	case strings.Contains(os, "centos"):
+		return "centos7.0"
+	case strings.Contains(os, "ubuntu"):
+		return "ubuntu18.04"
+	case strings.Contains(os, "debian"):
+		return "debian10"
+	case strings.Contains(os, "fedora"):
+		return "fedora31"
+	case strings.Contains(os, "sles") || strings.Contains(os, "suse") || strings.Contains(os, "opensuse"):
+		return "opensuse15.0"
+	case strings.Contains(os, "linux"):
+		return defaultTemplateOS
+	default:
+		return ""
+	}
 }
 
 func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {

--- a/pkg/controller/plan/adapter/hyperv/builder_test.go
+++ b/pkg/controller/plan/adapter/hyperv/builder_test.go
@@ -217,8 +217,8 @@ func TestMapHypervGuestOS(t *testing.T) {
 		{name: "Generic Linux", guestOS: "Some Linux Distribution", expected: defaultTemplateOS},
 
 		// Fallback
-		{name: "Unknown OS", guestOS: "FreeBSD 13", expected: defaultTemplateOS},
-		{name: "Empty string", guestOS: "", expected: defaultTemplateOS},
+		{name: "Unknown OS", guestOS: "FreeBSD 13", expected: ""},
+		{name: "Empty string", guestOS: "", expected: ""},
 	}
 
 	for _, tc := range tests {
@@ -226,6 +226,47 @@ func TestMapHypervGuestOS(t *testing.T) {
 			result := mapHypervGuestOS(tc.guestOS)
 			if result != tc.expected {
 				t.Errorf("mapHypervGuestOS(%q) = %q, want %q", tc.guestOS, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMapOperatingSystemToTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		os       string
+		expected string
+	}{
+		// virt-v2v inspection maps osinfo IDs through osV2VMap to these vSphere-style guest IDs.
+		// VMware naming: "Next" suffix = successor (2019srvNext → 2022, 2022srvNext → 2025).
+		{name: "Windows 2019", os: "windows2019srv_64Guest", expected: "win2k19"},
+		{name: "Windows 2022 (2019srvNext)", os: "windows2019srvNext_64Guest", expected: "win2k22"},
+		{name: "Windows 2025 (2022srvNext)", os: "windows2022srvNext_64Guest", expected: "win2k25"},
+		{name: "Windows 2016 (9Server)", os: "windows9Server64Guest", expected: "win2k16"},
+		{name: "Windows 2012 R2 (8Server)", os: "windows8Server64Guest", expected: "win2k12r2"},
+		{name: "Windows 2008 R2 (7Server)", os: "windows7Server64Guest", expected: "win2k8r2"},
+		{name: "Windows 10", os: "windows9_64Guest", expected: "win10"},
+		{name: "Windows 11", os: "windows11_64Guest", expected: "win11"},
+		{name: "RHEL 9", os: "rhel9_64Guest", expected: "rhel9.4"},
+		{name: "RHEL 8", os: "rhel8_64Guest", expected: defaultTemplateOS},
+		{name: "RHEL 7", os: "rhel7_64Guest", expected: "rhel7.7"},
+		{name: "RHEL 10", os: "rhel10_64Guest", expected: "rhel10.0"},
+		{name: "CentOS 9", os: "centos9_64Guest", expected: "centos-stream9"},
+		{name: "CentOS 8", os: "centos8_64Guest", expected: "centos8"},
+		{name: "Ubuntu", os: "ubuntu64Guest", expected: "ubuntu18.04"},
+		{name: "Debian", os: "debian10_64Guest", expected: "debian10"},
+		{name: "Fedora", os: "fedora64Guest", expected: "fedora31"},
+		{name: "SLES", os: "sles15_64Guest", expected: "opensuse15.0"},
+		{name: "Generic Linux", os: "genericLinuxGuest", expected: defaultTemplateOS},
+		{name: "Empty string", os: "", expected: ""},
+		{name: "Unknown OS", os: "otherGuest64", expected: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mapOperatingSystemToTemplate(tc.os)
+			if result != tc.expected {
+				t.Errorf("mapOperatingSystemToTemplate(%q) = %q, want %q", tc.os, result, tc.expected)
 			}
 		})
 	}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2432,12 +2432,17 @@ func (r *KubeVirt) GetGuestConversionPod(vm *plan.VMStatus) (*core.Pod, error) {
 	return r.GetConversionPod(vm.Ref, convctx.VirtV2vConversionPod, false)
 }
 
+// v2vHTTPClient is used for all requests to the virt-v2v pod HTTP server.
+// A 2-minute timeout prevents the controller from hanging indefinitely if the
+// pod accepts a connection but never responds.
+var v2vHTTPClient = &http.Client{Timeout: 2 * time.Minute}
+
 func (r *KubeVirt) getInspectionXml(pod *core.Pod) (string, error) {
 	if pod == nil {
 		return "", liberr.New("no pod found to get the inspection")
 	}
 	inspectionUrl := fmt.Sprintf("http://%s:8080/inspection", pod.Status.PodIP)
-	resp, err := http.Get(inspectionUrl)
+	resp, err := v2vHTTPClient.Get(inspectionUrl)
 	if err != nil {
 		return "", liberr.Wrap(err)
 	}
@@ -2464,7 +2469,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 	Once the VM server is running, we can make a single call to obtain the OVF configuration,
 	followed by a shutdown request. This will complete the pod process, allowing us to move to the next phase.
 	*/
-	resp, err := http.Get(url)
+	resp, err := v2vHTTPClient.Get(url)
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return nil
@@ -2479,9 +2484,23 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 	}
 
 	switch r.Source.Provider.Type() {
-	case api.Ova, api.HyperV:
+	case api.Ova:
 		if vm.Firmware, err = util.GetFirmwareFromYaml(vmConf); err != nil {
 			return liberr.Wrap(err)
+		}
+	case api.HyperV:
+		if vm.Firmware, err = util.GetFirmwareFromYaml(vmConf); err != nil {
+			return liberr.Wrap(err)
+		}
+		inspectionXML, err := r.getInspectionXml(pod)
+		if err != nil {
+			r.Log.Error(err, "Failed to get inspection XML for Hyper-V VM", "vmId", vm.ID)
+		} else {
+			if vm.OperatingSystem, err = inspectionparser.GetOperationSystemFromConfig(inspectionXML); err != nil {
+				r.Log.Error(err, "Failed to parse OS from inspection XML", "vmId", vm.ID)
+			} else {
+				r.Log.Info("Setting the vm OS from inspection", "os", vm.OperatingSystem, "vmId", vm.ID)
+			}
 		}
 	case api.VSphere:
 		inspectionXML, err := r.getInspectionXml(pod)
@@ -2503,7 +2522,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 
 	// Fetch warnings before shutting down
 	warningsURL := fmt.Sprintf("http://%s:8080/warnings", pod.Status.PodIP)
-	if resp, err = http.Get(warningsURL); err == nil {
+	if resp, err = v2vHTTPClient.Get(warningsURL); err == nil {
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
 			var body []byte
@@ -2538,7 +2557,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 	}
 
 	shutdownURL := fmt.Sprintf("http://%s:8080/shutdown", pod.Status.PodIP)
-	resp, err = http.Post(shutdownURL, "application/json", nil)
+	resp, err = v2vHTTPClient.Post(shutdownURL, "application/json", nil)
 	if err == nil {
 		defer resp.Body.Close()
 	} else {


### PR DESCRIPTION
Hyper-V inventory only populates GuestOS via KVP Exchange for running VMs. When migrating powered-off VMs, GuestOS is empty and mapHypervGuestOS defaulted to "rhel8", causing incorrect template labels.

Fix TemplateLabels to prefer the OperatingSystem detected by virt-v2v disk inspection over the inventory GuestOS.
Add mapOperatingSystemToTemplate to map virt-v2v inspection values  to KubeVirt template identifiers.
Return an error when neither source provides an OS, instead of silently defaulting to RHEL 8.

Parse the virt-v2v inspection XML for Hyper-V in
UpdateVmByConvertedConfig to populate the vm.OperatingSystem before TemplateLabels is called.

Ref: https://redhat.atlassian.net/browse/MTV-6508
Resolves: MTV-6508