### PR TITLE
MTV-6620 | Add plan flag to defer SELinux relabeling to guest boot

### DIFF
--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan.go
@@ -281,6 +281,16 @@ type PlanSpec struct {
 	// Can be overridden per VM via spec.vms[].scsiReservation.
 	// +optional
 	SCSIReservation bool `json:"scsiReservation,omitempty"`
+	// SelinuxRelabelAtBoot defers SELinux relabeling until the guest's first boot after conversion.
+	// Passed to virt-v2v as --selinux-relabel-at-boot. Can be overridden per VM via spec.vms[].selinuxRelabelAtBoot.
+	// +optional
+	SelinuxRelabelAtBoot bool `json:"selinuxRelabelAtBoot,omitempty"`
+	// SelinuxRelabelExclude lists guest directories excluded from SELinux relabeling during conversion.
+	// Passed to virt-v2v as --selinux-relabel-exclude. Can be overridden per VM via spec.vms[].selinuxRelabelExclude.
+	// Use carefully: changes made inside excluded directories during customization may retain incorrect
+	// SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+	// +optional
+	SelinuxRelabelExclude []string `json:"selinuxRelabelExclude,omitempty"`
 	// DeleteGuestConversionPod determines if the guest conversion pod should be deleted after successful migration.
 	// Note:
 	//   - If this option is enabled and migration succeeds then the pod will get deleted. However the VM could still not boot and the virt-v2v logs, with additional information, will be deleted alongside guest conversion pod.

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -203,6 +203,16 @@ type VM struct {
 	//
 	// +optional
 	SCSIReservation *bool `json:"scsiReservation,omitempty"`
+	// SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+	// When nil (default), the plan-level value is used.
+	// +optional
+	SelinuxRelabelAtBoot *bool `json:"selinuxRelabelAtBoot,omitempty"`
+	// SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+	// When nil (default), the plan-level value is used.
+	// Use carefully: changes made inside excluded directories during customization may retain incorrect
+	// SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+	// +optional
+	SelinuxRelabelExclude []string `json:"selinuxRelabelExclude,omitempty"`
 	// ExcludeDisks lists vSphere bus addresses to skip during migration (e.g. "scsi0:1").
 	// Empty or omitted: migrate all disks (subject to migrateSharedDisks).
 	// When set, matching disks are not imported and are not attached to the target VM.

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan/zz_generated.deepcopy.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan/zz_generated.deepcopy.go
@@ -335,6 +335,16 @@ func (in *VM) DeepCopyInto(out *VM) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SelinuxRelabelAtBoot != nil {
+		in, out := &in.SelinuxRelabelAtBoot, &out.SelinuxRelabelAtBoot
+		*out = new(bool)
+		**out = **in
+	}
+	if in.SelinuxRelabelExclude != nil {
+		in, out := &in.SelinuxRelabelExclude, &out.SelinuxRelabelExclude
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExcludeDisks != nil {
 		in, out := &in.ExcludeDisks, &out.ExcludeDisks
 		*out = make([]string, len(*in))

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/zz_generated.deepcopy.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/zz_generated.deepcopy.go
@@ -1583,6 +1583,11 @@ func (in *PlanSpec) DeepCopyInto(out *PlanSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SelinuxRelabelExclude != nil {
+		in, out := &in.SelinuxRelabelExclude, &out.SelinuxRelabelExclude
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.InstallLegacyDrivers != nil {
 		in, out := &in.InstallLegacyDrivers, &out.InstallLegacyDrivers
 		*out = new(bool)

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -5562,6 +5562,20 @@ spec:
                         When explicitly set to true, shared RDM LUNs for this VM get lun.reservation=true.
                         When explicitly set to false, shared RDM LUNs for this VM get lun.reservation=false.
                       type: boolean
+                    selinuxRelabelAtBoot:
+                      description: |-
+                        SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+                        When nil (default), the plan-level value is used.
+                      type: boolean
+                    selinuxRelabelExclude:
+                      description: |-
+                        SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+                        When nil (default), the plan-level value is used.
+                        Use carefully: changes made inside excluded directories during customization may retain incorrect
+                        SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                      items:
+                        type: string
+                      type: array
                     started:
                       description: Started timestamp.
                       format: date-time
@@ -7801,6 +7815,20 @@ spec:
                   which is required for workloads that use SCSI PR-based fencing (e.g. shared-disk clusters).
                   Can be overridden per VM via spec.vms[].scsiReservation.
                 type: boolean
+              selinuxRelabelAtBoot:
+                description: |-
+                  SelinuxRelabelAtBoot defers SELinux relabeling until the guest's first boot after conversion.
+                  Passed to virt-v2v as --selinux-relabel-at-boot. Can be overridden per VM via spec.vms[].selinuxRelabelAtBoot.
+                type: boolean
+              selinuxRelabelExclude:
+                description: |-
+                  SelinuxRelabelExclude lists guest directories excluded from SELinux relabeling during conversion.
+                  Passed to virt-v2v as --selinux-relabel-exclude. Can be overridden per VM via spec.vms[].selinuxRelabelExclude.
+                  Use carefully: changes made inside excluded directories during customization may retain incorrect
+                  SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                items:
+                  type: string
+                type: array
               serviceAccount:
                 description: |-
                   ServiceAccount is the name of the ServiceAccount to use for migration
@@ -9141,6 +9169,20 @@ spec:
                         When explicitly set to true, shared RDM LUNs for this VM get lun.reservation=true.
                         When explicitly set to false, shared RDM LUNs for this VM get lun.reservation=false.
                       type: boolean
+                    selinuxRelabelAtBoot:
+                      description: |-
+                        SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+                        When nil (default), the plan-level value is used.
+                      type: boolean
+                    selinuxRelabelExclude:
+                      description: |-
+                        SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+                        When nil (default), the plan-level value is used.
+                        Use carefully: changes made inside excluded directories during customization may retain incorrect
+                        SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                      items:
+                        type: string
+                      type: array
                     targetName:
                       description: |-
                         TargetName specifies a custom name for the VM in the target cluster.
@@ -9977,6 +10019,20 @@ spec:
                             When explicitly set to true, shared RDM LUNs for this VM get lun.reservation=true.
                             When explicitly set to false, shared RDM LUNs for this VM get lun.reservation=false.
                           type: boolean
+                        selinuxRelabelAtBoot:
+                          description: |-
+                            SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+                            When nil (default), the plan-level value is used.
+                          type: boolean
+                        selinuxRelabelExclude:
+                          description: |-
+                            SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+                            When nil (default), the plan-level value is used.
+                            Use carefully: changes made inside excluded directories during customization may retain incorrect
+                            SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                          items:
+                            type: string
+                          type: array
                         started:
                           description: Started timestamp.
                           format: date-time

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -5562,6 +5562,20 @@ spec:
                         When explicitly set to true, shared RDM LUNs for this VM get lun.reservation=true.
                         When explicitly set to false, shared RDM LUNs for this VM get lun.reservation=false.
                       type: boolean
+                    selinuxRelabelAtBoot:
+                      description: |-
+                        SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+                        When nil (default), the plan-level value is used.
+                      type: boolean
+                    selinuxRelabelExclude:
+                      description: |-
+                        SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+                        When nil (default), the plan-level value is used.
+                        Use carefully: changes made inside excluded directories during customization may retain incorrect
+                        SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                      items:
+                        type: string
+                      type: array
                     started:
                       description: Started timestamp.
                       format: date-time
@@ -7801,6 +7815,20 @@ spec:
                   which is required for workloads that use SCSI PR-based fencing (e.g. shared-disk clusters).
                   Can be overridden per VM via spec.vms[].scsiReservation.
                 type: boolean
+              selinuxRelabelAtBoot:
+                description: |-
+                  SelinuxRelabelAtBoot defers SELinux relabeling until the guest's first boot after conversion.
+                  Passed to virt-v2v as --selinux-relabel-at-boot. Can be overridden per VM via spec.vms[].selinuxRelabelAtBoot.
+                type: boolean
+              selinuxRelabelExclude:
+                description: |-
+                  SelinuxRelabelExclude lists guest directories excluded from SELinux relabeling during conversion.
+                  Passed to virt-v2v as --selinux-relabel-exclude. Can be overridden per VM via spec.vms[].selinuxRelabelExclude.
+                  Use carefully: changes made inside excluded directories during customization may retain incorrect
+                  SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                items:
+                  type: string
+                type: array
               serviceAccount:
                 description: |-
                   ServiceAccount is the name of the ServiceAccount to use for migration
@@ -9141,6 +9169,20 @@ spec:
                         When explicitly set to true, shared RDM LUNs for this VM get lun.reservation=true.
                         When explicitly set to false, shared RDM LUNs for this VM get lun.reservation=false.
                       type: boolean
+                    selinuxRelabelAtBoot:
+                      description: |-
+                        SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+                        When nil (default), the plan-level value is used.
+                      type: boolean
+                    selinuxRelabelExclude:
+                      description: |-
+                        SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+                        When nil (default), the plan-level value is used.
+                        Use carefully: changes made inside excluded directories during customization may retain incorrect
+                        SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                      items:
+                        type: string
+                      type: array
                     targetName:
                       description: |-
                         TargetName specifies a custom name for the VM in the target cluster.
@@ -9977,6 +10019,20 @@ spec:
                             When explicitly set to true, shared RDM LUNs for this VM get lun.reservation=true.
                             When explicitly set to false, shared RDM LUNs for this VM get lun.reservation=false.
                           type: boolean
+                        selinuxRelabelAtBoot:
+                          description: |-
+                            SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+                            When nil (default), the plan-level value is used.
+                          type: boolean
+                        selinuxRelabelExclude:
+                          description: |-
+                            SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+                            When nil (default), the plan-level value is used.
+                            Use carefully: changes made inside excluded directories during customization may retain incorrect
+                            SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                          items:
+                            type: string
+                          type: array
                         started:
                           description: Started timestamp.
                           format: date-time

--- a/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_migrations.yaml
@@ -715,6 +715,20 @@ spec:
                         When explicitly set to true, shared RDM LUNs for this VM get lun.reservation=true.
                         When explicitly set to false, shared RDM LUNs for this VM get lun.reservation=false.
                       type: boolean
+                    selinuxRelabelAtBoot:
+                      description: |-
+                        SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+                        When nil (default), the plan-level value is used.
+                      type: boolean
+                    selinuxRelabelExclude:
+                      description: |-
+                        SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+                        When nil (default), the plan-level value is used.
+                        Use carefully: changes made inside excluded directories during customization may retain incorrect
+                        SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                      items:
+                        type: string
+                      type: array
                     started:
                       description: Started timestamp.
                       format: date-time

--- a/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
+++ b/operator/config/crd/bases/forklift.konveyor.io_plans.yaml
@@ -1441,6 +1441,20 @@ spec:
                   which is required for workloads that use SCSI PR-based fencing (e.g. shared-disk clusters).
                   Can be overridden per VM via spec.vms[].scsiReservation.
                 type: boolean
+              selinuxRelabelAtBoot:
+                description: |-
+                  SelinuxRelabelAtBoot defers SELinux relabeling until the guest's first boot after conversion.
+                  Passed to virt-v2v as --selinux-relabel-at-boot. Can be overridden per VM via spec.vms[].selinuxRelabelAtBoot.
+                type: boolean
+              selinuxRelabelExclude:
+                description: |-
+                  SelinuxRelabelExclude lists guest directories excluded from SELinux relabeling during conversion.
+                  Passed to virt-v2v as --selinux-relabel-exclude. Can be overridden per VM via spec.vms[].selinuxRelabelExclude.
+                  Use carefully: changes made inside excluded directories during customization may retain incorrect
+                  SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                items:
+                  type: string
+                type: array
               serviceAccount:
                 description: |-
                   ServiceAccount is the name of the ServiceAccount to use for migration
@@ -2781,6 +2795,20 @@ spec:
                         When explicitly set to true, shared RDM LUNs for this VM get lun.reservation=true.
                         When explicitly set to false, shared RDM LUNs for this VM get lun.reservation=false.
                       type: boolean
+                    selinuxRelabelAtBoot:
+                      description: |-
+                        SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+                        When nil (default), the plan-level value is used.
+                      type: boolean
+                    selinuxRelabelExclude:
+                      description: |-
+                        SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+                        When nil (default), the plan-level value is used.
+                        Use carefully: changes made inside excluded directories during customization may retain incorrect
+                        SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                      items:
+                        type: string
+                      type: array
                     targetName:
                       description: |-
                         TargetName specifies a custom name for the VM in the target cluster.
@@ -3617,6 +3645,20 @@ spec:
                             When explicitly set to true, shared RDM LUNs for this VM get lun.reservation=true.
                             When explicitly set to false, shared RDM LUNs for this VM get lun.reservation=false.
                           type: boolean
+                        selinuxRelabelAtBoot:
+                          description: |-
+                            SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+                            When nil (default), the plan-level value is used.
+                          type: boolean
+                        selinuxRelabelExclude:
+                          description: |-
+                            SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+                            When nil (default), the plan-level value is used.
+                            Use carefully: changes made inside excluded directories during customization may retain incorrect
+                            SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+                          items:
+                            type: string
+                          type: array
                         started:
                           description: Started timestamp.
                           format: date-time

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -281,6 +281,16 @@ type PlanSpec struct {
 	// Can be overridden per VM via spec.vms[].scsiReservation.
 	// +optional
 	SCSIReservation bool `json:"scsiReservation,omitempty"`
+	// SelinuxRelabelAtBoot defers SELinux relabeling until the guest's first boot after conversion.
+	// Passed to virt-v2v as --selinux-relabel-at-boot. Can be overridden per VM via spec.vms[].selinuxRelabelAtBoot.
+	// +optional
+	SelinuxRelabelAtBoot bool `json:"selinuxRelabelAtBoot,omitempty"`
+	// SelinuxRelabelExclude lists guest directories excluded from SELinux relabeling during conversion.
+	// Passed to virt-v2v as --selinux-relabel-exclude. Can be overridden per VM via spec.vms[].selinuxRelabelExclude.
+	// Use carefully: changes made inside excluded directories during customization may retain incorrect
+	// SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+	// +optional
+	SelinuxRelabelExclude []string `json:"selinuxRelabelExclude,omitempty"`
 	// DeleteGuestConversionPod determines if the guest conversion pod should be deleted after successful migration.
 	// Note:
 	//   - If this option is enabled and migration succeeds then the pod will get deleted. However the VM could still not boot and the virt-v2v logs, with additional information, will be deleted alongside guest conversion pod.

--- a/pkg/apis/forklift/v1beta1/plan/vm.go
+++ b/pkg/apis/forklift/v1beta1/plan/vm.go
@@ -203,6 +203,16 @@ type VM struct {
 	//
 	// +optional
 	SCSIReservation *bool `json:"scsiReservation,omitempty"`
+	// SelinuxRelabelAtBoot overrides the plan-level selinuxRelabelAtBoot for this VM.
+	// When nil (default), the plan-level value is used.
+	// +optional
+	SelinuxRelabelAtBoot *bool `json:"selinuxRelabelAtBoot,omitempty"`
+	// SelinuxRelabelExclude overrides the plan-level selinuxRelabelExclude for this VM.
+	// When nil (default), the plan-level value is used.
+	// Use carefully: changes made inside excluded directories during customization may retain incorrect
+	// SELinux labels and cause failures later. Only exclude directories that are known not to need relabeling.
+	// +optional
+	SelinuxRelabelExclude []string `json:"selinuxRelabelExclude,omitempty"`
 	// ExcludeDisks lists vSphere bus addresses to skip during migration (e.g. "scsi0:1").
 	// Empty or omitted: migrate all disks (subject to migrateSharedDisks).
 	// When set, matching disks are not imported and are not attached to the target VM.

--- a/pkg/apis/forklift/v1beta1/plan/zz_generated.deepcopy.go
+++ b/pkg/apis/forklift/v1beta1/plan/zz_generated.deepcopy.go
@@ -335,6 +335,16 @@ func (in *VM) DeepCopyInto(out *VM) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SelinuxRelabelAtBoot != nil {
+		in, out := &in.SelinuxRelabelAtBoot, &out.SelinuxRelabelAtBoot
+		*out = new(bool)
+		**out = **in
+	}
+	if in.SelinuxRelabelExclude != nil {
+		in, out := &in.SelinuxRelabelExclude, &out.SelinuxRelabelExclude
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExcludeDisks != nil {
 		in, out := &in.ExcludeDisks, &out.ExcludeDisks
 		*out = make([]string, len(*in))

--- a/pkg/apis/forklift/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/forklift/v1beta1/zz_generated.deepcopy.go
@@ -1583,6 +1583,11 @@ func (in *PlanSpec) DeepCopyInto(out *PlanSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SelinuxRelabelExclude != nil {
+		in, out := &in.SelinuxRelabelExclude, &out.SelinuxRelabelExclude
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.InstallLegacyDrivers != nil {
 		in, out := &in.InstallLegacyDrivers, &out.InstallLegacyDrivers
 		*out = new(bool)

--- a/pkg/controller/plan/context/migration.go
+++ b/pkg/controller/plan/context/migration.go
@@ -134,6 +134,20 @@ func (r *Context) NestedVirtualizationSetting(vmRef ref.Ref, sourceDefault bool)
 	return nil
 }
 
+func (r *Context) SelinuxRelabelAtBoot(vmRef ref.Ref) bool {
+	if vm, found := r.Plan.Spec.FindVM(vmRef); found && vm.SelinuxRelabelAtBoot != nil {
+		return *vm.SelinuxRelabelAtBoot
+	}
+	return r.Plan.Spec.SelinuxRelabelAtBoot
+}
+
+func (r *Context) SelinuxRelabelExclude(vmRef ref.Ref) []string {
+	if vm, found := r.Plan.Spec.FindVM(vmRef); found && vm.SelinuxRelabelExclude != nil {
+		return vm.SelinuxRelabelExclude
+	}
+	return r.Plan.Spec.SelinuxRelabelExclude
+}
+
 // Source.
 type Source struct {
 	// Provider

--- a/pkg/controller/plan/context/migration_test.go
+++ b/pkg/controller/plan/context/migration_test.go
@@ -1,10 +1,129 @@
 package context
 
 import (
+	"slices"
 	"testing"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 )
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestSelinuxRelabelAtBoot(t *testing.T) {
+	tests := []struct {
+		name     string
+		planSpec api.PlanSpec
+		vmRef    ref.Ref
+		expected bool
+	}{
+		{
+			name:     "defaults to false",
+			planSpec: api.PlanSpec{},
+			vmRef:    ref.Ref{ID: "vm-1"},
+			expected: false,
+		},
+		{
+			name: "plan-level true",
+			planSpec: api.PlanSpec{
+				SelinuxRelabelAtBoot: true,
+			},
+			vmRef:    ref.Ref{ID: "vm-1"},
+			expected: true,
+		},
+		{
+			name: "vm override disables plan default",
+			planSpec: api.PlanSpec{
+				SelinuxRelabelAtBoot: true,
+				VMs: []plan.VM{
+					{Ref: ref.Ref{ID: "vm-1"}, SelinuxRelabelAtBoot: boolPtr(false)},
+				},
+			},
+			vmRef:    ref.Ref{ID: "vm-1"},
+			expected: false,
+		},
+		{
+			name: "vm override enables plan default",
+			planSpec: api.PlanSpec{
+				VMs: []plan.VM{
+					{Ref: ref.Ref{ID: "vm-1"}, SelinuxRelabelAtBoot: boolPtr(true)},
+				},
+			},
+			vmRef:    ref.Ref{ID: "vm-1"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &Context{
+				Plan: &api.Plan{Spec: tt.planSpec},
+			}
+			if got := ctx.SelinuxRelabelAtBoot(tt.vmRef); got != tt.expected {
+				t.Errorf("SelinuxRelabelAtBoot() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSelinuxRelabelExclude(t *testing.T) {
+	tests := []struct {
+		name     string
+		planSpec api.PlanSpec
+		vmRef    ref.Ref
+		expected []string
+	}{
+		{
+			name:     "defaults to nil",
+			planSpec: api.PlanSpec{},
+			vmRef:    ref.Ref{ID: "vm-1"},
+			expected: nil,
+		},
+		{
+			name: "plan-level dirs",
+			planSpec: api.PlanSpec{
+				SelinuxRelabelExclude: []string{"/foo", "/bar"},
+			},
+			vmRef:    ref.Ref{ID: "vm-1"},
+			expected: []string{"/foo", "/bar"},
+		},
+		{
+			name: "vm override replaces plan default",
+			planSpec: api.PlanSpec{
+				SelinuxRelabelExclude: []string{"/foo"},
+				VMs: []plan.VM{
+					{Ref: ref.Ref{ID: "vm-1"}, SelinuxRelabelExclude: []string{"/baz"}},
+				},
+			},
+			vmRef:    ref.Ref{ID: "vm-1"},
+			expected: []string{"/baz"},
+		},
+		{
+			name: "vm empty slice clears plan default",
+			planSpec: api.PlanSpec{
+				SelinuxRelabelExclude: []string{"/foo"},
+				VMs: []plan.VM{
+					{Ref: ref.Ref{ID: "vm-1"}, SelinuxRelabelExclude: []string{}},
+				},
+			},
+			vmRef:    ref.Ref{ID: "vm-1"},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &Context{
+				Plan: &api.Plan{Spec: tt.planSpec},
+			}
+			got := ctx.SelinuxRelabelExclude(tt.vmRef)
+			if !slices.Equal(got, tt.expected) {
+				t.Errorf("SelinuxRelabelExclude() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
 
 func TestIsResumeConversion(t *testing.T) {
 	tests := []struct {

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -320,6 +320,15 @@ func (r *KubeVirt) resolveConversionResources(vm *plan.VMStatus, podType convctx
 	if vm.NewName != "" {
 		res.podConfig.Environment = append(res.podConfig.Environment, core.EnvVar{Name: "V2V_NewName", Value: r.getNewVMName(vm)})
 	}
+	if r.SelinuxRelabelAtBoot(vm.Ref) {
+		res.podConfig.Environment = append(res.podConfig.Environment,
+			core.EnvVar{Name: "V2V_selinuxRelabelAtBoot", Value: "true"})
+	}
+	if dirs := r.SelinuxRelabelExclude(vm.Ref); len(dirs) > 0 {
+		b, _ := json.Marshal(dirs)
+		res.podConfig.Environment = append(res.podConfig.Environment,
+			core.EnvVar{Name: "V2V_selinuxRelabelExclude", Value: string(b)})
+	}
 
 	res.ready = true
 	if podType == convctx.VirtV2vInspectionPod && step != nil {

--- a/pkg/virt-v2v/config/variables.go
+++ b/pkg/virt-v2v/config/variables.go
@@ -39,6 +39,8 @@ const (
 	EnvVsphereVmwareDriverRemovalName   = "V2V_vsphereVmwareDriverRemoval"
 	EnvWindowsRegistryNetworkConfigName = "V2V_windowsRegistryNetworkConfig"
 	EnvWaitForGuestRebootName           = "V2V_waitForGuestReboot"
+	EnvSelinuxRelabelAtBootName         = "V2V_selinuxRelabelAtBoot"
+	EnvSelinuxRelabelExcludeName        = "V2V_selinuxRelabelExclude"
 	EnvXfsCompatibilityName             = "V2V_xfsCompatibility"
 	EnvXfsRepairIgnoreName              = "V2V_xfsRepairIgnore"
 	EnvOverlayEnabledName               = "V2V_overlayEnabled"
@@ -122,6 +124,10 @@ type AppConfig struct {
 	WindowsRegistryNetworkConfig bool
 	// V2V_waitForGuestReboot — upload first-boot script signaling CONVERSION_DONE on COM1
 	WaitForGuestReboot bool
+	// V2V_selinuxRelabelAtBoot — defer SELinux relabeling until first guest boot
+	SelinuxRelabelAtBoot bool
+	// V2V_selinuxRelabelExclude — guest directories excluded from SELinux relabeling
+	SelinuxRelabelExclude []string
 	// V2V_xfsCompatibility — use XFS-capable virt-v2v; omit --no-fstrim when true
 	XfsCompatibility bool
 	// SupportsNoFstrim is true when the virt-v2v binary supports --no-fstrim
@@ -178,9 +184,13 @@ func (s *AppConfig) Load() (err error) {
 	flag.BoolVar(&s.VsphereVmwareDriverRemoval, "vsphere-vmware-driver-removal", s.getEnvBool(EnvVsphereVmwareDriverRemovalName, false), "Run VMware driver removal scripts during Windows vSphere conversion")
 	flag.BoolVar(&s.WindowsRegistryNetworkConfig, "windows-registry-network-config", s.getEnvBool(EnvWindowsRegistryNetworkConfigName, false), "Use registry-based network configuration scripts for Windows static IP setup")
 	flag.BoolVar(&s.WaitForGuestReboot, "wait-for-guest-reboot", s.getEnvBool(EnvWaitForGuestRebootName, false), "Inject first-boot script to signal conversion completion on guest serial (COM1)")
+	flag.BoolVar(&s.SelinuxRelabelAtBoot, "selinux-relabel-at-boot", s.getEnvBool(EnvSelinuxRelabelAtBootName, false), "Defer SELinux relabeling until the guest's first boot after conversion")
+	excludeDirs := stringSliceFlag(s.getSelinuxRelabelExclude())
+	flag.Var(&excludeDirs, "selinux-relabel-exclude", "Exclude guest directory from SELinux relabeling (repeatable)")
 	flag.BoolVar(&s.XfsCompatibility, "xfs-compatibility", s.getEnvBool(EnvXfsCompatibilityName, false), "XFS compatibility mode: do not pass --no-fstrim to virt-v2v")
 	s.RemoteInspectionDisks = s.getRemoteInspectionDisks()
 	flag.Parse()
+	s.SelinuxRelabelExclude = []string(excludeDirs)
 
 	s.SupportsNoFstrim = detectNoFstrimSupport("/etc/os-release")
 
@@ -219,6 +229,27 @@ func (s *AppConfig) getInspectorExtraArgs() []string {
 		}
 	}
 	return extraArgs
+}
+
+func (s *AppConfig) getSelinuxRelabelExclude() []string {
+	var dirs []string
+	if envDirs, found := os.LookupEnv(EnvSelinuxRelabelExcludeName); found && envDirs != "" {
+		if err := json.Unmarshal([]byte(envDirs), &dirs); err != nil {
+			return nil
+		}
+	}
+	return dirs
+}
+
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string {
+	return fmt.Sprintf("%v", *s)
+}
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
 }
 
 func (s *AppConfig) getRemoteInspectionDisks() []string {

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -100,6 +100,12 @@ func (c *Conversion) addCommonArgs(cmd utils.CommandBuilder) error {
 
 // addConversionExtraArgs adds extra args that apply ONLY to virt-v2v and virt-v2v-in-place
 func (c *Conversion) addConversionExtraArgs(cmd utils.CommandBuilder) {
+	if c.SelinuxRelabelAtBoot {
+		cmd.AddFlag("--selinux-relabel-at-boot")
+	}
+	for _, dir := range c.SelinuxRelabelExclude {
+		cmd.AddArg("--selinux-relabel-exclude", dir)
+	}
 	if c.ExtraArgs != nil {
 		cmd.AddExtraArgs(c.ExtraArgs...)
 	}
@@ -203,6 +209,7 @@ func (c *Conversion) addVirtV2vArgs(cmd utils.CommandBuilder) (err error) {
 		AddArg("-o", "kubevirt").
 		AddArg("-os", c.Workdir).
 		AddArg("-on", outputName)
+	c.addConversionExtraArgs(cmd)
 	switch c.Source {
 	case config.VSPHERE:
 		err = c.addVirtV2vVsphereArgs(cmd)
@@ -230,7 +237,6 @@ func (c *Conversion) addVirtV2vVsphereArgs(cmd utils.CommandBuilder) (err error)
 	if err != nil {
 		return err
 	}
-	c.addConversionExtraArgs(cmd)
 	if c.addVsphereInputTransport(cmd) == vsphereTransportVddk {
 		var extraArgs = c.ExtraArgs
 		if _, err := os.Stat(c.VddkConfFile); !errors.Is(err, os.ErrNotExist) && len(extraArgs) == 0 {

--- a/pkg/virt-v2v/conversion/conversion_test.go
+++ b/pkg/virt-v2v/conversion/conversion_test.go
@@ -358,6 +358,27 @@ var _ = Describe("Conversion", func() {
 	})
 
 	Describe("addConversionExtraArgs", func() {
+		It("adds selinux-relabel-at-boot when enabled",
+			func() {
+				appConfig.SelinuxRelabelAtBoot = true
+
+				mockCommandBuilder.EXPECT().AddFlag("--selinux-relabel-at-boot").Return(mockCommandBuilder)
+
+				conversion.addConversionExtraArgs(mockCommandBuilder)
+			},
+		)
+
+		It("adds selinux-relabel-exclude for each configured directory",
+			func() {
+				appConfig.SelinuxRelabelExclude = []string{"/foo", "/bar"}
+
+				mockCommandBuilder.EXPECT().AddArg("--selinux-relabel-exclude", "/foo").Return(mockCommandBuilder)
+				mockCommandBuilder.EXPECT().AddArg("--selinux-relabel-exclude", "/bar").Return(mockCommandBuilder)
+
+				conversion.addConversionExtraArgs(mockCommandBuilder)
+			},
+		)
+
 		It("adds extra args when they are set",
 			func() {
 				appConfig.ExtraArgs = []string{"--arg1", "--arg2", "value"}
@@ -592,17 +613,19 @@ var _ = Describe("Conversion", func() {
 	})
 
 	Describe("addVirtV2vArgs", func() {
-		It("adds OVA args when source is OVA", func() {
+		It("adds OVA args and conversion extra args when source is OVA", func() {
 			appConfig.Source = config.OVA
 			appConfig.Workdir = "/var/tmp/v2v"
 			appConfig.NewVmName = "new-vm"
 			appConfig.DiskPath = "/path/to/disk.ova"
+			appConfig.ExtraArgs = []string{"--custom-flag"}
 
 			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-o", "kubevirt").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-os", "/var/tmp/v2v").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-on", "new-vm").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddExtraArgs("--custom-flag").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddArg("-i", "ova").Return(mockCommandBuilder)
 			mockCommandBuilder.EXPECT().AddPositional("/path/to/disk.ova").Return(mockCommandBuilder)
 
@@ -622,6 +645,45 @@ var _ = Describe("Conversion", func() {
 			mockCommandBuilder.EXPECT().AddArg("-on", "new-vm").Return(mockCommandBuilder)
 
 			err := conversion.addVirtV2vArgs(mockCommandBuilder)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("adds selinux conversion args before vSphere guest name", func() {
+			plugin, err := os.CreateTemp("", "nbdkit-nfc-plugin-*.so")
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = os.Remove(plugin.Name()) }()
+			Expect(plugin.Close()).To(Succeed())
+
+			appConfig.Source = config.VSPHERE
+			appConfig.Workdir = "/var/tmp/v2v"
+			appConfig.NewVmName = "new-vm"
+			appConfig.LibvirtUrl = "vpx://user@vcenter.example.com/Datacenter/Cluster/esxi-host?no_verify=1"
+			appConfig.SecretKey = "/etc/secret/secretKey"
+			appConfig.HostName = "vcenter.example.com"
+			appConfig.VmName = "test-vm"
+			appConfig.Fingerprint = "AA:BB:CC"
+			appConfig.NfcPluginPath = plugin.Name()
+			appConfig.SelinuxRelabelAtBoot = true
+			appConfig.SelinuxRelabelExclude = []string{"/foo"}
+
+			mockCommandBuilder.EXPECT().AddFlag("-v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("-x").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-o", "kubevirt").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-os", "/var/tmp/v2v").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-on", "new-vm").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddFlag("--selinux-relabel-at-boot").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--selinux-relabel-exclude", "/foo").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-i", "libvirt").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-ic", appConfig.LibvirtUrl).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-ip", appConfig.SecretKey).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--hostname", appConfig.HostName).Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("--root", "first").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-it", "nfc").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddArg("-io", "nfc-thumbprint=AA:BB:CC").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("--").Return(mockCommandBuilder)
+			mockCommandBuilder.EXPECT().AddPositional("test-vm").Return(mockCommandBuilder)
+
+			err = conversion.addVirtV2vArgs(mockCommandBuilder)
 			Expect(err).ToNot(HaveOccurred())
 		})
 


### PR DESCRIPTION
Add `selinuxRelabelAtBoot` and `selinuxRelabelExclude` to Plan spec with
per-VM overrides. The controller resolves the effective values per VM
and passes them to the conversion pod as V2V_selinuxRelabelAtBoot and
V2V_selinuxRelabelExclude (JSON array). The virt-v2v wrapper forwards
them as `--selinux-relabel-at-boot` and `--selinux-relabel-exclude`.

Usage examples:
```yaml
# Defer relabeling until first guest boot
  spec:
    selinuxRelabelAtBoot: true
    vms:
      - id: vm-123
        name: rhel-vm
  ```
  
  ```yaml
  # Exclude directories from relabeling during conversion
  spec:
    selinuxRelabelExclude:
      - /foo
      - /bar
    vms:
      - id: vm-123
        name: rhel-vm
  ```
  
  ```yaml
  # Per-VM overrides
  spec:
    selinuxRelabelAtBoot: true
    selinuxRelabelExclude:
      - /foo
    vms:
      - id: vm-456
        name: rhel-vm-fast
        selinuxRelabelAtBoot: false
        selinuxRelabelExclude:
          - /baz
```

Ref: https://redhat.atlassian.net/browse/MTV-6620
Resolves: MTV-6620