### PR TITLE
MTV-6207 | Disable MintMaker for EoL branches of MTV

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,11 @@
       "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["major"],
       "groupName": "all dockerfile major dependencies"
+    },
+    {
+      "description": "Disable all updates for EOL branches",
+      "matchBaseBranches": ["release-2.8", "release-2.9", "release-2.10"],
+      "enabled": false
     }
   ],
   "autoApprove": true,


### PR DESCRIPTION
Creates a disable section for renovate.json to prevent mintmaker updates for EOL branches Resolves: MTV-6207