### PR TITLE
[release-2.12] MTV-6511 | Fixes performance regression from #8250

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -2331,40 +2331,6 @@ func (r *Builder) getPVCNameTemplate(vm *model.VM) string {
 	return ""
 }
 
-// getPlanVMSafeName returns a safe name for the VM
-// that can be used in the template output
-// The name is sanitized to be a valid k8s label
-func (r *Builder) getPlanVMSafeName(vm *model.VM) string {
-	// Default to vm name
-	newName := vm.Name
-
-	// Get plan VM
-	planVM := r.getPlanVMStatus(vm)
-
-	// if plan VM status has a new name, use it
-	if planVM != nil && planVM.NewName != "" {
-		newName = planVM.NewName
-	}
-
-	// New name is a valid subdomain name,
-	// but we need to check if it is a valid k8s label
-
-	// Check if new vm name is valid k8s label
-	if len(newName) > 63 {
-		// if the new name is longer then 63 characters, trancate it
-		newName = newName[:63]
-	}
-
-	// Validate that template output is a valid k8s label
-	errs := k8svalidation.IsDNS1123Label(newName)
-	if len(errs) > 0 {
-		// if the new name replace "." with "-"
-		newName = strings.ReplaceAll(newName, ".", "-")
-	}
-
-	return newName
-}
-
 // getVolumeNameTemplate returns the volume name template
 func (r *Builder) getVolumeNameTemplate(vm *model.VM) string {
 	// Check VM-level template first

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -297,6 +297,9 @@ type Collector struct {
 	cancel func()
 	// has parity.
 	parity bool
+	// Cached missing privileges from the last check.
+	missingPrivs   *privilegeCheckResult
+	missingPrivsMu *sync.RWMutex
 }
 
 // New collector.
@@ -307,11 +310,12 @@ func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) *Collector
 			provider.GetNamespace(),
 			provider.GetName()))
 	return &Collector{
-		url:      provider.Spec.URL,
-		provider: provider,
-		secret:   secret,
-		db:       db,
-		log:      nlog,
+		url:            provider.Spec.URL,
+		provider:       provider,
+		secret:         secret,
+		db:             db,
+		log:            nlog,
+		missingPrivsMu: &sync.RWMutex{},
 	}
 }
 
@@ -343,6 +347,17 @@ func (r *Collector) Reset() {
 // Reset.
 func (r *Collector) HasParity() bool {
 	return r.parity
+}
+
+// MissingPrivileges returns the cached privilege check results.
+// The bool indicates whether the check has completed.
+func (r *Collector) MissingPrivileges() ([]MissingPrivileges, bool) {
+	r.missingPrivsMu.RLock()
+	defer r.missingPrivsMu.RUnlock()
+	if r.missingPrivs == nil {
+		return nil, false
+	}
+	return r.missingPrivs.missing, true
 }
 
 // Follow
@@ -431,6 +446,24 @@ func (r *Collector) getUpdates(ctx context.Context) error {
 		return err
 	}
 	defer r.close()
+	r.checkAndCachePermissions(ctx)
+
+	permCtx, cancelPerm := context.WithCancel(ctx)
+	defer cancelPerm()
+
+	go func() {
+		ticker := time.NewTicker(PrivilegeCheckInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-permCtx.Done():
+				return
+			case <-ticker.C:
+				r.checkAndCachePermissions(permCtx)
+			}
+		}
+	}()
+
 	about := r.client.ServiceContent.About
 	err = r.db.Insert(
 		&model.About{

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -300,6 +300,10 @@ type Collector struct {
 	// Cached missing privileges from the last check.
 	missingPrivs   *privilegeCheckResult
 	missingPrivsMu *sync.RWMutex
+	// Committed provider-global custom field definitions (keyed by field key)
+	// so repeated per-VM upserts can be skipped via in-memory comparison.
+	customFieldDefs   map[int32]model.CustomFieldDef
+	customFieldDefsMu *sync.RWMutex
 }
 
 // New collector.
@@ -310,12 +314,14 @@ func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) *Collector
 			provider.GetNamespace(),
 			provider.GetName()))
 	return &Collector{
-		url:            provider.Spec.URL,
-		provider:       provider,
-		secret:         secret,
-		db:             db,
-		log:            nlog,
-		missingPrivsMu: &sync.RWMutex{},
+		url:               provider.Spec.URL,
+		provider:          provider,
+		secret:            secret,
+		db:                db,
+		log:               nlog,
+		missingPrivsMu:    &sync.RWMutex{},
+		customFieldDefs:   map[int32]model.CustomFieldDef{},
+		customFieldDefsMu: &sync.RWMutex{},
 	}
 }
 
@@ -547,11 +553,13 @@ func (r *Collector) getUpdates(ctx context.Context) error {
 			err = tx.Commit()
 			if err != nil {
 				r.log.Error(err, "tx commit failed.")
+				r.resetCustomFieldDefs()
 			}
 		} else {
 			if endErr := tx.End(); endErr != nil {
 				r.log.Error(endErr, "tx rollback failed.")
 			}
+			r.resetCustomFieldDefs()
 		}
 		if err == nil && (updateSet.Truncated == nil || !*updateSet.Truncated) {
 			if !r.parity {
@@ -1263,7 +1271,7 @@ func (r *Collector) selectAdapter(u types.ObjectUpdate) (Adapter, bool) {
 }
 
 // Object created.
-func (r Collector) applyEnter(tx *libmodel.Tx, u types.ObjectUpdate) error {
+func (r *Collector) applyEnter(tx *libmodel.Tx, u types.ObjectUpdate) error {
 	adapter, selected := r.selectAdapter(u)
 	if !selected {
 		return nil
@@ -1283,7 +1291,7 @@ func (r Collector) applyEnter(tx *libmodel.Tx, u types.ObjectUpdate) error {
 }
 
 // Object modified.
-func (r Collector) applyModify(tx *libmodel.Tx, u types.ObjectUpdate) error {
+func (r *Collector) applyModify(tx *libmodel.Tx, u types.ObjectUpdate) error {
 	adapter, selected := r.selectAdapter(u)
 	if !selected {
 		return nil
@@ -1309,31 +1317,88 @@ func (r Collector) applyModify(tx *libmodel.Tx, u types.ObjectUpdate) error {
 // Upsert the custom field definitions reported on a VirtualMachine update
 // into the provider-global CustomFieldDef table. The same global definition
 // set is reported per-VM, so inserting by key naturally de-duplicates it.
-func (r Collector) upsertCustomFieldDefs(tx *libmodel.Tx, u types.ObjectUpdate) (err error) {
+//
+// The set of definitions is provider-global and identical for every VM, so it
+// is cached in memory. When the reported set matches the cache, the DB
+// upserts are skipped entirely, avoiding repeated inserts on every VM update.
+func (r *Collector) upsertCustomFieldDefs(tx *libmodel.Tx, u types.ObjectUpdate) (err error) {
 	if u.Obj.Type != VirtualMachine {
 		return nil
 	}
+	var reported []types.CustomFieldDef
 	for _, p := range u.ChangeSet {
 		if p.Name != fAvailableField {
 			continue
 		}
 		customFields, ok := p.Val.(types.ArrayOfCustomFieldDef)
 		if !ok {
-			continue
+			return nil
 		}
-		for _, f := range customFields.CustomFieldDef {
-			def := &model.CustomFieldDef{
-				Name:              f.Name,
-				Key:               f.Key,
-				ManagedObjectType: f.ManagedObjectType,
-			}
-			if err = tx.Insert(def); err != nil {
-				return liberr.Wrap(err)
-			}
+		reported = customFields.CustomFieldDef
+	}
+	if len(reported) == 0 {
+		return nil
+	}
+
+	incoming := make(map[int32]model.CustomFieldDef, len(reported))
+	for _, f := range reported {
+		incoming[f.Key] = model.CustomFieldDef{
+			Name:              f.Name,
+			Key:               f.Key,
+			ManagedObjectType: f.ManagedObjectType,
 		}
 	}
 
+	r.customFieldDefsMu.RLock()
+	equal := equalCustomFieldDefs(r.customFieldDefs, incoming)
+	r.customFieldDefsMu.RUnlock()
+	if equal {
+		return nil
+	}
+
+	for _, f := range reported {
+		def := &model.CustomFieldDef{
+			Name:              f.Name,
+			Key:               f.Key,
+			ManagedObjectType: f.ManagedObjectType,
+		}
+		if err = tx.Insert(def); err != nil {
+			return liberr.Wrap(err)
+		}
+	}
+
+	// The cache is updated in place. If the surrounding transaction is rolled
+	// back, resetCustomFieldDefs drops it so a later retry reinserts the defs
+	// rather than skipping them on a stale cache.
+	r.customFieldDefsMu.Lock()
+	r.customFieldDefs = incoming
+	r.customFieldDefsMu.Unlock()
+
 	return nil
+}
+
+// resetCustomFieldDefs drops the cached custom field definitions. It is called
+// when the transaction that updated them is rolled back, so that the cache
+// never reflects definitions that were not committed to the DB.
+func (r *Collector) resetCustomFieldDefs() {
+	r.customFieldDefsMu.Lock()
+	r.customFieldDefs = map[int32]model.CustomFieldDef{}
+	r.customFieldDefsMu.Unlock()
+}
+
+// equalCustomFieldDefs reports whether the two provider-global custom field
+// definition sets are identical.
+func equalCustomFieldDefs(a, b map[int32]model.CustomFieldDef) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || av != bv {
+			return false
+		}
+	}
+	return true
 }
 
 // Object deleted.

--- a/pkg/controller/provider/container/vsphere/model_test.go
+++ b/pkg/controller/provider/container/vsphere/model_test.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
@@ -723,8 +724,15 @@ func newTestInventoryDB(t *testing.T) libmodel.DB {
 	return db
 }
 
+func newTestCollector() *Collector {
+	return &Collector{
+		customFieldDefs:   map[int32]model.CustomFieldDef{},
+		customFieldDefsMu: &sync.RWMutex{},
+	}
+}
+
 func TestUpsertCustomFieldDefs(t *testing.T) {
-	adapter := Collector{}
+	adapter := newTestCollector()
 	db := newTestInventoryDB(t)
 	defs := []types.CustomFieldDef{
 		{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
@@ -780,7 +788,7 @@ func TestUpsertCustomFieldDefs(t *testing.T) {
 }
 
 func TestUpsertCustomFieldDefsSkipsNonVM(t *testing.T) {
-	adapter := Collector{}
+	adapter := newTestCollector()
 	db := newTestInventoryDB(t)
 
 	err := db.With(func(tx *libmodel.Tx) error {
@@ -799,6 +807,129 @@ func TestUpsertCustomFieldDefsSkipsNonVM(t *testing.T) {
 	}
 	if len(list) != 0 {
 		t.Errorf("expected no defs for non-VM object, got %d", len(list))
+	}
+}
+
+func TestUpsertCustomFieldDefsCaches(t *testing.T) {
+	adapter := newTestCollector()
+	db := newTestInventoryDB(t)
+
+	defs := []types.CustomFieldDef{
+		{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
+		{Name: "env", Key: 200, ManagedObjectType: ""},
+	}
+	update := func(defs []types.CustomFieldDef) types.ObjectUpdate {
+		return types.ObjectUpdate{
+			Obj: types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-1"},
+			ChangeSet: []types.PropertyChange{
+				{
+					Op:   Assign,
+					Name: fAvailableField,
+					Val:  types.ArrayOfCustomFieldDef{CustomFieldDef: defs},
+				},
+			},
+		}
+	}
+
+	countRows := func() int {
+		t.Helper()
+		list := []model.CustomFieldDef{}
+		if err := db.List(&list, libmodel.ListOptions{Detail: libmodel.MaxDetail}); err != nil {
+			t.Fatalf("List returned error: %v", err)
+		}
+		return len(list)
+	}
+
+	if err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, update(defs))
+	}); err != nil {
+		t.Fatalf("first upsert returned error: %v", err)
+	}
+	if got := countRows(); got != len(defs) {
+		t.Fatalf("expected %d rows after first upsert, got %d", len(defs), got)
+	}
+
+	// The same provider-global def set reported by a second VM should be
+	// skipped via the in-memory cache (no additional DB writes, no dup rows).
+	if err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, update(defs))
+	}); err != nil {
+		t.Fatalf("repeated upsert returned error: %v", err)
+	}
+	if got := countRows(); got != len(defs) {
+		t.Fatalf("expected %d rows after repeated upsert, got %d", len(defs), got)
+	}
+
+	// A changed def set should be reflected in the DB.
+	changed := []types.CustomFieldDef{
+		{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
+		{Name: "env-renamed", Key: 200, ManagedObjectType: ""},
+		{Name: "team", Key: 300, ManagedObjectType: "VirtualMachine"},
+	}
+	if err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, update(changed))
+	}); err != nil {
+		t.Fatalf("changed upsert returned error: %v", err)
+	}
+	if got := countRows(); got != len(changed) {
+		t.Fatalf("expected %d rows after changed upsert, got %d", len(changed), got)
+	}
+}
+
+func TestUpsertCustomFieldDefsRollbackRetriesIdentical(t *testing.T) {
+	adapter := newTestCollector()
+	db := newTestInventoryDB(t)
+
+	defs := []types.CustomFieldDef{
+		{Name: "owner", Key: 100, ManagedObjectType: "VirtualMachine"},
+		{Name: "env", Key: 200, ManagedObjectType: ""},
+	}
+	u := types.ObjectUpdate{
+		Obj: types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-1"},
+		ChangeSet: []types.PropertyChange{
+			{
+				Op:   Assign,
+				Name: fAvailableField,
+				Val:  types.ArrayOfCustomFieldDef{CustomFieldDef: defs},
+			},
+		},
+	}
+
+	countRows := func() int {
+		t.Helper()
+		list := []model.CustomFieldDef{}
+		if err := db.List(&list, libmodel.ListOptions{Detail: libmodel.MaxDetail}); err != nil {
+			t.Fatalf("List returned error: %v", err)
+		}
+		return len(list)
+	}
+
+	// Stage the defs inside a transaction that is then rolled back.
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin returned error: %v", err)
+	}
+	if err := adapter.upsertCustomFieldDefs(tx, u); err != nil {
+		t.Fatalf("upsertCustomFieldDefs returned error: %v", err)
+	}
+	if err := tx.End(); err != nil {
+		t.Fatalf("rollback returned error: %v", err)
+	}
+	// The cache must not retain defs from the rolled-back transaction.
+	adapter.resetCustomFieldDefs()
+
+	if got := countRows(); got != 0 {
+		t.Fatalf("expected 0 rows after rollback, got %d", got)
+	}
+
+	// Retrying identical definitions after the rollback must reinsert them.
+	if err := db.With(func(tx *libmodel.Tx) error {
+		return adapter.upsertCustomFieldDefs(tx, u)
+	}); err != nil {
+		t.Fatalf("retry upsert returned error: %v", err)
+	}
+	if got := countRows(); got != len(defs) {
+		t.Fatalf("expected %d rows after retry, got %d", len(defs), got)
 	}
 }
 

--- a/pkg/controller/provider/container/vsphere/permissions.go
+++ b/pkg/controller/provider/container/vsphere/permissions.go
@@ -1,0 +1,208 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	liberr "github.com/kubev2v/forklift/pkg/lib/error"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+const PrivilegeCheckInterval = 10 * time.Minute
+
+type privilegeGroup struct {
+	Description string
+	Privileges  []string
+}
+
+// MissingPrivileges groups missing privilege IDs by their functional description.
+type MissingPrivileges struct {
+	Group      string
+	Privileges []string
+}
+
+type privilegeCheckResult struct {
+	missing []MissingPrivileges
+}
+
+// requiredPrivileges defines the vSphere privileges MTV needs for migration,
+// grouped by functional area. Derived from the govmomi operations in
+// pkg/controller/plan/adapter/vsphere/client.go and
+// pkg/controller/conversion/client.go.
+var requiredPrivileges = []privilegeGroup{
+	{
+		Description: "Virtual Machine Snapshot Operations",
+		Privileges: []string{
+			"VirtualMachine.State.CreateSnapshot",
+			"VirtualMachine.State.RemoveSnapshot",
+		},
+	},
+	{
+		Description: "Virtual Machine Power Management",
+		Privileges: []string{
+			"VirtualMachine.Interact.PowerOn",
+			"VirtualMachine.Interact.PowerOff",
+		},
+	},
+	{
+		Description: "Virtual Machine Disk Access (VDDK)",
+		Privileges: []string{
+			"VirtualMachine.Provisioning.DiskRandomRead",
+			"VirtualMachine.Provisioning.GetVmFiles",
+			"VirtualMachine.Config.ChangeTracking",
+		},
+	},
+	{
+		Description: "Datastore Access",
+		Privileges: []string{
+			"Datastore.Browse",
+			"Datastore.FileManagement",
+		},
+	},
+}
+
+// pruneToAvailablePrivileges intersects required privilege groups against the
+// set of privileges the vCenter actually supports. This prevents false positives
+// on older vCenter versions that lack certain privilege IDs.
+func pruneToAvailablePrivileges(required []privilegeGroup, available map[string]bool) []privilegeGroup {
+	var pruned []privilegeGroup
+	for _, group := range required {
+		var kept []string
+		for _, priv := range group.Privileges {
+			if available[priv] {
+				kept = append(kept, priv)
+			}
+		}
+		if len(kept) > 0 {
+			pruned = append(pruned, privilegeGroup{
+				Description: group.Description,
+				Privileges:  kept,
+			})
+		}
+	}
+	return pruned
+}
+
+// flattenPrivileges extracts all privilege IDs from a slice of privilege groups
+// into a single flat list, preserving order.
+func flattenPrivileges(groups []privilegeGroup) []string {
+	var flat []string
+	for _, g := range groups {
+		flat = append(flat, g.Privileges...)
+	}
+	return flat
+}
+
+// comparePrivileges checks which required privileges are missing given the
+// granted booleans (aligned 1:1 with the flat privilege ID list).
+func comparePrivileges(groups []privilegeGroup, granted map[string]bool) []MissingPrivileges {
+	var result []MissingPrivileges
+	for _, group := range groups {
+		var missing []string
+		for _, priv := range group.Privileges {
+			if !granted[priv] {
+				missing = append(missing, priv)
+			}
+		}
+		if len(missing) > 0 {
+			result = append(result, MissingPrivileges{
+				Group:      group.Description,
+				Privileges: missing,
+			})
+		}
+	}
+	return result
+}
+
+// FormatMissing produces a human-readable summary of missing privileges
+// suitable for a condition Suggestion field.
+func FormatMissing(missing []MissingPrivileges) string {
+	var sb strings.Builder
+	sb.WriteString("MISSING VSPHERE PRIVILEGES:\n\n")
+	for _, m := range missing {
+		fmt.Fprintf(&sb, "%s:\n", m.Group)
+		for _, p := range m.Privileges {
+			fmt.Fprintf(&sb, "  - %s\n", p)
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("RESOLUTION:\n")
+	sb.WriteString("Assign a vSphere role with these privileges to the service account\n")
+	sb.WriteString("on the vCenter root folder with propagation enabled.\n")
+	sb.WriteString("See: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#vmware-prerequisites_mtv\n")
+	return sb.String()
+}
+
+// checkPermissionsWithClient checks whether the service account has the
+// privileges required for migration using the provided govmomi client.
+// Returns nil, nil if all privileges are granted.
+func checkPermissionsWithClient(ctx context.Context, client *govmomi.Client) ([]MissingPrivileges, error) {
+	authManager := object.NewAuthorizationManager(client.Client)
+
+	var moAuthMgr mo.AuthorizationManager
+	err := authManager.Properties(ctx, authManager.Reference(), []string{"privilegeList"}, &moAuthMgr)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+
+	available := make(map[string]bool, len(moAuthMgr.PrivilegeList))
+	for _, priv := range moAuthMgr.PrivilegeList {
+		available[priv.PrivId] = true
+	}
+
+	pruned := pruneToAvailablePrivileges(requiredPrivileges, available)
+	if len(pruned) == 0 {
+		return nil, nil
+	}
+
+	flatPrivIDs := flattenPrivileges(pruned)
+
+	sessionMgr := session.NewManager(client.Client)
+	userSession, err := sessionMgr.UserSession(ctx)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+
+	rootFolder := client.ServiceContent.RootFolder
+	results, err := authManager.HasPrivilegeOnEntity(ctx, rootFolder, userSession.Key, flatPrivIDs)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+
+	granted := make(map[string]bool, len(flatPrivIDs))
+	for i, privID := range flatPrivIDs {
+		if i < len(results) {
+			granted[privID] = results[i]
+		}
+	}
+
+	return comparePrivileges(pruned, granted), nil
+}
+
+// checkAndCachePermissions runs the privilege check using the collector's
+// already-open client and caches the result. Called from getUpdates() after
+// the client connects, before parity is achieved.
+func (r *Collector) checkAndCachePermissions(ctx context.Context) {
+	if r.provider.Spec.Settings[api.SDK] == api.ESXI {
+		r.missingPrivsMu.Lock()
+		r.missingPrivs = &privilegeCheckResult{}
+		r.missingPrivsMu.Unlock()
+		return
+	}
+
+	missing, err := checkPermissionsWithClient(ctx, r.client)
+	if err != nil {
+		r.log.Error(err, "Privilege check failed.")
+		return
+	}
+
+	r.missingPrivsMu.Lock()
+	r.missingPrivs = &privilegeCheckResult{missing: missing}
+	r.missingPrivsMu.Unlock()
+}

--- a/pkg/controller/provider/container/vsphere/permissions_test.go
+++ b/pkg/controller/provider/container/vsphere/permissions_test.go
@@ -1,0 +1,204 @@
+package vsphere
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("vSphere permissions", func() {
+	Describe("pruneToAvailablePrivileges", func() {
+		input := []privilegeGroup{
+			{
+				Description: "Group A",
+				Privileges:  []string{"Priv.A1", "Priv.A2"},
+			},
+			{
+				Description: "Group B",
+				Privileges:  []string{"Priv.B1", "Priv.B2", "Priv.B3"},
+			},
+		}
+
+		It("should keep all privileges when all are available", func() {
+			available := map[string]bool{
+				"Priv.A1": true, "Priv.A2": true,
+				"Priv.B1": true, "Priv.B2": true, "Priv.B3": true,
+			}
+			result := pruneToAvailablePrivileges(input, available)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Privileges).To(Equal([]string{"Priv.A1", "Priv.A2"}))
+			Expect(result[1].Privileges).To(Equal([]string{"Priv.B1", "Priv.B2", "Priv.B3"}))
+		})
+
+		It("should remove unavailable privileges from a group", func() {
+			available := map[string]bool{
+				"Priv.A1": true, "Priv.A2": true,
+				"Priv.B1": true,
+			}
+			result := pruneToAvailablePrivileges(input, available)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Privileges).To(Equal([]string{"Priv.A1", "Priv.A2"}))
+			Expect(result[1].Privileges).To(Equal([]string{"Priv.B1"}))
+		})
+
+		It("should drop a group entirely when none of its privileges are available", func() {
+			available := map[string]bool{
+				"Priv.A1": true, "Priv.A2": true,
+			}
+			result := pruneToAvailablePrivileges(input, available)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Description).To(Equal("Group A"))
+		})
+
+		It("should return nil for empty input", func() {
+			result := pruneToAvailablePrivileges(nil, map[string]bool{"Priv.X": true})
+			Expect(result).To(BeNil())
+		})
+
+		It("should return nil when no privileges are available", func() {
+			result := pruneToAvailablePrivileges(input, map[string]bool{})
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("comparePrivileges", func() {
+		groups := []privilegeGroup{
+			{
+				Description: "Snapshots",
+				Privileges:  []string{"VM.Snap.Create", "VM.Snap.Remove"},
+			},
+			{
+				Description: "Power",
+				Privileges:  []string{"VM.PowerOn", "VM.PowerOff"},
+			},
+		}
+
+		It("should return nil when all privileges are granted", func() {
+			granted := map[string]bool{
+				"VM.Snap.Create": true, "VM.Snap.Remove": true,
+				"VM.PowerOn": true, "VM.PowerOff": true,
+			}
+			result := comparePrivileges(groups, granted)
+			Expect(result).To(BeNil())
+		})
+
+		It("should report missing privileges from one group", func() {
+			granted := map[string]bool{
+				"VM.Snap.Create": true, "VM.Snap.Remove": true,
+				"VM.PowerOn": true, "VM.PowerOff": false,
+			}
+			result := comparePrivileges(groups, granted)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Group).To(Equal("Power"))
+			Expect(result[0].Privileges).To(Equal([]string{"VM.PowerOff"}))
+		})
+
+		It("should report missing privileges across multiple groups", func() {
+			granted := map[string]bool{
+				"VM.Snap.Create": true, "VM.Snap.Remove": false,
+				"VM.PowerOn": false, "VM.PowerOff": true,
+			}
+			result := comparePrivileges(groups, granted)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Group).To(Equal("Snapshots"))
+			Expect(result[0].Privileges).To(Equal([]string{"VM.Snap.Remove"}))
+			Expect(result[1].Group).To(Equal("Power"))
+			Expect(result[1].Privileges).To(Equal([]string{"VM.PowerOn"}))
+		})
+
+		It("should report all privileges when none are granted", func() {
+			granted := map[string]bool{}
+			result := comparePrivileges(groups, granted)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].Privileges).To(Equal([]string{"VM.Snap.Create", "VM.Snap.Remove"}))
+			Expect(result[1].Privileges).To(Equal([]string{"VM.PowerOn", "VM.PowerOff"}))
+		})
+	})
+
+	Describe("flattenPrivileges", func() {
+		It("should flatten all privilege IDs preserving order", func() {
+			groups := []privilegeGroup{
+				{Description: "A", Privileges: []string{"A.1", "A.2"}},
+				{Description: "B", Privileges: []string{"B.1"}},
+			}
+			result := flattenPrivileges(groups)
+			Expect(result).To(Equal([]string{"A.1", "A.2", "B.1"}))
+		})
+
+		It("should return nil for empty input", func() {
+			result := flattenPrivileges(nil)
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("requiredPrivileges", func() {
+		It("should have no duplicate privilege IDs", func() {
+			seen := make(map[string]bool)
+			for _, group := range requiredPrivileges {
+				for _, priv := range group.Privileges {
+					Expect(seen[priv]).To(BeFalse(), "duplicate privilege: %s", priv)
+					seen[priv] = true
+				}
+			}
+		})
+
+		It("should have non-empty descriptions and privileges", func() {
+			for _, group := range requiredPrivileges {
+				Expect(group.Description).ToNot(BeEmpty())
+				Expect(group.Privileges).ToNot(BeEmpty())
+			}
+		})
+	})
+
+	Describe("FormatMissing", func() {
+		It("should produce readable output", func() {
+			missing := []MissingPrivileges{
+				{Group: "Snapshots", Privileges: []string{"VM.Snap.Create"}},
+				{Group: "Power", Privileges: []string{"VM.PowerOn", "VM.PowerOff"}},
+			}
+			result := FormatMissing(missing)
+			Expect(result).To(ContainSubstring("MISSING VSPHERE PRIVILEGES"))
+			Expect(result).To(ContainSubstring("Snapshots:"))
+			Expect(result).To(ContainSubstring("  - VM.Snap.Create"))
+			Expect(result).To(ContainSubstring("Power:"))
+			Expect(result).To(ContainSubstring("  - VM.PowerOn"))
+			Expect(result).To(ContainSubstring("RESOLUTION"))
+		})
+	})
+
+	Describe("MissingPrivileges accessor", func() {
+		It("should return not-checked before any check runs", func() {
+			c := &Collector{missingPrivsMu: &sync.RWMutex{}}
+			missing, checked := c.MissingPrivileges()
+			Expect(checked).To(BeFalse())
+			Expect(missing).To(BeNil())
+		})
+
+		It("should return cached results after setting them", func() {
+			c := &Collector{missingPrivsMu: &sync.RWMutex{}}
+			expected := []MissingPrivileges{
+				{Group: "Snapshots", Privileges: []string{"VM.Snap.Create"}},
+			}
+			c.missingPrivsMu.Lock()
+			c.missingPrivs = &privilegeCheckResult{missing: expected}
+			c.missingPrivsMu.Unlock()
+
+			missing, checked := c.MissingPrivileges()
+			Expect(checked).To(BeTrue())
+			Expect(missing).To(HaveLen(1))
+			Expect(missing[0].Group).To(Equal("Snapshots"))
+		})
+
+		It("should return checked with nil missing when all privileges are granted", func() {
+			c := &Collector{missingPrivsMu: &sync.RWMutex{}}
+			c.missingPrivsMu.Lock()
+			c.missingPrivs = &privilegeCheckResult{}
+			c.missingPrivsMu.Unlock()
+
+			missing, checked := c.MissingPrivileges()
+			Expect(checked).To(BeTrue())
+			Expect(missing).To(BeNil())
+		})
+	})
+})

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -16,6 +16,7 @@ import (
 	hvutil "github.com/kubev2v/forklift/pkg/controller/hyperv"
 	"github.com/kubev2v/forklift/pkg/controller/ova"
 	"github.com/kubev2v/forklift/pkg/controller/provider/container"
+	vsphereCollector "github.com/kubev2v/forklift/pkg/controller/provider/container/vsphere"
 	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
 	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
@@ -48,6 +49,7 @@ const (
 	ConnectionInsecure      = "ConnectionInsecure"
 	SSHReady                = "SSHReady"
 	SSHNotReady             = "SSHNotReady"
+	InsufficientPrivileges  = "InsufficientPrivileges"
 	SMBCSIDriverNotReady    = "SMBCSIDriverNotReady"
 	SMBMountFailed          = "SMBMountFailed"
 	WaitingForService       = "WaitingForService"
@@ -119,6 +121,10 @@ func (r *Reconciler) validate(provider *api.Provider) error {
 		return liberr.Wrap(err)
 	}
 	err = r.testConnection(provider, secret)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	err = r.validateVSpherePrivileges(provider)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -494,6 +500,64 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 					err.Error()),
 			})
 	}
+
+	return nil
+}
+
+// Validate vSphere service account privileges.
+func (r *Reconciler) validateVSpherePrivileges(provider *api.Provider) error {
+	if provider.Type() != api.VSphere {
+		return nil
+	}
+	if provider.Status.HasBlockerCondition() {
+		return nil
+	}
+
+	log.Info(
+		"Validating vSphere privileges.",
+		"name", provider.Name,
+		"namespace", provider.Namespace,
+	)
+
+	collector, found := r.container.Get(provider)
+	if !found {
+		return nil
+	}
+	vsphColl, ok := collector.(*vsphereCollector.Collector)
+	if !ok {
+		return nil
+	}
+
+	missing, checked := vsphColl.MissingPrivileges()
+	if !checked {
+		return nil
+	}
+
+	if len(missing) == 0 {
+		provider.Status.DeleteCondition(InsufficientPrivileges)
+		return nil
+	}
+
+	totalMissing := 0
+	var items []string
+	for _, m := range missing {
+		totalMissing += len(m.Privileges)
+		items = append(items, m.Privileges...)
+	}
+
+	provider.Status.SetCondition(
+		libcnd.Condition{
+			Type:     InsufficientPrivileges,
+			Status:   True,
+			Reason:   "PrivilegesNotGranted",
+			Category: Warn,
+			Message: fmt.Sprintf(
+				"The vSphere service account is missing %d privilege(s) required for migration. "+
+					"See the suggestion field in the Provider's YAML for details.",
+				totalMissing),
+			Suggestion: vsphereCollector.FormatMissing(missing),
+			Items:      items,
+		})
 
 	return nil
 }


### PR DESCRIPTION
**Manual Backport**: https://github.com/kubev2v/forklift/pull/8367

Manually added pre required code from MTV-1878 

Replaces failed automatic backport - https://github.com/kubev2v/forklift/pull/8385

With the PR https://github.com/kubev2v/forklift/pull/8250 there was a performance regression that caused the initial inventory parsing to take 3-4 times longer due to heavier reliance on the database to process updates instead of only inserts.

This change caches the custom def fields into memory in the inventory application and then does a compare against that before attempting the database insert/update. This is especially impactful on the initial startup which attempts to insert/update the same custom def fields for each VM.

Resolves: MTV-6511