### PR TITLE
MTV-6458 | Fall back to system CA for wrong VMExport cert

### DIFF
--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -20,6 +20,7 @@ import (
 	ocpclient "github.com/kubev2v/forklift/pkg/lib/client/openshift"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 	libitr "github.com/kubev2v/forklift/pkg/lib/itinerary"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
 	core "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -762,13 +763,15 @@ func (r *Builder) SourceVMLabelsAndAnnotations(vmRef ref.Ref, tagMapping *v1beta
 
 const exportTLSTimeout = 10 * time.Second
 
+var builderLog = logging.WithName("ocp|builder")
+
 // tlsCertForExport returns providedCert if it verifies exportURL, "" if system CA works instead, or an error if neither works.
 func tlsCertForExport(exportURL, providedCert string) (string, error) {
 	if providedCert == "" {
 		return "", nil
 	}
 	if exportURL == "" {
-		return providedCert, nil
+		return "", fmt.Errorf("export URL is required to verify VMExport certificate")
 	}
 	if err := verifyExportTLS(exportURL, providedCert); err == nil {
 		return providedCert, nil
@@ -784,10 +787,11 @@ func verifyExportTLS(exportURL, caPEM string) error {
 	if err != nil {
 		return err
 	}
-	addr := u.Host
-	if _, _, err := net.SplitHostPort(addr); err != nil {
-		addr = net.JoinHostPort(addr, "443")
+	port := u.Port()
+	if port == "" {
+		port = "443"
 	}
+	addr := net.JoinHostPort(u.Hostname(), port)
 	var roots *x509.CertPool
 	if caPEM != "" {
 		roots = x509.NewCertPool()
@@ -805,7 +809,9 @@ func verifyExportTLS(exportURL, caPEM string) error {
 		RootCAs:    roots,
 	})
 	if conn != nil {
-		conn.Close()
+		if closeErr := conn.Close(); closeErr != nil {
+			builderLog.Info("Failed to close TLS probe connection", "error", closeErr)
+		}
 	}
 	return err
 }

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -6,7 +6,10 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
@@ -102,6 +105,19 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *v1.Secret, configMap *v1.Co
 		storageMap[storage.Source.Name] = storage.Destination
 	}
 
+	certConfigMap := configMap.Name
+	if len(vmExport.Status.Links.External.Volumes) > 0 {
+		probeURL := getExportURL(vmExport.Status.Links.External.Volumes[0].Formats)
+		caCert, certErr := tlsCertForExport(probeURL, vmExport.Status.Links.External.Cert)
+		if certErr != nil {
+			return nil, liberr.Wrap(certErr)
+		}
+		if caCert == "" {
+			r.Log.Info("VMExport cert does not verify export endpoint, using system CA certificates")
+			certConfigMap = ""
+		}
+	}
+
 	dataVolumes := []cdi.DataVolume{}
 	for diskIndex, volume := range vmExport.Status.Links.External.Volumes {
 		// Get PVC
@@ -129,7 +145,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *v1.Secret, configMap *v1.Co
 			return nil, liberr.Wrap(fmt.Errorf("failed to get export URL, available formats: %v", volume.Formats))
 		}
 		storageClassName := storageMap[*pvc.Spec.StorageClassName].StorageClass
-		dataVolume.Spec = *createDataVolumeSpec(size, storageClassName, url, configMap.Name, secret.Name)
+		dataVolume.Spec = *createDataVolumeSpec(size, storageClassName, url, certConfigMap, secret.Name)
 
 		err = r.Destination.Client.Create(context.TODO(), dataVolume, &client.CreateOptions{})
 		if err != nil {
@@ -559,21 +575,17 @@ func (r *Builder) getSourceVmFromDefinition(vmRef ref.Ref) (*cnv.VirtualMachine,
 		}
 	}
 
-	caCert := vme.Status.Links.External.Cert
+	caCert, err := tlsCertForExport(vmManifestUrl, vme.Status.Links.External.Cert)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
 	var transport *http.Transport
-
 	if caCert != "" {
 		caCertPool := x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM([]byte(caCert)) {
 			return nil, liberr.New("failed to parse CA certificate")
 		}
-
-		tlsConfig := &tls.Config{
-			RootCAs: caCertPool,
-		}
-
-		transport = &http.Transport{TLSClientConfig: tlsConfig}
-
+		transport = &http.Transport{TLSClientConfig: &tls.Config{RootCAs: caCertPool}}
 	} else {
 		r.Log.Info("Certificate from VM export is empty, using system CA certificates")
 		transport = &http.Transport{}
@@ -640,14 +652,17 @@ func (r *Builder) getSourceVmFromDefinition(vmRef ref.Ref) (*cnv.VirtualMachine,
 	return nil, liberr.New("failed to find vm in manifest")
 }
 
-func createDataVolumeSpec(size resource.Quantity, storageClassName, url, configMap, secret string) *cdi.DataVolumeSpec {
+func createDataVolumeSpec(size resource.Quantity, storageClassName, url, certConfigMap, secret string) *cdi.DataVolumeSpec {
+	httpSource := &cdi.DataVolumeSourceHTTP{
+		URL:                url,
+		SecretExtraHeaders: []string{secret},
+	}
+	if certConfigMap != "" {
+		httpSource.CertConfigMap = certConfigMap
+	}
 	return &cdi.DataVolumeSpec{
 		Source: &cdi.DataVolumeSource{
-			HTTP: &cdi.DataVolumeSourceHTTP{
-				URL:                url,
-				CertConfigMap:      configMap,
-				SecretExtraHeaders: []string{secret},
-			},
+			HTTP: httpSource,
 		},
 		Storage: &cdi.StorageSpec{
 			Resources: core.VolumeResourceRequirements{
@@ -743,4 +758,54 @@ func (r *Builder) setPVCNameFromTemplate(objectMeta *metav1.ObjectMeta, vmRef re
 // NO-OP
 func (r *Builder) SourceVMLabelsAndAnnotations(vmRef ref.Ref, tagMapping *v1beta1.TagMapping) (labels map[string]string, annotations map[string]string, sanitizationReport map[string]string, err error) {
 	return
+}
+
+const exportTLSTimeout = 10 * time.Second
+
+// tlsCertForExport returns providedCert if it verifies exportURL, "" if system CA works instead, or an error if neither works.
+func tlsCertForExport(exportURL, providedCert string) (string, error) {
+	if providedCert == "" {
+		return "", nil
+	}
+	if exportURL == "" {
+		return providedCert, nil
+	}
+	if err := verifyExportTLS(exportURL, providedCert); err == nil {
+		return providedCert, nil
+	}
+	if err := verifyExportTLS(exportURL, ""); err == nil {
+		return "", nil
+	}
+	return "", fmt.Errorf("export endpoint TLS verification failed with VMExport cert and system CA")
+}
+
+func verifyExportTLS(exportURL, caPEM string) error {
+	u, err := url.Parse(exportURL)
+	if err != nil {
+		return err
+	}
+	addr := u.Host
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		addr = net.JoinHostPort(addr, "443")
+	}
+	var roots *x509.CertPool
+	if caPEM != "" {
+		roots = x509.NewCertPool()
+		if !roots.AppendCertsFromPEM([]byte(caPEM)) {
+			return fmt.Errorf("failed to parse CA certificate")
+		}
+	} else {
+		roots, err = x509.SystemCertPool()
+		if err != nil {
+			roots = x509.NewCertPool()
+		}
+	}
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: exportTLSTimeout}, "tcp", addr, &tls.Config{
+		ServerName: u.Hostname(),
+		RootCAs:    roots,
+	})
+	if conn != nil {
+		conn.Close()
+	}
+	return err
 }

--- a/pkg/controller/plan/adapter/ocp/builder_test.go
+++ b/pkg/controller/plan/adapter/ocp/builder_test.go
@@ -362,6 +362,13 @@ func TestTlsCertForExport(t *testing.T) {
 		}
 	})
 
+	t.Run("missing export URL", func(t *testing.T) {
+		_, err := tlsCertForExport("", string(caPEM))
+		if err == nil {
+			t.Fatal("expected error for missing export URL")
+		}
+	})
+
 	t.Run("wrong CA when system also untrusted", func(t *testing.T) {
 		wrongCAPEM, _, _ := newTestTLSCredentials(t)
 		_, err := tlsCertForExport(exportURL, string(wrongCAPEM))

--- a/pkg/controller/plan/adapter/ocp/builder_test.go
+++ b/pkg/controller/plan/adapter/ocp/builder_test.go
@@ -1,7 +1,18 @@
 package ocp
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
 	"testing"
+	"time"
 
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
@@ -222,7 +233,7 @@ func TestDataVolumes_PVCNameTemplate(t *testing.T) {
 			Status: &export.VirtualMachineExportStatus{
 				Links: &export.VirtualMachineExportLinks{
 					External: &export.VirtualMachineExportLink{
-						Cert: "cert",
+						Cert: "",
 						Volumes: []export.VirtualMachineExportVolume{{
 							Name: volumeName,
 							Formats: []export.VirtualMachineExportVolumeFormat{
@@ -324,4 +335,112 @@ func TestDataVolumes_PVCNameTemplate(t *testing.T) {
 			t.Errorf("expected Name %q, got Name=%q GenerateName=%q", "ocpglob-0", dvs[0].Name, dvs[0].GenerateName)
 		}
 	})
+}
+
+func TestTlsCertForExport(t *testing.T) {
+	caPEM, serverCert, _ := newTestTLSCredentials(t)
+	listener := startTestTLSServer(t, serverCert)
+	exportURL := "https://" + listener.Addr().String()
+
+	t.Run("empty cert", func(t *testing.T) {
+		got, err := tlsCertForExport(exportURL, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Fatalf("expected empty cert, got %q", got)
+		}
+	})
+
+	t.Run("matching CA", func(t *testing.T) {
+		got, err := tlsCertForExport(exportURL, string(caPEM))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != string(caPEM) {
+			t.Fatalf("expected provided CA, got %q", got)
+		}
+	})
+
+	t.Run("wrong CA when system also untrusted", func(t *testing.T) {
+		wrongCAPEM, _, _ := newTestTLSCredentials(t)
+		_, err := tlsCertForExport(exportURL, string(wrongCAPEM))
+		if err == nil {
+			t.Fatal("expected error when neither VMExport cert nor system CA verifies")
+		}
+	})
+}
+
+func TestCreateDataVolumeSpec_OmitsCertConfigMap(t *testing.T) {
+	spec := createDataVolumeSpec(resource.MustParse("1Gi"), "sc", "https://example/disk", "", "secret")
+	if spec.Source.HTTP.CertConfigMap != "" {
+		t.Fatalf("expected empty CertConfigMap, got %q", spec.Source.HTTP.CertConfigMap)
+	}
+
+	spec = createDataVolumeSpec(resource.MustParse("1Gi"), "sc", "https://example/disk", "ca-cm", "secret")
+	if spec.Source.HTTP.CertConfigMap != "ca-cm" {
+		t.Fatalf("expected CertConfigMap ca-cm, got %q", spec.Source.HTTP.CertConfigMap)
+	}
+}
+
+func newTestTLSCredentials(t *testing.T) (caPEM []byte, serverCert tls.Certificate, serverKey *ecdsa.PrivateKey) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	serverKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create server cert: %v", err)
+	}
+	serverCert = tls.Certificate{
+		Certificate: [][]byte{serverDER, caDER},
+		PrivateKey:  serverKey,
+	}
+	return caPEM, serverCert, serverKey
+}
+
+func startTestTLSServer(t *testing.T, serverCert tls.Certificate) net.Listener {
+	t.Helper()
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+	})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+
+	go http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	return listener
 }

--- a/pkg/controller/plan/adapter/ocp/builder_test.go
+++ b/pkg/controller/plan/adapter/ocp/builder_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"net"
 	"net/http"
@@ -446,8 +447,22 @@ func startTestTLSServer(t *testing.T, serverCert tls.Certificate) net.Listener {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	t.Cleanup(func() { listener.Close() })
+	t.Cleanup(func() {
+		if closeErr := listener.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+			t.Errorf("listener.Close: %v", closeErr)
+		}
+	})
 
-	go http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	go func() {
+		serveErr := http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		if serveErr == nil || errors.Is(serveErr, http.ErrServerClosed) {
+			return
+		}
+		var opErr *net.OpError
+		if errors.As(serveErr, &opErr) && errors.Is(opErr.Err, net.ErrClosed) {
+			return
+		}
+		t.Errorf("http.Serve: %v", serveErr)
+	}()
 	return listener
 }


### PR DESCRIPTION
Probe the export proxy TLS endpoint before setting certConfigMap on OCP cold-migration DataVolumes. Omit the cert when VMExport's CA does not verify but system trust does.

Ref: https://redhat.atlassian.net/browse/MTV-6458
Resolves: MTV-6458