### PR TITLE
fix(hyperv): use CIM API for graceful VM shutdown before migration

### DIFF
--- a/pkg/controller/plan/adapter/hyperv/client.go
+++ b/pkg/controller/plan/adapter/hyperv/client.go
@@ -1,7 +1,6 @@
 package hyperv
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -158,38 +157,12 @@ func (r *Client) PowerOff(vmRef ref.Ref) error {
 		return err
 	}
 
-	// In cluster mode, the VM may be on a different node than the entry
-	// point. Route the Stop-VM command to the correct node via RunOnNode.
-	if r.Source.Provider.IsHyperVCluster() && vm.Host != "" {
-		cmd := ps.BuildCommand(ps.StopVM, vm.Name)
-		if _, err = drv.RunOnNode(cmd, vm.Host); err != nil {
-			return fmt.Errorf("failed to power off VM %s on node %s: %w", vm.Name, vm.Host, err)
-		}
-		log.Info("Powered off VM via RunOnNode", "vm", vm.Name, "node", vm.Host)
-		return nil
+	cmd := ps.BuildCommand(ps.InitiateShutdown, vm.Name)
+	if _, err = drv.RunOnNode(cmd, vm.Host); err != nil {
+		return fmt.Errorf("failed to initiate shutdown for VM %s: %w", vm.Name, err)
 	}
 
-	domain, err := drv.LookupDomainByName(vm.Name)
-	if err != nil {
-		log.Info("VM not found on provider, treating as already off", "vm", vm.Name)
-		return nil
-	}
-	defer func() { _ = domain.Free() }()
-
-	state, _, err := domain.GetState()
-	if err != nil {
-		return fmt.Errorf("failed to get VM state: %w", err)
-	}
-	if state == driver.DOMAIN_SHUTOFF {
-		log.Info("VM already powered off (confirmed via WinRM)", "vm", vm.Name)
-		return nil
-	}
-
-	if err := domain.Shutdown(context.TODO()); err != nil {
-		return fmt.Errorf("failed to power off VM %s: %w", vm.Name, err)
-	}
-
-	log.Info("Powered off VM", "vm", vm.Name)
+	log.Info("Initiated graceful shutdown", "vm", vm.Name, "host", vm.Host)
 	return nil
 }
 

--- a/pkg/controller/plan/adapter/hyperv/client_test.go
+++ b/pkg/controller/plan/adapter/hyperv/client_test.go
@@ -1,11 +1,16 @@
 package hyperv
 
 import (
+	"errors"
 	"testing"
 
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
+	"github.com/kubev2v/forklift/pkg/lib/hyperv/driver"
+	ps "github.com/kubev2v/forklift/pkg/lib/hyperv/powershell"
 )
 
 func TestParseStateString(t *testing.T) {
@@ -54,5 +59,148 @@ func TestPowerStateFromInventory(t *testing.T) {
 					tc.state, got, tc.expected)
 			}
 		})
+	}
+}
+
+// stubDriver is a minimal driver.HyperVDriver implementation for testing
+// Client.PowerOff without a real WinRM connection. Only RunOnNode is
+// exercised by PowerOff; the rest satisfy the interface and are unused.
+type stubDriver struct {
+	runOnNodeCmd  string
+	runOnNodeHost string
+	runOnNodeErr  error
+	runOnNodeN    int
+}
+
+func (s *stubDriver) Connect() error { return nil }
+func (s *stubDriver) Close() error   { return nil }
+func (s *stubDriver) IsAlive() (bool, error) {
+	return true, nil
+}
+func (s *stubDriver) ListAllDomains() ([]driver.Domain, error)        { return nil, nil }
+func (s *stubDriver) ListAllClusterDomains() ([]driver.Domain, error) { return nil, nil }
+func (s *stubDriver) LookupDomainByName(_ string) (driver.Domain, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubDriver) LookupDomainByUUIDString(_ string) (driver.Domain, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubDriver) ListAllNetworks() ([]driver.Network, error) { return nil, nil }
+func (s *stubDriver) LookupNetworkByUUIDString(_ string) (driver.Network, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubDriver) GetCluster() (*driver.ClusterData, error)           { return nil, nil }
+func (s *stubDriver) GetClusterNodes() ([]driver.ClusterNodeData, error) { return nil, nil }
+func (s *stubDriver) GetClusterInfo() (*driver.ClusterInfoData, error)   { return nil, nil }
+func (s *stubDriver) GetClusterVMGroups() ([]driver.ClusterGroupData, error) {
+	return nil, nil
+}
+func (s *stubDriver) GetComputerInfo() (*driver.ComputerInfoData, error) { return nil, nil }
+func (s *stubDriver) ExecuteCommand(_ string) (string, error)            { return "", nil }
+
+func (s *stubDriver) RunOnNode(command, computerName string) (string, error) {
+	s.runOnNodeN++
+	s.runOnNodeCmd = command
+	s.runOnNodeHost = computerName
+	if s.runOnNodeErr != nil {
+		return "", s.runOnNodeErr
+	}
+	return "", nil
+}
+
+func makePowerVM(id, host, powerState string) *hyperv.VM {
+	vm := makeVM(id, host)
+	vm.Name = id
+	vm.PowerState = powerState
+	return vm
+}
+
+func TestPowerOff_AlreadyOff(t *testing.T) {
+	inv := &stubInventory{
+		vms: map[string]*hyperv.VM{"vm-1": makePowerVM("vm-1", "node-1", model.PowerStateOff)},
+	}
+	drv := &stubDriver{}
+	c := &Client{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{Inventory: inv},
+		},
+		driver: drv,
+	}
+
+	if err := c.PowerOff(ref.Ref{ID: "vm-1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if drv.runOnNodeN != 0 {
+		t.Errorf("expected RunOnNode not to be called, called %d times", drv.runOnNodeN)
+	}
+}
+
+func TestPowerOff_RunsOnNode(t *testing.T) {
+	inv := &stubInventory{
+		vms: map[string]*hyperv.VM{"vm-1": makePowerVM("vm-1", "node-1", model.PowerStateOn)},
+	}
+	drv := &stubDriver{}
+	c := &Client{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{Inventory: inv},
+		},
+		driver: drv,
+	}
+
+	if err := c.PowerOff(ref.Ref{ID: "vm-1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantCmd := ps.BuildCommand(ps.InitiateShutdown, "vm-1")
+	if drv.runOnNodeCmd != wantCmd {
+		t.Errorf("RunOnNode command = %q, want %q", drv.runOnNodeCmd, wantCmd)
+	}
+	if drv.runOnNodeHost != "node-1" {
+		t.Errorf("RunOnNode host = %q, want %q", drv.runOnNodeHost, "node-1")
+	}
+}
+
+func TestPowerOff_RunOnNodeError(t *testing.T) {
+	inv := &stubInventory{
+		vms: map[string]*hyperv.VM{"vm-1": makePowerVM("vm-1", "node-1", model.PowerStateOn)},
+	}
+	drv := &stubDriver{runOnNodeErr: errors.New("boom")}
+	c := &Client{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{Inventory: inv},
+		},
+		driver: drv,
+	}
+
+	err := c.PowerOff(ref.Ref{ID: "vm-1"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	wantMsg := "failed to initiate shutdown for VM vm-1: boom"
+	if err.Error() != wantMsg {
+		t.Errorf("error = %q, want %q", err.Error(), wantMsg)
+	}
+}
+
+func TestPowerOff_EmptyHostStandalone(t *testing.T) {
+	inv := &stubInventory{
+		vms: map[string]*hyperv.VM{"vm-1": makePowerVM("vm-1", "", model.PowerStateOn)},
+	}
+	drv := &stubDriver{}
+	c := &Client{
+		Context: &plancontext.Context{
+			Source: plancontext.Source{Inventory: inv},
+		},
+		driver: drv,
+	}
+
+	if err := c.PowerOff(ref.Ref{ID: "vm-1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if drv.runOnNodeN != 1 {
+		t.Errorf("expected RunOnNode to be called once, called %d times", drv.runOnNodeN)
+	}
+	if drv.runOnNodeHost != "" {
+		t.Errorf("RunOnNode host = %q, want empty string", drv.runOnNodeHost)
 	}
 }

--- a/pkg/lib/hyperv/driver/driver.go
+++ b/pkg/lib/hyperv/driver/driver.go
@@ -1,7 +1,6 @@
 package driver
 
 import (
-	"context"
 	"time"
 )
 
@@ -70,7 +69,6 @@ type Domain interface {
 	GetNICs() ([]NICInfo, error)
 	// GetComputerName returns the cluster node hosting this VM, or "" for local VMs.
 	GetComputerName() string
-	Shutdown(ctx context.Context) error
 	Free() error
 }
 

--- a/pkg/lib/hyperv/driver/winrm.go
+++ b/pkg/lib/hyperv/driver/winrm.go
@@ -576,12 +576,6 @@ func (d *WinRMDomain) GetNICs() ([]NICInfo, error) {
 	return nics, nil
 }
 
-func (d *WinRMDomain) Shutdown(_ context.Context) error {
-	cmd := ps.BuildCommand(ps.StopVM, d.data().Name)
-	_, err := d.driver.ExecuteCommand(cmd)
-	return err
-}
-
 func (d *WinRMDomain) Free() error {
 	return nil // No resources to free for WinRM
 }

--- a/pkg/lib/hyperv/powershell/scripts.go
+++ b/pkg/lib/hyperv/powershell/scripts.go
@@ -65,9 +65,18 @@ const (
 	// Parameters: vmName
 	GetVMState = `Get-VM -Name '%s' | Select-Object -ExpandProperty State`
 
-	// StopVM forcefully stops a VM.
+	// InitiateShutdown gracefully shuts down a VM via Hyper-V WMI.
+	// Uses Msvm_ShutdownComponent which is async — returns immediately,
+	// shutdown is owned by vmms.exe and survives WinRM session closure.
 	// Parameters: vmName
-	StopVM = `Stop-VM -Name '%s' -Force -Confirm:$false`
+	InitiateShutdown = `$vmName = '%s'
+$vm = Get-CimInstance -Namespace root\virtualization\v2 -ClassName Msvm_ComputerSystem -Filter "ElementName='$vmName'" | Select-Object -First 1
+if (-not $vm) { throw "VM '$vmName' not found" }
+if ($vm.EnabledState -eq 3) { return }
+$sc = @(Get-CimAssociatedInstance -InputObject $vm -ResultClassName Msvm_ShutdownComponent)
+if ($sc.Count -eq 0) { throw "Shutdown Integration Service not available for VM '$vmName'" }
+$r = Invoke-CimMethod -InputObject $sc[0] -MethodName InitiateShutdown -Arguments @{Force=$true; Reason='Forklift migration'}
+if ($r.ReturnValue -notin 0, 4096, 32782) { throw "InitiateShutdown failed for VM '$vmName': return code $($r.ReturnValue)" }`
 )
 
 const (

--- a/pkg/lib/hyperv/powershell/scripts_test.go
+++ b/pkg/lib/hyperv/powershell/scripts_test.go
@@ -1,0 +1,32 @@
+package powershell
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildCommandInitiateShutdown(t *testing.T) {
+	script := BuildCommand(InitiateShutdown, "test-vm")
+
+	for _, want := range []string{
+		"$vmName = 'test-vm'",
+		"Get-CimInstance",
+		"InitiateShutdown",
+		"Msvm_ShutdownComponent",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("BuildCommand(InitiateShutdown, %q) missing %q\ngot: %s", "test-vm", want, script)
+		}
+	}
+}
+
+func TestBuildCommandInitiateShutdownQuoteEscaping(t *testing.T) {
+	script := BuildCommand(InitiateShutdown, "vm'name")
+
+	if !strings.Contains(script, "vm''name") {
+		t.Errorf("BuildCommand(InitiateShutdown, %q) did not escape single quote, got: %s", "vm'name", script)
+	}
+	if strings.Contains(script, "$vmName = 'vm'name'") {
+		t.Errorf("BuildCommand(InitiateShutdown, %q) produced unescaped quote, got: %s", "vm'name", script)
+	}
+}


### PR DESCRIPTION
Replace Stop-VM -Force with Msvm_ShutdownComponent.InitiateShutdown() for VM shutdown before migration.

The previous Stop-VM -Force was synchronous — it blocked the WinRM session for the entire shutdown duration, making the WaitForPowerOff phase effectively redundant since the VM was already off by the time PowerOff() returned. The new InitiateShutdown CIM method is async — it dispatches the shutdown request to vmms.exe and returns immediately. The existing WaitForPowerOff phase (which polls Forklift inventory every ~3s) now serves its intended purpose of waiting for the VM to actually power off.

This also avoids two problems with the synchronous approach:
1. The 60-second WinRM timeout could cancel Stop-VM mid-flight. It cancels the shutdown entirely. The Stop-VM cmdlet runs inside wsmprovhost.exe, which is placed in a Windows Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. When the WinRM session terminates, the hosting process is killed, and the WMI state change request that Stop-VM initiated is aborted. The VM remains running, and the migration proceeds against a live VM.

2. -Force hard-kills the VM after 5 minutes which risks data corruption during long graceful shutdowns.

The CIM method's Force=$true argument closes guest applications with unsaved data (equivalent to guest-side 'shutdown /f'), appropriate for migration where no user interaction is expected.

Removes Domain.Shutdown() from the driver interface (zero callers).

Resolves: None