### PR TITLE
MTV-6664 | Add Nutanix to providers detail list

### DIFF
--- a/pkg/controller/provider/web/provider.go
+++ b/pkg/controller/provider/web/provider.go
@@ -5,6 +5,7 @@ import (
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/nutanix"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/ocp"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/openstack"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web/ova"
@@ -192,6 +193,27 @@ func (h ProviderHandler) List(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
+	// Nutanix
+	nutanixHandler := &nutanix.ProviderHandler{
+		Handler: base.Handler{
+			Container: h.Container,
+		},
+	}
+	status, err = nutanixHandler.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		base.SetForkliftError(ctx, err)
+		return
+	}
+	nutanixList, err := nutanixHandler.ListContent(ctx)
+	if err != nil {
+		log.Trace(
+			err,
+			"url",
+			ctx.Request.URL)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
 	r := Provider{
 		string(api.OpenShift): ocpList,
 		string(api.VSphere):   vSphereList,
@@ -200,6 +222,7 @@ func (h ProviderHandler) List(ctx *gin.Context) {
 		string(api.Ova):       ovaList,
 		string(api.EC2):       ec2List,
 		string(api.HyperV):    hypervList,
+		string(api.Nutanix):   nutanixList,
 	}
 
 	content := r


### PR DESCRIPTION
Issue: Nutanix inventory doesn't show up in `GET /providers?detail=1`

Fix: add Nutanix to the List response, copy-pasted from other existing providers.

Resolves: MTV-6664

Ref: [MTV-6664](https://redhat.atlassian.net/browse/MTV-6664)

[MTV-6664]: https://redhat.atlassian.net/browse/MTV-6664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ