### PR TITLE
MTV-6639 | VM Shutdown Timeouts in Large Hyper-V Clusters

### DIFF
--- a/pkg/controller/plan/adapter/hyperv/client.go
+++ b/pkg/controller/plan/adapter/hyperv/client.go
@@ -2,8 +2,10 @@ package hyperv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	planapi "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
@@ -19,6 +21,17 @@ import (
 )
 
 var log = logging.WithName("hyperv|client")
+
+const clusterPowerOffTimeout = 5 * time.Minute
+
+func isTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	// WinRM may wrap the context error in its own message string
+	// rather than chaining it, so fall back to a substring check.
+	return strings.Contains(err.Error(), "context deadline exceeded")
+}
 
 // HyperV VM Client
 type Client struct {
@@ -158,11 +171,22 @@ func (r *Client) PowerOff(vmRef ref.Ref) error {
 		return err
 	}
 
-	// In cluster mode, the VM may be on a different node than the entry
-	// point. Route the Stop-VM command to the correct node via RunOnNode.
+	// Cluster mode: route Stop-VM to the owner node with an extended
+	// timeout (the multi-hop WinRM call can exceed the default 60s).
 	if r.Source.Provider.IsHyperVCluster() && vm.Host != "" {
 		cmd := ps.BuildCommand(ps.StopVM, vm.Name)
-		if _, err = drv.RunOnNode(cmd, vm.Host); err != nil {
+		if _, err = drv.RunOnNodeWithTimeout(cmd, vm.Host, clusterPowerOffTimeout); err != nil {
+			// Timeouts are non-fatal: Stop-VM -Force is accepted by
+			// VMMS before the WinRM response. Returning nil here lets
+			// PhasePowerOffSource state call NextPhase(vm),
+			// advancing to WaitForPowerOff which polls the actual
+			// power state via WinRM and will only proceed once the
+			// VM is truly off.
+			if isTimeoutError(err) {
+				log.Info("Stop-VM timed out, deferring to WaitForPowerOff",
+					"vm", vm.Name, "node", vm.Host, "error", err)
+				return nil
+			}
 			return fmt.Errorf("failed to power off VM %s on node %s: %w", vm.Name, vm.Host, err)
 		}
 		log.Info("Powered off VM via RunOnNode", "vm", vm.Name, "node", vm.Host)


### PR DESCRIPTION
Issue:
In a clustered Hyper-V environment, PowerOff issues this chain: WinRM → entry-point host → Invoke-Command -ComputerName <owner-node> → Stop-VM -Force On large clusters the default 60s WinRM timeout can be exceeded, causing:
1. WinRM returns "context deadline exceeded"
2. PowerOff wraps it as "failed to power off the vm..."
3. PhasePowerOffSource calls step.AddError(), which is terminal: it sets vm.Error, the VM is marked PhaseCompleted + ConditionFailed, and the migration never retries.

Fix:
1. Use RunOnNodeWithTimeout with a 5-minute timeout instead of RunOnNode with the default 60s timeout.
2. If Stop-VM still times out, PowerOff returns nil instead of an error. This is safe because Stop-VM -Force is accepted by VMMS before the WinRM response completes. Returning nil lets PhasePowerOffSource advance to WaitForPowerOff, which polls the actual VM power state via WinRM until the VM is truly off.

Resolves: MTV-6639
Ref: https://redhat.atlassian.net/browse/MTV-6639