### PR TITLE
MTV-3116 | detect IPv4/IPv6 pod IP for nginx listen directive

### DIFF
--- a/operator/roles/forkliftcontroller/templates/ui-plugin/configmap-ui-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/configmap-ui-plugin.yml.j2
@@ -17,7 +17,7 @@ data:
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              9443 ssl;
+        listen              LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
         root                /opt/app-root/src;

--- a/operator/roles/forkliftcontroller/templates/ui-plugin/deployment-ui-plugin.yml.j2
+++ b/operator/roles/forkliftcontroller/templates/ui-plugin/deployment-ui-plugin.yml.j2
@@ -21,6 +21,22 @@ spec:
     spec:
       containers:
         - name: "{{ ui_plugin_container_name }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if echo "$POD_IP" | grep -q ':'; then
+                LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="[::]:9443"
+              else
+                LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="9443"
+              fi
+              sed "s/LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/$LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/g" /etc/nginx/nginx.conf > /tmp/nginx.conf
+              exec nginx -c /tmp/nginx.conf -g 'daemon off;'
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           image: "{{ ui_plugin_image_fqin or lookup('env', 'UI_PLUGIN_IMAGE') or lookup('env', 'RELATED_IMAGE_UI_PLUGIN') }}"
           ports:
             - containerPort: 9443


### PR DESCRIPTION
Revives #5951 after validation on an IPv6 OCP cluster.

## Summary

On IPv6-only OCP clusters the forklift console plugin fails with:
> "Failed to get a valid plugin manifest from /api/plugins/forklift-console-plugin/"

**Root cause:** The nginx ConfigMap template hardcodes `listen 9443 ssl;` which only binds to IPv4 (`0.0.0.0:9443`). On IPv6-only pods the Service routes to the pod's IPv6 address, so nginx never receives connections from the console backend while localhost curl can still succeed.

**Fix:** Apply the same runtime detection pattern used by the [OpenShift cluster-monitoring-operator](https://github.com/openshift/cluster-monitoring-operator/pull/2173):

1. **ConfigMap** (`configmap-ui-plugin.yml.j2`): Replace hardcoded port with a `LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME` placeholder
2. **Deployment** (`deployment-ui-plugin.yml.j2`): Inject `POD_IP` via the Kubernetes downward API and add a startup command that detects IPv4 vs IPv6, substitutes the correct listen address, and starts nginx

Rebased onto current `main` (preserves `ui_plugin_image_fqin` env fallbacks on the image line).

## Test plan

Validated on IPv6 OCP cluster (`clusterNetwork=fd02::/48`, `podIP=fd02:0:0:1::2ae2`):

**Before fix:**
- `ss -tlnp`: `0.0.0.0:9443`
- curl `127.0.0.1:9443/plugin-manifest.json` → 200
- curl `[podIPv6]:9443` → 000 (connection refused)
- curl via Service → 000

**After fix:**
- `ss -tlnp`: `[::]:9443`
- `/tmp/nginx.conf`: `listen [::]:9443 ssl;`
- curl `[podIPv6]:9443` → 200
- curl via Service → 200
- Console plugins page: version 5.0.0, status loaded

**IPv4 regression** on separate cluster (`clusterNetwork=10.128.0.0/14`, `podIP=10.131.0.171`, qemtv-09):

**After fix applied:**
- `ss -tlnp`: `0.0.0.0:9443`
- `/tmp/nginx.conf`: `listen 9443 ssl;`
- curl `127.0.0.1:9443` → 200
- curl `[podIPv4]:9443` → 200
- curl via Service → 200
- No CrashLoopBackOff; nginx starts cleanly

- [x] IPv6 cluster: service-path curl returns 200, nginx listen `[::]:9443`
- [x] IPv4 regression: service-path curl returns 200, nginx listen `9443`, no pod crash
- [x] Console plugins page shows version 5.0.0 and loaded status (IPv6 cluster)
- [x] No CrashLoopBackOff on forklift-ui-plugin

/cc @yaacov @mnecas — reviving stale PR #5951

Resolves: MTV-3116