### PR TITLE
chore(ci): fix golangci-lint v2 mechanical findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ MUST_GATHER_IMAGE ?= $(REGISTRY)/$(REGISTRY_ORG)/forklift-must-gather:$(REGISTRY
 UI_PLUGIN_IMAGE ?= $(REGISTRY)/$(REGISTRY_ORG)/forklift-console-plugin:$(REGISTRY_TAG)
 
 # Golangci-lint version
-GOLANGCI_LINT_VERSION ?= v1.64.2
+GOLANGCI_LINT_VERSION ?= v2.12
 GOLANGCI_LINT_BIN ?= $(GOBIN)/golangci-lint
 
 ##@ Main Targets
@@ -779,7 +779,7 @@ export DEPLOYMENT_VARS
 .PHONY: lint-install
 lint-install: ## Install golangci-lint
 	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."
-	GOBIN=$(GOBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOBIN=$(GOBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@echo "golangci-lint installed successfully."
 
 .PHONY: lint

--- a/cmd/forklift-controller/main.go
+++ b/cmd/forklift-controller/main.go
@@ -99,7 +99,7 @@ func main() {
 	// Create a new Cmd to provide shared dependencies and start components
 	log.Info("setting up manager")
 	mgr, err := manager.New(cfg, manager.Options{
-		Metrics: server.Options{BindAddress: Settings.Metrics.Address()},
+		Metrics: server.Options{BindAddress: Settings.Address()},
 	})
 	if err != nil {
 		log.Error(err, "unable to set up overall controller manager")
@@ -179,7 +179,7 @@ func profiler() (profiler interface{ Stop() }) {
 	default:
 		kind = profile.MemProfile
 	}
-	if len(Settings.Profiler.Path) == 0 {
+	if len(Settings.Path) == 0 {
 		return
 	}
 	settings := Settings.Profiler

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan.go
@@ -524,7 +524,7 @@ func (r *Plan) DestinationHasUdnNetwork(client k8sclient.Client) bool {
 	if err != nil {
 		return false
 	}
-	_, hasUdnLabel := namespace.ObjectMeta.Labels[namespaceLabelPrimaryUDN]
+	_, hasUdnLabel := namespace.Labels[namespaceLabelPrimaryUDN]
 	if !hasUdnLabel {
 		return false
 	}

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/lib/itinerary/simple.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/lib/itinerary/simple.go
@@ -154,12 +154,12 @@ func (r *Itinerary) hasAny(step Step) (pTrue bool, err error) {
 		pTrue = true
 		return
 	}
-	for i := 0; i < r.Predicate.Count(); i++ {
+	for i := 0; i < r.Count(); i++ {
 		flag := Flag(1 << i)
 		if (step.Any & flag) == 0 {
 			continue
 		}
-		pTrue, err = r.Predicate.Evaluate(flag)
+		pTrue, err = r.Evaluate(flag)
 		if pTrue || err != nil {
 			return
 		}
@@ -175,12 +175,12 @@ func (r *Itinerary) hasAll(step Step) (pTrue bool, err error) {
 		pTrue = true
 		return
 	}
-	for i := 0; i < r.Predicate.Count(); i++ {
+	for i := 0; i < r.Count(); i++ {
 		flag := Flag(1 << i)
 		if (step.All & flag) == 0 {
 			continue
 		}
-		pTrue, err = r.Predicate.Evaluate(flag)
+		pTrue, err = r.Evaluate(flag)
 		if !pTrue || err != nil {
 			return
 		}

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/settings/migration.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/settings/migration.go
@@ -230,7 +230,7 @@ func (r *Migration) Load() (err error) {
 	}
 	if virtCustomizeConfigMap, ok := os.LookupEnv(VirtCustomizeConfigMap); ok {
 		r.VirtCustomizeConfigMap = virtCustomizeConfigMap
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtCustomizeConfigMap))
 	}
 	if val, found := os.LookupEnv(NAAOUIMapConfigMap); found {
@@ -244,15 +244,15 @@ func (r *Migration) Load() (err error) {
 	}
 	if virtV2vImage, ok := os.LookupEnv(VirtV2vImage); ok {
 		r.VirtV2vImage = virtV2vImage
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtV2vImage))
 	}
 	if virtV2vImageXFS, ok := os.LookupEnv(VirtV2vImageXFS); ok {
 		r.VirtV2vImageXFS = virtV2vImageXFS
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtV2vImageXFS))
 	}
-	if r.VirtV2vImageXFS == "" && Settings.Role.Has(MainRole) {
+	if r.VirtV2vImageXFS == "" && Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("environment variable %s was empty", VirtV2vImageXFS))
 	}
 	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
@@ -278,12 +278,12 @@ func (r *Migration) Load() (err error) {
 	}
 	if val, found := os.LookupEnv(OvirtOsConfigMap); found {
 		r.OvirtOsConfigMap = val
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", OvirtOsConfigMap))
 	}
 	if val, found := os.LookupEnv(VsphereOsConfigMap); found {
 		r.VsphereOsConfigMap = val
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VsphereOsConfigMap))
 	}
 	if r.VddkJobActiveDeadline, err = getPositiveEnvLimit(VddkJobActiveDeadline, 300); err != nil {

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/settings/settings.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/settings/settings.go
@@ -133,8 +133,8 @@ func getEnvBool(name string, def bool) bool {
 // GetVDDKImage gets the VDDK image from provider spec settings with fall back to global settings.
 func GetVDDKImage(providerSpecSettings map[string]string) string {
 	vddkImage := providerSpecSettings[api.VDDK]
-	if vddkImage == "" && Settings.Migration.VddkImage != "" {
-		vddkImage = Settings.Migration.VddkImage
+	if vddkImage == "" && Settings.VddkImage != "" {
+		vddkImage = Settings.VddkImage
 	}
 
 	return vddkImage

--- a/pkg/apis/forklift/v1beta1/plan.go
+++ b/pkg/apis/forklift/v1beta1/plan.go
@@ -524,7 +524,7 @@ func (r *Plan) DestinationHasUdnNetwork(client k8sclient.Client) bool {
 	if err != nil {
 		return false
 	}
-	_, hasUdnLabel := namespace.ObjectMeta.Labels[namespaceLabelPrimaryUDN]
+	_, hasUdnLabel := namespace.Labels[namespaceLabelPrimaryUDN]
 	if !hasUdnLabel {
 		return false
 	}

--- a/pkg/controller/base/controller.go
+++ b/pkg/controller/base/controller.go
@@ -82,7 +82,7 @@ func (r *Reconciler) Record(object runtime.Object, cnd libcnd.Conditions) {
 		default:
 			event = core.EventTypeNormal
 		}
-		r.EventRecorder.Event(
+		r.Event(
 			object,
 			event,
 			cnd.Type,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -66,14 +66,14 @@ func AddToManager(m manager.Manager) error {
 		}
 		return nil
 	}
-	if Settings.Role.Has(settings.InventoryRole) {
+	if Settings.Has(settings.InventoryRole) {
 		err := load(InventoryControllers)
 		if err != nil {
 			return err
 		}
 
 	}
-	if Settings.Role.Has(settings.MainRole) {
+	if Settings.Has(settings.MainRole) {
 		err := load(MainControllers)
 		if err != nil {
 			return err

--- a/pkg/controller/conversion/builder.go
+++ b/pkg/controller/conversion/builder.go
@@ -185,12 +185,12 @@ func (b *Builder) GetVirtV2vPodSpec(vm *plan.VMStatus, volumes []core.Volume, vo
 					ImagePullPolicy: core.PullAlways,
 					Resources: core.ResourceRequirements{
 						Requests: core.ResourceList{
-							core.ResourceCPU:    resource.MustParse(Settings.Migration.VirtV2vContainerRequestsCpu),
-							core.ResourceMemory: resource.MustParse(Settings.Migration.VirtV2vContainerRequestsMemory),
+							core.ResourceCPU:    resource.MustParse(Settings.VirtV2vContainerRequestsCpu),
+							core.ResourceMemory: resource.MustParse(Settings.VirtV2vContainerRequestsMemory),
 						},
 						Limits: core.ResourceList{
-							core.ResourceCPU:    resource.MustParse(Settings.Migration.VirtV2vContainerLimitsCpu),
-							core.ResourceMemory: resource.MustParse(Settings.Migration.VirtV2vContainerLimitsMemory),
+							core.ResourceCPU:    resource.MustParse(Settings.VirtV2vContainerLimitsCpu),
+							core.ResourceMemory: resource.MustParse(Settings.VirtV2vContainerLimitsMemory),
 						},
 					},
 					EnvFrom: []core.EnvFromSource{
@@ -440,19 +440,19 @@ func (b *Builder) BuildDeepInspectionPod(vm *plan.VMStatus, volumes []core.Volum
 func (b *Builder) BuildV2vPodEnvironment(env []core.EnvVar, vm *plan.VMStatus) ([]core.EnvVar, error) {
 	env = append(env, b.Config.Environment...)
 
-	if settings.Settings.Migration.VirtV2vMemSize > 0 {
+	if settings.Settings.VirtV2vMemSize > 0 {
 		env = append(env, core.EnvVar{
 			Name:  "V2V_memSize",
-			Value: strconv.Itoa(settings.Settings.Migration.VirtV2vMemSize),
+			Value: strconv.Itoa(settings.Settings.VirtV2vMemSize),
 		})
 	}
-	if settings.Settings.Migration.VirtV2vSmp > 0 {
+	if settings.Settings.VirtV2vSmp > 0 {
 		env = append(env, core.EnvVar{
 			Name:  "V2V_smp",
-			Value: strconv.Itoa(settings.Settings.Migration.VirtV2vSmp),
+			Value: strconv.Itoa(settings.Settings.VirtV2vSmp),
 		})
 	}
-	if settings.Settings.Features.VsphereVmwareDriverRemoval {
+	if settings.Settings.VsphereVmwareDriverRemoval {
 		env = append(env,
 			core.EnvVar{
 				Name:  "V2V_vsphereVmwareDriverRemoval",
@@ -473,7 +473,7 @@ func (b *Builder) BuildV2vPodEnvironment(env []core.EnvVar, vm *plan.VMStatus) (
 				Value: "true",
 			})
 	}
-	if settings.Settings.Features.WindowsRegistryNetworkConfig {
+	if settings.Settings.WindowsRegistryNetworkConfig {
 		env = append(env,
 			core.EnvVar{
 				Name:  "V2V_windowsRegistryNetworkConfig",
@@ -530,12 +530,12 @@ done
 		ImagePullPolicy: core.PullIfNotPresent,
 		Resources: core.ResourceRequirements{
 			Requests: core.ResourceList{
-				core.ResourceCPU:    resource.MustParse(settings.Settings.Migration.NetAppShiftDiskPermsInitRequestsCpu),
-				core.ResourceMemory: resource.MustParse(settings.Settings.Migration.NetAppShiftDiskPermsInitRequestsMemory),
+				core.ResourceCPU:    resource.MustParse(settings.Settings.NetAppShiftDiskPermsInitRequestsCpu),
+				core.ResourceMemory: resource.MustParse(settings.Settings.NetAppShiftDiskPermsInitRequestsMemory),
 			},
 			Limits: core.ResourceList{
-				core.ResourceCPU:    resource.MustParse(settings.Settings.Migration.NetAppShiftDiskPermsInitLimitsCpu),
-				core.ResourceMemory: resource.MustParse(settings.Settings.Migration.NetAppShiftDiskPermsInitLimitsMemory),
+				core.ResourceCPU:    resource.MustParse(settings.Settings.NetAppShiftDiskPermsInitLimitsCpu),
+				core.ResourceMemory: resource.MustParse(settings.Settings.NetAppShiftDiskPermsInitLimitsMemory),
 			},
 		},
 		SecurityContext: &core.SecurityContext{

--- a/pkg/controller/conversion/context/doc.go
+++ b/pkg/controller/conversion/context/doc.go
@@ -151,11 +151,11 @@ func GetVirtV2vImage(cfg *PodConfig) string {
 		return cfg.Image
 	}
 	if cfg.XfsCompatibility {
-		if settings.Settings.Migration.VirtV2vImageXFS != "" {
-			return settings.Settings.Migration.VirtV2vImageXFS
+		if settings.Settings.VirtV2vImageXFS != "" {
+			return settings.Settings.VirtV2vImageXFS
 		}
 	}
-	return settings.Settings.Migration.VirtV2vImage
+	return settings.Settings.VirtV2vImage
 }
 
 // GetDeepInspectionImage resolves the deep inspection workload image from PodConfig.
@@ -166,7 +166,7 @@ func GetDeepInspectionImage(cfg *PodConfig) string {
 		return cfg.Image
 	}
 	if cfg.XfsCompatibility {
-		if settings.Settings.Migration.DeepInspectionImageXFS != "" {
+		if settings.Settings.DeepInspectionImageXFS != "" {
 			return settings.Settings.DeepInspectionImageXFS
 		}
 	}

--- a/pkg/controller/host/predicate.go
+++ b/pkg/controller/host/predicate.go
@@ -69,7 +69,7 @@ func (r *ProviderPredicate) Update(e event.TypedUpdateEvent[*api.Provider]) bool
 // Provider deleted event.
 func (r *ProviderPredicate) Delete(e event.TypedDeleteEvent[*api.Provider]) bool {
 	p := e.Object
-	r.WatchManager.Deleted(p)
+	r.Deleted(p)
 	return true
 }
 

--- a/pkg/controller/host/validation.go
+++ b/pkg/controller/host/validation.go
@@ -107,7 +107,7 @@ func (r *Reconciler) validateProvider(host *api.Host) error {
 	if pVal.Referenced == nil {
 		return nil
 	}
-	host.Referenced.Provider.Source = pVal.Referenced
+	host.Provider.Source = pVal.Referenced
 	switch pVal.Referenced.Type() {
 	case api.VSphere:
 	default:
@@ -138,7 +138,7 @@ func (r *Reconciler) validateRef(host *api.Host) error {
 			})
 		return nil
 	}
-	provider := host.Referenced.Provider.Source
+	provider := host.Provider.Source
 	if provider == nil {
 		return nil
 	}
@@ -227,10 +227,10 @@ func (r *Reconciler) validateSecret(host *api.Host) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	host.Referenced.Secret = secret
+	host.Secret = secret
 	// DataErr
 	keyList := []string{}
-	provider := host.Referenced.Provider.Source
+	provider := host.Provider.Source
 	if provider != nil {
 		switch provider.Type() {
 		case api.VSphere:
@@ -268,8 +268,8 @@ func (r *Reconciler) testConnection(host *api.Host) (err error) {
 	if host.Status.HasBlockerCondition() {
 		return
 	}
-	provider := host.Referenced.Provider.Source
-	secret := host.Referenced.Secret
+	provider := host.Provider.Source
+	secret := host.Secret
 	inventory, err := web.NewClient(provider)
 	if err != nil {
 		err = liberr.Wrap(err)

--- a/pkg/controller/hyperv/builder.go
+++ b/pkg/controller/hyperv/builder.go
@@ -192,12 +192,12 @@ func (r *Builder) PodSpec(provider *api.Provider, secret *core.Secret, pvc *core
 				},
 				Resources: core.ResourceRequirements{
 					Requests: core.ResourceList{
-						core.ResourceCPU:    resource.MustParse(Settings.Providers.HyperV.Resources.CPU.Request),
-						core.ResourceMemory: resource.MustParse(Settings.Providers.HyperV.Resources.Memory.Request),
+						core.ResourceCPU:    resource.MustParse(Settings.HyperV.Resources.CPU.Request),
+						core.ResourceMemory: resource.MustParse(Settings.HyperV.Resources.Memory.Request),
 					},
 					Limits: core.ResourceList{
-						core.ResourceCPU:    resource.MustParse(Settings.Providers.HyperV.Resources.CPU.Limit),
-						core.ResourceMemory: resource.MustParse(Settings.Providers.HyperV.Resources.Memory.Limit),
+						core.ResourceCPU:    resource.MustParse(Settings.HyperV.Resources.CPU.Limit),
+						core.ResourceMemory: resource.MustParse(Settings.HyperV.Resources.Memory.Limit),
 					},
 				},
 				ReadinessProbe: &core.Probe{
@@ -274,5 +274,5 @@ func (r *Builder) Service(provider *api.Provider) (svc *core.Service) {
 }
 
 func (r *Builder) containerImage() string {
-	return Settings.Providers.HyperV.ContainerImage
+	return Settings.HyperV.ContainerImage
 }

--- a/pkg/controller/map/network/predicate.go
+++ b/pkg/controller/map/network/predicate.go
@@ -69,7 +69,7 @@ func (r *ProviderPredicate) Update(e event.TypedUpdateEvent[*api.Provider]) bool
 // Provider deleted event.
 func (r *ProviderPredicate) Delete(e event.TypedDeleteEvent[*api.Provider]) bool {
 	p := e.Object
-	r.WatchManager.Deleted(p)
+	r.Deleted(p)
 	return true
 }
 

--- a/pkg/controller/map/network/validation.go
+++ b/pkg/controller/map/network/validation.go
@@ -63,8 +63,8 @@ func (r *Reconciler) validate(mp *api.NetworkMap) error {
 		validation.DestinationProviderNotReady) {
 		return nil
 	}
-	mp.Referenced.Provider.Source = pv.Referenced.Source
-	mp.Referenced.Provider.Destination = pv.Referenced.Destination
+	mp.Provider.Source = pv.Referenced.Source
+	mp.Provider.Destination = pv.Referenced.Destination
 
 	err = r.validateSource(mp)
 	if err != nil {
@@ -145,7 +145,7 @@ func (r *Reconciler) validateSource(mp *api.NetworkMap) (err error) {
 
 // Validate destination refs.
 func (r *Reconciler) validateDestination(mp *api.NetworkMap) (err error) {
-	provider := mp.Referenced.Provider.Destination
+	provider := mp.Provider.Destination
 	inventory, err := web.NewClient(provider)
 	if err != nil {
 		return

--- a/pkg/controller/map/storage/predicate.go
+++ b/pkg/controller/map/storage/predicate.go
@@ -69,7 +69,7 @@ func (r *ProviderPredicate) Update(e event.TypedUpdateEvent[*api.Provider]) bool
 // Provider deleted event.
 func (r *ProviderPredicate) Delete(e event.TypedDeleteEvent[*api.Provider]) bool {
 	p := e.Object
-	r.WatchManager.Deleted(p)
+	r.Deleted(p)
 	return true
 }
 

--- a/pkg/controller/map/storage/validation.go
+++ b/pkg/controller/map/storage/validation.go
@@ -53,8 +53,8 @@ func (r *Reconciler) validate(mp *api.StorageMap) error {
 		validation.DestinationProviderNotReady) {
 		return nil
 	}
-	mp.Referenced.Provider.Source = pv.Referenced.Source
-	mp.Referenced.Provider.Destination = pv.Referenced.Destination
+	mp.Provider.Source = pv.Referenced.Source
+	mp.Provider.Destination = pv.Referenced.Destination
 	err = r.validateSource(mp)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func (r *Reconciler) validate(mp *api.StorageMap) error {
 
 // Validate source refs.
 func (r *Reconciler) validateSource(mp *api.StorageMap) (err error) {
-	provider := mp.Referenced.Provider.Source
+	provider := mp.Provider.Source
 	inventory, err := web.NewClient(provider)
 	if err != nil {
 		return
@@ -132,7 +132,7 @@ func (r *Reconciler) validateSource(mp *api.StorageMap) (err error) {
 
 // Validate destination refs.
 func (r *Reconciler) validateDestination(mp *api.StorageMap) (err error) {
-	provider := mp.Referenced.Provider.Destination
+	provider := mp.Provider.Destination
 	inventory, err := web.NewClient(provider)
 	if err != nil {
 		return

--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -243,7 +243,7 @@ func (r *Reconciler) reflectPlan(plan *api.Plan, migration *api.Migration) {
 //   - error: An error if something goes wrong during the process.
 func (r *Reconciler) setOwnerReference(migration *api.Migration) error {
 	plan := &api.Plan{}
-	err := r.Client.Get(
+	err := r.Get(
 		context.TODO(),
 		client.ObjectKey{
 			Namespace: migration.Spec.Plan.Namespace,
@@ -264,12 +264,12 @@ func (r *Reconciler) setOwnerReference(migration *api.Migration) error {
 		return err
 	}
 
-	err = r.Client.Update(context.TODO(), migration)
+	err = r.Update(context.TODO(), migration)
 	if err != nil {
 		return err
 	}
 
-	err = r.Client.Get(
+	err = r.Get(
 		context.TODO(),
 		client.ObjectKey{
 			Namespace: migration.Namespace,

--- a/pkg/controller/ova/builder.go
+++ b/pkg/controller/ova/builder.go
@@ -182,12 +182,12 @@ func (r *Builder) PodSpec(provider *api.Provider, pvc *core.PersistentVolumeClai
 				},
 				Resources: core.ResourceRequirements{
 					Requests: core.ResourceList{
-						core.ResourceCPU:    resource.MustParse(Settings.Providers.OVA.Resources.CPU.Request),
-						core.ResourceMemory: resource.MustParse(Settings.Providers.OVA.Resources.Memory.Request),
+						core.ResourceCPU:    resource.MustParse(Settings.OVA.Resources.CPU.Request),
+						core.ResourceMemory: resource.MustParse(Settings.OVA.Resources.Memory.Request),
 					},
 					Limits: core.ResourceList{
-						core.ResourceCPU:    resource.MustParse(Settings.Providers.OVA.Resources.CPU.Limit),
-						core.ResourceMemory: resource.MustParse(Settings.Providers.OVA.Resources.Memory.Limit),
+						core.ResourceCPU:    resource.MustParse(Settings.OVA.Resources.CPU.Limit),
+						core.ResourceMemory: resource.MustParse(Settings.OVA.Resources.Memory.Limit),
 					},
 				},
 				SecurityContext: r.securityContext(),
@@ -287,13 +287,13 @@ func (r *Builder) securityContext() (sc *core.SecurityContext) {
 }
 
 func (r *Builder) applianceEndpoints(provider *api.Provider) string {
-	gateEnabled := Settings.Features.OVFApplianceManagement
+	gateEnabled := Settings.OVFApplianceManagement
 	providerEnabled, _ := strconv.ParseBool(provider.Spec.Settings[SettingApplianceManagement])
 	return strconv.FormatBool(gateEnabled && providerEnabled)
 }
 
 func (r *Builder) containerImage() string {
-	return Settings.Providers.OVA.ContainerImage
+	return Settings.OVA.ContainerImage
 }
 
 func (r *Builder) nfsMountPath() string {

--- a/pkg/controller/plan/adapter/base/mac_conflicts.go
+++ b/pkg/controller/plan/adapter/base/mac_conflicts.go
@@ -75,8 +75,8 @@ func GetDestinationVMsFromInventory(client InventoryClient, params ...webbase.Pa
 			macs = ExtractMACsFromInterfaces(kVM.Object.Spec.Template.Spec.Domain.Devices.Interfaces)
 		}
 		destinationVMs = append(destinationVMs, DestinationVM{
-			Namespace: kVM.Resource.Namespace,
-			Name:      kVM.Resource.Name,
+			Namespace: kVM.Namespace,
+			Name:      kVM.Name,
 			MACs:      macs,
 		})
 	}

--- a/pkg/controller/plan/adapter/converter.go
+++ b/pkg/controller/plan/adapter/converter.go
@@ -99,7 +99,7 @@ func (c *Converter) ConvertPVCs(pvcs []*v1.PersistentVolumeClaim, srcFormat srcF
 }
 
 func (c *Converter) deleteScratchDV(scratchDV *cdi.DataVolume) {
-	err := c.Destination.Client.Delete(context.Background(), scratchDV)
+	err := c.Destination.Delete(context.Background(), scratchDV)
 	if err != nil {
 		c.Log.Error(err, "Failed to delete scratch DV", "DV", scratchDV.Name)
 	}
@@ -109,7 +109,7 @@ func (c *Converter) ensureJob(pvc *v1.PersistentVolumeClaim, dv *cdi.DataVolume,
 	// Find existing job by label
 	jobList := &batchv1.JobList{}
 	label := client.MatchingLabels{planbase.AnnConversionSourcePVC: pvc.Name}
-	err := c.Destination.Client.List(context.Background(), jobList, client.InNamespace(pvc.Namespace), label)
+	err := c.Destination.List(context.Background(), jobList, client.InNamespace(pvc.Namespace), label)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (c *Converter) ensureJob(pvc *v1.PersistentVolumeClaim, dv *cdi.DataVolume,
 	// Job doesn't exist, create it
 	job := createConvertJob(pvc, dv, srcFormat, dstFormat, c.Labels, c.VirtV2vImage, c.ServiceAccountName)
 	c.Log.Info("Creating convert job", "pvc", pvc.Name, "srcFormat", srcFormat, "dstFormat", dstFormat)
-	err = c.Destination.Client.Create(context.Background(), job)
+	err = c.Destination.Create(context.Background(), job)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func makeConversionContainer(pvc *v1.PersistentVolumeClaim, srcFormat, dstFormat
 func (c *Converter) ensureScratchDV(sourcePVC *v1.PersistentVolumeClaim) (*cdi.DataVolume, error) {
 	dvList := &cdi.DataVolumeList{}
 	label := client.MatchingLabels{planbase.AnnConversionSourcePVC: sourcePVC.Name}
-	err := c.Destination.Client.List(context.Background(), dvList, client.InNamespace(sourcePVC.Namespace), label)
+	err := c.Destination.List(context.Background(), dvList, client.InNamespace(sourcePVC.Namespace), label)
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +268,7 @@ func (c *Converter) ensureScratchDV(sourcePVC *v1.PersistentVolumeClaim) (*cdi.D
 	// DV doesn't exist, create it
 	scratchDV := makeScratchDV(sourcePVC)
 	c.Log.Info("DV doesn't exist, creating", "dv", scratchDV.Name)
-	err = c.Destination.Client.Create(context.Background(), scratchDV)
+	err = c.Destination.Create(context.Background(), scratchDV)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/plan/adapter/converter_test.go
+++ b/pkg/controller/plan/adapter/converter_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Converter tests", func() {
 			Expect(job).ToNot(BeNil())
 
 			createdJob := &batchv1.Job{}
-			err = converter.Destination.Client.Get(context.TODO(), types.NamespacedName{
+			err = converter.Destination.Get(context.TODO(), types.NamespacedName{
 				Name:      job.Name,
 				Namespace: job.Namespace,
 			}, createdJob)
@@ -201,7 +201,7 @@ var _ = Describe("Converter tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check if scratch DV is removed
-			err = converter.Destination.Client.Get(context.TODO(), types.NamespacedName{Name: dv.Name, Namespace: dv.Namespace}, dv)
+			err = converter.Destination.Get(context.TODO(), types.NamespacedName{Name: dv.Name, Namespace: dv.Namespace}, dv)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -395,10 +395,10 @@ func (r *Builder) mapDataVolume(vm *model.VM, disk hyperv.Disk, diskIndex int, d
 
 	dv := dvTemplate.DeepCopy()
 	dv.Spec = dvSpec
-	if dv.ObjectMeta.Annotations == nil {
-		dv.ObjectMeta.Annotations = make(map[string]string)
+	if dv.Annotations == nil {
+		dv.Annotations = make(map[string]string)
 	}
-	dv.ObjectMeta.Annotations[planbase.AnnDiskSource] = disk.ID
+	dv.Annotations[planbase.AnnDiskSource] = disk.ID
 
 	templateData := &api.PVCNameTemplateData{
 		VmName:       vm.Name,
@@ -416,8 +416,8 @@ func (r *Builder) mapDataVolume(vm *model.VM, disk hyperv.Disk, diskIndex int, d
 }
 
 func (r *Builder) getStorageClass() string {
-	if r.Context.Map.Storage != nil {
-		for _, pair := range r.Context.Map.Storage.Spec.Map {
+	if r.Map.Storage != nil {
+		for _, pair := range r.Map.Storage.Spec.Map {
 			return pair.Destination.StorageClass
 		}
 	}
@@ -543,8 +543,8 @@ func mapOperatingSystemToTemplate(operatingSystem string) string {
 }
 
 func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
-	if dv.ObjectMeta.Annotations != nil {
-		if id, ok := dv.ObjectMeta.Annotations[planbase.AnnDiskSource]; ok {
+	if dv.Annotations != nil {
+		if id, ok := dv.Annotations[planbase.AnnDiskSource]; ok {
 			return id
 		}
 	}

--- a/pkg/controller/plan/adapter/hyperv/validator.go
+++ b/pkg/controller/plan/adapter/hyperv/validator.go
@@ -60,7 +60,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (bool, error) {
 		return false, liberr.Wrap(err, "vm", vmRef.String())
 	}
 
-	if r.Context.Map.Network == nil {
+	if r.Map.Network == nil {
 		return false, nil
 	}
 
@@ -74,7 +74,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (bool, error) {
 			continue // Truly disconnected NIC
 		}
 		mapped := false
-		for _, pair := range r.Context.Map.Network.Spec.Map {
+		for _, pair := range r.Map.Network.Spec.Map {
 			if pair.Source.ID == nic.Network.ID {
 				mapped = true
 				break

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -148,7 +148,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *v1.Secret, configMap *v1.Co
 		storageClassName := storageMap[*pvc.Spec.StorageClassName].StorageClass
 		dataVolume.Spec = *createDataVolumeSpec(size, storageClassName, url, certConfigMap, secret.Name)
 
-		err = r.Destination.Client.Create(context.TODO(), dataVolume, &client.CreateOptions{})
+		err = r.Destination.Create(context.TODO(), dataVolume, &client.CreateOptions{})
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
 				r.Log.Error(err, "Failed to create DataVolume")
@@ -179,7 +179,7 @@ func (*Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env []
 
 // ResolveDataVolumeIdentifier implements base.Builder
 func (*Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
-	return dv.ObjectMeta.Annotations[planbase.AnnDiskSource]
+	return dv.Annotations[planbase.AnnDiskSource]
 }
 
 // ResolvePersistentVolumeClaimIdentifier implements base.Builder

--- a/pkg/controller/plan/adapter/ocp/validator.go
+++ b/pkg/controller/plan/adapter/ocp/validator.go
@@ -202,7 +202,7 @@ func (r *Validator) HasSnapshot(vmRef ref.Ref) (ok bool, msg string, category st
 }
 
 func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Storage == nil {
+	if r.Plan.Map.Storage == nil {
 		return
 	}
 
@@ -248,7 +248,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 			return false, nil
 		}
 
-		_, found := r.Plan.Referenced.Map.Storage.FindStorageByName(*storageClass)
+		_, found := r.Plan.Map.Storage.FindStorageByName(*storageClass)
 		if !found {
 			err = liberr.Wrap(
 				err,
@@ -265,7 +265,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 
 // Validate that a VM's networks have been mapped.
 func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
+	if r.Plan.Map.Network == nil {
 		return
 	}
 
@@ -282,7 +282,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 
 	for _, net := range vm.Spec.Template.Spec.Networks {
 		if net.Pod != nil {
-			_, found := r.Plan.Referenced.Map.Network.FindNetworkByType(Pod)
+			_, found := r.Plan.Map.Network.FindNetworkByType(Pod)
 			if !found {
 				err = liberr.Wrap(
 					err,
@@ -296,7 +296,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 			}
 		} else if net.Multus != nil {
 			name, namespace := ocpclient.GetNetworkNameAndNamespace(net.Multus.NetworkName, &vmRef)
-			_, found := r.Plan.Referenced.Map.Network.FindNetworkByNameAndNamespace(namespace, name)
+			_, found := r.Plan.Map.Network.FindNetworkByNameAndNamespace(namespace, name)
 			if !found {
 				err = liberr.Wrap(
 					err,

--- a/pkg/controller/plan/adapter/ocp/validator_test.go
+++ b/pkg/controller/plan/adapter/ocp/validator_test.go
@@ -78,7 +78,7 @@ func TestNICNetworkRefs_NoDuplicates(t *testing.T) {
 	client := newFakeClient(vm).Build()
 
 	plan := &api.Plan{}
-	plan.Referenced.Map.Network = &api.NetworkMap{
+	plan.Map.Network = &api.NetworkMap{
 		Spec: api.NetworkMapSpec{
 			Map: []api.NetworkPair{
 				{
@@ -128,7 +128,7 @@ func TestNICNetworkRefs_TwoNICsSameNAD(t *testing.T) {
 	client := newFakeClient(vm).Build()
 
 	plan := &api.Plan{}
-	plan.Referenced.Map.Network = &api.NetworkMap{
+	plan.Map.Network = &api.NetworkMap{
 		Spec: api.NetworkMapSpec{
 			Map: []api.NetworkPair{
 				{
@@ -175,7 +175,7 @@ func TestNICNetworkRefs_TwoNICsSameSourceNetwork(t *testing.T) {
 	client := newFakeClient(vm).Build()
 
 	plan := &api.Plan{}
-	plan.Referenced.Map.Network = &api.NetworkMap{
+	plan.Map.Network = &api.NetworkMap{
 		Spec: api.NetworkMapSpec{
 			Map: []api.NetworkPair{
 				{
@@ -217,7 +217,7 @@ func TestNICNetworkRefs_VMOnlyUsesOneOfDuplicateMappings(t *testing.T) {
 	client := newFakeClient(vm).Build()
 
 	plan := &api.Plan{}
-	plan.Referenced.Map.Network = &api.NetworkMap{
+	plan.Map.Network = &api.NetworkMap{
 		Spec: api.NetworkMapSpec{
 			Map: []api.NetworkPair{
 				{
@@ -264,7 +264,7 @@ func TestNICNetworkRefs_PodAndMultus(t *testing.T) {
 	client := newFakeClient(vm).Build()
 
 	plan := &api.Plan{}
-	plan.Referenced.Map.Network = &api.NetworkMap{
+	plan.Map.Network = &api.NetworkMap{
 		Spec: api.NetworkMapSpec{
 			Map: []api.NetworkPair{
 				{

--- a/pkg/controller/plan/adapter/openstack/builder.go
+++ b/pkg/controller/plan/adapter/openstack/builder.go
@@ -566,7 +566,7 @@ func (r *Builder) mapNetworks(vm *model.Workload, object *cnv.VirtualMachineSpec
 					}
 				}
 				var networkPair *api.NetworkPair
-				networkMaps := r.Context.Map.Network.Spec.Map
+				networkMaps := r.Map.Network.Spec.Map
 				found := false
 				for i := range networkMaps {
 					networkPair = &networkMaps[i]
@@ -1000,7 +1000,7 @@ func (r *Builder) ensureVolumePopulatorPVC(workload *model.Workload, image *mode
 			originalVolumeDiskId = imageProperty.(string)
 		}
 
-		mapList := r.Context.Map.Storage.Spec.Map
+		mapList := r.Map.Storage.Spec.Map
 
 		// Check if there's a storage map available
 		if len(mapList) == 0 {
@@ -1098,7 +1098,7 @@ func (r *Builder) createVolumePopulatorCR(image model.Image, secretName, vmId st
 			TransferNetwork: r.Plan.Spec.TransferNetwork,
 		},
 	}
-	err = r.Context.Client.Create(context.TODO(), populatorCR, &client.CreateOptions{})
+	err = r.Create(context.TODO(), populatorCR, &client.CreateOptions{})
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -1128,7 +1128,7 @@ func (r *Builder) getStorageClassName(workload *model.Workload, volumeTypeName s
 		r.Log.Trace(err)
 		return
 	}
-	for _, storageMap := range r.Context.Map.Storage.Spec.Map {
+	for _, storageMap := range r.Map.Storage.Spec.Map {
 		if storageMap.Source.ID == volumeTypeID || storageMap.Source.Name == volumeTypeName {
 			storageClassName = storageMap.Destination.StorageClass
 		}
@@ -1145,7 +1145,7 @@ func (r *Builder) getStorageClassName(workload *model.Workload, volumeTypeName s
 func (r *Builder) getVolumeAndAccessMode(storageClassName string) ([]core.PersistentVolumeAccessMode, *core.PersistentVolumeMode, error) {
 	filesystemMode := core.PersistentVolumeFilesystem
 	storageProfile := &cdi.StorageProfile{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: storageClassName}, storageProfile)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: storageClassName}, storageProfile)
 	if err != nil {
 		return nil, nil, liberr.Wrap(err, "storageClassName", storageClassName)
 	}
@@ -1169,7 +1169,7 @@ func (r *Builder) getVolumeAndAccessMode(storageClassName string) ([]core.Persis
 // Get the OpenstackVolumePopulator CustomResource based on the image ID.
 func (r *Builder) getVolumePopulatorCR(imageID string) (populatorCr api.OpenstackVolumePopulator, err error) {
 	populatorCrList := &api.OpenstackVolumePopulatorList{}
-	err = r.Destination.Client.List(context.TODO(), populatorCrList, &client.ListOptions{
+	err = r.Destination.List(context.TODO(), populatorCrList, &client.ListOptions{
 		Namespace: r.Plan.Spec.TargetNamespace,
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"migration": getMigrationID(r.Context),
@@ -1196,7 +1196,7 @@ func (r *Builder) getVolumePopulatorCR(imageID string) (populatorCr api.Openstac
 
 func (r *Builder) getVolumePopulatorPVC(imageID string) (populatorPvc *core.PersistentVolumeClaim, err error) {
 	populatorPvcList := &core.PersistentVolumeClaimList{}
-	err = r.Destination.Client.List(context.TODO(), populatorPvcList, &client.ListOptions{
+	err = r.Destination.List(context.TODO(), populatorPvcList, &client.ListOptions{
 		Namespace: r.Plan.Spec.TargetNamespace,
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"migration": getMigrationID(r.Context),
@@ -1295,7 +1295,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(image model.Image,
 		return
 	}
 
-	err = r.Client.Create(context.TODO(), pvc, &client.CreateOptions{})
+	err = r.Create(context.TODO(), pvc, &client.CreateOptions{})
 	if err != nil {
 		err = liberr.Wrap(err)
 	}
@@ -1404,7 +1404,7 @@ func (r *Builder) setPopulatorLabels(populatorCr api.OpenstackVolumePopulator, v
 	populatorCr.Labels["migration"] = migrationId
 	populatorCr.Labels["plan"] = string(r.Plan.GetUID())
 	patch := client.MergeFrom(populatorCrCopy)
-	err = r.Destination.Client.Patch(context.TODO(), &populatorCr, patch)
+	err = r.Destination.Patch(context.TODO(), &populatorCr, patch)
 	return
 }
 

--- a/pkg/controller/plan/adapter/openstack/client.go
+++ b/pkg/controller/plan/adapter/openstack/client.go
@@ -145,7 +145,7 @@ func (r *Client) Close() {
 
 func (r *Client) Finalize(vmStatuses []*planapi.VMStatus, migrationName string) {
 	for _, vmStatus := range vmStatuses {
-		vmRef := ref.Ref{ID: vmStatus.Ref.ID}
+		vmRef := ref.Ref{ID: vmStatus.ID}
 		vm, err := r.getVM(vmRef)
 		if err != nil {
 			r.Log.Error(err, "failed to find vm", "vm", vm.Name)

--- a/pkg/controller/plan/adapter/openstack/destinationclient.go
+++ b/pkg/controller/plan/adapter/openstack/destinationclient.go
@@ -51,7 +51,7 @@ func (r *DestinationClient) SetPopulatorCrOwnership() (err error) {
 			continue
 		}
 		patch := client.MergeFrom(populatorCrCopy)
-		err = r.Destination.Client.Patch(context.TODO(), &populatorCr, patch)
+		err = r.Destination.Patch(context.TODO(), &populatorCr, patch)
 		if err != nil {
 			continue
 		}
@@ -67,7 +67,7 @@ func (r *DestinationClient) getPopulatorCrList(vmID string) (populatorCrList v1b
 	if vmID != "" {
 		labelSet["vmID"] = vmID
 	}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		&populatorCrList,
 		&client.ListOptions{
@@ -80,7 +80,7 @@ func (r *DestinationClient) getPopulatorCrList(vmID string) (populatorCrList v1b
 // Deletes an object from destination cluster associated with the VM.
 func (r *DestinationClient) DeleteObject(object client.Object, vm *plan.VMStatus, message, objType string) (err error) {
 	//TODO use kubevirt? it will move most of the logic of the DestinationClient out.
-	err = r.Destination.Client.Delete(context.TODO(), object)
+	err = r.Destination.Delete(context.TODO(), object)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			err = nil
@@ -102,7 +102,7 @@ func (r *DestinationClient) DeleteObject(object client.Object, vm *plan.VMStatus
 
 func (r *DestinationClient) findPVCByCR(cr *v1beta1.OpenstackVolumePopulator) (pvc *core.PersistentVolumeClaim, err error) {
 	pvcList := core.PersistentVolumeClaimList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		&pvcList,
 		&client.ListOptions{

--- a/pkg/controller/plan/adapter/openstack/destionationclient_test.go
+++ b/pkg/controller/plan/adapter/openstack/destionationclient_test.go
@@ -85,7 +85,7 @@ var _ = Describe("openstack destinationclient tests", func() {
 			destinationClient.SetPopulatorCrOwnership()
 
 			patchedOpenstackVolPopCr := &v1beta1.OpenstackVolumePopulator{}
-			err := destinationClient.Client.Get(context.TODO(), client.ObjectKey{
+			err := destinationClient.Get(context.TODO(), client.ObjectKey{
 				Name:      "test",
 				Namespace: "test",
 			}, patchedOpenstackVolPopCr)

--- a/pkg/controller/plan/adapter/openstack/validator.go
+++ b/pkg/controller/plan/adapter/openstack/validator.go
@@ -29,7 +29,7 @@ type Validator struct {
 }
 
 func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Storage == nil {
+	if r.Plan.Map.Storage == nil {
 		return
 	}
 	vm := &model.Workload{}
@@ -39,13 +39,13 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 		return
 	}
 	for _, volType := range vm.VolumeTypes {
-		if !r.Plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: volType.ID}) {
+		if !r.Plan.Map.Storage.Status.Find(ref.Ref{ID: volType.ID}) {
 			return
 		}
 	}
 
 	// If vm is image based, we need to see glance in the storage map
-	if vm.ImageID != "" && !r.Plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{Name: api.GlanceSource}) {
+	if vm.ImageID != "" && !r.Plan.Map.Storage.Status.Find(ref.Ref{Name: api.GlanceSource}) {
 		return
 	}
 
@@ -55,7 +55,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 
 // Validate that a VM's networks have been mapped.
 func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
+	if r.Plan.Map.Network == nil {
 		return
 	}
 	vm := &model.Workload{}
@@ -65,7 +65,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 		return
 	}
 	for _, network := range vm.Networks {
-		if !r.Plan.Referenced.Map.Network.Status.Refs.Find(ref.Ref{ID: network.ID}) {
+		if !r.Plan.Map.Network.Status.Find(ref.Ref{ID: network.ID}) {
 			return
 		}
 	}

--- a/pkg/controller/plan/adapter/ovfbase/builder.go
+++ b/pkg/controller/plan/adapter/ovfbase/builder.go
@@ -118,7 +118,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 	}
 
 	diskIndex := 0
-	storageMapIn := r.Context.Map.Storage.Spec.Map
+	storageMapIn := r.Map.Storage.Spec.Map
 	for i := range storageMapIn {
 		mapped := &storageMapIn[i]
 		ref := mapped.Source
@@ -190,10 +190,10 @@ func (r *Builder) mapDataVolume(vm *model.VM, disk ovfmodel.Disk, destination ap
 }
 
 func updateDataVolumeAnnotations(dv *cdi.DataVolume, disk *ovfmodel.Disk) {
-	if dv.ObjectMeta.Annotations == nil {
-		dv.ObjectMeta.Annotations = make(map[string]string)
+	if dv.Annotations == nil {
+		dv.Annotations = make(map[string]string)
 	}
-	dv.ObjectMeta.Annotations[planbase.AnnDiskSource] = getDiskFullPath(disk)
+	dv.Annotations[planbase.AnnDiskSource] = getDiskFullPath(disk)
 }
 
 // Create the destination Kubevirt VM.
@@ -462,7 +462,7 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 }
 
 func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
-	return trimBackingFileName(dv.ObjectMeta.Annotations[planbase.AnnDiskSource])
+	return trimBackingFileName(dv.Annotations[planbase.AnnDiskSource])
 }
 
 // Return a stable identifier for a PersistentDataVolume.

--- a/pkg/controller/plan/adapter/ovfbase/validator.go
+++ b/pkg/controller/plan/adapter/ovfbase/validator.go
@@ -100,7 +100,7 @@ func (r *Validator) HasSnapshot(vmRef ref.Ref) (ok bool, msg string, category st
 
 // Validate that a VM's networks have been mapped.
 func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
+	if r.Plan.Map.Network == nil {
 		return
 	}
 	vm := &model.VM{}
@@ -111,7 +111,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	for _, net := range vm.Networks {
-		if !r.Plan.Referenced.Map.Network.Status.Refs.Find(ref.Ref{ID: net.ID}) {
+		if !r.Plan.Map.Network.Status.Find(ref.Ref{ID: net.ID}) {
 			return
 		}
 	}
@@ -136,7 +136,7 @@ func (r *Validator) NICNetworkRefs(vmRef ref.Ref) (refs []ref.Ref, err error) {
 
 // Validate that a VM's disk backing storage has been mapped.
 func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Storage == nil {
+	if r.Plan.Map.Storage == nil {
 		return
 	}
 	vm := &model.VM{}
@@ -147,7 +147,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	for _, disk := range vm.Disks {
-		if !r.Plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: disk.ID}) {
+		if !r.Plan.Map.Storage.Status.Find(ref.Ref{ID: disk.ID}) {
 			return
 		}
 	}

--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -198,7 +198,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 	}
 	url := r.Source.Provider.Spec.URL
 
-	dsMapIn := r.Context.Map.Storage.Spec.Map
+	dsMapIn := r.Map.Storage.Spec.Map
 	for i := range dsMapIn {
 		mapped := &dsMapIn[i]
 		ref := mapped.Source
@@ -255,10 +255,10 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *cor
 
 				dv := dvTemplate.DeepCopy()
 				dv.Spec = dvSpec
-				if dv.ObjectMeta.Annotations == nil {
-					dv.ObjectMeta.Annotations = make(map[string]string)
+				if dv.Annotations == nil {
+					dv.Annotations = make(map[string]string)
 				}
-				dv.ObjectMeta.Annotations[planbase.AnnDiskSource] = da.Disk.ID
+				dv.Annotations[planbase.AnnDiskSource] = da.Disk.ID
 				dvs = append(dvs, *dv)
 			}
 		}
@@ -483,7 +483,7 @@ func (r *Builder) mapDisks(vm *model.Workload, persistentVolumeClaims []*core.Pe
 			bus = Virtio
 		}
 		var disk cnv.Disk
-		if da.Disk.Disk.StorageType == "lun" {
+		if da.Disk.StorageType == "lun" {
 			claimName = volumeName
 			disk = cnv.Disk{
 				Name: volumeName,
@@ -514,7 +514,7 @@ func (r *Builder) mapDisks(vm *model.Workload, persistentVolumeClaims []*core.Pe
 				},
 			},
 		}
-		if da.DiskAttachment.Bootable {
+		if da.Bootable {
 			var bootOrder uint = 1
 			disk.BootOrder = &bootOrder
 		}
@@ -612,7 +612,7 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 
 // Return a stable identifier for a DataVolume.
 func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
-	return dv.ObjectMeta.Annotations[planbase.AnnDiskSource]
+	return dv.Annotations[planbase.AnnDiskSource]
 }
 
 // Return a stable identifier for a PersistentDataVolume.
@@ -735,7 +735,7 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 }
 
 func (r *Builder) SupportsVolumePopulators() bool {
-	return !r.Context.Plan.IsWarm() && r.Context.Plan.Provider.Destination.IsHost()
+	return !r.Plan.IsWarm() && r.Plan.Provider.Destination.IsHost()
 }
 
 func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string, secretName string) (pvcs []*core.PersistentVolumeClaim, err error) {
@@ -754,7 +754,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 			// diskIndex so that the index stays aligned with migrated disks.
 			continue
 		}
-		_, err = r.getVolumePopulator(diskAttachment.DiskAttachment.ID)
+		_, err = r.getVolumePopulator(diskAttachment.ID)
 		if err != nil {
 			if !k8serr.IsNotFound(err) {
 				err = liberr.Wrap(err)
@@ -776,7 +776,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 			pvc, err = r.persistentVolumeClaimWithSourceRef(diskAttachment, storageClassName, populatorName, annotations, vmRef, diskIndex)
 			if err != nil {
 				if !k8serr.IsAlreadyExists(err) {
-					err = liberr.Wrap(err, "disk attachment", diskAttachment.DiskAttachment.ID, "storage class", storageClassName, "populator", populatorName)
+					err = liberr.Wrap(err, "disk attachment", diskAttachment.ID, "storage class", storageClassName, "populator", populatorName)
 					return
 				}
 				err = nil
@@ -795,7 +795,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 
 func (r *Builder) mapStorageDomainToStorageClass() (map[string]string, error) {
 	sdToStorageClass := make(map[string]string)
-	for _, mapped := range r.Context.Map.Storage.Spec.Map {
+	for _, mapped := range r.Map.Storage.Spec.Map {
 		sd := &model.StorageDomain{}
 		if err := r.Source.Inventory.Find(sd, mapped.Source); err != nil {
 			return nil, liberr.Wrap(err)
@@ -808,7 +808,7 @@ func (r *Builder) mapStorageDomainToStorageClass() (map[string]string, error) {
 // Get the OvirtVolumePopulator CustomResource based on the disk ID.
 func (r *Builder) getVolumePopulator(diskID string) (populatorCr api.OvirtVolumePopulator, err error) {
 	list := api.OvirtVolumePopulatorList{}
-	err = r.Destination.Client.List(context.TODO(), &list, &client.ListOptions{
+	err = r.Destination.List(context.TODO(), &list, &client.ListOptions{
 		Namespace: r.Plan.Spec.TargetNamespace,
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"migration": string(r.Migration.UID),
@@ -847,7 +847,7 @@ func (r *Builder) createVolumePopulatorCR(diskAttachment model.XDiskAttachment, 
 	}
 	populatorCR := &api.OvirtVolumePopulator{
 		ObjectMeta: meta.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", diskAttachment.DiskAttachment.ID),
+			GenerateName: fmt.Sprintf("%s-", diskAttachment.ID),
 			Namespace:    r.Plan.Spec.TargetNamespace,
 			Labels: map[string]string{
 				"vmID":      vmId,
@@ -863,7 +863,7 @@ func (r *Builder) createVolumePopulatorCR(diskAttachment model.XDiskAttachment, 
 			TransferNetwork:  r.Plan.Spec.TransferNetwork,
 		},
 	}
-	err = r.Context.Client.Create(context.TODO(), populatorCR, &client.CreateOptions{})
+	err = r.Create(context.TODO(), populatorCR, &client.CreateOptions{})
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -876,7 +876,7 @@ func (r *Builder) createVolumePopulatorCR(diskAttachment model.XDiskAttachment, 
 func (r *Builder) getDefaultVolumeAndAccessMode(storageClassName string) ([]core.PersistentVolumeAccessMode, *core.PersistentVolumeMode, error) {
 	var filesystemMode = core.PersistentVolumeFilesystem
 	storageProfile := &cdi.StorageProfile{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: storageClassName}, storageProfile)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: storageClassName}, storageProfile)
 	if err != nil {
 		return nil, nil, liberr.Wrap(err)
 	}
@@ -960,7 +960,7 @@ func (r *Builder) persistentVolumeClaimWithSourceRef(diskAttachment model.XDiskA
 		return
 	}
 
-	err = r.Client.Create(context.TODO(), pvc, &client.CreateOptions{})
+	err = r.Create(context.TODO(), pvc, &client.CreateOptions{})
 	return
 }
 
@@ -1038,7 +1038,7 @@ func (r *Builder) setOvirtPopulatorLabels(populatorCr api.OvirtVolumePopulator, 
 	populatorCr.Labels["migration"] = migrationId
 	populatorCr.Labels["plan"] = string(r.Plan.GetUID())
 	patch := client.MergeFrom(populatorCrCopy)
-	err = r.Destination.Client.Patch(context.TODO(), &populatorCr, patch)
+	err = r.Destination.Patch(context.TODO(), &populatorCr, patch)
 	return
 }
 

--- a/pkg/controller/plan/adapter/ovirt/client.go
+++ b/pkg/controller/plan/adapter/ovirt/client.go
@@ -442,7 +442,7 @@ func (r Client) Finalize(vms []*planapi.VMStatus, planName string) {
 	for _, vm := range vms {
 		_, vmService, err := r.getVM(vm.Ref)
 		if err != nil {
-			r.Log.Error(err, "Failed to get VM", "vm", vm.Ref.String())
+			r.Log.Error(err, "Failed to get VM", "vm", vm.String())
 			continue
 		}
 
@@ -464,7 +464,7 @@ func (r Client) removePrecopies(precopies []planapi.Precopy, vmService *ovirtsdk
 		snapshotID := precopies[i].Snapshot
 		snapService := snapsService.SnapshotService(snapshotID)
 		correlationID := fmt.Sprintf("%s_finalize", snapshotID[0:8])
-		cleanupTimeout := time.Now().Add(time.Duration(settings.Settings.Migration.SnapshotRemovalTimeout) * time.Minute)
+		cleanupTimeout := time.Now().Add(time.Duration(settings.Settings.SnapshotRemovalTimeout) * time.Minute)
 		for {
 			_, err := snapService.Get().Send()
 			if err != nil {
@@ -502,7 +502,7 @@ func (r Client) removePrecopies(precopies []planapi.Precopy, vmService *ovirtsdk
 				r.Log.Info("Timeout waiting for snapshot removal")
 				return
 			} else {
-				time.Sleep(time.Duration(settings.Settings.Migration.SnapshotStatusCheckRate) * time.Second)
+				time.Sleep(time.Duration(settings.Settings.SnapshotStatusCheckRate) * time.Second)
 			}
 		}
 	}

--- a/pkg/controller/plan/adapter/ovirt/destinationclient.go
+++ b/pkg/controller/plan/adapter/ovirt/destinationclient.go
@@ -53,7 +53,7 @@ func (r *DestinationClient) SetPopulatorCrOwnership() (err error) {
 			continue
 		}
 		patch := client.MergeFrom(populatorCrCopy)
-		err = r.Destination.Client.Patch(context.TODO(), &populatorCr, patch)
+		err = r.Destination.Patch(context.TODO(), &populatorCr, patch)
 		if err != nil {
 			continue
 		}
@@ -69,7 +69,7 @@ func (r *DestinationClient) getPopulatorCrList(vmID string) (populatorCrList v1b
 	if vmID != "" {
 		labelSet["vmID"] = vmID
 	}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		&populatorCrList,
 		&client.ListOptions{
@@ -81,7 +81,7 @@ func (r *DestinationClient) getPopulatorCrList(vmID string) (populatorCrList v1b
 
 // Deletes an object from destination cluster associated with the VM.
 func (r *DestinationClient) DeleteObject(object client.Object, vm *plan.VMStatus, message, objType string) (err error) {
-	err = r.Destination.Client.Delete(context.TODO(), object)
+	err = r.Destination.Delete(context.TODO(), object)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			err = nil
@@ -103,7 +103,7 @@ func (r *DestinationClient) DeleteObject(object client.Object, vm *plan.VMStatus
 
 func (r *DestinationClient) findPVCByCR(cr *v1beta1.OvirtVolumePopulator) (pvc *core.PersistentVolumeClaim, err error) {
 	pvcList := core.PersistentVolumeClaimList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		&pvcList,
 		&client.ListOptions{

--- a/pkg/controller/plan/adapter/ovirt/destinationclient_test.go
+++ b/pkg/controller/plan/adapter/ovirt/destinationclient_test.go
@@ -84,7 +84,7 @@ var _ = Describe("ovirt destinationclient tests", func() {
 			destinationClient.SetPopulatorCrOwnership()
 
 			patchedOvirtVolPopCr := &v1beta1.OvirtVolumePopulator{}
-			err := destinationClient.Client.Get(context.TODO(), client.ObjectKey{
+			err := destinationClient.Get(context.TODO(), client.ObjectKey{
 				Name:      "test",
 				Namespace: "test",
 			}, patchedOvirtVolPopCr)

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -102,7 +102,7 @@ func (r *Validator) HasSnapshot(vmRef ref.Ref) (ok bool, msg string, category st
 
 // Validate whether warm migration is supported from this provider type.
 func (r *Validator) WarmMigration() (ok bool) {
-	ok = settings.Settings.Features.OvirtWarmMigration
+	ok = settings.Settings.OvirtWarmMigration
 	return
 }
 
@@ -113,7 +113,7 @@ func (r *Validator) MigrationType() bool {
 	case api.MigrationCold, "":
 		return true
 	case api.MigrationWarm:
-		return settings.Settings.Features.OvirtWarmMigration
+		return settings.Settings.OvirtWarmMigration
 	default:
 		return false
 	}
@@ -121,7 +121,7 @@ func (r *Validator) MigrationType() bool {
 
 // Validate that a VM's networks have been mapped.
 func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
+	if r.Plan.Map.Network == nil {
 		return
 	}
 	vm := &model.Workload{}
@@ -132,7 +132,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	for _, nic := range vm.NICs {
-		if !r.Plan.Referenced.Map.Network.Status.Refs.Find(ref.Ref{ID: nic.Profile.Network}) {
+		if !r.Plan.Map.Network.Status.Find(ref.Ref{ID: nic.Profile.Network}) {
 			return
 		}
 	}
@@ -157,7 +157,7 @@ func (r *Validator) NICNetworkRefs(vmRef ref.Ref) (refs []ref.Ref, err error) {
 
 // Validate that a VM's disk backing storage has been mapped.
 func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Storage == nil {
+	if r.Plan.Map.Storage == nil {
 		return
 	}
 	vm := &model.Workload{}
@@ -168,7 +168,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	for _, da := range vm.DiskAttachments {
-		if da.Disk.StorageType != "lun" && !r.Plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: da.Disk.StorageDomain}) {
+		if da.Disk.StorageType != "lun" && !r.Plan.Map.Storage.Status.Find(ref.Ref{ID: da.Disk.StorageDomain}) {
 			return
 		}
 	}
@@ -201,7 +201,7 @@ func (r *Validator) DirectStorage(vmRef ref.Ref) (ok bool, err error) {
 // Checks the version for ovirt direct LUN/FC
 func (r *Validator) canImportDirectDisksFromProvider() (bool, error) {
 	// validate ovirt version > ovirt-engine-4.5.2.1 (https://github.com/oVirt/ovirt-engine/commit/e7c1f585863a332bcecfc8c3d909c9a3a56eb922)
-	rl := container.Build(nil, r.Plan.Referenced.Provider.Source, r.Plan.Referenced.Secret)
+	rl := container.Build(nil, r.Plan.Provider.Source, r.Plan.Secret)
 	major, minor, build, revision, err := rl.Version()
 	if err != nil {
 		return false, err

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -295,11 +295,11 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		},
 		core.EnvVar{
 			Name:  "V2V_extra_args",
-			Value: settings.Settings.Migration.VirtV2vExtraArgs,
+			Value: settings.Settings.VirtV2vExtraArgs,
 		},
 		core.EnvVar{
 			Name:  "V2V_inspector_extra_args",
-			Value: settings.Settings.Migration.VirtV2vInspectorExtraArgs,
+			Value: settings.Settings.VirtV2vInspectorExtraArgs,
 		},
 	)
 	if macsToIps != "" {
@@ -572,7 +572,7 @@ func (r *Builder) Secret(vmRef ref.Ref, in, object *core.Secret) (err error) {
 // buildDatastoreMap builds a map of storage mappings keyed by source datastore ID
 func (r *Builder) buildDatastoreMap() (map[string]*api.StoragePair, error) {
 	dsMap := make(map[string]*api.StoragePair)
-	dsMapIn := r.Context.Map.Storage.Spec.Map
+	dsMapIn := r.Map.Storage.Spec.Map
 
 	for i := range dsMapIn {
 		mapped := &dsMapIn[i]
@@ -657,7 +657,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 	var pvcMap map[string]core.PersistentVolumeClaim
 	if r.Plan.IsWarm() && r.SupportsVolumePopulators() {
 		pvcs := &core.PersistentVolumeClaimList{}
-		err = r.Context.Destination.Client.List(
+		err = r.Destination.List(
 			context.TODO(),
 			pvcs,
 			&client.ListOptions{
@@ -753,24 +753,24 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 
 		dv := dvTemplate.DeepCopy()
 		dv.Spec = dvSpec
-		if dv.ObjectMeta.Annotations == nil {
-			dv.ObjectMeta.Annotations = make(map[string]string)
+		if dv.Annotations == nil {
+			dv.Annotations = make(map[string]string)
 		}
-		dv.ObjectMeta.Annotations[planbase.AnnDiskSource] = baseVolume(disk.File, r.Plan.IsWarm())
+		dv.Annotations[planbase.AnnDiskSource] = baseVolume(disk.File, r.Plan.IsWarm())
 		if disk.Shared {
-			dv.ObjectMeta.Labels[Shareable] = "true"
+			dv.Labels[Shareable] = "true"
 		}
 
 		// Preserve the disk index as an annotation on the created DataVolume.
 		// Note: this annotation will be used to match the PVC to the VM disks by
 		//       matching the disk and PVC index.
-		dv.ObjectMeta.Annotations[planbase.AnnDiskIndex] = fmt.Sprintf("%d", diskIndex)
+		dv.Annotations[planbase.AnnDiskIndex] = fmt.Sprintf("%d", diskIndex)
 
 		if pvcMap != nil && dvSource.VDDK != nil {
 			// In a warm migration with storage offload, the PVC has already been created with
 			// the name template. Copy the result to the DataVolume so it can adopt the PVC.
 			if pvc, present := pvcMap[dvSource.VDDK.BackingFile]; present {
-				dv.ObjectMeta.Name = pvc.Name
+				dv.Name = pvc.Name
 			}
 		} else {
 			if err = r.setPVCNameFromTemplate(&dv.ObjectMeta, vm, diskIndex, disk); err != nil {
@@ -779,7 +779,7 @@ func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, _ *core.Config
 		}
 
 		if !useV2vForTransfer && vddkConfigMap != nil {
-			dv.ObjectMeta.Annotations[planbase.AnnVddkExtraArgs] = vddkConfigMap.Name
+			dv.Annotations[planbase.AnnVddkExtraArgs] = vddkConfigMap.Name
 		}
 		dvs = append(dvs, *dv)
 	}
@@ -1038,7 +1038,7 @@ func (r *Builder) mapClock(host *model.Host, object *cnv.VirtualMachineSpec) {
 			object.Template.Spec.Domain.Clock = &cnv.Clock{}
 		}
 		tz := cnv.ClockOffsetTimezone(host.Timezone)
-		object.Template.Spec.Domain.Clock.ClockOffset.Timezone = &tz
+		object.Template.Spec.Domain.Clock.Timezone = &tz
 	}
 }
 
@@ -1318,7 +1318,7 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 
 // Return a stable identifier for a VDDK DataVolume.
 func (r *Builder) ResolveDataVolumeIdentifier(dv *cdi.DataVolume) string {
-	return baseVolume(dv.ObjectMeta.Annotations[planbase.AnnDiskSource], r.Plan.IsWarm())
+	return baseVolume(dv.Annotations[planbase.AnnDiskSource], r.Plan.IsWarm())
 }
 
 // Return a stable identifier for a PersistentDataVolume.
@@ -1441,13 +1441,13 @@ func (r *Builder) LunPersistentVolumeClaims(vmRef ref.Ref) (pvcs []core.Persiste
 // For now this method returns true, if there's a mapping (backend by copy-offload-mapping ConfigMap, that
 // maps StoragetClasses to Vsphere data stores
 func (r *Builder) SupportsVolumePopulators() bool {
-	if !settings.Settings.Features.CopyOffload {
+	if !settings.Settings.CopyOffload {
 		return false
 	}
-	if r.Context.Map.Storage == nil {
+	if r.Map.Storage == nil {
 		return false
 	}
-	dsMapIn := r.Context.Map.Storage.Spec.Map
+	dsMapIn := r.Map.Storage.Spec.Map
 	for _, m := range dsMapIn {
 		ref := m.Source
 		ds := &model.Datastore{}
@@ -1485,7 +1485,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 		"vmID":      vmRef.ID,
 	}
 	pvcList := &core.PersistentVolumeClaimList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		pvcList,
 		&client.ListOptions{
@@ -1504,7 +1504,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 	// Get sorted disks to maintain consistent indexing with other parts of the system
 	sortedDisks := vm.SortedDisksAsVmware()
 
-	dsMapIn := r.Context.Map.Storage.Spec.Map
+	dsMapIn := r.Map.Storage.Spec.Map
 	naaPrefixes := loadNAAPrefixes(r.Client)
 	dsNaaMap := make(map[string]string)
 
@@ -1604,7 +1604,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				naa := r.lookupDatastoreNAA(naaDS, dsNaaMap)
 				storageClass := effectiveMapped.Destination.StorageClass
 				r.Log.Info(fmt.Sprintf("getting storage mapping by storage class %q and datastore %v datastore name %s datastore", storageClass, disk.Datastore, disk.Datastore))
-				vsphereInstance := r.Context.Plan.Provider.Source.GetName()
+				vsphereInstance := r.Plan.Provider.Source.GetName()
 				migrationHosts := effectiveMapped.OffloadPlugin.VSphereXcopyPluginConfig.DedicatedMigrationHosts
 				storageVendorProduct := effectiveMapped.OffloadPlugin.VSphereXcopyPluginConfig.StorageVendorProduct
 				storageVendorSecretRef := effectiveMapped.OffloadPlugin.VSphereXcopyPluginConfig.SecretRef
@@ -1674,15 +1674,15 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				if err = r.setPVCNameFromTemplate(&pvc.ObjectMeta, vm, diskIndex, disk); err != nil {
 					return
 				}
-				if pvc.ObjectMeta.GenerateName != "" {
+				if pvc.GenerateName != "" {
 					suffix := r.generatePopulatorSuffix(string(r.Migration.UID), vmRef.ID, disk.Key, disk.File, diskIndex)
-					pvc.ObjectMeta.Name = strings.TrimSuffix(pvc.ObjectMeta.GenerateName, "-") + "-" + suffix
-					pvc.ObjectMeta.GenerateName = ""
+					pvc.Name = strings.TrimSuffix(pvc.GenerateName, "-") + "-" + suffix
+					pvc.GenerateName = ""
 				}
 
 				// populator name is the name of the populator, and we can't use generateName for the populator
-				populatorName := pvc.ObjectMeta.Name
-				r.Log.V(2).Info("Initial populator name from new PVC", "populatorName", populatorName, "pvcName", pvc.ObjectMeta.Name)
+				populatorName := pvc.Name
+				r.Log.V(2).Info("Initial populator name from new PVC", "populatorName", populatorName, "pvcName", pvc.Name)
 
 				// For warm migration, add annotations to jump-start the DataVolume
 				v := r.getPlanVMStatus(vm)
@@ -1752,17 +1752,17 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 				// Check if a PVC was created for the current disk
 				if !r.isPVCExistsInList(&pvc, pvcList) {
 					r.Log.Info("Creating pvc", "pvc", pvc)
-					err = r.Destination.Client.Create(context.TODO(), &pvc, &client.CreateOptions{})
+					err = r.Destination.Create(context.TODO(), &pvc, &client.CreateOptions{})
 					if err != nil {
 						if k8serr.IsAlreadyExists(err) {
-							r.Log.Info("PVC already exists in Kubernetes, skipping", "pvcName", pvc.ObjectMeta.Name)
+							r.Log.Info("PVC already exists in Kubernetes, skipping", "pvcName", pvc.Name)
 							continue
 						}
 						return nil, err
 					}
 				}
 				// Fetch the PVC back to get the UID assigned by Kubernetes
-				err = r.Destination.Client.Get(context.TODO(), client.ObjectKey{
+				err = r.Destination.Get(context.TODO(), client.ObjectKey{
 					Namespace: pvc.Namespace,
 					Name:      pvc.Name,
 				}, createdPVC)
@@ -1789,7 +1789,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 		}
 		if len(pvcs) > 0 {
 			secret := &core.Secret{}
-			err = r.Destination.Client.Get(context.TODO(), client.ObjectKey{
+			err = r.Destination.Get(context.TODO(), client.ObjectKey{
 				Namespace: r.Plan.Spec.TargetNamespace,
 				Name:      secretName,
 			}, secret)
@@ -1800,7 +1800,7 @@ func (r *Builder) PopulatorVolumes(vmRef ref.Ref, annotations map[string]string,
 			if err != nil {
 				r.Log.Error(err, "Failed to set pvc as owner reference for migration secret '%s'", secret.Name)
 			} else {
-				err = r.Destination.Client.Update(context.TODO(), secret)
+				err = r.Destination.Update(context.TODO(), secret)
 				if err != nil {
 					r.Log.Error(err, "Failed to update migration secret '%s' with owner reference", secret.Name)
 				}
@@ -2025,7 +2025,7 @@ func (r *Builder) PopulatorOffloadInfo(pvc *core.PersistentVolumeClaim) (map[str
 
 func (r *Builder) getVolumePopulator(vmId, vmdkKey string) (api.VSphereXcopyVolumePopulator, error) {
 	list := api.VSphereXcopyVolumePopulatorList{}
-	err := r.Destination.Client.List(context.TODO(), &list, &client.ListOptions{
+	err := r.Destination.List(context.TODO(), &list, &client.ListOptions{
 		Namespace: r.Plan.Spec.TargetNamespace,
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"migration": string(r.Migration.UID),
@@ -2098,7 +2098,7 @@ func (r *Builder) shouldMigrateSharedDisks(vm *model.VM) bool {
 	if planVM := r.getPlanVM(vm); planVM != nil && planVM.MigrateSharedDisks != nil {
 		return *planVM.MigrateSharedDisks
 	}
-	return r.Context.Plan.Spec.MigrateSharedDisks
+	return r.Plan.Spec.MigrateSharedDisks
 }
 
 func (r *Builder) removeExcludedDisks(vm *model.VM) {
@@ -2113,7 +2113,7 @@ func (r *Builder) shouldRDMAsLun(vm *model.VM) bool {
 	if planVM := r.getPlanVM(vm); planVM != nil && planVM.RDMAsLun != nil {
 		return *planVM.RDMAsLun
 	}
-	return r.Context.Plan.Spec.RDMAsLun
+	return r.Plan.Spec.RDMAsLun
 }
 
 // shouldSCSIReservation returns whether SCSI persistent reservation should be
@@ -2347,11 +2347,11 @@ func (r *Builder) mergeSecrets(migrationSecret, migrationSecretNS, storageVendor
 	}
 
 	// Add controller-level settings for host leases (copy offload)
-	if settings.Settings.Migration.HostLeaseNamespace != "" {
-		dst.Data["HOST_LEASE_NAMESPACE"] = []byte(settings.Settings.Migration.HostLeaseNamespace)
+	if settings.Settings.HostLeaseNamespace != "" {
+		dst.Data["HOST_LEASE_NAMESPACE"] = []byte(settings.Settings.HostLeaseNamespace)
 	}
-	if settings.Settings.Migration.HostLeaseDurationSeconds != "" {
-		dst.Data["HOST_LEASE_DURATION_SECONDS"] = []byte(settings.Settings.Migration.HostLeaseDurationSeconds)
+	if settings.Settings.HostLeaseDurationSeconds != "" {
+		dst.Data["HOST_LEASE_DURATION_SECONDS"] = []byte(settings.Settings.HostLeaseDurationSeconds)
 	}
 
 	// Add SSH keys for vSphere providers
@@ -2399,7 +2399,7 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 			Namespace: namespace,
 		},
 	}
-	err := r.Destination.Client.Create(context.TODO(), &sa, &client.CreateOptions{})
+	err := r.Destination.Create(context.TODO(), &sa, &client.CreateOptions{})
 	if err != nil && !k8serr.IsAlreadyExists(err) {
 		return err
 	}
@@ -2421,7 +2421,7 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 			},
 		},
 	}
-	err = r.Destination.Client.Create(context.TODO(), &role, &client.CreateOptions{})
+	err = r.Destination.Create(context.TODO(), &role, &client.CreateOptions{})
 	if err != nil && !k8serr.IsAlreadyExists(err) {
 		return err
 	}
@@ -2446,7 +2446,7 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 		},
 	}
 
-	err = r.Destination.Client.Create(context.TODO(), &binding, &client.CreateOptions{})
+	err = r.Destination.Create(context.TODO(), &binding, &client.CreateOptions{})
 	if err != nil && !k8serr.IsAlreadyExists(err) {
 		return err
 	}
@@ -2542,7 +2542,7 @@ func (r *Builder) ensurePopulatorServiceAccount(namespace string) error {
 		},
 	}
 
-	err = r.Destination.Client.Create(context.TODO(), &clusterRole, &client.CreateOptions{})
+	err = r.Destination.Create(context.TODO(), &clusterRole, &client.CreateOptions{})
 	if err != nil && !k8serr.IsAlreadyExists(err) {
 		return err
 	}
@@ -2681,14 +2681,14 @@ func (r *Builder) generatePopulatorSuffix(migrationUID, vmID string, diskKey int
 
 func (r *Builder) ensureXCopyVolumePopulator(vp *api.VSphereXcopyVolumePopulator) error {
 	existingPopulator := &api.VSphereXcopyVolumePopulator{}
-	err := r.Destination.Client.Get(context.TODO(), client.ObjectKey{
+	err := r.Destination.Get(context.TODO(), client.ObjectKey{
 		Namespace: vp.Namespace,
 		Name:      vp.Name,
 	}, existingPopulator)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			r.Log.Info("Creating the populator resource", "VSphereXcopyVolumePopulator", vp.Name, "namespace", vp.Namespace)
-			err = r.Destination.Client.Create(context.TODO(), vp, &client.CreateOptions{})
+			err = r.Destination.Create(context.TODO(), vp, &client.CreateOptions{})
 			if err != nil {
 				return err
 			}
@@ -2820,7 +2820,7 @@ func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) (pvcs
 			return
 		}
 
-		ann := pvc.ObjectMeta.Annotations
+		ann := pvc.Annotations
 		ann[planbase.AnnDiskSource] = baseVolume(disk.File, r.Plan.IsWarm())
 		ann[planbase.AnnDiskIndex] = fmt.Sprintf("%d", diskIndex)
 		ann[planbase.AnnVmId] = vmRef.ID

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -292,7 +292,7 @@ var _ = Describe("vSphere builder", func() {
 				},
 			}
 			builder.Source.Inventory = &mockInventory{ds: model.Datastore{Resource: model.Resource{ID: "ds-2"}}, vm: vm}
-			builder.Context.Map.Storage = &v1beta1.StorageMap{
+			builder.Map.Storage = &v1beta1.StorageMap{
 				Spec: v1beta1.StorageMapSpec{
 					Map: []v1beta1.StoragePair{{
 						Source: ref.Ref{ID: "ds-2"},

--- a/pkg/controller/plan/adapter/vsphere/destinationclient.go
+++ b/pkg/controller/plan/adapter/vsphere/destinationclient.go
@@ -73,7 +73,7 @@ func (r *DestinationClient) getPopulatorCrList(vmID string) (populatorCrList v1b
 		"vmID", vmID)
 
 	populatorCrList = v1beta1.VSphereXcopyVolumePopulatorList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		&populatorCrList,
 		&client.ListOptions{
@@ -98,7 +98,7 @@ func (r *DestinationClient) DeleteObject(object client.Object, vm *plan.VMStatus
 		"namespace", object.GetNamespace(),
 		"vm", vm.String())
 
-	err = r.Destination.Client.Delete(context.TODO(), object)
+	err = r.Destination.Delete(context.TODO(), object)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			r.Log.Info("Object not found, already deleted",
@@ -135,7 +135,7 @@ func (r *DestinationClient) findPVCByCR(cr *v1beta1.VSphereXcopyVolumePopulator)
 		"migrationUID", migUID)
 
 	pvcList := core.PersistentVolumeClaimList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		&pvcList,
 		&client.ListOptions{

--- a/pkg/controller/plan/adapter/vsphere/destinationclient_test.go
+++ b/pkg/controller/plan/adapter/vsphere/destinationclient_test.go
@@ -81,7 +81,7 @@ var _ = Describe("DestinationClient", func() {
 
 			// Verify only vm-1 populators are deleted; vm-2 populator survives
 			populatorList := &v1beta1.VSphereXcopyVolumePopulatorList{}
-			err = destClient.Destination.Client.List(context.TODO(), populatorList, client.InNamespace("test"))
+			err = destClient.Destination.List(context.TODO(), populatorList, client.InNamespace("test"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(populatorList.Items).To(HaveLen(1))
 			Expect(populatorList.Items[0].Name).To(Equal("populator-other-vm"))
@@ -212,7 +212,7 @@ var _ = Describe("DestinationClient", func() {
 
 			// Verify object is deleted
 			deletedPop := &v1beta1.VSphereXcopyVolumePopulator{}
-			err = destClient.Destination.Client.Get(context.TODO(), client.ObjectKey{
+			err = destClient.Destination.Get(context.TODO(), client.ObjectKey{
 				Name:      "test-populator",
 				Namespace: "test",
 			}, deletedPop)

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -66,7 +66,7 @@ func (r *Validator) MigrationType() bool {
 
 // Validate that a VM's networks have been mapped.
 func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Network == nil {
+	if r.Plan.Map.Network == nil {
 		return
 	}
 	vm := &model.VM{}
@@ -77,7 +77,7 @@ func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	for _, net := range vm.Networks {
-		if !r.Plan.Referenced.Map.Network.Status.Refs.Find(ref.Ref{ID: net.ID}) {
+		if !r.Plan.Map.Network.Status.Find(ref.Ref{ID: net.ID}) {
 			return
 		}
 	}
@@ -102,7 +102,7 @@ func (r *Validator) NICNetworkRefs(vmRef ref.Ref) (refs []ref.Ref, err error) {
 
 // Validate that a VM's disk backing storage has been mapped.
 func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
-	if r.Plan.Referenced.Map.Storage == nil {
+	if r.Plan.Map.Storage == nil {
 		return
 	}
 	vm := &model.VM{}
@@ -113,7 +113,7 @@ func (r *Validator) StorageMapped(vmRef ref.Ref) (ok bool, err error) {
 	}
 
 	for _, disk := range vm.Disks {
-		if !r.Plan.Referenced.Map.Storage.Status.Refs.Find(ref.Ref{ID: disk.Datastore.ID}) {
+		if !r.Plan.Map.Storage.Status.Find(ref.Ref{ID: disk.Datastore.ID}) {
 			return
 		}
 	}
@@ -497,7 +497,7 @@ func (r *Validator) getUdnSubnet(client client.Client) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	_, hasUdnLabel := namespace.ObjectMeta.Labels[namespaceLabelPrimaryUDN]
+	_, hasUdnLabel := namespace.Labels[namespaceLabelPrimaryUDN]
 	if !hasUdnLabel {
 		return "", nil
 	}
@@ -533,7 +533,7 @@ func (r *Validator) getSourceNetworkForPodNetworkTarget(vmRef ref.Ref) (net *mod
 		return
 	}
 
-	mapping := r.Plan.Referenced.Map.Network.Spec.Map
+	mapping := r.Plan.Map.Network.Spec.Map
 	for i := range mapping {
 		mapped := &mapping[i]
 		ref := mapped.Source

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -72,13 +72,13 @@ func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 	case *model.Workload:
 		*res = model.Workload{VM: m.vm}
 		if ref.Name == "full_guest_network" {
-			res.VM.GuestNetworks = append(res.VM.GuestNetworks, vsphere.GuestNetwork{MAC: "mac2"})
+			res.GuestNetworks = append(res.GuestNetworks, vsphere.GuestNetwork{MAC: "mac2"})
 		}
 		if ref.Name == "not_windows_guest" {
-			res.VM.GuestID = "rhel8_64Guest"
+			res.GuestID = "rhel8_64Guest"
 		}
 		if ref.Name == "nics_no_guest_networks" {
-			res.VM.GuestNetworks = nil
+			res.GuestNetworks = nil
 		}
 		if ref.Name == "missing_from_inventory" {
 			return base.NotFoundError{}
@@ -102,7 +102,7 @@ func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 			*res = defaultVM()
 		}
 		if ref.Name == "empty_disk_vm" {
-			res.VM1.Disks = []vsphere.Disk{}
+			res.Disks = []vsphere.Disk{}
 		}
 		// Test cases for GuestToolsInstalled
 		switch ref.Name {

--- a/pkg/controller/plan/context/migration.go
+++ b/pkg/controller/plan/context/migration.go
@@ -75,7 +75,7 @@ func (r *Context) IsResumeConversion() bool {
 
 // Build.
 func (r *Context) build() (err error) {
-	r.Map.Network = r.Plan.Referenced.Map.Network
+	r.Map.Network = r.Plan.Map.Network
 	if r.Map.Network == nil {
 		err = liberr.Wrap(NotEnoughDataError{},
 			"Network map not found.",
@@ -83,7 +83,7 @@ func (r *Context) build() (err error) {
 			"namespace", r.Plan.Spec.Map.Network.Namespace)
 		return
 	}
-	r.Map.Storage = r.Plan.Referenced.Map.Storage
+	r.Map.Storage = r.Plan.Map.Storage
 	if r.Map.Storage == nil && r.Plan.Spec.Type != api.MigrationOnlyConversion {
 		err = liberr.Wrap(NotEnoughDataError{},
 			"Storage map not found.",
@@ -149,7 +149,7 @@ type Source struct {
 //
 //	Plan.Referenced.Source is not complete.
 func (r *Source) build(ctx *Context) (err error) {
-	r.Provider = ctx.Plan.Referenced.Provider.Source
+	r.Provider = ctx.Plan.Provider.Source
 	if r.Provider == nil {
 		err = liberr.Wrap(NotEnoughDataError{},
 			"Source provider not found.",
@@ -198,7 +198,7 @@ type Destination struct {
 //
 //	Plan.Referenced.Destination is not complete.
 func (r *Destination) build(ctx *Context) (err error) {
-	r.Provider = ctx.Plan.Referenced.Provider.Destination
+	r.Provider = ctx.Plan.Provider.Destination
 	if r.Provider == nil {
 		err = liberr.Wrap(NotEnoughDataError{},
 			"Destination provider not found.",

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -69,7 +69,7 @@ var Settings = &settings.Settings
 // controller_blocker_grace_period_minutes / BLOCKER_GRACE_PERIOD_MINUTES).
 // If settings were not loaded (e.g. unit tests), defaults to 5 minutes.
 func blockerGracePeriod() time.Duration {
-	m := Settings.Migration.BlockerGracePeriodMinutes
+	m := Settings.BlockerGracePeriodMinutes
 	if m <= 0 {
 		return 5 * time.Minute
 	}
@@ -293,7 +293,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 }
 
 func (r *Reconciler) isDanglingArchivedPlan(plan *api.Plan) bool {
-	return plan.Spec.Archived && plan.Referenced.Provider.Source == nil
+	return plan.Spec.Archived && plan.Provider.Source == nil
 }
 
 func (r *Reconciler) updatePlanStatus(plan *api.Plan) error {
@@ -329,7 +329,7 @@ func (r *Reconciler) setPopulatorDataSourceLabels(plan *api.Plan) {
 			}
 			plan.Annotations[AnnPopulatorLabels] = "True"
 			patch := client.MergeFrom(planCopy)
-			err = r.Client.Patch(context.TODO(), plan, patch)
+			err = r.Patch(context.TODO(), plan, patch)
 			if err != nil {
 				r.Log.Error(err, "Couldn't patch plan with populator labels.")
 			}
@@ -602,7 +602,7 @@ func (r *Reconciler) failExecutingMigrationOnBlocker(plan *api.Plan) {
 func criticalOrErrorCondition(plan *api.Plan, gracePeriod time.Duration) string {
 	now := time.Now()
 	var messages []string
-	for _, cnd := range plan.Status.Conditions.List {
+	for _, cnd := range plan.Status.List {
 		if cnd.Status != True {
 			continue
 		}
@@ -632,11 +632,11 @@ func (r *Reconciler) newSnapshot(ctx *plancontext.Context) *planapi.Snapshot {
 	snapshot := planapi.Snapshot{}
 	snapshot.Plan.With(plan)
 	snapshot.Migration.With(migration)
-	snapshot.Provider.Source.With(plan.Referenced.Provider.Source)
-	snapshot.Provider.Destination.With(plan.Referenced.Provider.Destination)
-	snapshot.Map.Network.With(plan.Referenced.Map.Network)
+	snapshot.Provider.Source.With(plan.Provider.Source)
+	snapshot.Provider.Destination.With(plan.Provider.Destination)
+	snapshot.Map.Network.With(plan.Map.Network)
 	if plan.Spec.Type != api.MigrationOnlyConversion {
-		snapshot.Map.Storage.With(plan.Referenced.Map.Storage)
+		snapshot.Map.Storage.With(plan.Map.Storage)
 	}
 	plan.Status.Migration.NewSnapshot(snapshot)
 	log.V(1).Info(
@@ -672,19 +672,19 @@ func (r *Reconciler) matchSnapshot(ctx *plancontext.Context) (matched bool) {
 		log.Info("Snapshot: plan not matched.")
 		return false
 	}
-	if !snapshot.Provider.Source.Match(plan.Referenced.Provider.Source) {
+	if !snapshot.Provider.Source.Match(plan.Provider.Source) {
 		log.Info("Snapshot: provider (source) not matched.")
 		return false
 	}
-	if !snapshot.Provider.Destination.Match(plan.Referenced.Provider.Destination) {
+	if !snapshot.Provider.Destination.Match(plan.Provider.Destination) {
 		log.Info("Snapshot: provider (destination) not matched.")
 		return false
 	}
-	if !snapshot.Map.Network.Match(plan.Referenced.Map.Network) {
+	if !snapshot.Map.Network.Match(plan.Map.Network) {
 		log.Info("Snapshot: networkMap not matched.")
 		return false
 	}
-	if plan.Spec.Type != api.MigrationOnlyConversion && !snapshot.Map.Storage.Match(plan.Referenced.Map.Storage) {
+	if plan.Spec.Type != api.MigrationOnlyConversion && !snapshot.Map.Storage.Match(plan.Map.Storage) {
 		log.Info("Snapshot: storageMap not matched.")
 		return false
 	}

--- a/pkg/controller/plan/controller_test.go
+++ b/pkg/controller/plan/controller_test.go
@@ -437,8 +437,8 @@ var _ = ginkgo.Describe("failExecutingMigrationOnBlocker", func() {
 
 	backdateBlockerConditions := func(plan *api.Plan, age time.Duration) {
 		past := meta.NewTime(time.Now().Add(-age))
-		for i := range plan.Status.Conditions.List {
-			cnd := &plan.Status.Conditions.List[i]
+		for i := range plan.Status.List {
+			cnd := &plan.Status.List[i]
 			if cnd.Category == api.CategoryCritical || cnd.Category == libcnd.Error {
 				cnd.LastTransitionTime = past
 			}
@@ -702,7 +702,7 @@ var _ = ginkgo.Describe("failExecutingMigrationOnBlocker - transient conditions"
 var _ = ginkgo.Describe("criticalOrErrorCondition", func() {
 	backdateCondition := func(plan *api.Plan, condType string, age time.Duration) {
 		past := meta.NewTime(time.Now().Add(-age))
-		for i := range plan.Status.Conditions.List {
+		for i := range plan.Status.List {
 			if plan.Status.Conditions.List[i].Type == condType {
 				plan.Status.Conditions.List[i].LastTransitionTime = past
 			}

--- a/pkg/controller/plan/ensurer/ensurer.go
+++ b/pkg/controller/plan/ensurer/ensurer.go
@@ -26,7 +26,7 @@ type Ensurer struct {
 // VMs are ensured by label, not by name.
 func (r *Ensurer) VirtualMachine(vm *planapi.VMStatus, target *cnv.VirtualMachine) (err error) {
 	vms := &cnv.VirtualMachineList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		vms,
 		&client.ListOptions{
@@ -41,7 +41,7 @@ func (r *Ensurer) VirtualMachine(vm *planapi.VMStatus, target *cnv.VirtualMachin
 
 	if len(vms.Items) == 0 {
 		r.Labeler.SetLabels(target, r.Labeler.MigrationVMLabels(vm.Ref))
-		err = r.Destination.Client.Create(context.TODO(), target)
+		err = r.Destination.Create(context.TODO(), target)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -62,7 +62,7 @@ func (r *Ensurer) VirtualMachine(vm *planapi.VMStatus, target *cnv.VirtualMachin
 // names they had on the source cluster, we search by label so that we notice conflicts with existing DVs.
 func (r *Ensurer) DataVolumes(vm *planapi.VMStatus, dvs []cdi.DataVolume) (err error) {
 	list := &cdi.DataVolumeList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.Background(),
 		list,
 		&client.ListOptions{
@@ -82,7 +82,7 @@ func (r *Ensurer) DataVolumes(vm *planapi.VMStatus, dvs []cdi.DataVolume) (err e
 	for _, dv := range dvs {
 		if !exists[dv.Annotations[api.AnnDiskSource]] {
 			r.Labeler.SetLabels(&dv, r.Labeler.MigrationVMLabels(vm.Ref))
-			err = r.Destination.Client.Create(context.Background(), &dv)
+			err = r.Destination.Create(context.Background(), &dv)
 			if err != nil {
 				err = liberr.Wrap(err)
 				return
@@ -103,7 +103,7 @@ func (r *Ensurer) DataVolumes(vm *planapi.VMStatus, dvs []cdi.DataVolume) (err e
 // names they had on the source cluster, we search by label so that we notice conflicts with existing PVCs.
 func (r *Ensurer) PersistentVolumeClaims(vm *planapi.VMStatus, pvcs []core.PersistentVolumeClaim) (err error) {
 	list := &core.PersistentVolumeClaimList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.Background(),
 		list,
 		&client.ListOptions{
@@ -123,7 +123,7 @@ func (r *Ensurer) PersistentVolumeClaims(vm *planapi.VMStatus, pvcs []core.Persi
 	for _, pvc := range pvcs {
 		if !exists[pvc.Annotations[api.AnnDiskSource]] {
 			r.Labeler.SetLabels(&pvc, r.Labeler.MigrationVMLabels(vm.Ref))
-			err = r.Destination.Client.Create(context.Background(), &pvc)
+			err = r.Destination.Create(context.Background(), &pvc)
 			if err != nil {
 				err = liberr.Wrap(err)
 				return
@@ -151,7 +151,7 @@ func (r *Ensurer) PersistentVolumeClaims(vm *planapi.VMStatus, pvcs []core.Persi
 // name already exists but does not have the annotation indicating that Forklift created it.
 func (r *Ensurer) SharedConfigMaps(vm *planapi.VMStatus, configMaps []core.ConfigMap) (err error) {
 	for _, configMap := range configMaps {
-		err = r.Destination.Client.Create(context.Background(), &configMap)
+		err = r.Destination.Create(context.Background(), &configMap)
 		if err != nil {
 			if k8serr.IsAlreadyExists(err) {
 				_, found := configMap.Annotations[api.AnnSource]
@@ -193,7 +193,7 @@ func (r *Ensurer) SharedConfigMaps(vm *planapi.VMStatus, configMaps []core.Confi
 // name already exists but does not have the annotation indicating that Forklift created it.
 func (r *Ensurer) SharedSecrets(vm *planapi.VMStatus, secrets []core.Secret) (err error) {
 	for _, secret := range secrets {
-		err = r.Destination.Client.Create(context.Background(), &secret)
+		err = r.Destination.Create(context.Background(), &secret)
 		if err != nil {
 			if k8serr.IsAlreadyExists(err) {
 				_, found := secret.Annotations[api.AnnSource]

--- a/pkg/controller/plan/hook.go
+++ b/pkg/controller/plan/hook.go
@@ -96,7 +96,7 @@ func (r *HookRunner) Run(vm *planapi.VMStatus) (err error) {
 	if conditions.HasCondition("Failed") {
 		step.AddError(conditions.FindCondition("Failed").Message)
 		step.MarkCompleted()
-	} else if int(job.Status.Failed) > Settings.Migration.HookRetry {
+	} else if int(job.Status.Failed) > Settings.HookRetry {
 		step.AddError("Retry limit exceeded.")
 		step.MarkCompleted()
 	} else if job.Status.Succeeded > 0 {
@@ -114,7 +114,7 @@ func (r *HookRunner) ensureJob() (job *batch.Job, err error) {
 		return
 	}
 	list := batch.JobList{}
-	err = r.Client.List(
+	err = r.List(
 		context.TODO(),
 		&list,
 		&client.ListOptions{
@@ -130,7 +130,7 @@ func (r *HookRunner) ensureJob() (job *batch.Job, err error) {
 		if err != nil {
 			return
 		}
-		err = r.Client.Create(context.TODO(), job)
+		err = r.Create(context.TODO(), job)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -155,7 +155,7 @@ func (r *HookRunner) ensureJob() (job *batch.Job, err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	err = r.Client.Update(context.TODO(), mp)
+	err = r.Update(context.TODO(), mp)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -204,12 +204,12 @@ func (r *HookRunner) template(mp *core.ConfigMap) (template *core.PodTemplateSpe
 					Image: r.hook.Spec.Image,
 					Resources: core.ResourceRequirements{
 						Requests: core.ResourceList{
-							core.ResourceCPU:    resource.MustParse(Settings.Migration.HooksContainerRequestsCpu),
-							core.ResourceMemory: resource.MustParse(Settings.Migration.HooksContainerRequestsMemory),
+							core.ResourceCPU:    resource.MustParse(Settings.HooksContainerRequestsCpu),
+							core.ResourceMemory: resource.MustParse(Settings.HooksContainerRequestsMemory),
 						},
 						Limits: core.ResourceList{
-							core.ResourceCPU:    resource.MustParse(Settings.Migration.HooksContainerLimitsCpu),
-							core.ResourceMemory: resource.MustParse(Settings.Migration.HooksContainerLimitsMemory),
+							core.ResourceCPU:    resource.MustParse(Settings.HooksContainerLimitsCpu),
+							core.ResourceMemory: resource.MustParse(Settings.HooksContainerLimitsMemory),
 						},
 					},
 					VolumeMounts: []core.VolumeMount{
@@ -239,7 +239,7 @@ func (r *HookRunner) template(mp *core.ConfigMap) (template *core.PodTemplateSpe
 		template.Spec.ActiveDeadlineSeconds = &deadline
 	}
 	// Hook SA > plan SA > global controller SA > namespace default (empty).
-	if sa := cmp.Or(r.hook.Spec.ServiceAccount, r.Context.Plan.Spec.ServiceAccount, Settings.Migration.ServiceAccount); sa != "" {
+	if sa := cmp.Or(r.hook.Spec.ServiceAccount, r.Plan.Spec.ServiceAccount, Settings.ServiceAccount); sa != "" {
 		template.Spec.ServiceAccountName = sa
 	}
 	if len(r.hook.Spec.Playbook) > 0 {
@@ -260,7 +260,7 @@ func (r *HookRunner) template(mp *core.ConfigMap) (template *core.PodTemplateSpe
 // Ensure the ConfigMap.
 func (r *HookRunner) ensureConfigMap() (mp *core.ConfigMap, err error) {
 	list := core.ConfigMapList{}
-	err = r.Client.List(
+	err = r.List(
 		context.TODO(),
 		&list,
 		&client.ListOptions{
@@ -276,7 +276,7 @@ func (r *HookRunner) ensureConfigMap() (mp *core.ConfigMap, err error) {
 		if err != nil {
 			return
 		}
-		err = r.Client.Create(context.TODO(), mp)
+		err = r.Create(context.TODO(), mp)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -398,7 +398,7 @@ func (r *HookRunner) aapJobExtraVars() map[string]string {
 		"plan_namespace":  r.Plan.Namespace,
 		"migration_phase": r.vm.Phase,
 	}
-	if id := r.vm.Ref.ID; id != "" {
+	if id := r.vm.ID; id != "" {
 		m["vm_source_id"] = id
 	}
 	return m

--- a/pkg/controller/plan/hook_test.go
+++ b/pkg/controller/plan/hook_test.go
@@ -41,26 +41,26 @@ func hookTestScheme(t *testing.T) *runtime.Scheme {
 
 func savedHookRunnerSettings(t *testing.T) func() {
 	t.Helper()
-	savedServiceAccount := Settings.Migration.ServiceAccount
-	savedRequestsCPU := Settings.Migration.HooksContainerRequestsCpu
-	savedRequestsMemory := Settings.Migration.HooksContainerRequestsMemory
-	savedLimitsCPU := Settings.Migration.HooksContainerLimitsCpu
-	savedLimitsMemory := Settings.Migration.HooksContainerLimitsMemory
-	Settings.Migration.HooksContainerRequestsCpu = "100m"
-	Settings.Migration.HooksContainerRequestsMemory = "128Mi"
-	Settings.Migration.HooksContainerLimitsCpu = "1"
-	Settings.Migration.HooksContainerLimitsMemory = "512Mi"
+	savedServiceAccount := Settings.ServiceAccount
+	savedRequestsCPU := Settings.HooksContainerRequestsCpu
+	savedRequestsMemory := Settings.HooksContainerRequestsMemory
+	savedLimitsCPU := Settings.HooksContainerLimitsCpu
+	savedLimitsMemory := Settings.HooksContainerLimitsMemory
+	Settings.HooksContainerRequestsCpu = "100m"
+	Settings.HooksContainerRequestsMemory = "128Mi"
+	Settings.HooksContainerLimitsCpu = "1"
+	Settings.HooksContainerLimitsMemory = "512Mi"
 	return func() {
-		Settings.Migration.ServiceAccount = savedServiceAccount
-		Settings.Migration.HooksContainerRequestsCpu = savedRequestsCPU
-		Settings.Migration.HooksContainerRequestsMemory = savedRequestsMemory
-		Settings.Migration.HooksContainerLimitsCpu = savedLimitsCPU
-		Settings.Migration.HooksContainerLimitsMemory = savedLimitsMemory
+		Settings.ServiceAccount = savedServiceAccount
+		Settings.HooksContainerRequestsCpu = savedRequestsCPU
+		Settings.HooksContainerRequestsMemory = savedRequestsMemory
+		Settings.HooksContainerLimitsCpu = savedLimitsCPU
+		Settings.HooksContainerLimitsMemory = savedLimitsMemory
 	}
 }
 
 func newHookRunnerForTemplateTest(hookSA, planSA, globalSA string) *HookRunner {
-	Settings.Migration.ServiceAccount = globalSA
+	Settings.ServiceAccount = globalSA
 	return &HookRunner{
 		Context: &plancontext.Context{
 			Plan: &api.Plan{

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -407,7 +407,7 @@ func (r *KubeVirt) EnsureConversion(vm *plan.VMStatus, conversionType api.Conver
 	maps.Copy(labels, resources.podConfig.PodLabels)
 
 	list := &api.ConversionList{}
-	err = r.Client.List(context.TODO(), list,
+	err = r.List(context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabels(labels),
 	)
@@ -493,7 +493,7 @@ func (r *KubeVirt) EnsureConversion(vm *plan.VMStatus, conversionType api.Conver
 			sourceNS = r.Plan.Namespace
 		}
 		source := &core.Secret{}
-		if err = r.Client.Get(context.TODO(),
+		if err = r.Get(context.TODO(),
 			types.NamespacedName{Namespace: sourceNS, Name: vm.LUKS.Name}, source,
 		); err != nil {
 			err = liberr.Wrap(err)
@@ -522,7 +522,7 @@ func (r *KubeVirt) EnsureConversion(vm *plan.VMStatus, conversionType api.Conver
 		}
 	}
 
-	err = r.Client.Create(context.TODO(), conversion)
+	err = r.Create(context.TODO(), conversion)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -557,7 +557,7 @@ func (r *KubeVirt) getConversionLabels(convType api.ConversionType, vmID, planID
 // all supplied labels. Returns nil (no error) when no match is found.
 func (r *KubeVirt) getConversion(labels map[string]string) (*api.Conversion, error) {
 	list := &api.ConversionList{}
-	if err := r.Client.List(context.TODO(), list,
+	if err := r.List(context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabels(labels),
 	); err != nil {
@@ -586,7 +586,7 @@ func (r *KubeVirt) buildConversion(planName, vmID string, labels map[string]stri
 // found its Spec is refreshed; otherwise the provided CR is created verbatim.
 func (r *KubeVirt) ensureConversion(cr *api.Conversion) (*api.Conversion, error) {
 	list := &api.ConversionList{}
-	if err := r.Client.List(context.TODO(), list,
+	if err := r.List(context.TODO(), list,
 		client.InNamespace(cr.Namespace),
 		client.MatchingLabels(cr.Labels),
 	); err != nil {
@@ -595,7 +595,7 @@ func (r *KubeVirt) ensureConversion(cr *api.Conversion) (*api.Conversion, error)
 	if len(list.Items) > 0 {
 		existing := &list.Items[0]
 		existing.Spec = cr.Spec
-		if err := r.Client.Update(context.TODO(), existing); err != nil {
+		if err := r.Update(context.TODO(), existing); err != nil {
 			return nil, liberr.Wrap(err)
 		}
 		r.Log.Info("Conversion CR updated.",
@@ -603,7 +603,7 @@ func (r *KubeVirt) ensureConversion(cr *api.Conversion) (*api.Conversion, error)
 			"type", string(existing.Spec.Type))
 		return existing, nil
 	}
-	if err := r.Client.Create(context.TODO(), cr); err != nil {
+	if err := r.Create(context.TODO(), cr); err != nil {
 		return nil, liberr.Wrap(err)
 	}
 	r.Log.Info("Conversion CR created.",
@@ -704,11 +704,11 @@ func (r *KubeVirt) CreateDeepInspectionConversion(
 	// Connection secret goes to Plan.Namespace on the management cluster
 	// (DeepInspection pods run there, not on the destination cluster).
 	connSecretData := r.buildDeepInspectionConnectionSecretData()
-	connLabels := r.getConversionLabels(api.DeepInspection, vm.Ref.ID, planID,
+	connLabels := r.getConversionLabels(api.DeepInspection, vm.ID, planID,
 		map[string]string{kConnection: "true"})
 	connSecretSpec := r.buildConversionSecret(
 		r.Plan.Namespace,
-		planName+"-"+vm.Ref.ID+"-di-",
+		planName+"-"+vm.ID+"-di-",
 		connLabels,
 		connSecretData,
 	)
@@ -728,16 +728,16 @@ func (r *KubeVirt) CreateDeepInspectionConversion(
 			sourceNS = r.Plan.Namespace
 		}
 		source := &core.Secret{}
-		if err = r.Client.Get(context.TODO(),
+		if err = r.Get(context.TODO(),
 			types.NamespacedName{Namespace: sourceNS, Name: vm.LUKS.Name}, source,
 		); err != nil {
 			return nil, liberr.Wrap(err)
 		}
-		luksLabels := r.getConversionLabels(api.DeepInspection, vm.Ref.ID, planID,
+		luksLabels := r.getConversionLabels(api.DeepInspection, vm.ID, planID,
 			map[string]string{kLUKS: "true"})
 		luksSecretSpec := r.buildConversionSecret(
 			r.Plan.Namespace,
-			planName+"-"+vm.Ref.ID+"-di-luks-",
+			planName+"-"+vm.ID+"-di-luks-",
 			luksLabels,
 			source.Data,
 		)
@@ -795,7 +795,7 @@ func (r *KubeVirt) DeleteConversion(cr *api.Conversion) error {
 			return err
 		}
 	}
-	if err := r.Client.Delete(context.TODO(), cr); err != nil && !k8serr.IsNotFound(err) {
+	if err := r.Delete(context.TODO(), cr); err != nil && !k8serr.IsNotFound(err) {
 		return liberr.Wrap(err)
 	}
 	r.Log.Info("Conversion CR deleted.",
@@ -809,10 +809,10 @@ func (r *KubeVirt) DeleteConversion(cr *api.Conversion) error {
 func (r *KubeVirt) DeleteAllConversions(vm *plan.VMStatus) error {
 	labels := map[string]string{
 		convctx.LabelPlan: string(r.Plan.UID),
-		convctx.LabelVM:   vm.Ref.ID,
+		convctx.LabelVM:   vm.ID,
 	}
 	list := &api.ConversionList{}
-	if err := r.Client.List(context.TODO(), list,
+	if err := r.List(context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabels(labels),
 	); err != nil {
@@ -911,7 +911,7 @@ func (r *KubeVirt) deleteConversionSecrets(cr *api.Conversion) error {
 		return nil
 	}
 	v2vList := &core.SecretList{}
-	if err := r.Destination.Client.List(context.TODO(), v2vList,
+	if err := r.Destination.List(context.TODO(), v2vList,
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(map[string]string{
 				convctx.LabelVM: vmID,
@@ -924,7 +924,7 @@ func (r *KubeVirt) deleteConversionSecrets(cr *api.Conversion) error {
 	}
 	for i := range v2vList.Items {
 		s := &v2vList.Items[i]
-		if err := r.Destination.Client.Delete(context.TODO(), s); err != nil && !k8serr.IsNotFound(err) {
+		if err := r.Destination.Delete(context.TODO(), s); err != nil && !k8serr.IsNotFound(err) {
 			return liberr.Wrap(err)
 		}
 		r.Log.V(1).Info("Conversion v2v secret deleted.",
@@ -955,10 +955,10 @@ func (r *KubeVirt) buildDeepInspectionConnectionSecretData() map[string][]byte {
 func (r *KubeVirt) CancelConversion(vm *plan.VMStatus) error {
 	labels := map[string]string{
 		convctx.LabelPlan: string(r.Plan.UID),
-		convctx.LabelVM:   vm.Ref.ID,
+		convctx.LabelVM:   vm.ID,
 	}
 	list := &api.ConversionList{}
-	err := r.Client.List(context.TODO(), list,
+	err := r.List(context.TODO(), list,
 		client.InNamespace(r.Plan.Namespace),
 		client.MatchingLabels(labels),
 	)
@@ -1264,7 +1264,7 @@ func (r *KubeVirt) getVMVolumes(vm *plan.VMStatus) ([]cnv.Volume, error) {
 // resolveServiceAccount resolves the ServiceAccount for migration pods.
 // Priority: Plan.Spec.ServiceAccount > Settings.Migration.ServiceAccount > "" (namespace default).
 func resolveServiceAccount(plan *api.Plan) string {
-	return cmp.Or(plan.Spec.ServiceAccount, Settings.Migration.ServiceAccount)
+	return cmp.Or(plan.Spec.ServiceAccount, Settings.ServiceAccount)
 }
 
 // CNINetworkConfig represents a CNI network configuration parsed from a NetworkAttachmentDefinition.
@@ -1304,7 +1304,7 @@ func (r *KubeVirt) ListVMs() ([]VirtualMachine, error) {
 	planLabels := r.planLabels()
 	delete(planLabels, kMigration)
 	vList := &cnv.VirtualMachineList{}
-	err := r.Destination.Client.List(
+	err := r.Destination.List(
 		context.TODO(),
 		vList,
 		&client.ListOptions{
@@ -1325,7 +1325,7 @@ func (r *KubeVirt) ListVMs() ([]VirtualMachine, error) {
 			})
 	}
 	dvList := &cdi.DataVolumeList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		dvList,
 		r.getListOptionsNamespaced(),
@@ -1339,7 +1339,7 @@ func (r *KubeVirt) ListVMs() ([]VirtualMachine, error) {
 			dv := &dvList.Items[i]
 			if vm.Owner(dv) {
 				pvc := &core.PersistentVolumeClaim{}
-				err = r.Destination.Client.Get(
+				err = r.Destination.Get(
 					context.TODO(),
 					types.NamespacedName{Namespace: r.Plan.Spec.TargetNamespace, Name: dv.Name},
 					pvc,
@@ -1374,14 +1374,14 @@ func (r *KubeVirt) EnsureNamespace() error {
 
 // Ensure the config map that contains extra configuration for virt-v2v exists on the destination.
 func (r *KubeVirt) EnsureExtraV2vConfConfigMap() error {
-	if len(Settings.Migration.VirtV2vExtraConfConfigMap) == 0 {
+	if len(Settings.VirtV2vExtraConfConfigMap) == 0 {
 		return nil
 	}
 	configMap := &core.ConfigMap{}
-	err := r.Client.Get(
+	err := r.Get(
 		context.TODO(),
 		client.ObjectKey{
-			Name:      Settings.Migration.VirtV2vExtraConfConfigMap,
+			Name:      Settings.VirtV2vExtraConfConfigMap,
 			Namespace: r.Plan.Namespace,
 		},
 		configMap,
@@ -1501,7 +1501,7 @@ func (r *KubeVirt) GetImporterPod(pvc core.PersistentVolumeClaim) (pod *core.Pod
 		return
 	}
 
-	err = r.Destination.Client.Get(
+	err = r.Destination.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      pvc.Annotations[AnnImporterPodName],
@@ -1529,7 +1529,7 @@ func (r *KubeVirt) getImporterPods(pvc *core.PersistentVolumeClaim) (pods []core
 	}
 
 	podList := &core.PodList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		podList,
 		&client.ListOptions{
@@ -1564,7 +1564,7 @@ func (r *KubeVirt) DeleteDataVolumes(vm *plan.VMStatus) (err error) {
 			path.Join(dv.Namespace, dv.Name),
 			"vm",
 			vm.String())
-		err = r.Destination.Client.Delete(context.TODO(), dv.DataVolume)
+		err = r.Destination.Delete(context.TODO(), dv.DataVolume)
 		if err != nil {
 			return
 		}
@@ -1579,7 +1579,7 @@ func (r *KubeVirt) DeleteImporterPods(pvc *core.PersistentVolumeClaim) (err erro
 		return
 	}
 	for _, pod := range pods {
-		err = r.Destination.Client.Delete(context.TODO(), &pod)
+		err = r.Destination.Delete(context.TODO(), &pod)
 		if err != nil {
 			err = liberr.Wrap(err)
 			r.Log.Error(
@@ -1608,7 +1608,7 @@ func (r *KubeVirt) DeleteImporterPods(pvc *core.PersistentVolumeClaim) (err erro
 func (r *KubeVirt) DeleteJobs(vm *plan.VMStatus) (err error) {
 	vmLabels := r.vmAllButMigrationLabels(vm.Ref)
 	list := &batch.JobList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -1643,7 +1643,7 @@ func (r *KubeVirt) DeleteJobs(vm *plan.VMStatus) (err error) {
 	// One day we'll figure out why client.PropagationPolicy(meta.DeletePropagationBackground) doesn't remove the pods
 	for _, job := range jobNames {
 		podList := &core.PodList{}
-		err = r.Destination.Client.List(
+		err = r.Destination.List(
 			context.TODO(),
 			podList,
 			&client.ListOptions{
@@ -1678,7 +1678,7 @@ func (r *KubeVirt) DeleteJobs(vm *plan.VMStatus) (err error) {
 // Ensure the kubevirt VirtualMachine exists on the destination.
 func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) error {
 	vms := &cnv.VirtualMachineList{}
-	err := r.Destination.Client.List(
+	err := r.Destination.List(
 		context.TODO(),
 		vms,
 		&client.ListOptions{
@@ -1695,7 +1695,7 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) error {
 		if virtualMachine, err = r.virtualMachine(vm, false); err != nil {
 			return liberr.Wrap(err)
 		}
-		if err = r.Destination.Client.Create(context.TODO(), virtualMachine); err != nil {
+		if err = r.Destination.Create(context.TODO(), virtualMachine); err != nil {
 			return liberr.Wrap(err)
 		}
 		r.Log.Info(
@@ -1713,7 +1713,7 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) error {
 	// set DataVolume owner references so that they'll be cleaned up
 	// when the VirtualMachine is removed.
 	dvs := &cdi.DataVolumeList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		dvs,
 		&client.ListOptions{
@@ -1733,7 +1733,7 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) error {
 		pvcCopy := pvc.DeepCopy()
 		pvc.OwnerReferences = ownerRefs
 		patch := client.MergeFrom(pvcCopy)
-		err = r.Destination.Client.Patch(context.TODO(), pvc, patch)
+		err = r.Destination.Patch(context.TODO(), pvc, patch)
 		if err != nil {
 			return liberr.Wrap(err)
 		}
@@ -1746,7 +1746,7 @@ func (r *KubeVirt) EnsureVM(vm *plan.VMStatus) error {
 func (r *KubeVirt) DeleteSecret(vm *plan.VMStatus) (err error) {
 	vmLabels := r.vmAllButMigrationLabels(vm.Ref)
 	list := &core.SecretList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -1772,7 +1772,7 @@ func (r *KubeVirt) DeleteSecret(vm *plan.VMStatus) (err error) {
 func (r *KubeVirt) DeleteConfigMap(vm *plan.VMStatus) (err error) {
 	vmLabels := r.vmAllButMigrationLabels(vm.Ref)
 	list := &core.ConfigMapList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -1798,7 +1798,7 @@ func (r *KubeVirt) DeleteConfigMap(vm *plan.VMStatus) (err error) {
 func (r *KubeVirt) DeleteVM(vm *plan.VMStatus) (err error) {
 	vmLabels := r.vmAllButMigrationLabels(vm.Ref)
 	list := &cnv.VirtualMachineList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -1814,7 +1814,7 @@ func (r *KubeVirt) DeleteVM(vm *plan.VMStatus) (err error) {
 	for _, object := range list.Items {
 		foreground := meta.DeletePropagationForeground
 		opts := &client.DeleteOptions{PropagationPolicy: &foreground}
-		err = r.Destination.Client.Delete(context.TODO(), &object, opts)
+		err = r.Destination.Delete(context.TODO(), &object, opts)
 		if err != nil {
 			if k8serr.IsNotFound(err) {
 				err = nil
@@ -1884,7 +1884,7 @@ func (r *KubeVirt) PopulatorVolumes(vmRef ref.Ref) (pvcs []*core.PersistentVolum
 // Ensure the DataVolumes exist on the destination.
 func (r *KubeVirt) EnsureDataVolumes(vm *plan.VMStatus, dataVolumes []cdi.DataVolume) (err error) {
 	dataVolumeList := &cdi.DataVolumeList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		dataVolumeList,
 		&client.ListOptions{
@@ -1898,7 +1898,7 @@ func (r *KubeVirt) EnsureDataVolumes(vm *plan.VMStatus, dataVolumes []cdi.DataVo
 
 	for _, dv := range dataVolumes {
 		if !r.isDataVolumeExistsInList(&dv, dataVolumeList) {
-			err = r.Destination.Client.Create(context.TODO(), &dv)
+			err = r.Destination.Create(context.TODO(), &dv)
 			if err != nil {
 				err = liberr.Wrap(err)
 				return
@@ -1979,7 +1979,7 @@ func (r *KubeVirt) ensureVddkConfigMap() (configMap *core.ConfigMap, err error) 
 	}
 
 	list := &core.ConfigMapList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -1994,7 +1994,7 @@ func (r *KubeVirt) ensureVddkConfigMap() (configMap *core.ConfigMap, err error) 
 	if len(list.Items) > 0 {
 		configMap = &list.Items[0]
 		configMap.Data = newConfigMap.Data
-		err = r.Destination.Client.Update(context.TODO(), configMap)
+		err = r.Destination.Update(context.TODO(), configMap)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -2007,7 +2007,7 @@ func (r *KubeVirt) ensureVddkConfigMap() (configMap *core.ConfigMap, err error) 
 				configMap.Name))
 	} else {
 		configMap = newConfigMap
-		err = r.Destination.Client.Create(context.TODO(), configMap)
+		err = r.Destination.Create(context.TODO(), configMap)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -2050,7 +2050,7 @@ func (r *KubeVirt) isDataVolumeExistsInList(dv *cdi.DataVolume, dataVolumeList *
 // Return DataVolumes associated with a VM.
 func (r *KubeVirt) getDVs(vm *plan.VMStatus) (edvs []ExtendedDataVolume, err error) {
 	dvsList := &cdi.DataVolumeList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		dvsList,
 		&client.ListOptions{
@@ -2096,7 +2096,7 @@ func (r *KubeVirt) getPVCs(vmRef ref.Ref) (pvcs []*core.PersistentVolumeClaim, e
 		kMigration: string(r.Migration.UID),
 	}
 	pvcsList := &core.PersistentVolumeClaimList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		pvcsList,
 		&client.ListOptions{
@@ -2299,12 +2299,12 @@ func (r *KubeVirt) createPodToBindPVCs(vm *plan.VMStatus, pvcNames []string) (er
 					Command: []string{"/bin/sh", "-c", "exit 0"},
 					Resources: core.ResourceRequirements{
 						Requests: core.ResourceList{
-							core.ResourceCPU:    resource.MustParse(Settings.Migration.VirtV2vContainerRequestsCpu),
-							core.ResourceMemory: resource.MustParse(Settings.Migration.VirtV2vContainerRequestsMemory),
+							core.ResourceCPU:    resource.MustParse(Settings.VirtV2vContainerRequestsCpu),
+							core.ResourceMemory: resource.MustParse(Settings.VirtV2vContainerRequestsMemory),
 						},
 						Limits: core.ResourceList{
-							core.ResourceCPU:    resource.MustParse(Settings.Migration.VirtV2vContainerLimitsCpu),
-							core.ResourceMemory: resource.MustParse(Settings.Migration.VirtV2vContainerLimitsMemory),
+							core.ResourceCPU:    resource.MustParse(Settings.VirtV2vContainerLimitsCpu),
+							core.ResourceMemory: resource.MustParse(Settings.VirtV2vContainerLimitsMemory),
 						},
 					},
 					SecurityContext: &core.SecurityContext{
@@ -2330,7 +2330,7 @@ func (r *KubeVirt) createPodToBindPVCs(vm *plan.VMStatus, pvcNames []string) (er
 	}
 	convbuilder.SetKvmOnPodSpec(&pod.Spec, shouldRequestKVM(r.Plan.Provider.Source))
 
-	err = r.Client.Create(context.TODO(), pod, &client.CreateOptions{})
+	err = r.Create(context.TODO(), pod, &client.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -2382,7 +2382,7 @@ func (r *KubeVirt) EnsureProviderVirtV2VPVCStatus(vmID string) (ready bool, err 
 		return false, nil
 	}
 
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		pvcs,
 		&client.ListOptions{
@@ -2400,7 +2400,7 @@ func (r *KubeVirt) EnsureProviderVirtV2VPVCStatus(vmID string) (ready bool, err 
 	if len(pvcs.Items) > 1 {
 		for i := range pvcs.Items {
 			pvcVirtV2v := &pvcs.Items[i]
-			if pvcVirtV2v.CreationTimestamp.Time.After(r.Migration.CreationTimestamp.Time) {
+			if pvcVirtV2v.CreationTimestamp.After(r.Migration.CreationTimestamp.Time) {
 				pvc = pvcVirtV2v
 			}
 		}
@@ -2653,7 +2653,7 @@ func (r *KubeVirt) GetPods(vm *plan.VMStatus) (pods *core.PodList, err error) {
 // Gets pods associated with the VM.
 func (r *KubeVirt) GetPodsWithLabels(podLabels map[string]string) (pods *core.PodList, err error) {
 	pods = &core.PodList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		pods,
 		&client.ListOptions{
@@ -2670,7 +2670,7 @@ func (r *KubeVirt) GetPodsWithLabels(podLabels map[string]string) (pods *core.Po
 
 // Deletes an object from destination cluster associated with the VM.
 func (r *KubeVirt) DeleteObject(object client.Object, vm *plan.VMStatus, message, objType string, options ...client.DeleteOption) (err error) {
-	err = r.Destination.Client.Delete(context.TODO(), object, options...)
+	err = r.Destination.Delete(context.TODO(), object, options...)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			err = nil
@@ -2695,12 +2695,12 @@ func (r *KubeVirt) DeleteHookJobs(vm *plan.VMStatus) (err error) {
 	// Build labels that match hook jobs (plan + vmID + resource:hook-config)
 	labels := map[string]string{
 		kPlan:     string(r.Plan.UID),
-		kVM:       vm.Ref.ID,
+		kVM:       vm.ID,
 		kResource: ResourceHookConfig,
 	}
 
 	list := &batch.JobList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -2743,7 +2743,7 @@ func (r *KubeVirt) DeletePopulatedPVCs(vm *plan.VMStatus) error {
 
 func (r *KubeVirt) deleteCorrespondingPrimePVC(pvc *core.PersistentVolumeClaim, vm *plan.VMStatus) error {
 	primePVC := core.PersistentVolumeClaim{}
-	err := r.Destination.Client.Get(context.TODO(), client.ObjectKey{Namespace: r.Plan.Spec.TargetNamespace, Name: fmt.Sprintf("prime-%s", string(pvc.UID))}, &primePVC)
+	err := r.Destination.Get(context.TODO(), client.ObjectKey{Namespace: r.Plan.Spec.TargetNamespace, Name: fmt.Sprintf("prime-%s", string(pvc.UID))}, &primePVC)
 	switch {
 	case err != nil && !k8serr.IsNotFound(err):
 		return err
@@ -2765,7 +2765,7 @@ func (r *KubeVirt) deletePopulatedPVC(pvc *core.PersistentVolumeClaim, vm *plan.
 		pvcCopy := pvc.DeepCopy()
 		pvc.Finalizers = nil
 		patch := client.MergeFrom(pvcCopy)
-		if err = r.Destination.Client.Patch(context.TODO(), pvc, patch); err != nil {
+		if err = r.Destination.Patch(context.TODO(), pvc, patch); err != nil {
 			return err
 		}
 	}
@@ -3000,25 +3000,25 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus, sortVolumesByLibvirt bool) 
 
 	// Add the original name and ID info to the VM annotations
 	if len(vm.NewName) > 0 {
-		if object.ObjectMeta.Annotations == nil {
-			object.ObjectMeta.Annotations = make(map[string]string)
+		if object.Annotations == nil {
+			object.Annotations = make(map[string]string)
 		}
-		object.ObjectMeta.Annotations[AnnDisplayName] = vm.Name
-		object.ObjectMeta.Annotations[AnnOriginalID] = vm.ID
+		object.Annotations[AnnDisplayName] = vm.Name
+		object.Annotations[AnnOriginalID] = vm.ID
 	}
 
 	sourceLabels, sourceAnnotations, sanitizationReport, tagErr := r.Builder.SourceVMLabelsAndAnnotations(vm.Ref, r.Plan.Spec.TagMapping)
 	if tagErr != nil {
 		r.Log.Error(tagErr, "Failed to get source VM labels/annotations", "vm", vm.String())
 	} else {
-		if object.ObjectMeta.Labels == nil {
-			object.ObjectMeta.Labels = make(map[string]string)
+		if object.Labels == nil {
+			object.Labels = make(map[string]string)
 		}
-		maps.Copy(object.ObjectMeta.Labels, sourceLabels)
-		if object.ObjectMeta.Annotations == nil {
-			object.ObjectMeta.Annotations = make(map[string]string)
+		maps.Copy(object.Labels, sourceLabels)
+		if object.Annotations == nil {
+			object.Annotations = make(map[string]string)
 		}
-		maps.Copy(object.ObjectMeta.Annotations, sourceAnnotations)
+		maps.Copy(object.Annotations, sourceAnnotations)
 		if len(sanitizationReport) > 0 {
 			reportJSON, jsonErr := json.Marshal(sanitizationReport)
 			if jsonErr != nil {
@@ -3027,7 +3027,7 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus, sortVolumesByLibvirt bool) 
 					"namespace", object.Namespace,
 					"annotation", planbase.AnnSanitizedMetadata)
 			} else {
-				object.ObjectMeta.Annotations[planbase.AnnSanitizedMetadata] = string(reportJSON)
+				object.Annotations[planbase.AnnSanitizedMetadata] = string(reportJSON)
 			}
 		}
 	}
@@ -3118,11 +3118,11 @@ func (r *KubeVirt) setInstanceType(vm *plan.VMStatus, object *cnv.VirtualMachine
 }
 
 func (r *KubeVirt) setVmLabels(object *cnv.VirtualMachine) (err error) {
-	if object.ObjectMeta.Labels == nil {
-		object.ObjectMeta.Labels = make(map[string]string)
+	if object.Labels == nil {
+		object.Labels = make(map[string]string)
 	}
 	if r.Plan.Provider.Source.RequiresConversion() {
-		object.ObjectMeta.Labels["guestConverted"] = strconv.FormatBool(!r.Plan.Spec.SkipGuestConversion)
+		object.Labels["guestConverted"] = strconv.FormatBool(!r.Plan.Spec.SkipGuestConversion)
 	}
 	return
 }
@@ -3148,7 +3148,7 @@ func (r *KubeVirt) getInstanceType(vm *plan.VMStatus, instanceTypeName string) (
 
 func (r *KubeVirt) getVirtualMachineInstanceType(instanceTypeName string) (kind string, err error) {
 	virtualMachineInstancetype := &instancetype.VirtualMachineInstancetype{}
-	err = r.Destination.Client.Get(
+	err = r.Destination.Get(
 		context.TODO(),
 		client.ObjectKey{Name: instanceTypeName, Namespace: r.Plan.Spec.TargetNamespace},
 		virtualMachineInstancetype)
@@ -3161,7 +3161,7 @@ func (r *KubeVirt) getVirtualMachineInstanceType(instanceTypeName string) (kind 
 
 func (r *KubeVirt) getVirtualMachineClusterInstanceType(vm *plan.VMStatus, instanceTypeName string) (kind string, err error) {
 	virtualMachineClusterInstancetype := &instancetype.VirtualMachineClusterInstancetype{}
-	err = r.Destination.Client.Get(
+	err = r.Destination.Get(
 		context.TODO(),
 		client.ObjectKey{Name: instanceTypeName},
 		virtualMachineClusterInstancetype)
@@ -3189,7 +3189,7 @@ func (r *KubeVirt) getOsMapConfig(providerType api.ProviderType) (configMap *cor
 	default:
 		return
 	}
-	err = r.Client.Get(
+	err = r.Get(
 		context.TODO(),
 		client.ObjectKey{Name: configMapName, Namespace: os.Getenv("POD_NAMESPACE")},
 		configMap,
@@ -3220,7 +3220,7 @@ func (r *KubeVirt) getPreference(vm *plan.VMStatus, preferenceName string) (name
 
 func (r *KubeVirt) getVirtualMachinePreference(preferenceName string) (name, kind string, err error) {
 	virtualMachinePreference := &instancetype.VirtualMachinePreference{}
-	err = r.Destination.Client.Get(
+	err = r.Destination.Get(
 		context.TODO(),
 		client.ObjectKey{Name: preferenceName, Namespace: r.Plan.Spec.TargetNamespace},
 		virtualMachinePreference)
@@ -3232,7 +3232,7 @@ func (r *KubeVirt) getVirtualMachinePreference(preferenceName string) (name, kin
 
 func (r *KubeVirt) getVirtualMachineClusterPreference(vm *plan.VMStatus, preferenceName string) (name, kind string, err error) {
 	virtualMachineClusterPreference := &instancetype.VirtualMachineClusterPreference{}
-	err = r.Destination.Client.Get(
+	err = r.Destination.Get(
 		context.TODO(),
 		client.ObjectKey{Name: preferenceName},
 		virtualMachineClusterPreference)
@@ -3394,7 +3394,7 @@ func (r *KubeVirt) findTemplate(vm *plan.VMStatus) (tmpl *template.Template, err
 	}
 
 	templateList := &template.TemplateList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		templateList,
 		&client.ListOptions{
@@ -3470,9 +3470,9 @@ func (r *KubeVirt) buildInspectionPodEnvironment(env []core.EnvVar, vm *plan.VMS
 
 	// Get VM model and data from inventory
 	virtualMachine := &model.VM{}
-	err = r.Context.Source.Inventory.Find(virtualMachine, vm.Ref)
+	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 
@@ -3505,14 +3505,14 @@ func (r *KubeVirt) buildInspectionPodEnvironment(env []core.EnvVar, vm *plan.VMS
 			errMsg := fmt.Sprintf("Parent disk of %s was not found. This is possibly an environment issue. Please investigate if a precopy snapshot has a parent backing.", disk.File)
 			step.AddError(errMsg)
 			err = liberr.New(errMsg)
-			r.Log.Error(err, "Failed to get parent backing of VM disk.", "vm", vm.Ref.String())
+			r.Log.Error(err, "Failed to get parent backing of VM disk.", "vm", vm.String())
 		} else {
 			// Retry on the next run and log the missing parent disk
 			retries += 1
 			step.Annotations[ParentBackingRetriesAnnotation] = strconv.Itoa(retries)
 			errMsg := fmt.Sprintf("Parent disk of %s was not found, will retry on next attempt", disk.File)
 			r.Log.Info(errMsg,
-				"vm", vm.Ref.String())
+				"vm", vm.String())
 			return
 		}
 	}
@@ -3562,7 +3562,7 @@ func (r *KubeVirt) podVolumeMounts(vmVolumes []cnv.Volume, vddkConfigmap *core.C
 		}
 	}
 
-	extraConfigMapExists := len(Settings.Migration.VirtV2vExtraConfConfigMap) > 0
+	extraConfigMapExists := len(Settings.VirtV2vExtraConfConfigMap) > 0
 	if extraConfigMapExists {
 		extraV2vConfVol := core.Volume{
 			Name: ExtraV2vConf,
@@ -3763,7 +3763,7 @@ func (r *KubeVirt) DiskRefsFromPodVolumeMounts(vmVolumes []cnv.Volume, pvcs []*c
 
 func (r *KubeVirt) findConfigMapInNamespace(name string, namespace string) (configMap *core.ConfigMap, exists bool, err error) {
 	configmap := &core.ConfigMap{}
-	err = r.Destination.Client.Get(
+	err = r.Destination.Get(
 		context.TODO(),
 		types.NamespacedName{Namespace: namespace, Name: name},
 		configmap,
@@ -3785,7 +3785,7 @@ func (r *KubeVirt) ensureConfigMap(vmRef ref.Ref) (configMap *core.ConfigMap, er
 	}
 
 	list := &core.ConfigMapList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -3804,7 +3804,7 @@ func (r *KubeVirt) ensureConfigMap(vmRef ref.Ref) (configMap *core.ConfigMap, er
 		if err != nil {
 			return
 		}
-		err = r.Destination.Client.Create(context.TODO(), configMap)
+		err = r.Destination.Create(context.TODO(), configMap)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -3856,7 +3856,7 @@ func (r *KubeVirt) secretDataSetterForCDI(vmRef ref.Ref) func(*core.Secret) erro
 func (r *KubeVirt) secretLUKS(name, namespace string) func(*core.Secret) error {
 	return func(secret *core.Secret) error {
 		sourceSecret := &core.Secret{}
-		err := r.Client.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: namespace}, sourceSecret)
+		err := r.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: namespace}, sourceSecret)
 		if err != nil {
 			return err
 		}
@@ -3878,7 +3878,7 @@ func (r *KubeVirt) ensureSecret(vmRef ref.Ref, setSecretData func(*core.Secret) 
 	}
 
 	list := &core.SecretList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -3895,7 +3895,7 @@ func (r *KubeVirt) ensureSecret(vmRef ref.Ref, setSecretData func(*core.Secret) 
 		// Copy Data because Builder.Secret() puts credentials (accessKeyId, secretKey) there, not in StringData.
 		secret.Data = newSecret.Data
 		secret.StringData = newSecret.StringData
-		err = r.Destination.Client.Update(context.TODO(), secret)
+		err = r.Destination.Update(context.TODO(), secret)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -3910,7 +3910,7 @@ func (r *KubeVirt) ensureSecret(vmRef ref.Ref, setSecretData func(*core.Secret) 
 			vmRef.String())
 	} else {
 		secret = newSecret
-		err = r.Destination.Client.Create(context.TODO(), secret)
+		err = r.Destination.Create(context.TODO(), secret)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -4211,14 +4211,14 @@ func (r *KubeVirt) setPopulatorPodLabels(pod core.Pod, migrationId string) (err 
 	pod.Labels[kMigration] = migrationId
 	pod.Labels[kPlan] = string(r.Plan.GetUID())
 	patch := client.MergeFrom(podCopy)
-	err = r.Destination.Client.Patch(context.TODO(), &pod, patch)
+	err = r.Destination.Patch(context.TODO(), &pod, patch)
 	return
 }
 
 // Ensure the PV exist on the destination.
 func (r *KubeVirt) EnsurePersistentVolume(vmRef ref.Ref, persistentVolumes []core.PersistentVolume) (err error) {
 	list := &core.PersistentVolumeList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -4241,7 +4241,7 @@ func (r *KubeVirt) EnsurePersistentVolume(vmRef ref.Ref, persistentVolumes []cor
 		}
 
 		if !exists {
-			err = r.Destination.Client.Create(context.TODO(), &pv)
+			err = r.Destination.Create(context.TODO(), &pv)
 			if err != nil {
 				err = liberr.Wrap(err)
 				return
@@ -4335,7 +4335,7 @@ func GetHyperVPvListSmb(dClient client.Client, planID string) (pvs *core.Persist
 
 func (r *KubeVirt) EnsurePVForNFS(pv *core.PersistentVolume) (out *core.PersistentVolume, err error) {
 	list := &core.PersistentVolumeList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -4349,7 +4349,7 @@ func (r *KubeVirt) EnsurePVForNFS(pv *core.PersistentVolume) (out *core.Persiste
 	if len(list.Items) > 0 {
 		out = &list.Items[0]
 	} else {
-		err = r.Destination.Client.Create(context.TODO(), pv)
+		err = r.Destination.Create(context.TODO(), pv)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -4394,7 +4394,7 @@ func (r *KubeVirt) BuildPVForNFS(vm *plan.VMStatus) (pv *core.PersistentVolume) 
 func (r *KubeVirt) EnsureProviderStoragePVC(pvc *core.PersistentVolumeClaim, providerType api.ProviderType) (out *core.PersistentVolumeClaim, err error) {
 	// Query k8s for existing PVC matching labels (plan, migration, vmID)
 	list := &core.PersistentVolumeClaimList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -4412,7 +4412,7 @@ func (r *KubeVirt) EnsureProviderStoragePVC(pvc *core.PersistentVolumeClaim, pro
 		out = &list.Items[0]
 	} else {
 		// Create PVC in k8s (triggers CSI provisioning for SMB)
-		err = r.Destination.Client.Create(context.TODO(), pvc)
+		err = r.Destination.Create(context.TODO(), pvc)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -4532,7 +4532,7 @@ func (r *KubeVirt) BuildPVForSMB(vm *plan.VMStatus) (pv *core.PersistentVolume) 
 // EnsurePVForSMB ensures the static PV exists for HyperV SMB.
 func (r *KubeVirt) EnsurePVForSMB(pv *core.PersistentVolume) (out *core.PersistentVolume, err error) {
 	list := &core.PersistentVolumeList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -4547,7 +4547,7 @@ func (r *KubeVirt) EnsurePVForSMB(pv *core.PersistentVolume) (out *core.Persiste
 	if len(list.Items) > 0 {
 		out = &list.Items[0]
 	} else {
-		err = r.Destination.Client.Create(context.TODO(), pv)
+		err = r.Destination.Create(context.TODO(), pv)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -4631,7 +4631,7 @@ func (r *KubeVirt) EnsurePersistentVolumeClaim(vmRef ref.Ref, persistentVolumeCl
 		}
 
 		if !exists {
-			err = r.Destination.Client.Create(context.TODO(), &pvc)
+			err = r.Destination.Create(context.TODO(), &pvc)
 			if err != nil {
 				err = liberr.Wrap(err)
 				return

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -302,36 +302,36 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 		var savedGlobalSA string
 
 		ginkgo.BeforeEach(func() {
-			savedGlobalSA = Settings.Migration.ServiceAccount
+			savedGlobalSA = Settings.ServiceAccount
 		})
 
 		ginkgo.AfterEach(func() {
-			Settings.Migration.ServiceAccount = savedGlobalSA
+			Settings.ServiceAccount = savedGlobalSA
 		})
 
 		ginkgo.It("should return plan SA when both plan and global are set", func() {
-			Settings.Migration.ServiceAccount = "global-sa"
+			Settings.ServiceAccount = "global-sa"
 			p := createPlanKubevirt(nil)
 			p.Spec.ServiceAccount = "plan-sa"
 			Expect(resolveServiceAccount(p)).To(Equal("plan-sa"))
 		})
 
 		ginkgo.It("should return global SA when plan SA is empty", func() {
-			Settings.Migration.ServiceAccount = "global-sa"
+			Settings.ServiceAccount = "global-sa"
 			p := createPlanKubevirt(nil)
 			p.Spec.ServiceAccount = ""
 			Expect(resolveServiceAccount(p)).To(Equal("global-sa"))
 		})
 
 		ginkgo.It("should return empty string when both are empty", func() {
-			Settings.Migration.ServiceAccount = ""
+			Settings.ServiceAccount = ""
 			p := createPlanKubevirt(nil)
 			p.Spec.ServiceAccount = ""
 			Expect(resolveServiceAccount(p)).To(BeEmpty())
 		})
 
 		ginkgo.It("should return plan SA when global is empty", func() {
-			Settings.Migration.ServiceAccount = ""
+			Settings.ServiceAccount = ""
 			p := createPlanKubevirt(nil)
 			p.Spec.ServiceAccount = "plan-sa"
 			Expect(resolveServiceAccount(p)).To(Equal("plan-sa"))
@@ -342,15 +342,15 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 		var savedGlobalSA string
 
 		ginkgo.BeforeEach(func() {
-			savedGlobalSA = Settings.Migration.ServiceAccount
+			savedGlobalSA = Settings.ServiceAccount
 		})
 
 		ginkgo.AfterEach(func() {
-			Settings.Migration.ServiceAccount = savedGlobalSA
+			Settings.ServiceAccount = savedGlobalSA
 		})
 
 		ginkgo.It("should set CDI SA annotation when plan SA is set", func() {
-			Settings.Migration.ServiceAccount = ""
+			Settings.ServiceAccount = ""
 			p := createPlanKubevirt(nil)
 			p.Spec.ServiceAccount = "plan-sa"
 			annotations := make(map[string]string)
@@ -361,7 +361,7 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 		})
 
 		ginkgo.It("should set CDI SA annotation when global SA is set", func() {
-			Settings.Migration.ServiceAccount = "global-sa"
+			Settings.ServiceAccount = "global-sa"
 			p := createPlanKubevirt(nil)
 			annotations := make(map[string]string)
 			if sa := resolveServiceAccount(p); sa != "" {
@@ -371,7 +371,7 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 		})
 
 		ginkgo.It("should not set CDI SA annotation when both SAs are empty", func() {
-			Settings.Migration.ServiceAccount = ""
+			Settings.ServiceAccount = ""
 			p := createPlanKubevirt(nil)
 			annotations := make(map[string]string)
 			if sa := resolveServiceAccount(p); sa != "" {
@@ -412,8 +412,8 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 		const xfsImage = "quay.io/kubev2v/forklift-virt-v2v-rhel9:latest"
 
 		ginkgo.BeforeEach(func() {
-			Settings.Migration.VirtV2vImage = globalImage
-			Settings.Migration.VirtV2vImageXFS = xfsImage
+			Settings.VirtV2vImage = globalImage
+			Settings.VirtV2vImageXFS = xfsImage
 		})
 
 		ginkgo.It("should return the global image when plan has no override", func() {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -175,7 +175,7 @@ func (r *Migration) Run() (reQ time.Duration, err error) {
 
 // Get/Build resources.
 func (r *Migration) init() (err error) {
-	adapter, err := adapter.New(r.Context.Source.Provider)
+	adapter, err := adapter.New(r.Source.Provider)
 	if err != nil {
 		return
 	}
@@ -744,7 +744,7 @@ func (r *Migration) deleteProviderPVs(getPVs func(client.Client, string) (*core.
 	}
 
 	for _, pv := range pvList.Items {
-		err := r.Destination.Client.Delete(context.TODO(), &pv)
+		err := r.Destination.Delete(context.TODO(), &pv)
 		if err != nil {
 			r.Log.Error(err, "Failed to delete "+pvType+" PV", "pv", pv.Name)
 			return err
@@ -762,7 +762,7 @@ func (r *Migration) deleteProviderPVCs(getPVCs func(client.Client, string, strin
 	}
 
 	for _, pvc := range pvcList.Items {
-		err := r.Destination.Client.Delete(context.TODO(), &pvc)
+		err := r.Destination.Delete(context.TODO(), &pvc)
 		if err != nil {
 			r.Log.Error(err, "Failed to delete "+pvcType+" PVC", "pvc", pvc.Name)
 			return err
@@ -777,7 +777,7 @@ func (r *Migration) deleteConfigMap() (err error) {
 		kUse:  VddkConf,
 	})
 	list := &core.ConfigMapList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -791,7 +791,7 @@ func (r *Migration) deleteConfigMap() (err error) {
 	for _, configmap := range list.Items {
 		background := meta.DeletePropagationBackground
 		opts := &client.DeleteOptions{PropagationPolicy: &background}
-		err = r.Destination.Client.Delete(context.TODO(), &configmap, opts)
+		err = r.Destination.Delete(context.TODO(), &configmap, opts)
 		if err != nil {
 			r.Log.Error(err, "Failed to delete vddk-config", "configmap", configmap)
 		} else {
@@ -804,7 +804,7 @@ func (r *Migration) deleteConfigMap() (err error) {
 func (r *Migration) deleteValidateVddkJob() (err error) {
 	selector := labels.SelectorFromSet(map[string]string{"plan": string(r.Plan.UID)})
 	jobs := &batchv1.JobList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		jobs,
 		&client.ListOptions{
@@ -818,7 +818,7 @@ func (r *Migration) deleteValidateVddkJob() (err error) {
 	for _, job := range jobs.Items {
 		background := meta.DeletePropagationBackground
 		opts := &client.DeleteOptions{PropagationPolicy: &background}
-		err = r.Destination.Client.Delete(context.TODO(), &job, opts)
+		err = r.Destination.Delete(context.TODO(), &job, opts)
 		if err != nil {
 			r.Log.Error(err, "Failed to delete validate-vddk job", "job", job)
 		}
@@ -828,9 +828,9 @@ func (r *Migration) deleteValidateVddkJob() (err error) {
 
 // Best effort attempt to resolve canceled refs.
 func (r *Migration) resolveCanceledRefs() {
-	for i := range r.Context.Migration.Spec.Cancel {
+	for i := range r.Migration.Spec.Cancel {
 		// resolve the VM ref in place
-		ref := &r.Context.Migration.Spec.Cancel[i]
+		ref := &r.Migration.Spec.Cancel[i]
 		_, _ = r.Source.Inventory.VM(ref)
 	}
 }
@@ -851,7 +851,7 @@ func (r *Migration) runningVMs() (vms []*plan.VMStatus) {
 func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 	vm.DeleteCondition(api.ConditionPending)
 	// check whether the VM has been canceled by the user
-	if r.Context.Migration.Spec.Canceled(vm.Ref) {
+	if r.Migration.Spec.Canceled(vm.Ref) {
 		vm.SetCondition(
 			libcnd.Condition{
 				Type:     api.ConditionCanceled,
@@ -1153,7 +1153,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 							continue
 						}
 						dataVolume := &cdi.DataVolume{}
-						err = r.Destination.Client.Get(
+						err = r.Destination.Get(
 							context.TODO(),
 							types.NamespacedName{Namespace: pvc.Namespace, Name: owner.Name},
 							dataVolume)
@@ -1171,7 +1171,7 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 						// allows forklift to reuse all the existing warm migration
 						// logic to continue after a storage offload initial copy.
 						dataVolume.Annotations[base.AnnAllowClaimAdoption] = "false"
-						err = r.Destination.Client.Update(context.TODO(), dataVolume)
+						err = r.Destination.Update(context.TODO(), dataVolume)
 						if err != nil {
 							r.Log.Error(err, "error updating DataVolume, retrying", "dv", dataVolume.Name)
 							return
@@ -1379,11 +1379,11 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 			if r.converter == nil {
 				labels := map[string]string{
 					"plan":      string(r.Plan.GetUID()),
-					"migration": string(r.Context.Migration.UID),
+					"migration": string(r.Migration.UID),
 					"vmID":      vm.ID,
 					"app":       "forklift",
 				}
-				r.converter = adapter.NewConverter(&r.Context.Destination, r.Log.WithName("converter"), labels, getVirtV2vImage(r.Plan), resolveServiceAccount(r.Plan))
+				r.converter = adapter.NewConverter(&r.Destination, r.Log.WithName("converter"), labels, getVirtV2vImage(r.Plan), resolveServiceAccount(r.Plan))
 				r.converter.FilterFn = func(pvc *core.PersistentVolumeClaim) bool {
 					val, ok := pvc.Annotations[base.AnnRequiresConversion]
 					return ok && val == "true"
@@ -2050,7 +2050,7 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 				r.setTaskCompleted(task)
 			case cdi.Paused:
 				pvc := &core.PersistentVolumeClaim{}
-				err = r.Destination.Client.Get(context.TODO(), types.NamespacedName{
+				err = r.Destination.Get(context.TODO(), types.NamespacedName{
 					Namespace: r.Plan.Spec.TargetNamespace,
 					Name:      dv.Status.ClaimName,
 				}, pvc)
@@ -2110,7 +2110,7 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 					found = false
 				} else {
 					pvc := &core.PersistentVolumeClaim{}
-					err = r.Destination.Client.Get(context.TODO(), types.NamespacedName{
+					err = r.Destination.Get(context.TODO(), types.NamespacedName{
 						Namespace: r.Plan.Spec.TargetNamespace,
 						Name:      dv.Status.ClaimName,
 					}, pvc)
@@ -2124,7 +2124,7 @@ func (r *Migration) updateCopyProgress(vm *plan.VMStatus, step *plan.Step) (err 
 							path.Join(dv.Namespace, dv.Name))
 						continue
 					}
-					err = r.Destination.Client.Get(context.TODO(), types.NamespacedName{
+					err = r.Destination.Get(context.TODO(), types.NamespacedName{
 						Namespace: r.Plan.Spec.TargetNamespace,
 						Name:      fmt.Sprintf("prime-%s", pvc.UID),
 					}, pvc)
@@ -2360,7 +2360,7 @@ func (r *Migration) setDataVolumeCheckpoints(vm *plan.VMStatus) (err error) {
 		return
 	}
 	for i := range dvs {
-		err = r.Destination.Client.Update(context.TODO(), &dvs[i])
+		err = r.Destination.Update(context.TODO(), &dvs[i])
 		if err != nil {
 			err = liberr.Wrap(err)
 			return

--- a/pkg/controller/plan/migrator/base/migrator.go
+++ b/pkg/controller/plan/migrator/base/migrator.go
@@ -19,7 +19,7 @@ type BaseMigrator struct {
 }
 
 func (r *BaseMigrator) Init() (err error) {
-	a, err := adapter.New(r.Context.Source.Provider)
+	a, err := adapter.New(r.Source.Provider)
 	if err != nil {
 		return
 	}
@@ -42,9 +42,9 @@ func (r *BaseMigrator) Complete(vm *plan.VMStatus) {
 }
 
 func (r *BaseMigrator) Status(vm plan.VM) (status *plan.VMStatus) {
-	if current, found := r.Context.Plan.Status.Migration.FindVM(vm.Ref); !found {
+	if current, found := r.Plan.Status.Migration.FindVM(vm.Ref); !found {
 		status = &plan.VMStatus{VM: vm}
-		if r.Context.Plan.IsWarm() {
+		if r.Plan.IsWarm() {
 			status.Warm = &plan.Warm{}
 		}
 	} else {
@@ -65,7 +65,7 @@ func (r *BaseMigrator) Reset(vm *plan.VMStatus, pipeline []*plan.Step) {
 		return
 	}
 	vm.DisksCopied = false
-	if r.Context.Plan.IsWarm() {
+	if r.Plan.IsWarm() {
 		vm.Warm = &plan.Warm{}
 	}
 }
@@ -288,7 +288,7 @@ func (r *BaseMigrator) Step(status *plan.VMStatus) (step string) {
 	case api.PhaseCreateDataVolumes:
 		// This phase should be present in DiskTransfer step only when executing Preflight Inspection to avoid UI pipeline artifacts.
 		// If not executing Preflight Inspection, keep the Initialize step.
-		if r.Context.Plan.ShouldRunPreflightInspection() {
+		if r.Plan.ShouldRunPreflightInspection() {
 			step = DiskTransfer
 		} else {
 			step = Initialize
@@ -307,7 +307,7 @@ func (r *BaseMigrator) Step(status *plan.VMStatus) (step string) {
 	case api.PhasePreHook, api.PhasePostHook:
 		step = status.Phase
 	case api.PhaseStorePowerState, api.PhasePowerOffSource, api.PhaseWaitForPowerOff:
-		if r.Context.Plan.IsWarm() {
+		if r.Plan.IsWarm() {
 			step = Cutover
 		} else {
 			step = Initialize

--- a/pkg/controller/plan/migrator/ocp/live.go
+++ b/pkg/controller/plan/migrator/ocp/live.go
@@ -105,7 +105,7 @@ type LiveMigrator struct {
 }
 
 func (r *LiveMigrator) Init() (err error) {
-	r.sourceClient, err = K8sClient(r.Context.Source.Provider)
+	r.sourceClient, err = K8sClient(r.Source.Provider)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -169,7 +169,7 @@ func (r *LiveMigrator) Complete(vm *planapi.VMStatus) {
 }
 
 func (r *LiveMigrator) Status(vm planapi.VM) (status *planapi.VMStatus) {
-	if current, found := r.Context.Plan.Status.Migration.FindVM(vm.Ref); !found {
+	if current, found := r.Plan.Status.Migration.FindVM(vm.Ref); !found {
 		status = &planapi.VMStatus{VM: vm}
 	} else {
 		status = current
@@ -671,7 +671,7 @@ func (r *LiveMigrator) SynchronizeCertificateBundles() (err error) {
 	destExternalData := destExternalCA.Data[KeyCABundle]
 	if !strings.Contains(destExternalData, sourceData) {
 		destExternalCA.Data[KeyCABundle] = destExternalData + fmt.Sprintf("\n%s", sourceData)
-		err = r.Destination.Client.Update(context.TODO(), destExternalCA)
+		err = r.Destination.Update(context.TODO(), destExternalCA)
 		if err != nil {
 			err = liberr.New("Unable to update external KubeVirt CA bundle on destination cluster.", "reason", err) // TODO
 			return
@@ -710,9 +710,9 @@ func (r *LiveMigrator) WaitForStateTransfer(vm *planapi.VMStatus) (done bool, er
 // local (namespaced) VirtualMachinePreference.
 func (r *LiveMigrator) RequiresLocalPreference(vm *planapi.VMStatus) (required bool, err error) {
 	virtualMachine := &model.VM{}
-	err = r.Context.Source.Inventory.Find(virtualMachine, vm.Ref)
+	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	required = virtualMachine.Object.Spec.Preference != nil &&
@@ -724,9 +724,9 @@ func (r *LiveMigrator) RequiresLocalPreference(vm *planapi.VMStatus) (required b
 // VirtualMachineClusterPreference.
 func (r *LiveMigrator) RequiresClusterPreference(vm *planapi.VMStatus) (required bool, err error) {
 	virtualMachine := &model.VM{}
-	err = r.Context.Source.Inventory.Find(virtualMachine, vm.Ref)
+	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	required = virtualMachine.Object.Spec.Preference != nil &&
@@ -738,9 +738,9 @@ func (r *LiveMigrator) RequiresClusterPreference(vm *planapi.VMStatus) (required
 // (namespaced) VirtualMachineInstancetype.
 func (r *LiveMigrator) RequiresLocalInstanceType(vm *planapi.VMStatus) (required bool, err error) {
 	virtualMachine := &model.VM{}
-	err = r.Context.Source.Inventory.Find(virtualMachine, vm.Ref)
+	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	required = virtualMachine.Object.Spec.Instancetype != nil &&
@@ -752,9 +752,9 @@ func (r *LiveMigrator) RequiresLocalInstanceType(vm *planapi.VMStatus) (required
 // VirtualMachineClusterInstancetype.
 func (r *LiveMigrator) RequiresClusterInstanceType(vm *planapi.VMStatus) (required bool, err error) {
 	virtualMachine := &model.VM{}
-	err = r.Context.Source.Inventory.Find(virtualMachine, vm.Ref)
+	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	required = virtualMachine.Object.Spec.Instancetype != nil &&
@@ -775,12 +775,12 @@ func (r *LiveMigrator) SynchronizationAddressReady(vmim *cnv.VirtualMachineInsta
 // more than one VM matches the selection criteria, the first is returned.
 func (r *LiveMigrator) GetTargetVM(vm *planapi.VMStatus) (target *cnv.VirtualMachine, err error) {
 	vms := &cnv.VirtualMachineList{}
-	err = r.Context.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		vms,
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
-			Namespace:     r.Context.Plan.Spec.TargetNamespace,
+			Namespace:     r.Plan.Spec.TargetNamespace,
 		},
 	)
 	if err != nil {
@@ -815,12 +815,12 @@ func (r *LiveMigrator) GetConfigMap(ctx context.Context, c client.Client, namesp
 // GetTargetVMIM object from the destination cluster.
 func (r *LiveMigrator) GetTargetVMIM(vm *planapi.VMStatus) (vmim *cnv.VirtualMachineInstanceMigration, err error) {
 	vmims := &cnv.VirtualMachineInstanceMigrationList{}
-	err = r.Context.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		vmims,
 		&client.ListOptions{
 			LabelSelector: k8slabels.SelectorFromSet(r.Labeler.MigrationVMLabels(vm.Ref)),
-			Namespace:     r.Context.Plan.Spec.TargetNamespace,
+			Namespace:     r.Plan.Spec.TargetNamespace,
 		})
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -838,9 +838,9 @@ func (r *LiveMigrator) GetTargetVMIM(vm *planapi.VMStatus) (vmim *cnv.VirtualMac
 // GetSourceVMIM object from the source cluster.
 func (r *LiveMigrator) GetSourceVMIM(vm *planapi.VMStatus) (vmim *cnv.VirtualMachineInstanceMigration, err error) {
 	virtualMachine := &model.VM{}
-	err = r.Context.Source.Inventory.Find(virtualMachine, vm.Ref)
+	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	vmims := &cnv.VirtualMachineInstanceMigrationList{}
@@ -870,7 +870,7 @@ func (r *LiveMigrator) GetSourceVMIM(vm *planapi.VMStatus) (vmim *cnv.VirtualMac
 func (r *LiveMigrator) WaitForTargetVMI(vm *planapi.VMStatus) (ready bool, err error) {
 	key := types.NamespacedName{Namespace: r.Plan.Spec.TargetNamespace, Name: vm.Name}
 	vmi := &cnv.VirtualMachineInstance{}
-	err = r.Destination.Client.Get(context.TODO(), key, vmi)
+	err = r.Destination.Get(context.TODO(), key, vmi)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			err = nil
@@ -917,7 +917,7 @@ func (r *LiveMigrator) DeleteServiceExports(vm *planapi.VMStatus) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	err = r.Destination.Client.DeleteAllOf(
+	err = r.Destination.DeleteAllOf(
 		context.Background(),
 		&multicluster.ServiceExport{},
 		&client.DeleteAllOfOptions{
@@ -934,7 +934,7 @@ func (r *LiveMigrator) DeleteServiceExports(vm *planapi.VMStatus) (err error) {
 
 // DeleteDataVolumes deletes the DataVolumes that were created for this VM.
 func (r *LiveMigrator) DeleteDataVolumes(vm *planapi.VMStatus) (err error) {
-	err = r.Destination.Client.DeleteAllOf(
+	err = r.Destination.DeleteAllOf(
 		context.Background(),
 		&cdi.DataVolume{},
 		&client.DeleteAllOfOptions{
@@ -951,7 +951,7 @@ func (r *LiveMigrator) DeleteDataVolumes(vm *planapi.VMStatus) (err error) {
 
 // DeletePersistentVolumeClaims deletes the PersistentVolumeClaims that were created for this VM.
 func (r *LiveMigrator) DeletePersistentVolumeClaims(vm *planapi.VMStatus) (err error) {
-	err = r.Destination.Client.DeleteAllOf(
+	err = r.Destination.DeleteAllOf(
 		context.Background(),
 		&core.PersistentVolumeClaim{},
 		&client.DeleteAllOfOptions{
@@ -968,7 +968,7 @@ func (r *LiveMigrator) DeletePersistentVolumeClaims(vm *planapi.VMStatus) (err e
 
 // DeleteVirtualMachine deletes the target VirtualMachine.
 func (r *LiveMigrator) DeleteVirtualMachine(vm *planapi.VMStatus) (err error) {
-	err = r.Destination.Client.DeleteAllOf(
+	err = r.Destination.DeleteAllOf(
 		context.Background(),
 		&cnv.VirtualMachine{},
 		&client.DeleteAllOfOptions{
@@ -986,9 +986,9 @@ func (r *LiveMigrator) DeleteVirtualMachine(vm *planapi.VMStatus) (err error) {
 // DeleteSourceVMIM deletes the VMIM resource from the source cluster.
 func (r *LiveMigrator) DeleteSourceVMIM(vm *planapi.VMStatus) (err error) {
 	inventoryVm := &model.VM{}
-	err = r.Context.Source.Inventory.Find(inventoryVm, vm.Ref)
+	err = r.Source.Inventory.Find(inventoryVm, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	err = r.sourceClient.DeleteAllOf(
@@ -1008,7 +1008,7 @@ func (r *LiveMigrator) DeleteSourceVMIM(vm *planapi.VMStatus) (err error) {
 
 // DeleteTargetVMIM deletes the VMIM resource from the target cluster.
 func (r *LiveMigrator) DeleteTargetVMIM(vm *planapi.VMStatus) (err error) {
-	err = r.Destination.Client.DeleteAllOf(
+	err = r.Destination.DeleteAllOf(
 		context.Background(),
 		&cnv.VirtualMachineInstanceMigration{},
 		&client.DeleteAllOfOptions{
@@ -1025,7 +1025,7 @@ func (r *LiveMigrator) DeleteTargetVMIM(vm *planapi.VMStatus) (err error) {
 
 // DeleteJobs deletes any hook jobs created for the VM on the target cluster.
 func (r *LiveMigrator) DeleteJobs(vm *planapi.VMStatus) (err error) {
-	err = r.Destination.Client.DeleteAllOf(
+	err = r.Destination.DeleteAllOf(
 		context.Background(),
 		&batch.Job{},
 		&client.DeleteAllOfOptions{
@@ -1050,7 +1050,7 @@ type Ensurer struct {
 // EnsureOwnerReferences are set on the target VM's DataVolumes.
 func (r *Ensurer) EnsureOwnerReferences(vm *planapi.VMStatus) (err error) {
 	vms := &cnv.VirtualMachineList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		vms,
 		&client.ListOptions{
@@ -1068,7 +1068,7 @@ func (r *Ensurer) EnsureOwnerReferences(vm *planapi.VMStatus) (err error) {
 	}
 	target := &vms.Items[0]
 	dvs := &cdi.DataVolumeList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.Background(),
 		dvs,
 		&client.ListOptions{
@@ -1086,14 +1086,14 @@ func (r *Ensurer) EnsureOwnerReferences(vm *planapi.VMStatus) (err error) {
 		if err != nil {
 			return
 		}
-		err = r.Destination.Client.Patch(context.Background(), dv, client.MergeFrom(original))
+		err = r.Destination.Patch(context.Background(), dv, client.MergeFrom(original))
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
 		}
 	}
 	pvcs := &core.PersistentVolumeClaimList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.Background(),
 		pvcs,
 		&client.ListOptions{
@@ -1111,7 +1111,7 @@ func (r *Ensurer) EnsureOwnerReferences(vm *planapi.VMStatus) (err error) {
 		if err != nil {
 			return
 		}
-		err = r.Destination.Client.Patch(context.Background(), pvc, client.MergeFrom(original))
+		err = r.Destination.Patch(context.Background(), pvc, client.MergeFrom(original))
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -1123,7 +1123,7 @@ func (r *Ensurer) EnsureOwnerReferences(vm *planapi.VMStatus) (err error) {
 // EnsureTargetVMIM
 func (r *Ensurer) EnsureTargetVMIM(vm *planapi.VMStatus, target *cnv.VirtualMachineInstanceMigration) (out *cnv.VirtualMachineInstanceMigration, err error) {
 	list := &cnv.VirtualMachineInstanceMigrationList{}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		&client.ListOptions{
@@ -1137,7 +1137,7 @@ func (r *Ensurer) EnsureTargetVMIM(vm *planapi.VMStatus, target *cnv.VirtualMach
 	}
 
 	if len(list.Items) == 0 {
-		err = r.Destination.Client.Create(context.TODO(), target)
+		err = r.Destination.Create(context.TODO(), target)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -1194,7 +1194,7 @@ func (r *Ensurer) EnsureSourceVMIM(vm *planapi.VMStatus, source *cnv.VirtualMach
 // EnsureLocalPreference ensures that the target local Preference has been created in the destination cluster.
 // If one already exists, we assume it's the intended preference to use.
 func (r *Ensurer) EnsureLocalPreference(vm *planapi.VMStatus, target *instancetype.VirtualMachinePreference) (err error) {
-	err = r.Destination.Client.Create(context.Background(), target)
+	err = r.Destination.Create(context.Background(), target)
 	if err != nil {
 		if k8serr.IsAlreadyExists(err) {
 			_, found := target.Annotations[AnnSource]
@@ -1226,7 +1226,7 @@ func (r *Ensurer) EnsureLocalPreference(vm *planapi.VMStatus, target *instancety
 // EnsureLocalInstanceType ensures that the target local InstanceType has been created in the destination cluster.
 // If one already exists, we assume it's the intended preference to use.
 func (r *Ensurer) EnsureLocalInstanceType(vm *planapi.VMStatus, target *instancetype.VirtualMachineInstancetype) (err error) {
-	err = r.Destination.Client.Create(context.Background(), target)
+	err = r.Destination.Create(context.Background(), target)
 	if err != nil {
 		if k8serr.IsAlreadyExists(err) {
 			_, found := target.Annotations[AnnSource]
@@ -1257,7 +1257,7 @@ func (r *Ensurer) EnsureLocalInstanceType(vm *planapi.VMStatus, target *instance
 
 // EnsureServiceExport exists on destination cluster.
 func (r *Ensurer) EnsureServiceExport(vm *planapi.VMStatus, export *multicluster.ServiceExport) (err error) {
-	err = r.Destination.Client.Create(context.TODO(), export)
+	err = r.Destination.Create(context.TODO(), export)
 	if err != nil {
 		if k8serr.IsAlreadyExists(err) {
 			err = nil
@@ -1285,7 +1285,7 @@ func (r *Builder) VirtualMachine(vm *planapi.VMStatus) (object *cnv.VirtualMachi
 	source := &model.VM{}
 	err = r.Source.Inventory.Find(source, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 
@@ -1367,7 +1367,7 @@ func (r *Builder) DataVolumes(vm *planapi.VMStatus) (dvs []cdi.DataVolume, err e
 	virtualMachine := &model.VM{}
 	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	storageMap := make(map[string]api.DestinationStorage)
@@ -1423,7 +1423,7 @@ func (r *Builder) PersistentVolumeClaims(vm *planapi.VMStatus) (pvcs []core.Pers
 	virtualMachine := &model.VM{}
 	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	storageMap := make(map[string]api.DestinationStorage)
@@ -1437,14 +1437,14 @@ func (r *Builder) PersistentVolumeClaims(vm *planapi.VMStatus) (pvcs []core.Pers
 			pvcRef := ref.Ref{Name: vol.PersistentVolumeClaim.ClaimName, Namespace: vm.Namespace}
 			err = r.Source.Inventory.Find(source, pvcRef)
 			if err != nil {
-				err = liberr.Wrap(err, "vm", vm.Ref.String(), "volume", vol.Name)
+				err = liberr.Wrap(err, "vm", vm.String(), "volume", vol.Name)
 				return
 			}
 		case vol.Ephemeral != nil && vol.Ephemeral.PersistentVolumeClaim != nil:
 			pvcRef := ref.Ref{Name: vol.Ephemeral.PersistentVolumeClaim.ClaimName, Namespace: vm.Namespace}
 			err = r.Source.Inventory.Find(source, pvcRef)
 			if err != nil {
-				err = liberr.Wrap(err, "vm", vm.Ref.String(), "volume", vol.Name)
+				err = liberr.Wrap(err, "vm", vm.String(), "volume", vol.Name)
 				return
 			}
 		default:
@@ -1551,7 +1551,7 @@ func (r *Builder) LocalInstanceType(vm *planapi.VMStatus) (target *instancetype.
 	virtualMachine := &model.VM{}
 	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 
@@ -1580,7 +1580,7 @@ func (r *Builder) LocalPreference(vm *planapi.VMStatus) (target *instancetype.Vi
 	virtualMachine := &model.VM{}
 	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 
@@ -1611,7 +1611,7 @@ func (r *Builder) ConfigMaps(vm *planapi.VMStatus) (list []core.ConfigMap, err e
 	virtualMachine := &model.VM{}
 	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	sources := []types.NamespacedName{}
@@ -1658,7 +1658,7 @@ func (r *Builder) Secrets(vm *planapi.VMStatus) (list []core.Secret, err error) 
 	virtualMachine := &model.VM{}
 	err = r.Source.Inventory.Find(virtualMachine, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 	sources := []types.NamespacedName{}
@@ -1737,13 +1737,13 @@ func (r *Builder) TargetVMIM(vm *planapi.VMStatus) (vmim *cnv.VirtualMachineInst
 	inventoryVm := &model.VM{}
 	err = r.Source.Inventory.Find(inventoryVm, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 
 	vmim = &cnv.VirtualMachineInstanceMigration{}
 	vmim.GenerateName = "forklift-"
-	vmim.Namespace = r.Context.Plan.Spec.TargetNamespace
+	vmim.Namespace = r.Plan.Spec.TargetNamespace
 	vmim.Labels = r.Labeler.MigrationVMLabels(vm.Ref)
 	vmim.Spec.VMIName = inventoryVm.Name
 	vmim.Spec.Receive = &cnv.VirtualMachineInstanceMigrationTarget{
@@ -1754,9 +1754,9 @@ func (r *Builder) TargetVMIM(vm *planapi.VMStatus) (vmim *cnv.VirtualMachineInst
 
 func (r *Builder) SourceVMIM(vm *planapi.VMStatus, syncAddress string) (vmim *cnv.VirtualMachineInstanceMigration, err error) {
 	inventoryVm := &model.VM{}
-	err = r.Context.Source.Inventory.Find(inventoryVm, vm.Ref)
+	err = r.Source.Inventory.Find(inventoryVm, vm.Ref)
 	if err != nil {
-		err = liberr.Wrap(err, "vm", vm.Ref.String())
+		err = liberr.Wrap(err, "vm", vm.String())
 		return
 	}
 

--- a/pkg/controller/plan/migrator/ocp/live_test.go
+++ b/pkg/controller/plan/migrator/ocp/live_test.go
@@ -205,7 +205,7 @@ var _ = Describe("requestSize", func() {
 func makeBuilder(networkPairs ...api.NetworkPair) *Builder {
 	b := &Builder{}
 	b.Context = &plancontext.Context{}
-	b.Context.Map.Network = &api.NetworkMap{
+	b.Map.Network = &api.NetworkMap{
 		Spec: api.NetworkMapSpec{
 			Map: networkPairs,
 		},

--- a/pkg/controller/plan/predicate.go
+++ b/pkg/controller/plan/predicate.go
@@ -73,7 +73,7 @@ func (r *ProviderPredicate) Update(e event.TypedUpdateEvent[*api.Provider]) bool
 // Provider deleted event.
 func (r *ProviderPredicate) Delete(e event.TypedDeleteEvent[*api.Provider]) bool {
 	p := e.Object
-	r.WatchManager.Deleted(p)
+	r.Deleted(p)
 	return true
 }
 

--- a/pkg/controller/plan/ssh.go
+++ b/pkg/controller/plan/ssh.go
@@ -17,7 +17,7 @@ const (
 // validateSSHReadiness validates SSH readiness for migration plans using xcopy volume populators
 func (r *Reconciler) validateSSHReadiness(plan *api.Plan) error {
 	// Check source provider for SSH readiness issues
-	sourceProvider := plan.Referenced.Provider.Source
+	sourceProvider := plan.Provider.Source
 	if sourceProvider == nil {
 		return nil // This would be caught by other validation
 	}
@@ -88,13 +88,13 @@ func (r *Reconciler) validateSSHReadiness(plan *api.Plan) error {
 // planUsesVSphereXcopyPopulator checks if a plan uses VSphere xcopy volume populators
 func (r *Reconciler) planUsesVSphereXcopyPopulator(plan *api.Plan) bool {
 	// Check storage mappings for VSphereXcopyPluginConfig
-	if plan.Referenced.Map.Storage == nil {
+	if plan.Map.Storage == nil {
 		return false
 	}
-	if plan.Referenced.Map.Storage.Spec.Map == nil {
+	if plan.Map.Storage.Spec.Map == nil {
 		return false
 	}
-	dsMapIn := plan.Referenced.Map.Storage.Spec.Map
+	dsMapIn := plan.Map.Storage.Spec.Map
 	for _, mapping := range dsMapIn {
 		if mapping.OffloadPlugin != nil && mapping.OffloadPlugin.VSphereXcopyPluginConfig != nil {
 			r.Log.V(2).Info("Plan uses VSphere xcopy volume populator", "plan", plan.Name)

--- a/pkg/controller/plan/util/ovirt.go
+++ b/pkg/controller/plan/util/ovirt.go
@@ -16,7 +16,7 @@ import (
 func OvirtVolumePopulator(da ovirt.XDiskAttachment, sourceUrl *url.URL, transferNetwork *core.ObjectReference, targetNamespace, secretName, vmId, migrationId string) *api.OvirtVolumePopulator {
 	return &api.OvirtVolumePopulator{
 		ObjectMeta: meta.ObjectMeta{
-			Name:      da.DiskAttachment.ID,
+			Name:      da.ID,
 			Namespace: targetNamespace,
 			Labels:    map[string]string{"vmID": vmId, "migration": migrationId},
 		},

--- a/pkg/controller/plan/util/utils.go
+++ b/pkg/controller/plan/util/utils.go
@@ -117,7 +117,7 @@ func GetBootDiskNumber(deviceString string) int {
 }
 
 func GetDeviceNumber(deviceString string) int {
-	if !(strings.HasPrefix(deviceString, diskPrefix) && len(deviceString) > len(diskPrefix)) {
+	if !strings.HasPrefix(deviceString, diskPrefix) || len(deviceString) <= len(diskPrefix) {
 		// In case we encounter an issue detecting the root disk order,
 		// we will return zero to avoid failing the migration due to boot orde
 		return 0

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -178,8 +178,8 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 		return nil
 	}
 
-	plan.Referenced.Provider.Source = pv.Referenced.Source
-	plan.Referenced.Provider.Destination = pv.Referenced.Destination
+	plan.Provider.Source = pv.Referenced.Source
+	plan.Provider.Destination = pv.Referenced.Destination
 
 	if err = r.ensureSecretForProvider(plan); err != nil {
 		return err
@@ -325,12 +325,12 @@ func (r *Reconciler) validateNetworkNameTemplate(plan *api.Plan) error {
 }
 
 func (r *Reconciler) validateOpenShiftVersion(plan *api.Plan) error {
-	source := plan.Referenced.Provider.Source
+	source := plan.Provider.Source
 	if source == nil {
 		return nil
 	}
 
-	destination := plan.Referenced.Provider.Destination
+	destination := plan.Provider.Destination
 	if destination == nil {
 		return nil
 	}
@@ -345,7 +345,7 @@ func (r *Reconciler) validateOpenShiftVersion(plan *api.Plan) error {
 			Items:    []string{},
 		}
 
-		restCfg := ocp.RestCfg(source, plan.Referenced.Secret)
+		restCfg := ocp.RestCfg(source, plan.Secret)
 		clientset, err := kubernetes.NewForConfig(restCfg)
 		if err != nil {
 			return liberr.Wrap(err)
@@ -362,9 +362,9 @@ func (r *Reconciler) validateOpenShiftVersion(plan *api.Plan) error {
 }
 
 func (r *Reconciler) ensureSecretForProvider(plan *api.Plan) error {
-	if plan.Referenced.Provider.Source != nil &&
-		plan.Referenced.Secret == nil &&
-		!plan.Referenced.Provider.Source.IsHost() {
+	if plan.Provider.Source != nil &&
+		plan.Secret == nil &&
+		!plan.Provider.Source.IsHost() {
 		err := r.setupSecret(plan)
 		if err != nil {
 			return err
@@ -441,7 +441,7 @@ func (r *Reconciler) validateWarmMigration(ctx *plancontext.Context) (err error)
 	if !ctx.Plan.IsWarm() {
 		return
 	}
-	provider := ctx.Plan.Referenced.Provider.Source
+	provider := ctx.Plan.Provider.Source
 	if provider == nil {
 		return nil
 	}
@@ -466,7 +466,7 @@ func (r *Reconciler) validateWarmMigration(ctx *plancontext.Context) (err error)
 }
 
 func (r *Reconciler) validateMigrationType(ctx *plancontext.Context) (err error) {
-	provider := ctx.Plan.Referenced.Provider.Source
+	provider := ctx.Plan.Provider.Source
 	if provider == nil {
 		return nil
 	}
@@ -548,7 +548,7 @@ func (r *Reconciler) getDestinationNamespaceNads(ctx *plancontext.Context) (*k8s
 		client.MatchingLabels{"k8s.ovn.org/user-defined-network": ""},
 	}
 
-	err := ctx.Destination.Client.List(context.TODO(), nadList, listOpts...)
+	err := ctx.Destination.List(context.TODO(), nadList, listOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -636,7 +636,7 @@ func (r *Reconciler) validateNetworkMap(plan *api.Plan) (err error) {
 			return
 		}
 	}
-	plan.Referenced.Map.Network = mp
+	plan.Map.Network = mp
 
 	return
 }
@@ -684,7 +684,7 @@ func (r *Reconciler) validateStorageMap(plan *api.Plan) (err error) {
 		})
 	}
 
-	plan.Referenced.Map.Storage = mp
+	plan.Map.Storage = mp
 
 	return
 }
@@ -996,8 +996,8 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 	setOfTargetName := map[string]bool{}
 
 	// Check if plan uses storage offload (vSphere only)
-	source := plan.Referenced.Provider.Source
-	checkMixedUsage := source != nil && source.Type() == api.VSphere && settings.Settings.Features.CopyOffload
+	source := plan.Provider.Source
+	checkMixedUsage := source != nil && source.Type() == api.VSphere && settings.Settings.CopyOffload
 	planUsesOffload := checkMixedUsage && plan.IsUsingOffloadPlugin()
 	netAppShift := plan.HasNetAppShiftDestination()
 
@@ -1024,7 +1024,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			continue
 		}
 		// Source.
-		provider := plan.Referenced.Provider.Source
+		provider := plan.Provider.Source
 		if provider == nil {
 			return nil
 		}
@@ -1101,7 +1101,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 		// CSI import only supports VVol and RDM — VMDK disks require xcopy.
 		if planUsesOffload {
 			if vsphereVM, ok := v.(*vsphere.VM); ok {
-				storageMap := plan.Referenced.Map.Storage
+				storageMap := plan.Map.Storage
 				if storageMap != nil {
 					curVMHasVddk, err := r.vmUsesVddk(storageMap, vsphereVM, vm.Name)
 					if err != nil {
@@ -1126,7 +1126,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 		if err != nil {
 			return err
 		}
-		if plan.Referenced.Map.Network != nil {
+		if plan.Map.Network != nil {
 			ok, err := validator.NetworksMapped(*ref)
 			if err != nil {
 				return err
@@ -1142,7 +1142,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 				multiplePodNetworkMappings.Items = append(multiplePodNetworkMappings.Items, ref.String())
 			}
 		}
-		if plan.Referenced.Map.Storage != nil {
+		if plan.Map.Storage != nil {
 			ok, err := validator.StorageMapped(*ref)
 			if err != nil {
 				return err
@@ -1304,7 +1304,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			}
 		}
 		// Destination.
-		provider = plan.Referenced.Provider.Destination
+		provider = plan.Provider.Destination
 		if provider == nil {
 			return nil
 		}
@@ -1515,7 +1515,7 @@ func (r *Reconciler) getVmPVCs(plan *api.Plan, vm *vsphere.VM) (pvcs []*core.Per
 		return
 	}
 	pvcsList := &core.PersistentVolumeClaimList{}
-	err = ctx.Destination.Client.List(
+	err = ctx.Destination.List(
 		context.TODO(),
 		pvcsList,
 		&client.ListOptions{
@@ -1785,7 +1785,7 @@ func (r *Reconciler) validateHooks(plan *api.Plan) (err error) {
 				notFound.Items = append(notFound.Items, planHookVMRefDescription(vm, ref))
 				continue
 			}
-			plan.Referenced.Hooks = append(plan.Referenced.Hooks, hook)
+			plan.Hooks = append(plan.Hooks, hook)
 			hookRefDesc := planHookVMRefDescription(vm, ref)
 			if !api.HookExecutionConfigValid(hook) {
 				hookNotExecutable.Items = append(hookNotExecutable.Items, hookRefDesc)
@@ -1823,11 +1823,11 @@ func (r *Reconciler) validateHooks(plan *api.Plan) (err error) {
 }
 
 func (r *Reconciler) validateVddkImage(plan *api.Plan) (err error) {
-	source := plan.Referenced.Provider.Source
+	source := plan.Provider.Source
 	if source == nil {
 		return liberr.New("source provider is not set")
 	}
-	destination := plan.Referenced.Provider.Destination
+	destination := plan.Provider.Destination
 	if destination == nil {
 		return liberr.New("destination provider is not set")
 	}
@@ -1869,7 +1869,7 @@ func (r *Reconciler) validateVddkImage(plan *api.Plan) (err error) {
 
 func missingStaticIPsMessage(plan *api.Plan) string {
 	guestTools := "guest tools"
-	source := plan.Referenced.Provider.Source
+	source := plan.Provider.Source
 	if source != nil {
 		switch source.Type() {
 		case api.VSphere:
@@ -1882,7 +1882,7 @@ func missingStaticIPsMessage(plan *api.Plan) string {
 }
 
 func jobExceedsDeadline(job *batchv1.Job) bool {
-	ActiveDeadlineSeconds := settings.Settings.Migration.VddkJobActiveDeadline
+	ActiveDeadlineSeconds := settings.Settings.VddkJobActiveDeadline
 
 	if job.Status.StartTime == nil {
 		return false
@@ -1891,7 +1891,7 @@ func jobExceedsDeadline(job *batchv1.Job) bool {
 }
 
 func (r *Reconciler) validateVddkImageJob(job *batchv1.Job, plan *api.Plan) (err error) {
-	image := settings.GetVDDKImage(plan.Referenced.Provider.Source.Spec.Settings)
+	image := settings.GetVDDKImage(plan.Provider.Source.Spec.Settings)
 	vddkInvalid := libcnd.Condition{
 		Type:     VDDKInvalid,
 		Status:   True,
@@ -1918,7 +1918,7 @@ func (r *Reconciler) validateVddkImageJob(job *batchv1.Job, plan *api.Plan) (err
 	}
 	// check if a pod exists for the job
 	pods := &core.PodList{}
-	if err = ctx.Destination.Client.List(context.TODO(), pods, &client.ListOptions{
+	if err = ctx.Destination.List(context.TODO(), pods, &client.ListOptions{
 		Namespace:     plan.Spec.TargetNamespace,
 		LabelSelector: labels.SelectorFromSet(map[string]string{"job-name": job.Name}),
 	}); err != nil {
@@ -1997,7 +1997,7 @@ func (r *Reconciler) cancelOtherActiveVddkCheckJobs(plan *api.Plan) (err error) 
 	delete(queryLabels, "vddk")
 
 	jobs := &batchv1.JobList{}
-	if err = ctx.Destination.Client.List(
+	if err = ctx.Destination.List(
 		context.TODO(),
 		jobs,
 		&client.ListOptions{
@@ -2018,7 +2018,7 @@ func (r *Reconciler) cancelOtherActiveVddkCheckJobs(plan *api.Plan) (err error) 
 			// become orphaned while trying to pull its image indefinitely
 			fg := meta.DeletePropagationForeground
 			opts := &client.DeleteOptions{PropagationPolicy: &fg}
-			if err = ctx.Destination.Client.Delete(context.TODO(), &job, opts); err != nil {
+			if err = ctx.Destination.Delete(context.TODO(), &job, opts); err != nil {
 				return
 			}
 		}
@@ -2043,7 +2043,7 @@ func (r *Reconciler) ensureVddkImageValidationJob(plan *api.Plan) (*batchv1.Job,
 
 	jobLabels := getVddkImageValidationJobLabels(ctx.Plan)
 	jobs := &batchv1.JobList{}
-	err = ctx.Destination.Client.List(
+	err = ctx.Destination.List(
 		context.TODO(),
 		jobs,
 		&client.ListOptions{
@@ -2056,7 +2056,7 @@ func (r *Reconciler) ensureVddkImageValidationJob(plan *api.Plan) (*batchv1.Job,
 		return nil, err
 	case len(jobs.Items) == 0:
 		job := createVddkCheckJob(ctx.Plan)
-		err = ctx.Destination.Client.Create(context.Background(), job)
+		err = ctx.Destination.Create(context.Background(), job)
 		if err != nil {
 			return nil, err
 		}
@@ -2078,16 +2078,16 @@ func (r *Reconciler) ensureNamespace(ctx *plancontext.Context) error {
 }
 
 func getVddkImageValidationJobLabels(plan *api.Plan) map[string]string {
-	image := settings.GetVDDKImage(plan.Referenced.Provider.Source.Spec.Settings)
+	image := settings.GetVDDKImage(plan.Provider.Source.Spec.Settings)
 	sum := md5.Sum([]byte(image))
 	return map[string]string{
-		"plan": string(plan.ObjectMeta.UID),
+		"plan": string(plan.UID),
 		"vddk": hex.EncodeToString(sum[:]),
 	}
 }
 
 func createVddkCheckJob(plan *api.Plan) *batchv1.Job {
-	image := settings.GetVDDKImage(plan.Referenced.Provider.Source.Spec.Settings)
+	image := settings.GetVDDKImage(plan.Provider.Source.Spec.Settings)
 
 	mount := core.VolumeMount{
 		Name:      VddkVolumeName,
@@ -2141,7 +2141,7 @@ func createVddkCheckJob(plan *api.Plan) *batchv1.Job {
 			Namespace:    plan.Spec.TargetNamespace,
 			Labels:       getVddkImageValidationJobLabels(plan),
 			Annotations: map[string]string{
-				"provider": plan.Referenced.Provider.Source.Name,
+				"provider": plan.Provider.Source.Name,
 				"vddk":     image,
 				"plan":     plan.Name,
 			},
@@ -2194,8 +2194,8 @@ func createVddkCheckJob(plan *api.Plan) *batchv1.Job {
 
 func (r *Reconciler) setupSecret(plan *api.Plan) (err error) {
 	key := client.ObjectKey{
-		Namespace: plan.Referenced.Provider.Source.Spec.Secret.Namespace,
-		Name:      plan.Referenced.Provider.Source.Spec.Secret.Name,
+		Namespace: plan.Provider.Source.Spec.Secret.Namespace,
+		Name:      plan.Provider.Source.Spec.Secret.Name,
 	}
 
 	secret := core.Secret{}
@@ -2204,7 +2204,7 @@ func (r *Reconciler) setupSecret(plan *api.Plan) (err error) {
 		return
 	}
 
-	plan.Referenced.Secret = &secret
+	plan.Secret = &secret
 	return
 }
 
@@ -2352,7 +2352,7 @@ func (r *Reconciler) validateConversionTempStorage(plan *api.Plan) error {
 
 	// Validate that the StorageClass exists in the cluster (conversion runs on destination/target)
 	sc := &storagev1.StorageClass{}
-	if err := r.Client.Get(context.Background(), client.ObjectKey{Name: storageClass}, sc); err != nil {
+	if err := r.Get(context.Background(), client.ObjectKey{Name: storageClass}, sc); err != nil {
 		if k8serr.IsNotFound(err) {
 			plan.Status.SetCondition(libcnd.Condition{
 				Type:     NotValid,
@@ -2384,7 +2384,7 @@ func (r *Reconciler) validateConversionTempStorage(plan *api.Plan) error {
 func (r *Reconciler) validateConversionTempStorageCapacity(plan *api.Plan, storageClassName string, requested resource.Quantity) error {
 	ctx := context.Background()
 	list := &storagev1.CSIStorageCapacityList{}
-	if err := r.Client.List(ctx, list, client.InNamespace(core.NamespaceAll)); err != nil {
+	if err := r.List(ctx, list, client.InNamespace(core.NamespaceAll)); err != nil {
 		r.Log.Info("Could not list CSIStorageCapacity (capacity check skipped)", "error", err.Error(), "storageClass", storageClassName)
 		plan.Status.SetCondition(libcnd.Condition{
 			Type:     NotValid,
@@ -2444,7 +2444,7 @@ func (r *Reconciler) validatePodSecurity(plan *api.Plan) error {
 	controllerNamespace := os.Getenv("POD_NAMESPACE")
 	if controllerNamespace == "" {
 		// Fallback to settings if available (loaded from POD_NAMESPACE env var)
-		controllerNamespace = settings.Settings.Inventory.Namespace
+		controllerNamespace = settings.Settings.Namespace
 	}
 	if controllerNamespace == "" {
 		// Can't check if we don't know the controller namespace
@@ -2463,7 +2463,7 @@ func (r *Reconciler) validatePodSecurity(plan *api.Plan) error {
 
 	// Read the namespace object
 	ns := &core.Namespace{}
-	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: controllerNamespace}, ns)
+	err := r.Get(context.TODO(), client.ObjectKey{Name: controllerNamespace}, ns)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			// Namespace not found, skip check

--- a/pkg/controller/plan/validation_test.go
+++ b/pkg/controller/plan/validation_test.go
@@ -89,8 +89,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			source := createProvider(sourceName, sourceNamespace, "https://source", api.OpenShift, &core.ObjectReference{Name: sourceSecretName, Namespace: sourceNamespace})
 			destination := createProvider(destName, destNamespace, "", api.OpenShift, &core.ObjectReference{})
 			plan := createPlan(testPlanName, testNamespace, source, destination)
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
 			err := reconciler.ensureSecretForProvider(plan)
@@ -105,8 +105,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			source := createProvider(sourceName, sourceNamespace, "", api.OpenShift, &core.ObjectReference{Name: sourceSecretName, Namespace: sourceNamespace})
 			destination := createProvider(destName, destNamespace, "https://destination", api.OpenShift, &core.ObjectReference{})
 			plan := createPlan(testPlanName, testNamespace, source, destination)
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
 			err := reconciler.ensureSecretForProvider(plan)
@@ -524,14 +524,14 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 		})
 
 		ginkgo.It("should skip SA validation for AAP hooks", func() {
-			savedURL := Settings.Migration.AAPURL
-			savedTok := Settings.Migration.AAPTokenSecretName
+			savedURL := Settings.AAPURL
+			savedTok := Settings.AAPTokenSecretName
 			defer func() {
-				Settings.Migration.AAPURL = savedURL
-				Settings.Migration.AAPTokenSecretName = savedTok
+				Settings.AAPURL = savedURL
+				Settings.AAPTokenSecretName = savedTok
 			}()
-			Settings.Migration.AAPURL = "https://aap.example.com"
-			Settings.Migration.AAPTokenSecretName = "aap-token"
+			Settings.AAPURL = "https://aap.example.com"
+			Settings.AAPTokenSecretName = "aap-token"
 
 			aapCfg := &api.AAPConfig{
 				JobTemplateID: 42,
@@ -564,8 +564,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			plan := createPlan(testPlanName, testNamespace, source, destination)
 			plan.Spec.ConversionTempStorageClass = "fast-ssd"
 			plan.Spec.ConversionTempStorageSize = "50Gi"
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			sc := &storagev1.StorageClass{ObjectMeta: meta.ObjectMeta{Name: "fast-ssd"}, Provisioner: "kubernetes.io/fake"}
 			csiCap := &storagev1.CSIStorageCapacity{
@@ -585,8 +585,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			source := createProvider(sourceName, sourceNamespace, "https://source", api.OpenShift, &core.ObjectReference{Name: sourceSecretName, Namespace: sourceNamespace})
 			destination := createProvider(destName, destNamespace, "", api.OpenShift, &core.ObjectReference{})
 			plan := createPlan(testPlanName, testNamespace, source, destination)
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
 			err := reconciler.validateConversionTempStorage(plan)
@@ -602,8 +602,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			plan := createPlan(testPlanName, testNamespace, source, destination)
 			plan.Spec.ConversionTempStorageClass = "fast-ssd"
 			plan.Spec.ConversionTempStorageSize = ""
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
 			err := reconciler.validateConversionTempStorage(plan)
@@ -622,8 +622,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			plan := createPlan(testPlanName, testNamespace, source, destination)
 			plan.Spec.ConversionTempStorageClass = ""
 			plan.Spec.ConversionTempStorageSize = "50Gi"
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
 			err := reconciler.validateConversionTempStorage(plan)
@@ -642,8 +642,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			plan := createPlan(testPlanName, testNamespace, source, destination)
 			plan.Spec.ConversionTempStorageClass = "fast-ssd"
 			plan.Spec.ConversionTempStorageSize = "invalid-size"
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			reconciler = createFakeReconciler(secret, plan, source, destination)
 			err := reconciler.validateConversionTempStorage(plan)
@@ -659,8 +659,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			secret := createSecret(sourceSecretName, sourceNamespace, false)
 			source := createProvider(sourceName, sourceNamespace, "https://source", api.OpenShift, &core.ObjectReference{Name: sourceSecretName, Namespace: sourceNamespace})
 			destination := createProvider(destName, destNamespace, "", api.OpenShift, &core.ObjectReference{})
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			sc := &storagev1.StorageClass{ObjectMeta: meta.ObjectMeta{Name: "fast-ssd"}, Provisioner: "kubernetes.io/fake"}
 			csiCap := &storagev1.CSIStorageCapacity{
@@ -689,8 +689,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			plan := createPlan(testPlanName, testNamespace, source, destination)
 			plan.Spec.ConversionTempStorageClass = "error-sc"
 			plan.Spec.ConversionTempStorageSize = "150Gi"
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			// No StorageClass "error-sc" in fake client -> should block
 			reconciler = createFakeReconciler(secret, plan, source, destination)
@@ -712,8 +712,8 @@ var _ = ginkgo.Describe("Plan Validations", func() {
 			plan := createPlan(testPlanName, testNamespace, source, destination)
 			plan.Spec.ConversionTempStorageClass = "ocs-storagecluster-ceph-rbd"
 			plan.Spec.ConversionTempStorageSize = "1Ti"
-			source.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
-			destination.Status.Conditions.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			source.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
+			destination.Status.SetCondition(libcnd.Condition{Type: libcnd.Ready, Status: libcnd.True})
 
 			sc := &storagev1.StorageClass{ObjectMeta: meta.ObjectMeta{Name: "ocs-storagecluster-ceph-rbd"}, Provisioner: "kubernetes.io/fake"}
 			// Only 70Gi available - not enough for 1Ti
@@ -1190,18 +1190,18 @@ var _ = ginkgo.Describe("Template Validation", func() {
 		}
 
 		ginkgo.BeforeEach(func() {
-			Settings.Migration.VirtV2vImage = globalImage
-			savedGlobalSA = Settings.Migration.ServiceAccount
+			Settings.VirtV2vImage = globalImage
+			savedGlobalSA = Settings.ServiceAccount
 		})
 
 		ginkgo.AfterEach(func() {
-			Settings.Migration.ServiceAccount = savedGlobalSA
+			Settings.ServiceAccount = savedGlobalSA
 		})
 
 		ginkgo.It("should set plan SA on the VDDK validation job", func() {
 			p := newPlanWithVddkProvider()
 			p.Spec.ServiceAccount = "plan-sa"
-			Settings.Migration.ServiceAccount = ""
+			Settings.ServiceAccount = ""
 			job := createVddkCheckJob(p)
 			gomega.Expect(job.Spec.Template.Spec.ServiceAccountName).To(gomega.Equal("plan-sa"))
 		})
@@ -1209,7 +1209,7 @@ var _ = ginkgo.Describe("Template Validation", func() {
 		ginkgo.It("should fall back to global SA when plan SA is empty", func() {
 			p := newPlanWithVddkProvider()
 			p.Spec.ServiceAccount = ""
-			Settings.Migration.ServiceAccount = "global-sa"
+			Settings.ServiceAccount = "global-sa"
 			job := createVddkCheckJob(p)
 			gomega.Expect(job.Spec.Template.Spec.ServiceAccountName).To(gomega.Equal("global-sa"))
 		})
@@ -1217,7 +1217,7 @@ var _ = ginkgo.Describe("Template Validation", func() {
 		ginkgo.It("should leave SA empty when both plan and global are empty", func() {
 			p := newPlanWithVddkProvider()
 			p.Spec.ServiceAccount = ""
-			Settings.Migration.ServiceAccount = ""
+			Settings.ServiceAccount = ""
 			job := createVddkCheckJob(p)
 			gomega.Expect(job.Spec.Template.Spec.ServiceAccountName).To(gomega.BeEmpty())
 		})
@@ -1225,7 +1225,7 @@ var _ = ginkgo.Describe("Template Validation", func() {
 		ginkgo.It("should prefer plan SA over global SA", func() {
 			p := newPlanWithVddkProvider()
 			p.Spec.ServiceAccount = "plan-sa"
-			Settings.Migration.ServiceAccount = "global-sa"
+			Settings.ServiceAccount = "global-sa"
 			job := createVddkCheckJob(p)
 			gomega.Expect(job.Spec.Template.Spec.ServiceAccountName).To(gomega.Equal("plan-sa"))
 		})
@@ -1264,7 +1264,7 @@ var _ = ginkgo.Describe("Template Validation", func() {
 		}
 
 		ginkgo.BeforeEach(func() {
-			Settings.Migration.VirtV2vImage = globalImage
+			Settings.VirtV2vImage = globalImage
 		})
 
 		ginkgo.It("should use global virt-v2v image when plan has no override", func() {

--- a/pkg/controller/plan/vm_name_handler.go
+++ b/pkg/controller/plan/vm_name_handler.go
@@ -41,7 +41,7 @@ func (r *KubeVirt) checkIfVmNameExistsInNamespace(name string, namespace string)
 			namespaceField: namespace,
 		}),
 	}
-	err = r.Destination.Client.List(
+	err = r.Destination.List(
 		context.TODO(),
 		list,
 		listOptions,

--- a/pkg/controller/provider/container/hyperv/watch.go
+++ b/pkg/controller/provider/container/hyperv/watch.go
@@ -148,7 +148,7 @@ func (r *VMEventHandler) run() {
 	r.log.Info("Run started.")
 	defer r.log.Info("Run stopped.")
 	interval := time.Second * time.Duration(
-		Settings.PolicyAgent.SearchInterval)
+		Settings.SearchInterval)
 	r.list()
 	r.reset()
 	for {

--- a/pkg/controller/provider/container/openstack/resource.go
+++ b/pkg/controller/provider/container/openstack/resource.go
@@ -249,7 +249,7 @@ func (r *Fault) ApplyTo(m *model.Fault) {
 
 func (r *Fault) equalsTo(m *model.Fault) bool {
 	return m.Code == r.Code &&
-		m.Created == r.Created &&
+		m.Created.Equal(r.Created) &&
 		m.Details == r.Details &&
 		m.Message == r.Message
 }

--- a/pkg/controller/provider/container/openstack/watch.go
+++ b/pkg/controller/provider/container/openstack/watch.go
@@ -153,7 +153,7 @@ func (r *VMEventHandler) run() {
 	r.log.Info("Run started.")
 	defer r.log.Info("Run stopped.")
 	interval := time.Second * time.Duration(
-		Settings.PolicyAgent.SearchInterval)
+		Settings.SearchInterval)
 	r.list()
 	r.reset()
 	for {

--- a/pkg/controller/provider/container/ovfbase/resource.go
+++ b/pkg/controller/provider/container/ovfbase/resource.go
@@ -179,7 +179,7 @@ type Network struct {
 func (r *Network) ApplyTo(m *model.Network) {
 	m.ID = r.ID
 	m.Description = r.Description
-	m.Base.Name = r.Name
+	m.Name = r.Name
 }
 
 // Disk.
@@ -197,8 +197,8 @@ type Disk struct {
 
 // Apply to (update) the model.
 func (r *Disk) ApplyTo(m *model.Disk) {
-	m.Base.Name = r.Name
-	m.Base.ID = r.ID
+	m.Name = r.Name
+	m.ID = r.ID
 	m.FilePath = r.FilePath
 	m.Capacity = r.Capacity
 	m.CapacityAllocationUnits = r.CapacityAllocationUnits
@@ -214,6 +214,6 @@ type Storage struct {
 }
 
 func (r *Storage) ApplyTo(m *model.Storage) {
-	m.Base.Name = m.Name
-	m.Base.ID = m.ID
+	m.Name = r.Name
+	m.ID = r.ID
 }

--- a/pkg/controller/provider/container/ovfbase/watch.go
+++ b/pkg/controller/provider/container/ovfbase/watch.go
@@ -134,7 +134,7 @@ func (r *VMEventHandler) run() {
 	r.log.Info("Run started.")
 	defer r.log.Info("Run stopped.")
 	interval := time.Second * time.Duration(
-		Settings.PolicyAgent.SearchInterval)
+		Settings.SearchInterval)
 	r.list()
 	r.reset()
 	for {

--- a/pkg/controller/provider/container/ovirt/watch.go
+++ b/pkg/controller/provider/container/ovirt/watch.go
@@ -153,7 +153,7 @@ func (r *VMEventHandler) run() {
 	r.log.Info("Run started.")
 	defer r.log.Info("Run stopped.")
 	interval := time.Second * time.Duration(
-		Settings.PolicyAgent.SearchInterval)
+		Settings.SearchInterval)
 	r.list()
 	r.reset()
 	for {

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -228,7 +228,7 @@ func (r *VMEventHandler) run() {
 	r.log.Info("Run started.")
 	defer r.log.Info("Run stopped.")
 	interval := time.Second * time.Duration(
-		Settings.PolicyAgent.SearchInterval)
+		Settings.SearchInterval)
 	r.list()
 	r.reset()
 	for {

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -80,7 +80,7 @@ func Add(mgr manager.Manager) error {
 		web.TLS.Enabled = true
 		web.TLS.Certificate = Settings.Inventory.TLS.Certificate
 		web.TLS.Key = Settings.Inventory.TLS.Key
-		web.AllowedOrigins = Settings.Inventory.CORS.AllowedOrigins
+		web.AllowedOrigins = Settings.CORS.AllowedOrigins
 	}
 	reconciler := &Reconciler{
 		Reconciler: base.Reconciler{
@@ -393,7 +393,7 @@ func (r *Reconciler) updateContainer(provider *api.Provider) (err error) {
 
 // Build DB for provider.
 func (r *Reconciler) getDB(provider *api.Provider) (db libmodel.DB) {
-	dir := Settings.Inventory.WorkingDir
+	dir := Settings.WorkingDir
 	dir = filepath.Join(
 		dir,
 		provider.Namespace,
@@ -463,12 +463,12 @@ func (r *Reconciler) removeVolumeOfOVAServer(provider *api.Provider) error {
 		"provider": provider.Name,
 	})
 	pvList := &v1.PersistentVolumeList{}
-	if err := r.Client.List(context.TODO(), pvList, &client.ListOptions{LabelSelector: labelSelector}); err != nil {
+	if err := r.List(context.TODO(), pvList, &client.ListOptions{LabelSelector: labelSelector}); err != nil {
 		r.Log.Error(err, "Failed to list PVs for OVA provider", "provider", provider)
 		return err
 	} else {
 		for _, pv := range pvList.Items {
-			if err = r.Client.Delete(context.TODO(), &pv); err != nil {
+			if err = r.Delete(context.TODO(), &pv); err != nil {
 				r.Log.Error(err, "Failed to delete PV", "PV", pv)
 				return err
 			}

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -828,7 +828,7 @@ func smbMountBlocked(pod *core.Pod) (string, bool) {
 }
 
 func providerServicePendingTimeout() time.Duration {
-	return time.Duration(Settings.Providers.ProviderPendingTimeoutSeconds) * time.Second
+	return time.Duration(Settings.ProviderPendingTimeoutSeconds) * time.Second
 }
 
 func isPodReady(pod *core.Pod) bool {
@@ -1296,9 +1296,9 @@ func (r *Reconciler) ValidateSSHReadiness(provider *api.Provider, secret *core.S
 			// Parse "id|name|ip" format for human-readable display
 			parts := strings.Split(item, "|")
 			if len(parts) == 3 {
-				successSuggestion.WriteString(fmt.Sprintf("  - %s (%s)\n", parts[1], parts[2]))
+				fmt.Fprintf(&successSuggestion, "  - %s (%s)\n", parts[1], parts[2])
 			} else {
-				successSuggestion.WriteString(fmt.Sprintf("  - %s\n", item))
+				fmt.Fprintf(&successSuggestion, "  - %s\n", item)
 			}
 		}
 		successSuggestion.WriteString("\nTo use the xcopy volume populator, ensure your VMs are located on these ESXi hosts before starting the migration.\n")
@@ -1323,9 +1323,9 @@ func (r *Reconciler) ValidateSSHReadiness(provider *api.Provider, secret *core.S
 		// Parse "id|name|ip" format for human-readable display
 		parts := strings.Split(item, "|")
 		if len(parts) == 3 {
-			failSuggestion.WriteString(fmt.Sprintf("  - %s (%s)\n", parts[1], parts[2]))
+			fmt.Fprintf(&failSuggestion, "  - %s (%s)\n", parts[1], parts[2])
 		} else {
-			failSuggestion.WriteString(fmt.Sprintf("  - %s\n", item))
+			fmt.Fprintf(&failSuggestion, "  - %s\n", item)
 		}
 	}
 	failSuggestion.WriteString("\n")

--- a/pkg/controller/provider/web/base/auth.go
+++ b/pkg/controller/provider/web/base/auth.go
@@ -56,7 +56,7 @@ func (r *Auth) Permit(ctx *gin.Context, p *api.Provider) (int, error) {
 			return http.StatusOK, nil
 		}
 	}
-	if p.ObjectMeta.UID == "" {
+	if p.UID == "" {
 		q := ctx.Request.URL.Query()
 		ns = q.Get(NsParam)
 	}
@@ -110,7 +110,7 @@ func (r *Auth) permit(token string, ns string, p *api.Provider) (int, error) {
 		return http.StatusInternalServerError, liberr.Wrap(err)
 	}
 	var verb, namespace string
-	if p.ObjectMeta.UID != "" {
+	if p.UID != "" {
 		verb = "get"
 		namespace = p.Namespace
 	} else {

--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -203,11 +203,11 @@ func (c *RestClient) Get(resource interface{}, id string) (status int, err error
 	}
 	lv := reflect.ValueOf(resource)
 	switch lv.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 	default:
 		return -1, libmodel.MustBePtrErr
 	}
-	path, err := c.Resolver.Path(resource, id)
+	path, err := c.Path(resource, id)
 	if err != nil {
 		return
 	}
@@ -223,7 +223,7 @@ func (c *RestClient) List(list interface{}, param ...Param) (status int, err err
 	lt := reflect.TypeOf(list)
 	lv := reflect.ValueOf(list)
 	switch lv.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		lt := lt.Elem()
 		lv = lv.Elem()
 		switch lv.Kind() {
@@ -235,7 +235,7 @@ func (c *RestClient) List(list interface{}, param ...Param) (status int, err err
 	default:
 		return -1, libmodel.MustBeSlicePtrErr
 	}
-	path, err := c.Resolver.Path(resource, "/")
+	path, err := c.Path(resource, "/")
 	if err != nil {
 		return
 	}
@@ -260,12 +260,12 @@ func (c *RestClient) Watch(resource interface{}, h EventHandler) (status int, w 
 	}
 	lv := reflect.ValueOf(resource)
 	switch lv.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 	default:
 		err = libmodel.MustBePtrErr
 		return
 	}
-	path, err := c.Resolver.Path(resource, "/")
+	path, err := c.Path(resource, "/")
 	if err != nil {
 		return
 	}
@@ -334,13 +334,13 @@ func (c *RestClient) url(path string) string {
 	if c.Host == "" {
 		c.Host = fmt.Sprintf(
 			"%s:%d",
-			Settings.Inventory.Host,
+			Settings.Host,
 			Settings.Inventory.Port)
 	}
 	path = (&Handler{}).Link(path, c.Params)
 	url, _ := liburl.Parse(path)
 	if url.Host == "" {
-		url.Scheme = Settings.Inventory.Scheme
+		url.Scheme = Settings.Scheme
 		url.Host = c.Host
 	}
 

--- a/pkg/controller/provider/web/base/client_test.go
+++ b/pkg/controller/provider/web/base/client_test.go
@@ -34,17 +34,17 @@ func TestRestClientURL_UsesConfiguredScheme(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Save and restore globals to avoid cross-test interference.
-			origHost, origPort, origScheme := Settings.Inventory.Host, Settings.Inventory.Port, Settings.Inventory.Scheme
+			origHost, origPort, origScheme := Settings.Host, Settings.Inventory.Port, Settings.Scheme
 			t.Cleanup(func() {
-				Settings.Inventory.Host = origHost
+				Settings.Host = origHost
 				Settings.Inventory.Port = origPort
-				Settings.Inventory.Scheme = origScheme
+				Settings.Scheme = origScheme
 			})
 
 			// Set up inventory settings
-			Settings.Inventory.Host = tt.host
+			Settings.Host = tt.host
 			Settings.Inventory.Port = tt.port
-			Settings.Inventory.Scheme = tt.scheme
+			Settings.Scheme = tt.scheme
 
 			c := &RestClient{Host: ""} // Empty Host forces use of Settings
 			got := c.url(tt.path)

--- a/pkg/controller/provider/web/hyperv/types.go
+++ b/pkg/controller/provider/web/hyperv/types.go
@@ -34,22 +34,22 @@ func (r *Resolver) Path(resource interface{}, id string) (path string, err error
 		})
 	case *VM:
 		path = base.Link(VMRoot, base.Params{
-			base.ProviderParam: string(r.Provider.UID),
+			base.ProviderParam: string(r.UID),
 			VMParam:            id,
 		})
 	case *Network:
 		path = base.Link(NetworkRoot, base.Params{
-			base.ProviderParam: string(r.Provider.UID),
+			base.ProviderParam: string(r.UID),
 			NetworkParam:       id,
 		})
 	case *Storage:
 		path = base.Link(StorageRoot, base.Params{
-			base.ProviderParam: string(r.Provider.UID),
+			base.ProviderParam: string(r.UID),
 			StorageParam:       id,
 		})
 	case *Disk:
 		path = base.Link(DiskRoot, base.Params{
-			base.ProviderParam: string(r.Provider.UID),
+			base.ProviderParam: string(r.UID),
 			DiskParam:          id,
 		})
 	default:

--- a/pkg/controller/provider/web/ocp/base.go
+++ b/pkg/controller/provider/web/ocp/base.go
@@ -96,7 +96,7 @@ func (r *PathBuilder) forNamespace(id, leaf string) (path string, err error) {
 	name, cached := r.cache[id]
 	if !cached {
 		list := core.NamespaceList{}
-		err = r.Client.List(context.TODO(), &list,
+		err = r.List(context.TODO(), &list,
 			ocpclient.MatchingFieldsSelector{
 				Selector: fields.OneTermEqualSelector(metav1.ObjectNameField, id),
 			},

--- a/pkg/controller/provider/web/ocp/namespace.go
+++ b/pkg/controller/provider/web/ocp/namespace.go
@@ -86,7 +86,7 @@ func (h NamespaceHandler) Get(ctx *gin.Context) {
 	}
 	uid := types.UID(ctx.Param(NsParam))
 	for _, ns := range namespaces {
-		if ns.Object.ObjectMeta.UID == uid {
+		if ns.Object.UID == uid {
 			r := Namespace{}
 			r.With(&ns)
 			r.Link(h.Provider)

--- a/pkg/controller/provider/web/openstack/image.go
+++ b/pkg/controller/provider/web/openstack/image.go
@@ -59,9 +59,9 @@ func (h *ImageHandler) AddRoutes(e *gin.Engine) {
 
 // Build the resource using the model.
 func (r *Image) With(m *model.Image) {
-	r.Resource.ID = m.ID
-	r.Resource.Revision = m.Revision
-	r.Resource.Name = m.Name
+	r.ID = m.ID
+	r.Revision = m.Revision
+	r.Name = m.Name
 	r.Status = string(m.Status)
 	r.Tags = m.Tags
 	r.ContainerFormat = m.ContainerFormat

--- a/pkg/controller/provider/web/openstack/workload.go
+++ b/pkg/controller/provider/web/openstack/workload.go
@@ -67,7 +67,7 @@ func (h WorkloadHandler) Get(ctx *gin.Context) {
 	}
 	h.Detail = model.MaxDetail
 	r := Workload{}
-	r.VM.With(m)
+	r.With(m)
 	err = r.Expand(h.Collector.DB())
 	if err != nil {
 		return

--- a/pkg/controller/provider/web/ovirt/workload.go
+++ b/pkg/controller/provider/web/ovirt/workload.go
@@ -112,7 +112,7 @@ type XDiskAttachment struct {
 
 func (r *XDiskAttachment) Expand(db libmodel.DB) (err error) {
 	disk := &model.Disk{
-		Base: model.Base{ID: r.DiskAttachment.ID},
+		Base: model.Base{ID: r.ID},
 	}
 	disk.ID = r.DiskAttachment.Disk
 	err = db.Get(disk)

--- a/pkg/controller/provider/web/vsphere/vddk.go
+++ b/pkg/controller/provider/web/vsphere/vddk.go
@@ -50,7 +50,7 @@ func (h *VddkHandler) AddRoutes(e *gin.Engine) {
 // BuildImage receives a VDDK tar file, writes it to disk,
 // and triggers an OpenShift BuildConfig to build and push the image.
 func (h *VddkHandler) BuildImage(ctx *gin.Context) {
-	status, err := h.Handler.Prepare(ctx)
+	status, err := h.Prepare(ctx)
 	if status != http.StatusOK {
 		ctx.Status(status)
 		base.SetForkliftError(ctx, err)
@@ -97,14 +97,14 @@ func (h *VddkHandler) BuildImage(ctx *gin.Context) {
 // it returns a 200 JSON response containing the image reference. On error,
 // it writes a JSON error with the appropriate HTTP status.
 func (h *VddkHandler) ImageUrl(ctx *gin.Context) {
-	status, err := h.Handler.Prepare(ctx)
+	status, err := h.Prepare(ctx)
 	if status != http.StatusOK {
 		ctx.Status(status)
 		base.SetForkliftError(ctx, err)
 		return
 	}
 
-	if h.Handler.WatchRequest {
+	if h.WatchRequest {
 		h.watchImageURL(ctx)
 		return
 	}
@@ -137,7 +137,7 @@ func (h *VddkHandler) ImageUrl(ctx *gin.Context) {
 
 // DownloadVddkTar streams the uploaded VDDK tar back to the client.
 func (h *VddkHandler) DownloadVddkTar(ctx *gin.Context) {
-	status, err := h.Handler.Prepare(ctx)
+	status, err := h.Prepare(ctx)
 	if status != http.StatusOK {
 		ctx.Status(status)
 		base.SetForkliftError(ctx, err)

--- a/pkg/controller/provider/web/vsphere/workload.go
+++ b/pkg/controller/provider/web/vsphere/workload.go
@@ -113,17 +113,17 @@ func (r *Workload) Expand(db libmodel.DB) (err error) {
 	}
 	err = db.Get(host)
 	if err != nil {
-		return fmt.Errorf("error from %w: For VM '%s', host id '%s' not found - probably due to permissions issue", err, r.VM.ID, r.Host.ID)
+		return fmt.Errorf("error from %w: For VM '%s', host id '%s' not found - probably due to permissions issue", err, r.ID, r.Host.ID)
 	}
-	r.Host.Host.With(host)
+	r.Host.With(host)
 	cluster := &model.Cluster{
 		Base: model.Base{ID: host.Cluster},
 	}
 	err = db.Get(cluster)
 	if err != nil {
-		return fmt.Errorf("error from %w: For VM '%s' cluster id '%s' not found - probably due to permissions issue", err, r.VM.ID, host.Cluster)
+		return fmt.Errorf("error from %w: For VM '%s' cluster id '%s' not found - probably due to permissions issue", err, r.ID, host.Cluster)
 	}
-	r.Host.Cluster.Cluster.With(cluster)
+	r.Host.Cluster.With(cluster)
 
 	return
 }

--- a/pkg/controller/validation/policy/client.go
+++ b/pkg/controller/validation/policy/client.go
@@ -46,7 +46,7 @@ type Client struct {
 
 // Enabled.
 func (r *Client) Enabled() bool {
-	return Settings.PolicyAgent.Enabled()
+	return Settings.Enabled()
 }
 
 // Policy version.
@@ -116,7 +116,7 @@ func (r *Client) Validate(
 
 // Get request.
 func (r *Client) get(path string, out interface{}) (err error) {
-	parsedURL, err := liburl.Parse(Settings.PolicyAgent.URL)
+	parsedURL, err := liburl.Parse(Settings.URL)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -131,7 +131,7 @@ func (r *Client) get(path string, out interface{}) (err error) {
 		"GET request.",
 		"url",
 		url)
-	status, err := r.LibClient.Get(url, out)
+	status, err := r.Get(url, out)
 	if err != nil {
 		return
 	}
@@ -144,7 +144,7 @@ func (r *Client) get(path string, out interface{}) (err error) {
 
 // Post request.
 func (r *Client) post(path string, in interface{}, out interface{}) (err error) {
-	parsedURL, err := liburl.Parse(Settings.PolicyAgent.URL)
+	parsedURL, err := liburl.Parse(Settings.URL)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -161,7 +161,7 @@ func (r *Client) post(path string, in interface{}, out interface{}) (err error) 
 		url,
 		"body",
 		in)
-	status, err := r.LibClient.Post(url, in, out)
+	status, err := r.Post(url, in, out)
 	if err != nil {
 		return
 	}
@@ -174,7 +174,7 @@ func (r *Client) post(path string, in interface{}, out interface{}) (err error) 
 
 // Build and set the transport as needed.
 func (c *Client) buildTransport() (err error) {
-	if c.Transport != nil || !Settings.PolicyAgent.Enabled() {
+	if c.Transport != nil || !Settings.Enabled() {
 		return
 	}
 	transport := &http.Transport{
@@ -428,7 +428,7 @@ func (r *Pool) Backlog() int {
 
 // Number of workers.
 func (r *Pool) parallel() (limit int) {
-	limit = Settings.PolicyAgent.Limit.Worker
+	limit = Settings.Limit.Worker
 	if limit < 1 {
 		limit = 1
 	}

--- a/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
+++ b/pkg/forklift-api/webhooks/validating-webhook/admitters/plan-admitter.go
@@ -168,8 +168,8 @@ func (admitter *PlanAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv
 		return util.ToAdmissionResponseError(err)
 	}
 
-	admitter.plan.Referenced.Provider.Source = &admitter.sourceProvider
-	admitter.plan.Referenced.Provider.Destination = &admitter.destinationProvider
+	admitter.plan.Provider.Source = &admitter.sourceProvider
+	admitter.plan.Provider.Destination = &admitter.destinationProvider
 
 	if admitter.destinationProvider.IsHost() {
 		// Check whether the user has permission to create VMs in the target namespace

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -324,7 +324,7 @@ func getRecorder(kubeClient kubernetes.Interface, controllerName string) record.
 
 func (c *controller) addNotification(keyToCall, objType, namespace, name string) {
 	var key string
-	if 0 == len(namespace) {
+	if len(namespace) == 0 {
 		key = objType + "/" + name
 	} else {
 		key = objType + "/" + namespace + "/" + name
@@ -358,7 +358,7 @@ func (c *controller) cleanupNotifications(keyToCall string) {
 			continue
 		}
 		delete(t.set, keyToCall)
-		if 0 == len(t.set) {
+		if len(t.set) == 0 {
 			delete(c.notifyMap, key)
 		}
 	}
@@ -508,7 +508,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 	if dataSourceRef.APIGroup != nil {
 		apiGroup = *dataSourceRef.APIGroup
 	}
-	if c.gk.Group != apiGroup || c.gk.Kind != dataSourceRef.Kind || "" == dataSourceRef.Name {
+	if c.gk.Group != apiGroup || c.gk.Kind != dataSourceRef.Kind || dataSourceRef.Name == "" {
 		// Ignore PVCs that aren't for this populator to handle
 		return nil
 	}
@@ -604,7 +604,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 	// *** Here is the first place we start to create/modify objects ***
 
 	// If the PVC is unbound, we need to perform the population
-	if "" == pvc.Spec.VolumeName {
+	if pvc.Spec.VolumeName == "" {
 
 		// Record start time for populator metric
 		c.metrics.operationStart(pvc.UID)
@@ -682,7 +682,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 			} else if sa, ok := pvc.Annotations[AnnPopulatorServiceAccount]; ok && sa != "" {
 				pod.Spec.ServiceAccountName = sa // Other populators use the annotation
 			}
-			pod.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName = pvcPrimeName
+			pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcPrimeName
 			con := &pod.Spec.Containers[0]
 			con.Image = c.imageName
 			con.Args = args

--- a/pkg/lib-volume-populator/populator-machinery/metrics.go
+++ b/pkg/lib-volume-populator/populator-machinery/metrics.go
@@ -159,7 +159,7 @@ func (pl promklog) Println(v ...interface{}) {
 }
 
 func (m *metricsManager) startListener(httpEndpoint, metricsPath string) {
-	if "" == httpEndpoint || "" == metricsPath {
+	if httpEndpoint == "" || metricsPath == "" {
 		return
 	}
 

--- a/pkg/lib/aap/client_test.go
+++ b/pkg/lib/aap/client_test.go
@@ -29,15 +29,15 @@ func TestClientResolveAPIPrefixFromGetAPI(t *testing.T) {
 	apiRootHits := 0
 	jtHits := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/" || r.URL.Path == "/api":
+		switch r.URL.Path {
+		case "/api/", "/api":
 			if r.Method != http.MethodGet {
 				t.Fatalf("expected GET, got %s", r.Method)
 			}
 			apiRootHits++
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"current_version": "/api/v2/"}`))
-		case r.URL.Path == "/api/v2/job_templates/":
+		case "/api/v2/job_templates/":
 			jtHits++
 			if r.Method != http.MethodGet {
 				t.Fatalf("expected GET, got %s", r.Method)

--- a/pkg/lib/client/openshift/client.go
+++ b/pkg/lib/client/openshift/client.go
@@ -38,7 +38,7 @@ func RestCfg(p *api.Provider, secret *core.Secret) *rest.Config {
 	}
 
 	if !insecure && hasCACert {
-		cfg.TLSClientConfig.CAData = cacert
+		cfg.CAData = cacert
 	}
 
 	cfg.Burst = 1000

--- a/pkg/lib/client/openshift/client_test.go
+++ b/pkg/lib/client/openshift/client_test.go
@@ -92,12 +92,12 @@ func TestRestCfg(t *testing.T) {
 				t.Fatalf("Expected non-nil config")
 			}
 
-			if config != nil && config.TLSClientConfig.Insecure != tc.expectedInsecure {
-				t.Errorf("Expected TLSClientConfig.Insecure to be %v, got %v", tc.expectedInsecure, config.TLSClientConfig.Insecure)
+			if config != nil && config.Insecure != tc.expectedInsecure {
+				t.Errorf("Expected TLSClientConfig.Insecure to be %v, got %v", tc.expectedInsecure, config.Insecure)
 			}
 
-			if config != nil && string(config.TLSClientConfig.CAData) != string(tc.expectedCAData) {
-				t.Errorf("Expected TLSClientConfig.CAData to be %s, got %s", string(tc.expectedCAData), string(config.TLSClientConfig.CAData))
+			if config != nil && string(config.CAData) != string(tc.expectedCAData) {
+				t.Errorf("Expected TLSClientConfig.CAData to be %s, got %s", string(tc.expectedCAData), string(config.CAData))
 			}
 		})
 	}

--- a/pkg/lib/cmd/inventory/main.go
+++ b/pkg/lib/cmd/inventory/main.go
@@ -136,7 +136,7 @@ func (h Endpoint) Get(ctx *gin.Context) {
 
 func (h Endpoint) List(ctx *gin.Context) {
 	// Watch request.
-	h.Watched.Prepare(ctx)
+	h.Prepare(ctx)
 	if h.WatchRequest {
 		err := h.Watch(
 			ctx,

--- a/pkg/lib/condition/condition_test.go
+++ b/pkg/lib/condition/condition_test.go
@@ -61,7 +61,7 @@ func TestCondition_Update(t *testing.T) {
 	condB.staged = true
 
 	// Validation
-	g.Expect(LastTransitionTime).NotTo(gomega.Equal(nil))
+	g.Expect(LastTransitionTime).NotTo(gomega.BeNil())
 	g.Expect(condA.staged).To(gomega.BeTrue())
 	g.Expect(condA).To(gomega.Equal(condB))
 }
@@ -141,7 +141,7 @@ func TestConditions_SetCondition(t *testing.T) {
 	conditions.List[0].LastTransitionTime = now // for comparison in validation.
 
 	// Validation
-	g.Expect(LastTransitionTime).NotTo(gomega.Equal(nil))
+	g.Expect(LastTransitionTime).NotTo(gomega.BeNil())
 	g.Expect(conditions.List).To(
 		gomega.Equal([]Condition{
 			{
@@ -159,7 +159,7 @@ func TestConditions_SetCondition(t *testing.T) {
 	conditions.SetCondition(condition)
 
 	// Validation
-	g.Expect(len(conditions.List)).To(gomega.Equal(1))
+	g.Expect(conditions.List).To(gomega.HaveLen(1))
 	g.Expect(conditions.List).To(
 		gomega.Equal([]Condition{
 			{
@@ -407,10 +407,10 @@ func TestConditions_ChangeSet(t *testing.T) {
 	conditions.EndStagingConditions()
 	explain := conditions.Explain()
 
-	g.Expect(len(explain.Added)).To(gomega.Equal(1))
+	g.Expect(explain.Added).To(gomega.HaveLen(1))
 	g.Expect(explain.Added["E"].Type).To(gomega.Equal("E"))
-	g.Expect(len(explain.Updated)).To(gomega.Equal(1))
+	g.Expect(explain.Updated).To(gomega.HaveLen(1))
 	g.Expect(explain.Updated["A"].Type).To(gomega.Equal("A"))
-	g.Expect(len(explain.Deleted)).To(gomega.Equal(1))
+	g.Expect(explain.Deleted).To(gomega.HaveLen(1))
 	g.Expect(explain.Deleted["D"].Type).To(gomega.Equal("D"))
 }

--- a/pkg/lib/error/error_test.go
+++ b/pkg/lib/error/error_test.go
@@ -13,26 +13,26 @@ func TestError(t *testing.T) {
 
 	err := errors.New("failed")
 	le := Wrap(err).(*Error)
-	g.Expect(le).NotTo(gomega.BeNil())
+	g.Expect(le).To(gomega.HaveOccurred())
 	g.Expect(le.wrapped).To(gomega.Equal(err))
-	g.Expect(len(le.stack)).To(gomega.Equal(4))
+	g.Expect(le.stack).To(gomega.HaveLen(4))
 	g.Expect(le.Error()).To(gomega.Equal(err.Error()))
 	g.Expect(le.Context()).To(gomega.BeNil())
 
 	le2 := Wrap(err).(*Error)
-	g.Expect(le2).NotTo(gomega.BeNil())
+	g.Expect(le2).To(gomega.HaveOccurred())
 	g.Expect(le2.wrapped).To(gomega.Equal(err))
-	g.Expect(len(le2.stack)).To(gomega.Equal(4))
+	g.Expect(le2.stack).To(gomega.HaveLen(4))
 	g.Expect(le2.Error()).To(gomega.Equal(err.Error()))
 
 	wrapped := errors2.Wrap(err, "help")
 	le3 := Wrap(wrapped).(*Error)
-	g.Expect(le3).NotTo(gomega.BeNil())
+	g.Expect(le3).To(gomega.HaveOccurred())
 	g.Expect(le3.wrapped).To(gomega.Equal(wrapped))
 	g.Expect(le3.wrapped).To(gomega.Equal(wrapped))
-	g.Expect(len(le3.stack)).To(gomega.Equal(4))
+	g.Expect(le3.stack).To(gomega.HaveLen(4))
 	g.Expect(errors.Unwrap(le3)).To(gomega.Equal(err))
-	g.Expect(len(le3.Context())).To(gomega.Equal(0))
+	g.Expect(le3.Context()).To(gomega.BeEmpty())
 	g.Expect(le3.Error()).To(gomega.Equal("help: failed"))
 
 	le4 := Wrap(
@@ -63,17 +63,17 @@ func TestNew(t *testing.T) {
 		"name", "Elmer",
 		"age", 10)
 	le := err.(*Error)
-	g.Expect(le).NotTo(gomega.BeNil())
-	g.Expect(len(le.stack)).To(gomega.Equal(5))
+	g.Expect(le).To(gomega.HaveOccurred())
+	g.Expect(le.stack).To(gomega.HaveLen(5))
 	g.Expect(le.Error()).To(gomega.Equal(err.Error()))
-	g.Expect(len(le.Context())).To(gomega.Equal(4))
+	g.Expect(le.Context()).To(gomega.HaveLen(4))
 }
 
 func TestUnwrap(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	err := errors.New("failed")
 	g.Expect(err).To(gomega.Equal(Unwrap(err)))
-	g.Expect(Unwrap(nil)).To(gomega.BeNil())
+	g.Expect(Unwrap(nil)).To(gomega.Succeed())
 	g.Expect(Unwrap(Wrap(err))).To(gomega.Equal(err))
 	g.Expect(Unwrap(errors2.Wrap(err, ""))).To(gomega.Equal(err))
 	g.Expect(Unwrap(errors2.Wrap(errors2.Wrap(err, ""), ""))).To(gomega.Equal(err))

--- a/pkg/lib/filebacked/catalog.go
+++ b/pkg/lib/filebacked/catalog.go
@@ -23,7 +23,7 @@ func (r *Catalog) add(object interface{}) (kind uint16) {
 	defer r.Unlock()
 	ot := reflect.TypeOf(object)
 	ov := reflect.ValueOf(object)
-	if reflect.TypeOf(object).Kind() == reflect.Ptr {
+	if reflect.TypeOf(object).Kind() == reflect.Pointer {
 		ot = ot.Elem()
 		ov = ov.Elem()
 	}

--- a/pkg/lib/filebacked/list_test.go
+++ b/pkg/lib/filebacked/list_test.go
@@ -55,7 +55,7 @@ func TestList(t *testing.T) {
 	for i := 0; i < len(input); i++ {
 		list.Append(input[i])
 	}
-	g.Expect(len(cat.content)).To(gomega.Equal(2))
+	g.Expect(cat.content).To(gomega.HaveLen(2))
 	g.Expect(list.Len()).To(gomega.Equal(len(input)))
 
 	// iterate

--- a/pkg/lib/inventory/model/field.go
+++ b/pkg/lib/inventory/model/field.go
@@ -369,7 +369,7 @@ func (f *Field) Incremented() bool {
 func (f *Field) AsValue(object interface{}) (value interface{}, err error) {
 	val := reflect.ValueOf(object)
 	switch val.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		val = val.Elem()
 	case reflect.Struct,
 		reflect.Slice,

--- a/pkg/lib/inventory/model/inspect.go
+++ b/pkg/lib/inventory/model/inspect.go
@@ -112,7 +112,7 @@ func (r *Definition) IsKind(kind string) bool {
 // Get the table name for the model.
 func (r Definition) kind(model interface{}) string {
 	mt := reflect.TypeOf(model)
-	if mt.Kind() == reflect.Ptr {
+	if mt.Kind() == reflect.Pointer {
 		mt = mt.Elem()
 	}
 
@@ -139,7 +139,7 @@ func (r *Definition) validate() (err error) {
 func (r *Definition) fields(model interface{}) (fields []*Field, err error) {
 	mt := reflect.TypeOf(model)
 	mv := reflect.ValueOf(model)
-	if mt.Kind() == reflect.Ptr {
+	if mt.Kind() == reflect.Pointer {
 		mt = mt.Elem()
 		mv = mv.Elem()
 	} else {
@@ -208,7 +208,7 @@ func (r *Definition) fields(model interface{}) (fields []*Field, err error) {
 // New model for kind.
 func (r *Definition) NewModel() (m interface{}) {
 	mt := reflect.TypeOf(r.model)
-	if mt.Kind() == reflect.Ptr {
+	if mt.Kind() == reflect.Pointer {
 		mt = mt.Elem()
 	}
 	m = reflect.New(mt).Interface()

--- a/pkg/lib/inventory/model/model.go
+++ b/pkg/lib/inventory/model/model.go
@@ -43,7 +43,7 @@ type Page struct {
 func (p *Page) Slice(collection interface{}) {
 	v := reflect.ValueOf(collection)
 	switch v.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		v = v.Elem()
 	default:
 		return
@@ -94,7 +94,7 @@ func Clone(model Model) Model {
 	mt := reflect.TypeOf(model)
 	mv := reflect.ValueOf(model)
 	switch mt.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		mt = mt.Elem()
 		mv = mv.Elem()
 	}

--- a/pkg/lib/inventory/model/model_test.go
+++ b/pkg/lib/inventory/model/model_test.go
@@ -213,7 +213,7 @@ func (w *MutatingHandler) Parity() {
 }
 
 func (w *MutatingHandler) Created(e Event) {
-	tx, _ := w.DB.Begin()
+	tx, _ := w.Begin()
 	tx.Get(e.Model)
 	e.Model.(*TestObject).Age++
 	_ = tx.Update(e.Model)
@@ -227,7 +227,7 @@ func (w *MutatingHandler) Updated(e Event) {
 		// ignore the echo event.
 		return
 	}
-	tx, _ := w.DB.Begin(label)
+	tx, _ := w.Begin(label)
 	tx.Get(e.Model)
 	e.Model.(*TestObject).Age++
 	_ = tx.Update(e.Model)
@@ -354,7 +354,7 @@ func TestCRUD(t *testing.T) {
 				Parent: a.PK,
 				Name:   k,
 			}
-			g.Expect(DB.Get(l)).To(gomega.BeNil())
+			g.Expect(DB.Get(l)).To(gomega.Succeed())
 			g.Expect(v).To(gomega.Equal(l.Value))
 		}
 	}
@@ -514,7 +514,7 @@ func TestCascade(t *testing.T) {
 	for len(handler.deleted) != wantDeleted && time.Now().Before(deadline) {
 		time.Sleep(5 * time.Millisecond)
 	}
-	g.Expect(len(handler.deleted)).To(gomega.Equal(wantDeleted))
+	g.Expect(handler.deleted).To(gomega.HaveLen(wantDeleted))
 
 }
 
@@ -646,7 +646,7 @@ func TestList(t *testing.T) {
 	list := []TestObject{}
 	err = DB.List(&list, ListOptions{})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(10))
+	g.Expect(list).To(gomega.HaveLen(10))
 	g.Expect(list[0].Name).To(gomega.Equal(""))
 	g.Expect(list[0].Slice).To(gomega.BeNil())
 	g.Expect(list[0].D1).To(gomega.Equal(""))
@@ -657,7 +657,7 @@ func TestList(t *testing.T) {
 	list = []TestObject{}
 	err = DB.List(&list, ListOptions{Detail: 1})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(10))
+	g.Expect(list).To(gomega.HaveLen(10))
 	g.Expect(list[0].Name).To(gomega.Equal(""))
 	g.Expect(list[0].Slice).To(gomega.BeNil())
 	g.Expect(list[0].D1).To(gomega.Equal("d-1"))
@@ -668,7 +668,7 @@ func TestList(t *testing.T) {
 	list = []TestObject{}
 	err = DB.List(&list, ListOptions{Detail: 2})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(10))
+	g.Expect(list).To(gomega.HaveLen(10))
 	g.Expect(list[0].Name).To(gomega.Equal(""))
 	g.Expect(list[0].Slice).To(gomega.BeNil())
 	g.Expect(list[0].D1).To(gomega.Equal("d-1"))
@@ -679,7 +679,7 @@ func TestList(t *testing.T) {
 	list = []TestObject{}
 	err = DB.List(&list, ListOptions{Detail: 3})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(10))
+	g.Expect(list).To(gomega.HaveLen(10))
 	g.Expect(list[0].Name).To(gomega.Equal(""))
 	g.Expect(list[0].Slice).To(gomega.BeNil())
 	g.Expect(list[0].D1).To(gomega.Equal("d-1"))
@@ -690,7 +690,7 @@ func TestList(t *testing.T) {
 	list = []TestObject{}
 	err = DB.List(&list, ListOptions{Detail: 4})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(10))
+	g.Expect(list).To(gomega.HaveLen(10))
 	g.Expect(list[0].Name).To(gomega.Equal(""))
 	g.Expect(list[0].Slice).To(gomega.BeNil())
 	g.Expect(list[0].D1).To(gomega.Equal("d-1"))
@@ -701,9 +701,9 @@ func TestList(t *testing.T) {
 	list = []TestObject{}
 	err = DB.List(&list, ListOptions{Detail: MaxDetail})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(10))
+	g.Expect(list).To(gomega.HaveLen(10))
 	g.Expect(list[0].Name).To(gomega.Equal("Elmer"))
-	g.Expect(len(list[0].Slice)).To(gomega.Equal(2))
+	g.Expect(list[0].Slice).To(gomega.HaveLen(2))
 	g.Expect(list[0].D1).To(gomega.Equal("d-1"))
 	g.Expect(list[0].D2).To(gomega.Equal("d-2"))
 	g.Expect(list[0].D3).To(gomega.Equal("d-3"))
@@ -716,7 +716,7 @@ func TestList(t *testing.T) {
 			Predicate: Eq("ID", 0),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(1))
+	g.Expect(list).To(gomega.HaveLen(1))
 	g.Expect(list[0].ID).To(gomega.Equal(0))
 	// List = (multiple).
 	list = []TestObject{}
@@ -726,7 +726,7 @@ func TestList(t *testing.T) {
 			Predicate: Eq("ID", []int{2, 4}),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list).To(gomega.HaveLen(2))
 	g.Expect(list[0].ID).To(gomega.Equal(2))
 	g.Expect(list[1].ID).To(gomega.Equal(4))
 	// List != AND
@@ -743,7 +743,7 @@ func TestList(t *testing.T) {
 				Neq("ID", 9)),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(5))
+	g.Expect(list).To(gomega.HaveLen(5))
 	g.Expect(list[0].ID).To(gomega.Equal(0))
 	g.Expect(list[1].ID).To(gomega.Equal(2))
 	g.Expect(list[2].ID).To(gomega.Equal(4))
@@ -759,7 +759,7 @@ func TestList(t *testing.T) {
 				Eq("ID", 6)),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list).To(gomega.HaveLen(2))
 	g.Expect(list[0].ID).To(gomega.Equal(0))
 	g.Expect(list[1].ID).To(gomega.Equal(6))
 	// List < (lt).
@@ -770,7 +770,7 @@ func TestList(t *testing.T) {
 			Predicate: Lt("ID", 2),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list).To(gomega.HaveLen(2))
 	g.Expect(list[0].ID).To(gomega.Equal(0))
 	g.Expect(list[1].ID).To(gomega.Equal(1))
 	// List > (gt).
@@ -781,7 +781,7 @@ func TestList(t *testing.T) {
 			Predicate: Gt("ID", 7),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list).To(gomega.HaveLen(2))
 	g.Expect(list[0].ID).To(gomega.Equal(8))
 	g.Expect(list[1].ID).To(gomega.Equal(9))
 	// List > (gt) virtual.
@@ -793,7 +793,7 @@ func TestList(t *testing.T) {
 			Detail:    MaxDetail,
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(N / 2))
+	g.Expect(list).To(gomega.HaveLen(N / 2))
 	g.Expect(list[0].RowID).To(gomega.Equal(int64(N/2) + 1))
 	// List (Eq) Field values.
 	list = []TestObject{}
@@ -804,7 +804,7 @@ func TestList(t *testing.T) {
 			Detail:    MaxDetail,
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(1))
+	g.Expect(list).To(gomega.HaveLen(1))
 	g.Expect(list[0].RowID).To(gomega.Equal(int64(8)))
 	// List (nEq) Field values.
 	list = []TestObject{}
@@ -814,7 +814,7 @@ func TestList(t *testing.T) {
 			Predicate: Neq("RowID", Field{Name: "int8"}),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(N - 1))
+	g.Expect(list).To(gomega.HaveLen(N - 1))
 	// List (Lt) Field values.
 	list = []TestObject{}
 	err = DB.List(
@@ -823,7 +823,7 @@ func TestList(t *testing.T) {
 			Predicate: Lt("int8", Field{Name: "int16"}),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(N))
+	g.Expect(list).To(gomega.HaveLen(N))
 	// List (Gt) Field values.
 	list = []TestObject{}
 	err = DB.List(
@@ -832,7 +832,7 @@ func TestList(t *testing.T) {
 			Predicate: Gt("RowID", Field{Name: "int8"}),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list).To(gomega.HaveLen(2))
 	// By label.
 	list = []TestObject{}
 	err = DB.List(
@@ -844,7 +844,7 @@ func TestList(t *testing.T) {
 				Eq("ID", 8)),
 		})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(2))
+	g.Expect(list).To(gomega.HaveLen(2))
 	g.Expect(list[0].ID).To(gomega.Equal(4))
 	g.Expect(list[1].ID).To(gomega.Equal(8))
 	// Test count all.
@@ -902,7 +902,7 @@ func TestFind(t *testing.T) {
 			break
 		}
 	}
-	g.Expect(len(list)).To(gomega.Equal(10))
+	g.Expect(list).To(gomega.HaveLen(10))
 	// List all; detail level=0
 	itr, err = DB.Find(
 		&TestObject{},
@@ -1131,7 +1131,7 @@ func TestWatch(t *testing.T) {
 			break
 		}
 	}
-	g.Expect(len(watchA.journal.watches)).To(gomega.Equal(0))
+	g.Expect(watchA.journal.watches).To(gomega.BeEmpty())
 	g.Expect(ended).To(gomega.BeTrue())
 	g.Expect(handlerA.done).To(gomega.BeTrue())
 	g.Expect(handlerB.done).To(gomega.BeTrue())

--- a/pkg/lib/inventory/model/table.go
+++ b/pkg/lib/inventory/model/table.go
@@ -488,7 +488,7 @@ func (t Table) List(list interface{}, options ListOptions) (err error) {
 	lt := reflect.TypeOf(list)
 	lv := reflect.ValueOf(list)
 	switch lt.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		lt = lt.Elem()
 		lv = lv.Elem()
 	default:

--- a/pkg/lib/inventory/web/client.go
+++ b/pkg/lib/inventory/web/client.go
@@ -438,7 +438,7 @@ func (r *WatchReader) clone(in interface{}) (out interface{}) {
 	mt := reflect.TypeOf(in)
 	mv := reflect.ValueOf(in)
 	switch mt.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		mt = mt.Elem()
 		mv = mv.Elem()
 	}

--- a/pkg/lib/itinerary/simple.go
+++ b/pkg/lib/itinerary/simple.go
@@ -154,12 +154,12 @@ func (r *Itinerary) hasAny(step Step) (pTrue bool, err error) {
 		pTrue = true
 		return
 	}
-	for i := 0; i < r.Predicate.Count(); i++ {
+	for i := 0; i < r.Count(); i++ {
 		flag := Flag(1 << i)
 		if (step.Any & flag) == 0 {
 			continue
 		}
-		pTrue, err = r.Predicate.Evaluate(flag)
+		pTrue, err = r.Evaluate(flag)
 		if pTrue || err != nil {
 			return
 		}
@@ -175,12 +175,12 @@ func (r *Itinerary) hasAll(step Step) (pTrue bool, err error) {
 		pTrue = true
 		return
 	}
-	for i := 0; i < r.Predicate.Count(); i++ {
+	for i := 0; i < r.Count(); i++ {
 		flag := Flag(1 << i)
 		if (step.All & flag) == 0 {
 			continue
 		}
-		pTrue, err = r.Predicate.Evaluate(flag)
+		pTrue, err = r.Evaluate(flag)
 		if !pTrue || err != nil {
 			return
 		}

--- a/pkg/lib/itinerary/simple_test.go
+++ b/pkg/lib/itinerary/simple_test.go
@@ -152,7 +152,7 @@ func TestList(t *testing.T) {
 
 	list, err := itinerary.List()
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(len(list)).To(gomega.Equal(3))
+	g.Expect(list).To(gomega.HaveLen(3))
 	g.Expect(list[0].Name).To(gomega.Equal("ONE"))
 	g.Expect(list[1].Name).To(gomega.Equal("TWO"))
 	g.Expect(list[2].Name).To(gomega.Equal("THREE"))

--- a/pkg/lib/ref/predicate.go
+++ b/pkg/lib/ref/predicate.go
@@ -88,7 +88,7 @@ func (r *EventMapper) findRefs(object interface{}) []Target {
 	list := []Target{}
 	rt := reflect.TypeOf(object)
 	rv := reflect.ValueOf(object)
-	if rt.Kind() == reflect.Ptr {
+	if rt.Kind() == reflect.Pointer {
 		rt = rt.Elem()
 		rv = rv.Elem()
 	}

--- a/pkg/lib/ref/ref_test.go
+++ b/pkg/lib/ref/ref_test.go
@@ -60,7 +60,7 @@ func TestFindRefs(t *testing.T) {
 	aRefs := mapper.findRefs(thing)
 
 	// Validation
-	g.Expect(len(aRefs)).To(gomega.Equal(2))
+	g.Expect(aRefs).To(gomega.HaveLen(2))
 }
 
 func TestMapperCreate(t *testing.T) {
@@ -112,7 +112,7 @@ func TestMapperCreate(t *testing.T) {
 		Namespace: "nsB",
 		Name:      "thingB",
 	}
-	g.Expect(len(m.Content)).To(gomega.Equal(2))
+	g.Expect(m.Content).To(gomega.HaveLen(2))
 	g.Expect(m.Match(targetA, owner)).To(gomega.BeTrue())
 	g.Expect(m.Match(targetB, owner)).To(gomega.BeTrue())
 }
@@ -190,7 +190,7 @@ func TestMapperUpdate(t *testing.T) {
 		Namespace: "nsC",
 		Name:      "thingC",
 	}
-	g.Expect(len(m.Content)).To(gomega.Equal(2))
+	g.Expect(m.Content).To(gomega.HaveLen(2))
 	g.Expect(m.Match(targetA, owner)).To(gomega.BeFalse())
 	g.Expect(m.Match(targetB, owner)).To(gomega.BeTrue())
 	g.Expect(m.Match(targetC, owner)).To(gomega.BeTrue())
@@ -242,7 +242,7 @@ func TestMapperDelete(t *testing.T) {
 		Namespace: "nsB",
 		Name:      "thingB",
 	}
-	g.Expect(len(m.Content)).To(gomega.Equal(2))
+	g.Expect(m.Content).To(gomega.HaveLen(2))
 	g.Expect(m.Match(targetA, owner)).To(gomega.BeTrue())
 	g.Expect(m.Match(targetB, owner)).To(gomega.BeTrue())
 
@@ -253,7 +253,7 @@ func TestMapperDelete(t *testing.T) {
 		})
 
 	// Validation
-	g.Expect(len(m.Content)).To(gomega.Equal(0))
+	g.Expect(m.Content).To(gomega.BeEmpty())
 }
 
 func TestHandler(t *testing.T) {
@@ -304,5 +304,5 @@ func TestHandler(t *testing.T) {
 		target,
 	)
 
-	g.Expect(len(list)).To(gomega.Equal(1))
+	g.Expect(list).To(gomega.HaveLen(1))
 }

--- a/pkg/provider/ec2/controller/builder/volumes.go
+++ b/pkg/provider/ec2/controller/builder/volumes.go
@@ -93,8 +93,8 @@ func (r *Builder) calculatePVCSize(volumeSizeBytes int64, volumeMode *core.Persi
 // ResolvePersistentVolumeClaimIdentifier extracts the EBS volume ID from a PVC's annotations.
 // Enables tracking which PVC corresponds to which source EBS volume.
 func (r *Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVolumeClaim) string {
-	if pvc.ObjectMeta.Annotations != nil {
-		return pvc.ObjectMeta.Annotations["forklift.konveyor.io/volume-id"]
+	if pvc.Annotations != nil {
+		return pvc.Annotations["forklift.konveyor.io/volume-id"]
 	}
 	return ""
 }

--- a/pkg/provider/ec2/controller/ensurer/volumes.go
+++ b/pkg/provider/ec2/controller/ensurer/volumes.go
@@ -21,7 +21,7 @@ func (r *Ensurer) EnsurePersistentVolumes(ctx context.Context, vm *planapi.VMSta
 	// List existing PVs by label
 	existingPVList := &core.PersistentVolumeList{}
 	vmLabels := r.Labeler.MigrationVMLabels(vm.Ref)
-	err := r.Client.List(ctx, existingPVList, &client.ListOptions{
+	err := r.List(ctx, existingPVList, &client.ListOptions{
 		LabelSelector: k8slabels.SelectorFromSet(vmLabels),
 	})
 	if err != nil {
@@ -53,7 +53,7 @@ func (r *Ensurer) EnsurePersistentVolumes(ctx context.Context, vm *planapi.VMSta
 		}
 
 		// Create new PV
-		err = r.Client.Create(ctx, pv)
+		err = r.Create(ctx, pv)
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
 				// Race condition: another reconcile created it
@@ -62,7 +62,7 @@ func (r *Ensurer) EnsurePersistentVolumes(ctx context.Context, vm *planapi.VMSta
 					"ebsVolumeID", ebsVolumeID)
 				// Fetch the created PV to get its name
 				freshPVList := &core.PersistentVolumeList{}
-				listErr := r.Client.List(ctx, freshPVList, &client.ListOptions{
+				listErr := r.List(ctx, freshPVList, &client.ListOptions{
 					LabelSelector: k8slabels.SelectorFromSet(map[string]string{
 						"forklift.konveyor.io/ebs-volume-id": ebsVolumeID,
 					}),
@@ -99,7 +99,7 @@ func (r *Ensurer) EnsureDirectPVCs(ctx context.Context, vm *planapi.VMStatus, pv
 	// List existing PVCs by label
 	existingPVCList := &core.PersistentVolumeClaimList{}
 	vmLabels := r.Labeler.MigrationVMLabels(vm.Ref)
-	err := r.Client.List(ctx, existingPVCList, &client.ListOptions{
+	err := r.List(ctx, existingPVCList, &client.ListOptions{
 		Namespace:     r.Plan.Spec.TargetNamespace,
 		LabelSelector: k8slabels.SelectorFromSet(vmLabels),
 	})
@@ -131,13 +131,13 @@ func (r *Ensurer) EnsureDirectPVCs(ctx context.Context, vm *planapi.VMStatus, pv
 		}
 
 		// Set owner reference to the plan for cleanup
-		err = controllerutil.SetOwnerReference(r.Plan, pvc, r.Client.Scheme())
+		err = controllerutil.SetOwnerReference(r.Plan, pvc, r.Scheme())
 		if err != nil {
 			r.log.Error(err, "Failed to set owner reference on PVC", "vm", vm.Name)
 		}
 
 		// Create new PVC
-		err = r.Client.Create(ctx, pvc)
+		err = r.Create(ctx, pvc)
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
 				r.log.V(1).Info("PVC created by another reconcile",
@@ -169,7 +169,7 @@ func (r *Ensurer) CheckDirectPVCsBound(ctx context.Context, vm *planapi.VMStatus
 	// List existing PVCs by label
 	existingPVCList := &core.PersistentVolumeClaimList{}
 	vmLabels := r.Labeler.MigrationVMLabels(vm.Ref)
-	err = r.Client.List(ctx, existingPVCList, &client.ListOptions{
+	err = r.List(ctx, existingPVCList, &client.ListOptions{
 		Namespace:     r.Plan.Spec.TargetNamespace,
 		LabelSelector: k8slabels.SelectorFromSet(vmLabels),
 	})

--- a/pkg/provider/ec2/controller/migrator/core.go
+++ b/pkg/provider/ec2/controller/migrator/core.go
@@ -87,8 +87,8 @@ func (r *Migrator) Type() api.MigrationType {
 
 // Supported returns whether the plan's migration type is supported.
 func (r *Migrator) Supported() bool {
-	return r.Context.Plan.Spec.Type == api.MigrationCold ||
-		r.Context.Plan.Spec.Type == ""
+	return r.Plan.Spec.Type == api.MigrationCold ||
+		r.Plan.Spec.Type == ""
 }
 
 // DestinationClient returns the destination client (not used for EC2).

--- a/pkg/provider/ec2/controller/validator/migration.go
+++ b/pkg/provider/ec2/controller/validator/migration.go
@@ -7,7 +7,7 @@ import (
 // MigrationType validates migration type. EC2 only supports cold migration (or empty/default).
 // Warm/live migration not supported - EC2 requires instance shutdown for consistent EBS snapshots.
 func (r *Validator) MigrationType() bool {
-	if r.Context.Plan.Spec.Type == "" || r.Context.Plan.Spec.Type == api.MigrationCold {
+	if r.Plan.Spec.Type == "" || r.Plan.Spec.Type == api.MigrationCold {
 		return true
 	}
 	return false

--- a/pkg/provider/ec2/controller/validator/validator_test.go
+++ b/pkg/provider/ec2/controller/validator/validator_test.go
@@ -169,18 +169,18 @@ var _ = Describe("EC2 Controller Validator", func() {
 
 	Describe("MigrationType", func() {
 		It("should return true for empty migration type", func() {
-			validator.Context.Plan.Spec.Type = ""
+			validator.Plan.Spec.Type = ""
 			Expect(validator.MigrationType()).To(BeTrue())
 		})
 
 		It("should return true for cold migration", func() {
-			validator.Context.Plan.Spec.Type = api.MigrationCold
+			validator.Plan.Spec.Type = api.MigrationCold
 			Expect(validator.MigrationType()).To(BeTrue())
 		})
 
 		table.DescribeTable("should return false for unsupported migration types",
 			func(migrationType api.MigrationType) {
-				validator.Context.Plan.Spec.Type = migrationType
+				validator.Plan.Spec.Type = migrationType
 				Expect(validator.MigrationType()).To(BeFalse())
 			},
 			table.Entry("warm migration", api.MigrationWarm),

--- a/pkg/provider/testutil/context.go
+++ b/pkg/provider/testutil/context.go
@@ -114,17 +114,17 @@ func (b *ContextBuilder) Build() *plancontext.Context {
 
 	// Set up provider reference in plan
 	if b.provider != nil {
-		plan.Referenced.Provider.Source = b.provider
+		plan.Provider.Source = b.provider
 	}
 
 	// Set up network map reference in plan
 	if b.networkMap != nil {
-		plan.Referenced.Map.Network = b.networkMap
+		plan.Map.Network = b.networkMap
 	}
 
 	// Set up storage map reference in plan
 	if b.storageMap != nil {
-		plan.Referenced.Map.Storage = b.storageMap
+		plan.Map.Storage = b.storageMap
 	}
 
 	// Build the context

--- a/pkg/provider/testutil/fixtures.go
+++ b/pkg/provider/testutil/fixtures.go
@@ -73,25 +73,25 @@ func (b *PlanBuilder) WithVMs(vms ...planapi.VM) *PlanBuilder {
 
 // WithSourceProvider sets the source provider reference.
 func (b *PlanBuilder) WithSourceProvider(provider *api.Provider) *PlanBuilder {
-	b.plan.Referenced.Provider.Source = provider
+	b.plan.Provider.Source = provider
 	return b
 }
 
 // WithDestinationProvider sets the destination provider reference.
 func (b *PlanBuilder) WithDestinationProvider(provider *api.Provider) *PlanBuilder {
-	b.plan.Referenced.Provider.Destination = provider
+	b.plan.Provider.Destination = provider
 	return b
 }
 
 // WithNetworkMap sets the network map reference.
 func (b *PlanBuilder) WithNetworkMap(networkMap *api.NetworkMap) *PlanBuilder {
-	b.plan.Referenced.Map.Network = networkMap
+	b.plan.Map.Network = networkMap
 	return b
 }
 
 // WithStorageMap sets the storage map reference.
 func (b *PlanBuilder) WithStorageMap(storageMap *api.StorageMap) *PlanBuilder {
-	b.plan.Referenced.Map.Storage = storageMap
+	b.plan.Map.Storage = storageMap
 	return b
 }
 

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -230,7 +230,7 @@ func (r *Migration) Load() (err error) {
 	}
 	if virtCustomizeConfigMap, ok := os.LookupEnv(VirtCustomizeConfigMap); ok {
 		r.VirtCustomizeConfigMap = virtCustomizeConfigMap
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtCustomizeConfigMap))
 	}
 	if val, found := os.LookupEnv(NAAOUIMapConfigMap); found {
@@ -244,15 +244,15 @@ func (r *Migration) Load() (err error) {
 	}
 	if virtV2vImage, ok := os.LookupEnv(VirtV2vImage); ok {
 		r.VirtV2vImage = virtV2vImage
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtV2vImage))
 	}
 	if virtV2vImageXFS, ok := os.LookupEnv(VirtV2vImageXFS); ok {
 		r.VirtV2vImageXFS = virtV2vImageXFS
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VirtV2vImageXFS))
 	}
-	if r.VirtV2vImageXFS == "" && Settings.Role.Has(MainRole) {
+	if r.VirtV2vImageXFS == "" && Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("environment variable %s was empty", VirtV2vImageXFS))
 	}
 	r.VirtV2vDontRequestKVM = getEnvBool(VirtV2vDontRequestKVM, false)
@@ -278,12 +278,12 @@ func (r *Migration) Load() (err error) {
 	}
 	if val, found := os.LookupEnv(OvirtOsConfigMap); found {
 		r.OvirtOsConfigMap = val
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", OvirtOsConfigMap))
 	}
 	if val, found := os.LookupEnv(VsphereOsConfigMap); found {
 		r.VsphereOsConfigMap = val
-	} else if Settings.Role.Has(MainRole) {
+	} else if Settings.Has(MainRole) {
 		return liberr.Wrap(fmt.Errorf("failed to find environment variable %s", VsphereOsConfigMap))
 	}
 	if r.VddkJobActiveDeadline, err = getPositiveEnvLimit(VddkJobActiveDeadline, 300); err != nil {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -133,8 +133,8 @@ func getEnvBool(name string, def bool) bool {
 // GetVDDKImage gets the VDDK image from provider spec settings with fall back to global settings.
 func GetVDDKImage(providerSpecSettings map[string]string) string {
 	vddkImage := providerSpecSettings[api.VDDK]
-	if vddkImage == "" && Settings.Migration.VddkImage != "" {
-		vddkImage = Settings.Migration.VddkImage
+	if vddkImage == "" && Settings.VddkImage != "" {
+		vddkImage = Settings.VddkImage
 	}
 
 	return vddkImage


### PR DESCRIPTION
Align local lint fixes with the golangci-lint GitHub Action upgrade in #5882

Most issues were resolved with `golangci-lint run --fix` (embedded-field selector simplifications, Ginkgo assertion style, formatting). Remaining findings were fixed manually where auto-fix did not apply.

Harder to fix errors like variable renames (ST1012) are intentionally left for a follow-up.