### PR TITLE
chore(ci): fix remaining golangci-lint v2 findings

### DIFF
--- a/cmd/hyperv-provider-server/main.go
+++ b/cmd/hyperv-provider-server/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "ok")
+		_, _ = fmt.Fprintln(w, "ok")
 	})
 
 	mux.HandleFunc("/validate-disks", validateDisksHandler(catalogPath))

--- a/cmd/openstack-populator/openstack-populator.go
+++ b/cmd/openstack-populator/openstack-populator.go
@@ -78,10 +78,10 @@ func downloadAndSaveImage(client *libclient.Client, config *AppConfig) {
 		klog.Fatal(err)
 	}
 
-	defer imageReader.Close()
+	defer func() { _ = imageReader.Close() }()
 
 	file := openFile(config.volumePath)
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	progressVec := createProgressCounter()
 	writeData(imageReader, file, config, progressVec)

--- a/cmd/openstack-populator/openstack-populator_test.go
+++ b/cmd/openstack-populator/openstack-populator_test.go
@@ -37,11 +37,11 @@ func setupMockServer() (*httptest.Server, string, int, error) {
                 ]
             }
         }`, baseURL)
-		fmt.Fprint(w, response)
+		_, _ = fmt.Fprint(w, response)
 	})
 
 	mux.HandleFunc("/v2/images/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `mock_data`)
+		_, _ = fmt.Fprintln(w, `mock_data`)
 	})
 
 	mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
@@ -116,7 +116,7 @@ func setupMockServer() (*httptest.Server, string, int, error) {
 			identityServer,
 			imageServiceURL)
 
-		fmt.Fprint(w, response)
+		_, _ = fmt.Fprint(w, response)
 	})
 
 	server := httptest.NewUnstartedServer(mux)
@@ -128,14 +128,14 @@ func setupMockServer() (*httptest.Server, string, int, error) {
 }
 
 func TestPopulate(t *testing.T) {
-	os.Setenv("username", "testuser")
-	os.Setenv("password", "testpassword")
-	os.Setenv("projectName", "Default")
-	os.Setenv("domainName", "Default")
-	os.Setenv("insecureSkipVerify", "true")
-	os.Setenv("availability", "public")
-	os.Setenv("regionName", "RegionOne")
-	os.Setenv("authType", "password")
+	t.Setenv("username", "testuser")
+	t.Setenv("password", "testpassword")
+	t.Setenv("projectName", "Default")
+	t.Setenv("domainName", "Default")
+	t.Setenv("insecureSkipVerify", "true")
+	t.Setenv("availability", "public")
+	t.Setenv("regionName", "RegionOne")
+	t.Setenv("authType", "password")
 
 	server, identityServerURL, port, err := setupMockServer()
 	if err != nil {
@@ -166,7 +166,7 @@ func TestPopulate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
 	}
-	defer file.Close() // Ensure the file is closed after reading
+	defer func() { _ = file.Close() }() // Ensure the file is closed after reading
 
 	content, err := io.ReadAll(file)
 	if err != nil {
@@ -177,5 +177,5 @@ func TestPopulate(t *testing.T) {
 		t.Errorf("Expected %s, got %s", "mock_data", string(content))
 	}
 
-	os.Remove(fileName)
+	_ = os.Remove(fileName)
 }

--- a/cmd/ovirt-populator/ovirt-populator.go
+++ b/cmd/ovirt-populator/ovirt-populator.go
@@ -78,7 +78,7 @@ func writeFile(filename, content string) {
 	if err != nil {
 		klog.Fatalf("Failed to create %s: %v", filename, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	if _, err := file.Write([]byte(content)); err != nil {
 		klog.Fatalf("Failed to write to %s: %v", filename, err)

--- a/cmd/virt-v2v-monitor/virt-v2v-monitor.go
+++ b/cmd/virt-v2v-monitor/virt-v2v-monitor.go
@@ -122,8 +122,8 @@ func main() {
 	scanner.Split(LimitedScanLines)
 	for scanner.Scan() {
 		line := scanner.Bytes()
-		os.Stdout.Write(line)
-		os.Stdout.Write([]byte("\n"))
+		_, _ = os.Stdout.Write(line)
+		_, _ = os.Stdout.Write([]byte("\n"))
 		err := scanner.Err()
 		if err != nil {
 			fmt.Println("virt-v2v monitoring: Output monitoring failed! ", err)

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/lib/itinerary/simple.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/lib/itinerary/simple.go
@@ -45,6 +45,8 @@ type Itinerary struct {
 }
 
 // Errors.
+//
+//nolint:staticcheck // legacy exported error name; rename in follow-up
 var (
 	StepNotFound = errors.New("step not found")
 )

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/lib/util/sshutils.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/lib/util/sshutils.go
@@ -116,7 +116,7 @@ func TestSSHConnectivity(ctx context.Context, hostIP string, privateKey []byte, 
 		return false
 	}
 	sshClient := ssh.NewClient(cc, chans, reqs)
-	defer sshClient.Close()
+	defer func() { _ = sshClient.Close() }()
 
 	log.V(3).Info("Connected to SSH server", "hostIP", hostIP)
 
@@ -128,7 +128,7 @@ func TestSSHConnectivity(ctx context.Context, hostIP string, privateKey []byte, 
 		log.V(2).Info("SSH connectivity test failed to create session", "hostIP", hostIP, "error", err)
 		return false
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	// Execute the status command with the provided datastore (or empty for connectivity test mode)
 	// Format: DS=<datastore>;CMD=<command>

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/lib/util/util.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/lib/util/util.go
@@ -29,7 +29,7 @@ func dialTLSWithTimeout(host string, cfg *tls.Config, timeout time.Duration) (*t
 	// Set handshake timeout
 	err = tlsConn.Handshake()
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 

--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/settings/migration.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/settings/migration.go
@@ -273,7 +273,7 @@ func (r *Migration) Load() (err error) {
 		if quantity, err := resource.ParseQuantity(overhead); err != nil {
 			return liberr.Wrap(err)
 		} else if r.BlockOverhead, ok = quantity.AsInt64(); !ok {
-			return fmt.Errorf("Block overhead is invalid: %s", overhead)
+			return fmt.Errorf("block overhead is invalid: %s", overhead)
 		}
 	}
 	if val, found := os.LookupEnv(OvirtOsConfigMap); found {

--- a/pkg/controller/base/controller.go
+++ b/pkg/controller/base/controller.go
@@ -165,7 +165,7 @@ func VerifyTLSConnection(rawURL string, secret *core.Secret) (*x509.Certificate,
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a secure TLS connection: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	return cert, nil
 }

--- a/pkg/controller/conversion/pipeline.go
+++ b/pkg/controller/conversion/pipeline.go
@@ -510,7 +510,7 @@ func (p *ConversionPipeline) signalPodShutdown(podIP string) {
 		p.r.Log.V(3).Info("Could not signal pod shutdown; it will be deleted by the controller.", "error", err.Error())
 		return
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 }
 
 // fetchInspectionResults calls GET /results on the deep-inspection pod and
@@ -522,7 +522,7 @@ func (p *ConversionPipeline) fetchInspectionResults(podIP string) (*api.Inspecti
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusServiceUnavailable {
 		return nil, nil //nolint:nilnil

--- a/pkg/controller/plan/adapter/ocp/builder.go
+++ b/pkg/controller/plan/adapter/ocp/builder.go
@@ -22,7 +22,6 @@ import (
 	libitr "github.com/kubev2v/forklift/pkg/lib/itinerary"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	core "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +80,7 @@ func (r *Builder) ConfigMap(vmRef ref.Ref, secret *core.Secret, object *core.Con
 }
 
 // DataVolumes implements base.Builder
-func (r *Builder) DataVolumes(vmRef ref.Ref, secret *v1.Secret, configMap *v1.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *v1.ConfigMap) (dvs []cdi.DataVolume, err error) {
+func (r *Builder) DataVolumes(vmRef ref.Ref, secret *core.Secret, configMap *core.ConfigMap, dvTemplate *cdi.DataVolume, vddkConfigMap *core.ConfigMap) (dvs []cdi.DataVolume, err error) {
 	vmExport := &export.VirtualMachineExport{}
 	key := client.ObjectKey{
 		Namespace: vmRef.Namespace,
@@ -294,7 +293,7 @@ func (r *Builder) TemplateLabels(vmRef ref.Ref) (labels map[string]string, err e
 }
 
 // VirtualMachine implements base.Builder
-func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []*v1.PersistentVolumeClaim, usesInstanceType bool, sortVolumesByLibvirt bool) error {
+func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim, usesInstanceType bool, sortVolumesByLibvirt bool) error {
 	sourceVm, err := r.getSourceVmFromDefinition(vmRef)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -520,7 +519,7 @@ func (r *Builder) mapNetworks(sourceVm *cnv.VirtualMachine, targetVmSpec *cnv.Vi
 
 // mapVolumes updates volume references from source PVC names to target (templated) PVC names.
 // It uses the AnnDiskSource annotation on target PVCs to map source PVC identifiers to target PVC names.
-func (r *Builder) mapVolumes(sourceVm *cnv.VirtualMachine, targetVmSpec *cnv.VirtualMachineSpec, persistentVolumeClaims []*v1.PersistentVolumeClaim) {
+func (r *Builder) mapVolumes(sourceVm *cnv.VirtualMachine, targetVmSpec *cnv.VirtualMachineSpec, persistentVolumeClaims []*core.PersistentVolumeClaim) {
 	// Build a map from source PVC identifier (namespace/name) to target PVC name
 	// using the AnnDiskSource annotation
 	pvcMap := make(map[string]string) // sourcePVCIdentifier -> targetPVCName
@@ -619,7 +618,7 @@ func (r *Builder) getSourceVmFromDefinition(vmRef ref.Ref) (*cnv.VirtualMachine,
 		return nil, liberr.New("failed to get vm manifest", "status", resp.StatusCode)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -633,7 +632,7 @@ func (r *Builder) getSourceVmFromDefinition(vmRef ref.Ref) (*cnv.VirtualMachine,
 	}
 
 	switch t := obj.(type) {
-	case *v1.List:
+	case *core.List:
 		for _, item := range t.Items {
 			decoded, _, err := decode(item.Raw, nil, nil)
 			if err != nil {
@@ -722,11 +721,11 @@ func (r *Builder) ConversionPodConfig(_ ref.Ref) (*planbase.ConversionPodConfigR
 	return &planbase.ConversionPodConfigResult{}, nil
 }
 
-func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]v1.PersistentVolumeClaim, error) {
+func (r *Builder) NetAppShiftPVCs(vmRef ref.Ref, labels map[string]string) ([]core.PersistentVolumeClaim, error) {
 	return nil, nil
 }
 
-func (r *Builder) CsiImportPVCs(_ ref.Ref, _ map[string]string) ([]v1.PersistentVolumeClaim, error) {
+func (r *Builder) CsiImportPVCs(_ ref.Ref, _ map[string]string) ([]core.PersistentVolumeClaim, error) {
 	return nil, nil
 }
 

--- a/pkg/controller/plan/adapter/openstack/client.go
+++ b/pkg/controller/plan/adapter/openstack/client.go
@@ -36,9 +36,12 @@ const (
 	VolumeStatusUploading = libclient.VolumeStatusUploading
 )
 
-var ResourceNotFoundError = errors.New("resource not found")
-var NameOrIDRequiredError = errors.New("id or name is required")
-var UnexpectedVolumeStatusError = errors.New("unexpected volume status")
+//nolint:staticcheck // legacy exported error names; rename in follow-up
+var (
+	ResourceNotFoundError       = errors.New("resource not found")
+	NameOrIDRequiredError       = errors.New("id or name is required")
+	UnexpectedVolumeStatusError = errors.New("unexpected volume status")
+)
 
 type Client struct {
 	libclient.Client

--- a/pkg/controller/plan/adapter/vsphere/inspectionparser.go
+++ b/pkg/controller/plan/adapter/vsphere/inspectionparser.go
@@ -81,7 +81,7 @@ func ParseInspectionFromString(xmlData string) (InspectionV2V, error) {
 	var xmlConf InspectionV2V
 	err := xml.Unmarshal([]byte(xmlData), &xmlConf)
 	if err != nil {
-		return InspectionV2V{}, fmt.Errorf("Error unmarshalling XML: %v\n", err)
+		return InspectionV2V{}, fmt.Errorf("error unmarshalling XML: %v", err)
 	}
 	return xmlConf, nil
 }

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -23,7 +23,6 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	core "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -488,12 +487,12 @@ func rootDiskExcluded(vm *model.VM, rootDiskSpec string, exclude []string) (bus 
 	return root.BusAddress, excluded
 }
 
-func (r *Validator) getUdnSubnet(client client.Client) (string, error) {
-	key := k8sclient.ObjectKey{
+func (r *Validator) getUdnSubnet(k8sClient client.Client) (string, error) {
+	key := client.ObjectKey{
 		Name: r.Plan.Spec.TargetNamespace,
 	}
 	namespace := &core.Namespace{}
-	err := client.Get(context.TODO(), key, namespace)
+	err := k8sClient.Get(context.TODO(), key, namespace)
 	if err != nil {
 		return "", err
 	}
@@ -503,12 +502,12 @@ func (r *Validator) getUdnSubnet(client client.Client) (string, error) {
 	}
 
 	nadList := &k8snet.NetworkAttachmentDefinitionList{}
-	listOpts := []k8sclient.ListOption{
-		k8sclient.InNamespace(r.Plan.Spec.TargetNamespace),
-		k8sclient.MatchingLabels{nadLabelUDN: ""},
+	listOpts := []client.ListOption{
+		client.InNamespace(r.Plan.Spec.TargetNamespace),
+		client.MatchingLabels{nadLabelUDN: ""},
 	}
 
-	err = client.List(context.TODO(), nadList, listOpts...)
+	err = k8sClient.List(context.TODO(), nadList, listOpts...)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -2446,7 +2446,7 @@ func (r *KubeVirt) getInspectionXml(pod *core.Pod) (string, error) {
 	if err != nil {
 		return "", liberr.Wrap(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	inspectionBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", liberr.Wrap(err)
@@ -2476,7 +2476,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 		}
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	vmConf, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -2523,7 +2523,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 	// Fetch warnings before shutting down
 	warningsURL := fmt.Sprintf("http://%s:8080/warnings", pod.Status.PodIP)
 	if resp, err = v2vHTTPClient.Get(warningsURL); err == nil {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode == http.StatusOK {
 			var body []byte
 			if resp.Body != nil {
@@ -2559,7 +2559,7 @@ func (r *KubeVirt) UpdateVmByConvertedConfig(vm *plan.VMStatus, pod *core.Pod, s
 	shutdownURL := fmt.Sprintf("http://%s:8080/shutdown", pod.Status.PodIP)
 	resp, err = v2vHTTPClient.Post(shutdownURL, "application/json", nil)
 	if err == nil {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 	} else {
 		// This error indicates that the server was shut down
 		if strings.Contains(err.Error(), "EOF") {

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -2299,7 +2299,7 @@ func (r *Migration) updateConversionProgressV2vMonitor(pod *core.Pod, step *plan
 	resp, err := http.Get(url)
 	switch {
 	case err == nil:
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 	case strings.Contains(err.Error(), "connection refused"):
 		return nil
 	default:

--- a/pkg/controller/provider/container/hyperv/client.go
+++ b/pkg/controller/provider/container/hyperv/client.go
@@ -1008,7 +1008,7 @@ func (r *Client) validateDisksOnSMB(vms []types.VM) {
 		r.Log.Error(err, "Failed to call validate-disks endpoint", "url", baseURL)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		r.Log.Info("SMB disk validation unavailable, provider-server returned unexpected status",

--- a/pkg/controller/provider/web/vsphere/vddk.go
+++ b/pkg/controller/provider/web/vsphere/vddk.go
@@ -183,7 +183,7 @@ func saveFile(filePath string, file *multipart.FileHeader) error {
 	if err != nil {
 		return fmt.Errorf("could not process uploaded file: %v", err)
 	}
-	defer src.Close()
+	defer func() { _ = src.Close() }()
 
 	if err := os.MkdirAll(uploadDir, 0600); err != nil {
 		return fmt.Errorf("could not prepare upload directory: %v", err)
@@ -193,7 +193,7 @@ func saveFile(filePath string, file *multipart.FileHeader) error {
 	if err != nil {
 		return fmt.Errorf("error: %v, Could not save file on disk: %s. ", err, filePath)
 	}
-	defer dst.Close()
+	defer func() { _ = dst.Close() }()
 
 	if _, err := io.Copy(dst, src); err != nil {
 		return fmt.Errorf("error copy to the local file: %v", err)

--- a/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator.go
+++ b/pkg/forklift-api/webhooks/mutating-webhook/mutators/secret-mutator.go
@@ -111,7 +111,7 @@ func (mutator *SecretMutator) mutateProviderSecret() *admissionv1.AdmissionRespo
 			log.Error(err, "mutating webhook error, failed to send request for CA certificate retrieval")
 			return util.ToAdmissionResponseError(err)
 		}
-		defer response.Body.Close()
+		defer func() { _ = response.Body.Close() }()
 
 		cert, err := io.ReadAll(response.Body)
 		if err != nil {

--- a/pkg/forklift-api/webhooks/util/util.go
+++ b/pkg/forklift-api/webhooks/util/util.go
@@ -117,7 +117,7 @@ func PermitUser(request *admissionv1.AdmissionRequest,
 		} else {
 			namedResource = groupResource.Resource + "/" + name
 		}
-		err = fmt.Errorf("Action is forbidden: User %q cannot %s resource %q in API group %q in the namespace %q: %s",
+		err = fmt.Errorf("action is forbidden: User %q cannot %s resource %q in API group %q in the namespace %q: %s",
 			user.Username, verb, namedResource, groupResource.Group, ns, review.Status.Reason)
 		return err
 	}

--- a/pkg/lib-volume-populator/populator-machinery/controller.go
+++ b/pkg/lib-volume-populator/populator-machinery/controller.go
@@ -818,7 +818,7 @@ func (c *controller) syncPvc(ctx context.Context, key, pvcNamespace, pvcName str
 
 		// This would be bad
 		if pvcPrime == nil {
-			return fmt.Errorf("Failed to find PVC for populator pod")
+			return fmt.Errorf("failed to find PVC for populator pod")
 		}
 
 		// Get PV
@@ -937,7 +937,7 @@ func (c *controller) updateProgress(pod *corev1.Pod, pvc *corev1.PersistentVolum
 		return err
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.V(5).Info(err)

--- a/pkg/lib-volume-populator/populator-machinery/metrics_test.go
+++ b/pkg/lib-volume-populator/populator-machinery/metrics_test.go
@@ -138,7 +138,7 @@ func verifyInFlightMetric(expected string, srvAddr string) error {
 	if err != nil {
 		return err
 	}
-	defer rsp.Body.Close()
+	defer func() { _ = rsp.Body.Close() }()
 
 	if rsp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to get response from serve: %s", http.StatusText(rsp.StatusCode))
@@ -160,7 +160,7 @@ func verifyMetric(expected, srvAddr string) error {
 	if err != nil {
 		return err
 	}
-	defer rsp.Body.Close()
+	defer func() { _ = rsp.Body.Close() }()
 
 	if rsp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to get response from serve: %s", http.StatusText(rsp.StatusCode))

--- a/pkg/lib/aap/client.go
+++ b/pkg/lib/aap/client.go
@@ -128,7 +128,7 @@ func (c *Client) fetchPathPrefixFromAPIDoc(ctx context.Context) (string, error) 
 	if err != nil {
 		return "", liberr.Wrap(err, "AAP/AWX: GET /api")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("GET /api: status %d", resp.StatusCode)
 	}
@@ -220,7 +220,7 @@ func (c *Client) LaunchJob(ctx context.Context, jobTemplateID int, extraVars map
 	if err != nil {
 		return 0, liberr.Wrap(err, "failed to launch AAP job")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
@@ -253,7 +253,7 @@ func (c *Client) GetJobStatus(ctx context.Context, jobID int) (*JobStatusRespons
 	if err != nil {
 		return nil, liberr.Wrap(err, "failed to get AAP job status")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -302,7 +302,7 @@ func (c *Client) ListJobTemplates(ctx context.Context, page, pageSize int) (*Job
 	if err != nil {
 		return nil, liberr.Wrap(err, "failed to list AAP job templates")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("AAP returned status %d: %s", resp.StatusCode, string(body))

--- a/pkg/lib/inventory/model/table.go
+++ b/pkg/lib/inventory/model/table.go
@@ -122,6 +122,8 @@ LIMIT {{.Page.Limit}} OFFSET {{.Page.Offset}}
 `
 
 // Errors
+//
+//nolint:staticcheck // legacy exported error names; rename in follow-up
 var (
 	// Must have PK.
 	MustHavePkErr = errors.New("must have PK field")

--- a/pkg/lib/inventory/web/client.go
+++ b/pkg/lib/inventory/web/client.go
@@ -255,7 +255,7 @@ func (r *Client) Watch(url string, resource interface{}, h EventHandler) (status
 	post := func(w *WatchReader) (pStatus int, pErr error) {
 		socket, response, pErr := dialer.Dial(url, header)
 		if response != nil {
-			defer response.Body.Close()
+			defer func() { _ = response.Body.Close() }()
 			pStatus = response.StatusCode
 			switch pStatus {
 			case http.StatusOK,

--- a/pkg/lib/itinerary/simple.go
+++ b/pkg/lib/itinerary/simple.go
@@ -45,6 +45,8 @@ type Itinerary struct {
 }
 
 // Errors.
+//
+//nolint:staticcheck // legacy exported error name; rename in follow-up
 var (
 	StepNotFound = errors.New("step not found")
 )

--- a/pkg/lib/logging/gin_test.go
+++ b/pkg/lib/logging/gin_test.go
@@ -212,7 +212,7 @@ func captureStderr(t *testing.T, fn func()) string {
 
 	fn()
 
-	w.Close()
+	_ = w.Close()
 	os.Stderr = origStderr
 
 	scanner := bufio.NewScanner(r)
@@ -220,7 +220,7 @@ func captureStderr(t *testing.T, fn func()) string {
 	for scanner.Scan() {
 		output += scanner.Text() + "\n"
 	}
-	r.Close()
+	_ = r.Close()
 	return output
 }
 

--- a/pkg/lib/util/sshutils.go
+++ b/pkg/lib/util/sshutils.go
@@ -116,7 +116,7 @@ func TestSSHConnectivity(ctx context.Context, hostIP string, privateKey []byte, 
 		return false
 	}
 	sshClient := ssh.NewClient(cc, chans, reqs)
-	defer sshClient.Close()
+	defer func() { _ = sshClient.Close() }()
 
 	log.V(3).Info("Connected to SSH server", "hostIP", hostIP)
 
@@ -128,7 +128,7 @@ func TestSSHConnectivity(ctx context.Context, hostIP string, privateKey []byte, 
 		log.V(2).Info("SSH connectivity test failed to create session", "hostIP", hostIP, "error", err)
 		return false
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	// Execute the status command with the provided datastore (or empty for connectivity test mode)
 	// Format: DS=<datastore>;CMD=<command>

--- a/pkg/lib/util/util.go
+++ b/pkg/lib/util/util.go
@@ -29,7 +29,7 @@ func dialTLSWithTimeout(host string, cfg *tls.Config, timeout time.Duration) (*t
 	// Set handshake timeout
 	err = tlsConn.Handshake()
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 

--- a/pkg/provider/ec2/inventory/collector/collector_test.go
+++ b/pkg/provider/ec2/inventory/collector/collector_test.go
@@ -61,10 +61,10 @@ var _ = Describe("EC2 Collector", func() {
 
 	AfterEach(func() {
 		if db != nil {
-			db.Close(true)
+			_ = db.Close(true)
 		}
 		if dbPath != "" {
-			os.RemoveAll(filepath.Dir(dbPath))
+			_ = os.RemoveAll(filepath.Dir(dbPath))
 		}
 	})
 

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -273,7 +273,7 @@ func (r *Migration) Load() (err error) {
 		if quantity, err := resource.ParseQuantity(overhead); err != nil {
 			return liberr.Wrap(err)
 		} else if r.BlockOverhead, ok = quantity.AsInt64(); !ok {
-			return fmt.Errorf("Block overhead is invalid: %s", overhead)
+			return fmt.Errorf("block overhead is invalid: %s", overhead)
 		}
 	}
 	if val, found := os.LookupEnv(OvirtOsConfigMap); found {

--- a/pkg/virt-v2v/conversion/conversion.go
+++ b/pkg/virt-v2v/conversion/conversion.go
@@ -307,7 +307,7 @@ func (c *Conversion) RunVirtV2v() error {
 	monitorCmd.SetStdin(pipe)
 	v2vCmd.SetStdout(writer)
 	v2vCmd.SetStderr(writer)
-	defer writer.Close()
+	defer func() { _ = writer.Close() }()
 
 	if err := monitorCmd.Start(); err != nil {
 		fmt.Printf("Error executing monitor command: %v\n", err)
@@ -319,7 +319,7 @@ func (c *Conversion) RunVirtV2v() error {
 	}
 
 	// virt-v2v is done, we can close the pipe to virt-v2v-monitor
-	writer.Close()
+	_ = writer.Close()
 
 	if err := monitorCmd.Wait(); err != nil {
 		fmt.Printf("Error waiting for virt-v2v-monitor to finish: %v\n", err)
@@ -401,7 +401,7 @@ func (c *Conversion) addVsphereInputTransport(cmd utils.CommandBuilder) vsphereT
 
 func (c *Conversion) addVirtV2vRemoteInspectionArgs(cmd utils.CommandBuilder) (err error) {
 	if len(c.RemoteInspectionDisks) == 0 {
-		return fmt.Errorf("No remote disks were supplied")
+		return fmt.Errorf("no remote disks were supplied")
 	}
 	fileKey := "vddk-file"
 	if c.vsphereInputTransport() == vsphereTransportNfc {
@@ -456,7 +456,7 @@ func (c *Conversion) GetDomainXML() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer conn.Close()
+	defer func() { _, _ = conn.Close() }()
 
 	domain, err := conn.LookupDomainByName(c.VmName)
 	if err != nil {

--- a/pkg/virt-v2v/conversion/conversion_test.go
+++ b/pkg/virt-v2v/conversion/conversion_test.go
@@ -466,7 +466,7 @@ var _ = Describe("Conversion", func() {
 
 				err := conversion.addVirtV2vRemoteInspectionArgs(mockCommandBuilder)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("No remote disks were supplied"))
+				Expect(err.Error()).To(Equal("no remote disks were supplied"))
 			},
 		)
 	})

--- a/pkg/virt-v2v/server/server_test.go
+++ b/pkg/virt-v2v/server/server_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Server", func() {
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(tempDir)
+		_ = os.RemoveAll(tempDir)
 	})
 
 	Describe("vmHandler", func() {

--- a/pkg/virt-v2v/utils/filesystem_test.go
+++ b/pkg/virt-v2v/utils/filesystem_test.go
@@ -21,7 +21,7 @@ var _ = Describe("FileSystem", func() {
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(tempDir)
+		_ = os.RemoveAll(tempDir)
 	})
 
 	Describe("FileSystemImpl", func() {

--- a/pkg/virt-v2v/utils/xml-reader.go
+++ b/pkg/virt-v2v/utils/xml-reader.go
@@ -28,7 +28,7 @@ func GetInspectionV2vFromFile(xmlFilePath string) (*InspectionV2V, error) {
 	var xmlConf InspectionV2V
 	err = xml.Unmarshal(xmlData, &xmlConf)
 	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling XML: %v\n", err)
+		return nil, fmt.Errorf("error unmarshalling XML: %v", err)
 	}
 	return &xmlConf, nil
 }

--- a/pkg/virt-v2v/utils/xml_reader_test.go
+++ b/pkg/virt-v2v/utils/xml_reader_test.go
@@ -19,7 +19,7 @@ var _ = Describe("XML Reader", func() {
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(tempDir)
+		_ = os.RemoveAll(tempDir)
 	})
 
 	Describe("GetInspectionV2vFromFile", func() {


### PR DESCRIPTION
Address errcheck and low-risk staticcheck issues left after the v2.12 upgrade (#8439). Aligns local make lint with the golangci-lint GitHub Action changes from #5882.

- Check ignored Close/Write return values (defer func pattern)
- Fix ST1005 error string style and ST1019 duplicate imports
- Suppress ST1012 on legacy exported error names with targeted nolint comments pending a dedicated rename follow-up