### PR TITLE
chore: hide unnessary params from controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,9 +290,12 @@ manifests: controller-gen ## Generate CRD and webhook manifests
 
 .PHONY: generate-csv
 generate-csv: operator-sdk ## Generate CSV specDescriptors from Go markers
-	cd operator && $(OPERATOR_SDK) generate kustomize manifests \
+	cd operator && \
+	sed -i 's/$${VERSION}/$(VERSION)/g' config/manifests/bases/forklift-operator.clusterserviceversion.yaml && \
+	$(OPERATOR_SDK) generate kustomize manifests \
 		--plugins go.kubebuilder.io/v4 --package $(OPERATOR_NAME) \
-		--apis-dir ../pkg/apis --interactive=false -q
+		--apis-dir ../pkg/apis --interactive=false -q && \
+	sed -i 's/$(subst .,\.,$(VERSION))/$${VERSION}/g' config/manifests/bases/forklift-operator.clusterserviceversion.yaml
 
 MANIFEST_VARS = $${CSV_NAME} $${CSV_DISPLAYNAME} $${NAMESPACE} $${CSV_CERTIFIED} $${CSV_SUPPORT} $${MAINTAINER_NAME} $${MAINTAINER_EMAIL} $${PROVIDER} $${DOCS_LINK_NAME} $${DOCS_LINK_URL}
 

--- a/operator/.downstream_manifests
+++ b/operator/.downstream_manifests
@@ -11979,8 +11979,7 @@ spec:
         displayName: Require Authentication
         path: feature_auth_required
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable CLI download service (default true)
         displayName: Enable CLI Download Service
         path: feature_cli_download
@@ -12518,6 +12517,95 @@ spec:
       - description: Volume Populator memory request (default 512Mi)
         displayName: Volume Populator Memory Request
         path: populator_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ansible Automation Platform base URL (e.g. https://aap.example.com)
+        displayName: AAP URL
+        path: aap_url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Name of the Secret containing the AAP API Bearer token (data
+          key token)
+        displayName: AAP Token Secret Name
+        path: aap_token_secret_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Skip TLS certificate verification when connecting to AAP (default
+          false)
+        displayName: AAP Insecure Skip Verify
+        path: aap_insecure_skip_verify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Name of the Secret containing a custom CA certificate for AAP
+          TLS (data key ca.crt)
+        displayName: AAP CA Secret Name
+        path: aap_ca_secret_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for NAA OUI mappings
+        displayName: NAA OUI Map ConfigMap Name
+        path: naa_oui_map_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server CPU limit (default 1000m)
+        displayName: MCP Server CPU Limit
+        path: mcp_server_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server memory limit (default 512Mi)
+        displayName: MCP Server Memory Limit
+        path: mcp_server_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server CPU request (default 100m)
+        displayName: MCP Server CPU Request
+        path: mcp_server_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server memory request (default 256Mi)
+        displayName: MCP Server Memory Request
+        path: mcp_server_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server output format (default markdown)
+        displayName: MCP Server Output Format
+        path: mcp_server_output_format
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Skip TLS verification for in-cluster MCP calls (default true)
+        displayName: MCP Server Kube Insecure
+        path: mcp_server_kube_insecure
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Run MCP server in read-only mode (default false)
+        displayName: MCP Server Read Only
+        path: mcp_server_read_only
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Namespace for host lease objects (default openshift-mtv)
+        displayName: Host Lease Namespace
+        path: controller_host_lease_namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Global default ServiceAccount for migration pods in the target
+          namespace
+        displayName: Migration Service Account
+        path: controller_migration_service_account
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Optional NAD name for controller pod transfer network
+        displayName: Controller Transfer Network
+        path: controller_transfer_network
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Timeout in seconds for the wait-for-reboot step (default 1800)
+        displayName: Windows Reboot Timeout
+        path: controller_windows_reboot_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Wait for final snapshot consolidation before completing migration
+        displayName: Wait For Final Snapshot Consolidation
+        path: wait_for_final_snapshot_consolidation
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Log verbosity level (default 3)

--- a/operator/.upstream_manifests
+++ b/operator/.upstream_manifests
@@ -11979,8 +11979,7 @@ spec:
         displayName: Require Authentication
         path: feature_auth_required
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Enable CLI download service (default true)
         displayName: Enable CLI Download Service
         path: feature_cli_download
@@ -12518,6 +12517,95 @@ spec:
       - description: Volume Populator memory request (default 512Mi)
         displayName: Volume Populator Memory Request
         path: populator_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ansible Automation Platform base URL (e.g. https://aap.example.com)
+        displayName: AAP URL
+        path: aap_url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Name of the Secret containing the AAP API Bearer token (data
+          key token)
+        displayName: AAP Token Secret Name
+        path: aap_token_secret_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Skip TLS certificate verification when connecting to AAP (default
+          false)
+        displayName: AAP Insecure Skip Verify
+        path: aap_insecure_skip_verify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Name of the Secret containing a custom CA certificate for AAP
+          TLS (data key ca.crt)
+        displayName: AAP CA Secret Name
+        path: aap_ca_secret_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for NAA OUI mappings
+        displayName: NAA OUI Map ConfigMap Name
+        path: naa_oui_map_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server CPU limit (default 1000m)
+        displayName: MCP Server CPU Limit
+        path: mcp_server_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server memory limit (default 512Mi)
+        displayName: MCP Server Memory Limit
+        path: mcp_server_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server CPU request (default 100m)
+        displayName: MCP Server CPU Request
+        path: mcp_server_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server memory request (default 256Mi)
+        displayName: MCP Server Memory Request
+        path: mcp_server_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server output format (default markdown)
+        displayName: MCP Server Output Format
+        path: mcp_server_output_format
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Skip TLS verification for in-cluster MCP calls (default true)
+        displayName: MCP Server Kube Insecure
+        path: mcp_server_kube_insecure
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Run MCP server in read-only mode (default false)
+        displayName: MCP Server Read Only
+        path: mcp_server_read_only
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Namespace for host lease objects (default openshift-mtv)
+        displayName: Host Lease Namespace
+        path: controller_host_lease_namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Global default ServiceAccount for migration pods in the target
+          namespace
+        displayName: Migration Service Account
+        path: controller_migration_service_account
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Optional NAD name for controller pod transfer network
+        displayName: Controller Transfer Network
+        path: controller_transfer_network
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Timeout in seconds for the wait-for-reboot step (default 1800)
+        displayName: Windows Reboot Timeout
+        path: controller_windows_reboot_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Wait for final snapshot consolidation before completing migration
+        displayName: Wait For Final Snapshot Consolidation
+        path: wait_for_final_snapshot_consolidation
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Log verbosity level (default 3)

--- a/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/forklift-operator.clusterserviceversion.yaml
@@ -46,6 +46,701 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: VM migration controller
+      displayName: ForkliftController
+      kind: ForkliftController
+      name: forkliftcontrollers.forklift.konveyor.io
+      specDescriptors:
+      - description: Enable UI plugin (default true)
+        displayName: Enable UI Plugin
+        path: feature_ui_plugin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable validation service (default true)
+        displayName: Enable Validation Service
+        path: feature_validation
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable volume populators (default true)
+        displayName: Enable Volume Populators
+        path: feature_volume_populator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable copy offload plugins (default true)
+        displayName: Enable Copy Offload Plugins
+        path: feature_copy_offload
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OCP live migration (default false)
+        displayName: Enable OCP Live Migration
+        path: feature_ocp_live_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Use VMware system serial numbers (default true)
+        displayName: Use VMware System Serial Numbers
+        path: feature_vmware_system_serial_number
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Run VMware driver removal scripts during Windows vSphere conversion
+          (default false)
+        displayName: Enable VMware Driver Removal On Windows vSphere Conversion
+        path: feature_vsphere_vmware_driver_removal
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Delegate VM conversion to Conversion CRs instead of managing
+          it directly (default true)
+        displayName: Enable Conversion CR
+        path: feature_use_conversion_cr
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Require authentication (default true)
+        displayName: Require Authentication
+        path: feature_auth_required
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable CLI download service (default true)
+        displayName: Enable CLI Download Service
+        path: feature_cli_download
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable MCP server (requires OpenShift with Lightspeed) (default
+          false)
+        displayName: Enable MCP Server
+        path: feature_mcp_server
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Register MCP server with OpenShift Lightspeed (default true)
+        displayName: MCP Lightspeed Integration
+        path: mcp_server_lightspeed_integration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Add MCPServer to OLSConfig featureGates when registering with
+          Lightspeed (default false)
+        displayName: MCP Lightspeed Set MCP Gate
+        path: mcp_server_lightspeed_set_mcp_gate
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Enable OVA appliance management endpoints (default false)
+        displayName: Enable OVA Appliance Management
+        path: feature_ova_appliance_management
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:radio:true
+        - urn:alm:descriptor:com.tectonic.ui:radio:false
+      - description: Controller pod image
+        displayName: Controller Image
+        path: controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Virt-v2v conversion image used by migration pods
+        displayName: Virt-v2v Image
+        path: virt_v2v_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deep inspection image used by deep-inspection pods
+        displayName: Deep Inspection Image
+        path: deep_inspection_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deep inspection image built on RHEL9, used when xfsCompatibility
+          is enabled
+        displayName: Deep Inspection Image (RHEL9)
+        path: deep_inspection_image_xfs_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK image for VMware disk access
+        displayName: VDDK Image
+        path: vddk_image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service image
+        displayName: API Image
+        path: api_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service image
+        displayName: CLI Download Image
+        path: cli_download_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin image
+        displayName: UI Plugin Image
+        path: ui_plugin_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation service image
+        displayName: Validation Image
+        path: validation_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume populator controller image
+        displayName: Populator Controller Image
+        path: populator_controller_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: oVirt populator image
+        displayName: oVirt Populator Image
+        path: populator_ovirt_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OpenStack populator image
+        displayName: OpenStack Populator Image
+        path: populator_openstack_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: vSphere xcopy populator image
+        displayName: vSphere Populator Image
+        path: populator_vsphere_copy_offload_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA provider server image
+        displayName: OVA Provider Server Image
+        path: ova_provider_server_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Must-gather debugging image
+        displayName: Must-gather Image
+        path: must_gather_image_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA inventory proxy image
+        displayName: OVA Proxy Image
+        path: ova_proxy_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller CPU limit (default 500m)
+        displayName: Controller CPU Limit
+        path: controller_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory limit (default 800Mi)
+        displayName: Controller Memory Limit
+        path: controller_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller CPU request (default 100m)
+        displayName: Controller CPU Request
+        path: controller_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Controller memory request (default 350Mi)
+        displayName: Controller Memory Request
+        path: controller_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory CPU limit (default 1000m)
+        displayName: Inventory CPU Limit
+        path: inventory_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory limit (default 1Gi)
+        displayName: Inventory Memory Limit
+        path: inventory_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory CPU request (default 500m)
+        displayName: Inventory CPU Request
+        path: inventory_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory memory request (default 500Mi)
+        displayName: Inventory Memory Request
+        path: inventory_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Inventory route timeout (default 360s)
+        displayName: Inventory Route Timeout
+        path: inventory_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service CPU limit (default 1000m)
+        displayName: API CPU Limit
+        path: api_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory limit (default 1Gi)
+        displayName: API Memory Limit
+        path: api_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service CPU request (default 100m)
+        displayName: API CPU Request
+        path: api_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: API service memory request (default 150Mi)
+        displayName: API Memory Request
+        path: api_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service CPU limit (default 100m)
+        displayName: CLI Download CPU Limit
+        path: cli_download_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory limit (default 128Mi)
+        displayName: CLI Download Memory Limit
+        path: cli_download_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service CPU request (default 50m)
+        displayName: CLI Download CPU Request
+        path: cli_download_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: CLI download service memory request (default 64Mi)
+        displayName: CLI Download Memory Request
+        path: cli_download_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin CPU limit (default 100m)
+        displayName: UI Plugin CPU Limit
+        path: ui_plugin_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory limit (default 800Mi)
+        displayName: UI Plugin Memory Limit
+        path: ui_plugin_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin CPU request (default 100m)
+        displayName: UI Plugin CPU Request
+        path: ui_plugin_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: UI plugin memory request (default 150Mi)
+        displayName: UI Plugin Memory Request
+        path: ui_plugin_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation CPU limit (default 1000m)
+        displayName: Validation CPU Limit
+        path: validation_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory limit (default 300Mi)
+        displayName: Validation Memory Limit
+        path: validation_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation CPU request (default 400m)
+        displayName: Validation CPU Request
+        path: validation_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Validation memory request (default 50Mi)
+        displayName: Validation Memory Request
+        path: validation_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Policy agent search interval in seconds (default 120)
+        displayName: Policy Agent Search Interval
+        path: validation_policy_agent_search_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume name for extra validation rules (default validation-extra-rules)
+        displayName: Validation Extra Volume Name
+        path: validation_extra_volume_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Mount path for extra validation rules (default /usr/share/opa/policies/extra)
+        displayName: Validation Extra Volume Mount Path
+        path: validation_extra_volume_mountpath
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for oVirt OS mappings (default forklift-ovirt-osmap)
+        displayName: oVirt OS Map ConfigMap Name
+        path: ovirt_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for vSphere OS mappings (default forklift-vsphere-osmap)
+        displayName: vSphere OS Map ConfigMap Name
+        path: vsphere_osmap_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for virt-customize configuration (default forklift-virt-customize)
+        displayName: Virt-Customize ConfigMap Name
+        path: virt_customize_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent VM migrations (default 20)
+        displayName: Max VM Inflight
+        path: controller_max_vm_inflight
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Precopy interval in minutes (default 60)
+        displayName: Precopy Interval
+        path: controller_precopy_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: How long Critical/Error blocker conditions must persist before
+          failing an active migration, in minutes (default 5)
+        displayName: Blocker Grace Period
+        path: controller_blocker_grace_period_minutes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Max concurrent reconciles (default 10)
+        displayName: Max Concurrent Reconciles
+        path: controller_max_concurrent_reconciles
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal timeout in minutes (default 120)
+        displayName: Snapshot Removal Timeout
+        path: controller_snapshot_removal_timeout_minuts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot status check rate in seconds (default 10)
+        displayName: Snapshot Status Check Rate
+        path: controller_snapshot_status_check_rate_seconds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Cleanup retry count (default 10)
+        displayName: Cleanup Retries
+        path: controller_cleanup_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Snapshot removal retries (default 20)
+        displayName: Snapshot Removal Check Retries
+        path: controller_snapshot_removal_check_retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: VDDK job timeout in seconds (default 300)
+        displayName: VDDK Job Active Deadline
+        path: controller_vddk_job_active_deadline_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: TLS connection timeout seconds (default 5)
+        displayName: TLS Connection Timeout
+        path: controller_tls_connection_timeout_sec
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Use vSphere incremental backup (default true)
+        displayName: vSphere Incremental Backup
+        path: controller_vsphere_incremental_backup
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable oVirt warm migration (default true)
+        displayName: oVirt Warm Migration
+        path: controller_ovirt_warm_migration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain precopy pods (default false)
+        displayName: Retain Precopy Importer Pods
+        path: controller_retain_precopy_importer_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Retain populator pods after migration for debugging (default
+          false)
+        displayName: Retain Populator Pods
+        path: controller_retain_populator_pods
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Enable static udn IP addresses feature (default false)
+        displayName: Static UDN IP Addresses
+        path: controller_static_udn_ip_addresses
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Filesystem overhead percentage (default 10)
+        displayName: Filesystem Overhead
+        path: controller_filesystem_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Block overhead in bytes (default 0)
+        displayName: Block Overhead
+        path: controller_block_overhead
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v CPU limit (default 4000m)
+        displayName: Virt-v2v CPU Limit
+        path: virt_v2v_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory limit (default 8Gi)
+        displayName: Virt-v2v Memory Limit
+        path: virt_v2v_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v CPU request (default 1000m)
+        displayName: Virt-v2v CPU Request
+        path: virt_v2v_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: virt-v2v memory request (default 1Gi)
+        displayName: Virt-v2v Memory Request
+        path: virt_v2v_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Memory (in MB) allocated for the virt-v2v conversion appliance
+        displayName: Virt-v2v Memory Size
+        path: virt_v2v_memsize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Number of virtual CPUs for the virt-v2v conversion appliance
+        displayName: Virt-v2v SMP
+        path: virt_v2v_smp
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Don't request KVM for virt-v2v
+        displayName: Virt-v2v Don't Request KVM
+        path: virt_v2v_dont_request_kvm
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v conversion
+        displayName: Virt-v2v Extra Args
+        path: virt_v2v_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Additional arguments for virt-v2v-inspector
+        displayName: Virt-v2v Inspector Extra Args
+        path: virt_v2v_inspector_extra_args
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name containing extra virt-v2v configuration
+        displayName: Virt-v2v Extra Config ConfigMap
+        path: virt_v2v_extra_conf_config_map
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks CPU limit (default 1000m)
+        displayName: Hooks CPU Limit
+        path: hooks_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory limit (default 1Gi)
+        displayName: Hooks Memory Limit
+        path: hooks_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks CPU request (default 100m)
+        displayName: Hooks CPU Request
+        path: hooks_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Hooks memory request (default 150Mi)
+        displayName: Hooks Memory Request
+        path: hooks_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA CPU limit (default 1000m)
+        displayName: OVA CPU Limit
+        path: ova_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory limit (default 1Gi)
+        displayName: OVA Memory Limit
+        path: ova_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA CPU request (default 100m)
+        displayName: OVA CPU Request
+        path: ova_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA memory request (default 150Mi)
+        displayName: OVA Memory Request
+        path: ova_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: HyperV CPU limit (default 1000m)
+        displayName: HyperV CPU Limit
+        path: hyperv_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: HyperV memory limit (default 1Gi)
+        displayName: HyperV Memory Limit
+        path: hyperv_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: HyperV CPU request (default 100m)
+        displayName: HyperV CPU Request
+        path: hyperv_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: HyperV memory request (default 512Mi)
+        displayName: HyperV Memory Request
+        path: hyperv_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: HyperV provider server image
+        displayName: HyperV Provider Server Image
+        path: hyperv_provider_server_fqin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: HyperV inventory refresh interval (default 10s)
+        displayName: HyperV Refresh Interval
+        path: controller_hyperv_refresh_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Timeout for HyperV SMB disk validation (default 30s)
+        displayName: HyperV Validation Timeout
+        path: controller_hyperv_validation_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy CPU limit (default 1000m)
+        displayName: OVA Proxy CPU Limit
+        path: ova_proxy_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory limit (default 1Gi)
+        displayName: OVA Proxy Memory Limit
+        path: ova_proxy_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy CPU request (default 250m)
+        displayName: OVA Proxy CPU Request
+        path: ova_proxy_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy memory request (default 512Mi)
+        displayName: OVA Proxy Memory Request
+        path: ova_proxy_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: OVA Proxy route timeout (default 360s)
+        displayName: OVA Proxy Route Timeout
+        path: ova_proxy_route_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator CPU limit (default 1000m)
+        displayName: Volume Populator CPU Limit
+        path: populator_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator memory limit (default 1Gi)
+        displayName: Volume Populator Memory Limit
+        path: populator_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator CPU request (default 100m)
+        displayName: Volume Populator CPU Request
+        path: populator_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Volume Populator memory request (default 512Mi)
+        displayName: Volume Populator Memory Request
+        path: populator_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Ansible Automation Platform base URL (e.g. https://aap.example.com)
+        displayName: AAP URL
+        path: aap_url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Name of the Secret containing the AAP API Bearer token (data
+          key token)
+        displayName: AAP Token Secret Name
+        path: aap_token_secret_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Skip TLS certificate verification when connecting to AAP (default
+          false)
+        displayName: AAP Insecure Skip Verify
+        path: aap_insecure_skip_verify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Name of the Secret containing a custom CA certificate for AAP
+          TLS (data key ca.crt)
+        displayName: AAP CA Secret Name
+        path: aap_ca_secret_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: ConfigMap name for NAA OUI mappings
+        displayName: NAA OUI Map ConfigMap Name
+        path: naa_oui_map_configmap_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server CPU limit (default 1000m)
+        displayName: MCP Server CPU Limit
+        path: mcp_server_container_limits_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server memory limit (default 512Mi)
+        displayName: MCP Server Memory Limit
+        path: mcp_server_container_limits_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server CPU request (default 100m)
+        displayName: MCP Server CPU Request
+        path: mcp_server_container_requests_cpu
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server memory request (default 256Mi)
+        displayName: MCP Server Memory Request
+        path: mcp_server_container_requests_memory
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: MCP server output format (default markdown)
+        displayName: MCP Server Output Format
+        path: mcp_server_output_format
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Skip TLS verification for in-cluster MCP calls (default true)
+        displayName: MCP Server Kube Insecure
+        path: mcp_server_kube_insecure
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Run MCP server in read-only mode (default false)
+        displayName: MCP Server Read Only
+        path: mcp_server_read_only
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Namespace for host lease objects (default openshift-mtv)
+        displayName: Host Lease Namespace
+        path: controller_host_lease_namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Global default ServiceAccount for migration pods in the target
+          namespace
+        displayName: Migration Service Account
+        path: controller_migration_service_account
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Optional NAD name for controller pod transfer network
+        displayName: Controller Transfer Network
+        path: controller_transfer_network
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Timeout in seconds for the wait-for-reboot step (default 1800)
+        displayName: Windows Reboot Timeout
+        path: controller_windows_reboot_timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Wait for final snapshot consolidation before completing migration
+        displayName: Wait For Final Snapshot Consolidation
+        path: wait_for_final_snapshot_consolidation
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Log verbosity level (default 3)
+        displayName: Controller Log Level
+        path: controller_log_level
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Image pull policy (default Always)
+        displayName: Image Pull Policy
+        path: image_pull_policy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Whether running on Kubernetes (vs OpenShift) (default false)
+        displayName: K8s Cluster
+        path: k8s_cluster
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Metrics scrape interval (default 30s)
+        displayName: Metric Interval
+        path: metric_interval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      version: v1beta1
     - description: VM migration
       displayName: Migration
       kind: Migration
@@ -95,792 +790,6 @@ spec:
       displayName: Conversion
       kind: Conversion
       name: conversions.forklift.konveyor.io
-      version: v1beta1
-    - description: ForkliftController is the Schema for the forkliftcontrollers API.
-      displayName: Forklift Controller
-      kind: ForkliftController
-      name: forkliftcontrollers.forklift.konveyor.io
-      specDescriptors:
-      - description: 'Name of the Secret containing a custom CA certificate (data
-          key: ca.crt) for AAP TLS verification.'
-        displayName: AAPCASecret Name
-        path: aap_ca_secret_name
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Skip TLS certificate verification when connecting to AAP.
-        displayName: AAPInsecure Skip Verify
-        path: aap_insecure_skip_verify
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Default timeout in seconds for AAP HTTP calls and job polling.
-        displayName: AAPTimeout
-        path: aap_timeout
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: 'Name of the Secret containing the AAP API Bearer token (data
-          key: token).'
-        displayName: AAPToken Secret Name
-        path: aap_token_secret_name
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: |-
-          Ansible Automation Platform base URL.
-          Required for centralized AAP connection together with aap_token_secret_name.
-        displayName: AAPUrl
-        path: aap_url
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: API service CPU limit.
-        displayName: APIContainer Limits CPU
-        path: api_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: API service memory limit.
-        displayName: APIContainer Limits Memory
-        path: api_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: API service CPU request.
-        displayName: APIContainer Requests CPU
-        path: api_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: API service memory request.
-        displayName: APIContainer Requests Memory
-        path: api_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: API service image. Optional. If left empty, the operator automatically
-          sets this from the release payload.
-        displayName: APIImage FQIN
-        path: api_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: CLI download service CPU limit.
-        displayName: CLIDownload Container Limits CPU
-        path: cli_download_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: CLI download service memory limit.
-        displayName: CLIDownload Container Limits Memory
-        path: cli_download_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: CLI download service CPU request.
-        displayName: CLIDownload Container Requests CPU
-        path: cli_download_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: CLI download service memory request.
-        displayName: CLIDownload Container Requests Memory
-        path: cli_download_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: CLI download service image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: CLIDownload Image FQIN
-        path: cli_download_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Block overhead in bytes.
-        displayName: Controller Block Overhead
-        path: controller_block_overhead
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: How long Critical/Error blocker conditions must persist before
-          failing an active migration, in minutes.
-        displayName: Controller Blocker Grace Period Minutes
-        path: controller_blocker_grace_period_minutes
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Cleanup retry count.
-        displayName: Controller Cleanup Retries
-        path: controller_cleanup_retries
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Controller CPU limit.
-        displayName: Controller Container Limits CPU
-        path: controller_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Controller memory limit.
-        displayName: Controller Container Limits Memory
-        path: controller_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Controller CPU request.
-        displayName: Controller Container Requests CPU
-        path: controller_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Controller memory request.
-        displayName: Controller Container Requests Memory
-        path: controller_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Filesystem overhead percentage.
-        displayName: Controller Filesystem Overhead
-        path: controller_filesystem_overhead
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Host lease duration in seconds.
-        displayName: Controller Host Lease Duration Seconds
-        path: controller_host_lease_duration_seconds
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Namespace for host lease objects.
-        displayName: Controller Host Lease Namespace
-        path: controller_host_lease_namespace
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: HyperV inventory refresh interval as a Go duration.
-        displayName: Controller Hyper VRefresh Interval
-        path: controller_hyperv_refresh_interval
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Timeout for HyperV SMB disk validation HTTP calls as a Go duration.
-        displayName: Controller Hyper VValidation Timeout
-        path: controller_hyperv_validation_timeout
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Controller pod image. Optional. If left empty, the operator automatically
-          sets this from the release payload.
-        displayName: Controller Image FQIN
-        path: controller_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Log verbosity level.
-        displayName: Controller Log Level
-        path: controller_log_level
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Max concurrent reconciles.
-        displayName: Controller Max Concurrent Reconciles
-        path: controller_max_concurrent_reconciles
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Max retries when getting parent disks.
-        displayName: Controller Max Parent Backing Retries
-        path: controller_max_parent_backing_retries
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Max concurrent populator pods per ESXi host.
-        displayName: Controller Max Populator Inflight
-        path: controller_max_populator_inflight
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Max concurrent VM migrations.
-        displayName: Controller Max VMInflight
-        path: controller_max_vm_inflight
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: |-
-          Global default ServiceAccount for migration pods in the target namespace.
-          Overridden by Plan-level serviceAccount.
-        displayName: Controller Migration Service Account
-        path: controller_migration_service_account
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: |-
-          Global default PVC name template for OpenShift (OCP) sources.
-          Used when Plan/VM pvcNameTemplate is empty. Empty falls back to "{{.SourcePVCName}}"
-          (exact name, preserves the source PVC name).
-          Does not apply to non-OCP providers (see controller_pvc_name_template).
-        displayName: Controller OCP PVC Name Template
-        path: controller_ocp_pvc_name_template
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Enable oVirt warm migration.
-        displayName: Controller Ovirt Warm Migration
-        path: controller_ovirt_warm_migration
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Precopy interval in minutes.
-        displayName: Controller Precopy Interval
-        path: controller_precopy_interval
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: |-
-          Global default PVC name template for non-OCP providers.
-          Used when Plan/VM pvcNameTemplate is empty. Empty falls back to the hardcoded default
-          "{{trunc 15 .PlanName}}-{{trunc 15 .TargetVmName}}-disk-{{.DiskIndex}}".
-          Does not apply to OpenShift sources (see controller_ocp_pvc_name_template).
-        displayName: Controller PVC Name Template
-        path: controller_pvc_name_template
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Retain populator pods after migration for debugging.
-        displayName: Controller Retain Populator Pods
-        path: controller_retain_populator_pods
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Retain precopy pods.
-        displayName: Controller Retain Precopy Importer Pods
-        path: controller_retain_precopy_importer_pods
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Snapshot removal retries.
-        displayName: Controller Snapshot Removal Check Retries
-        path: controller_snapshot_removal_check_retries
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Snapshot removal timeout in minutes.
-        displayName: Controller Snapshot Removal Timeout Minuts
-        path: controller_snapshot_removal_timeout_minuts
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Snapshot status check rate in seconds.
-        displayName: Controller Snapshot Status Check Rate Seconds
-        path: controller_snapshot_status_check_rate_seconds
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Enable static UDN IP addresses feature.
-        displayName: Controller Static UDNIPAddresses
-        path: controller_static_udn_ip_addresses
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: TLS connection timeout seconds.
-        displayName: Controller TLSConnection Timeout Sec
-        path: controller_tls_connection_timeout_sec
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: 'Optional NAD name for controller pod transfer network (format:
-          ''namespace/network-name'').'
-        displayName: Controller Transfer Network
-        path: controller_transfer_network
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: VDDK job timeout in seconds.
-        displayName: Controller VDDKJob Active Deadline Sec
-        path: controller_vddk_job_active_deadline_sec
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Use vSphere incremental backup.
-        displayName: Controller VSphere Incremental Backup
-        path: controller_vsphere_incremental_backup
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Timeout in seconds for the wait-for-reboot step.
-        displayName: Controller Windows Reboot Timeout
-        path: controller_windows_reboot_timeout
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Deep inspection image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Deep Inspection Image FQIN
-        path: deep_inspection_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Deep inspection XFS image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Deep Inspection Image XFSFQIN
-        path: deep_inspection_image_xfs_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Require authentication.
-        displayName: Feature Auth Required
-        path: feature_auth_required
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Enable CLI download service.
-        displayName: Feature CLIDownload
-        path: feature_cli_download
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable copy offload plugins.
-        displayName: Feature Copy Offload
-        path: feature_copy_offload
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable MCP server deployment (requires OpenShift with Lightspeed).
-        displayName: Feature MCPServer
-        path: feature_mcp_server
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable OCP live migration.
-        displayName: Feature OCPLive Migration
-        path: feature_ocp_live_migration
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable OVF-based appliance management endpoints (OVA, HyperV).
-        displayName: Feature OVAAppliance Management
-        path: feature_ova_appliance_management
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable UI plugin.
-        displayName: Feature UIPlugin
-        path: feature_ui_plugin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Delegate VM conversion to Conversion CRs instead of managing
-          it directly.
-        displayName: Feature Use Conversion CR
-        path: feature_use_conversion_cr
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable validation service.
-        displayName: Feature Validation
-        path: feature_validation
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Use VMware system serial numbers.
-        displayName: Feature VMware System Serial Number
-        path: feature_vmware_system_serial_number
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Enable volume populators.
-        displayName: Feature Volume Populator
-        path: feature_volume_populator
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Run VMware driver removal scripts during Windows vSphere conversion.
-        displayName: Feature VSphere VMware Driver Removal
-        path: feature_vsphere_vmware_driver_removal
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Use registry-based network configuration scripts for Windows
-          static IP setup.
-        displayName: Feature Windows Registry Network Config
-        path: feature_windows_registry_network_config
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Enable automatic wait-for-reboot step for Windows VM migrations.
-        displayName: Feature Windows Wait For Reboot
-        path: feature_windows_wait_for_reboot
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Ignore xfs_repair exit status during conversion.
-        displayName: Feature XFSRepair Ignore
-        path: feature_xfs_repair_ignore
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Hooks CPU limit.
-        displayName: Hooks Container Limits CPU
-        path: hooks_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Hooks memory limit.
-        displayName: Hooks Container Limits Memory
-        path: hooks_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Hooks CPU request.
-        displayName: Hooks Container Requests CPU
-        path: hooks_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Hooks memory request.
-        displayName: Hooks Container Requests Memory
-        path: hooks_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: HyperV CPU limit.
-        displayName: Hyper VContainer Limits CPU
-        path: hyperv_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: HyperV memory limit.
-        displayName: Hyper VContainer Limits Memory
-        path: hyperv_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: HyperV CPU request.
-        displayName: Hyper VContainer Requests CPU
-        path: hyperv_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: HyperV memory request.
-        displayName: Hyper VContainer Requests Memory
-        path: hyperv_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: HyperV provider server image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Hyper VProvider Server FQIN
-        path: hyperv_provider_server_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Image pull policy.
-        displayName: Image Pull Policy
-        path: image_pull_policy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Inventory CPU limit.
-        displayName: Inventory Container Limits CPU
-        path: inventory_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Inventory memory limit.
-        displayName: Inventory Container Limits Memory
-        path: inventory_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Inventory CPU request.
-        displayName: Inventory Container Requests CPU
-        path: inventory_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Inventory memory request.
-        displayName: Inventory Container Requests Memory
-        path: inventory_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Inventory route timeout.
-        displayName: Inventory Route Timeout
-        path: inventory_route_timeout
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Whether running on Kubernetes (vs OpenShift).
-        displayName: K8s Cluster
-        path: k8s_cluster
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: MCP server CPU limit.
-        displayName: MCPServer Container Limits CPU
-        path: mcp_server_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: MCP server memory limit.
-        displayName: MCPServer Container Limits Memory
-        path: mcp_server_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: MCP server CPU request.
-        displayName: MCPServer Container Requests CPU
-        path: mcp_server_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: MCP server memory request.
-        displayName: MCPServer Container Requests Memory
-        path: mcp_server_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Skip TLS verification for in-cluster MCP calls.
-        displayName: MCPServer Kube Insecure
-        path: mcp_server_kube_insecure
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Register MCP server with OpenShift Lightspeed.
-        displayName: MCPServer Lightspeed Integration
-        path: mcp_server_lightspeed_integration
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: Add MCPServer to OLSConfig featureGates when registering with
-          Lightspeed.
-        displayName: MCPServer Lightspeed Set MCPGate
-        path: mcp_server_lightspeed_set_mcp_gate
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:radio:true
-        - urn:alm:descriptor:com.tectonic.ui:radio:false
-      - description: MCP server max response chars, 0 for unlimited.
-        displayName: MCPServer Max Response Chars
-        path: mcp_server_max_response_chars
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: MCP server output format.
-        displayName: MCPServer Output Format
-        path: mcp_server_output_format
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Run MCP server in read-only mode.
-        displayName: MCPServer Read Only
-        path: mcp_server_read_only
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: MCP server verbosity level.
-        displayName: MCPServer Verbose
-        path: mcp_server_verbose
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Metrics scrape interval.
-        displayName: Metric Interval
-        path: metric_interval
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Must-gather debugging image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Must Gather Image FQIN
-        path: must_gather_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: ConfigMap name for custom NAA OUI to storage vendor mappings.
-        displayName: NAAOUIMap Config Map Name
-        path: naa_oui_map_configmap_name
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA CPU limit.
-        displayName: OVAContainer Limits CPU
-        path: ova_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA memory limit.
-        displayName: OVAContainer Limits Memory
-        path: ova_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA CPU request.
-        displayName: OVAContainer Requests CPU
-        path: ova_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA memory request.
-        displayName: OVAContainer Requests Memory
-        path: ova_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA provider server image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: OVAProvider Server FQIN
-        path: ova_provider_server_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA Proxy CPU limit.
-        displayName: OVAProxy Container Limits CPU
-        path: ova_proxy_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA Proxy memory limit.
-        displayName: OVAProxy Container Limits Memory
-        path: ova_proxy_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA Proxy CPU request.
-        displayName: OVAProxy Container Requests CPU
-        path: ova_proxy_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA Proxy memory request.
-        displayName: OVAProxy Container Requests Memory
-        path: ova_proxy_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA inventory proxy image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: OVAProxy FQIN
-        path: ova_proxy_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OVA Proxy route timeout.
-        displayName: OVAProxy Route Timeout
-        path: ova_proxy_route_timeout
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: ConfigMap name for oVirt OS mappings.
-        displayName: Ovirt OSMap Config Map Name
-        path: ovirt_osmap_configmap_name
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Volume Populator CPU limit.
-        displayName: Populator Container Limits CPU
-        path: populator_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Volume Populator memory limit.
-        displayName: Populator Container Limits Memory
-        path: populator_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Volume Populator CPU request.
-        displayName: Populator Container Requests CPU
-        path: populator_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Volume Populator memory request.
-        displayName: Populator Container Requests Memory
-        path: populator_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Volume populator controller image. Optional. If left empty, the
-          operator automatically sets this from the release payload.
-        displayName: Populator Controller Image FQIN
-        path: populator_controller_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: OpenStack populator image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Populator Openstack Image FQIN
-        path: populator_openstack_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: oVirt populator image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Populator Ovirt Image FQIN
-        path: populator_ovirt_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: vSphere xcopy populator image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Populator VSphere Copy Offload Image FQIN
-        path: populator_vsphere_copy_offload_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: UI plugin CPU limit.
-        displayName: UIPlugin Container Limits CPU
-        path: ui_plugin_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: UI plugin memory limit.
-        displayName: UIPlugin Container Limits Memory
-        path: ui_plugin_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: UI plugin CPU request.
-        displayName: UIPlugin Container Requests CPU
-        path: ui_plugin_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: UI plugin memory request.
-        displayName: UIPlugin Container Requests Memory
-        path: ui_plugin_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: UI plugin image. Optional. If left empty, the operator automatically
-          sets this from the release payload.
-        displayName: UIPlugin Image FQIN
-        path: ui_plugin_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Validation CPU limit.
-        displayName: Validation Container Limits CPU
-        path: validation_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Validation memory limit.
-        displayName: Validation Container Limits Memory
-        path: validation_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Validation CPU request.
-        displayName: Validation Container Requests CPU
-        path: validation_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Validation memory request.
-        displayName: Validation Container Requests Memory
-        path: validation_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Mount path for extra validation rules.
-        displayName: Validation Extra Volume Mountpath
-        path: validation_extra_volume_mountpath
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Volume name for extra validation rules.
-        displayName: Validation Extra Volume Name
-        path: validation_extra_volume_name
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Validation service image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Validation Image FQIN
-        path: validation_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Policy agent search interval in seconds.
-        displayName: Validation Policy Agent Search Interval
-        path: validation_policy_agent_search_interval
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: VDDK image for VMware disk access. Optional. If left empty, no
-          VDDK image is configured.
-        displayName: VDDKImage
-        path: vddk_image
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: ConfigMap name for virt-customize configuration.
-        displayName: Virt Customize Config Map Name
-        path: virt_customize_configmap_name
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Virt-v2v CPU limit.
-        displayName: Virt V2 VContainer Limits CPU
-        path: virt_v2v_container_limits_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Virt-v2v memory limit.
-        displayName: Virt V2 VContainer Limits Memory
-        path: virt_v2v_container_limits_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Virt-v2v CPU request.
-        displayName: Virt V2 VContainer Requests CPU
-        path: virt_v2v_container_requests_cpu
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Virt-v2v memory request.
-        displayName: Virt V2 VContainer Requests Memory
-        path: virt_v2v_container_requests_memory
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Don't request KVM for virt-v2v. Optional. If left empty, the
-          operator automatically sets this from the environment.
-        displayName: Virt V2 VDont Request KVM
-        path: virt_v2v_dont_request_kvm
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Additional arguments for virt-v2v conversion. Optional. If left
-          empty, the operator automatically sets this from the environment.
-        displayName: Virt V2 VExtra Args
-        path: virt_v2v_extra_args
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: ConfigMap name containing extra virt-v2v configuration. Optional.
-          If left empty, the operator automatically sets this from the environment.
-        displayName: Virt V2 VExtra Conf Config Map
-        path: virt_v2v_extra_conf_config_map
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Virt-v2v conversion image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Virt V2 VImage FQIN
-        path: virt_v2v_image_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Virt-v2v XFS conversion image. Optional. If left empty, the operator
-          automatically sets this from the release payload.
-        displayName: Virt V2 VImage XFSFQIN
-        path: virt_v2v_image_xfs_fqin
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Additional arguments for virt-v2v-inspector. Optional. If left
-          empty, the operator automatically sets this from the environment.
-        displayName: Virt V2 VInspector Extra Args
-        path: virt_v2v_inspector_extra_args
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Memory (in MB) allocated for the virt-v2v conversion appliance.
-        displayName: Virt V2 VMemsize
-        path: virt_v2v_memsize
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Number of virtual CPUs for the virt-v2v conversion appliance.
-        displayName: Virt V2 VSMP
-        path: virt_v2v_smp
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: ConfigMap name for vSphere OS mappings.
-        displayName: VSphere OSMap Config Map Name
-        path: vsphere_osmap_configmap_name
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Wait for final snapshot removal and consolidation in a VMware
-          warm migration.
-        displayName: Wait For Final Snapshot Consolidation
-        path: wait_for_final_snapshot_consolidation
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       version: v1beta1
   description: |
     The Forklift Operator fully manages the deployment and life cycle of Forklift on [OpenShift](https://www.openshift.com/).
@@ -955,4 +864,4 @@ spec:
   provider:
     name: Konveyor
     url: https://www.konveyor.io
-  version: 0.0.0
+  version: ${VERSION}

--- a/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
+++ b/operator/streams/downstream/mtv-operator.clusterserviceversion.yaml
@@ -171,8 +171,7 @@ spec:
           displayName: Require Authentication
           path: feature_auth_required
           x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:radio:true
-          - urn:alm:descriptor:com.tectonic.ui:radio:false
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Enable CLI download service (default true)
           displayName: Enable CLI Download Service
           path: feature_cli_download
@@ -723,6 +722,93 @@ spec:
         - description: Volume Populator memory request (default 512Mi)
           displayName: Volume Populator Memory Request
           path: populator_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # AAP Settings
+        - description: Ansible Automation Platform base URL (e.g. https://aap.example.com)
+          displayName: AAP URL
+          path: aap_url
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Name of the Secret containing the AAP API Bearer token (data key token)
+          displayName: AAP Token Secret Name
+          path: aap_token_secret_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Skip TLS certificate verification when connecting to AAP (default false)
+          displayName: AAP Insecure Skip Verify
+          path: aap_insecure_skip_verify
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Name of the Secret containing a custom CA certificate for AAP TLS (data key ca.crt)
+          displayName: AAP CA Secret Name
+          path: aap_ca_secret_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: ConfigMap name for NAA OUI mappings
+          displayName: NAA OUI Map ConfigMap Name
+          path: naa_oui_map_configmap_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # MCP Server Resource Configuration
+        - description: MCP server CPU limit (default 1000m)
+          displayName: MCP Server CPU Limit
+          path: mcp_server_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: MCP server memory limit (default 512Mi)
+          displayName: MCP Server Memory Limit
+          path: mcp_server_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: MCP server CPU request (default 100m)
+          displayName: MCP Server CPU Request
+          path: mcp_server_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: MCP server memory request (default 256Mi)
+          displayName: MCP Server Memory Request
+          path: mcp_server_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: MCP server output format (default markdown)
+          displayName: MCP Server Output Format
+          path: mcp_server_output_format
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Skip TLS verification for in-cluster MCP calls (default true)
+          displayName: MCP Server Kube Insecure
+          path: mcp_server_kube_insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Run MCP server in read-only mode (default false)
+          displayName: MCP Server Read Only
+          path: mcp_server_read_only
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Namespace for host lease objects (default openshift-mtv)
+          displayName: Host Lease Namespace
+          path: controller_host_lease_namespace
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Global default ServiceAccount for migration pods in the target namespace
+          displayName: Migration Service Account
+          path: controller_migration_service_account
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Optional NAD name for controller pod transfer network
+          displayName: Controller Transfer Network
+          path: controller_transfer_network
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Timeout in seconds for the wait-for-reboot step (default 1800)
+          displayName: Windows Reboot Timeout
+          path: controller_windows_reboot_timeout
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Wait for final snapshot consolidation before completing migration
+          displayName: Wait For Final Snapshot Consolidation
+          path: wait_for_final_snapshot_consolidation
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
         # Logging & General Settings

--- a/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
+++ b/operator/streams/upstream/forklift-operator.clusterserviceversion.yaml
@@ -173,8 +173,7 @@ spec:
           displayName: Require Authentication
           path: feature_auth_required
           x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:radio:true
-          - urn:alm:descriptor:com.tectonic.ui:radio:false
+          - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Enable CLI download service (default true)
           displayName: Enable CLI Download Service
           path: feature_cli_download
@@ -725,6 +724,93 @@ spec:
         - description: Volume Populator memory request (default 512Mi)
           displayName: Volume Populator Memory Request
           path: populator_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # AAP Settings
+        - description: Ansible Automation Platform base URL (e.g. https://aap.example.com)
+          displayName: AAP URL
+          path: aap_url
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Name of the Secret containing the AAP API Bearer token (data key token)
+          displayName: AAP Token Secret Name
+          path: aap_token_secret_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Skip TLS certificate verification when connecting to AAP (default false)
+          displayName: AAP Insecure Skip Verify
+          path: aap_insecure_skip_verify
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Name of the Secret containing a custom CA certificate for AAP TLS (data key ca.crt)
+          displayName: AAP CA Secret Name
+          path: aap_ca_secret_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: ConfigMap name for NAA OUI mappings
+          displayName: NAA OUI Map ConfigMap Name
+          path: naa_oui_map_configmap_name
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        # MCP Server Resource Configuration
+        - description: MCP server CPU limit (default 1000m)
+          displayName: MCP Server CPU Limit
+          path: mcp_server_container_limits_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: MCP server memory limit (default 512Mi)
+          displayName: MCP Server Memory Limit
+          path: mcp_server_container_limits_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: MCP server CPU request (default 100m)
+          displayName: MCP Server CPU Request
+          path: mcp_server_container_requests_cpu
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: MCP server memory request (default 256Mi)
+          displayName: MCP Server Memory Request
+          path: mcp_server_container_requests_memory
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: MCP server output format (default markdown)
+          displayName: MCP Server Output Format
+          path: mcp_server_output_format
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Skip TLS verification for in-cluster MCP calls (default true)
+          displayName: MCP Server Kube Insecure
+          path: mcp_server_kube_insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Run MCP server in read-only mode (default false)
+          displayName: MCP Server Read Only
+          path: mcp_server_read_only
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Namespace for host lease objects (default openshift-mtv)
+          displayName: Host Lease Namespace
+          path: controller_host_lease_namespace
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Global default ServiceAccount for migration pods in the target namespace
+          displayName: Migration Service Account
+          path: controller_migration_service_account
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Optional NAD name for controller pod transfer network
+          displayName: Controller Transfer Network
+          path: controller_transfer_network
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Timeout in seconds for the wait-for-reboot step (default 1800)
+          displayName: Windows Reboot Timeout
+          path: controller_windows_reboot_timeout
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:hidden
+        - description: Wait for final snapshot consolidation before completing migration
+          displayName: Wait For Final Snapshot Consolidation
+          path: wait_for_final_snapshot_consolidation
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:hidden
         # Logging & General Settings


### PR DESCRIPTION
- aap_url
- naa_oui_map_configmap_name
- controller_host_lease_namespace
- mcp_server_container_requests_cpu
- aap_insecure_skip_verify
- aap_token_secret_name
- controller_windows_reboot_timeout
- mcp_server_container_requests_memory
- aap_ca_secret_name
- controller_migration_service_account
- mcp_server_container_limits_memory
- mcp_server_container_limits_cpu
- mcp_server_kube_insecure
- wait_for_final_snapshot_consolidation
- controller_transfer_network
- mcp_server_output_format
- mcp_server_read_only
- feature_auth_required