### PR TITLE
MTV-6551 | Mount nbdkit NFC plugin via VDDK sidecar subPath

### DIFF
--- a/cmd/virt-v2v/entrypoint.go
+++ b/cmd/virt-v2v/entrypoint.go
@@ -136,13 +136,6 @@ func linkCertificates(env *config.AppConfig) (err error) {
 				os.Exit(1)
 			}
 		}
-		if _, err := os.Stat(config.NfcPlugin); err == nil {
-			err = os.Symlink(config.NfcPlugin, config.NfcPluginBuiltin)
-			if err != nil {
-				fmt.Println("Error creating nfc plugin link ", err)
-				os.Exit(1)
-			}
-		}
 	}
 	return nil
 }

--- a/pkg/controller/conversion/builder.go
+++ b/pkg/controller/conversion/builder.go
@@ -17,6 +17,9 @@ import (
 const (
 	qemuUser  = int64(107)
 	qemuGroup = int64(107)
+
+	nbdkitNfcPluginSubPath   = "nbdkit-nfc-plugin.so"
+	nbdkitNfcPluginMountPath = "/usr/lib64/nbdkit/plugins/nbdkit-nfc-plugin.so"
 )
 
 // Builder constructs virt-v2v pod specs from a fully-resolved PodConfig.
@@ -130,6 +133,13 @@ func (b *Builder) GetVirtV2vPodSpec(vm *plan.VMStatus, volumes []core.Volume, vo
 				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 				Capabilities:             &core.Capabilities{Drop: []core.Capability{"ALL"}},
 			},
+		})
+		// Sidecar images such as go-nfc copy /opt/nbdkit-nfc-plugin.so; overlay that file
+		// on the nbdkit plugin path without replacing the image's built-in plugin directory.
+		volumeMounts = append(volumeMounts, core.VolumeMount{
+			Name:      convctx.VddkVolumeName,
+			MountPath: nbdkitNfcPluginMountPath,
+			SubPath:   nbdkitNfcPluginSubPath,
 		})
 	}
 


### PR DESCRIPTION
When VDDKImage is set, overlay nbdkit-nfc-plugin.so from the vddk
emptyDir onto /usr/lib64/nbdkit/plugins/ so virt-v2v can use -it nfc
without replacing the image's built-in nbdkit plugins. Remove the
virt-v2v entrypoint symlink; non-root qemu cannot create it.


Ref: https://redhat.atlassian.net/browse/MTV-6551
Resolves: MTV-6551