### PR TITLE
MTV-6697 | Fix plan stuck in Executing when source VM is deleted

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -135,6 +135,12 @@ func (r *Migration) Run() (reQ time.Duration, err error) {
 		vm, hasNext, err = r.scheduler.Next()
 		if err != nil {
 			if errors.As(err, &web.NotFoundError{}) {
+				if vm == nil {
+					// The scheduler couldn't identify which VM triggered
+					// the error, so there's nothing to mark. Retry next
+					// reconcile rather than panic on a nil receiver.
+					return
+				}
 				if !r.Source.Provider.Status.HasCondition(libcnd.Ready) {
 					r.Log.Info(
 						"VM not found in inventory but source provider is not ready, will retry.",

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -137,8 +137,12 @@ func (r *Migration) Run() (reQ time.Duration, err error) {
 			if errors.As(err, &web.NotFoundError{}) {
 				if vm == nil {
 					// The scheduler couldn't identify which VM triggered
-					// the error, so there's nothing to mark. Retry next
-					// reconcile rather than panic on a nil receiver.
+					// the error, so there's nothing to mark. Missing VMs
+					// should already be handled by the scheduler's
+					// markNotFound; retry next reconcile rather than panic.
+					r.Log.Info(
+						"Scheduler returned NotFoundError without selecting a VM; retrying on next reconcile.",
+						"plan", r.Plan.Name)
 					return
 				}
 				if !r.Source.Provider.Status.HasCondition(libcnd.Ready) {

--- a/pkg/controller/plan/scheduler/vsphere/scheduler.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler.go
@@ -10,6 +10,7 @@ import (
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/controller/provider/web"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
+	libcnd "github.com/kubev2v/forklift/pkg/lib/condition"
 	liberr "github.com/kubev2v/forklift/pkg/lib/error"
 )
 
@@ -112,6 +113,48 @@ func (r *Scheduler) buildSchedule() (err error) {
 	return
 }
 
+// markNotFound stops migrating vmStatus because it no longer exists in
+// the source inventory (e.g. deleted on the source provider mid-migration).
+// A VM that had already started (mid-transfer, mid-conversion, etc.) is
+// marked Failed since real work was interrupted; a VM that was still
+// queued and never started is marked Canceled since nothing was attempted.
+// It also marks the VM completed so plan/migration finalization
+// (which requires every VM to be MarkedCompleted) isn't blocked by it.
+func (r *Scheduler) markNotFound(vmStatus *plan.VMStatus) {
+	conditionType := api.ConditionCanceled
+	if vmStatus.Running() {
+		conditionType = api.ConditionFailed
+		reason := "VM was not found in inventory."
+		// Record error.phase/reasons (consistent with how other failures
+		// are reported) before Phase is overwritten to Completed below.
+		vmStatus.AddError(reason)
+		// Also record the error on the actively-running pipeline step,
+		// matching how naturally-occurring task/step failures report it
+		// (e.g. guest inspection pod failure at migration.go). Without
+		// this, the step never shows an error of its own even though the
+		// VM-level condition and error block do.
+		for _, step := range vmStatus.Pipeline {
+			if step.Phase == api.StepRunning {
+				step.Error = &plan.Error{
+					Phase:   step.Phase,
+					Reasons: []string{reason},
+				}
+				break
+			}
+		}
+	}
+	vmStatus.Phase = api.PhaseCompleted
+	vmStatus.SetCondition(libcnd.Condition{
+		Type:     conditionType,
+		Status:   libcnd.True,
+		Category: api.CategoryAdvisory,
+		Reason:   NotFound,
+		Message:  "VM was not found in inventory.",
+		Durable:  true,
+	})
+	vmStatus.MarkCompleted()
+}
+
 // Build the map of the number of disks that
 // are currently in flight for each host.
 func (r *Scheduler) buildInFlight() (err error) {
@@ -121,12 +164,16 @@ func (r *Scheduler) buildInFlight() (err error) {
 	// we need to use the plan from the context rather
 	// than from the list of plans that are retrieved below.
 	for _, vmStatus := range r.Plan.Status.Migration.VMs {
-		if vmStatus.HasCondition(Canceled) {
+		if vmStatus.HasCondition(Canceled) || vmStatus.MarkedCompleted() {
 			continue
 		}
 		vm := &model.VM{}
 		err = r.Source.Inventory.Find(vm, vmStatus.Ref)
 		if err != nil {
+			if errors.As(err, &web.NotFoundError{}) {
+				r.markNotFound(vmStatus)
+				continue
+			}
 			return
 		}
 		if vmStatus.Running() {
@@ -199,15 +246,20 @@ func (r *Scheduler) buildPending() (err error) {
 	}
 
 	for _, vmStatus := range r.Plan.Status.Migration.VMs {
-		if vmStatus.HasCondition(Canceled) {
+		if vmStatus.HasCondition(Canceled) || vmStatus.MarkedCompleted() {
 			continue
 		}
 		vm := &model.VM{}
 		err = r.Source.Inventory.Find(vm, vmStatus.Ref)
 		if err != nil {
+			if errors.As(err, &web.NotFoundError{}) {
+				r.markNotFound(vmStatus)
+				err = nil
+				continue
+			}
 			return
 		}
-		if vmStatus.MarkedStarted() || vmStatus.MarkedCompleted() {
+		if vmStatus.MarkedStarted() {
 			continue
 		}
 		if hasActiveCreators && vm.HasSharedDisk() && !r.migratesSharedDisks(vmStatus) {
@@ -231,6 +283,10 @@ func (r *Scheduler) hasActiveSharedDiskCreators() (bool, error) {
 		}
 		vm := &model.VM{}
 		if err := r.Source.Inventory.Find(vm, vmStatus.Ref); err != nil {
+			if errors.As(err, &web.NotFoundError{}) {
+				r.markNotFound(vmStatus)
+				continue
+			}
 			return false, err
 		}
 		if vm.HasSharedDisk() && r.migratesSharedDisks(vmStatus) {

--- a/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
+++ b/pkg/controller/plan/scheduler/vsphere/scheduler_test.go
@@ -1,10 +1,22 @@
 package vsphere
 
 import (
+	"fmt"
 	"testing"
 
+	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/plan"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/provider"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
+	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
+	vspheremodel "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	model "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
+	"github.com/kubev2v/forklift/pkg/lib/logging"
 	"github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestScheduler(t *testing.T) {
@@ -210,4 +222,239 @@ func TestSharedDiskPriority(t *testing.T) {
 		g.Expect(pending["h1"]).To(gomega.HaveLen(1))
 		g.Expect(pending["h1"][0].status.ID).To(gomega.Equal("vm-2998"))
 	})
+}
+
+type stubInventory struct {
+	base.Client
+	vms map[string]model.VM
+}
+
+func (s *stubInventory) Find(resource interface{}, r ref.Ref) error {
+	switch res := resource.(type) {
+	case *model.VM:
+		vm, ok := s.vms[r.ID]
+		if !ok {
+			return base.NotFoundError{Ref: r}
+		}
+		*res = vm
+	}
+	return nil
+}
+
+func inventoryVM(id, host string, sharedDisks ...bool) model.VM {
+	vm := model.VM{}
+	vm.ID = id
+	vm.Name = id
+	vm.Host = host
+	if len(sharedDisks) == 0 {
+		vm.Disks = []vspheremodel.Disk{
+			{File: id + "-disk0"},
+			{File: id + "-disk1"},
+		}
+		return vm
+	}
+	for i, shared := range sharedDisks {
+		vm.Disks = append(vm.Disks, vspheremodel.Disk{
+			File:   fmt.Sprintf("%s-disk%d", id, i),
+			Shared: shared,
+		})
+	}
+	return vm
+}
+
+func newTestScheduler(vms []*plan.VMStatus, inv *stubInventory) *Scheduler {
+	scheme := runtime.NewScheme()
+	_ = api.SchemeBuilder.AddToScheme(scheme)
+	pt := api.VSphere
+	return &Scheduler{
+		Context: &plancontext.Context{
+			Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			Plan: &api.Plan{
+				Spec: api.PlanSpec{
+					Provider: provider.Pair{
+						Source: core.ObjectReference{Name: "src", Namespace: "ns"},
+					},
+				},
+				Status: api.PlanStatus{
+					Migration: plan.MigrationStatus{VMs: vms},
+				},
+			},
+			Source: plancontext.Source{
+				Provider:  &api.Provider{Spec: api.ProviderSpec{Type: &pt}},
+				Inventory: inv,
+			},
+			Log: logging.WithName("test"),
+		},
+		MaxInFlight: 10,
+	}
+}
+
+func vmRef(id string) ref.Ref {
+	return ref.Ref{ID: id, Name: id}
+}
+
+func TestMarkNotFound_queuedVM(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	vmStatus := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("missing-queued")},
+		Phase: api.PhaseStarted,
+	}
+	scheduler := newTestScheduler([]*plan.VMStatus{vmStatus}, &stubInventory{})
+
+	scheduler.markNotFound(vmStatus)
+
+	g.Expect(vmStatus.MarkedCompleted()).To(gomega.BeTrue())
+	g.Expect(vmStatus.Phase).To(gomega.Equal(api.PhaseCompleted))
+	g.Expect(vmStatus.HasCondition(api.ConditionCanceled)).To(gomega.BeTrue())
+	g.Expect(vmStatus.HasCondition(api.ConditionFailed)).To(gomega.BeFalse())
+	g.Expect(vmStatus.Error).To(gomega.BeNil())
+	condition := vmStatus.FindCondition(api.ConditionCanceled)
+	g.Expect(condition.Reason).To(gomega.Equal(NotFound))
+}
+
+func TestMarkNotFound_runningVM(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	vmStatus := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("missing-running")},
+		Phase: api.PhaseStarted,
+		Pipeline: []*plan.Step{
+			{Task: plan.Task{Name: DiskTransfer, Phase: api.StepRunning}},
+		},
+	}
+	vmStatus.MarkStarted()
+	scheduler := newTestScheduler([]*plan.VMStatus{vmStatus}, &stubInventory{})
+
+	scheduler.markNotFound(vmStatus)
+
+	g.Expect(vmStatus.MarkedCompleted()).To(gomega.BeTrue())
+	g.Expect(vmStatus.Phase).To(gomega.Equal(api.PhaseCompleted))
+	g.Expect(vmStatus.HasCondition(api.ConditionFailed)).To(gomega.BeTrue())
+	g.Expect(vmStatus.HasCondition(api.ConditionCanceled)).To(gomega.BeFalse())
+	g.Expect(vmStatus.Error).NotTo(gomega.BeNil())
+	g.Expect(vmStatus.Error.Reasons).To(gomega.ContainElement("VM was not found in inventory."))
+	g.Expect(vmStatus.Pipeline[0].Error).NotTo(gomega.BeNil())
+	g.Expect(vmStatus.Pipeline[0].Error.Reasons).To(gomega.ContainElement("VM was not found in inventory."))
+}
+
+func TestBuildInFlight_continuesAfterNotFound(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	missingRunning := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("missing-running")},
+		Phase: api.PhaseStarted,
+	}
+	missingRunning.MarkStarted()
+
+	running := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("running")},
+		Phase: api.PhaseStarted,
+	}
+	running.MarkStarted()
+
+	inv := &stubInventory{
+		vms: map[string]model.VM{
+			"running": inventoryVM("running", "host-a"),
+		},
+	}
+	scheduler := newTestScheduler([]*plan.VMStatus{missingRunning, running}, inv)
+
+	err := scheduler.buildInFlight()
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(missingRunning.MarkedCompleted()).To(gomega.BeTrue())
+	g.Expect(missingRunning.HasCondition(api.ConditionFailed)).To(gomega.BeTrue())
+	g.Expect(running.MarkedCompleted()).To(gomega.BeFalse())
+	g.Expect(scheduler.inFlight["host-a"]).To(gomega.Equal(2))
+}
+
+func TestBuildPending_continuesAfterNotFound(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	missingQueued := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("missing-queued")},
+		Phase: api.PhaseStarted,
+	}
+	queued := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("queued")},
+		Phase: api.PhaseStarted,
+	}
+
+	inv := &stubInventory{
+		vms: map[string]model.VM{
+			"queued": inventoryVM("queued", "host-a"),
+		},
+	}
+	scheduler := newTestScheduler([]*plan.VMStatus{missingQueued, queued}, inv)
+
+	err := scheduler.buildPending()
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(missingQueued.MarkedCompleted()).To(gomega.BeTrue())
+	g.Expect(missingQueued.HasCondition(api.ConditionCanceled)).To(gomega.BeTrue())
+	g.Expect(scheduler.pending["host-a"]).To(gomega.HaveLen(1))
+	g.Expect(scheduler.pending["host-a"][0].status.Ref.ID).To(gomega.Equal("queued"))
+}
+
+func TestHasActiveSharedDiskCreators_continuesAfterNotFound(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	migrateShared := true
+	missingCreator := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("missing-creator")},
+		Phase: api.PhaseStarted,
+	}
+	consumer := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("consumer")},
+		Phase: api.PhaseStarted,
+	}
+
+	inv := &stubInventory{
+		vms: map[string]model.VM{
+			"consumer": inventoryVM("consumer", "host-a", true),
+		},
+	}
+	scheduler := newTestScheduler([]*plan.VMStatus{missingCreator, consumer}, inv)
+	scheduler.Plan.Spec.VMs = []plan.VM{
+		{Ref: vmRef("missing-creator"), MigrateSharedDisks: &migrateShared},
+		{Ref: vmRef("consumer")},
+	}
+	scheduler.Plan.Spec.MigrateSharedDisks = false
+
+	active, err := scheduler.hasActiveSharedDiskCreators()
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(active).To(gomega.BeFalse())
+	g.Expect(missingCreator.MarkedCompleted()).To(gomega.BeTrue())
+	g.Expect(missingCreator.HasCondition(api.ConditionCanceled)).To(gomega.BeTrue())
+}
+
+func TestBuildPending_activeSharedDiskCreatorStillBlocks(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	migrateShared := true
+	creator := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("creator")},
+		Phase: api.PhaseStarted,
+	}
+	consumer := &plan.VMStatus{
+		VM:    plan.VM{Ref: vmRef("consumer")},
+		Phase: api.PhaseStarted,
+	}
+
+	inv := &stubInventory{
+		vms: map[string]model.VM{
+			"creator":  inventoryVM("creator", "host-a", true),
+			"consumer": inventoryVM("consumer", "host-a", true),
+		},
+	}
+	scheduler := newTestScheduler([]*plan.VMStatus{creator, consumer}, inv)
+	scheduler.Plan.Spec.VMs = []plan.VM{
+		{Ref: vmRef("creator"), MigrateSharedDisks: &migrateShared},
+		{Ref: vmRef("consumer")},
+	}
+	scheduler.Plan.Spec.MigrateSharedDisks = false
+
+	err := scheduler.buildPending()
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(scheduler.pending["host-a"]).To(gomega.HaveLen(1))
+	g.Expect(scheduler.pending["host-a"][0].status.Ref.ID).To(gomega.Equal("creator"))
 }


### PR DESCRIPTION
Summary
- vsphere.Scheduler aborted its whole scheduling pass instead of isolating the affected VM whenever a source inventory lookup returned NotFoundError, causing a nil-pointer panic loop and leaving the Plan/Migration stuck in Executing forever
- Mark the VM Canceled (never started) or Failed (was actively running) instead of propagating the error, and mark it completed so plan finalization isn't blocked
- Add a nil guard in migration.go as defense-in-depth

Ref: https://redhat.atlassian.net/browse/MTV-6697
Resolves: MTV-6697