### PR TITLE
MTV-6706 | Fix static IP preservation for name-based network maps

### DIFF
--- a/pkg/controller/plan/adapter/base/network.go
+++ b/pkg/controller/plan/adapter/base/network.go
@@ -42,19 +42,21 @@ type NICRef struct {
 	NetworkID string
 }
 
-// NICRefsFrom converts a slice of any NIC type to []NICRef using the provided accessor.
-func NICRefsFrom[N any](nics []N, toRef func(N) NICRef) []NICRef {
-	refs := make([]NICRef, len(nics))
-	for i := range nics {
-		refs[i] = toRef(nics[i])
+// NICRefsFromKeys pairs each MAC with its resolved lookup key. macs and keys
+// must be the same length and share NIC order.
+func NICRefsFromKeys(macs []string, keys []string) []NICRef {
+	refs := make([]NICRef, len(macs))
+	for i := range macs {
+		refs[i] = NICRef{MAC: macs[i], NetworkID: keys[i]}
 	}
 	return refs
 }
 
-// ResolveNICModes returns a MAC->mode map based on NetworkMap pairs and NADPool allocation.
-func ResolveNICModes(nics []NICRef, networkMap *api.NetworkMap, preserveStaticIPs bool) map[string]string {
+// ResolveNICModes returns a MAC->mode map based on pre-resolved NetworkPairs and NADPool
+// allocation. pairsBySource must be keyed by each NIC's resolved network key.
+func ResolveNICModes(nics []NICRef, pairsBySource map[string][]api.NetworkPair, preserveStaticIPs bool) map[string]string {
 	modes := map[string]string{}
-	if networkMap == nil {
+	if pairsBySource == nil {
 		for _, nic := range nics {
 			if preserveStaticIPs {
 				modes[nic.MAC] = string(api.NetworkIPModePreserve)
@@ -66,7 +68,7 @@ func ResolveNICModes(nics []NICRef, networkMap *api.NetworkMap, preserveStaticIP
 	}
 	pool := NewNADPool()
 	for _, nic := range nics {
-		pairs := networkMap.FindAllNetworks(nic.NetworkID)
+		pairs := pairsBySource[nic.NetworkID]
 		if len(pairs) == 0 {
 			continue
 		}

--- a/pkg/controller/plan/adapter/base/network_test.go
+++ b/pkg/controller/plan/adapter/base/network_test.go
@@ -304,6 +304,21 @@ func TestValidateNetworkDuplicates_1toN_MixedNetworks(t *testing.T) {
 
 // --- ResolveNICModes ---
 
+// pairsBySourceFromMap groups a NetworkMap's pairs by Source.ID, mimicking the
+// resolved-ID-keyed map each adapter's buildNICResolver builds from inventory
+// lookups. Tests that exercise name/type-based sources build pairsBySource
+// directly, keyed by the NIC's own resolved network ID instead.
+func pairsBySourceFromMap(nm *api.NetworkMap) map[string][]api.NetworkPair {
+	if nm == nil {
+		return nil
+	}
+	pairs := map[string][]api.NetworkPair{}
+	for _, pair := range nm.Spec.Map {
+		pairs[pair.Source.ID] = append(pairs[pair.Source.ID], pair)
+	}
+	return pairs
+}
+
 func TestResolveNICModes_NilNetworkMap_PreserveTrue(t *testing.T) {
 	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
 	modes := ResolveNICModes(nics, nil, true)
@@ -325,7 +340,7 @@ func TestResolveNICModes_EmptyNetworkIPMode_PreserveTrue(t *testing.T) {
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
 	}}}
 	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
-	modes := ResolveNICModes(nics, nm, true)
+	modes := ResolveNICModes(nics, pairsBySourceFromMap(nm), true)
 	if modes["aa:bb:cc:dd:ee:01"] != "preserve" {
 		t.Errorf("expected 'preserve', got %q", modes["aa:bb:cc:dd:ee:01"])
 	}
@@ -336,7 +351,7 @@ func TestResolveNICModes_EmptyNetworkIPMode_PreserveFalse(t *testing.T) {
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}},
 	}}}
 	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
-	modes := ResolveNICModes(nics, nm, false)
+	modes := ResolveNICModes(nics, pairsBySourceFromMap(nm), false)
 	if modes["aa:bb:cc:dd:ee:01"] != "none" {
 		t.Errorf("expected 'none', got %q", modes["aa:bb:cc:dd:ee:01"])
 	}
@@ -347,7 +362,7 @@ func TestResolveNICModes_NetworkIPModeOverridesPlanLevel(t *testing.T) {
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}, NetworkIPMode: api.NetworkIPModeDHCP},
 	}}}
 	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
-	modes := ResolveNICModes(nics, nm, true)
+	modes := ResolveNICModes(nics, pairsBySourceFromMap(nm), true)
 	if modes["aa:bb:cc:dd:ee:01"] != "dhcp" {
 		t.Errorf("networkIPMode should override plan-level, expected 'dhcp', got %q", modes["aa:bb:cc:dd:ee:01"])
 	}
@@ -358,7 +373,7 @@ func TestResolveNICModes_PreserveOverridesPreserveFalse(t *testing.T) {
 		{Source: api.NetworkSourceRef{Ref: ref.Ref{ID: "net-1"}}, Destination: api.DestinationNetwork{Type: Pod}, NetworkIPMode: api.NetworkIPModePreserve},
 	}}}
 	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"}}
-	modes := ResolveNICModes(nics, nm, false)
+	modes := ResolveNICModes(nics, pairsBySourceFromMap(nm), false)
 	if modes["aa:bb:cc:dd:ee:01"] != "preserve" {
 		t.Errorf("networkIPMode=preserve should override preserveStaticIPs=false, got %q", modes["aa:bb:cc:dd:ee:01"])
 	}
@@ -372,7 +387,7 @@ func TestResolveNICModes_UnmappedNICSkipped(t *testing.T) {
 		{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "net-1"},
 		{MAC: "aa:bb:cc:dd:ee:02", NetworkID: "net-unmapped"},
 	}
-	modes := ResolveNICModes(nics, nm, true)
+	modes := ResolveNICModes(nics, pairsBySourceFromMap(nm), true)
 	if len(modes) != 1 {
 		t.Errorf("expected 1 entry, got %d", len(modes))
 	}
@@ -394,7 +409,7 @@ func TestResolveNICModes_MixedModes(t *testing.T) {
 		{MAC: "mac-3", NetworkID: "net-3"},
 		{MAC: "mac-4", NetworkID: "net-4"},
 	}
-	modes := ResolveNICModes(nics, nm, true)
+	modes := ResolveNICModes(nics, pairsBySourceFromMap(nm), true)
 	if modes["mac-1"] != "preserve" {
 		t.Errorf("mac-1: expected 'preserve', got %q", modes["mac-1"])
 	}
@@ -406,6 +421,29 @@ func TestResolveNICModes_MixedModes(t *testing.T) {
 	}
 	if modes["mac-4"] != "preserve" {
 		t.Errorf("mac-4: expected 'preserve' (plan-level fallback), got %q", modes["mac-4"])
+	}
+}
+
+// TestResolveNICModes_NameBasedSource_HonorsOverride is the Defect B regression test:
+// a NetworkMap source specified by Name (Source.ID empty, as buildNICResolver
+// produces for name/type-based sources) must still resolve mode overrides once
+// the caller has resolved it to the NIC's actual (inventory) network ID — exactly
+// how vsphere/hyperv's buildNICResolver key their pairsBySource maps.
+func TestResolveNICModes_NameBasedSource_HonorsOverride(t *testing.T) {
+	nameBasedPair := api.NetworkPair{
+		Source:        api.NetworkSourceRef{Ref: ref.Ref{Name: "vlan100"}},
+		Destination:   api.DestinationNetwork{Type: Multus, Namespace: "ns", Name: "nad-a"},
+		NetworkIPMode: api.NetworkIPModeNone,
+	}
+	// buildNICResolver resolves the name-based source via inventory and keys
+	// pairsBySource by the resolved network ID, not the (empty) Source.ID.
+	pairsBySource := map[string][]api.NetworkPair{
+		"network-52": {nameBasedPair},
+	}
+	nics := []NICRef{{MAC: "aa:bb:cc:dd:ee:01", NetworkID: "network-52"}}
+	modes := ResolveNICModes(nics, pairsBySource, true)
+	if mode, ok := modes["aa:bb:cc:dd:ee:01"]; !ok || mode != "none" {
+		t.Errorf("expected name-based source's 'none' override to apply, got %q (ok=%v)", mode, ok)
 	}
 }
 
@@ -422,7 +460,7 @@ func TestResolveNICModes_1toN_DifferentNetworkIPMode(t *testing.T) {
 		{MAC: "mac-1", NetworkID: "net-1"},
 		{MAC: "mac-2", NetworkID: "net-1"},
 	}
-	modes := ResolveNICModes(nics, nm, true)
+	modes := ResolveNICModes(nics, pairsBySourceFromMap(nm), true)
 	if modes["mac-1"] != "preserve" {
 		t.Errorf("mac-1: expected 'preserve' (from row 0), got %q", modes["mac-1"])
 	}
@@ -442,7 +480,7 @@ func TestResolveNICModes_1toN_PoolExhausted(t *testing.T) {
 		{MAC: "mac-2", NetworkID: "net-1"},
 		{MAC: "mac-3", NetworkID: "net-1"},
 	}
-	modes := ResolveNICModes(nics, nm, true)
+	modes := ResolveNICModes(nics, pairsBySourceFromMap(nm), true)
 	if modes["mac-1"] != "preserve" {
 		t.Errorf("mac-1: expected 'preserve', got %q", modes["mac-1"])
 	}
@@ -466,7 +504,7 @@ func TestResolveNICModes_1toN_MixedNetworks(t *testing.T) {
 		{MAC: "mac-2", NetworkID: "net-1"},
 		{MAC: "mac-3", NetworkID: "net-2"},
 	}
-	modes := ResolveNICModes(nics, nm, false)
+	modes := ResolveNICModes(nics, pairsBySourceFromMap(nm), false)
 	if modes["mac-1"] != "preserve" {
 		t.Errorf("mac-1: expected 'preserve', got %q", modes["mac-1"])
 	}
@@ -475,34 +513,6 @@ func TestResolveNICModes_1toN_MixedNetworks(t *testing.T) {
 	}
 	if modes["mac-3"] != "dhcp" {
 		t.Errorf("mac-3: expected 'dhcp', got %q", modes["mac-3"])
-	}
-}
-
-// --- HasPreserveMode ---
-
-func TestHasPreserveMode_True(t *testing.T) {
-	modes := map[string]string{"mac-1": "none", "mac-2": "preserve"}
-	if !HasPreserveMode(modes) {
-		t.Error("expected true when at least one NIC is preserve")
-	}
-}
-
-func TestHasPreserveMode_False(t *testing.T) {
-	modes := map[string]string{"mac-1": "none", "mac-2": "dhcp"}
-	if HasPreserveMode(modes) {
-		t.Error("expected false when no NIC is preserve")
-	}
-}
-
-func TestHasPreserveMode_Empty(t *testing.T) {
-	if HasPreserveMode(map[string]string{}) {
-		t.Error("expected false for empty map")
-	}
-}
-
-func TestHasPreserveMode_Nil(t *testing.T) {
-	if HasPreserveMode(nil) {
-		t.Error("expected false for nil map")
 	}
 }
 

--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -560,12 +560,6 @@ func (r *Builder) ResolvePersistentVolumeClaimIdentifier(pvc *core.PersistentVol
 	return pvc.Name
 }
 
-func nicRefsFromVM(vm *model.VM) []planbase.NICRef {
-	return planbase.NICRefsFrom(vm.NICs, func(n hyperv.NIC) planbase.NICRef {
-		return planbase.NICRef{MAC: n.MAC, NetworkID: n.Network.ID}
-	})
-}
-
 func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env []core.EnvVar, err error) {
 	vm := &model.VM{}
 	err = r.Source.Inventory.Find(vm, vmRef)
@@ -587,11 +581,18 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		core.EnvVar{Name: "V2V_diskPath", Value: strings.Join(diskPaths, ",")},
 	)
 
-	modeByMAC := planbase.ResolveNICModes(nicRefsFromVM(vm), r.Map.Network, r.Plan.Spec.PreserveStaticIPs)
-	if planbase.HasPreserveMode(modeByMAC) {
+	nicKeys, pairsBySource := r.buildNICResolver(vm.NICs)
+	macs := make([]string, len(vm.NICs))
+	for i, nic := range vm.NICs {
+		macs[i] = nic.MAC
+	}
+	modeByMAC := planbase.ResolveNICModes(planbase.NICRefsFromKeys(macs, nicKeys), pairsBySource, r.Plan.Spec.PreserveStaticIPs)
+	// A per-network "preserve" override applies even when the plan-level flag is false.
+	if r.Plan.Spec.PreserveStaticIPs || planbase.HasPreserveMode(modeByMAC) {
 		macsToIps := r.mapMacStaticIps(vm, modeByMAC)
 		if macsToIps != "" {
 			env = append(env,
+				core.EnvVar{Name: "V2V_preserveStaticIPs", Value: "true"},
 				core.EnvVar{Name: "V2V_staticIPs", Value: macsToIps},
 			)
 		}

--- a/pkg/controller/plan/adapter/hyperv/builder.go
+++ b/pkg/controller/plan/adapter/hyperv/builder.go
@@ -126,7 +126,9 @@ func (r *Builder) VirtualMachine(vmRef ref.Ref, object *cnv.VirtualMachineSpec, 
 	r.mapFirmware(vm, object)
 	r.mapInput(object)
 	r.mapTpm(vm, object)
-	r.mapNetworks(vm, object)
+	if err := r.mapNetworks(vm, object); err != nil {
+		return err
+	}
 	r.mapCPU(vmRef, vm, object, usesInstanceType)
 	r.mapMemory(vm, object, usesInstanceType)
 
@@ -222,13 +224,16 @@ func (r *Builder) mapInput(object *cnv.VirtualMachineSpec) {
 	}
 }
 
-func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) {
+func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) error {
 	var kNetworks []cnv.Network
 	var kInterfaces []cnv.Interface
 
 	numNetworks := 0
 	pool := planbase.NewNADPool()
-	nicKeys, pairsBySource := r.buildNICResolver(vm.NICs)
+	nicKeys, pairsBySource, err := r.buildNICResolver(vm.NICs)
+	if err != nil {
+		return err
+	}
 
 	for i, nic := range vm.NICs {
 		pair, allocated := planbase.AllocateNetwork(pool, pairsBySource[nicKeys[i]])
@@ -270,9 +275,10 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) {
 
 	object.Template.Spec.Networks = kNetworks
 	object.Template.Spec.Domain.Devices.Interfaces = kInterfaces
+	return nil
 }
 
-func (r *Builder) buildNICResolver(nics []hyperv.NIC) ([]string, map[string][]api.NetworkPair) {
+func (r *Builder) buildNICResolver(nics []hyperv.NIC) ([]string, map[string][]api.NetworkPair, error) {
 	networkCount := nicNetworkCount(nics)
 
 	pairsBySource := map[string][]api.NetworkPair{}
@@ -281,7 +287,7 @@ func (r *Builder) buildNICResolver(nics []hyperv.NIC) ([]string, map[string][]ap
 		for _, pair := range r.Map.Network.Spec.Map {
 			network := &model.Network{}
 			if err := r.Source.Inventory.Find(network, pair.Source.Ref); err != nil {
-				continue
+				return nil, nil, liberr.Wrap(err, "buildNICResolver, source", pair.Source.String())
 			}
 			key := buildPairKey(network.ID, pair.Source.Vlan, networkCount)
 			pairsBySource[key] = append(pairsBySource[key], pair)
@@ -291,7 +297,7 @@ func (r *Builder) buildNICResolver(nics []hyperv.NIC) ([]string, map[string][]ap
 		}
 	}
 
-	return buildNICKeys(nics, networkCount, vlanQualifiedNetworks), pairsBySource
+	return buildNICKeys(nics, networkCount, vlanQualifiedNetworks), pairsBySource, nil
 }
 
 // nicNetworkCount returns a map of network ID → number of NICs attached to it.
@@ -581,7 +587,10 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		core.EnvVar{Name: "V2V_diskPath", Value: strings.Join(diskPaths, ",")},
 	)
 
-	nicKeys, pairsBySource := r.buildNICResolver(vm.NICs)
+	nicKeys, pairsBySource, err := r.buildNICResolver(vm.NICs)
+	if err != nil {
+		return
+	}
 	macs := make([]string, len(vm.NICs))
 	for i, nic := range vm.NICs {
 		macs[i] = nic.MAC

--- a/pkg/controller/plan/adapter/hyperv/builder_test.go
+++ b/pkg/controller/plan/adapter/hyperv/builder_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 
 	v1beta1 "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1/ref"
 	plancontext "github.com/kubev2v/forklift/pkg/controller/plan/context"
 	"github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
 	model "github.com/kubev2v/forklift/pkg/controller/provider/web/hyperv"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cnv "kubevirt.io/api/core/v1"
 )
@@ -380,6 +382,135 @@ var _ = Describe("HyperV builder", func() {
 			Expect(result).To(ContainSubstring("00:15:5D:01:02:03"))
 			Expect(result).NotTo(ContainSubstring("00:15:5D:01:02:04"))
 			Expect(result).NotTo(ContainSubstring("00:15:5D:01:02:05"))
+		})
+	})
+
+	Context("PodEnvironment with a name-based NetworkMap", func() {
+		staticIPsEnv := func(env []core.EnvVar) (string, bool) {
+			for _, e := range env {
+				if e.Name == "V2V_staticIPs" {
+					return e.Value, true
+				}
+			}
+			return "", false
+		}
+		hasPreserveFlagEnv := func(env []core.EnvVar) bool {
+			for _, e := range env {
+				if e.Name == "V2V_preserveStaticIPs" && e.Value == "true" {
+					return true
+				}
+			}
+			return false
+		}
+
+		It("should populate V2V_staticIPs when the plan requests preservation (Defect A)", func() {
+			vm := &model.VM{}
+			vm.ID = "vm-1"
+			vm.Name = "test-vm"
+			vm.GuestOS = "Windows Server 2019"
+			vm.NICs = []hyperv.NIC{
+				{MAC: "00:15:5D:01:02:03", Network: hyperv.Ref{ID: "net-A"}},
+			}
+			vm.GuestNetworks = []hyperv.GuestNetwork{
+				{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+			}
+
+			builder := createBuilder()
+			builder.Plan.Spec.PreserveStaticIPs = true
+			builder.Source.Inventory = &stubInventory{
+				vms: map[string]*model.VM{"vm-1": vm},
+				networksByName: map[string]model.Network{
+					"network-a": {Resource: model.Resource{ID: "net-A"}},
+				},
+			}
+			builder.Map.Network = &v1beta1.NetworkMap{
+				Spec: v1beta1.NetworkMapSpec{Map: []v1beta1.NetworkPair{
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-a"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}},
+				}},
+			}
+
+			env, err := builder.PodEnvironment(ref.Ref{ID: "vm-1"}, &core.Secret{})
+			Expect(err).NotTo(HaveOccurred())
+			staticIPs, found := staticIPsEnv(env)
+			Expect(found).To(BeTrue())
+			Expect(staticIPs).To(ContainSubstring("00:15:5D:01:02:03"))
+			Expect(hasPreserveFlagEnv(env)).To(BeTrue())
+		})
+
+		It("should honor a per-network 'none' override on a name-based NetworkMap (Defect B)", func() {
+			vm := &model.VM{}
+			vm.ID = "vm-1"
+			vm.Name = "test-vm"
+			vm.GuestOS = "Windows Server 2019"
+			vm.NICs = []hyperv.NIC{
+				{MAC: "00:15:5D:01:02:03", Network: hyperv.Ref{ID: "net-A"}},
+				{MAC: "00:15:5D:01:02:04", Network: hyperv.Ref{ID: "net-B"}},
+			}
+			vm.GuestNetworks = []hyperv.GuestNetwork{
+				{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				{MAC: "00:15:5D:01:02:04", IP: "172.29.3.194", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+			}
+
+			builder := createBuilder()
+			builder.Plan.Spec.PreserveStaticIPs = true
+			builder.Source.Inventory = &stubInventory{
+				vms: map[string]*model.VM{"vm-1": vm},
+				networksByName: map[string]model.Network{
+					"network-a": {Resource: model.Resource{ID: "net-A"}},
+					"network-b": {Resource: model.Resource{ID: "net-B"}},
+				},
+			}
+			builder.Map.Network = &v1beta1.NetworkMap{
+				Spec: v1beta1.NetworkMapSpec{Map: []v1beta1.NetworkPair{
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-a"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}},
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-b"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}, NetworkIPMode: v1beta1.NetworkIPModeNone},
+				}},
+			}
+
+			env, err := builder.PodEnvironment(ref.Ref{ID: "vm-1"}, &core.Secret{})
+			Expect(err).NotTo(HaveOccurred())
+			staticIPs, found := staticIPsEnv(env)
+			Expect(found).To(BeTrue())
+			Expect(staticIPs).To(ContainSubstring("00:15:5D:01:02:03"))
+			Expect(staticIPs).NotTo(ContainSubstring("00:15:5D:01:02:04"))
+		})
+
+		It("should honor a per-network 'preserve' override when the plan-level flag is false", func() {
+			vm := &model.VM{}
+			vm.ID = "vm-1"
+			vm.Name = "test-vm"
+			vm.GuestOS = "Windows Server 2019"
+			vm.NICs = []hyperv.NIC{
+				{MAC: "00:15:5D:01:02:03", Network: hyperv.Ref{ID: "net-A"}},
+				{MAC: "00:15:5D:01:02:04", Network: hyperv.Ref{ID: "net-B"}},
+			}
+			vm.GuestNetworks = []hyperv.GuestNetwork{
+				{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+				{MAC: "00:15:5D:01:02:04", IP: "172.29.3.194", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+			}
+
+			builder := createBuilder()
+			builder.Plan.Spec.PreserveStaticIPs = false
+			builder.Source.Inventory = &stubInventory{
+				vms: map[string]*model.VM{"vm-1": vm},
+				networksByName: map[string]model.Network{
+					"network-a": {Resource: model.Resource{ID: "net-A"}},
+					"network-b": {Resource: model.Resource{ID: "net-B"}},
+				},
+			}
+			builder.Map.Network = &v1beta1.NetworkMap{
+				Spec: v1beta1.NetworkMapSpec{Map: []v1beta1.NetworkPair{
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-a"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}, NetworkIPMode: v1beta1.NetworkIPModePreserve},
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-b"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}},
+				}},
+			}
+
+			env, err := builder.PodEnvironment(ref.Ref{ID: "vm-1"}, &core.Secret{})
+			Expect(err).NotTo(HaveOccurred())
+			staticIPs, found := staticIPsEnv(env)
+			Expect(found).To(BeTrue())
+			Expect(staticIPs).To(ContainSubstring("00:15:5D:01:02:03"))
+			Expect(staticIPs).NotTo(ContainSubstring("00:15:5D:01:02:04"))
 		})
 	})
 

--- a/pkg/controller/plan/adapter/hyperv/builder_test.go
+++ b/pkg/controller/plan/adapter/hyperv/builder_test.go
@@ -512,6 +512,35 @@ var _ = Describe("HyperV builder", func() {
 			Expect(staticIPs).To(ContainSubstring("00:15:5D:01:02:03"))
 			Expect(staticIPs).NotTo(ContainSubstring("00:15:5D:01:02:04"))
 		})
+
+		It("should fail when a NetworkMap source cannot be resolved", func() {
+			vm := &model.VM{}
+			vm.ID = "vm-1"
+			vm.Name = "test-vm"
+			vm.GuestOS = "Windows Server 2019"
+			vm.NICs = []hyperv.NIC{
+				{MAC: "00:15:5D:01:02:03", Network: hyperv.Ref{ID: "net-A"}},
+			}
+			vm.GuestNetworks = []hyperv.GuestNetwork{
+				{MAC: "00:15:5D:01:02:03", IP: "172.29.3.193", Origin: hyperv.OriginManual, PrefixLength: 16, Gateway: "172.29.3.1"},
+			}
+
+			builder := createBuilder()
+			builder.Plan.Spec.PreserveStaticIPs = true
+			builder.Source.Inventory = &stubInventory{
+				vms: map[string]*model.VM{"vm-1": vm},
+			}
+			builder.Map.Network = &v1beta1.NetworkMap{
+				Spec: v1beta1.NetworkMapSpec{Map: []v1beta1.NetworkPair{
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "missing-network"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}, NetworkIPMode: v1beta1.NetworkIPModeNone},
+				}},
+			}
+
+			env, err := builder.PodEnvironment(ref.Ref{ID: "vm-1"}, &core.Secret{})
+			Expect(err).To(HaveOccurred())
+			_, found := staticIPsEnv(env)
+			Expect(found).To(BeFalse())
+		})
 	})
 
 })

--- a/pkg/controller/plan/adapter/hyperv/validator_test.go
+++ b/pkg/controller/plan/adapter/hyperv/validator_test.go
@@ -15,8 +15,10 @@ import (
 // stubInventory returns pre-configured VMs and Hosts for testing.
 type stubInventory struct {
 	base.Client
-	vms   map[string]*hyperv.VM
-	hosts map[string]*hyperv.Host
+	vms            map[string]*hyperv.VM
+	hosts          map[string]*hyperv.Host
+	networks       map[string]hyperv.Network // keyed by ID
+	networksByName map[string]hyperv.Network // keyed by name; for name-based NetworkMap sources
 }
 
 func (s *stubInventory) Find(resource interface{}, r base.Ref) error {
@@ -33,6 +35,18 @@ func (s *stubInventory) Find(resource interface{}, r base.Ref) error {
 			return base.NotFoundError{Ref: r}
 		}
 		*res = *host
+	case *hyperv.Network:
+		if net, ok := s.networks[r.ID]; ok {
+			*res = net
+			return nil
+		}
+		if r.ID == "" {
+			if net, ok := s.networksByName[r.Name]; ok {
+				*res = net
+				return nil
+			}
+		}
+		return base.NotFoundError{Ref: r}
 	}
 	return nil
 }

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -210,18 +210,22 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		vm.RemoveSharedDisks()
 	}
 	r.removeExcludedDisks(vm)
+	nicKeys, pairsBySource, err := r.buildNICResolver(vm.NICs)
+	if err != nil {
+		return
+	}
+	macs := make([]string, len(vm.NICs))
+	for i, nic := range vm.NICs {
+		macs[i] = nic.MAC
+	}
 	macsToIps := ""
-	modeByMAC := planbase.ResolveNICModes(nicRefsFromVM(vm), r.Map.Network, r.Plan.Spec.PreserveStaticIPs)
-	if planbase.HasPreserveMode(modeByMAC) {
+	modeByMAC := planbase.ResolveNICModes(planbase.NICRefsFromKeys(macs, nicKeys), pairsBySource, r.Plan.Spec.PreserveStaticIPs)
+	// A per-network "preserve" override applies even when the plan-level flag is false.
+	if r.Plan.Spec.PreserveStaticIPs || planbase.HasPreserveMode(modeByMAC) {
 		macsToIps, err = r.mapMacStaticIps(vm, modeByMAC)
 		if err != nil {
 			return
 		}
-
-		env = append(env, core.EnvVar{
-			Name:  "V2V_preserveStaticIPs",
-			Value: "true",
-		})
 	}
 
 	useLegacyDrivers := false
@@ -303,10 +307,10 @@ func (r *Builder) PodEnvironment(vmRef ref.Ref, sourceSecret *core.Secret) (env 
 		},
 	)
 	if macsToIps != "" {
-		env = append(env, core.EnvVar{
-			Name:  "V2V_staticIPs",
-			Value: macsToIps,
-		})
+		env = append(env,
+			core.EnvVar{Name: "V2V_preserveStaticIPs", Value: "true"},
+			core.EnvVar{Name: "V2V_staticIPs", Value: macsToIps},
+		)
 	}
 	return
 }
@@ -417,12 +421,6 @@ func formatNetworkConfig(network vsphere.GuestNetwork, gateway string) string {
 	config := fmt.Sprintf("%s:ip:%s,%s,%d,%s",
 		network.MAC, network.IP, gateway, network.PrefixLength, dnsString)
 	return strings.TrimSuffix(config, ",")
-}
-
-func nicRefsFromVM(vm *model.VM) []planbase.NICRef {
-	return planbase.NICRefsFrom(vm.NICs, func(n vsphere.NIC) planbase.NICRef {
-		return planbase.NICRef{MAC: n.MAC, NetworkID: n.Network.ID}
-	})
 }
 
 func (r *Builder) mapMacStaticIps(vm *model.VM, modeByMAC map[string]string) (ipMap string, err error) {
@@ -1002,15 +1000,17 @@ func (r *Builder) mapNetworks(vm *model.VM, object *cnv.VirtualMachineSpec) (err
 
 func (r *Builder) buildNICResolver(nics []vsphere.NIC) ([]string, map[string][]api.NetworkPair, error) {
 	pairsBySource := map[string][]api.NetworkPair{}
-	for _, pair := range r.Map.Network.Spec.Map {
-		network := &model.Network{}
-		if err := r.Source.Inventory.Find(network, pair.Source.Ref); err != nil {
-			return nil, nil, liberr.Wrap(err, "buildNICResolver, source", pair.Source.String())
+	if r.Map.Network != nil {
+		for _, pair := range r.Map.Network.Spec.Map {
+			network := &model.Network{}
+			if err := r.Source.Inventory.Find(network, pair.Source.Ref); err != nil {
+				return nil, nil, liberr.Wrap(err, "buildNICResolver, source", pair.Source.String())
+			}
+			if network.Variant == vsphere.NetDvPortGroup || network.Variant == vsphere.OpaqueNetwork {
+				pairsBySource[network.Key] = append(pairsBySource[network.Key], pair)
+			}
+			pairsBySource[network.ID] = append(pairsBySource[network.ID], pair)
 		}
-		if network.Variant == vsphere.NetDvPortGroup || network.Variant == vsphere.OpaqueNetwork {
-			pairsBySource[network.Key] = append(pairsBySource[network.Key], pair)
-		}
-		pairsBySource[network.ID] = append(pairsBySource[network.ID], pair)
 	}
 	nicKeys := make([]string, len(nics))
 	for i, nic := range nics {

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -1067,6 +1067,7 @@ var _ = Describe("vSphere builder", func() {
 			Expect(found).To(BeTrue())
 			Expect(staticIPs).To(ContainSubstring("00:50:56:83:25:47"))
 			Expect(staticIPs).NotTo(ContainSubstring("00:50:56:83:25:48"))
+			Expect(hasPreserveFlagEnv(env)).To(BeTrue())
 		})
 
 		It("should honor a per-network 'none' override on a name-based NetworkMap (Defect B)", func() {

--- a/pkg/controller/plan/adapter/vsphere/builder_test.go
+++ b/pkg/controller/plan/adapter/vsphere/builder_test.go
@@ -977,6 +977,138 @@ var _ = Describe("vSphere builder", func() {
 		})
 	})
 
+	Context("PodEnvironment with a name-based NetworkMap", func() {
+		staticIPsEnv := func(env []core.EnvVar) (string, bool) {
+			for _, e := range env {
+				if e.Name == "V2V_staticIPs" {
+					return e.Value, true
+				}
+			}
+			return "", false
+		}
+		hasPreserveFlagEnv := func(env []core.EnvVar) bool {
+			for _, e := range env {
+				if e.Name == "V2V_preserveStaticIPs" && e.Value == "true" {
+					return true
+				}
+			}
+			return false
+		}
+
+		It("should populate V2V_staticIPs when the plan requests preservation (Defect A)", func() {
+			vm := model.VM{
+				VM1: model.VM1{VM0: model.VM0{ID: "vm-1", Name: "test-vm"}},
+			}
+			vm.GuestID = "windows9Guest"
+			vm.NICs = []vsphere.NIC{
+				{MAC: "00:50:56:83:25:47", Network: vsphere.Ref{ID: "net-A"}},
+			}
+			vm.GuestNetworks = []vsphere.GuestNetwork{
+				{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+			}
+			vm.GuestIpStacks = []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}}
+
+			builder := createBuilder()
+			builder.Plan.Spec.PreserveStaticIPs = true
+			builder.Source.Inventory = &mockInventory{
+				vm: vm,
+				networksByName: map[string]model.Network{
+					"network-a": {Resource: model.Resource{ID: "net-A"}},
+				},
+			}
+			builder.Map.Network = &v1beta1.NetworkMap{
+				Spec: v1beta1.NetworkMapSpec{Map: []v1beta1.NetworkPair{
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-a"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}},
+				}},
+			}
+
+			env, err := builder.PodEnvironment(ref.Ref{ID: "vm-1"}, &core.Secret{})
+			Expect(err).NotTo(HaveOccurred())
+			staticIPs, found := staticIPsEnv(env)
+			Expect(found).To(BeTrue())
+			Expect(staticIPs).To(ContainSubstring("00:50:56:83:25:47"))
+			Expect(hasPreserveFlagEnv(env)).To(BeTrue())
+		})
+
+		It("should honor a per-network 'preserve' override when the plan-level flag is false", func() {
+			vm := model.VM{
+				VM1: model.VM1{VM0: model.VM0{ID: "vm-1", Name: "test-vm"}},
+			}
+			vm.GuestID = "windows9Guest"
+			vm.NICs = []vsphere.NIC{
+				{MAC: "00:50:56:83:25:47", Network: vsphere.Ref{ID: "net-A"}},
+				{MAC: "00:50:56:83:25:48", Network: vsphere.Ref{ID: "net-B"}},
+			}
+			vm.GuestNetworks = []vsphere.GuestNetwork{
+				{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+				{MAC: "00:50:56:83:25:48", IP: "172.29.3.194", Origin: ManualOrigin, PrefixLength: 16},
+			}
+			vm.GuestIpStacks = []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}}
+
+			builder := createBuilder()
+			builder.Plan.Spec.PreserveStaticIPs = false
+			builder.Source.Inventory = &mockInventory{
+				vm: vm,
+				networksByName: map[string]model.Network{
+					"network-a": {Resource: model.Resource{ID: "net-A"}},
+					"network-b": {Resource: model.Resource{ID: "net-B"}},
+				},
+			}
+			builder.Map.Network = &v1beta1.NetworkMap{
+				Spec: v1beta1.NetworkMapSpec{Map: []v1beta1.NetworkPair{
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-a"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}, NetworkIPMode: v1beta1.NetworkIPModePreserve},
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-b"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}},
+				}},
+			}
+
+			env, err := builder.PodEnvironment(ref.Ref{ID: "vm-1"}, &core.Secret{})
+			Expect(err).NotTo(HaveOccurred())
+			staticIPs, found := staticIPsEnv(env)
+			Expect(found).To(BeTrue())
+			Expect(staticIPs).To(ContainSubstring("00:50:56:83:25:47"))
+			Expect(staticIPs).NotTo(ContainSubstring("00:50:56:83:25:48"))
+		})
+
+		It("should honor a per-network 'none' override on a name-based NetworkMap (Defect B)", func() {
+			vm := model.VM{
+				VM1: model.VM1{VM0: model.VM0{ID: "vm-1", Name: "test-vm"}},
+			}
+			vm.GuestID = "windows9Guest"
+			vm.NICs = []vsphere.NIC{
+				{MAC: "00:50:56:83:25:47", Network: vsphere.Ref{ID: "net-A"}},
+				{MAC: "00:50:56:83:25:48", Network: vsphere.Ref{ID: "net-B"}},
+			}
+			vm.GuestNetworks = []vsphere.GuestNetwork{
+				{MAC: "00:50:56:83:25:47", IP: "172.29.3.193", Origin: ManualOrigin, PrefixLength: 16},
+				{MAC: "00:50:56:83:25:48", IP: "172.29.3.194", Origin: ManualOrigin, PrefixLength: 16},
+			}
+			vm.GuestIpStacks = []vsphere.GuestIpStack{{Gateway: "172.29.3.1", Network: "0.0.0.0"}}
+
+			builder := createBuilder()
+			builder.Plan.Spec.PreserveStaticIPs = true
+			builder.Source.Inventory = &mockInventory{
+				vm: vm,
+				networksByName: map[string]model.Network{
+					"network-a": {Resource: model.Resource{ID: "net-A"}},
+					"network-b": {Resource: model.Resource{ID: "net-B"}},
+				},
+			}
+			builder.Map.Network = &v1beta1.NetworkMap{
+				Spec: v1beta1.NetworkMapSpec{Map: []v1beta1.NetworkPair{
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-a"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}},
+					{Source: v1beta1.NetworkSourceRef{Ref: ref.Ref{Name: "network-b"}}, Destination: v1beta1.DestinationNetwork{Type: Pod}, NetworkIPMode: v1beta1.NetworkIPModeNone},
+				}},
+			}
+
+			env, err := builder.PodEnvironment(ref.Ref{ID: "vm-1"}, &core.Secret{})
+			Expect(err).NotTo(HaveOccurred())
+			staticIPs, found := staticIPsEnv(env)
+			Expect(found).To(BeTrue())
+			Expect(staticIPs).To(ContainSubstring("00:50:56:83:25:47"))
+			Expect(staticIPs).NotTo(ContainSubstring("00:50:56:83:25:48"))
+		})
+	})
+
 	DescribeTable("should", func(disks []vsphere.Disk, output []vsphere.Disk) {
 		vm := &model.VM1{}
 		vm.Disks = disks

--- a/pkg/controller/plan/adapter/vsphere/validator_test.go
+++ b/pkg/controller/plan/adapter/vsphere/validator_test.go
@@ -24,11 +24,12 @@ var ErrNotImplemented = errors.New("not implemented")
 
 // Mock inventory struct and methods for testing
 type mockInventory struct {
-	ds         model.Datastore
-	datastores map[string]model.Datastore // keyed by ID; used when tests need more than one datastore
-	vm         model.VM
-	networks   map[string]model.Network // keyed by ID
-	customDefs []model.CustomFieldDef   // global custom field definitions
+	ds             model.Datastore
+	datastores     map[string]model.Datastore // keyed by ID; used when tests need more than one datastore
+	vm             model.VM
+	networks       map[string]model.Network // keyed by ID
+	networksByName map[string]model.Network // keyed by name; used for name-based NetworkMap sources
+	customDefs     []model.CustomFieldDef   // global custom field definitions
 }
 
 // defaultVM returns a VM with sensible defaults for testing
@@ -86,6 +87,12 @@ func (m *mockInventory) Find(resource interface{}, ref ref.Ref) error {
 	case *model.Network:
 		if m.networks != nil {
 			if net, ok := m.networks[ref.ID]; ok {
+				*res = net
+				return nil
+			}
+		}
+		if ref.ID == "" && m.networksByName != nil {
+			if net, ok := m.networksByName[ref.Name]; ok {
 				*res = net
 				return nil
 			}


### PR DESCRIPTION
ResolveNICModes matched NetworkMap sources by ID only, so plans using name- or type-based network map sources (with an empty Source.ID) resolved to an empty mode map. HasPreserveMode then gated out static IP handling, so no virt-v2v --mac argument was emitted and no firstboot IP script was generated on the migrated Windows guest.

Route mode resolution through the same buildNICResolver keys used for network routing (pairsBySource) so name/type-based sources match, and open the static IP gate on either the plan-level PreserveStaticIPs flag or a per-network networkIPMode: preserve override. Applied consistently to the vSphere and Hyper-V adapters.

Resolves: MTV-6706