### PR TITLE
MTV-6695 | Default STORAGE_HOSTNAME to https when scheme is missing

### DIFF
--- a/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/storage/resolver/util.go
+++ b/cmd/vsphere-copy-offload-populator/vendor/github.com/kubev2v/forklift/pkg/storage/resolver/util.go
@@ -1,0 +1,14 @@
+package resolver
+
+import "strings"
+
+// EnsureScheme prepends "https://" to host if it has no URL scheme.
+// This lets a single secret's STORAGE_HOSTNAME work for both plugins that
+// require a scheme (csiVolumeImport) and plugins/drivers that accept a bare
+// host (xcopy → Trident's ManagementLIF).
+func EnsureScheme(host string) string {
+	if host == "" || strings.Contains(host, "://") {
+		return host
+	}
+	return "https://" + host
+}

--- a/pkg/storage/resolver/hpe/importer.go
+++ b/pkg/storage/resolver/hpe/importer.go
@@ -24,6 +24,7 @@ type HpeImporter struct {
 }
 
 func NewHpeImporter(host, user, pass string, skipSSL bool) (*HpeImporter, error) {
+	host = resolver.EnsureScheme(host)
 	parsedURL, err := url.Parse(host)
 	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
 		return nil, fmt.Errorf("STORAGE_HOSTNAME must be a full URL with scheme (e.g. https://host:8080), got %q", host)

--- a/pkg/storage/resolver/hpe/importer_test.go
+++ b/pkg/storage/resolver/hpe/importer_test.go
@@ -54,6 +54,8 @@ func TestNewHpeImporter(t *testing.T) {
 		{"http://host:8080", "http://host:8080"},
 		{"https://10.46.2.10:8080", "https://10.46.2.10:8080"},
 		{"https://10.46.2.10:8080/", "https://10.46.2.10:8080"},
+		{"10.46.2.10", "https://10.46.2.10"},
+		{"host:8080", "https://host:8080"},
 	}
 	for _, tt := range validTests {
 		imp, err := NewHpeImporter(tt.input, "user", "pass", true)
@@ -66,8 +68,6 @@ func TestNewHpeImporter(t *testing.T) {
 	}
 
 	invalidTests := []string{
-		"10.46.2.10",
-		"host:8080",
 		"",
 	}
 	for _, input := range invalidTests {

--- a/pkg/storage/resolver/ontap/importer.go
+++ b/pkg/storage/resolver/ontap/importer.go
@@ -66,6 +66,7 @@ type OntapImporter struct {
 }
 
 func NewOntapImporter(host, user, pass, svm, backendUUID, driverType string, skipSSL bool, k8sClient client.Client, storageClass string) (*OntapImporter, error) {
+	host = resolver.EnsureScheme(host)
 	parsedURL, err := url.Parse(host)
 	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
 		return nil, fmt.Errorf("STORAGE_HOSTNAME must be a full URL with scheme (e.g. https://host), got %q", host)

--- a/pkg/storage/resolver/ontap/importer_test.go
+++ b/pkg/storage/resolver/ontap/importer_test.go
@@ -56,6 +56,8 @@ func TestNewOntapImporter(t *testing.T) {
 		{"https://10.46.246.90", "https://10.46.246.90"},
 		{"https://10.46.246.90/", "https://10.46.246.90"},
 		{"http://host:8080", "http://host:8080"},
+		{"10.46.246.90", "https://10.46.246.90"},
+		{"host:8080", "https://host:8080"},
 	}
 	for _, tt := range validTests {
 		imp, err := NewOntapImporter(tt.host, "user", "pass", "svm", "uuid", "", true, nil, "")
@@ -68,8 +70,6 @@ func TestNewOntapImporter(t *testing.T) {
 	}
 
 	invalidHosts := []string{
-		"10.46.246.90",
-		"host:8080",
 		"",
 	}
 	for _, host := range invalidHosts {

--- a/pkg/storage/resolver/util.go
+++ b/pkg/storage/resolver/util.go
@@ -1,0 +1,14 @@
+package resolver
+
+import "strings"
+
+// EnsureScheme prepends "https://" to host if it has no URL scheme.
+// This lets a single secret's STORAGE_HOSTNAME work for both plugins that
+// require a scheme (csiVolumeImport) and plugins/drivers that accept a bare
+// host (xcopy → Trident's ManagementLIF).
+func EnsureScheme(host string) string {
+	if host == "" || strings.Contains(host, "://") {
+		return host
+	}
+	return "https://" + host
+}

--- a/pkg/storage/resolver/util_test.go
+++ b/pkg/storage/resolver/util_test.go
@@ -1,0 +1,18 @@
+package resolver
+
+import "testing"
+
+func TestEnsureScheme(t *testing.T) {
+	tests := []struct{ host, want string }{
+		{"10.46.246.90", "https://10.46.246.90"},
+		{"host:8080", "https://host:8080"},
+		{"https://host", "https://host"},
+		{"http://host:8080", "http://host:8080"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := EnsureScheme(tt.host); got != tt.want {
+			t.Errorf("EnsureScheme(%q) = %q, want %q", tt.host, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
csiVolumeImport (ONTAP/HPE) requires STORAGE_HOSTNAME to be a full URL with scheme, while the xcopy plugin (Trident ManagementLIF) accepts a bare host/IP - so the same secret couldn't satisfy both plugins, and csiVolumeImport failed with "STORAGE_HOSTNAME must be a full URL with scheme".

Adds resolver.EnsureScheme() to default a missing scheme to https:// before validation, so one secret works for both plugins instead of requiring two.

Resolves: MTV-6695