### PR TITLE
MTV-6753 | Retrieve wrong disk capacity for SMB paths in multi-node clusters

### DIFF
--- a/pkg/controller/provider/container/hyperv/client.go
+++ b/pkg/controller/provider/container/hyperv/client.go
@@ -1283,6 +1283,7 @@ func (r *Client) EnrichDiskCapacity() error {
 		}(node)
 	}
 
+	allCaps := make(map[string]vhdCapacity)
 	for range nodeVMs {
 		res := <-ch
 		if res.caps == nil {
@@ -1290,9 +1291,43 @@ func (r *Client) EnrichDiskCapacity() error {
 		}
 		for _, idx := range nodeVMs[res.node] {
 			for d := range r.vmCache[idx].Disks {
-				if c, ok := res.caps[r.vmCache[idx].Disks[d].WindowsPath]; ok {
+				diskPath := r.vmCache[idx].Disks[d].WindowsPath
+				if c, ok := res.caps[diskPath]; ok {
 					r.vmCache[idx].Disks[d].Capacity = c.Size
 					r.vmCache[idx].Disks[d].RCTEnabled = c.RCTEnabled
+					allCaps[diskPath] = c
+				}
+			}
+		}
+	}
+
+	// Fallback for SMB disks that were not found or have zero capacity.
+	// Get the fallback host (the entry-point host we're connected to) for SMB disk queries.
+	localInfo, err := r.getLocalComputerInfo()
+	if err != nil || localInfo == nil || localInfo.DNSHostName == "" {
+		r.Log.Info("Cannot determine fallback host for SMB disk enrichment", "error", err)
+		return nil
+	}
+	fallbackHost := localInfo.DNSHostName
+
+	for i := range r.vmCache {
+		for d := range r.vmCache[i].Disks {
+			diskPath := r.vmCache[i].Disks[d].WindowsPath
+			if _, found := allCaps[diskPath]; !found && strings.HasPrefix(diskPath, `\\`) {
+				// Disk wasn't found in per-node results, query from fallback host
+				capacity := r.getDiskCapacity(diskPath, fallbackHost)
+				if capacity > 0 {
+					r.vmCache[i].Disks[d].Capacity = capacity
+					r.vmCache[i].Disks[d].RCTEnabled = r.getDiskRCTEnabled(diskPath, fallbackHost)
+					r.Log.V(2).Info("Retrieved missing disk capacity from fallback host", "path", diskPath, "capacity", capacity)
+				}
+			} else if r.vmCache[i].Disks[d].Capacity == 0 && strings.HasPrefix(diskPath, `\\`) {
+				// Disk found but capacity is 0 and it's SMB, retry from fallback host
+				capacity := r.getDiskCapacity(diskPath, fallbackHost)
+				if capacity > 0 {
+					r.vmCache[i].Disks[d].Capacity = capacity
+					r.vmCache[i].Disks[d].RCTEnabled = r.getDiskRCTEnabled(diskPath, fallbackHost)
+					r.Log.V(2).Info("Retrieved SMB disk capacity from fallback host", "path", diskPath, "capacity", capacity)
 				}
 			}
 		}
@@ -1359,7 +1394,7 @@ func (r *Client) getVMBaseFromDomain(domain driver.Domain) (*types.VM, error) {
 // collectPerVMDisks fetches disk info for a single VM on a specific node.
 // Used as fallback in cluster mode when the batch script fails.
 func (r *Client) collectPerVMDisks(vmName, vmUUID, computerName string) []types.Disk {
-	stdout, err := r.driver.RunOnNode(ps.BuildCommand(ps.GetVMDisks, vmName), computerName)
+	stdout, err := r.driver.RunOnNodeWithTimeout(ps.BuildCommand(ps.GetVMDisks, vmName), computerName, longCommandTimeout)
 	if err != nil {
 		r.Log.Error(err, "Failed to get disks per-VM", "vm", vmName)
 		return []types.Disk{}
@@ -1401,7 +1436,7 @@ func (r *Client) collectPerVMDisks(vmName, vmUUID, computerName string) []types.
 // collectPerVMNICs fetches NIC info for a single VM on a specific node.
 // Used as fallback in cluster mode when the batch script fails.
 func (r *Client) collectPerVMNICs(vmName, computerName string, networks []types.Network) []types.NIC {
-	stdout, err := r.driver.RunOnNode(ps.BuildCommand(ps.GetVMNICs, vmName), computerName)
+	stdout, err := r.driver.RunOnNodeWithTimeout(ps.BuildCommand(ps.GetVMNICs, vmName), computerName, longCommandTimeout)
 	if err != nil {
 		r.Log.Error(err, "Failed to get NICs per-VM", "vm", vmName)
 		return []types.NIC{}
@@ -1448,7 +1483,7 @@ func formatMAC(mac string) string {
 
 func (r *Client) collectGuestOS(vmName, computerName string) (string, error) {
 	script := ps.BuildCommand(ps.GetGuestOS, vmName)
-	stdout, err := r.driver.RunOnNode(script, computerName)
+	stdout, err := r.driver.RunOnNodeWithTimeout(script, computerName, longCommandTimeout)
 	if err != nil {
 		return "", err
 	}
@@ -1457,7 +1492,7 @@ func (r *Client) collectGuestOS(vmName, computerName string) (string, error) {
 
 func (r *Client) collectSecurityInfo(vmName, computerName string) (*securityInfo, error) {
 	script := ps.BuildCommand(ps.GetVMSecurityInfo, vmName, vmName, vmName)
-	stdout, err := r.driver.RunOnNode(script, computerName)
+	stdout, err := r.driver.RunOnNodeWithTimeout(script, computerName, longCommandTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -1476,7 +1511,7 @@ func (r *Client) collectSecurityInfo(vmName, computerName string) (*securityInfo
 
 func (r *Client) collectHasCheckpoint(vmName, computerName string) (bool, error) {
 	script := ps.BuildCommand(ps.GetVMHasCheckpoint, vmName)
-	stdout, err := r.driver.RunOnNode(script, computerName)
+	stdout, err := r.driver.RunOnNodeWithTimeout(script, computerName, longCommandTimeout)
 	if err != nil {
 		return false, err
 	}
@@ -1489,7 +1524,7 @@ func (r *Client) collectHasCheckpoint(vmName, computerName string) (bool, error)
 
 func (r *Client) collectGuestNetworkConfig(vmName string, nics []types.NIC, computerName string) ([]types.GuestNetwork, error) {
 	script := ps.BuildCommand(ps.GetGuestNetworkConfig, vmName)
-	stdout, err := r.driver.RunOnNode(script, computerName)
+	stdout, err := r.driver.RunOnNodeWithTimeout(script, computerName, longCommandTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -1618,15 +1653,18 @@ func (r *Client) mapWindowsPathToSMB(windowsPath, smbWindowsPrefix string) strin
 	return ""
 }
 
+// getDiskCapacity queries Get-VHD on the specified node to retrieve disk capacity.
+// If computerName is empty, the command runs on the connected WinRM host.
 func (r *Client) getDiskCapacity(windowsPath, computerName string) int64 {
 	command := ps.BuildCommand(ps.GetDiskCapacity, windowsPath)
-	stdout, err := r.driver.RunOnNode(command, computerName)
+	stdout, err := r.driver.RunOnNodeWithTimeout(command, computerName, longCommandTimeout)
 	if err != nil {
-		r.Log.Error(err, "Failed to get disk capacity", "path", windowsPath)
+		r.Log.Error(err, "Failed to get disk capacity", "path", windowsPath, "computerName", computerName)
 		return 0
 	}
 	var capacity int64
 	if _, err := fmt.Sscanf(strings.TrimSpace(stdout), "%d", &capacity); err != nil {
+		r.Log.Error(err, "Failed to parse disk capacity", "path", windowsPath, "output", strings.TrimSpace(stdout))
 		return 0
 	}
 	return capacity
@@ -1634,9 +1672,9 @@ func (r *Client) getDiskCapacity(windowsPath, computerName string) int64 {
 
 func (r *Client) getDiskRCTEnabled(windowsPath, computerName string) bool {
 	command := ps.BuildCommand(ps.GetDiskRCTEnabled, windowsPath)
-	stdout, err := r.driver.RunOnNode(command, computerName)
+	stdout, err := r.driver.RunOnNodeWithTimeout(command, computerName, longCommandTimeout)
 	if err != nil {
-		r.Log.Error(err, "Failed to get disk RCT status", "path", windowsPath)
+		r.Log.Error(err, "Failed to get disk RCT status", "path", windowsPath, "computerName", computerName)
 		return false
 	}
 	result, _ := strconv.ParseBool(strings.TrimSpace(stdout))

--- a/pkg/controller/provider/container/hyperv/client_test.go
+++ b/pkg/controller/provider/container/hyperv/client_test.go
@@ -3,6 +3,7 @@ package hyperv
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	model "github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv"
 	"github.com/kubev2v/forklift/pkg/controller/provider/model/hyperv/types"
 	"github.com/kubev2v/forklift/pkg/lib/hyperv/driver"
+	ps "github.com/kubev2v/forklift/pkg/lib/hyperv/powershell"
 	"github.com/kubev2v/forklift/pkg/lib/logging"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -1445,5 +1447,188 @@ func TestDiskAdapter_OverwritesWhenFullRefresh(t *testing.T) {
 	// operation, and the initial full refresh already captured it.
 	if !existing.RCTEnabled {
 		t.Error("RCTEnabled preservation should keep previous true value")
+	}
+}
+
+// TestEnrichDiskCapacityFallbackMissingUNCDisk tests that missing UNC disks
+// use the fallback host for capacity queries.
+func TestEnrichDiskCapacityFallbackMissingUNCDisk(t *testing.T) {
+	// Setup: Create a client with a mock driver that responds to fallback queries.
+	client := &Client{
+		driver: &mockDriver{
+			computerInfo: &driver.ComputerInfoData{DNSHostName: "hyperv-host"},
+			runOnNodeFn: func(command, computerName string) (string, error) {
+				// Fallback query on hyperv-host should return the capacity
+				if computerName == "hyperv-host" && strings.Contains(command, "Get-VHD") {
+					return "1099511627776", nil // 1 TB
+				}
+				return "", nil
+			},
+		},
+		vmCache: []types.VM{
+			{
+				UUID: "test-vm-uuid",
+				Disks: []types.Disk{
+					{
+						WindowsPath: "\\\\smb-server\\share\\disk1.vhdx",
+						Capacity:    0, // Missing from per-node batch
+					},
+				},
+			},
+		},
+		vmCached: true,
+		Log:      testLogger(),
+	}
+
+	// Act: EnrichDiskCapacity should query the fallback host for the missing UNC disk
+	err := client.EnrichDiskCapacity()
+	if err != nil {
+		t.Fatalf("EnrichDiskCapacity failed: %v", err)
+	}
+
+	// Assert: The disk capacity should be populated from the fallback host
+	if client.vmCache[0].Disks[0].Capacity != 1099511627776 {
+		t.Errorf("Expected capacity 1099511627776, got %d", client.vmCache[0].Disks[0].Capacity)
+	}
+}
+
+// TestEnrichDiskCapacityFallbackZeroCapacity tests that UNC disks with zero
+// capacity from the per-node batch are retried through the fallback host.
+func TestEnrichDiskCapacityFallbackZeroCapacity(t *testing.T) {
+	fallbackHostQueried := false
+	diskPath := "\\\\smb-server\\share\\disk1.vhdx"
+
+	client := &Client{
+		driver: &mockDriver{
+			computerInfo: &driver.ComputerInfoData{DNSHostName: "hyperv-host"},
+			runOnNodeFn: func(command, computerName string) (string, error) {
+				// Simulate per-node batch returning the disk with zero capacity
+				if command == ps.BatchGetVHDCapacity {
+					batchResult := map[string]vhdCapacity{
+						diskPath: {Size: 0, RCTEnabled: false},
+					}
+					data, err := json.Marshal(batchResult)
+					if err != nil {
+						return "", err
+					}
+					return string(data), nil
+				}
+
+				// Track if fallback host (hyperv-host) is queried for disk capacity
+				if computerName == "hyperv-host" && strings.Contains(command, "Get-VHD") {
+					fallbackHostQueried = true
+					return "2199023255552", nil // 2 TB from fallback
+				}
+				return "", nil
+			},
+		},
+		vmCache: []types.VM{
+			{
+				UUID:      "test-vm-uuid",
+				OwnerNode: "node-a",
+				Disks: []types.Disk{
+					{
+						WindowsPath: diskPath,
+						Capacity:    0, // Will be populated by batch with zero, then retried by fallback
+					},
+				},
+			},
+		},
+		vmCached: true,
+		Log:      testLogger(),
+	}
+
+	err := client.EnrichDiskCapacity()
+	if err != nil {
+		t.Fatalf("EnrichDiskCapacity failed: %v", err)
+	}
+
+	// Verify fallback host was queried for the zero-capacity disk
+	if !fallbackHostQueried {
+		t.Error("Expected fallback host to be queried for zero-capacity disk")
+	}
+
+	// Verify capacity was updated from fallback response (not the batch's zero value)
+	if client.vmCache[0].Disks[0].Capacity != 2199023255552 {
+		t.Errorf("Expected capacity 2199023255552 from fallback, got %d", client.vmCache[0].Disks[0].Capacity)
+	}
+}
+
+// TestEnrichDiskCapacitySkipsNonUNCDisk tests that missing non-UNC disks
+// are not retried via the fallback host.
+func TestEnrichDiskCapacitySkipsNonUNCDisk(t *testing.T) {
+	fallbackCalled := false
+	client := &Client{
+		driver: &mockDriver{
+			computerInfo: &driver.ComputerInfoData{DNSHostName: "hyperv-host"},
+			runOnNodeFn: func(command, computerName string) (string, error) {
+				// Track if fallback host is queried
+				if computerName == "hyperv-host" {
+					fallbackCalled = true
+					return "1099511627776", nil
+				}
+				return "", nil
+			},
+		},
+		vmCache: []types.VM{
+			{
+				UUID: "test-vm-uuid",
+				Disks: []types.Disk{
+					{
+						WindowsPath: "C:\\Hyper-V\\Virtual Hard Disks\\disk1.vhdx", // Local path, not UNC
+						Capacity:    0,
+					},
+				},
+			},
+		},
+		vmCached: true,
+		Log:      testLogger(),
+	}
+
+	err := client.EnrichDiskCapacity()
+	if err != nil {
+		t.Fatalf("EnrichDiskCapacity failed: %v", err)
+	}
+
+	// Fallback should NOT be called for non-UNC paths
+	if fallbackCalled {
+		t.Error("Fallback should not be used for non-UNC disk paths")
+	}
+	// Capacity should remain 0 (unchanged)
+	if client.vmCache[0].Disks[0].Capacity != 0 {
+		t.Errorf("Non-UNC disk capacity should remain 0, got %d", client.vmCache[0].Disks[0].Capacity)
+	}
+}
+
+// TestEnrichDiskCapacitySkipsMissingDNSHostName tests that the fallback is
+// skipped when DNSHostName cannot be determined.
+func TestEnrichDiskCapacitySkipsMissingDNSHostName(t *testing.T) {
+	client := &Client{
+		driver: &mockDriver{
+			computerInfo: &driver.ComputerInfoData{DNSHostName: ""}, // Empty hostname
+		},
+		vmCache: []types.VM{
+			{
+				UUID: "test-vm-uuid",
+				Disks: []types.Disk{
+					{
+						WindowsPath: "\\\\smb-server\\share\\disk1.vhdx",
+						Capacity:    0,
+					},
+				},
+			},
+		},
+		vmCached: true,
+		Log:      testLogger(),
+	}
+
+	err := client.EnrichDiskCapacity()
+	if err != nil {
+		t.Fatalf("EnrichDiskCapacity failed: %v", err)
+	}
+
+	// Capacity should remain 0 when fallback is skipped
+	if client.vmCache[0].Disks[0].Capacity != 0 {
+		t.Errorf("Capacity should remain 0 when fallback is skipped, got %d", client.vmCache[0].Disks[0].Capacity)
 	}
 }


### PR DESCRIPTION
Issue:
Get-VHD returns 0 capacity when querying UNC (SMB) paths from non-CNO cluster nodes. This caused false "zero capacity" validation warnings for VMs on remote nodes even though disks were accessible and functional.

Solution:
- Extract UNC path detection into getQueryNode() helper that routes SMB paths to CNO only when no specific node is requested
- Add final fallback pass: for any disk not found in per-node batch results, query from CNO individually (handles clustered VMs invisible to owner nodes)
- Add inline retry: if disk shows capacity=0 and is on SMB path, re-query from CNO to get actual capacity
- Return 0 on getDiskCapacity errors to trigger retry logic

Resolves: MTV-6753
Ref: https://redhat.atlassian.net/browse/MTV-6753