### PR TITLE
MTV-6744 | Prevent false VM success before disk transfer completes

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -51,8 +51,9 @@ const (
 	// TODO: ImageConversion and DiskTransferV2v step names remain here
 	// until remaining cold/warm migration flow details can be
 	// moved into base migrators.
-	ImageConversion = "ImageConversion"
-	DiskTransferV2v = "DiskTransferV2v"
+	ImageConversion        = "ImageConversion"
+	DiskTransferV2v        = "DiskTransferV2v"
+	VirtualMachineCreation = "VirtualMachineCreation"
 
 	// annCookieRefreshedAt records when import credentials were last
 	// refreshed for a DataVolume so short-lived download cookies are not
@@ -1808,6 +1809,14 @@ func (r *Migration) execute(vm *plan.VMStatus) (err error) {
 	}
 	vm.ReflectPipeline()
 	if vm.Phase == api.PhaseCompleted && vm.Error == nil {
+		if !r.requiredPipelineStepsComplete(vm) {
+			r.Log.Info(
+				"VM reached completed phase before required pipeline steps finished; resuming migration",
+				"vm",
+				vm.String())
+			r.resumeIncompletePipelinePhase(vm)
+			return
+		}
 		err = r.provider.DetachDisks(vm.Ref)
 		if err != nil {
 			step, found := vm.FindStep(r.migrator.Step(vm))
@@ -2232,6 +2241,15 @@ func (r *Migration) updateConversionProgress(vm *plan.VMStatus, step *plan.Step)
 			}
 			switch conv.Status.Phase {
 			case api.PhaseSucceeded:
+				useV2v, vErr := r.Plan.ShouldUseV2vForTransfer(vm.Ref)
+				if vErr != nil {
+					return liberr.Wrap(vErr)
+				}
+				// For virt-v2v-for-transfer, guest conversion can finish before disk
+				// copy; keep ImageConversion open until the v2v monitor advances it.
+				if useV2v && step.Name == ImageConversion {
+					return nil
+				}
 				step.MarkCompleted()
 				step.Progress.Completed = step.Progress.Total
 				return nil
@@ -2343,7 +2361,54 @@ func (r *Migration) updateConversionProgressV2vMonitor(pod *core.Pod, step *plan
 		step.Progress.Completed = step.Progress.Total
 		return
 	}
+	if step.Name == DiskTransferV2v && len(step.Tasks) > 0 {
+		allDone := true
+		for _, task := range step.Tasks {
+			if task.Progress.Completed < task.Progress.Total {
+				allDone = false
+				break
+			}
+		}
+		if allDone {
+			step.MarkCompleted()
+			step.Progress.Completed = step.Progress.Total
+		}
+	}
 	return
+}
+
+// requiredPipelineStepsComplete reports whether mandatory pipeline steps have
+// finished before the VM is marked Succeeded.
+func (r *Migration) requiredPipelineStepsComplete(vm *plan.VMStatus) bool {
+	for _, step := range vm.Pipeline {
+		if step.Name == VirtualMachineCreation && !step.MarkedCompleted() {
+			return false
+		}
+		if step.Name == DiskTransferV2v {
+			useV2v, err := r.Plan.ShouldUseV2vForTransfer(vm.Ref)
+			if err != nil {
+				r.Log.Error(err, "Could not verify virt-v2v transfer requirement", "vm", vm.String())
+				return false
+			}
+			if useV2v && !step.MarkedCompleted() {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// resumeIncompletePipelinePhase rewinds a VM that reached PhaseCompleted before
+// disk transfer or VM creation finished.
+func (r *Migration) resumeIncompletePipelinePhase(vm *plan.VMStatus) {
+	vm.Completed = nil
+	if step, found := vm.FindStep(DiskTransferV2v); found && !step.MarkedCompleted() {
+		vm.Phase = api.PhaseCopyDisksVirtV2V
+		return
+	}
+	if step, found := vm.FindStep(VirtualMachineCreation); found && !step.MarkedCompleted() {
+		vm.Phase = api.PhaseCreateVM
+	}
 }
 
 func (r *Migration) setDataVolumeCheckpoints(vm *plan.VMStatus) (err error) {

--- a/pkg/controller/plan/migration_test.go
+++ b/pkg/controller/plan/migration_test.go
@@ -710,3 +710,76 @@ func (s *stubImportCredentialRefresher) RefreshImportCredentials(_ *cdi.DataVolu
 	s.calls++
 	return s.refreshed, nil
 }
+
+func newLocalV2vMigration(t *testing.T) *Migration {
+	t.Helper()
+	vsphere, openshift := api.VSphere, api.OpenShift
+	return &Migration{
+		Context: &plancontext.Context{
+			Plan: &api.Plan{
+				Spec:   api.PlanSpec{MigrateSharedDisks: true},
+				Status: api.PlanStatus{NetAppShiftDestination: false},
+				Referenced: api.Referenced{
+					Provider: struct {
+						Source, Destination *api.Provider
+					}{
+						Source:      &api.Provider{Spec: api.ProviderSpec{Type: &vsphere, URL: "https://vc"}},
+						Destination: &api.Provider{Spec: api.ProviderSpec{Type: &openshift, URL: ""}},
+					},
+				},
+			},
+			Log: logging.WithName("test"),
+		},
+	}
+}
+
+func TestRequiredPipelineStepsComplete(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	m := newLocalV2vMigration(t)
+	vm := &plan.VMStatus{
+		VM: plan.VM{Ref: ref.Ref{ID: "vm-1", Name: "test-vm"}},
+		Pipeline: []*plan.Step{
+			{Task: plan.Task{Name: ImageConversion}},
+			{Task: plan.Task{Name: DiskTransferV2v}},
+			{Task: plan.Task{Name: VirtualMachineCreation}},
+		},
+	}
+
+	g.Expect(m.requiredPipelineStepsComplete(vm)).To(gomega.BeFalse())
+
+	vm.Pipeline[0].MarkCompleted()
+	vm.Pipeline[1].MarkCompleted()
+	g.Expect(m.requiredPipelineStepsComplete(vm)).To(gomega.BeFalse())
+
+	vm.Pipeline[2].MarkCompleted()
+	g.Expect(m.requiredPipelineStepsComplete(vm)).To(gomega.BeTrue())
+}
+
+func TestResumeIncompletePipelinePhase(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	m := newLocalV2vMigration(t)
+	vm := &plan.VMStatus{
+		VM:    plan.VM{Ref: ref.Ref{ID: "vm-1", Name: "test-vm"}},
+		Phase: api.PhaseCompleted,
+		Pipeline: []*plan.Step{
+			{Task: plan.Task{Name: ImageConversion}},
+			{Task: plan.Task{Name: DiskTransferV2v}},
+			{Task: plan.Task{Name: VirtualMachineCreation}},
+		},
+	}
+	vm.MarkCompleted()
+	vm.Pipeline[0].MarkCompleted()
+
+	m.resumeIncompletePipelinePhase(vm)
+
+	g.Expect(vm.Phase).To(gomega.Equal(api.PhaseCopyDisksVirtV2V))
+	g.Expect(vm.MarkedCompleted()).To(gomega.BeFalse())
+
+	vm.Pipeline[1].MarkCompleted()
+	vm.Phase = api.PhaseCompleted
+	vm.MarkCompleted()
+	m.resumeIncompletePipelinePhase(vm)
+
+	g.Expect(vm.Phase).To(gomega.Equal(api.PhaseCreateVM))
+	g.Expect(vm.MarkedCompleted()).To(gomega.BeFalse())
+}


### PR DESCRIPTION
Block Succeeded when virt-v2v disk transfer or VM creation pipeline steps are incomplete, defer Conversion CR success on ImageConversion, and complete DiskTransferV2v when all disk tasks reach 100%.

Ref: https://redhat.atlassian.net/browse/MTV-6744
Resolves: MTV-6744