### PR TITLE
MTV-5319 | Cache provider inventory during plan validate and begin

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -215,6 +215,7 @@ func (r *Migration) init() (err error) {
 
 // Begin the migration.
 func (r *Migration) begin() (err error) {
+	start := time.Now()
 	snapshot := r.Plan.Status.Migration.ActiveSnapshot()
 	if snapshot.HasAnyCondition(api.ConditionExecuting, api.ConditionSucceeded, api.ConditionFailed, api.ConditionCanceled) {
 		return
@@ -264,6 +265,7 @@ func (r *Migration) begin() (err error) {
 			Message:  "The plan is EXECUTING.",
 			Durable:  true,
 		})
+	setupStart := time.Now()
 	err = r.kubevirt.EnsureNamespace()
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -279,8 +281,12 @@ func (r *Migration) begin() (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	setupDuration := time.Since(setupStart)
+
+	r.Source.Inventory = web.NewCachingClient(r.Source.Inventory)
 	//
 	// Delete
+	cleanupStart := time.Now()
 	kept := []*plan.VMStatus{}
 	for _, status := range r.Plan.Status.Migration.VMs {
 
@@ -296,8 +302,10 @@ func (r *Migration) begin() (err error) {
 		}
 	}
 	r.Plan.Status.Migration.VMs = kept
+	cleanupDuration := time.Since(cleanupStart)
 	//
 	// Add/Update.
+	pipelineStart := time.Now()
 	list := []*plan.VMStatus{}
 	for _, vm := range r.Plan.Spec.VMs {
 		status := r.migrator.Status(vm)
@@ -333,6 +341,7 @@ func (r *Migration) begin() (err error) {
 	}
 
 	r.Plan.Status.Migration.VMs = list
+	pipelineDuration := time.Since(pipelineStart)
 
 	err = r.migrator.Begin()
 	if err != nil {
@@ -340,9 +349,26 @@ func (r *Migration) begin() (err error) {
 		return
 	}
 
-	r.Log.Info("Migration [STARTED]")
+	r.logInventoryCacheStats("migration begin")
+	r.Log.Info(
+		"Migration [STARTED]",
+		"vmCount", len(r.Plan.Spec.VMs),
+		"setup", setupDuration,
+		"cleanup", cleanupDuration,
+		"pipeline", pipelineDuration,
+		"total", time.Since(start))
 
 	return
+}
+
+func (r *Migration) logInventoryCacheStats(phase string) {
+	if cached, ok := r.Source.Inventory.(*web.CachingClient); ok {
+		r.Log.Info(
+			"Inventory cache stats",
+			"phase", phase,
+			"plan", r.Plan.Name,
+			"stats", cached.Stats())
+	}
 }
 
 // Archive the plan.

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1001,6 +1001,15 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 	planUsesOffload := checkMixedUsage && plan.IsUsingOffloadPlugin()
 	netAppShift := plan.HasNetAppShiftDestination()
 
+	sourceProvider := plan.Provider.Source
+	if sourceProvider == nil {
+		return nil
+	}
+	pAdapter, err := adapter.New(sourceProvider)
+	if err != nil {
+		return err
+	}
+
 	// Referenced VMs.
 	for i := range plan.Spec.VMs {
 		vm := &plan.Spec.VMs[i]
@@ -1024,15 +1033,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			continue
 		}
 		// Source.
-		provider := plan.Provider.Source
-		if provider == nil {
-			return nil
-		}
-		inventory, pErr := web.NewClient(provider)
-		if pErr != nil {
-			return liberr.Wrap(pErr)
-		}
-		v, pErr := inventory.VM(ref)
+		v, pErr := ctx.Source.Inventory.VM(ref)
 		if pErr != nil {
 			if errors.As(pErr, &web.NotFoundError{}) {
 				notFound.Items = append(notFound.Items, ref.String())
@@ -1076,7 +1077,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 				if vsphereVM.Snapshot.ID != "" {
 					shiftSnapshotVMs.Items = append(shiftSnapshotVMs.Items, ref.String())
 				}
-				if label, sErr := hasShiftDiskMissingNAS(vsphereVM, plan.Map.Storage, inventory, ctx.Destination.Client); sErr != nil {
+				if label, sErr := hasShiftDiskMissingNAS(vsphereVM, plan.Map.Storage, ctx.Source.Inventory, ctx.Destination.Client); sErr != nil {
 					return sErr
 				} else if label != "" {
 					shiftNASMissing.Items = append(shiftNASMissing.Items, label)
@@ -1112,15 +1113,6 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 					}
 				}
 			}
-		}
-		pAdapter, err := adapter.New(provider)
-		if err != nil {
-			return err
-		}
-		var ctx *plancontext.Context
-		ctx, err = plancontext.New(r, plan, r.Log)
-		if err != nil {
-			return err
 		}
 		validator, err := pAdapter.Validator(ctx)
 		if err != nil {
@@ -1304,13 +1296,8 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			}
 		}
 		// Destination.
-		provider = plan.Provider.Destination
-		if provider == nil {
+		if plan.Provider.Destination == nil {
 			return nil
-		}
-		inventory, pErr = web.NewClient(provider)
-		if pErr != nil {
-			return liberr.Wrap(pErr)
 		}
 		vmName := ref.Name
 		if vm.TargetName != "" {
@@ -1321,7 +1308,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			Name:      vmName,
 			Namespace: plan.Spec.TargetNamespace,
 		}
-		_, pErr = inventory.VM(vmRef)
+		_, pErr = ctx.Destination.Inventory.VM(vmRef)
 		if pErr == nil {
 			if _, found := plan.Status.Migration.FindVM(*ref); !found {
 				// This VM is preexisting or is being managed by a

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	k8snet "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
@@ -166,6 +167,7 @@ const (
 
 // Validate the plan resource.
 func (r *Reconciler) validate(plan *api.Plan) error {
+	start := time.Now()
 	// Provider.
 	pv := validation.ProviderPair{Client: r}
 	conditions, err := pv.Validate(plan.Spec.Provider)
@@ -209,6 +211,8 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 	if err != nil {
 		return err
 	}
+	ctx.Source.Inventory = web.NewCachingClient(ctx.Source.Inventory)
+	ctx.Destination.Inventory = web.NewCachingClient(ctx.Destination.Inventory)
 
 	if err = r.validateUserDefinedNetwork(ctx); err != nil {
 		return err
@@ -285,7 +289,33 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 		r.Log.V(1).Info("Failed to validate pod security policies", "error", err)
 	}
 
+	r.logValidateInventoryCache(plan, ctx)
+	r.Log.Info(
+		"Plan validate timing",
+		"plan", plan.Name,
+		"vmCount", len(plan.Spec.VMs),
+		"duration", time.Since(start))
+
 	return nil
+}
+
+func (r *Reconciler) logValidateInventoryCache(plan *api.Plan, ctx *plancontext.Context) {
+	if cached, ok := ctx.Source.Inventory.(*web.CachingClient); ok {
+		r.Log.Info(
+			"Inventory cache stats",
+			"phase", "plan validate",
+			"plan", plan.Name,
+			"inventory", "source",
+			"stats", cached.Stats())
+	}
+	if cached, ok := ctx.Destination.Inventory.(*web.CachingClient); ok {
+		r.Log.Info(
+			"Inventory cache stats",
+			"phase", "plan validate",
+			"plan", plan.Name,
+			"inventory", "destination",
+			"stats", cached.Stats())
+	}
 }
 
 func (r *Reconciler) validateVolumeNameTemplate(plan *api.Plan) error {
@@ -720,6 +750,7 @@ func aggregateWarningConcerns(v interface{}, vmRef string, unsupportedOVFExportS
 
 // Validate listed VMs.
 func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error {
+	start := time.Now()
 	if plan.Status.HasCondition(Executing) {
 		return nil
 	}
@@ -1485,6 +1516,12 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 	if len(independentDiskWarning.Items) > 0 {
 		plan.Status.SetCondition(independentDiskWarning)
 	}
+
+	r.Log.Info(
+		"Plan validate VM timing",
+		"plan", plan.Name,
+		"vmCount", len(plan.Spec.VMs),
+		"duration", time.Since(start))
 
 	return nil
 }

--- a/pkg/controller/provider/web/caching_client.go
+++ b/pkg/controller/provider/web/caching_client.go
@@ -1,0 +1,202 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+)
+
+// CacheStats tracks inventory cache effectiveness for a reconcile.
+type CacheStats struct {
+	FindHits   int
+	FindMisses int
+	VMHits     int
+	VMMisses   int
+	ListHits   int
+	ListMisses int
+}
+
+// CachingClient wraps an inventory client and memoizes Find, VM, and List calls
+// for the lifetime of the wrapper (typically one plan reconcile or migration begin).
+type CachingClient struct {
+	inner Client
+	mu    sync.RWMutex
+	find  map[string][]byte
+	vm    map[string]vmCacheEntry
+	list  map[string][]byte
+	stats CacheStats
+}
+
+type vmCacheEntry struct {
+	data []byte
+	id   string
+	name string
+	typ  reflect.Type
+}
+
+// NewCachingClient wraps inner with a per-reconcile inventory cache.
+func NewCachingClient(inner Client) Client {
+	if inner == nil {
+		return nil
+	}
+	if cached, ok := inner.(*CachingClient); ok {
+		return cached
+	}
+	return &CachingClient{
+		inner: inner,
+		find:  map[string][]byte{},
+		vm:    map[string]vmCacheEntry{},
+		list:  map[string][]byte{},
+	}
+}
+
+// Stats returns a snapshot of cache hit/miss counters.
+func (r *CachingClient) Stats() CacheStats {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.stats
+}
+
+func (r *CachingClient) Finder() base.Finder {
+	return r.inner.Finder()
+}
+
+func (r *CachingClient) Get(resource interface{}, id string) error {
+	return r.inner.Get(resource, id)
+}
+
+func (r *CachingClient) Watch(resource interface{}, h EventHandler) (*Watch, error) {
+	return r.inner.Watch(resource, h)
+}
+
+func (r *CachingClient) Find(resource interface{}, ref base.Ref) error {
+	key := findCacheKey(resource, ref)
+	r.mu.RLock()
+	data, ok := r.find[key]
+	r.mu.RUnlock()
+	if ok {
+		r.mu.Lock()
+		r.stats.FindHits++
+		r.mu.Unlock()
+		return json.Unmarshal(data, resource)
+	}
+
+	err := r.inner.Find(resource, ref)
+	if err != nil {
+		return err
+	}
+	data, err = json.Marshal(resource)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	r.find[key] = data
+	r.stats.FindMisses++
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *CachingClient) VM(ref *base.Ref) (object interface{}, err error) {
+	key := refCacheKey(*ref)
+	r.mu.RLock()
+	entry, ok := r.vm[key]
+	r.mu.RUnlock()
+	if ok {
+		r.mu.Lock()
+		r.stats.VMHits++
+		r.mu.Unlock()
+		ref.ID = entry.id
+		ref.Name = entry.name
+		return unmarshalVM(entry.data, entry.typ)
+	}
+
+	object, err = r.inner.VM(ref)
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(object)
+	if err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	r.vm[key] = vmCacheEntry{data: data, id: ref.ID, name: ref.Name, typ: reflect.TypeOf(object)}
+	r.stats.VMMisses++
+	r.mu.Unlock()
+	return unmarshalVM(data, reflect.TypeOf(object))
+}
+
+func (r *CachingClient) Workload(ref *base.Ref) (object interface{}, err error) {
+	return r.inner.Workload(ref)
+}
+
+func (r *CachingClient) Network(ref *base.Ref) (object interface{}, err error) {
+	return r.inner.Network(ref)
+}
+
+func (r *CachingClient) Storage(ref *base.Ref) (object interface{}, err error) {
+	return r.inner.Storage(ref)
+}
+
+func (r *CachingClient) Host(ref *base.Ref) (object interface{}, err error) {
+	return r.inner.Host(ref)
+}
+
+func (r *CachingClient) List(resource interface{}, param ...base.Param) error {
+	key := listCacheKey(resource, param)
+	r.mu.RLock()
+	data, ok := r.list[key]
+	r.mu.RUnlock()
+	if ok {
+		r.mu.Lock()
+		r.stats.ListHits++
+		r.mu.Unlock()
+		return json.Unmarshal(data, resource)
+	}
+
+	err := r.inner.List(resource, param...)
+	if err != nil {
+		return err
+	}
+	data, err = json.Marshal(resource)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	r.list[key] = data
+	r.stats.ListMisses++
+	r.mu.Unlock()
+	return nil
+}
+
+func findCacheKey(resource interface{}, ref base.Ref) string {
+	return fmt.Sprintf("%s|%s", reflect.TypeOf(resource).String(), refCacheKey(ref))
+}
+
+func refCacheKey(ref base.Ref) string {
+	if ref.ID != "" {
+		return ref.ID
+	}
+	return ref.Name
+}
+
+func listCacheKey(resource interface{}, param []base.Param) string {
+	key := reflect.TypeOf(resource).String()
+	for _, p := range param {
+		key += fmt.Sprintf("|%s=%s", p.Key, p.Value)
+	}
+	return key
+}
+
+func unmarshalVM(data []byte, typ reflect.Type) (interface{}, error) {
+	if typ == nil {
+		return nil, fmt.Errorf("missing VM type in cache")
+	}
+	out := reflect.New(typ.Elem()).Interface()
+	if err := json.Unmarshal(data, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/controller/provider/web/caching_client_test.go
+++ b/pkg/controller/provider/web/caching_client_test.go
@@ -1,0 +1,107 @@
+package web
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	"github.com/kubev2v/forklift/pkg/controller/provider/web/base"
+	webvsphere "github.com/kubev2v/forklift/pkg/controller/provider/web/vsphere"
+	gomega "github.com/onsi/gomega"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+type stubInventory struct {
+	findCalls int
+	vmCalls   int
+	listCalls int
+}
+
+func (s *stubInventory) Finder() base.Finder               { return nil }
+func (s *stubInventory) Get(_ interface{}, _ string) error { return nil }
+func (s *stubInventory) Watch(_ interface{}, _ EventHandler) (*Watch, error) {
+	return nil, errNotImplemented
+}
+func (s *stubInventory) Find(resource interface{}, ref base.Ref) error {
+	s.findCalls++
+	vm, ok := resource.(*webvsphere.VM)
+	if !ok {
+		return nil
+	}
+	vm.ID = ref.ID
+	vm.Name = ref.Name
+	vm.NICs = []vsphere.NIC{{MAC: "00:11:22:33:44:55"}}
+	return nil
+}
+func (s *stubInventory) VM(ref *base.Ref) (interface{}, error) {
+	s.vmCalls++
+	vm := &webvsphere.VM{}
+	vm.ID = ref.ID
+	vm.Name = ref.Name
+	return vm, nil
+}
+func (s *stubInventory) Workload(ref *base.Ref) (interface{}, error) {
+	return nil, errNotImplemented
+}
+func (s *stubInventory) Network(ref *base.Ref) (interface{}, error) {
+	return nil, errNotImplemented
+}
+func (s *stubInventory) Storage(ref *base.Ref) (interface{}, error) {
+	return nil, errNotImplemented
+}
+func (s *stubInventory) Host(ref *base.Ref) (interface{}, error) {
+	return nil, errNotImplemented
+}
+func (s *stubInventory) List(list interface{}, _ ...base.Param) error {
+	s.listCalls++
+	items, ok := list.(*[]webvsphere.VM)
+	if !ok {
+		return nil
+	}
+	dest := webvsphere.VM{}
+	dest.ID = "dest-1"
+	dest.Name = "dest-vm"
+	*items = []webvsphere.VM{dest}
+	return nil
+}
+
+func TestCachingClientFindAndList(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	inner := &stubInventory{}
+	client := NewCachingClient(inner)
+	ref := base.Ref{ID: "vm-1", Name: "source-vm"}
+
+	vm := &webvsphere.VM{}
+	g.Expect(client.Find(vm, ref)).To(gomega.Succeed())
+	g.Expect(client.Find(&webvsphere.VM{}, ref)).To(gomega.Succeed())
+	g.Expect(inner.findCalls).To(gomega.Equal(1))
+
+	cached, ok := client.(*CachingClient)
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(cached.Stats().FindHits).To(gomega.Equal(1))
+
+	var list []webvsphere.VM
+	g.Expect(client.List(&list, base.Param{Key: base.DetailParam, Value: "all"})).To(gomega.Succeed())
+	g.Expect(client.List(&list, base.Param{Key: base.DetailParam, Value: "all"})).To(gomega.Succeed())
+	g.Expect(inner.listCalls).To(gomega.Equal(1))
+	g.Expect(cached.Stats().ListHits).To(gomega.Equal(1))
+}
+
+func TestCachingClientVMPreservesType(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	inner := &stubInventory{}
+	client := NewCachingClient(inner)
+	ref := base.Ref{ID: "vm-1", Name: "source-vm"}
+
+	first, err := client.VM(&ref)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	_, ok := first.(*webvsphere.VM)
+	g.Expect(ok).To(gomega.BeTrue())
+
+	second, err := client.VM(&ref)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	_, ok = second.(*webvsphere.VM)
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(inner.vmCalls).To(gomega.Equal(1))
+}


### PR DESCRIPTION
## Summary

- Add a per-reconcile `CachingClient` for provider inventory `Find`, `VM`, and `List` calls.
- Wrap source and destination inventory during plan validation and migration `begin()`.
- Log validation/begin timing and cache hit stats to profile cold migration start latency.

**Depends on:** #8563 (VM validation loop trim). Merge #8563 first, then rebase this branch onto `main` so only the cache commit remains in the PR diff.

## Test plan

- [ ] Run plan controller and `caching_client` unit tests
- [ ] Start a cold migration with many VMs and confirm reduced inventory API traffic in logs

Ref: https://redhat.atlassian.net/browse/MTV-5319
Resolves: MTV-5319