### PR TITLE
MTV-5319 | Reuse plan context inventory in VM validation loop

### DIFF
--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1001,6 +1001,15 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 	planUsesOffload := checkMixedUsage && plan.IsUsingOffloadPlugin()
 	netAppShift := plan.HasNetAppShiftDestination()
 
+	sourceProvider := plan.Provider.Source
+	if sourceProvider == nil {
+		return nil
+	}
+	pAdapter, err := adapter.New(sourceProvider)
+	if err != nil {
+		return err
+	}
+
 	// Referenced VMs.
 	for i := range plan.Spec.VMs {
 		vm := &plan.Spec.VMs[i]
@@ -1024,15 +1033,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			continue
 		}
 		// Source.
-		provider := plan.Provider.Source
-		if provider == nil {
-			return nil
-		}
-		inventory, pErr := web.NewClient(provider)
-		if pErr != nil {
-			return liberr.Wrap(pErr)
-		}
-		v, pErr := inventory.VM(ref)
+		v, pErr := ctx.Source.Inventory.VM(ref)
 		if pErr != nil {
 			if errors.As(pErr, &web.NotFoundError{}) {
 				notFound.Items = append(notFound.Items, ref.String())
@@ -1076,7 +1077,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 				if vsphereVM.Snapshot.ID != "" {
 					shiftSnapshotVMs.Items = append(shiftSnapshotVMs.Items, ref.String())
 				}
-				if label, sErr := hasShiftDiskMissingNAS(vsphereVM, plan.Map.Storage, inventory, ctx.Destination.Client); sErr != nil {
+				if label, sErr := hasShiftDiskMissingNAS(vsphereVM, plan.Map.Storage, ctx.Source.Inventory, ctx.Destination.Client); sErr != nil {
 					return sErr
 				} else if label != "" {
 					shiftNASMissing.Items = append(shiftNASMissing.Items, label)
@@ -1112,15 +1113,6 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 					}
 				}
 			}
-		}
-		pAdapter, err := adapter.New(provider)
-		if err != nil {
-			return err
-		}
-		var ctx *plancontext.Context
-		ctx, err = plancontext.New(r, plan, r.Log)
-		if err != nil {
-			return err
 		}
 		validator, err := pAdapter.Validator(ctx)
 		if err != nil {
@@ -1304,13 +1296,8 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			}
 		}
 		// Destination.
-		provider = plan.Provider.Destination
-		if provider == nil {
+		if plan.Provider.Destination == nil {
 			return nil
-		}
-		inventory, pErr = web.NewClient(provider)
-		if pErr != nil {
-			return liberr.Wrap(pErr)
 		}
 		vmName := ref.Name
 		if vm.TargetName != "" {
@@ -1321,7 +1308,7 @@ func (r *Reconciler) validateVM(plan *api.Plan, ctx *plancontext.Context) error 
 			Name:      vmName,
 			Namespace: plan.Spec.TargetNamespace,
 		}
-		_, pErr = inventory.VM(vmRef)
+		_, pErr = ctx.Destination.Inventory.VM(vmRef)
 		if pErr == nil {
 			if _, found := plan.Status.Migration.FindVM(*ref); !found {
 				// This VM is preexisting or is being managed by a


### PR DESCRIPTION
## Summary

- Hoist source adapter creation before the per-VM validation loop instead of creating it on every iteration.
- Reuse the plan context source and destination inventory clients instead of calling `web.NewClient` per VM.
- Remove the inner `plancontext.New` that shadowed the outer context inside the loop.

This is the first of two PRs for MTV-5319. The companion PR (#8561) adds inventory caching and timing instrumentation on top of this change.

## Test plan

- [ ] Run plan controller unit tests
- [ ] Validate a plan with many VMs and confirm validation completes faster than before


Made with [Cursor](https://cursor.com)